### PR TITLE
[9.3] Move esql:qa multi-node tests to Part5 (#146492)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -401,6 +401,8 @@ allprojects {
         splitForCI(project, "Part4")
       } else if (project.path.contains(":esql-datasource") || project.path.contains(":esql-core")) {
         splitForCI(project, "Part5")
+      } else if (project.path.contains(":esql:qa") && project.path.contains("multi-node")) {
+        splitForCI(project, "Part5")
       } else if (project.path.contains(":esql:qa")) {
         splitForCI(project, "Part3")
       } else if (project.path.contains(":eql") || project.path.contains(":sql") || project.path.contains(":transform") ||


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Move esql:qa multi-node tests to Part5 (#146492)