### PR TITLE
Fix test: sync index shard to ensure we have the latest global checkp…

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -262,9 +262,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeUnmappedLoadIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/145900
-- class: org.elasticsearch.indices.stats.IndexStatsIT
-  method: testFilterCacheStats
-  issue: https://github.com/elastic/elasticsearch/issues/124447
 - class: org.elasticsearch.xpack.eql.qa.ccs_rolling_upgrade.EqlCcsRollingUpgradeIT
   method: testSequences
   issue: https://github.com/elastic/elasticsearch/issues/146263

--- a/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
@@ -207,7 +207,7 @@ public final class SequenceNumbersTestUtils {
      *
      * Uses the default {@link ESIntegTestCase#internalCluster()}.
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(String index) throws IOException {
+    public static void persistGlobalCheckpointOnPrimaryShards(String index) {
         persistGlobalCheckpointOnPrimaryShards(internalCluster(), index);
     }
 
@@ -220,11 +220,14 @@ public final class SequenceNumbersTestUtils {
      * @param cluster the cluster containing the index
      * @param index   the name of the index
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) throws IOException {
+    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) {
         final var future = new PlainActionFuture<Void>();
         try (var listeners = new RefCountingListener(future)) {
             for (String node : cluster.nodesInclude(index)) {
                 for (IndexService indexService : cluster.getInstance(IndicesService.class, node)) {
+                    if (indexService.index().getName().equals(index) == false) {
+                        continue;
+                    }
                     for (IndexShard indexShard : indexService) {
                         if (indexShard.routingEntry().primary() == false) {
                             continue;
@@ -234,8 +237,6 @@ public final class SequenceNumbersTestUtils {
                             indexShard.routingEntry().active(),
                             equalTo(true)
                         );
-
-                        indexShard.sync();
 
                         final var globalCheckpoint = indexShard.getLastKnownGlobalCheckpoint();
                         final var listener = listeners.acquire(

--- a/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
@@ -17,6 +17,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
@@ -24,6 +25,7 @@ import org.elasticsearch.test.InternalTestCluster;
 import java.io.IOException;
 
 import static org.elasticsearch.test.ESIntegTestCase.internalCluster;
+import static org.elasticsearch.test.ESTestCase.assertBusy;
 import static org.elasticsearch.test.ESTestCase.assertThat;
 import static org.elasticsearch.test.ESTestCase.safeGet;
 import static org.hamcrest.Matchers.equalTo;
@@ -186,7 +188,7 @@ public final class SequenceNumbersTestUtils {
      * @param expectedRetainingSeqNo    the expected retaining sequence number for every lease
      */
     public static void assertRetentionLeasesAdvanced(Client client, String indexName, long expectedRetainingSeqNo) throws Exception {
-        ESIntegTestCase.assertBusy(() -> {
+        assertBusy(() -> {
             var stats = client.admin().indices().prepareStats(indexName).get();
             for (var shardStats : stats.getShards()) {
                 for (RetentionLease lease : shardStats.getRetentionLeaseStats().retentionLeases().leases()) {
@@ -208,7 +210,7 @@ public final class SequenceNumbersTestUtils {
      *
      * Uses the default {@link ESIntegTestCase#internalCluster()}.
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(String index) throws IOException {
+    public static void persistGlobalCheckpointOnPrimaryShards(String index) throws Exception {
         persistGlobalCheckpointOnPrimaryShards(internalCluster(), index);
     }
 
@@ -221,7 +223,7 @@ public final class SequenceNumbersTestUtils {
      * @param cluster the cluster containing the index
      * @param index   the name of the index
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) throws IOException {
+    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) throws Exception {
         final var future = new PlainActionFuture<Void>();
         try (var listeners = new RefCountingListener(future)) {
             for (String node : cluster.nodesInclude(index)) {
@@ -238,24 +240,23 @@ public final class SequenceNumbersTestUtils {
                             indexShard.routingEntry().active(),
                             equalTo(true)
                         );
+
+                        final var maxSeqNo = indexShard.withEngine(Engine::getMaxSeqNo);
+
                         indexShard.sync(); // sync to ensure local checkpoint is processed
 
-                        final var globalCheckpoint = indexShard.withEngine(Engine::getMaxSeqNo);
-
-                        // in case the durability is async, ensure local checkpoint updated in ReplicationTracker
-                        indexShard.updateLocalCheckpointForShard(
-                            indexShard.routingEntry().allocationId().getId(),
-                            indexShard.getLocalCheckpoint()
-                        );
+                        if (indexShard.getTranslogDurability() == Translog.Durability.ASYNC) {
+                            assertBusy(() -> assertThat(indexShard.getLastKnownGlobalCheckpoint(), equalTo(maxSeqNo)));
+                        }
 
                         final var listener = listeners.acquire(
                             ignored -> assertThat(
                                 "Global checkpoint not synced for shard: " + indexShard.routingEntry(),
                                 indexShard.getLastSyncedGlobalCheckpoint(),
-                                equalTo(globalCheckpoint)
+                                equalTo(maxSeqNo)
                             )
                         );
-                        indexShard.syncGlobalCheckpoint(globalCheckpoint, e -> {
+                        indexShard.syncGlobalCheckpoint(maxSeqNo, e -> {
                             if (e == null) {
                                 listener.onResponse(null);
                             } else {

--- a/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
@@ -208,7 +208,7 @@ public final class SequenceNumbersTestUtils {
      *
      * Uses the default {@link ESIntegTestCase#internalCluster()}.
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(String index) {
+    public static void persistGlobalCheckpointOnPrimaryShards(String index) throws IOException {
         persistGlobalCheckpointOnPrimaryShards(internalCluster(), index);
     }
 
@@ -221,7 +221,7 @@ public final class SequenceNumbersTestUtils {
      * @param cluster the cluster containing the index
      * @param index   the name of the index
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) {
+    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) throws IOException {
         final var future = new PlainActionFuture<Void>();
         try (var listeners = new RefCountingListener(future)) {
             for (String node : cluster.nodesInclude(index)) {
@@ -235,6 +235,8 @@ public final class SequenceNumbersTestUtils {
                             indexShard.routingEntry().active(),
                             equalTo(true)
                         );
+
+                        indexShard.sync();
 
                         final var globalCheckpoint = indexShard.withEngine(Engine::getMaxSeqNo);
                         final var listener = listeners.acquire(

--- a/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
@@ -238,7 +237,7 @@ public final class SequenceNumbersTestUtils {
 
                         indexShard.sync();
 
-                        final var globalCheckpoint = indexShard.withEngine(Engine::getMaxSeqNo);
+                        final var globalCheckpoint = indexShard.getLastKnownGlobalCheckpoint();
                         final var listener = listeners.acquire(
                             ignored -> assertThat(
                                 "Global checkpoint not synced for shard: " + indexShard.routingEntry(),

--- a/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
@@ -207,7 +208,7 @@ public final class SequenceNumbersTestUtils {
      *
      * Uses the default {@link ESIntegTestCase#internalCluster()}.
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(String index) {
+    public static void persistGlobalCheckpointOnPrimaryShards(String index) throws IOException {
         persistGlobalCheckpointOnPrimaryShards(internalCluster(), index);
     }
 
@@ -220,7 +221,7 @@ public final class SequenceNumbersTestUtils {
      * @param cluster the cluster containing the index
      * @param index   the name of the index
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) {
+    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) throws IOException {
         final var future = new PlainActionFuture<Void>();
         try (var listeners = new RefCountingListener(future)) {
             for (String node : cluster.nodesInclude(index)) {
@@ -237,8 +238,16 @@ public final class SequenceNumbersTestUtils {
                             indexShard.routingEntry().active(),
                             equalTo(true)
                         );
+                        indexShard.sync(); // sync to ensure local checkpoint is processed
 
-                        final var globalCheckpoint = indexShard.getLastKnownGlobalCheckpoint();
+                        final var globalCheckpoint = indexShard.withEngine(Engine::getMaxSeqNo);
+
+                        // in case the durability is async, ensure local checkpoint updated in ReplicationTracker
+                        indexShard.updateLocalCheckpointForShard(
+                            indexShard.routingEntry().allocationId().getId(),
+                            indexShard.getLocalCheckpoint()
+                        );
+
                         final var listener = listeners.acquire(
                             ignored -> assertThat(
                                 "Global checkpoint not synced for shard: " + indexShard.routingEntry(),

--- a/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
@@ -221,50 +222,51 @@ public final class SequenceNumbersTestUtils {
      * This helper method is useful if you do not use replicas in your test setup.
      *
      * @param cluster the cluster containing the index
-     * @param index   the name of the index
+     * @param indexName   the name of the index
      */
-    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String index) throws Exception {
+    public static void persistGlobalCheckpointOnPrimaryShards(InternalTestCluster cluster, String indexName) throws Exception {
         final var future = new PlainActionFuture<Void>();
         try (var listeners = new RefCountingListener(future)) {
-            for (String node : cluster.nodesInclude(index)) {
-                for (IndexService indexService : cluster.getInstance(IndicesService.class, node)) {
-                    if (indexService.index().getName().equals(index) == false) {
+            for (String node : cluster.nodesInclude(indexName)) {
+                final var index = cluster.clusterService().state().metadata().getProject().index(indexName).getIndex();
+                IndexService indexService = cluster.getInstance(IndicesService.class, node).indexServiceSafe(index);
+                for (IndexShard indexShard : indexService) {
+                    if (indexShard.routingEntry().primary() == false) {
                         continue;
                     }
-                    for (IndexShard indexShard : indexService) {
-                        if (indexShard.routingEntry().primary() == false) {
-                            continue;
-                        }
-                        assertThat(
-                            "Shard " + indexShard.getShardUuid() + " should be active",
-                            indexShard.routingEntry().active(),
-                            equalTo(true)
-                        );
+                    assertThat(
+                        "Shard " + indexShard.getShardUuid() + " should be active",
+                        indexShard.routingEntry().active(),
+                        equalTo(true)
+                    );
 
-                        final var maxSeqNo = indexShard.withEngine(Engine::getMaxSeqNo);
+                    final var maxSeqNo = indexShard.withEngine(Engine::getMaxSeqNo);
 
-                        indexShard.sync(); // sync to ensure local checkpoint is processed
+                    indexShard.sync(); // sync to ensure local checkpoint is processed
 
-                        if (indexShard.getTranslogDurability() == Translog.Durability.ASYNC) {
-                            assertBusy(() -> assertThat(indexShard.getLastKnownGlobalCheckpoint(), equalTo(maxSeqNo)));
-                        }
-
-                        final var listener = listeners.acquire(
-                            ignored -> assertThat(
-                                "Global checkpoint not synced for shard: " + indexShard.routingEntry(),
-                                indexShard.getLastSyncedGlobalCheckpoint(),
-                                equalTo(maxSeqNo)
-                            )
-                        );
-                        indexShard.syncGlobalCheckpoint(maxSeqNo, e -> {
-                            if (e == null) {
-                                listener.onResponse(null);
-                            } else {
-                                listener.onFailure(e);
-                            }
-                        });
+                    if (indexShard.getTranslogDurability() == Translog.Durability.ASYNC) {
+                        // in the async case, there is a background process that updates the global checkpoint.
+                        // We need to wait for that process to run. Alternatively, we could use indexShard.updateLocalCheckpointForShard
+                        // to enforce a sync but this would be a bit hacky.
+                        assertBusy(() -> assertThat(indexShard.getLastKnownGlobalCheckpoint(), equalTo(maxSeqNo)));
                     }
+
+                    final var listener = listeners.acquire(
+                        ignored -> assertThat(
+                            "Global checkpoint not synced for shard: " + indexShard.routingEntry(),
+                            indexShard.getLastSyncedGlobalCheckpoint(),
+                            equalTo(maxSeqNo)
+                        )
+                    );
+                    indexShard.syncGlobalCheckpoint(maxSeqNo, e -> {
+                        if (e == null) {
+                            listener.onResponse(null);
+                        } else {
+                            listener.onFailure(e);
+                        }
+                    });
                 }
+
             }
         }
         safeGet(future);

--- a/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersTestUtils.java
@@ -13,7 +13,6 @@ import org.apache.lucene.search.DocIdSetIterator;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;


### PR DESCRIPTION
After adding a method responsible for syncing the in-memory and persisted global checkpoint we directly called engine to get the max seq no. This sequence number might be ahead of the global checkpoint and then an error is triggered.

I changed the helper method to sync the global checkpoint before.

Closes: #124447 