### PR TITLE
ESQL: Disallow `FROM *` in the csv-spec tests (#146218)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
@@ -321,7 +321,8 @@ avoidAttributesRemoval
 required_capability: union_types
 required_capability: join_lookup_v12
 required_capability: keep_regex_extract_attributes
-from multivalue_points,h*,messa* 
+
+from multivalue_points,heights,histogram*,host*,messa*
 | eval  `card` = true, PbehoQUqKSF = "VLGjhcgNkQiEVyCLo", DsxMWtGL = true, qSxTIvUorMim = true, `location` = 8593178066470220111, type = -446161601, FSkGQkgmS = false 
 | eval  PbehoQUqKSF = 753987034, HLNMQfQj = true, `within` = true, `id` = "JDKKkYwhhh", lk = null, aecuvjTkgZza = 510616700, aDAMpuVtNX = null, qCopgNZPt = "AjhJUtZefqKdJYH", BxHHlFoA = "isBrmhKLc"
 | rename message as message 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -4284,7 +4284,7 @@ inlineStatsAfterPruningAggregate6
 required_capability: inline_stats_double_release_fix
 required_capability: join_lookup_v12
 
-from d*,*,-addresses_*
+from date*,decades,dense*,distances,*,-addresses_*
 | rename scalerank as other2
 | rename author.keyword as name_str
 | rename intersects as is_active_bool

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -1974,7 +1974,7 @@ required_capability: union_types
 required_capability: join_lookup_v12
 required_capability: fix_join_masking_regex_extract
 required_capability: lookup_join_sort_warning
-from books,message_*,ul*
+from books,message_*,ul_*
 | enrich languages_policy on status
 | drop `language_name`, `bytes_out`, `id`, id
 | dissect book_no "%{type}"

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -376,8 +376,25 @@ public class CsvIT extends ESTestCase {
         Stream.of(request.indices()).flatMap(pattern -> {
             assert pattern.contains("<") == false : "Date-math is not supported in test";
             if (pattern.contains("*")) {
-                assert pattern.endsWith("*") : "Only suffix patterns are supported in test";
-                var prefix = pattern.substring(pattern.startsWith("-") ? 1 : 0, pattern.length() - 1);
+                if (pattern.equals("*")) {
+                    switch (currentGroupName) {
+                        // Temporarily allow a few so they have time to migrate away
+                        case "enrich", "inlinestats", "limit", "lookup-join" -> logger.warn("stop using FROM *");
+                        default -> throw new IllegalStateException(
+                            "FROM * is not allowed in csv-spec tests because it makes them brittle. We add new data sets frequently."
+                        );
+                    }
+                    return CSV_DATASET.values().stream();
+                }
+                if (pattern.endsWith("*") == false) {
+                    throw new IllegalStateException("CsvIT only supports suffix patterns but got: " + pattern);
+                }
+                String prefix = pattern.substring(pattern.startsWith("-") ? 1 : 0, pattern.length() - 1);
+                if (prefix.length() < 3) {
+                    throw new IllegalStateException(
+                        "FROM pattern* may not be short in csv-spec tests because it makes them brittle. We add new data sets frequently."
+                    );
+                }
                 return CSV_DATASET.values().stream().filter(ds -> ds.indexName().startsWith(prefix));
             } else {
                 return Stream.of(CSV_DATASET.get(pattern));


### PR DESCRIPTION
They are brittle. When we add new things to load these unrelated tests change. We have tests for `FROM *` in the other tests.
