### PR TITLE
[9.4] Remove Security Manager references from modules (#146437)

### DIFF
--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
@@ -14,7 +14,6 @@ import org.apache.lucene.expressions.SimpleBindings;
 import org.apache.lucene.expressions.js.JavascriptCompiler;
 import org.apache.lucene.expressions.js.VariableContext;
 import org.apache.lucene.search.DoubleValuesSource;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
@@ -154,7 +153,6 @@ public class ExpressionScriptEngine implements ScriptEngine {
 
     @Override
     public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
-        SpecialPermission.check();
         Expression expr;
         try {
             // NOTE: validation is delayed to allow runtime vars, and we don't have access to per index stuff here

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.bootstrap.BootstrapInfo;
 import org.elasticsearch.painless.antlr.Walker;
 import org.elasticsearch.painless.ir.ClassNode;
 import org.elasticsearch.painless.lookup.PainlessLookup;
@@ -32,11 +31,6 @@ import org.elasticsearch.painless.symbol.WriteScope;
 import org.objectweb.asm.util.Printer;
 
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.security.CodeSource;
-import java.security.SecureClassLoader;
-import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,26 +46,9 @@ import static org.elasticsearch.painless.WriterConstants.CLASS_NAME;
 final class Compiler {
 
     /**
-     * Define the class with lowest privileges.
+     * A class loader used to define Painless scripts.
      */
-    private static final CodeSource CODESOURCE;
-
-    /**
-     * Setup the code privileges.
-     */
-    static {
-        try {
-            // Setup the code privileges.
-            CODESOURCE = new CodeSource(new URL("file:" + BootstrapInfo.UNTRUSTED_CODEBASE), (Certificate[]) null);
-        } catch (MalformedURLException impossible) {
-            throw new RuntimeException(impossible);
-        }
-    }
-
-    /**
-     * A secure class loader used to define Painless scripts.
-     */
-    final class Loader extends SecureClassLoader {
+    final class Loader extends ClassLoader {
         private final AtomicInteger lambdaCounter = new AtomicInteger(0);
 
         /**
@@ -105,7 +82,7 @@ final class Compiler {
          * @return A Class object defining a factory.
          */
         Class<?> defineFactory(String name, byte[] bytes) {
-            return defineClass(name, bytes, 0, bytes.length, CODESOURCE);
+            return defineClass(name, bytes, 0, bytes.length);
         }
 
         /**
@@ -115,7 +92,7 @@ final class Compiler {
          * @return A Class object extending {@link PainlessScript}.
          */
         Class<? extends PainlessScript> defineScript(String name, byte[] bytes) {
-            return defineClass(name, bytes, 0, bytes.length, CODESOURCE).asSubclass(PainlessScript.class);
+            return defineClass(name, bytes, 0, bytes.length).asSubclass(PainlessScript.class);
         }
 
         /**
@@ -125,7 +102,7 @@ final class Compiler {
          * @return A Class object.
          */
         Class<?> defineLambda(String name, byte[] bytes) {
-            return defineClass(name, bytes, 0, bytes.length, CODESOURCE);
+            return defineClass(name, bytes, 0, bytes.length);
         }
 
         /**

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.painless.Compiler.Loader;
@@ -28,7 +27,6 @@ import org.objectweb.asm.commons.GeneratorAdapter;
 
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
-import java.security.Permissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,14 +46,6 @@ public final class PainlessScriptEngine implements ScriptEngine {
      * Standard name of the Painless language.
      */
     public static final String NAME = "painless";
-
-    /*
-     * Setup the allowed permissions.
-     */
-    static {
-        final Permissions none = new Permissions();
-        none.setReadOnly();
-    }
 
     /**
      * Default compiler settings to be used. Note that {@link CompilerSettings} is mutable but this instance shouldn't be mutated outside
@@ -110,10 +100,6 @@ public final class PainlessScriptEngine implements ScriptEngine {
     public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
         Compiler compiler = contextsToCompilers.get(context);
 
-        // Check we ourselves are not being called by unprivileged code.
-        SpecialPermission.check();
-
-        // Create our loader (which loads compiled code with no permissions).
         final Loader loader = compiler.createLoader(getClass().getClassLoader());
 
         ScriptScope scriptScope = compile(contextsToCompilers.get(context), loader, scriptName, scriptSource, params);

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/MeteredStorage.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/MeteredStorage.java
@@ -24,7 +24,6 @@ import com.google.cloud.storage.StorageBatch;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.spi.v1.HttpStorageRpc;
 
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.core.SuppressForbidden;
 
@@ -52,7 +51,6 @@ public class MeteredStorage {
 
     public MeteredStorage(Storage storage, GcsRepositoryStatsCollector statsCollector) {
         this.storage = storage;
-        SpecialPermission.check();
         this.storageRpc = getStorageRpc(storage);
         this.statsCollector = statsCollector;
     }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Remove Security Manager references from modules (#146437)