### PR TITLE
Micro-optimize bulk requests

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkPrimaryExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkPrimaryExecutionContext.java
@@ -332,10 +332,12 @@ class BulkPrimaryExecutionContext {
     /** builds the bulk shard response to return to the user */
     public BulkShardResponse buildShardResponse() {
         assert hasMoreOperationsToExecute() == false;
-        return new BulkShardResponse(
-            request.shardId(),
-            Arrays.stream(request.items()).map(BulkItemRequest::getPrimaryResponse).toArray(BulkItemResponse[]::new)
-        );
+        final BulkItemRequest[] requests = request.items();
+        final BulkItemResponse[] responses = new BulkItemResponse[requests.length];
+        for (int i = 0; i < responses.length; i++) {
+            responses[i] = requests[i].getPrimaryResponse();
+        }
+        return new BulkShardResponse(request.shardId(), responses);
     }
 
     private boolean assertInvariants(ItemProcessingState... expectedCurrentState) {

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -138,14 +138,11 @@ public class BulkRequest extends LegacyActionRequest
      * @return the current bulk request
      */
     public BulkRequest add(DocWriteRequest<?> request) {
-        if (request instanceof IndexRequest indexRequest) {
-            add(indexRequest);
-        } else if (request instanceof DeleteRequest deleteRequest) {
-            add(deleteRequest);
-        } else if (request instanceof UpdateRequest updateRequest) {
-            add(updateRequest);
-        } else {
-            throw new IllegalArgumentException("No support for request [" + request + "]");
+        switch (request) {
+            case IndexRequest indexRequest -> add(indexRequest);
+            case DeleteRequest deleteRequest -> add(deleteRequest);
+            case UpdateRequest updateRequest -> add(updateRequest);
+            case null, default -> throw new IllegalArgumentException("No support for request [" + request + "]");
         }
         indices.add(request.index());
         return this;

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -144,7 +144,6 @@ public class BulkRequest extends LegacyActionRequest
             case UpdateRequest updateRequest -> add(updateRequest);
             case null, default -> throw new IllegalArgumentException("No support for request [" + request + "]");
         }
-        indices.add(request.index());
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -503,7 +503,11 @@ public class BulkRequest extends LegacyActionRequest
 
     @Override
     public long ramBytesUsed() {
-        return SHALLOW_SIZE + requests.stream().mapToLong(Accountable::ramBytesUsed).sum();
+        long ramBytesUsed = SHALLOW_SIZE;
+        for (final var request : requests) {
+            ramBytesUsed += request.ramBytesUsed();
+        }
+        return ramBytesUsed;
     }
 
     public Set<String> getIndices() {

--- a/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/IncrementalBulkService.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.action.bulk;
 
-import org.apache.lucene.util.Accountable;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
@@ -294,8 +293,11 @@ public class IncrementalBulkService {
             try {
                 bulkRequest.add(items);
                 releasables.add(releasable);
-                long size = items.stream().mapToLong(Accountable::ramBytesUsed).sum();
-                incrementalOperation.increment(items.size(), size);
+                long ramBytesUsed = 0;
+                for (final var item : items) {
+                    ramBytesUsed += item.ramBytesUsed();
+                }
+                incrementalOperation.increment(items.size(), ramBytesUsed);
                 return true;
             } catch (EsRejectedExecutionException e) {
                 handleBulkFailure(incrementalRequestSubmitted == false, e);


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/144853 (tangentially, in that I'm spending a lot of time looking at profiles, and none of this in mapping code, but it is showing up in my profiles of bulk indexing)

Here's one example of a branch-and-leaves from a profile where some of these changes show up (note though, that we call into this code more than just the once):

<img width="1726" height="260" alt="Screenshot 2026-04-16 at 8 32 17 AM" src="https://github.com/user-attachments/assets/1e0966a3-e3ed-4225-8c91-95fb90964e7a" />

And after (the streaming operations drop out (unrolled), the extra `HashSet.add` is gone, and `BulkRequest.add` inlines into its caller):

<img width="1725" height="270" alt="Screenshot 2026-04-16 at 8 31 36 AM" src="https://github.com/user-attachments/assets/df519f0e-e3a1-43f6-a9b7-a92914f739b1" />

Adding it all up, it's still less than a 1% difference, but it's a pretty low hanging fruit sort of improvement. (And it helps every bulk request that hits Elasticsearch, albeit just a bit.)