### PR TITLE
[9.3] Remove Security Manager references from client (#146537)

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
@@ -30,9 +30,7 @@ import org.apache.http.util.VersionInfo;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.AccessController;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -104,12 +102,7 @@ public final class RestClientBuilder {
 
         VersionInfo httpClientVersion = null;
         try {
-            httpClientVersion = AccessController.doPrivileged(
-                (PrivilegedAction<VersionInfo>) () -> VersionInfo.loadVersionInfo(
-                    "org.apache.http.nio.client",
-                    HttpAsyncClientBuilder.class.getClassLoader()
-                )
-            );
+            httpClientVersion = VersionInfo.loadVersionInfo("org.apache.http.nio.client", HttpAsyncClientBuilder.class.getClassLoader());
         } catch (Exception e) {
             // Keep unknown
         }
@@ -285,9 +278,7 @@ public final class RestClientBuilder {
         if (failureListener == null) {
             failureListener = new RestClient.FailureListener();
         }
-        CloseableHttpAsyncClient httpClient = AccessController.doPrivileged(
-            (PrivilegedAction<CloseableHttpAsyncClient>) this::createHttpClient
-        );
+        CloseableHttpAsyncClient httpClient = createHttpClient();
         RestClient restClient = new RestClient(
             httpClient,
             defaultHeaders,
@@ -344,8 +335,7 @@ public final class RestClientBuilder {
                 httpClientBuilder = httpClientConfigCallback.customizeHttpClient(httpClientBuilder);
             }
 
-            final HttpAsyncClientBuilder finalBuilder = httpClientBuilder;
-            return AccessController.doPrivileged((PrivilegedAction<CloseableHttpAsyncClient>) finalBuilder::build);
+            return httpClientBuilder.build();
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("could not create the default ssl context", e);
         }

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderIntegTests.java
@@ -35,10 +35,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.AccessController;
 import java.security.KeyFactory;
 import java.security.KeyStore;
-import java.security.PrivilegedAction;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -190,7 +188,7 @@ public class RestClientBuilderIntegTests extends RestClientTestCase {
      * 12.0.1 so we pin to TLSv1.2 when running on an earlier JDK
      */
     private static String getProtocol() {
-        String version = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("java.version"));
+        String version = System.getProperty("java.version");
         String[] parts = version.split("-");
         String[] numericComponents;
         if (parts.length == 1) {

--- a/client/sniffer/src/main/java/org/elasticsearch/client/sniff/Sniffer.java
+++ b/client/sniffer/src/main/java/org/elasticsearch/client/sniff/Sniffer.java
@@ -26,8 +26,6 @@ import org.elasticsearch.client.RestClientBuilder;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -298,25 +296,15 @@ public class Sniffer implements Closeable {
 
         private SnifferThreadFactory(String namePrefix) {
             this.namePrefix = namePrefix;
-            this.originalThreadFactory = AccessController.doPrivileged(new PrivilegedAction<ThreadFactory>() {
-                @Override
-                public ThreadFactory run() {
-                    return Executors.defaultThreadFactory();
-                }
-            });
+            this.originalThreadFactory = Executors.defaultThreadFactory();
         }
 
         @Override
         public Thread newThread(final Runnable r) {
-            return AccessController.doPrivileged(new PrivilegedAction<Thread>() {
-                @Override
-                public Thread run() {
-                    Thread t = originalThreadFactory.newThread(r);
-                    t.setName(namePrefix + "[T#" + threadNumber.getAndIncrement() + "]");
-                    t.setDaemon(true);
-                    return t;
-                }
-            });
+            Thread t = originalThreadFactory.newThread(r);
+            t.setName(namePrefix + "[T#" + threadNumber.getAndIncrement() + "]");
+            t.setDaemon(true);
+            return t;
         }
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Remove Security Manager references from client (#146537)