### PR TITLE
[ML] Fix flaky sparse_vector pruning test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -70,9 +70,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=termvectors/30_realtime/Realtime Term Vectors}
   issue: https://github.com/elastic/elasticsearch/issues/138370
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
-  issue: https://github.com/elastic/elasticsearch/issues/139196
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:spatial.convertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/139213

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
@@ -81,6 +81,17 @@ setup:
           {"index": { "_id": 6 }}
           {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
 
+  # Force merge to a single segment so that term statistics used by token pruning
+  # (averageTokenFreqRatio) are deterministic regardless of how many segments the
+  # bulk index produced. Without this, the per-segment max unique token count varies
+  # and borderline pruning decisions can flip between runs.
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      indices.forcemerge:
+        index: index-with-sparse-vector
+        max_num_segments: 1
+
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser


### PR DESCRIPTION
## Summary

Fixes the flaky `MlWithSecurityIT` yaml test `ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config` (#139196).

## Cause

The `averageTokenFreqRatio` used by token pruning in `WeightedTokensUtils.getAverageTokenFreqRatio()` computes:

```
sumDocFreq / fieldDocCount / numUniqueTokens
```

where `numUniqueTokens` is the **per-segment maximum** unique token count. When a bulk index produces multiple segments, this per-segment max can be significantly smaller than the total unique token count across all segments, inflating the average ratio.

Token `smells` (docFreq=2, ratio=0.333) sits right at the pruning boundary with `tokens_freq_ratio_threshold: 1`:
- **Single segment** (numUniqueTokens=12, avg=0.333): `0.333 < 1*0.333` is false → pruned → **3 hits** (expected)
- **Multiple segments** (numUniqueTokens<8, avg>0.5): `0.333 < 1*0.5` is true → kept → **4 hits** (failure)

## Fix

Added `indices.forcemerge` with `max_num_segments: 1` after the bulk index in the shared test setup. This guarantees a single segment, making term statistics deterministic regardless of how many segments the bulk index produced. No test logic or expected values need to change.

## Test plan

- [x] 20 iterations of the failing test pass locally
- [x] All sparse_vector yaml tests pass
- [x] CI green

Closes #139196

Made with [Cursor](https://cursor.com)