### PR TITLE
[9.4] Fail recovery when index not found with non-empty starting seq no (#146258)

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -465,9 +465,23 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                 metadataSnapshot = Store.MetadataSnapshot.EMPTY;
                 startingSeqNo = UNASSIGNED_SEQ_NO;
             }
-        } catch (final org.apache.lucene.index.IndexNotFoundException e) {
-            // happens on an empty folder. no need to log
-            assert startingSeqNo == UNASSIGNED_SEQ_NO : startingSeqNo;
+        } catch (final org.apache.lucene.index.IndexNotFoundException e) { // happens on an empty Lucene folder
+            // Normally, an empty index folder implies no translog data either so startingSeqNo should be UNASSIGNED.
+            // But in rare cases (e.g., filesystem corruption or random I/O errors in tests), the Lucene index files
+            // may be lost/deleted/unreadable while reading a sequence number from the translog succeeded. In this
+            // situation we throw an exception to fail the recovery and to remove the inconsistent local shard files.
+            if (startingSeqNo != UNASSIGNED_SEQ_NO) {
+                logger.error(
+                    "{} index not found but starting seq no is [{}], failing recovery due to inconsistent state",
+                    recoveryTarget,
+                    startingSeqNo
+                );
+                throw new RecoveryFailedException(
+                    recoveryTarget.state(),
+                    "index not found with non-empty starting sequence number [" + startingSeqNo + "]",
+                    e
+                );
+            }
             logger.trace("{} shard folder empty, recovering all files", recoveryTarget);
             metadataSnapshot = Store.MetadataSnapshot.EMPTY;
         } catch (final IOException e) {

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.indices.recovery;
 
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
@@ -56,6 +57,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -73,9 +76,12 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -199,7 +205,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
             }
         }
         shard.sync();
-        long globalCheckpoint = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, shard.getLocalCheckpoint());
+        long globalCheckpoint = randomLongBetween(NO_OPS_PERFORMED, shard.getLocalCheckpoint());
         shard.updateGlobalCheckpointOnReplica(globalCheckpoint, "test");
         shard.sync();
         return shard.seqNoStats();
@@ -325,7 +331,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         IndexShard shard = newStartedShard(false);
         populateRandomData(shard);
         DiscoveryNode pNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
-        DiscoveryNode rNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
+        DiscoveryNode rNode = DiscoveryNodeUtils.builder("bar").roles(Collections.emptySet()).build();
         shard = reinitShard(shard, ShardRoutingHelper.initWithSameId(shard.routingEntry(), RecoverySource.PeerRecoverySource.INSTANCE));
         shard.markAsRecovering("peer recovery", new RecoveryState(shard.routingEntry(), pNode, rNode));
         shard.prepareForIndexRecovery();
@@ -343,7 +349,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         IndexShard shard = newStartedShard(false);
         populateRandomData(shard);
         DiscoveryNode pNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
-        DiscoveryNode rNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
+        DiscoveryNode rNode = DiscoveryNodeUtils.builder("bar").roles(Collections.emptySet()).build();
         shard = reinitShard(shard, ShardRoutingHelper.initWithSameId(shard.routingEntry(), RecoverySource.PeerRecoverySource.INSTANCE));
         shard.markAsRecovering("peer recovery", new RecoveryState(shard.routingEntry(), pNode, rNode));
         shard.prepareForIndexRecovery();
@@ -374,7 +380,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
     public void testResetStartRequestIfTranslogIsCorrupted() throws Exception {
         DiscoveryNode pNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
-        DiscoveryNode rNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
+        DiscoveryNode rNode = DiscoveryNodeUtils.builder("bar").roles(Collections.emptySet()).build();
         IndexShard shard = newStartedShard(false);
         final SeqNoStats seqNoStats = populateRandomData(shard);
         closeShardNoCheck(shard);
@@ -408,7 +414,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
     public void testSnapshotFileWrite() throws Exception {
         DiscoveryNode pNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
-        DiscoveryNode rNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
+        DiscoveryNode rNode = DiscoveryNodeUtils.builder("bar").roles(Collections.emptySet()).build();
 
         IndexShard shard = newShard(false);
         shard = reinitShard(shard, ShardRoutingHelper.initWithSameId(shard.routingEntry(), RecoverySource.PeerRecoverySource.INSTANCE));
@@ -495,7 +501,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
     public void testSnapshotFileIsDeletedAfterFailure() throws Exception {
         DiscoveryNode pNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
-        DiscoveryNode rNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
+        DiscoveryNode rNode = DiscoveryNodeUtils.builder("bar").roles(Collections.emptySet()).build();
 
         IndexShard shard = newShard(false);
         shard.markAsRecovering("peer recovery", new RecoveryState(shard.routingEntry(), pNode, rNode));
@@ -576,7 +582,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
     public void testReceiveFileInfoDeletesRecoveredFiles() throws Exception {
         DiscoveryNode pNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
-        DiscoveryNode rNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
+        DiscoveryNode rNode = DiscoveryNodeUtils.builder("bar").roles(Collections.emptySet()).build();
 
         IndexShard shard = newShard(false);
         shard = reinitShard(shard, ShardRoutingHelper.initWithSameId(shard.routingEntry(), RecoverySource.PeerRecoverySource.INSTANCE));
@@ -669,7 +675,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
     public void testSnapshotFileAreDeletedAfterCancel() throws Exception {
         DiscoveryNode pNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
-        DiscoveryNode rNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
+        DiscoveryNode rNode = DiscoveryNodeUtils.builder("bar").roles(Collections.emptySet()).build();
 
         IndexShard shard = newShard(false);
         shard.markAsRecovering("peer recovery", new RecoveryState(shard.routingEntry(), pNode, rNode));
@@ -744,7 +750,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
 
     public void testSnapshotFileDownloadPermitIsReleasedAfterClosingRecoveryTarget() throws Exception {
         DiscoveryNode pNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
-        DiscoveryNode rNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
+        DiscoveryNode rNode = DiscoveryNodeUtils.builder("bar").roles(Collections.emptySet()).build();
 
         IndexShard shard = newShard(false);
         shard.markAsRecovering("peer recovery", new RecoveryState(shard.routingEntry(), pNode, rNode));
@@ -759,6 +765,35 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         recoveryTarget.decRef();
 
         assertThat(snapshotFileDownloadsPermitFlag.get(), is(equalTo(true)));
+        closeShards(shard);
+    }
+
+    public void testFailsRecoveryIfIndexNotFoundWithNonEmptyStartingSeqNoInTranslog() throws Exception {
+        IndexShard shard = newStartedShard(false);
+        populateRandomData(shard);
+
+        DiscoveryNode pNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
+        DiscoveryNode rNode = DiscoveryNodeUtils.builder("bar").roles(Collections.emptySet()).build();
+        shard = reinitShard(shard, ShardRoutingHelper.initWithSameId(shard.routingEntry(), RecoverySource.PeerRecoverySource.INSTANCE));
+        shard.markAsRecovering("peer recovery", new RecoveryState(shard.routingEntry(), pNode, rNode));
+        shard.prepareForIndexRecovery();
+        long startingSeqNo = recoverLocallyUpToGlobalCheckpoint(shard);
+        assertThat("test requires a valid starting sequence number from translog", startingSeqNo, greaterThan(NO_OPS_PERFORMED));
+
+        // Delete segments file to simulate IndexNotFoundException scenario
+        try (var files = Files.list(shard.shardPath().resolveIndex())) {
+            for (Path file : files.filter(f -> f.getFileName().toString().startsWith(IndexFileNames.SEGMENTS)).toList()) {
+                IOUtils.rm(file);
+            }
+        }
+
+        RecoveryTarget recoveryTarget = new RecoveryTarget(shard, null, 0L, null, null, null);
+        RecoveryFailedException exception = expectThrows(
+            RecoveryFailedException.class,
+            () -> PeerRecoveryTargetService.getStartRecoveryRequest(logger, rNode, recoveryTarget, startingSeqNo)
+        );
+        assertThat(exception.getMessage(), containsString("index not found with non-empty starting sequence number"));
+        recoveryTarget.decRef();
         closeShards(shard);
     }
 


### PR DESCRIPTION
Backport of #146258 for 9.4.

When an IndexNotFoundException is caught during peer recovery but the starting sequence number from translog is valid (!= UNASSIGNED), this indicates an inconsistent state between Lucene index files and the translog.

Previously, this was only checked via an assertion which could be disabled in production. This change throws a RecoveryFailedException in this scenario to properly fail the recovery and trigger cleanup of the inconsistent local shard files.

As far as I know this situation has never been observed in production but can occur in tests due to simulated I/O errors. I'm running the test SearchWithRandomIOExceptionsIT.testRandomDirectoryIOExceptions in a loop for a while now but it haven't failed yet after 1K iterations on main nor on 8.19.

But it reproduces easily on 8.18.0 on commit af14e5cb78550b90a1b80e891de7a98916d0e8ef with the following reproducer:

./gradlew ":server:internalClusterTest" --tests "org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT.testRandomDirectoryIOExceptions" -Dtests.seed=68D49D0C3D2BCBF6 -Dtests.locale=shi-Tfng -Dtests.timezone=America/Bahia

Fixes #118733
