### PR TITLE
[POC] Support inferring inference IDs for dense_vector fields and persisting in mappings

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.run.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.run.gradle
@@ -30,6 +30,10 @@ testClusters.register("runTask") {
       systemProperty 'ingest.geoip.downloader.enabled.default', 'true'
       setting 'xpack.security.enabled', 'true'
       keystore 'bootstrap.password', 'password'
+      def gcsCredFile = new File("${System.getProperty('user.home')}/.gcs/gcs.client.default.credentials_file.json")
+      if (gcsCredFile.exists()) {
+        keystore 'gcs.client.default.credentials_file', gcsCredFile
+      }
       user username: 'elastic-admin', password: 'elastic-password', role: '_es_test_root'
       numberOfNodes = 1
     }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/270_dense_vector_inference_id.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/270_dense_vector_inference_id.yml
@@ -1,0 +1,162 @@
+setup:
+  - requires:
+      cluster_features: ["mapper.dense_vector.inference_id"]
+      reason: 'inference_id support for dense_vector was added'
+
+---
+"Create index with inference_id":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              vector:
+                type: dense_vector
+                dims: 5
+                inference_id: my_inference_id
+
+  - match: { acknowledged: true }
+
+  - do:
+      indices.get_mapping:
+        index: test
+
+  - match: { test.mappings.properties.vector.type: dense_vector }
+  - match: { test.mappings.properties.vector.dims: 5 }
+  - match: { test.mappings.properties.vector.inference_id: my_inference_id }
+
+---
+"Create index without inference_id does not serialize it":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              vector:
+                type: dense_vector
+                dims: 5
+
+  - match: { acknowledged: true }
+
+  - do:
+      indices.get_mapping:
+        index: test
+
+  - match: { test.mappings.properties.vector.type: dense_vector }
+  - match: { test.mappings.properties.vector.dims: 5 }
+  - is_false: test.mappings.properties.vector.inference_id
+
+---
+"Update mapping to add inference_id":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              vector:
+                type: dense_vector
+                dims: 5
+
+  - do:
+      indices.get_mapping:
+        index: test
+
+  - is_false: test.mappings.properties.vector.inference_id
+
+  - do:
+      indices.put_mapping:
+        index: test
+        body:
+          properties:
+            vector:
+              type: dense_vector
+              dims: 5
+              inference_id: my_inference_id
+
+  - do:
+      indices.get_mapping:
+        index: test
+
+  - match: { test.mappings.properties.vector.inference_id: my_inference_id }
+
+---
+"Update mapping to change inference_id":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              vector:
+                type: dense_vector
+                dims: 5
+                inference_id: old_inference_id
+
+  - do:
+      indices.get_mapping:
+        index: test
+
+  - match: { test.mappings.properties.vector.inference_id: old_inference_id }
+
+  - do:
+      indices.put_mapping:
+        index: test
+        body:
+          properties:
+            vector:
+              type: dense_vector
+              dims: 5
+              inference_id: new_inference_id
+
+  - do:
+      indices.get_mapping:
+        index: test
+
+  - match: { test.mappings.properties.vector.inference_id: new_inference_id }
+
+---
+"Indexing and search still works with inference_id":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              vector:
+                type: dense_vector
+                dims: 3
+                similarity: cosine
+                inference_id: my_inference_id
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        body:
+          vector: [1.0, 2.0, 3.0]
+
+  - do:
+      index:
+        index: test
+        id: "2"
+        body:
+          vector: [4.0, 5.0, 6.0]
+
+  - do:
+      indices.refresh:
+        index: test
+
+  - do:
+      search:
+        index: test
+        body:
+          knn:
+            field: vector
+            query_vector: [1.0, 2.0, 3.0]
+            k: 2
+            num_candidates: 10
+
+  - match: { hits.total.value: 2 }

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -255,6 +255,7 @@ public class IndexVersions {
     public static final IndexVersion TIME_SERIES_USE_SYNTHETIC_ID_DEFAULT_PROD = def(9_093_0_00, Version.LUCENE_10_4_0);
     public static final IndexVersion TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT = def(9_094_0_00, Version.LUCENE_10_4_0);
     public static final IndexVersion DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES = def(9_095_0_00, Version.LUCENE_10_4_0);
+    public static final IndexVersion DENSE_VECTOR_INFERENCE_ID = def(9_096_0_00, Version.LUCENE_10_4_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 import static org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper.FLATTENED_MAPPED_SUBFIELDS_FEATURE;
 import static org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper.FLATTENED_PASSTHROUGH_FEATURE;
+import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.DENSE_VECTOR_INFERENCE_ID;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.RESCORE_VECTOR_QUANTIZED_VECTOR_MAPPING;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.RESCORE_ZERO_VECTOR_QUANTIZED_VECTOR_MAPPING;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.USE_DEFAULT_OVERSAMPLE_VALUE_FOR_BBQ;
@@ -145,7 +146,8 @@ public class MapperFeatures implements FeatureSpecification {
             DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX,
             FLATTENED_MAPPED_SUBFIELDS_FEATURE,
             ES940_DISK_BBQ,
-            FLATTENED_PASSTHROUGH_FEATURE
+            FLATTENED_PASSTHROUGH_FEATURE,
+            DENSE_VECTOR_INFERENCE_ID
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -403,13 +403,13 @@ public class DenseVectorFieldMapper extends FieldMapper {
             });
             // TODO: Re-enable index version gate before moving out of POC
             // .addValidator(v -> {
-            //     if (v != null && indexVersionCreated.before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
-            //         throw new IllegalArgumentException(
-            //             "Field [inference_id] requires an index created with version ["
-            //                 + IndexVersions.DENSE_VECTOR_INFERENCE_ID.toReleaseVersion()
-            //                 + "] or later"
-            //         );
-            //     }
+            // if (v != null && indexVersionCreated.before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
+            // throw new IllegalArgumentException(
+            // "Field [inference_id] requires an index created with version ["
+            // + IndexVersions.DENSE_VECTOR_INFERENCE_ID.toReleaseVersion()
+            // + "] or later"
+            // );
+            // }
             // });
             this.inferenceId = Parameter.stringParam("inference_id", true, m -> toType(m).fieldType().inferenceId, null)
                 .acceptsNull()

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -238,6 +238,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
     public static final NodeFeature USE_DEFAULT_OVERSAMPLE_VALUE_FOR_BBQ = new NodeFeature(
         "mapper.dense_vector.default_oversample_value_for_bbq"
     );
+    public static final NodeFeature DENSE_VECTOR_INFERENCE_ID = new NodeFeature("mapper.dense_vector.inference_id");
 
     public static final String CONTENT_TYPE = "dense_vector";
     public static final short MAX_DIMS_COUNT = 4096; // maximum allowed number of dimensions

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -403,7 +403,16 @@ public class DenseVectorFieldMapper extends FieldMapper {
             });
             this.inferenceId = Parameter.stringParam("inference_id", true, m -> toType(m).fieldType().inferenceId, null)
                 .acceptsNull()
-                .setSerializerCheck((id, ic, v) -> v != null);
+                .setSerializerCheck((id, ic, v) -> v != null)
+                .addValidator(v -> {
+                    if (v != null && indexVersionCreated.before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
+                        throw new IllegalArgumentException(
+                            "Field [inference_id] requires an index created with version ["
+                                + IndexVersions.DENSE_VECTOR_INFERENCE_ID.toReleaseVersion()
+                                + "] or later"
+                        );
+                    }
+                });
         }
 
         private boolean isVectorIndexTypeAllowedByProviders(VectorIndexType indexType) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -401,18 +401,19 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     }
                 }
             });
+            // TODO: Re-enable index version gate before moving out of POC
+            // .addValidator(v -> {
+            //     if (v != null && indexVersionCreated.before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
+            //         throw new IllegalArgumentException(
+            //             "Field [inference_id] requires an index created with version ["
+            //                 + IndexVersions.DENSE_VECTOR_INFERENCE_ID.toReleaseVersion()
+            //                 + "] or later"
+            //         );
+            //     }
+            // });
             this.inferenceId = Parameter.stringParam("inference_id", true, m -> toType(m).fieldType().inferenceId, null)
                 .acceptsNull()
-                .setSerializerCheck((id, ic, v) -> v != null)
-                .addValidator(v -> {
-                    if (v != null && indexVersionCreated.before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
-                        throw new IllegalArgumentException(
-                            "Field [inference_id] requires an index created with version ["
-                                + IndexVersions.DENSE_VECTOR_INFERENCE_ID.toReleaseVersion()
-                                + "] or later"
-                        );
-                    }
-                });
+                .setSerializerCheck((id, ic, v) -> v != null);
         }
 
         private boolean isVectorIndexTypeAllowedByProviders(VectorIndexType indexType) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -2826,6 +2826,10 @@ public class DenseVectorFieldMapper extends FieldMapper {
             return similarity;
         }
 
+        public Integer getDims() {
+            return dims;
+        }
+
         public String getInferenceId() {
             return inferenceId;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -269,6 +269,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         private final Parameter<DenseVectorIndexOptions> indexOptions;
 
         private final Parameter<Boolean> indexed;
+        private final Parameter<String> inferenceId;
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
         final IndexVersion indexVersionCreated;
@@ -399,6 +400,9 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     }
                 }
             });
+            this.inferenceId = Parameter.stringParam("inference_id", true, m -> toType(m).fieldType().inferenceId, null)
+                .acceptsNull()
+                .setSerializerCheck((id, ic, v) -> v != null);
         }
 
         private boolean isVectorIndexTypeAllowedByProviders(VectorIndexType indexType) {
@@ -473,7 +477,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
         @Override
         protected Parameter<?>[] getParameters() {
-            return new Parameter<?>[] { elementType, dims, indexed, similarity, indexOptions, meta };
+            return new Parameter<?>[] { elementType, dims, indexed, similarity, indexOptions, inferenceId, meta };
         }
 
         public Builder similarity(VectorSimilarity vectorSimilarity) {
@@ -493,6 +497,11 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
         public Builder indexOptions(DenseVectorIndexOptions indexOptions) {
             this.indexOptions.setValue(indexOptions);
+            return this;
+        }
+
+        public Builder inferenceId(String inferenceId) {
+            this.inferenceId.setValue(inferenceId);
             return this;
         }
 
@@ -517,6 +526,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     indexed.getValue(),
                     similarity.getValue(),
                     indexOptions.getValue(),
+                    inferenceId.getValue(),
                     meta.getValue(),
                     context.isSourceSynthetic()
                 ),
@@ -2785,6 +2795,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         private final VectorSimilarity similarity;
         private final IndexVersion indexVersionCreated;
         private final DenseVectorIndexOptions indexOptions;
+        private final String inferenceId;
         private final boolean isSyntheticSource;
 
         public DenseVectorFieldType(
@@ -2795,6 +2806,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
             boolean indexed,
             VectorSimilarity similarity,
             DenseVectorIndexOptions indexOptions,
+            String inferenceId,
             Map<String, String> meta,
             boolean isSyntheticSource
         ) {
@@ -2805,11 +2817,16 @@ public class DenseVectorFieldMapper extends FieldMapper {
             this.similarity = similarity;
             this.indexVersionCreated = indexVersionCreated;
             this.indexOptions = indexOptions;
+            this.inferenceId = inferenceId;
             this.isSyntheticSource = isSyntheticSource;
         }
 
         public VectorSimilarity similarity() {
             return similarity;
+        }
+
+        public String getInferenceId() {
+            return inferenceId;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
@@ -129,6 +129,7 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
     float boost = DEFAULT_BOOST;
     InnerHitBuilder innerHitBuilder;
     private final RescoreVectorBuilder rescoreVectorBuilder;
+    private String inferenceIdForMapping;
 
     /**
      * Defines a kNN search.
@@ -425,9 +426,17 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
             if (querySupplier.get() == null) {
                 return this;
             }
-            return new KnnSearchBuilder(field, querySupplier.get(), k, numCands, visitPercentage, rescoreVectorBuilder, similarity).boost(
-                boost
-            ).queryName(queryName).addFilterQueries(filterQueries).innerHit(innerHitBuilder);
+            KnnSearchBuilder resolved = new KnnSearchBuilder(
+                field,
+                querySupplier.get(),
+                k,
+                numCands,
+                visitPercentage,
+                rescoreVectorBuilder,
+                similarity
+            ).boost(boost).queryName(queryName).addFilterQueries(filterQueries).innerHit(innerHitBuilder);
+            resolved.inferenceIdForMapping = this.inferenceIdForMapping;
+            return resolved;
         }
         if (queryVectorBuilder != null) {
             SetOnce<float[]> toSet = new SetOnce<>();
@@ -447,10 +456,18 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
                 }
                 ll.onResponse(null);
             })));
-            return new KnnSearchBuilder(field, toSet::get, k, numCands, visitPercentage, rescoreVectorBuilder, filterQueries, similarity)
-                .boost(boost)
-                .queryName(queryName)
-                .innerHit(innerHitBuilder);
+            KnnSearchBuilder withSupplier = new KnnSearchBuilder(
+                field,
+                toSet::get,
+                k,
+                numCands,
+                visitPercentage,
+                rescoreVectorBuilder,
+                filterQueries,
+                similarity
+            ).boost(boost).queryName(queryName).innerHit(innerHitBuilder);
+            withSupplier.inferenceIdForMapping = queryVectorBuilder.getInferenceId();
+            return withSupplier;
         }
         boolean changed = false;
         List<QueryBuilder> rewrittenQueries = new ArrayList<>(filterQueries.size());
@@ -474,9 +491,17 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
         if (queryVectorBuilder != null) {
             throw new IllegalArgumentException("missing rewrite");
         }
-        return new KnnVectorQueryBuilder(field, queryVector, k, numCands, visitPercentage, rescoreVectorBuilder, similarity).boost(boost)
-            .queryName(queryName)
-            .addFilterQueries(filterQueries);
+        KnnVectorQueryBuilder builder = new KnnVectorQueryBuilder(
+            field,
+            queryVector,
+            k,
+            numCands,
+            visitPercentage,
+            rescoreVectorBuilder,
+            similarity
+        ).boost(boost).queryName(queryName).addFilterQueries(filterQueries);
+        builder.setInferenceIdForMapping(inferenceIdForMapping);
+        return builder;
     }
 
     public Float getSimilarity() {

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedObjectMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
@@ -549,7 +548,7 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
         }
         // TODO: Re-enable index version gate before moving out of POC
         // if (context.getIndexSettings().getIndexVersionCreated().before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
-        //     return;
+        // return;
         // }
         if (queryVector != null && vectorFieldType.getDims() != null && vectorFieldType.getDims() != queryVector.asFloatVector().length) {
             return;

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -16,10 +16,15 @@ import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.ToChildBlockJoinQuery;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.TransportAutoPutMappingAction;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedObjectMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
@@ -35,11 +40,14 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.ToChildBlockJoinQueryBuilder;
 import org.elasticsearch.index.query.support.AutoPrefilteringUtils;
 import org.elasticsearch.index.search.NestedHelper;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,6 +67,8 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  * {@link org.apache.lucene.search.KnnByteVectorQuery}.
  */
 public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilder> {
+
+    private static final Logger logger = LogManager.getLogger(KnnVectorQueryBuilder.class);
 
     public static final TransportVersion AUTO_PREFILTERING = TransportVersion.fromName("knn_vector_query_auto_prefiltering");
 
@@ -429,9 +439,11 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
             if (queryVectorSupplier.get() == null) {
                 return this;
             }
+            float[] resolvedVector = queryVectorSupplier.get();
+            maybeUpdateInferenceIdMapping(ctx, resolvedVector);
             return new KnnVectorQueryBuilder(
                 fieldName,
-                queryVectorSupplier.get(),
+                resolvedVector,
                 k,
                 numCands,
                 visitPercentage,
@@ -496,6 +508,86 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
             }
         }
         return this;
+    }
+
+    /**
+     * If the target dense_vector field has no inference_id set, and the query vector builder provides one,
+     * and the resolved vector's dimensions match the field's configured dimensions, fires a best-effort
+     * async mapping update to persist the inference_id. Failures are logged and swallowed — the search
+     * is never affected.
+     */
+    private void maybeUpdateInferenceIdMapping(QueryRewriteContext ctx, float[] resolvedVector) {
+        if (queryVectorBuilder == null) {
+            return;
+        }
+        String inferenceId = queryVectorBuilder.getInferenceId();
+        if (inferenceId == null) {
+            return;
+        }
+        Index index = ctx.getFullyQualifiedIndex();
+        if (index == null) {
+            return;
+        }
+        MappedFieldType mappedFieldType;
+        try {
+            mappedFieldType = ctx.getFieldType(fieldName);
+        } catch (Exception e) {
+            return;
+        }
+        if (mappedFieldType instanceof DenseVectorFieldType == false) {
+            return;
+        }
+        DenseVectorFieldType denseVectorFieldType = (DenseVectorFieldType) mappedFieldType;
+        if (denseVectorFieldType.getInferenceId() != null) {
+            return;
+        }
+        if (denseVectorFieldType.getDims() != null && denseVectorFieldType.getDims() != resolvedVector.length) {
+            return;
+        }
+        ctx.registerAsyncAction((client, listener) -> {
+            try {
+                PutMappingRequest request = new PutMappingRequest();
+                request.setConcreteIndex(index);
+                XContentBuilder builder = JsonXContent.contentBuilder();
+                builder.startObject();
+                builder.startObject("properties");
+                builder.startObject(fieldName);
+                builder.field("type", DenseVectorFieldMapper.CONTENT_TYPE);
+                builder.field("inference_id", inferenceId);
+                builder.endObject();
+                builder.endObject();
+                builder.endObject();
+                request.source(builder);
+                request.masterNodeTimeout(TimeValue.timeValueSeconds(30));
+                request.ackTimeout(TimeValue.ZERO);
+                client.execute(TransportAutoPutMappingAction.TYPE, request, ActionListener.wrap(response -> {
+                    logger.debug("Updated inference_id [{}] on dense_vector field [{}] in index [{}]", inferenceId, fieldName, index);
+                    listener.onResponse(null);
+                }, failure -> {
+                    logger.debug(
+                        () -> format(
+                            "Failed to update inference_id [%s] on dense_vector field [%s] in index [%s]",
+                            inferenceId,
+                            fieldName,
+                            index
+                        ),
+                        failure
+                    );
+                    listener.onResponse(null);
+                }));
+            } catch (Exception e) {
+                logger.debug(
+                    () -> format(
+                        "Failed to build mapping update for inference_id [%s] on field [%s] in index [%s]",
+                        inferenceId,
+                        fieldName,
+                        index
+                    ),
+                    e
+                );
+                listener.onResponse(null);
+            }
+        });
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -547,9 +547,10 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
         if (vectorFieldType.getInferenceId() != null) {
             return;
         }
-        if (context.getIndexSettings().getIndexVersionCreated().before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
-            return;
-        }
+        // TODO: Re-enable index version gate before moving out of POC
+        // if (context.getIndexSettings().getIndexVersionCreated().before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
+        //     return;
+        // }
         if (queryVector != null && vectorFieldType.getDims() != null && vectorFieldType.getDims() != queryVector.asFloatVector().length) {
             return;
         }

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -383,6 +383,10 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
         this.inferenceIdForMapping = inferenceIdForMapping;
     }
 
+    String inferenceIdForMapping() {
+        return inferenceIdForMapping;
+    }
+
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         if (queryVectorSupplier != null) {

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedObjectMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
@@ -526,6 +527,10 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
         }
         Index index = ctx.getFullyQualifiedIndex();
         if (index == null) {
+            return;
+        }
+        if (ctx.getIndexSettings() == null
+            || ctx.getIndexSettings().getIndexVersionCreated().before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
             return;
         }
         MappedFieldType mappedFieldType;

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -98,7 +98,8 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
             (Integer) args[3],
             (Float) args[4],
             (RescoreVectorBuilder) args[7],
-            (Float) args[5]
+            (Float) args[5],
+            null
         )
     );
 
@@ -159,6 +160,12 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
     private final RescoreVectorBuilder rescoreVectorBuilder;
 
     /**
+     * Inference ID extracted from the query vector builder during rewrite, carried forward
+     * to {@link #doToQuery} where it can be persisted to the field mapping.
+     */
+    private String inferenceIdForMapping;
+
+    /**
      * True if auto pre-filtering should be applied.
      */
     private boolean isAutoPrefilteringEnabled = false;
@@ -181,7 +188,8 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
             numCands,
             visitPercentage,
             rescoreVectorBuilder,
-            vectorSimilarity
+            vectorSimilarity,
+            null
         );
     }
 
@@ -193,7 +201,7 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
         Float visitPercentage,
         Float vectorSimilarity
     ) {
-        this(fieldName, null, queryVectorBuilder, null, k, numCands, visitPercentage, null, vectorSimilarity);
+        this(fieldName, null, queryVectorBuilder, null, k, numCands, visitPercentage, null, vectorSimilarity, null);
     }
 
     public KnnVectorQueryBuilder(
@@ -214,7 +222,8 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
             numCands,
             visitPercentage,
             rescoreVectorBuilder,
-            vectorSimilarity
+            vectorSimilarity,
+            null
         );
     }
 
@@ -227,7 +236,7 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
         RescoreVectorBuilder rescoreVectorBuilder,
         Float vectorSimilarity
     ) {
-        this(fieldName, queryVector, null, null, k, numCands, visitPercentage, rescoreVectorBuilder, vectorSimilarity);
+        this(fieldName, queryVector, null, null, k, numCands, visitPercentage, rescoreVectorBuilder, vectorSimilarity, null);
     }
 
     private KnnVectorQueryBuilder(
@@ -239,7 +248,8 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
         Integer numCands,
         Float visitPercentage,
         RescoreVectorBuilder rescoreVectorBuilder,
-        Float vectorSimilarity
+        Float vectorSimilarity,
+        String inferenceIdForMapping
     ) {
         if (k != null && k < 1) {
             throw new IllegalArgumentException("[" + K_FIELD.getPreferredName() + "] must be greater than 0");
@@ -281,6 +291,7 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
         this.queryVectorBuilder = queryVectorBuilder;
         this.queryVectorSupplier = queryVectorSupplier;
         this.rescoreVectorBuilder = rescoreVectorBuilder;
+        this.inferenceIdForMapping = inferenceIdForMapping;
     }
 
     public KnnVectorQueryBuilder(StreamInput in) throws IOException {
@@ -303,6 +314,7 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
         }
 
         this.queryVectorSupplier = null;
+        this.inferenceIdForMapping = null;
     }
 
     public String getFieldName() {
@@ -365,6 +377,10 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
 
     public boolean isAutoPrefilteringEnabled() {
         return isAutoPrefilteringEnabled;
+    }
+
+    void setInferenceIdForMapping(String inferenceIdForMapping) {
+        this.inferenceIdForMapping = inferenceIdForMapping;
     }
 
     @Override
@@ -440,16 +456,18 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
             if (queryVectorSupplier.get() == null) {
                 return this;
             }
-            float[] resolvedVector = queryVectorSupplier.get();
-            maybeUpdateInferenceIdMapping(ctx, resolvedVector);
+            String resolvedInferenceId = queryVectorBuilder != null ? queryVectorBuilder.getInferenceId() : null;
             return new KnnVectorQueryBuilder(
                 fieldName,
-                resolvedVector,
+                VectorData.fromFloats(queryVectorSupplier.get()),
+                null,
+                null,
                 k,
                 numCands,
                 visitPercentage,
                 rescoreVectorBuilder,
-                vectorSimilarity
+                vectorSimilarity,
+                resolvedInferenceId
             ).boost(boost).queryName(queryName).addFilterQueries(filterQueries).setAutoPrefilteringEnabled(isAutoPrefilteringEnabled);
         }
         if (queryVectorBuilder != null) {
@@ -464,7 +482,8 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
                 numCands,
                 visitPercentage,
                 rescoreVectorBuilder,
-                vectorSimilarity
+                vectorSimilarity,
+                null
             ).boost(boost).queryName(queryName).addFilterQueries(filterQueries).setAutoPrefilteringEnabled(isAutoPrefilteringEnabled);
         }
         boolean changed = false;
@@ -489,7 +508,8 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
                 numCands,
                 visitPercentage,
                 rescoreVectorBuilder,
-                vectorSimilarity
+                vectorSimilarity,
+                inferenceIdForMapping
             ).boost(boost).queryName(queryName).addFilterQueries(rewrittenQueries).setAutoPrefilteringEnabled(isAutoPrefilteringEnabled);
         }
         if (ctx.convertToInnerHitsRewriteContext() != null) {
@@ -512,87 +532,66 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
     }
 
     /**
-     * If the target dense_vector field has no inference_id set, and the query vector builder provides one,
-     * and the resolved vector's dimensions match the field's configured dimensions, fires a best-effort
-     * async mapping update to persist the inference_id. Failures are logged and swallowed — the search
-     * is never affected.
+     * If the target dense_vector field has no inference_id set, and the resolved inference ID is available,
+     * and the vector's dimensions match, fires a best-effort mapping update to persist the inference_id.
+     * Failures are logged and swallowed — the search is never affected.
      */
-    private void maybeUpdateInferenceIdMapping(QueryRewriteContext ctx, float[] resolvedVector) {
-        if (queryVectorBuilder == null) {
+    private void maybeUpdateInferenceIdMapping(SearchExecutionContext context, DenseVectorFieldType vectorFieldType) {
+        if (inferenceIdForMapping == null) {
             return;
         }
-        String inferenceId = queryVectorBuilder.getInferenceId();
-        if (inferenceId == null) {
+        if (vectorFieldType.getInferenceId() != null) {
             return;
         }
-        Index index = ctx.getFullyQualifiedIndex();
-        if (index == null) {
+        if (context.getIndexSettings().getIndexVersionCreated().before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
             return;
         }
-        if (ctx.getIndexSettings() == null
-            || ctx.getIndexSettings().getIndexVersionCreated().before(IndexVersions.DENSE_VECTOR_INFERENCE_ID)) {
+        if (queryVector != null && vectorFieldType.getDims() != null && vectorFieldType.getDims() != queryVector.asFloatVector().length) {
             return;
         }
-        MappedFieldType mappedFieldType;
+        Index index = context.getFullyQualifiedIndex();
         try {
-            mappedFieldType = ctx.getFieldType(fieldName);
-        } catch (Exception e) {
-            return;
-        }
-        if (mappedFieldType instanceof DenseVectorFieldType == false) {
-            return;
-        }
-        DenseVectorFieldType denseVectorFieldType = (DenseVectorFieldType) mappedFieldType;
-        if (denseVectorFieldType.getInferenceId() != null) {
-            return;
-        }
-        if (denseVectorFieldType.getDims() != null && denseVectorFieldType.getDims() != resolvedVector.length) {
-            return;
-        }
-        ctx.registerAsyncAction((client, listener) -> {
-            try {
-                PutMappingRequest request = new PutMappingRequest();
-                request.setConcreteIndex(index);
-                XContentBuilder builder = JsonXContent.contentBuilder();
-                builder.startObject();
-                builder.startObject("properties");
-                builder.startObject(fieldName);
-                builder.field("type", DenseVectorFieldMapper.CONTENT_TYPE);
-                builder.field("inference_id", inferenceId);
-                builder.endObject();
-                builder.endObject();
-                builder.endObject();
-                request.source(builder);
-                request.masterNodeTimeout(TimeValue.timeValueSeconds(30));
-                request.ackTimeout(TimeValue.ZERO);
-                client.execute(TransportAutoPutMappingAction.TYPE, request, ActionListener.wrap(response -> {
-                    logger.debug("Updated inference_id [{}] on dense_vector field [{}] in index [{}]", inferenceId, fieldName, index);
-                    listener.onResponse(null);
-                }, failure -> {
-                    logger.debug(
-                        () -> format(
-                            "Failed to update inference_id [%s] on dense_vector field [%s] in index [%s]",
-                            inferenceId,
-                            fieldName,
-                            index
-                        ),
-                        failure
-                    );
-                    listener.onResponse(null);
-                }));
-            } catch (Exception e) {
+            PutMappingRequest request = new PutMappingRequest();
+            request.setConcreteIndex(index);
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            builder.startObject("properties");
+            builder.startObject(fieldName);
+            builder.field("type", DenseVectorFieldMapper.CONTENT_TYPE);
+            if (vectorFieldType.getDims() != null) {
+                builder.field("dims", vectorFieldType.getDims());
+            }
+            builder.field("inference_id", inferenceIdForMapping);
+            builder.endObject();
+            builder.endObject();
+            builder.endObject();
+            request.source(builder);
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(30));
+            request.ackTimeout(TimeValue.ZERO);
+            context.getClient().execute(TransportAutoPutMappingAction.TYPE, request, ActionListener.wrap(response -> {
+                logger.debug("Updated inference_id [{}] on dense_vector field [{}] in index [{}]", inferenceIdForMapping, fieldName, index);
+            }, failure -> {
                 logger.debug(
                     () -> format(
-                        "Failed to build mapping update for inference_id [%s] on field [%s] in index [%s]",
-                        inferenceId,
+                        "Failed to update inference_id [%s] on dense_vector field [%s] in index [%s]",
+                        inferenceIdForMapping,
                         fieldName,
                         index
                     ),
-                    e
+                    failure
                 );
-                listener.onResponse(null);
-            }
-        });
+            }));
+        } catch (Exception e) {
+            logger.debug(
+                () -> format(
+                    "Failed to build mapping update for inference_id [%s] on field [%s] in index [%s]",
+                    inferenceIdForMapping,
+                    fieldName,
+                    index
+                ),
+                e
+            );
+        }
     }
 
     @Override
@@ -618,6 +617,8 @@ public class KnnVectorQueryBuilder extends LeafQueryBuilder<KnnVectorQueryBuilde
             );
         }
         DenseVectorFieldType vectorFieldType = (DenseVectorFieldType) fieldType;
+
+        maybeUpdateInferenceIdMapping(context, vectorFieldType);
 
         List<Query> filtersInitial = doFiltersToQuery(context);
 

--- a/server/src/main/java/org/elasticsearch/search/vectors/QueryVectorBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/QueryVectorBuilder.java
@@ -31,4 +31,12 @@ public interface QueryVectorBuilder extends VersionedNamedWriteable, ToXContentO
      * @param listener listener to accept the created vector
      */
     void buildVector(Client client, ActionListener<float[]> listener);
+
+    /**
+     * Returns the inference endpoint ID used by this query vector builder, or {@code null} if this builder
+     * does not use an inference endpoint.
+     */
+    default String getInferenceId() {
+        return null;
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -604,6 +604,17 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
                 b -> b.startObject("index_options").field("type", newType).endObject()
             );
         }
+
+        checker.registerUpdateCheck(
+            "inference_id",
+            b -> b.field("type", "dense_vector").field("dims", dims).field("index", true).field("similarity", "dot_product"),
+            b -> b.field("type", "dense_vector")
+                .field("dims", dims)
+                .field("index", true)
+                .field("similarity", "dot_product")
+                .field("inference_id", "my_inference_id"),
+            m -> assertEquals("my_inference_id", ((DenseVectorFieldMapper) m).fieldType().getInferenceId())
+        );
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
@@ -188,6 +188,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             indexed,
             VectorSimilarity.COSINE,
             indexed ? randomIndexOptionsAll() : null,
+            null,
             Collections.emptyMap(),
             false
         );
@@ -202,6 +203,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             true,
             VectorSimilarity.COSINE,
             randomIndexOptionsNonQuantized(),
+            null,
             Collections.emptyMap(),
             false
         );
@@ -268,6 +270,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             indexed,
             VectorSimilarity.COSINE,
             indexed ? randomIndexOptionsAll() : null,
+            null,
             Collections.emptyMap(),
             false
         );
@@ -285,6 +288,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             indexed,
             VectorSimilarity.COSINE,
             indexed ? randomIndexOptionsAll() : null,
+            null,
             Collections.emptyMap(),
             false
         );
@@ -319,6 +323,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 true,
                 VectorSimilarity.COSINE,
                 randomIndexOptionsAll(),
+                null,
                 Collections.emptyMap(),
                 false
             );
@@ -358,6 +363,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 true,
                 VectorSimilarity.COSINE,
                 randomIndexOptionsNonQuantized(),
+                null,
                 Collections.emptyMap(),
                 false
             );
@@ -421,6 +427,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 true,
                 VectorSimilarity.COSINE,
                 randomIndexOptionsAll(),
+                null,
                 Collections.emptyMap(),
                 false
             );
@@ -440,6 +447,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 true,
                 VectorSimilarity.COSINE,
                 randomIndexOptionsNonQuantized(),
+                null,
                 Collections.emptyMap(),
                 false
             );
@@ -460,6 +468,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             4,
             false,
             VectorSimilarity.COSINE,
+            null,
             null,
             Collections.emptyMap(),
             false
@@ -489,6 +498,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             true,
             VectorSimilarity.DOT_PRODUCT,
             randomIndexOptionsAll(),
+            null,
             Collections.emptyMap(),
             false
         );
@@ -521,6 +531,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             true,
             VectorSimilarity.COSINE,
             randomIndexOptionsAll(),
+            null,
             Collections.emptyMap(),
             false
         );
@@ -552,6 +563,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 true,
                 VectorSimilarity.COSINE,
                 randomIndexOptionsAll(),
+                null,
                 Collections.emptyMap(),
                 false
             );
@@ -590,6 +602,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 true,
                 VectorSimilarity.COSINE,
                 randomIndexOptionsNonQuantized(),
+                null,
                 Collections.emptyMap(),
                 false
             );
@@ -627,6 +640,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             false,
             VectorSimilarity.COSINE,
             randomIndexOptionsNonQuantized(),
+            null,
             Collections.emptyMap(),
             false
         );
@@ -655,6 +669,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             true,
             VectorSimilarity.COSINE,
             randomIndexOptionsNonQuantized(),
+            null,
             Collections.emptyMap(),
             false
         );
@@ -703,6 +718,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             true,
             VectorSimilarity.COSINE,
             randomIndexOptionsNonQuantized(),
+            null,
             Collections.emptyMap(),
             false
         );
@@ -748,6 +764,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             true,
             VectorSimilarity.COSINE,
             randomIndexOptionsHnswQuantized(),
+            null,
             Collections.emptyMap(),
             false
         );
@@ -770,6 +787,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             true,
             VectorSimilarity.COSINE,
             randomIndexOptionsHnswQuantized(new DenseVectorFieldMapper.RescoreVector(randomFloatBetween(1.1f, 9.9f, false))),
+            null,
             Collections.emptyMap(),
             false
         );
@@ -800,6 +818,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             true,
             VectorSimilarity.COSINE,
             randomIndexOptionsHnswQuantized(new DenseVectorFieldMapper.RescoreVector(0)),
+            null,
             Collections.emptyMap(),
             false
         );
@@ -840,6 +859,7 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
                 true,
                 VectorSimilarity.COSINE,
                 randomIndexOptionsHnswQuantized(),
+                null,
                 Collections.emptyMap(),
                 false
             );

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -245,6 +245,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
                     IndexVersion.current(),
                     false
                 ),
+                null,
                 new HashMap<>(),
                 false
             );

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
@@ -662,6 +662,60 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
         assertThat(rewritten.isAutoPrefilteringEnabled(), equalTo(knnVectorQueryBuilder.isAutoPrefilteringEnabled()));
     }
 
+    public void testRewriteWithQueryVectorBuilderSkipsInferenceIdUpdateWhenNoIndex() throws Exception {
+        float[] expectedArray = new float[] { 1.0f, 2.0f, 3.0f };
+        KnnVectorQueryBuilder knnVectorQueryBuilder = new KnnVectorQueryBuilder(
+            "field",
+            new TestQueryVectorBuilderPlugin.TestQueryVectorBuilder(expectedArray, "test-inference-id"),
+            null,
+            5,
+            10f,
+            1f
+        );
+
+        // Context with no fullyQualifiedIndex — mapping update should be skipped gracefully
+        QueryRewriteContext context = new QueryRewriteContext(null, null, null);
+        PlainActionFuture<QueryBuilder> knnFuture = new PlainActionFuture<>();
+        Rewriteable.rewriteAndFetch(knnVectorQueryBuilder, context, knnFuture);
+        KnnVectorQueryBuilder rewritten = (KnnVectorQueryBuilder) knnFuture.get();
+        assertThat(rewritten.queryVector().asFloatVector(), equalTo(expectedArray));
+        assertThat(rewritten.queryVectorBuilder(), nullValue());
+    }
+
+    public void testRewriteWithQueryVectorBuilderSkipsInferenceIdUpdateWhenNoInferenceId() throws Exception {
+        float[] expectedArray = new float[] { 1.0f, 2.0f, 3.0f };
+        // TestQueryVectorBuilder with no inference ID (default)
+        KnnVectorQueryBuilder knnVectorQueryBuilder = new KnnVectorQueryBuilder(
+            "field",
+            new TestQueryVectorBuilderPlugin.TestQueryVectorBuilder(expectedArray),
+            null,
+            5,
+            10f,
+            1f
+        );
+
+        QueryRewriteContext context = new QueryRewriteContext(null, null, null);
+        PlainActionFuture<QueryBuilder> knnFuture = new PlainActionFuture<>();
+        Rewriteable.rewriteAndFetch(knnVectorQueryBuilder, context, knnFuture);
+        KnnVectorQueryBuilder rewritten = (KnnVectorQueryBuilder) knnFuture.get();
+        assertThat(rewritten.queryVector().asFloatVector(), equalTo(expectedArray));
+        assertThat(rewritten.queryVectorBuilder(), nullValue());
+    }
+
+    public void testQueryVectorBuilderGetInferenceId() {
+        float[] vector = new float[] { 1.0f, 2.0f, 3.0f };
+        TestQueryVectorBuilderPlugin.TestQueryVectorBuilder withoutInferenceId = new TestQueryVectorBuilderPlugin.TestQueryVectorBuilder(
+            vector
+        );
+        assertNull(withoutInferenceId.getInferenceId());
+
+        TestQueryVectorBuilderPlugin.TestQueryVectorBuilder withInferenceId = new TestQueryVectorBuilderPlugin.TestQueryVectorBuilder(
+            vector,
+            "my-endpoint"
+        );
+        assertEquals("my-endpoint", withInferenceId.getInferenceId());
+    }
+
     public void testSetFilterQueries() {
         KnnVectorQueryBuilder knnQueryBuilder = doCreateTestQueryBuilder();
         List<QueryBuilder> newFilters = randomList(5, () -> RandomQueryBuilder.createQuery(random()));

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
@@ -336,6 +336,53 @@ public class KnnSearchBuilderTests extends AbstractXContentSerializingTestCase<K
         assertThat(rewritten.getRescoreVectorBuilder(), equalTo(expectedRescore));
     }
 
+    public void testRewriteCapturesInferenceId() throws Exception {
+        float[] expectedArray = randomVector(randomIntBetween(10, 1024));
+        String expectedInferenceId = "test-inference-endpoint";
+        KnnSearchBuilder searchBuilder = new KnnSearchBuilder(
+            "field",
+            new TestQueryVectorBuilderPlugin.TestQueryVectorBuilder(expectedArray, expectedInferenceId),
+            5,
+            10,
+            10f,
+            null,
+            1f
+        );
+
+        QueryRewriteContext context = new QueryRewriteContext(null, null, null);
+        PlainActionFuture<KnnSearchBuilder> future = new PlainActionFuture<>();
+        Rewriteable.rewriteAndFetch(searchBuilder, context, future);
+        KnnSearchBuilder rewritten = future.get();
+
+        assertThat(rewritten.queryVector.asFloatVector(), equalTo(expectedArray));
+        assertThat(rewritten.queryVectorBuilder, nullValue());
+
+        // toQueryBuilder should propagate the inference ID
+        KnnVectorQueryBuilder queryBuilder = rewritten.toQueryBuilder();
+        assertEquals(expectedInferenceId, queryBuilder.inferenceIdForMapping());
+    }
+
+    public void testRewriteWithoutInferenceId() throws Exception {
+        float[] expectedArray = randomVector(randomIntBetween(10, 1024));
+        KnnSearchBuilder searchBuilder = new KnnSearchBuilder(
+            "field",
+            new TestQueryVectorBuilderPlugin.TestQueryVectorBuilder(expectedArray),
+            5,
+            10,
+            10f,
+            null,
+            1f
+        );
+
+        QueryRewriteContext context = new QueryRewriteContext(null, null, null);
+        PlainActionFuture<KnnSearchBuilder> future = new PlainActionFuture<>();
+        Rewriteable.rewriteAndFetch(searchBuilder, context, future);
+        KnnSearchBuilder rewritten = future.get();
+
+        KnnVectorQueryBuilder queryBuilder = rewritten.toQueryBuilder();
+        assertNull(queryBuilder.inferenceIdForMapping());
+    }
+
     public static float[] randomVector(int dim) {
         float[] vector = new float[dim];
         for (int i = 0; i < vector.length; i++) {

--- a/server/src/test/java/org/elasticsearch/search/vectors/TestQueryVectorBuilderPlugin.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/TestQueryVectorBuilderPlugin.java
@@ -46,20 +46,32 @@ public class TestQueryVectorBuilderPlugin implements SearchPlugin {
         }
 
         private final List<Float> vectorToBuild;
+        private final String inferenceId;
 
         public TestQueryVectorBuilder(List<Float> vectorToBuild) {
+            this(vectorToBuild, null);
+        }
+
+        public TestQueryVectorBuilder(List<Float> vectorToBuild, String inferenceId) {
             this.vectorToBuild = Objects.requireNonNull(vectorToBuild);
+            this.inferenceId = inferenceId;
         }
 
         public TestQueryVectorBuilder(float[] expected) {
+            this(expected, null);
+        }
+
+        public TestQueryVectorBuilder(float[] expected, String inferenceId) {
             this.vectorToBuild = new ArrayList<>(expected.length);
             for (float f : expected) {
                 vectorToBuild.add(f);
             }
+            this.inferenceId = inferenceId;
         }
 
         TestQueryVectorBuilder(StreamInput in) throws IOException {
             this.vectorToBuild = in.readCollectionAsList(StreamInput::readFloat);
+            this.inferenceId = null;
         }
 
         @Override
@@ -80,6 +92,11 @@ public class TestQueryVectorBuilderPlugin implements SearchPlugin {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeCollection(vectorToBuild, StreamOutput::writeFloat);
+        }
+
+        @Override
+        public String getInferenceId() {
+            return inferenceId;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/search/vectors/VectorDataTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/VectorDataTests.java
@@ -107,6 +107,7 @@ public class VectorDataTests extends ESTestCase {
                 false,
                 VectorSimilarity.L2_NORM,
                 null,
+                null,
                 Collections.emptyMap(),
                 false
             );
@@ -153,6 +154,7 @@ public class VectorDataTests extends ESTestCase {
                 false,
                 VectorSimilarity.L2_NORM,
                 null,
+                null,
                 Collections.emptyMap(),
                 false
             );
@@ -180,6 +182,7 @@ public class VectorDataTests extends ESTestCase {
                 expected.length,
                 false,
                 VectorSimilarity.L2_NORM,
+                null,
                 null,
                 Collections.emptyMap(),
                 false
@@ -209,6 +212,7 @@ public class VectorDataTests extends ESTestCase {
                 false,
                 VectorSimilarity.L2_NORM,
                 null,
+                null,
                 Collections.emptyMap(),
                 false
             );
@@ -235,6 +239,7 @@ public class VectorDataTests extends ESTestCase {
                 3,
                 false,
                 VectorSimilarity.L2_NORM,
+                null,
                 null,
                 Collections.emptyMap(),
                 false

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/vectors/TextEmbeddingQueryVectorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/vectors/TextEmbeddingQueryVectorBuilder.java
@@ -140,6 +140,11 @@ public class TextEmbeddingQueryVectorBuilder implements QueryVectorBuilder {
         }, listener::onFailure));
     }
 
+    @Override
+    public String getInferenceId() {
+        return modelId;
+    }
+
     public String getModelText() {
         return modelText;
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilderTests.java
@@ -78,4 +78,16 @@ public class TextEmbeddingQueryVectorBuilderTests extends AbstractQueryVectorBui
     protected TextEmbeddingQueryVectorBuilder doParseInstance(XContentParser parser) throws IOException {
         return TextEmbeddingQueryVectorBuilder.fromXContent(parser);
     }
+
+    public void testGetInferenceIdReturnsModelId() {
+        String modelId = randomAlphaOfLength(8);
+        TextEmbeddingQueryVectorBuilder builder = new TextEmbeddingQueryVectorBuilder(modelId, randomAlphaOfLength(4));
+        assertEquals(modelId, builder.getInferenceId());
+        assertEquals(builder.getModelId(), builder.getInferenceId());
+    }
+
+    public void testGetInferenceIdReturnsNullWhenModelIdNull() {
+        TextEmbeddingQueryVectorBuilder builder = new TextEmbeddingQueryVectorBuilder(null, randomAlphaOfLength(4));
+        assertNull(builder.getInferenceId());
+    }
 }


### PR DESCRIPTION
POC to support adding a dynamic field to the `dense_vector` mappings, and automatically populate it when models are sent in via the `query_vector_builder`. 

Example script to test functionality: 
```
# ---------------------------------------------------------------
# 1. Create index with a bare dense_vector field — no inference_id or other configuration
# ---------------------------------------------------------------
PUT test-inference-id-demo
{
  "mappings": {
    "properties": {
      "embedding": {
        "type": "dense_vector"
      }
    }
  }
}

# Verify: configuration is absent
GET test-inference-id-demo/_mapping

# ---------------------------------------------------------------
# 2. Call the inference endpoint to get a real embedding
# ---------------------------------------------------------------
POST _inference/text_embedding/.jina-embeddings-v5-text-small
{
  "input": "Elasticsearch is a distributed search engine"
}

# Copy the embedding array from the response above, then index it:
# (The embedding will be a 1024-dim float array)
#
# TIP: In dev console, run the POST above, then copy the embedding
# from the response and paste it into the doc below.

# ---------------------------------------------------------------
# 3. Index the document — dims will be dynamically set to 1024
# ---------------------------------------------------------------
POST test-inference-id-demo/_doc/1
{
  "embedding": [... pasted vectors ...]
}

# Verify: dims should now be 1024, but still no inference_id
GET test-inference-id-demo/_mapping

# ---------------------------------------------------------------
# 4. Search using query_vector_builder with the inference endpoint
#    This triggers the automatic inference_id capture
# ---------------------------------------------------------------
POST test-inference-id-demo/_search
{
  "knn": {
    "field": "embedding",
    "query_vector_builder": {
      "text_embedding": {
        "model_id": ".jina-embeddings-v5-text-small",
        "model_text": "what is a search engine"
      }
    },
    "k": 1,
    "num_candidates": 10
  }
}

# ---------------------------------------------------------------
# 5. Check mappings — inference_id should now be present!
# ---------------------------------------------------------------
GET test-inference-id-demo/_mapping

# ---------------------------------------------------------------
# Cleanup
# ---------------------------------------------------------------
# DELETE test-inference-id-demo

```