### PR TITLE
Do not catch AssertionErrors in shard follow task tests

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -281,8 +281,6 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                                 delegate.run();
                             } catch (InterruptedException e) {
                                 Thread.currentThread().interrupt();
-                            } catch (AssertionError e) {
-                                errorHandler.accept(new RuntimeException(e));
                             } finally {
                                 if (acquired) {
                                     replacePrimaryLock.readLock().unlock();
@@ -841,18 +839,14 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
             Consumer<Exception> errorHandler
         ) {
             return () -> {
-                try {
-                    BulkShardOperationsRequest request = new BulkShardOperationsRequest(
-                        params.getFollowShardId(),
-                        followerHistoryUUID,
-                        operations,
-                        maxSeqNoOfUpdates
-                    );
-                    ActionListener<BulkShardOperationsResponse> listener = ActionListener.wrap(handler::accept, errorHandler);
-                    new CcrAction(request, listener, followerGroup).execute();
-                } catch (AssertionError e) {
-                    errorHandler.accept(new RuntimeException(e));
-                }
+                BulkShardOperationsRequest request = new BulkShardOperationsRequest(
+                    params.getFollowShardId(),
+                    followerHistoryUUID,
+                    operations,
+                    maxSeqNoOfUpdates
+                );
+                ActionListener<BulkShardOperationsResponse> listener = ActionListener.wrap(handler::accept, errorHandler);
+                new CcrAction(request, listener, followerGroup).execute();
             };
         }
 


### PR DESCRIPTION
Follows: https://github.com/elastic/elasticsearch/pull/144945

Removes the AssertionError catch blocks, which risk swallowing test failures. If an assertion error gets caught and handled/logged in a future version rather than propagated the test may pass silently even when it shouldn't.
