### PR TITLE
Rebalance checkPart tasks (round 3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -401,6 +401,8 @@ allprojects {
         splitForCI(project, "Part4")
       } else if (project.path.contains(":esql-datasource") || project.path.contains(":esql-core")) {
         splitForCI(project, "Part5")
+      } else if (project.path.contains(":esql:qa") && project.path.contains("multi-node")) {
+        splitForCI(project, "Part5")
       } else if (project.path.contains(":esql:qa")) {
         splitForCI(project, "Part3")
       } else if (project.path.contains(":eql") || project.path.contains(":sql") || project.path.contains(":transform") ||


### PR DESCRIPTION
## Summary
- Move `esql:qa:server:multi-node` tests from Part 3 to Part 5
- Part 3 is the current bottleneck at ~45 min p90, driven by two heavy ESQL QA tasks
- Part 5 has ~12 min of headroom at ~27 min p90
- Expected result: both parts converge to ~35-38 min p90

## Details
Adds a condition before the general `:esql:qa` → Part 3 rule that routes
`:esql:qa` paths containing `multi-node` to Part 5 instead. This specifically
targets `:x-pack:plugin:esql:qa:server:multi-node:javaRestTest` (p90 ~21 min).

## Test plan
- [ ] Verify CI pipeline passes
- [ ] Monitor `part-3` and `part-5` wall-clock times after merge