### PR TITLE
Remove 16-byte length limit from BBQ native implementations

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
@@ -304,16 +304,15 @@ public class VectorScorerOSQBenchmark {
                 ES940OSQVectorsScorer.BULK_SIZE,
                 resolvedEncoding
             );
-            case PANAMA -> new PanamaESVectorizationProvider(false)
-                .newES940OSQVectorsScorer(
-                    input,
-                    (byte) queryBits,
-                    (byte) docBits,
-                    dims,
-                    data.binaryIndexLength,
-                    BULK_SIZE,
-                    resolvedEncoding
-                );
+            case PANAMA -> new PanamaESVectorizationProvider(false).newES940OSQVectorsScorer(
+                input,
+                (byte) queryBits,
+                (byte) docBits,
+                dims,
+                data.binaryIndexLength,
+                BULK_SIZE,
+                resolvedEncoding
+            );
             case NATIVE -> ESVectorizationProvider.getInstance()
                 .newES940OSQVectorsScorer(
                     input,

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
@@ -22,6 +22,7 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.codec.vectors.diskbbq.es94.ES940DiskBBQVectorsFormat;
 import org.elasticsearch.simdvec.ES940OSQVectorsScorer;
 import org.elasticsearch.simdvec.internal.vectorization.ESVectorizationProvider;
+import org.elasticsearch.simdvec.internal.vectorization.PanamaESVectorizationProvider;
 import org.elasticsearch.simdvec.internal.vectorization.VectorScorerTestUtils;
 import org.elasticsearch.xpack.searchablesnapshots.store.SearchableSnapshotDirectoryFactory;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -71,7 +72,8 @@ public class VectorScorerOSQBenchmark {
 
     public enum VectorImplementation {
         SCALAR,
-        VECTORIZED
+        PANAMA,
+        NATIVE
     }
 
     @Param({ "384", "768", "1024" })
@@ -302,7 +304,17 @@ public class VectorScorerOSQBenchmark {
                 ES940OSQVectorsScorer.BULK_SIZE,
                 resolvedEncoding
             );
-            case VECTORIZED -> ESVectorizationProvider.getInstance()
+            case PANAMA -> new PanamaESVectorizationProvider(false)
+                .newES940OSQVectorsScorer(
+                    input,
+                    (byte) queryBits,
+                    (byte) docBits,
+                    dims,
+                    data.binaryIndexLength,
+                    BULK_SIZE,
+                    resolvedEncoding
+                );
+            case NATIVE -> ESVectorizationProvider.getInstance()
                 .newES940OSQVectorsScorer(
                     input,
                     (byte) queryBits,

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
@@ -50,13 +50,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
         for (int i = 0; i < REPETITIONS; i++) {
             var seed = randomLong();
 
-            var data = VectorScorerOSQBenchmark.generateRandomVectorData(
-                new Random(seed),
-                dims,
-                bits,
-                int4Encoding,
-                similarityFunction
-            );
+            var data = VectorScorerOSQBenchmark.generateRandomVectorData(new Random(seed), dims, bits, int4Encoding, similarityFunction);
 
             float[] expected = null;
             for (var impl : VectorScorerOSQBenchmark.VectorImplementation.values()) {
@@ -77,8 +71,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
                         continue;
                     }
                     assertArrayEqualsPercent(impl.toString(), expected, result, deltaPercent, DEFAULT_DELTA);
-                }
-                finally {
+                } finally {
                     bench.teardown();
                     IOUtils.rm(bench.tempDir);
                 }
@@ -90,13 +83,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
         for (int i = 0; i < REPETITIONS; i++) {
             var seed = randomLong();
 
-            var data = VectorScorerOSQBenchmark.generateRandomVectorData(
-                new Random(seed),
-                dims,
-                bits,
-                int4Encoding,
-                similarityFunction
-            );
+            var data = VectorScorerOSQBenchmark.generateRandomVectorData(new Random(seed), dims, bits, int4Encoding, similarityFunction);
 
             float[] expected = null;
             for (var impl : VectorScorerOSQBenchmark.VectorImplementation.values()) {
@@ -117,8 +104,7 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
                         continue;
                     }
                     assertArrayEqualsPercent(impl.toString(), expected, result, deltaPercent, DEFAULT_DELTA);
-                }
-                finally {
+                } finally {
                     bench.teardown();
                     IOUtils.rm(bench.tempDir);
                 }

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
@@ -46,92 +46,82 @@ public class VectorScorerOSQBenchmarkTests extends BenchmarkTest {
         this.similarityFunction = similarityFunction;
     }
 
-    public void testSingleScalarVsVectorized() throws Exception {
+    public void testSingle() throws Exception {
         for (int i = 0; i < REPETITIONS; i++) {
             var seed = randomLong();
 
-            var scalar = new VectorScorerOSQBenchmark();
-            var vectorized = new VectorScorerOSQBenchmark();
-            try {
-                var data = VectorScorerOSQBenchmark.generateRandomVectorData(
-                    new Random(seed),
-                    dims,
-                    bits,
-                    int4Encoding,
-                    similarityFunction
-                );
+            var data = VectorScorerOSQBenchmark.generateRandomVectorData(
+                new Random(seed),
+                dims,
+                bits,
+                int4Encoding,
+                similarityFunction
+            );
 
-                scalar.implementation = VectorScorerOSQBenchmark.VectorImplementation.SCALAR;
-                scalar.dims = dims;
-                scalar.bits = bits;
-                scalar.directoryType = directoryType;
-                scalar.int4Encoding = int4Encoding;
-                scalar.similarityFunction = similarityFunction;
-                scalar.setup(data);
+            float[] expected = null;
+            for (var impl : VectorScorerOSQBenchmark.VectorImplementation.values()) {
+                VectorScorerOSQBenchmark bench = new VectorScorerOSQBenchmark();
+                bench.implementation = impl;
+                bench.dims = dims;
+                bench.bits = bits;
+                bench.directoryType = directoryType;
+                bench.int4Encoding = int4Encoding;
+                bench.similarityFunction = similarityFunction;
+                bench.setup(data);
 
-                float[] expected = scalar.score();
-
-                vectorized.implementation = VectorScorerOSQBenchmark.VectorImplementation.VECTORIZED;
-                vectorized.dims = dims;
-                vectorized.bits = bits;
-                vectorized.directoryType = directoryType;
-                vectorized.int4Encoding = int4Encoding;
-                vectorized.similarityFunction = similarityFunction;
-                vectorized.setup(data);
-
-                float[] result = vectorized.score();
-
-                assertArrayEqualsPercent("single scoring, scalar VS vectorized", expected, result, deltaPercent, DEFAULT_DELTA);
-            } finally {
-                scalar.teardown();
-                vectorized.teardown();
-                IOUtils.rm(scalar.tempDir);
-                IOUtils.rm(vectorized.tempDir);
+                try {
+                    float[] result = bench.score();
+                    // just check against the first one - they should all be identical to each other
+                    if (expected == null) {
+                        expected = result;
+                        continue;
+                    }
+                    assertArrayEqualsPercent(impl.toString(), expected, result, deltaPercent, DEFAULT_DELTA);
+                }
+                finally {
+                    bench.teardown();
+                    IOUtils.rm(bench.tempDir);
+                }
             }
         }
     }
 
-    public void testBulkScalarVsVectorized() throws Exception {
+    public void testBulk() throws Exception {
         for (int i = 0; i < REPETITIONS; i++) {
             var seed = randomLong();
 
-            var scalar = new VectorScorerOSQBenchmark();
-            var vectorized = new VectorScorerOSQBenchmark();
-            try {
-                var data = VectorScorerOSQBenchmark.generateRandomVectorData(
-                    new Random(seed),
-                    dims,
-                    bits,
-                    int4Encoding,
-                    similarityFunction
-                );
+            var data = VectorScorerOSQBenchmark.generateRandomVectorData(
+                new Random(seed),
+                dims,
+                bits,
+                int4Encoding,
+                similarityFunction
+            );
 
-                scalar.implementation = VectorScorerOSQBenchmark.VectorImplementation.SCALAR;
-                scalar.dims = dims;
-                scalar.bits = bits;
-                scalar.directoryType = directoryType;
-                scalar.int4Encoding = int4Encoding;
-                scalar.similarityFunction = similarityFunction;
-                scalar.setup(data);
+            float[] expected = null;
+            for (var impl : VectorScorerOSQBenchmark.VectorImplementation.values()) {
+                VectorScorerOSQBenchmark bench = new VectorScorerOSQBenchmark();
+                bench.implementation = impl;
+                bench.dims = dims;
+                bench.bits = bits;
+                bench.directoryType = directoryType;
+                bench.int4Encoding = int4Encoding;
+                bench.similarityFunction = similarityFunction;
+                bench.setup(data);
 
-                float[] expected = scalar.bulkScore();
-
-                vectorized.implementation = VectorScorerOSQBenchmark.VectorImplementation.VECTORIZED;
-                vectorized.dims = dims;
-                vectorized.bits = bits;
-                vectorized.directoryType = directoryType;
-                vectorized.int4Encoding = int4Encoding;
-                vectorized.similarityFunction = similarityFunction;
-                vectorized.setup(data);
-
-                float[] result = vectorized.bulkScore();
-
-                assertArrayEqualsPercent("bulk scoring, scalar VS vectorized", expected, result, deltaPercent, DEFAULT_DELTA);
-            } finally {
-                scalar.teardown();
-                vectorized.teardown();
-                IOUtils.rm(scalar.tempDir);
-                IOUtils.rm(vectorized.tempDir);
+                try {
+                    float[] result = bench.bulkScore();
+                    // just check against the first one - they should all be identical to each other
+                    if (expected == null) {
+                        expected = result;
+                        continue;
+                    }
+                    assertArrayEqualsPercent(impl.toString(), expected, result, deltaPercent, DEFAULT_DELTA);
+                }
+                finally {
+                    bench.teardown();
+                    IOUtils.rm(bench.tempDir);
+                }
             }
         }
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES940OSQVectorsScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES940OSQVectorsScorer.java
@@ -64,7 +64,8 @@ public final class MemorySegmentES940OSQVectorsScorer extends ES940OSQVectorsSco
         int dimensions,
         int dataLength,
         int bulkSize,
-        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
+        ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding,
+        boolean nativeEnabled
     ) {
         super(
             in,
@@ -78,7 +79,7 @@ public final class MemorySegmentES940OSQVectorsScorer extends ES940OSQVectorsSco
         ES940OSQVectorsScorer.SymmetricInt4Encoding resolvedInt4 = int4Encoding == null
             ? ES940OSQVectorsScorer.SymmetricInt4Encoding.STRIPED
             : int4Encoding;
-        this.scorer = USE_NATIVE
+        this.scorer = USE_NATIVE && nativeEnabled
             ? createNativeScorer(QuantEncoding.of(queryBits, indexBits, resolvedInt4), in, dimensions, dataLength, bulkSize)
             : createPanamaScorer(QuantEncoding.of(queryBits, indexBits, resolvedInt4), in, dimensions, dataLength, bulkSize);
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/NativeMemorySegmentScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/NativeMemorySegmentScorer.java
@@ -33,7 +33,6 @@ abstract sealed class NativeMemorySegmentScorer extends MemorySegmentES940OSQVec
 
     NativeMemorySegmentScorer(IndexInput in, int dimensions, int dataLength, int bulkSize) {
         super(in, dimensions, dataLength, bulkSize);
-        assert dataLength >= 16 : "NativeMemorySegmentScorer requires dataLength >= 16, got " + dataLength;
     }
 
     private MemorySegment querySegment(byte[] q) {

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorizationProvider.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorizationProvider.java
@@ -48,7 +48,6 @@ final class PanamaESVectorizationProvider extends ESVectorizationProvider {
         ES940OSQVectorsScorer.SymmetricInt4Encoding int4Encoding
     ) {
         if (PanamaESVectorUtilSupport.HAS_FAST_INTEGER_VECTORS
-            && dataLength >= 16
             && ((queryBits == 4 && (indexBits == 1 || indexBits == 2 || indexBits == 4)) || (queryBits == 7 && indexBits == 7))) {
             IndexInput unwrappedInput = FilterIndexInput.unwrapOnlyTest(input);
             unwrappedInput = MemorySegmentAccessInputAccess.unwrap(unwrappedInput);

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorizationProvider.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorizationProvider.java
@@ -22,14 +22,20 @@ import org.elasticsearch.simdvec.internal.MemorySegmentES92Int7VectorsScorer;
 
 import java.io.IOException;
 
-final class PanamaESVectorizationProvider extends ESVectorizationProvider {
+public final class PanamaESVectorizationProvider extends ESVectorizationProvider {
 
     private final ESVectorUtilSupport vectorUtilSupport;
+    private final boolean nativeEnabled;
 
     private static final boolean NATIVE_SUPPORTED = NativeAccess.instance().getVectorSimilarityFunctions().isPresent();
 
-    PanamaESVectorizationProvider() {
+    public PanamaESVectorizationProvider() {
+        this(true);
+    }
+
+    public PanamaESVectorizationProvider(boolean nativeEnabled) {
         vectorUtilSupport = new PanamaESVectorUtilSupport();
+        this.nativeEnabled = nativeEnabled;
     }
 
     @Override
@@ -59,7 +65,8 @@ final class PanamaESVectorizationProvider extends ESVectorizationProvider {
                     dimension,
                     dataLength,
                     bulkSize,
-                    int4Encoding
+                    int4Encoding,
+                    nativeEnabled
                 );
             }
         }


### PR DESCRIPTION
The native BBQ implementations support all valid dimensions through use of scalar tails/masking. So we can remove the limit, and keep the existing Panama-specific checks that fallback on scalar implementations.

As part of this, I've added explicit tests for scalar vs panama vs native