### PR TITLE
[TEST] Fix MLModelDeploymentFullClusterRestartIT {cluster=OLD} Failures

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -16,10 +16,8 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AllocationStatus;
 import org.junit.Before;
 
@@ -95,6 +93,10 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractXpackFullClus
         String modelId = "trained-model-full-cluster-restart";
 
         if (isRunningAgainstOldCluster()) {
+            assumeTrue(
+                "PyTorch model deployment inference is not reliably supported before 8.3.0",
+                getOldClusterTestVersion().onOrAfter("8.3.0")
+            );
             createTrainedModel(modelId);
             putModelDefinition(modelId);
             putVocabulary(List.of("these", "are", "my", "words"), modelId);
@@ -147,10 +149,7 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractXpackFullClus
 
     private void assertInfer(String modelId) throws IOException {
         Response inference = infer("my words", modelId);
-        String expectedResponse = oldClusterHasInferEndpoint()
-            ? "{\"inference_results\":[{\"predicted_value\":[[1.0,1.0]]}]}"
-            : "{\"predicted_value\":[[1.0,1.0]]}";
-        assertThat(EntityUtils.toString(inference.getEntity()), equalTo(expectedResponse));
+        assertThat(EntityUtils.toString(inference.getEntity()), equalTo("{\"inference_results\":[{\"predicted_value\":[[1.0,1.0]]}]}"));
     }
 
     private void putModelDefinition(String modelId) throws IOException {
@@ -198,30 +197,14 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractXpackFullClus
     }
 
     private Response startDeployment(String modelId, String waitForState) throws IOException {
-        String inferenceThreadParamName = "threads_per_allocation";
-        String modelThreadParamName = "number_of_allocations";
-        String compatibleHeader = null;
-        if (isRunningAgainstOldCluster()) {
-            compatibleHeader = compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_8);
-            inferenceThreadParamName = "inference_threads";
-            modelThreadParamName = "model_threads";
-        }
-
         Request request = new Request(
             "POST",
             "/_ml/trained_models/"
                 + modelId
                 + "/deployment/_start?timeout=40s&wait_for="
                 + waitForState
-                + "&"
-                + inferenceThreadParamName
-                + "=1&"
-                + modelThreadParamName
-                + "=1"
+                + "&threads_per_allocation=1&number_of_allocations=1"
         );
-        if (compatibleHeader != null) {
-            request.setOptions(request.getOptions().toBuilder().addHeader("Accept", compatibleHeader).build());
-        }
         request.setOptions(request.getOptions().toBuilder().setWarningsHandler(PERMISSIVE).build());
         var response = client().performRequest(request);
         assertOK(response);
@@ -241,15 +224,8 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractXpackFullClus
         return response;
     }
 
-    private boolean oldClusterHasInferEndpoint() {
-        return isRunningAgainstOldCluster() == false || getOldClusterTestVersion().onOrAfter("8.3.0");
-    }
-
     private Response infer(String input, String modelId) throws IOException {
-        String endpoint = oldClusterHasInferEndpoint()
-            ? "/_ml/trained_models/" + modelId + "/_infer"
-            : "/_ml/trained_models/" + modelId + "/deployment/_infer?timeout=30s";
-        Request request = new Request("POST", endpoint);
+        Request request = new Request("POST", "/_ml/trained_models/" + modelId + "/_infer");
         request.setJsonEntity(Strings.format("""
             {  "docs": [{"input":"%s"}] }
             """, input));


### PR DESCRIPTION
The `{cluster=OLD}` variant of `testDeploymentSurvivesRestart` has been failing at 100% on the 8.0.1 and 8.1.3 BWC steps despite two prior fix attempts (#145159, #145690). The root cause is that PyTorch model deployment inference on those very old cluster versions has never been reliable in CI — the feature was experimental in 8.0.x–8.2.x — and the test has been muted for this reason repeatedly since 2022. This PR adds an `assumeTrue` version guard to skip the old-cluster path when the old cluster is before 8.3.0 (where the unified `_infer` endpoint and stable parameter names were introduced), mutes the test while the fix propagates to CI, and removes the now-dead code: the `oldClusterHasInferEndpoint()` helper, the `deployment/_infer` fallback branch, the deprecated `inference_threads`/`model_threads` parameter branching in `startDeployment`, and the response format ternary in `assertInfer`. 

Closes #146030.