### PR TITLE
[9.4] ES|QL: fix TBUCKET(n) on empty filter range (#146366)

### DIFF
--- a/docs/changelog/146366.yaml
+++ b/docs/changelog/146366.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 146354
+pr: 146366
+summary: Fix TBUCKET(n) on empty filter range
+type: bug

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RequestIndexFilteringTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RequestIndexFilteringTestCase.java
@@ -233,6 +233,39 @@ public abstract class RequestIndexFilteringTestCase extends ESRestTestCase {
         }
     }
 
+    /**
+     * Verify that a numeric TBUCKET bucket count succeeds even when the top-level filter covers an empty time range.
+     * When field-caps returns no matching indices due to the filter, the analysis is retried without the filter.
+     * The original filter must be preserved for timestamp bounds extraction so that TBUCKET can still determine
+     * its bucketing interval from the filter range, rather than failing with a verification exception.
+     */
+    public void testTopLevelFilterAllowsNumericTBucketWithoutExplicitBounds() throws IOException {
+        assumeTrue(
+            "requires fix for TBUCKET numeric on empty range",
+            RestEsqlTestCase.hasCapabilities(
+                adminClient(),
+                List.of(EsqlCapabilities.Cap.FIX_TBUCKET_NUMERIC_ON_EMPTY_RANGE.capabilityName())
+            )
+        );
+        // index data at 2024-11-26; the filter will cover 2020-12-13 to 2020-12-14 where no data exists
+        indexTimestampData(3, "test1", "2024-11-26", "id1");
+
+        RestEsqlTestCase.RequestObjectBuilder builder = requestObjectBuilder().filter(b -> {
+            b.startObject("range");
+            {
+                b.startObject("@timestamp").field("gte", "2020-12-13").field("lt", "2020-12-14").endObject();
+            }
+            b.endObject();
+        }).query(from("test*") + " | STATS count = COUNT(*) BY bucket = TBUCKET(10) | SORT bucket");
+
+        assertQueryResult(
+            runEsql(builder),
+            matchesList().item(matchesMap().entry("name", "count").entry("type", "long"))
+                .item(matchesMap().entry("name", "bucket").entry("type", "date")),
+            allOf(instanceOf(List.class), hasSize(0))
+        );
+    }
+
     protected static RestEsqlTestCase.RequestObjectBuilder timestampFilter(String op, String date) throws IOException {
         return requestObjectBuilder().filter(b -> {
             b.startObject("range");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2482,6 +2482,29 @@ public class EsqlCapabilities {
         FIX_FULL_TEXT_FUNCTIONS_ON_CONSTANT_KEYWORD,
 
         /**
+         * Fix for {@code PropagateNullable} incorrectly discarding surviving OR branches when
+         * a field is constrained by {@code IS NULL} or {@code IS NOT NULL} in the same AND conjunction.
+         * Previously {@code (a IS NOT NULL OR p) AND a IS NULL} was optimized to {@code null AND a IS NULL}
+         * (dropping {@code p}); now it correctly becomes {@code p AND a IS NULL}.
+         * Symmetric fix: {@code (a IS NULL OR p) AND a IS NOT NULL} now correctly becomes
+         * {@code p AND a IS NOT NULL} instead of remaining unoptimized.
+         * See https://github.com/elastic/elasticsearch/issues/141579
+         */
+        FIX_PROPAGATE_NULLABLE_OR_DISJUNCTION,
+
+        /**
+         * Fix TBUCKET with a numeric bucket count returning a verification exception instead of empty results
+         * when the top-level request filter covers a time range with no matching indices.
+         * See https://github.com/elastic/elasticsearch/issues/146354
+         */
+        FIX_TBUCKET_NUMERIC_ON_EMPTY_RANGE,
+
+        /**
+         * Support for the {@code EMBEDDING} function for generating dense vector embeddings using the {@code embedding} task type.
+         */
+        EMBEDDING_FUNCTION(Build.current().isSnapshot()),
+
+        /**
          * Fix for {@code STARTS_WITH} and {@code ENDS_WITH} Lucene pushdown on {@code _index}: use wildcard escaping instead of
          * query-parser escaping, and honour the {@code stringLikeOnIndex} flag so the wildcard query forces string matching on metadata
          * fields.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2482,15 +2482,11 @@ public class EsqlCapabilities {
         FIX_FULL_TEXT_FUNCTIONS_ON_CONSTANT_KEYWORD,
 
         /**
-         * Fix for {@code PropagateNullable} incorrectly discarding surviving OR branches when
-         * a field is constrained by {@code IS NULL} or {@code IS NOT NULL} in the same AND conjunction.
-         * Previously {@code (a IS NOT NULL OR p) AND a IS NULL} was optimized to {@code null AND a IS NULL}
-         * (dropping {@code p}); now it correctly becomes {@code p AND a IS NULL}.
-         * Symmetric fix: {@code (a IS NULL OR p) AND a IS NOT NULL} now correctly becomes
-         * {@code p AND a IS NOT NULL} instead of remaining unoptimized.
-         * See https://github.com/elastic/elasticsearch/issues/141579
+         * Fix for {@code STARTS_WITH} and {@code ENDS_WITH} Lucene pushdown on {@code _index}: use wildcard escaping instead of
+         * query-parser escaping, and honour the {@code stringLikeOnIndex} flag so the wildcard query forces string matching on metadata
+         * fields.
          */
-        FIX_PROPAGATE_NULLABLE_OR_DISJUNCTION,
+        FIX_STARTS_WITH_ENDS_WITH_PUSHDOWN_ON_INDEX,
 
         /**
          * Fix TBUCKET with a numeric bucket count returning a verification exception instead of empty results
@@ -2498,18 +2494,6 @@ public class EsqlCapabilities {
          * See https://github.com/elastic/elasticsearch/issues/146354
          */
         FIX_TBUCKET_NUMERIC_ON_EMPTY_RANGE,
-
-        /**
-         * Support for the {@code EMBEDDING} function for generating dense vector embeddings using the {@code embedding} task type.
-         */
-        EMBEDDING_FUNCTION(Build.current().isSnapshot()),
-
-        /**
-         * Fix for {@code STARTS_WITH} and {@code ENDS_WITH} Lucene pushdown on {@code _index}: use wildcard escaping instead of
-         * query-parser escaping, and honour the {@code stringLikeOnIndex} flag so the wildcard query forces string matching on metadata
-         * fields.
-         */
-        FIX_STARTS_WITH_ENDS_WITH_PUSHDOWN_ON_INDEX,
 
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -60,6 +60,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor;
+import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor.TimestampBounds;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolution;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
@@ -858,6 +859,13 @@ public class EsqlSession {
             unmappedResolution == UnmappedResolution.LOAD
         ).withMinimumTransportVersion(localClusterMinimumVersion);
         String description = requestFilter == null ? "the only attempt without filter" : "first attempt with filter";
+        // Extract timestamp bounds eagerly from the request filter so they can be threaded through to the analyzer,
+        // even when index resolution is retried without the filter (e.g. because the filter covers an empty time range).
+        // Extraction uses configuration::absoluteStartedTimeInMillis (fixed at request start), so it is safe to do here.
+        TimestampBounds timestampBounds = QueryDslTimestampBoundsExtractor.extractTimestampBounds(
+            requestFilter,
+            configuration::absoluteStartedTimeInMillis
+        );
 
         resolveIndicesAndAnalyze(
             parsed,
@@ -866,6 +874,7 @@ public class EsqlSession {
             executionInfo,
             description,
             requestFilter,
+            timestampBounds,
             preAnalysis,
             result,
             logicalPlanListener
@@ -879,6 +888,7 @@ public class EsqlSession {
         EsqlExecutionInfo executionInfo,
         String description,
         QueryBuilder requestFilter,
+        TimestampBounds timestampBounds,
         PreAnalyzer.PreAnalysis preAnalysis,
         PreAnalysisResult result,
         ActionListener<Versioned<LogicalPlan>> logicalPlanListener
@@ -963,7 +973,18 @@ public class EsqlSession {
                     }));
             })
             .<Versioned<LogicalPlan>>andThen((l, r) -> {
-                analyzeWithRetry(parsed, unmappedResolution, configuration, executionInfo, description, requestFilter, preAnalysis, r, l);
+                analyzeWithRetry(
+                    parsed,
+                    unmappedResolution,
+                    configuration,
+                    executionInfo,
+                    description,
+                    requestFilter,
+                    timestampBounds,
+                    preAnalysis,
+                    r,
+                    l
+                );
             })
             .addListener(logicalPlanListener);
     }
@@ -1479,6 +1500,7 @@ public class EsqlSession {
         EsqlExecutionInfo executionInfo,
         String description,
         QueryBuilder requestFilter,
+        TimestampBounds timestampBounds,
         PreAnalyzer.PreAnalysis preAnalysis,
         PreAnalysisResult result,
         ActionListener<Versioned<LogicalPlan>> listener
@@ -1496,7 +1518,7 @@ public class EsqlSession {
             }
             TimeSpanMarker analysisProfile = executionInfo.queryProfile().analysis();
             analysisProfile.start();
-            LogicalPlan plan = analyzedPlan(parsed, unmappedResolution, configuration, result, executionInfo, requestFilter);
+            LogicalPlan plan = analyzedPlan(parsed, unmappedResolution, configuration, result, executionInfo, timestampBounds);
             analysisProfile.stop();
             LOGGER.debug("Analyzed plan ({}):\n{}", description, plan);
             // the analysis succeeded from the first attempt, irrespective if it had a filter or not, just continue with the planning
@@ -1516,6 +1538,7 @@ public class EsqlSession {
                     executionInfo,
                     "second attempt, without filter",
                     null,
+                    timestampBounds,
                     preAnalysis,
                     result,
                     listener
@@ -1543,17 +1566,9 @@ public class EsqlSession {
         Configuration configuration,
         PreAnalysisResult r,
         EsqlExecutionInfo executionInfo,
-        QueryBuilder requestFilter
+        TimestampBounds timestampBounds
     ) throws Exception {
         handleFieldCapsFailures(configuration.allowPartialResults(), executionInfo, r.indexResolution());
-        var timestampBounds = QueryDslTimestampBoundsExtractor.extractTimestampBounds(
-            requestFilter,
-            // Resolve date math against the query start time. If this uses the wall clock during planning instead,
-            // filters like [@timestamp >= now-5m AND @timestamp <= now] drift relative to Configuration.now(), so inferred
-            // timestamp bounds can shift within one request and misanchor TBUCKET/TSTEP bucketing.
-            // TODO: support nanos resolution for date_nanos fields
-            configuration::absoluteStartedTimeInMillis
-        );
         AnalyzerContext analyzerContext = new AnalyzerContext(
             configuration,
             functionRegistry,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [ES|QL: fix TBUCKET(n) on empty filter range (#146366)](https://github.com/elastic/elasticsearch/pull/146366)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)