### PR TITLE
Fix RandomizedTimeSeriesIT for Increase single-value case

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -331,6 +331,11 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
                     && timeseries.getFirst().v2().v1().toEpochMilli() % (secondsInWindow * 1000L) == 0
                     && offset > 0) {
                     // Value at lower boundary is present, check if there's one in the previous window to use.
+                    // For INCREASE, return 0 because the increase was already accounted for in the previous bucket.
+                    // For RATE, we still need to calculate the rate using interpolation from the previous bucket.
+                    if (deltaAgg.equals(DeltaAgg.INCREASE)) {
+                        return new RateRange(0.0, 0.0);
+                    }
                     addLastTupleFromLowerWindow(timeseries, allTimeseries.get(offset - 1), secondsInWindow);
                 }
                 if (timeseries.size() < 2) {


### PR DESCRIPTION
Fixes #146392 to account for the behaviour that was introduced in https://github.com/elastic/elasticsearch/pull/145794.
We'll backport this fix to 9.3 and 9.4. I'll open a separate PR afterwards on 9.3 to unmute the test there.

I ran the reproducer and several iterations without failures. Though the latter one doesn't say much, as it took a while for the failure to show up.
