### PR TITLE
[8.19] Remove Security Manager references from modules (#146437)

### DIFF
--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
@@ -14,7 +14,6 @@ import org.apache.lucene.expressions.SimpleBindings;
 import org.apache.lucene.expressions.js.JavascriptCompiler;
 import org.apache.lucene.expressions.js.VariableContext;
 import org.apache.lucene.search.DoubleValuesSource;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
@@ -24,7 +23,6 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.script.BucketAggregationScript;
 import org.elasticsearch.script.BucketAggregationSelectorScript;
-import org.elasticsearch.script.ClassPermission;
 import org.elasticsearch.script.DoubleValuesScript;
 import org.elasticsearch.script.FieldScript;
 import org.elasticsearch.script.FilterScript;
@@ -36,9 +34,6 @@ import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.TermsSetQueryScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -156,36 +151,13 @@ public class ExpressionScriptEngine implements ScriptEngine {
 
     @Override
     public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
-        // classloader created here
-        final SecurityManager sm = System.getSecurityManager();
-        SpecialPermission.check();
-        Expression expr = AccessController.doPrivileged(new PrivilegedAction<Expression>() {
-            @Override
-            public Expression run() {
-                try {
-                    // snapshot our context here, we check on behalf of the expression
-                    AccessControlContext engineContext = AccessController.getContext();
-                    ClassLoader loader = getClass().getClassLoader();
-                    if (sm != null) {
-                        loader = new ClassLoader(loader) {
-                            @Override
-                            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-                                try {
-                                    engineContext.checkPermission(new ClassPermission(name));
-                                } catch (SecurityException e) {
-                                    throw new ClassNotFoundException(name, e);
-                                }
-                                return super.loadClass(name, resolve);
-                            }
-                        };
-                    }
-                    // NOTE: validation is delayed to allow runtime vars, and we don't have access to per index stuff here
-                    return JavascriptCompiler.compile(scriptSource, JavascriptCompiler.DEFAULT_FUNCTIONS, loader);
-                } catch (ParseException e) {
-                    throw convertToScriptException("compile error", scriptSource, scriptSource, e);
-                }
-            }
-        });
+        Expression expr;
+        try {
+            // NOTE: validation is delayed to allow runtime vars, and we don't have access to per index stuff here
+            expr = JavascriptCompiler.compile(scriptSource, JavascriptCompiler.DEFAULT_FUNCTIONS, getClass().getClassLoader());
+        } catch (ParseException e) {
+            throw convertToScriptException("compile error", scriptSource, scriptSource, e);
+        }
         if (contexts.containsKey(context) == false) {
             throw new IllegalArgumentException("expression engine does not know how to handle script context [" + context.name + "]");
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.bootstrap.BootstrapInfo;
 import org.elasticsearch.painless.antlr.Walker;
 import org.elasticsearch.painless.ir.ClassNode;
 import org.elasticsearch.painless.lookup.PainlessLookup;
@@ -31,11 +30,6 @@ import org.elasticsearch.painless.symbol.WriteScope;
 import org.objectweb.asm.util.Printer;
 
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.security.CodeSource;
-import java.security.SecureClassLoader;
-import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,26 +45,9 @@ import static org.elasticsearch.painless.WriterConstants.CLASS_NAME;
 final class Compiler {
 
     /**
-     * Define the class with lowest privileges.
+     * A class loader used to define Painless scripts.
      */
-    private static final CodeSource CODESOURCE;
-
-    /**
-     * Setup the code privileges.
-     */
-    static {
-        try {
-            // Setup the code privileges.
-            CODESOURCE = new CodeSource(new URL("file:" + BootstrapInfo.UNTRUSTED_CODEBASE), (Certificate[]) null);
-        } catch (MalformedURLException impossible) {
-            throw new RuntimeException(impossible);
-        }
-    }
-
-    /**
-     * A secure class loader used to define Painless scripts.
-     */
-    final class Loader extends SecureClassLoader {
+    final class Loader extends ClassLoader {
         private final AtomicInteger lambdaCounter = new AtomicInteger(0);
 
         /**
@@ -104,7 +81,7 @@ final class Compiler {
          * @return A Class object defining a factory.
          */
         Class<?> defineFactory(String name, byte[] bytes) {
-            return defineClass(name, bytes, 0, bytes.length, CODESOURCE);
+            return defineClass(name, bytes, 0, bytes.length);
         }
 
         /**
@@ -114,7 +91,7 @@ final class Compiler {
          * @return A Class object extending {@link PainlessScript}.
          */
         Class<? extends PainlessScript> defineScript(String name, byte[] bytes) {
-            return defineClass(name, bytes, 0, bytes.length, CODESOURCE).asSubclass(PainlessScript.class);
+            return defineClass(name, bytes, 0, bytes.length).asSubclass(PainlessScript.class);
         }
 
         /**
@@ -124,7 +101,7 @@ final class Compiler {
          * @return A Class object.
          */
         Class<?> defineLambda(String name, byte[] bytes) {
-            return defineClass(name, bytes, 0, bytes.length, CODESOURCE);
+            return defineClass(name, bytes, 0, bytes.length);
         }
 
         /**

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.painless.Compiler.Loader;
 import org.elasticsearch.painless.lookup.PainlessLookup;
@@ -27,7 +26,6 @@ import org.objectweb.asm.commons.GeneratorAdapter;
 
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
-import java.security.Permissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,14 +45,6 @@ public final class PainlessScriptEngine implements ScriptEngine {
      * Standard name of the Painless language.
      */
     public static final String NAME = "painless";
-
-    /*
-     * Setup the allowed permissions.
-     */
-    static {
-        final Permissions none = new Permissions();
-        none.setReadOnly();
-    }
 
     /**
      * Default compiler settings to be used. Note that {@link CompilerSettings} is mutable but this instance shouldn't be mutated outside
@@ -109,10 +99,6 @@ public final class PainlessScriptEngine implements ScriptEngine {
     public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
         Compiler compiler = contextsToCompilers.get(context);
 
-        // Check we ourselves are not being called by unprivileged code.
-        SpecialPermission.check();
-
-        // Create our loader (which loads compiled code with no permissions).
         final Loader loader = compiler.createLoader(getClass().getClassLoader());
 
         ScriptScope scriptScope = compile(contextsToCompilers.get(context), loader, scriptName, scriptSource, params);


### PR DESCRIPTION
Backport of #146437 to 8.19.

Note: On 8.19, `JavascriptCompiler.compile` requires an explicit `ClassLoader` parameter (no 2-arg overload), so the expression engine passes `getClass().getClassLoader()` directly instead of the SM-wrapped custom classloader.