### PR TITLE
[9.4] PromQL: absent labels must match empty-string label matchers (#146116)

### DIFF
--- a/docs/changelog/146116.yaml
+++ b/docs/changelog/146116.yaml
@@ -1,0 +1,5 @@
+area: PromQL
+issues: []
+pr: 146116
+summary: "PromQL: absent labels must match empty-string label matchers"
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -688,6 +688,39 @@ PROMQL index=k8s step=1h result=(rate(unmapped.metric[1h])) | SORT result;
 result:double | step:datetime | _timeseries:keyword
 ;
 
+// PromQL spec: absent labels are treated as having value "".
+// {label=""} must therefore match series where the label is absent (NULL).
+absent_label_equals_empty
+required_capability: promql_command_v0
+required_capability: promql_unmapped_fields_filter_nulls
+required_capability: promql_absent_label_matching
+PROMQL index=k8s step=1h result=(sum(network.cost{unmapped.label=""}));
+
+result:double | step:datetime
+61.0          | 2024-05-10T00:00:00.000Z
+;
+
+// {label!="foo"} must match absent series since absent maps to "" and "" != "foo".
+absent_label_not_equals_non_empty
+required_capability: promql_command_v0
+required_capability: promql_unmapped_fields_filter_nulls
+required_capability: promql_absent_label_matching
+PROMQL index=k8s step=1h result=(sum(network.cost{unmapped.label!="foo"}));
+
+result:double | step:datetime
+61.0          | 2024-05-10T00:00:00.000Z
+;
+
+// {label!=""} must NOT match absent series since absent maps to "" and "" does not satisfy != "".
+absent_label_not_equals_empty
+required_capability: promql_command_v0
+required_capability: promql_unmapped_fields_filter_nulls
+required_capability: promql_absent_label_matching
+PROMQL index=k8s step=1h result=(sum(network.cost{unmapped.label!=""}));
+
+result:double | step:datetime
+;
+
 scalar_single_element
 required_capability: promql_command_v0
 required_capability: promql_scalar

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2032,6 +2032,12 @@ public class EsqlCapabilities {
         PROMQL_WITHOUT_GROUPING,
 
         /**
+         * PromQL label matchers that accept the empty string (e.g. {@code {label=""}} or {@code {label!="foo"}})
+         * also match time series where the label is absent ({@code NULL}), per PromQL spec.
+         */
+        PROMQL_ABSENT_LABEL_MATCHING,
+
+        /**
          * Support for`WITHOUT` grouping function
          * that excludes specific dimensions from time-series grouping.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
@@ -958,22 +959,28 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
 
         // Try to extract the exact match
         String exactMatch = AutomatonUtils.matchesExact(matcher.automaton());
-        if (exactMatch != null) {
-            return new Equals(source, field, Literal.keyword(source, exactMatch));
-        }
-
         Expression condition;
-        // Try to extract disjoint patterns (handles mixed prefix/suffix/exact)
-        List<AutomatonUtils.PatternFragment> fragments = AutomatonUtils.extractFragments(matcher.value());
-        if (fragments != null && fragments.isEmpty() == false) {
-            condition = translateDisjointPatterns(source, field, fragments);
+        if (exactMatch != null) {
+            condition = new Equals(source, field, Literal.keyword(source, exactMatch));
         } else {
-            // Fallback to RLIKE with the full automaton pattern
-            // Note: We need to ensure the pattern is properly anchored for PromQL semantics
-            condition = new RLike(source, field, new RLikePattern(matcher.toString()));
+            // Try to extract disjoint patterns (handles mixed prefix/suffix/exact)
+            List<AutomatonUtils.PatternFragment> fragments = AutomatonUtils.extractFragments(matcher.value());
+            if (fragments != null && fragments.isEmpty() == false) {
+                condition = translateDisjointPatterns(source, field, fragments);
+            } else {
+                // Fallback to RLIKE with the full automaton pattern
+                // Note: We need to ensure the pattern is properly anchored for PromQL semantics
+                condition = new RLike(source, field, new RLikePattern(matcher.toString()));
+            }
+            if (matcher.isNegation()) {
+                condition = new Not(source, condition);
+            }
         }
-        if (matcher.isNegation()) {
-            condition = new Not(source, condition);
+        // PromQL spec: absent labels are treated as having value "". If the matcher's automaton
+        // accepts the empty string (e.g. {label=""} or {label!="foo"}), series where the label
+        // field is NULL (absent) must also match.
+        if (matcher.matchesEmpty()) {
+            condition = Predicates.combineOr(List.of(new IsNull(source, field), condition));
         }
         return condition;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanSelectorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlPlanSelectorTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.RLike;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
@@ -105,6 +106,44 @@ public class PromqlPlanSelectorTests extends AbstractPromqlPlanOptimizerTests {
         assertTrue(anyFilterContains(plan, Not.class));
         assertTrue(anyFilterContains(plan, In.class));
         assertTrue(anyFilterContains(plan, StartsWith.class));
+    }
+
+    /**
+     * {label=""} must match series where the label is absent (NULL), because PromQL treats absent labels as "".
+     * The generated filter must be: IS NULL OR field == "".
+     */
+    public void testEmptyStringLabelMatcherIncludesAbsentSeries() {
+        var plan = planPromql("PROMQL index=k8s step=1m avg(network.bytes_in{pod=\"\"})");
+        assertTrue(anyFilterContains(plan, IsNull.class));
+        assertTrue(anyFilterContains(plan, Equals.class));
+    }
+
+    /**
+     * {label!="foo"} must match series where the label is absent (NULL), because absent maps to ""
+     * and "" != "foo". The generated filter must be: IS NULL OR NOT(field == "foo").
+     */
+    public void testNotEqualLabelMatcherIncludesAbsentSeries() {
+        var plan = planPromql("PROMQL index=k8s step=1m avg(network.bytes_in{pod!=\"foo\"})");
+        assertTrue(anyFilterContains(plan, IsNull.class));
+        assertTrue(anyFilterContains(plan, Not.class));
+    }
+
+    /**
+     * {label="foo"} must NOT match absent series: absent maps to "" and "" != "foo".
+     * No IS NULL must appear in the generated filter.
+     */
+    public void testExactLabelMatcherExcludesAbsentSeries() {
+        var plan = planPromql("PROMQL index=k8s step=1m avg(network.bytes_in{pod=\"foo\"})");
+        assertFalse(anyFilterContains(plan, IsNull.class));
+    }
+
+    /**
+     * {label!=""} must NOT match absent series: absent maps to "" and "" does not satisfy != "".
+     * No IS NULL must appear in the generated filter.
+     */
+    public void testNotEqualsEmptyLabelMatcherExcludesAbsentSeries() {
+        var plan = planPromql("PROMQL index=k8s step=1m avg(network.bytes_in{pod!=\"\"})");
+        assertFalse(anyFilterContains(plan, IsNull.class));
     }
 
     public void testGroupByAllInstantSelector() {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - PromQL: absent labels must match empty-string label matchers (#146116)