### PR TITLE
[9.4] ESQL: Less memory usage for FIRST/LAST (#146148)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ The repository is organized into several key directories:
 - Debugging: append `--debug-jvm` to the Gradle test task and attach a debugger on port 5005.
 - CI reproductions: copy the `REPRODUCE WITH` line from CI logs; it includes project path, seed, and JVM flags.
 - Yaml REST tests: `./gradlew ":rest-api-spec:yamlRestTest" --tests "org.elasticsearch.test.rest.ClientYamlTestSuiteIT.test {yaml=<relative_test_file_path>}"`
+- ES|QL CSV tests: `./gradlew ":x-pack:plugin:esql:internalClusterTest" --tests "org.elasticsearch.xpack.esql.CsvIT.*<csv-file>*"` (e.g. `--tests "...CsvIT.*stats_first_last*"`); append `*<test-name>*` to target a single test within the file.
 - Use the Elasticsearch testing framework where possible for unit and yaml tests and be consistent in style with other elasticsearch tests.
 - Use real classes over mocks or stubs for unit tests, unless the real class is complex then either a simplified subclass should be created within the test or, as a last resort, a mock or stub can be used. Unit tests must be as close to real-world scenarios as possible.
 - Ensure mocks or stubs are well-documented and clearly indicate why they were necessary.

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -1203,6 +1203,9 @@ tasks.named('stringTemplates').configure {
               v1.forEach { k, v -> properties["v1_" + k] = v }
             }
             v2.forEach { k, v -> properties["v2_" + k] = v }
+            if (prefix != "") {
+              properties["v1_TailArray"] = properties["v1_boolean"] ? "ByteArray" : properties["v1_Array"]
+            }
 
             template {
               it.properties = addOccurrence(properties, Occurrence) + [Prefix: prefix]

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntAggregator.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -31,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -146,7 +145,7 @@ public class AllFirstBooleanByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntBooleanState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -180,127 +179,92 @@ public class AllFirstBooleanByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
-
+        private ByteArray firstValues;
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<ByteArray> values;
+        private ObjectArray<ByteArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newByteArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, BooleanBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                ByteArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.getBoolean(i + offset) ? 1 : 0));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, BooleanBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, (byte) (valuesBlock.getBoolean(offset) ? 1 : 0));
+                if (count > 1) {
+                    ByteArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, (byte) (valuesBlock.getBoolean(offset + i) ? 1 : 0));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -311,11 +275,11 @@ public class AllFirstBooleanByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -328,36 +292,75 @@ public class AllFirstBooleanByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private ByteArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private ByteArray getTailForWriting(int group, int count) {
+            ByteArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                ByteArray tail = bigArrays.newByteArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            ByteArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            ByteArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newBooleanBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendBoolean(values.get(group).get(0) == 1);
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        ByteArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendBoolean(firstValues.get(group) == 1);
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendBoolean(values.get(group).get(i) == 1);
+                            valuesBuilder.appendBoolean(firstValues.get(group) == 1);
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendBoolean(tail.get(i) == 1);
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBooleanByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBooleanByLongAggregator.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -31,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -146,7 +145,7 @@ public class AllFirstBooleanByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongBooleanState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -180,127 +179,92 @@ public class AllFirstBooleanByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
-
+        private ByteArray firstValues;
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<ByteArray> values;
+        private ObjectArray<ByteArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newByteArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, BooleanBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                ByteArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.getBoolean(i + offset) ? 1 : 0));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, BooleanBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, (byte) (valuesBlock.getBoolean(offset) ? 1 : 0));
+                if (count > 1) {
+                    ByteArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, (byte) (valuesBlock.getBoolean(offset + i) ? 1 : 0));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -311,11 +275,11 @@ public class AllFirstBooleanByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -328,36 +292,75 @@ public class AllFirstBooleanByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private ByteArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private ByteArray getTailForWriting(int group, int count) {
+            ByteArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                ByteArray tail = bigArrays.newByteArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            ByteArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            ByteArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newBooleanBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendBoolean(values.get(group).get(0) == 1);
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        ByteArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendBoolean(firstValues.get(group) == 1);
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendBoolean(values.get(group).get(i) == 1);
+                            valuesBuilder.appendBoolean(firstValues.get(group) == 1);
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendBoolean(tail.get(i) == 1);
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntAggregator.java
@@ -12,9 +12,9 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.BytesRefArray;
-import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +32,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -149,11 +149,11 @@ public class AllFirstBytesRefByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntBytesRefState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
-        return new GroupingState(driverContext.bigArrays());
+        return new GroupingState(driverContext.bigArrays(), driverContext.breaker());
     }
 
     public static void combine(GroupingState current, int group, @Position int position, BytesRefBlock values, IntBlock timestamps) {
@@ -183,128 +183,106 @@ public class AllFirstBytesRefByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
-
+        private ObjectArray<BreakingBytesRefBuilder> firstValues;
+        private final CircuitBreaker breaker;
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<BytesRefArray> values;
+        private ObjectArray<BytesRefArray> tailValues;
 
         private int maxGroupId = -1;
 
-        GroupingState(BigArrays bigArrays) {
+        GroupingState(BigArrays bigArrays, CircuitBreaker breaker) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
+            this.breaker = breaker;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newObjectArray(1);
+                this.firstValues.set(0, null);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, BytesRefBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                BytesRefArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, BytesRefBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                BytesRef firstScratch = new BytesRef();
+                valuesBlock.getBytesRef(offset, firstScratch);
+                BreakingBytesRefBuilder firstBuilder = firstValues.get(group);
+                if (firstBuilder == null) {
+                    firstBuilder = new BreakingBytesRefBuilder(breaker, "First", firstScratch.length);
+                    firstValues.set(group, firstBuilder);
+                }
+                firstBuilder.copyBytes(firstScratch);
+                if (count > 1) {
+                    BytesRefArray tail = getTailForWriting(group, count - 1);
+                    BytesRef scratch = new BytesRef();
+                    for (int i = 1; i < count; ++i) {
+                        tail.append(valuesBlock.getBytesRef(offset + i, scratch));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            for (long i = 0; i < firstValues.size(); i++) {
+                Releasables.close(firstValues.get(i));
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
+            }
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -315,11 +293,11 @@ public class AllFirstBytesRefByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -332,42 +310,67 @@ public class AllFirstBytesRefByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private BytesRefArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private BytesRefArray getTailForWriting(int group, int count) {
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+            } else {
+                Releasables.close(tailValues.get(group));
+            }
+            // BytesRefArray is append-only so we always need a fresh one; there is no way to clear and reuse it.
+            BytesRefArray tail = new BytesRefArray(count, bigArrays);
+            tailValues.set(group, tail);
+            return tail;
+        }
+
+        private void clearTailValues(int group) {
+            BytesRefArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newBytesRefBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        BytesRefArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendBytesRef(firstValues.get(group).bytesRefView());
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
+                            valuesBuilder.appendBytesRef(firstValues.get(group).bytesRefView());
+                            for (int i = 0; i < tailCount; ++i) {
                                 BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
+                                tail.get(i, bytesScratch);
                                 valuesBuilder.appendBytesRef(bytesScratch);
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBytesRefByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBytesRefByLongAggregator.java
@@ -12,9 +12,9 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.BytesRefArray;
-import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +32,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -149,11 +149,11 @@ public class AllFirstBytesRefByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongBytesRefState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
-        return new GroupingState(driverContext.bigArrays());
+        return new GroupingState(driverContext.bigArrays(), driverContext.breaker());
     }
 
     public static void combine(GroupingState current, int group, @Position int position, BytesRefBlock values, LongBlock timestamps) {
@@ -183,128 +183,106 @@ public class AllFirstBytesRefByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
-
+        private ObjectArray<BreakingBytesRefBuilder> firstValues;
+        private final CircuitBreaker breaker;
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<BytesRefArray> values;
+        private ObjectArray<BytesRefArray> tailValues;
 
         private int maxGroupId = -1;
 
-        GroupingState(BigArrays bigArrays) {
+        GroupingState(BigArrays bigArrays, CircuitBreaker breaker) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
+            this.breaker = breaker;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newObjectArray(1);
+                this.firstValues.set(0, null);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, BytesRefBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                BytesRefArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, BytesRefBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                BytesRef firstScratch = new BytesRef();
+                valuesBlock.getBytesRef(offset, firstScratch);
+                BreakingBytesRefBuilder firstBuilder = firstValues.get(group);
+                if (firstBuilder == null) {
+                    firstBuilder = new BreakingBytesRefBuilder(breaker, "First", firstScratch.length);
+                    firstValues.set(group, firstBuilder);
+                }
+                firstBuilder.copyBytes(firstScratch);
+                if (count > 1) {
+                    BytesRefArray tail = getTailForWriting(group, count - 1);
+                    BytesRef scratch = new BytesRef();
+                    for (int i = 1; i < count; ++i) {
+                        tail.append(valuesBlock.getBytesRef(offset + i, scratch));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            for (long i = 0; i < firstValues.size(); i++) {
+                Releasables.close(firstValues.get(i));
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
+            }
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -315,11 +293,11 @@ public class AllFirstBytesRefByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -332,42 +310,67 @@ public class AllFirstBytesRefByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private BytesRefArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private BytesRefArray getTailForWriting(int group, int count) {
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+            } else {
+                Releasables.close(tailValues.get(group));
+            }
+            // BytesRefArray is append-only so we always need a fresh one; there is no way to clear and reuse it.
+            BytesRefArray tail = new BytesRefArray(count, bigArrays);
+            tailValues.set(group, tail);
+            return tail;
+        }
+
+        private void clearTailValues(int group) {
+            BytesRefArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newBytesRefBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        BytesRefArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendBytesRef(firstValues.get(group).bytesRefView());
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
+                            valuesBuilder.appendBytesRef(firstValues.get(group).bytesRefView());
+                            for (int i = 0; i < tailCount; ++i) {
                                 BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
+                                tail.get(i, bytesScratch);
                                 valuesBuilder.appendBytesRef(bytesScratch);
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.DoubleArray;
-import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -147,7 +145,7 @@ public class AllFirstDoubleByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntDoubleState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -181,127 +179,93 @@ public class AllFirstDoubleByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private DoubleArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<DoubleArray> values;
+        private ObjectArray<DoubleArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newDoubleArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, DoubleBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                DoubleArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newDoubleArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getDouble(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, DoubleBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getDouble(offset));
+                if (count > 1) {
+                    DoubleArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getDouble(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -312,11 +276,11 @@ public class AllFirstDoubleByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -329,36 +293,75 @@ public class AllFirstDoubleByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private DoubleArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private DoubleArray getTailForWriting(int group, int count) {
+            DoubleArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                DoubleArray tail = bigArrays.newDoubleArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            DoubleArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            DoubleArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newDoubleBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendDouble(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        DoubleArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendDouble(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendDouble(values.get(group).get(i));
+                            valuesBuilder.appendDouble(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendDouble(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstDoubleByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstDoubleByLongAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.DoubleArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -147,7 +145,7 @@ public class AllFirstDoubleByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongDoubleState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -181,127 +179,93 @@ public class AllFirstDoubleByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private DoubleArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<DoubleArray> values;
+        private ObjectArray<DoubleArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newDoubleArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, DoubleBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                DoubleArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newDoubleArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getDouble(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, DoubleBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getDouble(offset));
+                if (count > 1) {
+                    DoubleArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getDouble(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -312,11 +276,11 @@ public class AllFirstDoubleByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -329,36 +293,75 @@ public class AllFirstDoubleByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private DoubleArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private DoubleArray getTailForWriting(int group, int count) {
+            DoubleArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                DoubleArray tail = bigArrays.newDoubleArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            DoubleArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            DoubleArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newDoubleBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendDouble(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        DoubleArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendDouble(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendDouble(values.get(group).get(i));
+                            valuesBuilder.appendDouble(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendDouble(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstFloatByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstFloatByIntAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.FloatArray;
-import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -141,7 +139,7 @@ public class AllFirstFloatByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntFloatState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -175,127 +173,93 @@ public class AllFirstFloatByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private FloatArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<FloatArray> values;
+        private ObjectArray<FloatArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newFloatArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, FloatBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                FloatArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newFloatArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getFloat(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, FloatBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getFloat(offset));
+                if (count > 1) {
+                    FloatArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getFloat(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -306,11 +270,11 @@ public class AllFirstFloatByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -323,36 +287,75 @@ public class AllFirstFloatByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private FloatArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private FloatArray getTailForWriting(int group, int count) {
+            FloatArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                FloatArray tail = bigArrays.newFloatArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            FloatArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            FloatArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newFloatBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendFloat(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        FloatArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendFloat(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendFloat(values.get(group).get(i));
+                            valuesBuilder.appendFloat(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendFloat(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstFloatByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstFloatByLongAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.FloatArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -147,7 +145,7 @@ public class AllFirstFloatByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongFloatState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -181,127 +179,93 @@ public class AllFirstFloatByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private FloatArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<FloatArray> values;
+        private ObjectArray<FloatArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newFloatArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, FloatBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                FloatArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newFloatArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getFloat(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, FloatBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getFloat(offset));
+                if (count > 1) {
+                    FloatArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getFloat(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -312,11 +276,11 @@ public class AllFirstFloatByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -329,36 +293,75 @@ public class AllFirstFloatByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private FloatArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private FloatArray getTailForWriting(int group, int count) {
+            FloatArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                FloatArray tail = bigArrays.newFloatArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            FloatArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            FloatArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newFloatBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendFloat(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        FloatArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendFloat(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendFloat(values.get(group).get(i));
+                            valuesBuilder.appendFloat(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendFloat(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstIntByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstIntByIntAggregator.java
@@ -12,8 +12,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
-import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -141,7 +139,7 @@ public class AllFirstIntByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntIntState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -175,127 +173,93 @@ public class AllFirstIntByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private IntArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<IntArray> values;
+        private ObjectArray<IntArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newIntArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, IntBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                IntArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newIntArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getInt(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, IntBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getInt(offset));
+                if (count > 1) {
+                    IntArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getInt(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -306,11 +270,11 @@ public class AllFirstIntByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -323,36 +287,75 @@ public class AllFirstIntByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private IntArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private IntArray getTailForWriting(int group, int count) {
+            IntArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                IntArray tail = bigArrays.newIntArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            IntArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            IntArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newIntBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendInt(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        IntArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendInt(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendInt(values.get(group).get(i));
+                            valuesBuilder.appendInt(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendInt(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstIntByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstIntByLongAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.IntArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -141,7 +139,7 @@ public class AllFirstIntByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongIntState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -175,127 +173,93 @@ public class AllFirstIntByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private IntArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<IntArray> values;
+        private ObjectArray<IntArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newIntArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, IntBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                IntArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newIntArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getInt(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, IntBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getInt(offset));
+                if (count > 1) {
+                    IntArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getInt(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -306,11 +270,11 @@ public class AllFirstIntByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -323,36 +287,75 @@ public class AllFirstIntByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private IntArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private IntArray getTailForWriting(int group, int count) {
+            IntArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                IntArray tail = bigArrays.newIntArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            IntArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            IntArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newIntBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendInt(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        IntArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendInt(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendInt(values.get(group).get(i));
+                            valuesBuilder.appendInt(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendInt(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstLongByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstLongByIntAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.LongArray;
-import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -141,7 +139,7 @@ public class AllFirstLongByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntLongState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -175,127 +173,93 @@ public class AllFirstLongByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private LongArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<LongArray> values;
+        private ObjectArray<LongArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newLongArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, LongBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                LongArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newLongArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getLong(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, LongBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getLong(offset));
+                if (count > 1) {
+                    LongArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getLong(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -306,11 +270,11 @@ public class AllFirstLongByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -323,36 +287,75 @@ public class AllFirstLongByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private LongArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private LongArray getTailForWriting(int group, int count) {
+            LongArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                LongArray tail = bigArrays.newLongArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            LongArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            LongArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newLongBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendLong(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        LongArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendLong(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendLong(values.get(group).get(i));
+                            valuesBuilder.appendLong(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendLong(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstLongByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstLongByLongAggregator.java
@@ -12,8 +12,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the First occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -141,7 +139,7 @@ public class AllFirstLongByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongLongState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -175,127 +173,93 @@ public class AllFirstLongByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private LongArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<LongArray> values;
+        private ObjectArray<LongArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newLongArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, LongBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp < timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp < key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                LongArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newLongArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getLong(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, LongBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getLong(offset));
+                if (count > 1) {
+                    LongArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getLong(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -306,11 +270,11 @@ public class AllFirstLongByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -323,36 +287,75 @@ public class AllFirstLongByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private LongArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private LongArray getTailForWriting(int group, int count) {
+            LongArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                LongArray tail = bigArrays.newLongArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            LongArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            LongArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newLongBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendLong(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        LongArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendLong(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendLong(values.get(group).get(i));
+                            valuesBuilder.appendLong(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendLong(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntBooleanState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntBooleanState.java
@@ -92,10 +92,10 @@ final class AllIntBooleanState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntBytesRefState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntBytesRefState.java
@@ -92,10 +92,10 @@ final class AllIntBytesRefState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntDoubleState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntDoubleState.java
@@ -92,10 +92,10 @@ final class AllIntDoubleState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntFloatState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntFloatState.java
@@ -92,10 +92,10 @@ final class AllIntFloatState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntIntState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntIntState.java
@@ -92,10 +92,10 @@ final class AllIntIntState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntLongState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllIntLongState.java
@@ -92,10 +92,10 @@ final class AllIntLongState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantIntBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBooleanByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBooleanByIntAggregator.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -31,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -146,7 +145,7 @@ public class AllLastBooleanByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntBooleanState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -180,127 +179,92 @@ public class AllLastBooleanByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
-
+        private ByteArray firstValues;
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<ByteArray> values;
+        private ObjectArray<ByteArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newByteArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, BooleanBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                ByteArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.getBoolean(i + offset) ? 1 : 0));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, BooleanBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, (byte) (valuesBlock.getBoolean(offset) ? 1 : 0));
+                if (count > 1) {
+                    ByteArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, (byte) (valuesBlock.getBoolean(offset + i) ? 1 : 0));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -311,11 +275,11 @@ public class AllLastBooleanByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -328,36 +292,75 @@ public class AllLastBooleanByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private ByteArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private ByteArray getTailForWriting(int group, int count) {
+            ByteArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                ByteArray tail = bigArrays.newByteArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            ByteArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            ByteArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newBooleanBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendBoolean(values.get(group).get(0) == 1);
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        ByteArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendBoolean(firstValues.get(group) == 1);
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendBoolean(values.get(group).get(i) == 1);
+                            valuesBuilder.appendBoolean(firstValues.get(group) == 1);
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendBoolean(tail.get(i) == 1);
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBooleanByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBooleanByLongAggregator.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -31,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -146,7 +145,7 @@ public class AllLastBooleanByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongBooleanState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -180,127 +179,92 @@ public class AllLastBooleanByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
-
+        private ByteArray firstValues;
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<ByteArray> values;
+        private ObjectArray<ByteArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newByteArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, BooleanBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                ByteArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.getBoolean(i + offset) ? 1 : 0));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, BooleanBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, (byte) (valuesBlock.getBoolean(offset) ? 1 : 0));
+                if (count > 1) {
+                    ByteArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, (byte) (valuesBlock.getBoolean(offset + i) ? 1 : 0));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -311,11 +275,11 @@ public class AllLastBooleanByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -328,36 +292,75 @@ public class AllLastBooleanByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private ByteArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private ByteArray getTailForWriting(int group, int count) {
+            ByteArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                ByteArray tail = bigArrays.newByteArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            ByteArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            ByteArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newBooleanBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendBoolean(values.get(group).get(0) == 1);
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        ByteArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendBoolean(firstValues.get(group) == 1);
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendBoolean(values.get(group).get(i) == 1);
+                            valuesBuilder.appendBoolean(firstValues.get(group) == 1);
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendBoolean(tail.get(i) == 1);
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntAggregator.java
@@ -12,9 +12,9 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.BytesRefArray;
-import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +32,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -149,11 +149,11 @@ public class AllLastBytesRefByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntBytesRefState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
-        return new GroupingState(driverContext.bigArrays());
+        return new GroupingState(driverContext.bigArrays(), driverContext.breaker());
     }
 
     public static void combine(GroupingState current, int group, @Position int position, BytesRefBlock values, IntBlock timestamps) {
@@ -183,128 +183,106 @@ public class AllLastBytesRefByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
-
+        private ObjectArray<BreakingBytesRefBuilder> firstValues;
+        private final CircuitBreaker breaker;
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<BytesRefArray> values;
+        private ObjectArray<BytesRefArray> tailValues;
 
         private int maxGroupId = -1;
 
-        GroupingState(BigArrays bigArrays) {
+        GroupingState(BigArrays bigArrays, CircuitBreaker breaker) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
+            this.breaker = breaker;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newObjectArray(1);
+                this.firstValues.set(0, null);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, BytesRefBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                BytesRefArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, BytesRefBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                BytesRef firstScratch = new BytesRef();
+                valuesBlock.getBytesRef(offset, firstScratch);
+                BreakingBytesRefBuilder firstBuilder = firstValues.get(group);
+                if (firstBuilder == null) {
+                    firstBuilder = new BreakingBytesRefBuilder(breaker, "Last", firstScratch.length);
+                    firstValues.set(group, firstBuilder);
+                }
+                firstBuilder.copyBytes(firstScratch);
+                if (count > 1) {
+                    BytesRefArray tail = getTailForWriting(group, count - 1);
+                    BytesRef scratch = new BytesRef();
+                    for (int i = 1; i < count; ++i) {
+                        tail.append(valuesBlock.getBytesRef(offset + i, scratch));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            for (long i = 0; i < firstValues.size(); i++) {
+                Releasables.close(firstValues.get(i));
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
+            }
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -315,11 +293,11 @@ public class AllLastBytesRefByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -332,42 +310,67 @@ public class AllLastBytesRefByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private BytesRefArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private BytesRefArray getTailForWriting(int group, int count) {
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+            } else {
+                Releasables.close(tailValues.get(group));
+            }
+            // BytesRefArray is append-only so we always need a fresh one; there is no way to clear and reuse it.
+            BytesRefArray tail = new BytesRefArray(count, bigArrays);
+            tailValues.set(group, tail);
+            return tail;
+        }
+
+        private void clearTailValues(int group) {
+            BytesRefArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newBytesRefBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        BytesRefArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendBytesRef(firstValues.get(group).bytesRefView());
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
+                            valuesBuilder.appendBytesRef(firstValues.get(group).bytesRefView());
+                            for (int i = 0; i < tailCount; ++i) {
                                 BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
+                                tail.get(i, bytesScratch);
                                 valuesBuilder.appendBytesRef(bytesScratch);
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBytesRefByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBytesRefByLongAggregator.java
@@ -12,9 +12,9 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.BytesRefArray;
-import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +32,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -149,11 +149,11 @@ public class AllLastBytesRefByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongBytesRefState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
-        return new GroupingState(driverContext.bigArrays());
+        return new GroupingState(driverContext.bigArrays(), driverContext.breaker());
     }
 
     public static void combine(GroupingState current, int group, @Position int position, BytesRefBlock values, LongBlock timestamps) {
@@ -183,128 +183,106 @@ public class AllLastBytesRefByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
-
+        private ObjectArray<BreakingBytesRefBuilder> firstValues;
+        private final CircuitBreaker breaker;
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<BytesRefArray> values;
+        private ObjectArray<BytesRefArray> tailValues;
 
         private int maxGroupId = -1;
 
-        GroupingState(BigArrays bigArrays) {
+        GroupingState(BigArrays bigArrays, CircuitBreaker breaker) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
+            this.breaker = breaker;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newObjectArray(1);
+                this.firstValues.set(0, null);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, BytesRefBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                BytesRefArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, BytesRefBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                BytesRef firstScratch = new BytesRef();
+                valuesBlock.getBytesRef(offset, firstScratch);
+                BreakingBytesRefBuilder firstBuilder = firstValues.get(group);
+                if (firstBuilder == null) {
+                    firstBuilder = new BreakingBytesRefBuilder(breaker, "Last", firstScratch.length);
+                    firstValues.set(group, firstBuilder);
+                }
+                firstBuilder.copyBytes(firstScratch);
+                if (count > 1) {
+                    BytesRefArray tail = getTailForWriting(group, count - 1);
+                    BytesRef scratch = new BytesRef();
+                    for (int i = 1; i < count; ++i) {
+                        tail.append(valuesBlock.getBytesRef(offset + i, scratch));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            for (long i = 0; i < firstValues.size(); i++) {
+                Releasables.close(firstValues.get(i));
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
+            }
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -315,11 +293,11 @@ public class AllLastBytesRefByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -332,42 +310,67 @@ public class AllLastBytesRefByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private BytesRefArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private BytesRefArray getTailForWriting(int group, int count) {
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+            } else {
+                Releasables.close(tailValues.get(group));
+            }
+            // BytesRefArray is append-only so we always need a fresh one; there is no way to clear and reuse it.
+            BytesRefArray tail = new BytesRefArray(count, bigArrays);
+            tailValues.set(group, tail);
+            return tail;
+        }
+
+        private void clearTailValues(int group) {
+            BytesRefArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newBytesRefBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        BytesRefArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendBytesRef(firstValues.get(group).bytesRefView());
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
+                            valuesBuilder.appendBytesRef(firstValues.get(group).bytesRefView());
+                            for (int i = 0; i < tailCount; ++i) {
                                 BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
+                                tail.get(i, bytesScratch);
                                 valuesBuilder.appendBytesRef(bytesScratch);
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastDoubleByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastDoubleByIntAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.DoubleArray;
-import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -147,7 +145,7 @@ public class AllLastDoubleByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntDoubleState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -181,127 +179,93 @@ public class AllLastDoubleByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private DoubleArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<DoubleArray> values;
+        private ObjectArray<DoubleArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newDoubleArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, DoubleBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                DoubleArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newDoubleArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getDouble(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, DoubleBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getDouble(offset));
+                if (count > 1) {
+                    DoubleArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getDouble(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -312,11 +276,11 @@ public class AllLastDoubleByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -329,36 +293,75 @@ public class AllLastDoubleByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private DoubleArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private DoubleArray getTailForWriting(int group, int count) {
+            DoubleArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                DoubleArray tail = bigArrays.newDoubleArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            DoubleArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            DoubleArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newDoubleBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendDouble(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        DoubleArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendDouble(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendDouble(values.get(group).get(i));
+                            valuesBuilder.appendDouble(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendDouble(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastDoubleByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastDoubleByLongAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.DoubleArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -147,7 +145,7 @@ public class AllLastDoubleByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongDoubleState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -181,127 +179,93 @@ public class AllLastDoubleByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private DoubleArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<DoubleArray> values;
+        private ObjectArray<DoubleArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newDoubleArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, DoubleBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                DoubleArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newDoubleArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getDouble(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, DoubleBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getDouble(offset));
+                if (count > 1) {
+                    DoubleArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getDouble(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -312,11 +276,11 @@ public class AllLastDoubleByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -329,36 +293,75 @@ public class AllLastDoubleByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private DoubleArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private DoubleArray getTailForWriting(int group, int count) {
+            DoubleArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                DoubleArray tail = bigArrays.newDoubleArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            DoubleArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            DoubleArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newDoubleBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendDouble(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        DoubleArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendDouble(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendDouble(values.get(group).get(i));
+                            valuesBuilder.appendDouble(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendDouble(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastFloatByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastFloatByIntAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.FloatArray;
-import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -141,7 +139,7 @@ public class AllLastFloatByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntFloatState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -175,127 +173,93 @@ public class AllLastFloatByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private FloatArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<FloatArray> values;
+        private ObjectArray<FloatArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newFloatArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, FloatBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                FloatArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newFloatArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getFloat(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, FloatBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getFloat(offset));
+                if (count > 1) {
+                    FloatArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getFloat(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -306,11 +270,11 @@ public class AllLastFloatByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -323,36 +287,75 @@ public class AllLastFloatByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private FloatArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private FloatArray getTailForWriting(int group, int count) {
+            FloatArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                FloatArray tail = bigArrays.newFloatArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            FloatArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            FloatArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newFloatBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendFloat(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        FloatArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendFloat(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendFloat(values.get(group).get(i));
+                            valuesBuilder.appendFloat(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendFloat(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastFloatByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastFloatByLongAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.FloatArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -147,7 +145,7 @@ public class AllLastFloatByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongFloatState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -181,127 +179,93 @@ public class AllLastFloatByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private FloatArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<FloatArray> values;
+        private ObjectArray<FloatArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newFloatArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, FloatBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                FloatArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newFloatArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getFloat(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, FloatBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getFloat(offset));
+                if (count > 1) {
+                    FloatArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getFloat(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -312,11 +276,11 @@ public class AllLastFloatByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -329,36 +293,75 @@ public class AllLastFloatByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private FloatArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private FloatArray getTailForWriting(int group, int count) {
+            FloatArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                FloatArray tail = bigArrays.newFloatArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            FloatArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            FloatArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newFloatBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendFloat(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        FloatArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendFloat(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendFloat(values.get(group).get(i));
+                            valuesBuilder.appendFloat(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendFloat(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastIntByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastIntByIntAggregator.java
@@ -12,8 +12,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
-import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -141,7 +139,7 @@ public class AllLastIntByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntIntState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -175,127 +173,93 @@ public class AllLastIntByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private IntArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<IntArray> values;
+        private ObjectArray<IntArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newIntArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, IntBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                IntArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newIntArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getInt(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, IntBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getInt(offset));
+                if (count > 1) {
+                    IntArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getInt(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -306,11 +270,11 @@ public class AllLastIntByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -323,36 +287,75 @@ public class AllLastIntByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private IntArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private IntArray getTailForWriting(int group, int count) {
+            IntArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                IntArray tail = bigArrays.newIntArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            IntArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            IntArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newIntBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendInt(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        IntArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendInt(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendInt(values.get(group).get(i));
+                            valuesBuilder.appendInt(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendInt(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastIntByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastIntByLongAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.IntArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -141,7 +139,7 @@ public class AllLastIntByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongIntState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -175,127 +173,93 @@ public class AllLastIntByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private IntArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<IntArray> values;
+        private ObjectArray<IntArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newIntArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, IntBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                IntArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newIntArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getInt(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, IntBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getInt(offset));
+                if (count > 1) {
+                    IntArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getInt(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -306,11 +270,11 @@ public class AllLastIntByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -323,36 +287,75 @@ public class AllLastIntByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private IntArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private IntArray getTailForWriting(int group, int count) {
+            IntArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                IntArray tail = bigArrays.newIntArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            IntArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            IntArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newIntBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendInt(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        IntArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendInt(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendInt(values.get(group).get(i));
+                            valuesBuilder.appendInt(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendInt(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastLongByIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastLongByIntAggregator.java
@@ -12,9 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.LongArray;
-import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -141,7 +139,7 @@ public class AllLastLongByIntAggregator {
     }
 
     public static Block evaluateFinal(AllIntLongState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -175,127 +173,93 @@ public class AllLastLongByIntAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByIntGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private LongArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private IntArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<LongArray> values;
+        private ObjectArray<LongArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            IntArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newIntArray(1, false);
-                timestamps.set(0, -1);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newLongArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, int timestamp, int position, LongBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                LongArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newLongArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getLong(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, int timestamp, LongBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getLong(offset));
+                if (count > 1) {
+                    LongArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getLong(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -306,11 +270,11 @@ public class AllLastLongByIntAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendInt(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendInt(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -323,36 +287,75 @@ public class AllLastLongByIntAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private LongArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private LongArray getTailForWriting(int group, int count) {
+            LongArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                LongArray tail = bigArrays.newLongArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            LongArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            LongArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newLongBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendLong(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        LongArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendLong(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendLong(values.get(group).get(i));
+                            valuesBuilder.appendLong(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendLong(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastLongByLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastLongByLongAggregator.java
@@ -12,8 +12,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.ByteArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
@@ -32,7 +30,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the Last occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -141,7 +139,7 @@ public class AllLastLongByLongAggregator {
     }
 
     public static Block evaluateFinal(AllLongLongState current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
@@ -175,127 +173,93 @@ public class AllLastLongByLongAggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllByLongGroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        private LongArray firstValues;
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private LongArray timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<LongArray> values;
+        private ObjectArray<LongArray> tailValues;
 
         private int maxGroupId = -1;
 
         GroupingState(BigArrays bigArrays) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            LongArray timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.newLongArray(1, false);
-                timestamps.set(0, -1L);
-                this.timestamps = timestamps;
-
-                // Initialize values
-                this.values = bigArrays.newObjectArray(1);
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
+                this.firstValues = bigArrays.newLongArray(1, false);
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, long timestamp, int position, LongBlock valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp > timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp > key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                LongArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = bigArrays.newLongArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.getLong(i + offset));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, long timestamp, LongBlock valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                firstValues.set(group, valuesBlock.getLong(offset));
+                if (count > 1) {
+                    LongArray tail = getTailForWriting(group, count - 1);
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.getLong(offset + i));
+                    }
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -306,11 +270,11 @@ public class AllLastLongByLongAggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.appendLong(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.appendLong(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -323,36 +287,75 @@ public class AllLastLongByLongAggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private LongArray getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+        private LongArray getTailForWriting(int group, int count) {
+            LongArray existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                LongArray tail = bigArrays.newLongArray(count);
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            LongArray resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+
+        private void clearTailValues(int group) {
+            LongArray tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.newLongBlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        case 1 -> valuesBuilder.appendLong(values.get(group).get(0));
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        LongArray tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            valuesBuilder.appendLong(firstValues.get(group));
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
-                                valuesBuilder.appendLong(values.get(group).get(i));
+                            valuesBuilder.appendLong(firstValues.get(group));
+                            for (int i = 0; i < tailCount; ++i) {
+                                valuesBuilder.appendLong(tail.get(i));
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongBooleanState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongBooleanState.java
@@ -92,10 +92,10 @@ final class AllLongBooleanState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantLongBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongBytesRefState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongBytesRefState.java
@@ -92,10 +92,10 @@ final class AllLongBytesRefState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantLongBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongDoubleState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongDoubleState.java
@@ -92,10 +92,10 @@ final class AllLongDoubleState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantLongBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongFloatState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongFloatState.java
@@ -92,10 +92,10 @@ final class AllLongFloatState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantLongBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongIntState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongIntState.java
@@ -92,10 +92,10 @@ final class AllLongIntState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantLongBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongLongState.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLongLongState.java
@@ -92,10 +92,10 @@ final class AllLongLongState implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstantLongBlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyBooleanAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyBooleanAggregator.java
@@ -150,6 +150,8 @@ public class AnyBooleanAggregator {
 
         /**
          * The group-indexed values
+         * TODO: apply the firstValue/tailValues optimization from X-AllValueByTimestampAggregator.java.st
+         * to inline single-element groups and avoid the ~64 byte ObjectArray wrapper overhead.
          */
         private ObjectArray<ByteArray> values;
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyBytesRefAggregator.java
@@ -153,6 +153,8 @@ public class AnyBytesRefAggregator {
 
         /**
          * The group-indexed values
+         * TODO: apply the firstValue/tailValues optimization from X-AllValueByTimestampAggregator.java.st
+         * to inline single-element groups and avoid the ~64 byte ObjectArray wrapper overhead.
          */
         private ObjectArray<BytesRefArray> values;
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyDoubleAggregator.java
@@ -149,6 +149,8 @@ public class AnyDoubleAggregator {
 
         /**
          * The group-indexed values
+         * TODO: apply the firstValue/tailValues optimization from X-AllValueByTimestampAggregator.java.st
+         * to inline single-element groups and avoid the ~64 byte ObjectArray wrapper overhead.
          */
         private ObjectArray<DoubleArray> values;
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyFloatAggregator.java
@@ -149,6 +149,8 @@ public class AnyFloatAggregator {
 
         /**
          * The group-indexed values
+         * TODO: apply the firstValue/tailValues optimization from X-AllValueByTimestampAggregator.java.st
+         * to inline single-element groups and avoid the ~64 byte ObjectArray wrapper overhead.
          */
         private ObjectArray<FloatArray> values;
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyIntAggregator.java
@@ -149,6 +149,8 @@ public class AnyIntAggregator {
 
         /**
          * The group-indexed values
+         * TODO: apply the firstValue/tailValues optimization from X-AllValueByTimestampAggregator.java.st
+         * to inline single-element groups and avoid the ~64 byte ObjectArray wrapper overhead.
          */
         private ObjectArray<IntArray> values;
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AnyLongAggregator.java
@@ -149,6 +149,8 @@ public class AnyLongAggregator {
 
         /**
          * The group-indexed values
+         * TODO: apply the firstValue/tailValues optimization from X-AllValueByTimestampAggregator.java.st
+         * to inline single-element groups and avoid the ~64 byte ObjectArray wrapper overhead.
          */
         private ObjectArray<LongArray> values;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractAllByIntGroupingState.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractAllByIntGroupingState.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Grouping state base class for "all first/last by int key" aggregators.
+ * Extends {@link AbstractAllByKeyGroupingState} with an {@code int}-typed key array.
+ */
+public abstract class AbstractAllByIntGroupingState extends AbstractAllByKeyGroupingState {
+
+    /**
+     * The group-indexed keys
+     */
+    private IntArray keys;
+
+    protected AbstractAllByIntGroupingState(BigArrays bigArrays) {
+        super(bigArrays);
+        boolean success = false;
+        try {
+            keys = bigArrays.newIntArray(1, false);
+            keys.set(0, -1);
+            success = true;
+        } finally {
+            if (success == false) {
+                Releasables.close(keys, super::close);
+            }
+        }
+    }
+
+    protected int key(int group) {
+        return keys.get(group);
+    }
+
+    protected void key(int group, int value) {
+        keys.set(group, value);
+    }
+
+    @Override
+    protected void grow(int group) {
+        keys = bigArrays.grow(keys, group + 1);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(keys, super::close);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractAllByKeyGroupingState.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractAllByKeyGroupingState.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Base class for the grouping state of all "all first/last by key" aggregators.
+ * Tracks the null-value and null-key flags per group.
+ * Subclasses add the key array itself, typed to the key element type.
+ * <p>
+ * Whether a group has ever been collected is tracked via {@link #hasValue(int)} from
+ * {@link AbstractArrayState}, driven by {@link #trackGroupId(int)} calls in
+ * {@code collectValue}. The {@code nullValue} bit only distinguishes null values
+ * from non-null values; it does not encode "never seen".
+ * </p>
+ */
+public abstract class AbstractAllByKeyGroupingState extends AbstractArrayState {
+
+    /**
+     * Markers for groups whose value is {@code null}. A set bit means the value is null.
+     * Lazily initialized on the first call to {@link #markNullValue(int)};
+     * {@code null} means no group has ever had a null value.
+     */
+    private BitArray nullValue;
+
+    /**
+     * Markers for groups whose key is {@code null}. A set bit means the key is null.
+     * Lazily initialized on the first call to {@link #markNullKey(int)};
+     * {@code null} means no group has ever had a null key.
+     */
+    private BitArray nullKey;
+
+    protected AbstractAllByKeyGroupingState(BigArrays bigArrays) {
+        super(bigArrays);
+        enableGroupIdTracking(new SeenGroupIds.Empty());
+    }
+
+    protected final boolean nullValue(int group) {
+        return nullValue != null && nullValue.get(group);
+    }
+
+    protected final void markNullValue(int group) {
+        if (nullValue == null) {
+            nullValue = new BitArray(group + 1, bigArrays);
+        }
+        nullValue.set(group);
+    }
+
+    protected final void clearNullValue(int group) {
+        if (nullValue != null) {
+            nullValue.clear(group);
+        }
+    }
+
+    protected final boolean nullKey(int group) {
+        return nullKey != null && nullKey.get(group);
+    }
+
+    protected final void markNullKey(int group) {
+        if (nullKey == null) {
+            nullKey = new BitArray(group + 1, bigArrays);
+        }
+        nullKey.set(group);
+    }
+
+    protected final void clearNullKey(int group) {
+        if (nullKey != null) {
+            nullKey.clear(group);
+        }
+    }
+
+    /**
+     * Called when a new group id is seen to grow subclass arrays to accommodate {@code group}.
+     * Both {@link #nullValue} and {@link #nullKey} are lazy {@link BitArray}s that handle
+     * out-of-range indices safely, so no grow is needed in this base class.
+     */
+    protected abstract void grow(int group);
+
+    @Override
+    public void close() {
+        Releasables.close(nullValue, nullKey, super::close);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractAllByLongGroupingState.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractAllByLongGroupingState.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Grouping state base class for "all first/last by long key" aggregators.
+ * Extends {@link AbstractAllByKeyGroupingState} with a {@code long}-typed key array.
+ */
+public abstract class AbstractAllByLongGroupingState extends AbstractAllByKeyGroupingState {
+
+    /**
+     * The group-indexed keys
+     */
+    private LongArray keys;
+
+    protected AbstractAllByLongGroupingState(BigArrays bigArrays) {
+        super(bigArrays);
+        boolean success = false;
+        try {
+            keys = bigArrays.newLongArray(1, false);
+            keys.set(0, -1L);
+            success = true;
+        } finally {
+            if (success == false) {
+                Releasables.close(keys, super::close);
+            }
+        }
+    }
+
+    protected long key(int group) {
+        return keys.get(group);
+    }
+
+    protected void key(int group, long value) {
+        keys.set(group, value);
+    }
+
+    @Override
+    protected void grow(int group) {
+        keys = bigArrays.grow(keys, group + 1);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(keys, super::close);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-All2State.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-All2State.java.st
@@ -100,10 +100,10 @@ final class All$v1_Type$$v2_Type$State implements AggregatorState {
         blocks[offset + 0] = driverContext.blockFactory().newConstantBooleanBlockWith(observed, 1);
         blocks[offset + 1] = driverContext.blockFactory().newConstantBooleanBlockWith(v1Seen, 1);
         blocks[offset + 2] = driverContext.blockFactory().newConstant$v1_Type$BlockWith(v1, 1);
-        blocks[offset + 3] = intermediateValuesBlockBuilder(driverContext);
+        blocks[offset + 3] = valuesBlock(driverContext);
     }
 
-    public Block intermediateValuesBlockBuilder(DriverContext driverContext) {
+    public Block valuesBlock(DriverContext driverContext) {
         if (v2 == null) {
             return driverContext.blockFactory().newConstantNullBlock(1);
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-AllValueByTimestampAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-AllValueByTimestampAggregator.java.st
@@ -12,11 +12,15 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.common.util.BigArrays;
+$if(v1_boolean)$
 import org.elasticsearch.common.util.ByteArray;
-$if(!v1_boolean)$
+$elseif(v1_BytesRef)$
+import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+$else$
 import org.elasticsearch.common.util.$v1_Type$Array;
 $endif$
-import org.elasticsearch.common.util.$v2_Type$Array;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.GroupingAggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
@@ -34,7 +38,7 @@ import java.util.BitSet;
 
 /**
  * A time-series aggregation function that collects the $Occurrence$ occurrence value of a time series in a specified interval.
- * This class is generated. Edit `X-AllValueByTimestafmpAggregator.java.st` instead.
+ * This class is generated. Edit `X-AllValueByTimestampAggregator.java.st` instead.
  */
 @Aggregator(
     processNulls = true,
@@ -185,11 +189,15 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
     }
 
     public static Block evaluateFinal($Prefix$$v2_Type$$v1_Type$State current, DriverContext ctx) {
-        return current.intermediateValuesBlockBuilder(ctx);
+        return current.valuesBlock(ctx);
     }
 
     public static GroupingState initGrouping(DriverContext driverContext) {
+        $if(v1_BytesRef)$
+        return new GroupingState(driverContext.bigArrays(), driverContext.breaker());
+        $else$
         return new GroupingState(driverContext.bigArrays());
+        $endif$
     }
 
     public static void combine(GroupingState current, int group, @Position int position, $v1_Type$Block values, $v2_Type$Block timestamps) {
@@ -223,164 +231,139 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
         return state.evaluateFinal(selected, ctx);
     }
 
-    public static final class GroupingState extends AbstractArrayState {
-        private final BigArrays bigArrays;
+    public static final class GroupingState extends AbstractAllBy$v2_Type$GroupingState {
 
         /**
-         * The group-indexed observed flags
+         * First values, stored in a dense array to minimize per-group overhead.
          */
-        private ByteArray observed;
+        $if(v1_BytesRef)$
+        private ObjectArray<BreakingBytesRefBuilder> firstValues;
+        private final CircuitBreaker breaker;
+        $elseif(v1_boolean)$
+        private ByteArray firstValues;
+        $else$
+        private $v1_Type$Array firstValues;
+        $endif$
 
         /**
-         * The group-indexed timestamps seen flags
+         * The second-and-beyond values. Null for groups with zero or one value.
          */
-        private ByteArray hasTimestamp;
-
-        /**
-         * The group-indexed timestamps
-         */
-        private $v2_Type$Array timestamps;
-
-        /**
-         * The group-indexed values
-         */
-        private ObjectArray<$if(v1_BytesRef)$BytesRefArray$elseif(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$> values;
+        private ObjectArray<$v1_TailArray$> tailValues;
 
         private int maxGroupId = -1;
 
-        GroupingState(BigArrays bigArrays) {
+        GroupingState(BigArrays bigArrays$if(v1_BytesRef)$, CircuitBreaker breaker$endif$) {
             super(bigArrays);
-            this.bigArrays = bigArrays;
+            $if(v1_BytesRef)$
+            this.breaker = breaker;
+            $endif$
             boolean success = false;
-            ByteArray observed = null;
-            ByteArray hasTimestamp = null;
-            $v2_Type$Array timestamps = null;
             try {
-                // Initialize observed
-                observed = bigArrays.newByteArray(1, false);
-                observed.set(0, (byte) -1);
-                this.observed = observed;
-
-                // Initialize hasTimestamp
-                hasTimestamp = bigArrays.newByteArray(1, false);
-                hasTimestamp.set(0, (byte) -1);
-                this.hasTimestamp = hasTimestamp;
-
-                // Initialize timestamps
-                timestamps = bigArrays.new$v2_Type$Array(1, false);
-                $if(v2_long)$
-                timestamps.set(0, -1L);
-                $else$
-                timestamps.set(0, -1);
-                $endif$
-                this.timestamps = timestamps;
-
-                // Initialize values
                 $if(v1_BytesRef)$
-                this.values = bigArrays.newObjectArray(1);
+                this.firstValues = bigArrays.newObjectArray(1);
+                this.firstValues.set(0, null);
+                $elseif(v1_boolean)$
+                this.firstValues = bigArrays.newByteArray(1, false);
                 $else$
-                this.values = bigArrays.newObjectArray(1);
+                this.firstValues = bigArrays.new$v1_Type$Array(1, false);
                 $endif$
-                this.values.set(0, null);
-
-                // Enable group id tracking because we use has hasValue in the
-                // collection itself to detect when a value first arrives.
-                enableGroupIdTracking(new SeenGroupIds.Empty());
                 success = true;
             } finally {
                 if (success == false) {
-                    if (values != null) {
-                        for (long i = 0; i < values.size(); i++) {
-                            Releasables.close(values.get(i));
-                        }
-                    }
-                    Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+                    Releasables.close(firstValues, super::close);
                 }
             }
         }
 
         void collectValue(int group, boolean timestampPresent, $v2_type$ timestamp, int position, $v1_Type$Block valuesBlock) {
-            boolean updated = false;
-            if (withinBounds(group)) {
-                if (hasValue(group) == false
-                    || (hasTimestamp.get(group) == 0 && timestampPresent)
-                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ timestamps.get(group))) {
-                    // We never saw this group before, even if it's within bounds.
-                    // Or, the incoming non-null timestamp wins against the null one in the state.
-                    // Or, we found a better timestamp for this group.
-                    updated = true;
+            if (group <= maxGroupId) {
+                if (hasValue(group) == false // We never saw this group before, even if it's within bounds.
+                    || (nullKey(group) && timestampPresent) // Or, the incoming non-null timestamp wins against the null one in the state.
+                    || (timestampPresent && timestamp $if(First)$<$else$>$endif$ key(group)) // Or, we found a better timestamp for this group.
+                ) {
+                    updateValue(group, timestampPresent, timestamp, valuesBlock, position);
                 }
             } else {
                 // We must grow all arrays to accommodate this group id
-                observed = bigArrays.grow(observed, group + 1);
-                hasTimestamp = bigArrays.grow(hasTimestamp, group + 1);
-                timestamps = bigArrays.grow(timestamps, group + 1);
-                values = bigArrays.grow(values, group + 1);
-                updated = true;
+                grow(group);
+                maxGroupId = group;
+                updateValue(group, timestampPresent, timestamp, valuesBlock, position);
             }
-            if (updated) {
-                observed.set(group, (byte) 1);
-                hasTimestamp.set(group, (byte) (timestampPresent ? 1 : 0));
-                timestamps.set(group, timestamp);
-                boolean success = false;
-                $if(v1_BytesRef)$
-                BytesRefArray groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        groupValues = new BytesRefArray(count, bigArrays);
-                        BytesRef scratch = new BytesRef();
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.append(valuesBlock.getBytesRef(i + offset, scratch));
-                        }
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $else$
-                $if(v1_boolean)$ByteArray$else$$v1_Type$Array$endif$ groupValues = null;
-                try {
-                    if (valuesBlock.isNull(position) == false) {
-                        int count = valuesBlock.getValueCount(position);
-                        int offset = valuesBlock.getFirstValueIndex(position);
-                        $if(v1_boolean)$
-                        groupValues = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, (byte) (valuesBlock.get$v1_Type$(i + offset) ? 1 : 0));
-                        }
-                        $else$
-                        groupValues = bigArrays.new$v1_Type$Array(count);
-                        for (int i = 0; i < count; ++i) {
-                            groupValues.set(i, valuesBlock.get$v1_Type$(i + offset));
-                        }
-                        $endif$
-                    }
-                    success = true;
-                    Releasables.close(values.get(group));
-                    values.set(group, groupValues);
-                } finally {
-                    if (success == false) {
-                        Releasables.close(groupValues);
-                    }
-                }
-                $endif$
-            }
-            maxGroupId = Math.max(maxGroupId, group);
             trackGroupId(group);
+        }
+
+        private void updateValue(int group, boolean timestampPresent, $v2_type$ timestamp, $v1_Type$Block valuesBlock, int position) {
+            if (valuesBlock.isNull(position)) {
+                markNullValue(group);
+            } else {
+                clearNullValue(group);
+            }
+            if (timestampPresent == false) {
+                markNullKey(group);
+            } else {
+                clearNullKey(group);
+            }
+            key(group, timestamp);
+            if (valuesBlock.isNull(position) == false) {
+                int count = valuesBlock.getValueCount(position);
+                int offset = valuesBlock.getFirstValueIndex(position);
+                $if(v1_BytesRef)$
+                BytesRef firstScratch = new BytesRef();
+                valuesBlock.getBytesRef(offset, firstScratch);
+                BreakingBytesRefBuilder firstBuilder = firstValues.get(group);
+                if (firstBuilder == null) {
+                    firstBuilder = new BreakingBytesRefBuilder(breaker, "$Occurrence$", firstScratch.length);
+                    firstValues.set(group, firstBuilder);
+                }
+                firstBuilder.copyBytes(firstScratch);
+                $elseif(v1_boolean)$
+                firstValues.set(group, (byte) (valuesBlock.getBoolean(offset) ? 1 : 0));
+                $else$
+                firstValues.set(group, valuesBlock.get$v1_Type$(offset));
+                $endif$
+                if (count > 1) {
+                    $v1_TailArray$ tail = getTailForWriting(group, count - 1);
+                    $if(v1_BytesRef)$
+                    BytesRef scratch = new BytesRef();
+                    for (int i = 1; i < count; ++i) {
+                        tail.append(valuesBlock.getBytesRef(offset + i, scratch));
+                    }
+                    $elseif(v1_boolean)$
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, (byte) (valuesBlock.getBoolean(offset + i) ? 1 : 0));
+                    }
+                    $else$
+                    for (int i = 1; i < count; ++i) {
+                        tail.set(i - 1, valuesBlock.get$v1_Type$(offset + i));
+                    }
+                    $endif$
+                } else {
+                    clearTailValues(group);
+                }
+            } else {
+                clearTailValues(group);
+            }
+        }
+
+        @Override
+        protected void grow(int group) {
+            super.grow(group);
+            firstValues = bigArrays.grow(firstValues, group + 1);
         }
 
         @Override
         public void close() {
-            for (long i = 0; i < values.size(); i++) {
-                Releasables.close(values.get(i));
+            $if(v1_BytesRef)$
+            for (long i = 0; i < firstValues.size(); i++) {
+                Releasables.close(firstValues.get(i));
             }
-            Releasables.close(observed, hasTimestamp, timestamps, values, super::close);
+            $endif$
+            if (tailValues != null) {
+                for (long i = 0; i < tailValues.size(); i++) {
+                    Releasables.close(tailValues.get(i));
+                }
+            }
+            Releasables.close(firstValues, tailValues, super::close);
         }
 
         public void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
@@ -391,11 +374,11 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
             ) {
                 for (int p = 0; p < selected.getPositionCount(); p++) {
                     int group = selected.getInt(p);
-                    if (withinBounds(group)) {
+                    if (group <= maxGroupId) {
                         // We must have seen this group before and saved its state
-                        observedBlockBuilder.appendBoolean(observed.get(group) == 1);
-                        hasTimestampBuilder.appendBoolean(hasTimestamp.get(group) == 1);
-                        timestampsBuilder.append$v2_Type$(timestamps.get(group));
+                        observedBlockBuilder.appendBoolean(hasValue(group));
+                        hasTimestampBuilder.appendBoolean(nullKey(group) == false);
+                        timestampsBuilder.append$v2_Type$(key(group));
                     } else {
                         // Unknown group so we append nulls everywhere
                         observedBlockBuilder.appendBoolean(false);
@@ -408,58 +391,112 @@ public class $Prefix$$Occurrence$$v1_Type$By$v2_Type$Aggregator {
                 blocks[offset + 0] = observedBlockBuilder.build();
                 blocks[offset + 1] = hasTimestampBuilder.build();
                 blocks[offset + 2] = timestampsBuilder.build();
-                blocks[offset + 3] = intermediateValuesBlockBuilder(selected, driverContext.blockFactory());
+                blocks[offset + 3] = valuesBlock(selected, driverContext.blockFactory());
             }
         }
 
         Block evaluateFinal(IntVector groups, GroupingAggregatorEvaluationContext evalContext) {
-            return intermediateValuesBlockBuilder(groups, evalContext.blockFactory());
+            return valuesBlock(groups, evalContext.blockFactory());
         }
 
-        private boolean withinBounds(int group) {
-            return group < Math.min(Math.min(timestamps.size(), values.size()), Math.min(observed.size(), hasTimestamp.size()));
+        private $v1_TailArray$ getTail(int group) {
+            if (tailValues == null) {
+                return null;
+            }
+            if (group >= tailValues.size()) {
+                return null;
+            }
+            return tailValues.get(group);
         }
 
-        private Block intermediateValuesBlockBuilder(IntVector groups, BlockFactory blockFactory) {
+$if(v1_BytesRef)$
+        private BytesRefArray getTailForWriting(int group, int count) {
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+            } else {
+                Releasables.close(tailValues.get(group));
+            }
+            // BytesRefArray is append-only so we always need a fresh one; there is no way to clear and reuse it.
+            BytesRefArray tail = new BytesRefArray(count, bigArrays);
+            tailValues.set(group, tail);
+            return tail;
+        }
+
+$else$
+        private $v1_TailArray$ getTailForWriting(int group, int count) {
+            $v1_TailArray$ existing;
+            if (tailValues == null) {
+                tailValues = bigArrays.newObjectArray(group + 1);
+                existing = null;
+            } else if (group >= tailValues.size()) {
+                tailValues = bigArrays.grow(tailValues, group + 1);
+                existing = null;
+            } else {
+                existing = tailValues.get(group);
+            }
+            if (existing == null) {
+                $v1_TailArray$ tail = $if(v1_boolean)$bigArrays.newByteArray(count)$else$bigArrays.new$v1_Type$Array(count)$endif$;
+                tailValues.set(group, tail);
+                return tail;
+            }
+            if (existing.size() == count) {
+                return existing;
+            }
+            $v1_TailArray$ resized = bigArrays.resize(existing, count);
+            tailValues.set(group, resized);
+            return resized;
+        }
+$endif$
+
+        private void clearTailValues(int group) {
+            $v1_TailArray$ tail = getTail(group);
+            if (tail != null) {
+                Releasables.close(tail);
+                tailValues.set(group, null);
+            }
+        }
+
+        private Block valuesBlock(IntVector groups, BlockFactory blockFactory) {
             try (var valuesBuilder = blockFactory.new$v1_Type$BlockBuilder(groups.getPositionCount())) {
                 for (int p = 0; p < groups.getPositionCount(); p++) {
                     int group = groups.getInt(p);
-                    int count = 0;
-                    if (withinBounds(group) && observed.get(group) == 1 && values.get(group) != null) {
-                        count = (int) values.get(group).size();
-                    }
-                    switch (count) {
-                        case 0 -> valuesBuilder.appendNull();
-                        $if(v1_BytesRef)$
-                        case 1 -> {
-                            BytesRef bytesScratch = new BytesRef();
-                            values.get(group).get(0, bytesScratch);
-                            valuesBuilder.appendBytesRef(bytesScratch);
-                        }
-                        $else$
-                        $if(v1_boolean)$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0) == 1);
-                        $else$
-                        case 1 -> valuesBuilder.append$v1_Type$(values.get(group).get(0));
-                        $endif$
-                        $endif$
-                        default -> {
+                    if (group <= maxGroupId && hasValue(group) && nullValue(group) == false) {
+                        $v1_TailArray$ tail = getTail(group);
+                        int tailCount = tail == null ? 0 : (int) tail.size();
+                        if (tailCount == 0) {
+                            $if(v1_BytesRef)$
+                            valuesBuilder.appendBytesRef(firstValues.get(group).bytesRefView());
+                            $elseif(v1_boolean)$
+                            valuesBuilder.appendBoolean(firstValues.get(group) == 1);
+                            $else$
+                            valuesBuilder.append$v1_Type$(firstValues.get(group));
+                            $endif$
+                        } else {
                             valuesBuilder.beginPositionEntry();
-                            for (int i = 0; i < count; ++i) {
+                            $if(v1_BytesRef)$
+                            valuesBuilder.appendBytesRef(firstValues.get(group).bytesRefView());
+                            $elseif(v1_boolean)$
+                            valuesBuilder.appendBoolean(firstValues.get(group) == 1);
+                            $else$
+                            valuesBuilder.append$v1_Type$(firstValues.get(group));
+                            $endif$
+                            for (int i = 0; i < tailCount; ++i) {
                                 $if(v1_BytesRef)$
                                 BytesRef bytesScratch = new BytesRef();
-                                values.get(group).get(i, bytesScratch);
+                                tail.get(i, bytesScratch);
                                 valuesBuilder.appendBytesRef(bytesScratch);
+                                $elseif(v1_boolean)$
+                                valuesBuilder.appendBoolean(tail.get(i) == 1);
                                 $else$
-                                $if(v1_boolean)$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i) == 1);
-                                $else$
-                                valuesBuilder.append$v1_Type$(values.get(group).get(i));
-                                $endif$
+                                valuesBuilder.append$v1_Type$(tail.get(i));
                                 $endif$
                             }
                             valuesBuilder.endPositionEntry();
                         }
+                    } else {
+                        valuesBuilder.appendNull();
                     }
                 }
                 return valuesBuilder.build();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-AnyValueAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-AnyValueAggregator.java.st
@@ -192,6 +192,8 @@ public class Any$v_Type$Aggregator {
 
         /**
          * The group-indexed values
+         * TODO: apply the firstValue/tailValues optimization from X-AllValueByTimestampAggregator.java.st
+         * to inline single-element groups and avoid the ~64 byte ObjectArray wrapper overhead.
          */
         private ObjectArray<$if(v_BytesRef)$BytesRefArray$elseif(v_boolean)$ByteArray$else$$v_Type$Array$endif$> values;
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBooleanByIntGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -51,5 +52,23 @@ public class AllFirstBooleanByIntGroupingAggregatorFunctionTests extends Groupin
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBooleanByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBooleanByLongGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -54,5 +55,23 @@ public class AllFirstBooleanByLongGroupingAggregatorFunctionTests extends Groupi
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBytesRefByIntGroupingAggregatorFunctionTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.aggregation;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.GroundTruthFirstLastAggregator;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -14,6 +15,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -53,5 +55,23 @@ public class AllFirstBytesRefByIntGroupingAggregatorFunctionTests extends Groupi
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantBytesRefBlockWith(new BytesRef(randomAlphaOfLength(5)), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantBytesRefBlockWith(new BytesRef(randomAlphaOfLength(5)), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBytesRefByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstBytesRefByLongGroupingAggregatorFunctionTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.aggregation;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.GroundTruthFirstLastAggregator;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -14,6 +15,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -56,5 +58,23 @@ public class AllFirstBytesRefByLongGroupingAggregatorFunctionTests extends Group
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantBytesRefBlockWith(new BytesRef(randomAlphaOfLength(5)), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantBytesRefBlockWith(new BytesRef(randomAlphaOfLength(5)), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstDoubleByIntGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -51,5 +52,23 @@ public class AllFirstDoubleByIntGroupingAggregatorFunctionTests extends Grouping
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantDoubleBlockWith(randomDouble(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantDoubleBlockWith(randomDouble(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstDoubleByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstDoubleByLongGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -54,5 +55,23 @@ public class AllFirstDoubleByLongGroupingAggregatorFunctionTests extends Groupin
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantDoubleBlockWith(randomDouble(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantDoubleBlockWith(randomDouble(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstFloatByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstFloatByIntGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -51,5 +52,23 @@ public class AllFirstFloatByIntGroupingAggregatorFunctionTests extends GroupingA
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantFloatBlockWith(randomFloat(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantFloatBlockWith(randomFloat(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstFloatByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstFloatByLongGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -54,5 +55,23 @@ public class AllFirstFloatByLongGroupingAggregatorFunctionTests extends Grouping
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantFloatBlockWith(randomFloat(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantFloatBlockWith(randomFloat(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstIntByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstIntByIntGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -51,5 +52,23 @@ public class AllFirstIntByIntGroupingAggregatorFunctionTests extends GroupingAgg
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstIntByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstIntByLongGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -54,5 +55,23 @@ public class AllFirstIntByLongGroupingAggregatorFunctionTests extends GroupingAg
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstLongByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstLongByIntGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -51,5 +52,23 @@ public class AllFirstLongByIntGroupingAggregatorFunctionTests extends GroupingAg
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstLongByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstLongByLongGroupingAggregatorFunctionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -53,5 +54,23 @@ public class AllFirstLongByLongGroupingAggregatorFunctionTests extends GroupingA
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBooleanByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBooleanByIntGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -51,5 +52,23 @@ public class AllLastBooleanByIntGroupingAggregatorFunctionTests extends Grouping
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBooleanByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBooleanByLongGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -54,5 +55,23 @@ public class AllLastBooleanByLongGroupingAggregatorFunctionTests extends Groupin
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBytesRefByIntGroupingAggregatorFunctionTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.aggregation;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.GroundTruthFirstLastAggregator;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -14,6 +15,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -53,5 +55,23 @@ public class AllLastBytesRefByIntGroupingAggregatorFunctionTests extends Groupin
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantBytesRefBlockWith(new BytesRef(randomAlphaOfLength(5)), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantBytesRefBlockWith(new BytesRef(randomAlphaOfLength(5)), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBytesRefByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastBytesRefByLongGroupingAggregatorFunctionTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.aggregation;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.aggregation.FirstLastAggregatorTestingUtils.GroundTruthFirstLastAggregator;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -14,6 +15,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -56,5 +58,23 @@ public class AllLastBytesRefByLongGroupingAggregatorFunctionTests extends Groupi
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantBytesRefBlockWith(new BytesRef(randomAlphaOfLength(5)), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantBytesRefBlockWith(new BytesRef(randomAlphaOfLength(5)), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastDoubleByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastDoubleByIntGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -51,5 +52,23 @@ public class AllLastDoubleByIntGroupingAggregatorFunctionTests extends GroupingA
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantDoubleBlockWith(randomDouble(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantDoubleBlockWith(randomDouble(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastDoubleByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastDoubleByLongGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -54,5 +55,23 @@ public class AllLastDoubleByLongGroupingAggregatorFunctionTests extends Grouping
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantDoubleBlockWith(randomDouble(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantDoubleBlockWith(randomDouble(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastFloatByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastFloatByIntGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -51,5 +52,23 @@ public class AllLastFloatByIntGroupingAggregatorFunctionTests extends GroupingAg
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantFloatBlockWith(randomFloat(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantFloatBlockWith(randomFloat(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastFloatByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastFloatByLongGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -54,5 +55,23 @@ public class AllLastFloatByLongGroupingAggregatorFunctionTests extends GroupingA
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantFloatBlockWith(randomFloat(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantFloatBlockWith(randomFloat(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastIntByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastIntByIntGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -51,5 +52,23 @@ public class AllLastIntByIntGroupingAggregatorFunctionTests extends GroupingAggr
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastIntByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastIntByLongGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -54,5 +55,23 @@ public class AllLastIntByLongGroupingAggregatorFunctionTests extends GroupingAgg
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastLongByIntGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastLongByIntGroupingAggregatorFunctionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -51,5 +52,23 @@ public class AllLastLongByIntGroupingAggregatorFunctionTests extends GroupingAgg
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1),
+            blockFactory.newConstantIntBlockWith(randomInt(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastLongByLongGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllLastLongByLongGroupingAggregatorFunctionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.TestDriverRunner;
 import org.elasticsearch.compute.test.operator.blocksource.ListRowsBlockSourceOperator;
 
 import java.util.List;
@@ -53,5 +54,23 @@ public class AllLastLongByLongGroupingAggregatorFunctionTests extends GroupingAg
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(false);
         processPages(work, input, group);
         work.check(BlockUtils.toJavaObject(result, position));
+    }
+
+    /** Tests that groups arriving out of order (key 1 before null key) are handled correctly. */
+    public void testTwoBlocksOneKeyNull() {
+        var runner = new TestDriverRunner().builder(driverContext()).collectDeepCopy();
+        BlockFactory blockFactory = runner.blockFactory();
+        Page page1 = new Page(
+            blockFactory.newConstantLongBlockWith(1L, 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        Page page2 = new Page(
+            blockFactory.newConstantNullBlock(1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1),
+            blockFactory.newConstantLongBlockWith(randomLong(), 1)
+        );
+        runner.input(List.of(page1, page2));
+        assertSimpleOutput(runner.deepCopy(), runner.run(simple()));
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ESQL: Less memory usage for FIRST/LAST (#146148)