### PR TITLE
Fix 'occured' -> 'occurred' typo in DataStreamAutoShardingEvent javadoc

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAutoShardingEvent.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAutoShardingEvent.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.util.function.LongSupplier;
 
 /**
- * Represents the last auto sharding event that occured for a data stream.
+ * Represents the last auto sharding event that occurred for a data stream.
  */
 public record DataStreamAutoShardingEvent(String triggerIndexName, int targetNumberOfShards, long timestamp)
     implements


### PR DESCRIPTION
Class-level javadoc on `DataStreamAutoShardingEvent` in `server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAutoShardingEvent.java:27` read `Represents the last auto sharding event that occured for a data stream`. Doc-only change.