### PR TITLE
Fix ref-count leak in MergeResultWireCompatibilityTopHitsTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/search/MergeResultWireCompatibilityTopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MergeResultWireCompatibilityTopHitsTests.java
@@ -105,7 +105,15 @@ public class MergeResultWireCompatibilityTopHitsTests extends ESTestCase {
      * {@link SearchHits} expanded during the write are released afterwards.
      */
     private void assertNoLeakOnWriteTo(TransportVersion serializedVersion, TransportVersion outVersion) throws Exception {
-        InternalAggregations pooledAggs = roundTripToPooledTopHits(createAggregationsWithTopHits(), serializedVersion);
+        InternalAggregations initialAggs = createAggregationsWithTopHits();
+        SearchHits initialHits = initialAggs.<InternalTopHits>get("th").getHits();
+        InternalAggregations pooledAggs;
+        try {
+            pooledAggs = roundTripToPooledTopHits(initialAggs, serializedVersion);
+        } finally {
+            // Release the pre-round-trip SearchHits (and their inner SearchHit objects via deallocate()).
+            initialHits.decRef();
+        }
         SearchHits pooledHits = pooledAggs.<InternalTopHits>get("th").getHits();
         assertTrue("round-trip must yield pooled SearchHits (hit with _source)", pooledHits.isPooled());
 


### PR DESCRIPTION
  - `assertNoLeakOnWriteTo` was creating `InternalAggregations` with pooled `SearchHits`
    via `createAggregationsWithTopHits()`, then passing them to `roundTripToPooledTopHits()`.
    The pre-round-trip `SearchHits` were never `decRef()`'d, causing a ref-count leak.
  - Capture the initial `SearchHits` reference before the round trip and release it
    in a `finally` block, so the pre-round-trip hits are always freed regardless of
    whether the round trip succeeds or throws.
