### PR TITLE
Remove request-body drain assertion in gcs http handler

### DIFF
--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
@@ -269,8 +269,6 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                 exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
             }
         } finally {
-            int read = exchange.getRequestBody().read();
-            assert read == -1 : "Request body should have been fully read here but saw [" + read + "]";
             exchange.close();
         }
     }


### PR DESCRIPTION
I'm not able to reproduce #146196 locally, but I see that the failure occurred when reading a byte at the end of a request, which was removed in https://github.com/elastic/elasticsearch/pull/118737
> This fails a lot because HttpExchange#sendResponseHeaders closes the request if there's no response body.

Resolves #146196