### PR TITLE
[ESQL] Filtered aggregate pushdown for external sources

### DIFF
--- a/docs/changelog/146597.yaml
+++ b/docs/changelog/146597.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 146597
+summary: Filtered aggregate pushdown for external sources
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdown.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdown.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared helpers for aggregate pushdown rules ({@link PushStatsToExternalSource} and
+ * {@link PushAggregatesToExternalSource}) that extract an {@link ExternalSourceExec}
+ * from the plan tree and resolve filtered metadata using {@link SplitFilterClassifier}.
+ */
+final class ExternalSourceAggregatePushdown {
+
+    private ExternalSourceAggregatePushdown() {}
+
+    /**
+     * Parsed result from the subtree below an {@code AggregateExec}: the external source,
+     * any alias mapping from intermediate {@code EvalExec}/{@code ProjectExec} nodes, and
+     * the filter condition from any intermediate {@code FilterExec}.
+     */
+    record ExternalSourceInfo(ExternalSourceExec externalExec, AttributeMap<Attribute> aliasReplacedBy, Expression filterCondition) {}
+
+    /**
+     * Extracts the ExternalSourceExec and optional filter/alias information from the plan
+     * subtree below an AggregateExec. Supports these patterns:
+     * <ul>
+     *   <li>{@code ExternalSourceExec}</li>
+     *   <li>{@code EvalExec -> ExternalSourceExec}</li>
+     *   <li>{@code ProjectExec -> ExternalSourceExec}</li>
+     *   <li>{@code FilterExec -> ExternalSourceExec}</li>
+     *   <li>{@code FilterExec -> EvalExec -> ExternalSourceExec}</li>
+     *   <li>{@code FilterExec -> ProjectExec -> ExternalSourceExec}</li>
+     * </ul>
+     * Returns null if the subtree doesn't match any recognized pattern.
+     */
+    static ExternalSourceInfo extractExternalSource(PhysicalPlan child) {
+        if (child instanceof ExternalSourceExec ext) {
+            return new ExternalSourceInfo(ext, AttributeMap.emptyAttributeMap(), null);
+        }
+        if (child instanceof EvalExec evalExec && evalExec.child() instanceof ExternalSourceExec ext) {
+            return new ExternalSourceInfo(ext, PushFiltersToSource.getAliasReplacedBy(evalExec), null);
+        }
+        if (child instanceof ProjectExec projectExec && projectExec.child() instanceof ExternalSourceExec ext) {
+            return new ExternalSourceInfo(ext, PushFiltersToSource.getAliasReplacedBy(projectExec), null);
+        }
+        if (child instanceof FilterExec filterExec) {
+            PhysicalPlan filterChild = filterExec.child();
+            if (filterChild instanceof ExternalSourceExec ext) {
+                return new ExternalSourceInfo(ext, AttributeMap.emptyAttributeMap(), filterExec.condition());
+            }
+            if (filterChild instanceof EvalExec evalExec && evalExec.child() instanceof ExternalSourceExec ext) {
+                return new ExternalSourceInfo(ext, PushFiltersToSource.getAliasReplacedBy(evalExec), filterExec.condition());
+            }
+            if (filterChild instanceof ProjectExec projectExec && projectExec.child() instanceof ExternalSourceExec ext) {
+                return new ExternalSourceInfo(ext, PushFiltersToSource.getAliasReplacedBy(projectExec), filterExec.condition());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves effective metadata for splits filtered by the given condition. Evaluates
+     * the filter against per-split statistics, classifying each split as MATCH, MISS, or
+     * AMBIGUOUS. Returns merged statistics from MATCH-only splits, or null if any split
+     * is AMBIGUOUS or classification fails.
+     * <p>
+     * When a single split is present and has its own statistics, those are preferred over
+     * file-level metadata to avoid misclassification when split stats differ from the whole.
+     */
+    static Map<String, Object> resolveFilteredMetadata(ExternalSourceExec externalExec, Expression filterCondition) {
+        List<? extends ExternalSplit> splits = externalExec.splits();
+
+        if (splits.isEmpty() || splits.size() == 1) {
+            Map<String, Object> metadata = null;
+            if (splits.size() == 1
+                && splits.getFirst() instanceof FileSplit fs
+                && fs.statistics() != null
+                && fs.statistics().isEmpty() == false) {
+                metadata = fs.statistics();
+            }
+            if (metadata == null) {
+                metadata = externalExec.sourceMetadata();
+            }
+            if (metadata == null || metadata.isEmpty()) {
+                return null;
+            }
+            SplitFilterClassifier.SplitMatch result = SplitFilterClassifier.classifyExpression(filterCondition, metadata);
+            return switch (result) {
+                case MATCH -> metadata;
+                case MISS -> emptyStatsMetadata();
+                case AMBIGUOUS -> null;
+            };
+        }
+
+        List<Map<String, Object>> matchedStats = new ArrayList<>();
+        for (ExternalSplit split : splits) {
+            if (split instanceof FileSplit == false) {
+                return null;
+            }
+            Map<String, Object> stats = ((FileSplit) split).statistics();
+            if (stats == null || stats.isEmpty()) {
+                return null;
+            }
+            SplitFilterClassifier.SplitMatch result = SplitFilterClassifier.classifyExpression(filterCondition, stats);
+            switch (result) {
+                case MATCH -> matchedStats.add(stats);
+                case MISS -> {
+                }
+                case AMBIGUOUS -> {
+                    return null;
+                }
+            }
+        }
+
+        if (matchedStats.isEmpty()) {
+            return emptyStatsMetadata();
+        }
+        return SourceStatisticsSerializer.mergeStatistics(matchedStats);
+    }
+
+    static Map<String, Object> emptyStatsMetadata() {
+        return Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 0L);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -24,11 +24,9 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
-import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
-import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 
 import java.util.ArrayList;
@@ -42,9 +40,10 @@ import java.util.OptionalLong;
  * required statistics are available in the file metadata. Replaces the AggregateExec +
  * ExternalSourceExec subtree with a LocalSourceExec containing pre-computed results.
  * <p>
- * Handles intermediate EvalExec (from EVAL) and ProjectExec (from RENAME) nodes between
- * the aggregate and external source by resolving aliased attribute names back to the
- * original column names before metadata lookup.
+ * Handles intermediate EvalExec (from EVAL), ProjectExec (from RENAME), and FilterExec
+ * nodes between the aggregate and external source by resolving aliased attribute names
+ * back to the original column names before metadata lookup, and by classifying filters
+ * against per-split statistics when present.
  * <p>
  * Supports multi-split queries when per-split statistics are available in
  * {@link FileSplit#statistics()}. Statistics are merged across splits (sum row counts,
@@ -58,31 +57,31 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
 
     @Override
     protected PhysicalPlan rule(AggregateExec aggregateExec) {
-        PhysicalPlan child = aggregateExec.child();
-        ExternalSourceExec externalExec;
-        AttributeMap<Attribute> aliasReplacedBy;
-
-        if (child instanceof ExternalSourceExec ext) {
-            externalExec = ext;
-            aliasReplacedBy = AttributeMap.emptyAttributeMap();
-        } else if (child instanceof EvalExec evalExec && evalExec.child() instanceof ExternalSourceExec ext) {
-            externalExec = ext;
-            aliasReplacedBy = PushFiltersToSource.getAliasReplacedBy(evalExec);
-        } else if (child instanceof ProjectExec projectExec && projectExec.child() instanceof ExternalSourceExec ext) {
-            externalExec = ext;
-            aliasReplacedBy = PushFiltersToSource.getAliasReplacedBy(projectExec);
-        } else {
+        ExternalSourceAggregatePushdown.ExternalSourceInfo info = ExternalSourceAggregatePushdown.extractExternalSource(
+            aggregateExec.child()
+        );
+        if (info == null) {
             return aggregateExec;
         }
+        ExternalSourceExec externalExec = info.externalExec();
+        AttributeMap<Attribute> aliasReplacedBy = info.aliasReplacedBy();
+        Expression filterCondition = info.filterCondition();
 
         if (aggregateExec.groupings().isEmpty() == false) {
             return aggregateExec;
         }
 
-        Map<String, Object> sourceMetadata = SourceStatisticsSerializer.resolveEffectiveMetadata(
-            externalExec.splits(),
-            externalExec.sourceMetadata()
-        );
+        Expression filterForClassification = filterCondition;
+        if (filterCondition != null && aliasReplacedBy.isEmpty() == false) {
+            filterForClassification = filterCondition.transformDown(ReferenceAttribute.class, r -> aliasReplacedBy.resolve(r, r));
+        }
+
+        Map<String, Object> sourceMetadata;
+        if (filterForClassification != null) {
+            sourceMetadata = ExternalSourceAggregatePushdown.resolveFilteredMetadata(externalExec, filterForClassification);
+        } else {
+            sourceMetadata = SourceStatisticsSerializer.resolveEffectiveMetadata(externalExec.splits(), externalExec.sourceMetadata());
+        }
         if (sourceMetadata == null) {
             return aggregateExec;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifier.java
@@ -542,17 +542,8 @@ final class SplitFilterClassifier {
             }
             return Double.compare(na.doubleValue(), nb.doubleValue());
         }
-        if (a instanceof Comparable ca && b.getClass().isAssignableFrom(a.getClass())) {
-            try {
-                return ca.compareTo(b);
-            } catch (ClassCastException e) {
-                return Integer.MIN_VALUE;
-            }
-        }
-        if (a instanceof Comparable && b instanceof Comparable) {
-            String sa = a.toString();
-            String sb = b.toString();
-            return sa.compareTo(sb);
+        if (a instanceof Comparable ca && a.getClass() == b.getClass()) {
+            return ca.compareTo(b);
         }
         return Integer.MIN_VALUE;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifier.java
@@ -1,0 +1,563 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * Evaluates filter predicates against per-split (row-group/stripe) statistics to classify
+ * each split into one of three states: all rows match the filter, no rows match, or the
+ * result is unknown from statistics alone.
+ * <p>
+ * Used by aggregate pushdown rules to determine whether aggregates (COUNT, MIN, MAX) can
+ * be resolved from metadata without scanning data. When all splits are classified as MATCH
+ * or MISS, the aggregate can be computed from the MATCH splits' statistics alone.
+ * <p>
+ * Supports AND, OR, and NOT logical operators, IS NULL / IS NOT NULL null checks, IN lists,
+ * and leaf comparisons (field op literal). Unsupported leaf expressions (function calls, etc.)
+ * conservatively return AMBIGUOUS.
+ * NOT of MATCH yields MISS; NOT of MISS conservatively yields AMBIGUOUS because null rows
+ * still produce UNKNOWN under WHERE semantics.
+ * <p>
+ * NULL handling: a split is only classified as MATCH when the filter column has zero null
+ * values ({@code null_count = 0}), because NULL comparisons evaluate to UNKNOWN and are
+ * dropped by WHERE clauses.
+ */
+final class SplitFilterClassifier {
+
+    enum SplitMatch {
+        /** All rows in the split satisfy the filter predicate. */
+        MATCH,
+        /** No rows in the split satisfy the filter predicate. */
+        MISS,
+        /** Cannot determine from statistics alone; data scan required. */
+        AMBIGUOUS
+    }
+
+    private SplitFilterClassifier() {}
+
+    /**
+     * Classifies a split by recursively evaluating the filter expression tree against its statistics.
+     * Supports AND, OR, NOT, and leaf comparisons (field op literal).
+     */
+    public static SplitMatch classifyExpression(Expression filter, Map<String, Object> splitStats) {
+        if (filter == null || splitStats == null || splitStats.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        return classifyRecursive(filter, splitStats);
+    }
+
+    /**
+     * Classifies a split by evaluating AND-connected filter conjuncts against its statistics.
+     * Each conjunct is classified recursively, so nested {@code And}, {@code Or}, and {@code Not}
+     * within a conjunct are handled.
+     * <p>
+     * Conjunction semantics: MISS if any conjunct is MISS (short-circuit), MATCH only if
+     * all conjuncts are MATCH, AMBIGUOUS otherwise.
+     *
+     * @param filterConjuncts AND-separated filter expressions (from {@code splitAnd()})
+     * @param splitStats per-split statistics map using {@link SourceStatisticsSerializer} keys
+     * @return the classification for this split
+     */
+    static SplitMatch classifySplit(List<Expression> filterConjuncts, Map<String, Object> splitStats) {
+        if (filterConjuncts.isEmpty() || splitStats == null || splitStats.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (filterConjuncts.size() == 1) {
+            return classifyRecursive(filterConjuncts.getFirst(), splitStats);
+        }
+        boolean allMatch = true;
+        for (Expression conjunct : filterConjuncts) {
+            SplitMatch result = classifyRecursive(conjunct, splitStats);
+            if (result == SplitMatch.MISS) {
+                return SplitMatch.MISS;
+            }
+            if (result != SplitMatch.MATCH) {
+                allMatch = false;
+            }
+        }
+        return allMatch ? SplitMatch.MATCH : SplitMatch.AMBIGUOUS;
+    }
+
+    private static SplitMatch classifyRecursive(Expression expr, Map<String, Object> splitStats) {
+        if (expr instanceof And and) {
+            SplitMatch left = classifyRecursive(and.left(), splitStats);
+            if (left == SplitMatch.MISS) {
+                return SplitMatch.MISS;
+            }
+            SplitMatch right = classifyRecursive(and.right(), splitStats);
+            if (right == SplitMatch.MISS) {
+                return SplitMatch.MISS;
+            }
+            if (left == SplitMatch.MATCH && right == SplitMatch.MATCH) {
+                return SplitMatch.MATCH;
+            }
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (expr instanceof Or or) {
+            SplitMatch left = classifyRecursive(or.left(), splitStats);
+            if (left == SplitMatch.MATCH) {
+                return SplitMatch.MATCH;
+            }
+            SplitMatch right = classifyRecursive(or.right(), splitStats);
+            if (right == SplitMatch.MATCH) {
+                return SplitMatch.MATCH;
+            }
+            if (left == SplitMatch.MISS && right == SplitMatch.MISS) {
+                return SplitMatch.MISS;
+            }
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (expr instanceof Not not) {
+            SplitMatch child = classifyRecursive(not.field(), splitStats);
+            return switch (child) {
+                case MATCH -> SplitMatch.MISS;
+                case MISS -> SplitMatch.AMBIGUOUS;
+                case AMBIGUOUS -> SplitMatch.AMBIGUOUS;
+            };
+        }
+        if (expr instanceof IsNull isNull) {
+            return classifyIsNull(isNull, splitStats);
+        }
+        if (expr instanceof IsNotNull isNotNull) {
+            return classifyIsNotNull(isNotNull, splitStats);
+        }
+        if (expr instanceof In in) {
+            return classifyIn(in, splitStats);
+        }
+        return classifyConjunct(expr, splitStats);
+    }
+
+    private static SplitMatch classifyConjunct(Expression expr, Map<String, Object> splitStats) {
+        String columnName;
+        Object literalValue;
+        boolean reversed;
+
+        if (expr instanceof GreaterThan gt) {
+            columnName = extractColumnName(gt.left());
+            literalValue = extractLiteralValue(gt.right());
+            reversed = false;
+            if (columnName == null || literalValue == null) {
+                columnName = extractColumnName(gt.right());
+                literalValue = extractLiteralValue(gt.left());
+                reversed = true;
+            }
+            if (columnName == null || literalValue == null) {
+                return SplitMatch.AMBIGUOUS;
+            }
+            return reversed
+                ? classifyLessThan(columnName, literalValue, splitStats)
+                : classifyGreaterThan(columnName, literalValue, splitStats);
+        } else if (expr instanceof GreaterThanOrEqual gte) {
+            columnName = extractColumnName(gte.left());
+            literalValue = extractLiteralValue(gte.right());
+            reversed = false;
+            if (columnName == null || literalValue == null) {
+                columnName = extractColumnName(gte.right());
+                literalValue = extractLiteralValue(gte.left());
+                reversed = true;
+            }
+            if (columnName == null || literalValue == null) {
+                return SplitMatch.AMBIGUOUS;
+            }
+            return reversed
+                ? classifyLessThanOrEqual(columnName, literalValue, splitStats)
+                : classifyGreaterThanOrEqual(columnName, literalValue, splitStats);
+        } else if (expr instanceof LessThan lt) {
+            columnName = extractColumnName(lt.left());
+            literalValue = extractLiteralValue(lt.right());
+            reversed = false;
+            if (columnName == null || literalValue == null) {
+                columnName = extractColumnName(lt.right());
+                literalValue = extractLiteralValue(lt.left());
+                reversed = true;
+            }
+            if (columnName == null || literalValue == null) {
+                return SplitMatch.AMBIGUOUS;
+            }
+            return reversed
+                ? classifyGreaterThan(columnName, literalValue, splitStats)
+                : classifyLessThan(columnName, literalValue, splitStats);
+        } else if (expr instanceof LessThanOrEqual lte) {
+            columnName = extractColumnName(lte.left());
+            literalValue = extractLiteralValue(lte.right());
+            reversed = false;
+            if (columnName == null || literalValue == null) {
+                columnName = extractColumnName(lte.right());
+                literalValue = extractLiteralValue(lte.left());
+                reversed = true;
+            }
+            if (columnName == null || literalValue == null) {
+                return SplitMatch.AMBIGUOUS;
+            }
+            return reversed
+                ? classifyGreaterThanOrEqual(columnName, literalValue, splitStats)
+                : classifyLessThanOrEqual(columnName, literalValue, splitStats);
+        } else if (expr instanceof Equals eq) {
+            columnName = extractColumnName(eq.left());
+            literalValue = extractLiteralValue(eq.right());
+            if (columnName == null || literalValue == null) {
+                columnName = extractColumnName(eq.right());
+                literalValue = extractLiteralValue(eq.left());
+            }
+            if (columnName == null || literalValue == null) {
+                return SplitMatch.AMBIGUOUS;
+            }
+            return classifyEquals(columnName, literalValue, splitStats);
+        } else if (expr instanceof NotEquals neq) {
+            columnName = extractColumnName(neq.left());
+            literalValue = extractLiteralValue(neq.right());
+            if (columnName == null || literalValue == null) {
+                columnName = extractColumnName(neq.right());
+                literalValue = extractLiteralValue(neq.left());
+            }
+            if (columnName == null || literalValue == null) {
+                return SplitMatch.AMBIGUOUS;
+            }
+            return classifyNotEquals(columnName, literalValue, splitStats);
+        }
+        return SplitMatch.AMBIGUOUS;
+    }
+
+    /**
+     * {@code col IS NULL}: MATCH when null_count == row_count, MISS when null_count == 0.
+     */
+    private static SplitMatch classifyIsNull(IsNull isNull, Map<String, Object> splitStats) {
+        String columnName = extractColumnName(isNull.field());
+        if (columnName == null) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        OptionalLong nullCount = SourceStatisticsSerializer.extractColumnNullCount(splitStats, columnName);
+        if (nullCount.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (nullCount.getAsLong() == 0) {
+            return SplitMatch.MISS;
+        }
+        OptionalLong rowCount = SourceStatisticsSerializer.extractRowCount(splitStats);
+        if (rowCount.isPresent() && nullCount.getAsLong() == rowCount.getAsLong()) {
+            return SplitMatch.MATCH;
+        }
+        return SplitMatch.AMBIGUOUS;
+    }
+
+    /**
+     * {@code col IS NOT NULL}: MATCH when null_count == 0, MISS when null_count == row_count.
+     */
+    private static SplitMatch classifyIsNotNull(IsNotNull isNotNull, Map<String, Object> splitStats) {
+        String columnName = extractColumnName(isNotNull.field());
+        if (columnName == null) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        OptionalLong nullCount = SourceStatisticsSerializer.extractColumnNullCount(splitStats, columnName);
+        if (nullCount.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (nullCount.getAsLong() == 0) {
+            return SplitMatch.MATCH;
+        }
+        OptionalLong rowCount = SourceStatisticsSerializer.extractRowCount(splitStats);
+        if (rowCount.isPresent() && nullCount.getAsLong() == rowCount.getAsLong()) {
+            return SplitMatch.MISS;
+        }
+        return SplitMatch.AMBIGUOUS;
+    }
+
+    /**
+     * {@code col IN (lit1, lit2, ...)}: MISS when all literals fall outside [min, max],
+     * MATCH when min == max and that value equals one of the literals and null_count == 0.
+     */
+    private static SplitMatch classifyIn(In in, Map<String, Object> splitStats) {
+        String columnName = extractColumnName(in.value());
+        if (columnName == null) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        List<Object> literalValues = in.list().stream().map(SplitFilterClassifier::extractLiteralValue).toList();
+        if (literalValues.stream().anyMatch(v -> v == null)) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        Object min = minOpt.get();
+        Object max = maxOpt.get();
+
+        boolean anyInRange = false;
+        for (Object lit : literalValues) {
+            int cmpMin = compareValues(lit, min);
+            int cmpMax = compareValues(lit, max);
+            if (cmpMin == Integer.MIN_VALUE || cmpMax == Integer.MIN_VALUE) {
+                return SplitMatch.AMBIGUOUS;
+            }
+            if (cmpMin >= 0 && cmpMax <= 0) {
+                anyInRange = true;
+            }
+        }
+
+        if (anyInRange == false) {
+            return SplitMatch.MISS;
+        }
+
+        int minMaxCmp = compareValues(min, max);
+        if (minMaxCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (minMaxCmp == 0) {
+            for (Object lit : literalValues) {
+                if (compareValues(min, lit) == 0 && hasNoNulls(columnName, splitStats)) {
+                    return SplitMatch.MATCH;
+                }
+            }
+        }
+        return SplitMatch.AMBIGUOUS;
+    }
+
+    /**
+     * {@code col > lit}: MATCH when min &gt; lit (and no nulls), MISS when max &lt;= lit
+     */
+    private static SplitMatch classifyGreaterThan(String columnName, Object literalValue, Map<String, Object> splitStats) {
+        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        int maxCmp = compareValues(maxOpt.get(), literalValue);
+        if (maxCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (maxCmp <= 0) {
+            return SplitMatch.MISS;
+        }
+        int minCmp = compareValues(minOpt.get(), literalValue);
+        if (minCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (minCmp > 0 && hasNoNulls(columnName, splitStats)) {
+            return SplitMatch.MATCH;
+        }
+        return SplitMatch.AMBIGUOUS;
+    }
+
+    /**
+     * {@code col >= lit}: MATCH when min &gt;= lit (and no nulls), MISS when max &lt; lit
+     */
+    private static SplitMatch classifyGreaterThanOrEqual(String columnName, Object literalValue, Map<String, Object> splitStats) {
+        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        int maxCmp = compareValues(maxOpt.get(), literalValue);
+        if (maxCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (maxCmp < 0) {
+            return SplitMatch.MISS;
+        }
+        int minCmp = compareValues(minOpt.get(), literalValue);
+        if (minCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (minCmp >= 0 && hasNoNulls(columnName, splitStats)) {
+            return SplitMatch.MATCH;
+        }
+        return SplitMatch.AMBIGUOUS;
+    }
+
+    /**
+     * {@code col < lit}: MATCH when max &lt; lit (and no nulls), MISS when min &gt;= lit
+     */
+    private static SplitMatch classifyLessThan(String columnName, Object literalValue, Map<String, Object> splitStats) {
+        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        int minCmp = compareValues(minOpt.get(), literalValue);
+        if (minCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (minCmp >= 0) {
+            return SplitMatch.MISS;
+        }
+        int maxCmp = compareValues(maxOpt.get(), literalValue);
+        if (maxCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (maxCmp < 0 && hasNoNulls(columnName, splitStats)) {
+            return SplitMatch.MATCH;
+        }
+        return SplitMatch.AMBIGUOUS;
+    }
+
+    /**
+     * {@code col <= lit}: MATCH when max &lt;= lit (and no nulls), MISS when min &gt; lit
+     */
+    private static SplitMatch classifyLessThanOrEqual(String columnName, Object literalValue, Map<String, Object> splitStats) {
+        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        int minCmp = compareValues(minOpt.get(), literalValue);
+        if (minCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (minCmp > 0) {
+            return SplitMatch.MISS;
+        }
+        int maxCmp = compareValues(maxOpt.get(), literalValue);
+        if (maxCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (maxCmp <= 0 && hasNoNulls(columnName, splitStats)) {
+            return SplitMatch.MATCH;
+        }
+        return SplitMatch.AMBIGUOUS;
+    }
+
+    /**
+     * {@code col = lit}: MATCH when min == max == lit (and no nulls), MISS when lit outside [min, max]
+     */
+    private static SplitMatch classifyEquals(String columnName, Object literalValue, Map<String, Object> splitStats) {
+        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        int minCmp = compareValues(literalValue, minOpt.get());
+        int maxCmp = compareValues(literalValue, maxOpt.get());
+        if (minCmp == Integer.MIN_VALUE || maxCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (minCmp < 0 || maxCmp > 0) {
+            return SplitMatch.MISS;
+        }
+        if (minCmp == 0 && maxCmp == 0 && hasNoNulls(columnName, splitStats)) {
+            return SplitMatch.MATCH;
+        }
+        return SplitMatch.AMBIGUOUS;
+    }
+
+    /**
+     * {@code col != lit}: MATCH when min == max and min != lit (and no nulls), MISS when min == max == lit
+     */
+    private static SplitMatch classifyNotEquals(String columnName, Object literalValue, Map<String, Object> splitStats) {
+        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        int minCmp = compareValues(literalValue, minOpt.get());
+        int maxCmp = compareValues(literalValue, maxOpt.get());
+        if (minCmp == Integer.MIN_VALUE || maxCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        int minMaxCmp = compareValues(minOpt.get(), maxOpt.get());
+        if (minMaxCmp == Integer.MIN_VALUE) {
+            return SplitMatch.AMBIGUOUS;
+        }
+        if (minMaxCmp == 0 && minCmp == 0) {
+            return SplitMatch.MISS;
+        }
+        if (minMaxCmp == 0 && minCmp != 0 && hasNoNulls(columnName, splitStats)) {
+            return SplitMatch.MATCH;
+        }
+        return SplitMatch.AMBIGUOUS;
+    }
+
+    /**
+     * Returns true when the column has zero null values in this split.
+     * When null_count is unavailable, assumes nulls may exist (conservative).
+     */
+    private static boolean hasNoNulls(String columnName, Map<String, Object> splitStats) {
+        OptionalLong nullCount = SourceStatisticsSerializer.extractColumnNullCount(splitStats, columnName);
+        return nullCount.isPresent() && nullCount.getAsLong() == 0;
+    }
+
+    private static String extractColumnName(Expression expr) {
+        if (expr instanceof Attribute attr) {
+            return attr.name();
+        }
+        return null;
+    }
+
+    private static Object extractLiteralValue(Expression expr) {
+        if (expr instanceof Literal lit) {
+            return lit.value();
+        }
+        if (expr.foldable()) {
+            return expr.fold(org.elasticsearch.xpack.esql.core.expression.FoldContext.small());
+        }
+        return null;
+    }
+
+    /**
+     * Compares two values, returning negative, zero, or positive as with {@link Comparable#compareTo}.
+     * Returns {@link Integer#MIN_VALUE} when the values are not comparable (type mismatch or null).
+     * Uses exact long comparison for integral types to avoid double precision loss.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    static int compareValues(Object a, Object b) {
+        if (a == null || b == null) {
+            return Integer.MIN_VALUE;
+        }
+        if (a instanceof BytesRef br) {
+            a = br.utf8ToString();
+        }
+        if (b instanceof BytesRef br) {
+            b = br.utf8ToString();
+        }
+        if (a instanceof Number na && b instanceof Number nb) {
+            if (isIntegral(na) && isIntegral(nb)) {
+                return Long.compare(na.longValue(), nb.longValue());
+            }
+            return Double.compare(na.doubleValue(), nb.doubleValue());
+        }
+        if (a instanceof Comparable ca && b.getClass().isAssignableFrom(a.getClass())) {
+            try {
+                return ca.compareTo(b);
+            } catch (ClassCastException e) {
+                return Integer.MIN_VALUE;
+            }
+        }
+        if (a instanceof Comparable && b instanceof Comparable) {
+            String sa = a.toString();
+            String sb = b.toString();
+            return sa.compareTo(sb);
+        }
+        return Integer.MIN_VALUE;
+    }
+
+    private static boolean isIntegral(Number n) {
+        return n instanceof Long || n instanceof Integer || n instanceof Short || n instanceof Byte;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.compute.aggregation.AggregatorMode;
-import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -32,8 +31,6 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Abs;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
@@ -49,73 +46,59 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-import static org.hamcrest.Matchers.instanceOf;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.alias;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.greaterThanOf;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.lessThanOrEqualOf;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.of;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
 
 public class PushStatsToExternalSourceTests extends ESTestCase {
 
+    private static final ReferenceAttribute AGE = referenceAttribute("age", DataType.INTEGER);
+    private static final ReferenceAttribute SCORE = referenceAttribute("score", DataType.DOUBLE);
+    private static final ReferenceAttribute SALARY = referenceAttribute("salary", DataType.INTEGER);
+
     public void testCountStarPushedDown() {
-        Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
-        AggregateExec agg = aggregateExec(externalSource(metadata), countStarAlias());
+        var agg = aggregateExec(externalSource(statsMetadata(1000L, null, null, null)), countStarAlias());
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
         assertEquals(1, local.output().size());
         Page page = local.supplier().get();
         assertNotNull(page);
         assertEquals(1, page.getPositionCount());
-        Block block = page.getBlock(0);
-        assertThat(block, instanceOf(LongBlock.class));
-        assertEquals(1000L, ((LongBlock) block).getLong(0));
+        assertEquals(1000L, as(page.getBlock(0), LongBlock.class).getLong(0));
     }
 
     public void testCountFieldPushedDown() {
-        Map<String, Object> metadata = statsMetadata(1000L, "age", 50L, null);
-        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        AggregateExec agg = aggregateExec(externalSource(metadata), countFieldAlias(field));
+        var agg = aggregateExec(externalSource(statsMetadata(1000L, "age", 50L, null)), countFieldAlias(AGE));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
-        Page page = local.supplier().get();
-        assertEquals(950L, ((LongBlock) page.getBlock(0)).getLong(0));
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(950L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
     public void testCountFieldWithoutNullCountNotPushed() {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 1000L);
-        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        AggregateExec agg = aggregateExec(externalSource(metadata), countFieldAlias(field));
+        var agg = aggregateExec(externalSource(metadata), countFieldAlias(AGE));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(AggregateExec.class));
+        as(applyRule(agg), AggregateExec.class);
     }
 
     public void testMinPushedDown() {
         Map<String, Object> metadata = statsMetadata(100L, "age", 0L, null);
         metadata.put("_stats.columns.age.min", 18);
-        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Alias minAlias = new Alias(Source.EMPTY, "m", new Min(Source.EMPTY, field));
-        AggregateExec agg = aggregateExec(externalSource(metadata), minAlias);
+        var agg = aggregateExec(externalSource(metadata), alias("m", new Min(Source.EMPTY, AGE)));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
+        as(applyRule(agg), LocalSourceExec.class);
     }
 
     public void testMaxPushedDown() {
         Map<String, Object> metadata = statsMetadata(100L, "age", 0L, null);
         metadata.put("_stats.columns.age.max", 99);
-        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Alias maxAlias = new Alias(Source.EMPTY, "m", new Max(Source.EMPTY, field));
-        AggregateExec agg = aggregateExec(externalSource(metadata), maxAlias);
+        var agg = aggregateExec(externalSource(metadata), alias("m", new Max(Source.EMPTY, AGE)));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
+        as(applyRule(agg), LocalSourceExec.class);
     }
 
     public void testMultipleAggsPushedDown() {
@@ -123,25 +106,21 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
         metadata.put("_stats.columns.score.min", 1.0);
         metadata.put("_stats.columns.score.max", 100.0);
 
-        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "score", DataType.DOUBLE);
-        Alias countAlias = countStarAlias();
-        Alias minAlias = new Alias(Source.EMPTY, "mn", new Min(Source.EMPTY, field));
-        Alias maxAlias = new Alias(Source.EMPTY, "mx", new Max(Source.EMPTY, field));
+        var agg = aggregateExec(
+            externalSource(metadata),
+            countStarAlias(),
+            alias("mn", new Min(Source.EMPTY, SCORE)),
+            alias("mx", new Max(Source.EMPTY, SCORE))
+        );
 
-        AggregateExec agg = aggregateExec(externalSource(metadata), countAlias, minAlias, maxAlias);
-
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
         assertEquals(3, local.output().size());
     }
 
     public void testNotPushedWithGroupings() {
-        Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
-        ExternalSourceExec ext = externalSource(metadata);
-        ReferenceAttribute groupField = new ReferenceAttribute(Source.EMPTY, "dept", DataType.KEYWORD);
-        AggregateExec agg = new AggregateExec(
+        ExternalSourceExec ext = externalSource(statsMetadata(1000L, null, null, null));
+        ReferenceAttribute groupField = referenceAttribute("dept", DataType.KEYWORD);
+        var agg = new AggregateExec(
             Source.EMPTY,
             ext,
             List.of(groupField),
@@ -151,113 +130,73 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
             null
         );
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(AggregateExec.class));
+        as(applyRule(agg), AggregateExec.class);
     }
 
     public void testNotPushedWithoutStats() {
-        Map<String, Object> metadata = Map.of();
-        AggregateExec agg = aggregateExec(externalSource(metadata), countStarAlias());
+        var agg = aggregateExec(externalSource(Map.of()), countStarAlias());
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(AggregateExec.class));
+        as(applyRule(agg), AggregateExec.class);
     }
 
     public void testNotPushedWithMultipleSplitsWithoutStats() {
-        Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
-        ExternalSourceExec ext = externalSourceWithSplits(metadata, null, null);
-        AggregateExec agg = aggregateExec(ext, countStarAlias());
+        ExternalSourceExec ext = externalSourceWithSplits(statsMetadata(1000L, null, null, null), (Map<String, Object>[]) null);
+        var agg = aggregateExec(ext, countStarAlias());
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(AggregateExec.class));
+        as(applyRule(agg), AggregateExec.class);
     }
 
     public void testPushedWithMultipleSplitsWithStats() {
-        Map<String, Object> stats1 = statsMetadata(100L, null, null, null);
-        Map<String, Object> stats2 = statsMetadata(200L, null, null, null);
-        Map<String, Object> stats3 = statsMetadata(300L, null, null, null);
-        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), stats1, stats2, stats3);
-        AggregateExec agg = aggregateExec(ext, countStarAlias());
+        ExternalSourceExec ext = externalSourceWithSplits(
+            Map.of(),
+            statsMetadata(100L, null, null, null),
+            statsMetadata(200L, null, null, null),
+            statsMetadata(300L, null, null, null)
+        );
+        var agg = aggregateExec(ext, countStarAlias());
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
-        Page page = local.supplier().get();
-        assertEquals(600L, ((LongBlock) page.getBlock(0)).getLong(0));
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(600L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
     public void testNotPushedWithMixedStatsAndNoStats() {
-        Map<String, Object> stats1 = statsMetadata(100L, null, null, null);
-        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), stats1, null);
-        AggregateExec agg = aggregateExec(ext, countStarAlias());
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), statsMetadata(100L, null, null, null), null);
+        var agg = aggregateExec(ext, countStarAlias());
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(AggregateExec.class));
+        as(applyRule(agg), AggregateExec.class);
     }
 
     public void testMinMaxPushedWithMultipleSplitsWithStats() {
-        Map<String, Object> stats1 = statsMetadata(100L, "age", 5L, null);
-        stats1.put("_stats.columns.age.min", 18);
-        stats1.put("_stats.columns.age.max", 50);
-
-        Map<String, Object> stats2 = statsMetadata(200L, "age", 10L, null);
-        stats2.put("_stats.columns.age.min", 22);
-        stats2.put("_stats.columns.age.max", 65);
-
+        Map<String, Object> stats1 = splitStatsWithMinMax("age", 18, 50, 100L, 5L);
+        Map<String, Object> stats2 = splitStatsWithMinMax("age", 22, 65, 200L, 10L);
         ExternalSourceExec ext = externalSourceWithSplits(Map.of(), stats1, stats2);
 
-        ReferenceAttribute ageField = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        AggregateExec agg = aggregateExec(
-            ext,
-            new Alias(Source.EMPTY, "mn", new Min(Source.EMPTY, ageField)),
-            new Alias(Source.EMPTY, "mx", new Max(Source.EMPTY, ageField))
-        );
+        var agg = aggregateExec(ext, alias("mn", new Min(Source.EMPTY, AGE)), alias("mx", new Max(Source.EMPTY, AGE)));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
         assertEquals(2, local.output().size());
         Page page = local.supplier().get();
-        assertEquals(18, ((IntBlock) page.getBlock(0)).getInt(0));
-        assertEquals(65, ((IntBlock) page.getBlock(1)).getInt(0));
+        assertEquals(18, as(page.getBlock(0), IntBlock.class).getInt(0));
+        assertEquals(65, as(page.getBlock(1), IntBlock.class).getInt(0));
     }
 
     public void testPushedWithSingleSplit() {
-        Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
-        ExternalSourceExec ext = externalSourceWithSplits(metadata, (Map<String, Object>) null);
-        AggregateExec agg = aggregateExec(ext, countStarAlias());
+        ExternalSourceExec ext = externalSourceWithSplits(statsMetadata(1000L, null, null, null), (Map<String, Object>) null);
+        var agg = aggregateExec(ext, countStarAlias());
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
+        as(applyRule(agg), LocalSourceExec.class);
     }
 
     public void testMinWithoutStatsNotPushed() {
-        Map<String, Object> metadata = statsMetadata(100L, null, null, null);
-        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Alias minAlias = new Alias(Source.EMPTY, "m", new Min(Source.EMPTY, field));
-        AggregateExec agg = aggregateExec(externalSource(metadata), minAlias);
+        var agg = aggregateExec(externalSource(statsMetadata(100L, null, null, null)), alias("m", new Min(Source.EMPTY, AGE)));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(AggregateExec.class));
+        as(applyRule(agg), AggregateExec.class);
     }
 
     public void testMaxWithoutStatsNotPushed() {
-        Map<String, Object> metadata = statsMetadata(100L, null, null, null);
-        ReferenceAttribute field = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Alias maxAlias = new Alias(Source.EMPTY, "m", new Max(Source.EMPTY, field));
-        AggregateExec agg = aggregateExec(externalSource(metadata), maxAlias);
+        var agg = aggregateExec(externalSource(statsMetadata(100L, null, null, null)), alias("m", new Max(Source.EMPTY, AGE)));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(AggregateExec.class));
+        as(applyRule(agg), AggregateExec.class);
     }
 
     public void testSerializerRoundTrip() {
@@ -312,136 +251,76 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
 
     // --- EvalExec intermediate node tests ---
 
-    /**
-     * EVAL age_years = age | STATS count(*)
-     * count(*) doesn't reference any aliased column so it should still push down.
-     */
     public void testCountStarPushedThroughEval() {
-        Map<String, Object> metadata = statsMetadata(1000L, "age", 0L, null);
-        EvalExec eval = evalWithSimpleAlias(externalSource(metadata), "age_years", "age");
-        AggregateExec agg = aggregateExec(eval, countStarAlias());
+        EvalExec eval = evalWithSimpleAlias(externalSource(statsMetadata(1000L, "age", 0L, null)), "age_years", "age");
+        var agg = aggregateExec(eval, countStarAlias());
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
-        Page page = local.supplier().get();
-        assertEquals(1000L, ((LongBlock) page.getBlock(0)).getLong(0));
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(1000L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
-    /**
-     * EVAL age_years = age | STATS count(age_years)
-     * count(age_years) references an alias for "age"; should resolve and push.
-     */
     public void testCountFieldPushedThroughEval() {
-        Map<String, Object> metadata = statsMetadata(1000L, "age", 50L, null);
-        ReferenceAttribute ageRef = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Alias evalAlias = new Alias(Source.EMPTY, "age_years", ageRef);
-        EvalExec eval = new EvalExec(Source.EMPTY, externalSource(metadata), List.of(evalAlias));
-        ReferenceAttribute aliasedField = (ReferenceAttribute) evalAlias.toAttribute();
-        AggregateExec agg = aggregateExec(eval, countFieldAlias(aliasedField));
+        Alias evalAlias = alias("age_years", AGE);
+        EvalExec eval = new EvalExec(Source.EMPTY, externalSource(statsMetadata(1000L, "age", 50L, null)), List.of(evalAlias));
+        var agg = aggregateExec(eval, countFieldAlias((ReferenceAttribute) evalAlias.toAttribute()));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
-        Page page = local.supplier().get();
-        assertEquals(950L, ((LongBlock) page.getBlock(0)).getLong(0));
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(950L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
-    /**
-     * EVAL age_years = age | STATS min(age_years)
-     * min(age_years) should resolve to min(age) via alias and push.
-     */
     public void testMinPushedThroughEval() {
         Map<String, Object> metadata = statsMetadata(100L, "age", 0L, null);
         metadata.put("_stats.columns.age.min", 18);
-        ReferenceAttribute ageRef = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Alias evalAlias = new Alias(Source.EMPTY, "age_years", ageRef);
+        Alias evalAlias = alias("age_years", AGE);
         EvalExec eval = new EvalExec(Source.EMPTY, externalSource(metadata), List.of(evalAlias));
-        ReferenceAttribute aliasedField = (ReferenceAttribute) evalAlias.toAttribute();
-        AggregateExec agg = aggregateExec(eval, new Alias(Source.EMPTY, "m", new Min(Source.EMPTY, aliasedField)));
+        var agg = aggregateExec(eval, alias("m", new Min(Source.EMPTY, evalAlias.toAttribute())));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
+        as(applyRule(agg), LocalSourceExec.class);
     }
 
-    /**
-     * EVAL age_years = age | STATS max(age_years)
-     * max(age_years) should resolve to max(age) via alias and push.
-     */
     public void testMaxPushedThroughEval() {
         Map<String, Object> metadata = statsMetadata(100L, "age", 0L, null);
         metadata.put("_stats.columns.age.max", 99);
-        ReferenceAttribute ageRef = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Alias evalAlias = new Alias(Source.EMPTY, "age_years", ageRef);
+        Alias evalAlias = alias("age_years", AGE);
         EvalExec eval = new EvalExec(Source.EMPTY, externalSource(metadata), List.of(evalAlias));
-        ReferenceAttribute aliasedField = (ReferenceAttribute) evalAlias.toAttribute();
-        AggregateExec agg = aggregateExec(eval, new Alias(Source.EMPTY, "m", new Max(Source.EMPTY, aliasedField)));
+        var agg = aggregateExec(eval, alias("m", new Max(Source.EMPTY, evalAlias.toAttribute())));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
+        as(applyRule(agg), LocalSourceExec.class);
     }
 
-    /**
-     * EVAL age_years = age | STATS count(*), min(age_years), max(age_years)
-     * All three aggregates should resolve through the alias and push.
-     */
     public void testMultipleAggsPushedThroughEval() {
         Map<String, Object> metadata = statsMetadata(500L, "age", 10L, null);
         metadata.put("_stats.columns.age.min", 1);
         metadata.put("_stats.columns.age.max", 100);
-        ReferenceAttribute ageRef = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Alias evalAlias = new Alias(Source.EMPTY, "age_years", ageRef);
+        Alias evalAlias = alias("age_years", AGE);
         EvalExec eval = new EvalExec(Source.EMPTY, externalSource(metadata), List.of(evalAlias));
         ReferenceAttribute aliasedField = (ReferenceAttribute) evalAlias.toAttribute();
-        AggregateExec agg = aggregateExec(
+        var agg = aggregateExec(
             eval,
             countStarAlias(),
-            new Alias(Source.EMPTY, "mn", new Min(Source.EMPTY, aliasedField)),
-            new Alias(Source.EMPTY, "mx", new Max(Source.EMPTY, aliasedField))
+            alias("mn", new Min(Source.EMPTY, aliasedField)),
+            alias("mx", new Max(Source.EMPTY, aliasedField))
         );
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
         assertEquals(3, local.output().size());
     }
 
-    /**
-     * EVAL computed_val = abs(age) | STATS min(computed_val)
-     * The eval field is not a simple attribute alias (it's a function call),
-     * so no alias map entry is created and pushdown should fail.
-     */
     public void testNotPushedThroughEvalWithComputedExpression() {
         Map<String, Object> metadata = statsMetadata(100L, "age", 0L, null);
         metadata.put("_stats.columns.age.min", 18);
-        ExternalSourceExec ext = externalSource(metadata);
-        ReferenceAttribute ageRef = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Alias computedAlias = new Alias(Source.EMPTY, "computed_val", new Abs(Source.EMPTY, ageRef));
-        EvalExec eval = new EvalExec(Source.EMPTY, ext, List.of(computedAlias));
-        ReferenceAttribute computedRef = (ReferenceAttribute) computedAlias.toAttribute();
-        AggregateExec agg = aggregateExec(eval, new Alias(Source.EMPTY, "m", new Min(Source.EMPTY, computedRef)));
+        Alias computedAlias = alias("computed_val", new Abs(Source.EMPTY, AGE));
+        EvalExec eval = new EvalExec(Source.EMPTY, externalSource(metadata), List.of(computedAlias));
+        var agg = aggregateExec(eval, alias("m", new Min(Source.EMPTY, computedAlias.toAttribute())));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(AggregateExec.class));
+        as(applyRule(agg), AggregateExec.class);
     }
 
-    /**
-     * EVAL age_years = age | STATS count(*) BY age_years
-     * Grouped aggregates should not be pushed regardless of intermediate nodes.
-     */
     public void testNotPushedWithGroupingsThroughEval() {
-        Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
-        ReferenceAttribute ageRef = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Alias evalAlias = new Alias(Source.EMPTY, "age_years", ageRef);
-        EvalExec eval = new EvalExec(Source.EMPTY, externalSource(metadata), List.of(evalAlias));
+        Alias evalAlias = alias("age_years", AGE);
+        EvalExec eval = new EvalExec(Source.EMPTY, externalSource(statsMetadata(1000L, null, null, null)), List.of(evalAlias));
         ReferenceAttribute groupField = (ReferenceAttribute) evalAlias.toAttribute();
-        AggregateExec agg = new AggregateExec(
+        var agg = new AggregateExec(
             Source.EMPTY,
             eval,
             List.of(groupField),
@@ -451,76 +330,41 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
             null
         );
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(AggregateExec.class));
+        as(applyRule(agg), AggregateExec.class);
     }
 
     // --- ProjectExec intermediate node tests ---
 
-    /**
-     * RENAME salary AS pay | STATS min(pay)
-     * ProjectExec renames salary to pay; min(pay) should resolve to min(salary).
-     */
     public void testMinPushedThroughProject() {
         Map<String, Object> metadata = statsMetadata(100L, "salary", 0L, null);
         metadata.put("_stats.columns.salary.min", 30000);
-        ExternalSourceExec ext = externalSource(metadata);
-        ReferenceAttribute salaryRef = new ReferenceAttribute(Source.EMPTY, "salary", DataType.INTEGER);
-        Alias renameAlias = new Alias(Source.EMPTY, "pay", salaryRef);
-        ProjectExec project = new ProjectExec(Source.EMPTY, ext, List.of(renameAlias));
-        ReferenceAttribute payRef = (ReferenceAttribute) renameAlias.toAttribute();
-        AggregateExec agg = aggregateExec(project, new Alias(Source.EMPTY, "m", new Min(Source.EMPTY, payRef)));
+        Alias renameAlias = alias("pay", SALARY);
+        ProjectExec project = new ProjectExec(Source.EMPTY, externalSource(metadata), List.of(renameAlias));
+        var agg = aggregateExec(project, alias("m", new Min(Source.EMPTY, renameAlias.toAttribute())));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
+        as(applyRule(agg), LocalSourceExec.class);
     }
 
-    /**
-     * RENAME salary AS pay | STATS min(pay), max(pay)
-     * Both aggregates should resolve through the project rename.
-     */
     public void testMultipleAggsPushedThroughProject() {
         Map<String, Object> metadata = statsMetadata(100L, "salary", 0L, null);
         metadata.put("_stats.columns.salary.min", 30000);
         metadata.put("_stats.columns.salary.max", 150000);
-        ExternalSourceExec ext = externalSource(metadata);
-        ReferenceAttribute salaryRef = new ReferenceAttribute(Source.EMPTY, "salary", DataType.INTEGER);
-        Alias renameAlias = new Alias(Source.EMPTY, "pay", salaryRef);
-        ProjectExec project = new ProjectExec(Source.EMPTY, ext, List.of(renameAlias));
+        Alias renameAlias = alias("pay", SALARY);
+        ProjectExec project = new ProjectExec(Source.EMPTY, externalSource(metadata), List.of(renameAlias));
         ReferenceAttribute payRef = (ReferenceAttribute) renameAlias.toAttribute();
-        AggregateExec agg = aggregateExec(
-            project,
-            new Alias(Source.EMPTY, "mn", new Min(Source.EMPTY, payRef)),
-            new Alias(Source.EMPTY, "mx", new Max(Source.EMPTY, payRef))
-        );
+        var agg = aggregateExec(project, alias("mn", new Min(Source.EMPTY, payRef)), alias("mx", new Max(Source.EMPTY, payRef)));
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
         assertEquals(2, local.output().size());
     }
 
-    /**
-     * RENAME salary AS pay | STATS count(*)
-     * count(*) doesn't reference columns, so project intermediate should not prevent pushdown.
-     */
     public void testCountStarPushedThroughProject() {
-        Map<String, Object> metadata = statsMetadata(1000L, null, null, null);
-        ExternalSourceExec ext = externalSource(metadata);
-        ReferenceAttribute salaryRef = new ReferenceAttribute(Source.EMPTY, "salary", DataType.INTEGER);
-        Alias renameAlias = new Alias(Source.EMPTY, "pay", salaryRef);
-        ProjectExec project = new ProjectExec(Source.EMPTY, ext, List.of(renameAlias));
-        AggregateExec agg = aggregateExec(project, countStarAlias());
+        Alias renameAlias = alias("pay", SALARY);
+        ProjectExec project = new ProjectExec(Source.EMPTY, externalSource(statsMetadata(1000L, null, null, null)), List.of(renameAlias));
+        var agg = aggregateExec(project, countStarAlias());
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
-        Page page = local.supplier().get();
-        assertEquals(1000L, ((LongBlock) page.getBlock(0)).getLong(0));
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(1000L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
     // --- filter tests ---
@@ -529,41 +373,22 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
         Map<String, Object> split1 = splitStatsWithMinMax("age", 30L, 50L, 500L, 0L);
         Map<String, Object> split2 = splitStatsWithMinMax("age", 60L, 80L, 500L, 0L);
         ExternalSourceExec ext = externalSourceWithSplits(Map.of(), split1, split2);
-        ReferenceAttribute ageRef = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Expression filterCondition = new Or(
-            Source.EMPTY,
-            new GreaterThan(Source.EMPTY, ageRef, new Literal(Source.EMPTY, 20L, DataType.LONG), null),
-            new LessThanOrEqual(Source.EMPTY, ageRef, new Literal(Source.EMPTY, 90L, DataType.LONG), null)
-        );
-        FilterExec filter = new FilterExec(Source.EMPTY, ext, filterCondition);
-        AggregateExec agg = aggregateExec(filter, countStarAlias());
+        Expression filterCondition = new Or(Source.EMPTY, greaterThanOf(AGE, of(20L)), lessThanOrEqualOf(AGE, of(90L)));
+        var agg = aggregateExec(new FilterExec(Source.EMPTY, ext, filterCondition), countStarAlias());
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
-        Page page = local.supplier().get();
-        assertEquals(1000L, ((LongBlock) page.getBlock(0)).getLong(0));
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(1000L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
     public void testCountPushedThroughNotFilter() {
         Map<String, Object> split1 = splitStatsWithMinMax("age", 30L, 50L, 500L, 0L);
         Map<String, Object> split2 = splitStatsWithMinMax("age", 60L, 80L, 500L, 0L);
         ExternalSourceExec ext = externalSourceWithSplits(Map.of(), split1, split2);
-        ReferenceAttribute ageRef = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
-        Expression filterCondition = new Not(
-            Source.EMPTY,
-            new GreaterThan(Source.EMPTY, ageRef, new Literal(Source.EMPTY, 20L, DataType.LONG), null)
-        );
-        FilterExec filter = new FilterExec(Source.EMPTY, ext, filterCondition);
-        AggregateExec agg = aggregateExec(filter, countStarAlias());
+        Expression filterCondition = new Not(Source.EMPTY, greaterThanOf(AGE, of(20L)));
+        var agg = aggregateExec(new FilterExec(Source.EMPTY, ext, filterCondition), countStarAlias());
 
-        PhysicalPlan result = applyRule(agg);
-
-        assertThat(result, instanceOf(LocalSourceExec.class));
-        LocalSourceExec local = (LocalSourceExec) result;
-        Page page = local.supplier().get();
-        assertEquals(0L, ((LongBlock) page.getBlock(0)).getLong(0));
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(0L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
     // --- helpers ---
@@ -571,31 +396,20 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
     @SafeVarargs
     @SuppressWarnings("varargs")
     private static ExternalSourceExec externalSourceWithSplits(Map<String, Object> sourceMetadata, Map<String, Object>... perSplitStats) {
-        List<Attribute> attrs = List.of(
-            new ReferenceAttribute(Source.EMPTY, "x", DataType.INTEGER),
-            new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER)
-        );
-        List<ExternalSplit> splits = new ArrayList<>(perSplitStats.length);
-        for (int i = 0; i < perSplitStats.length; i++) {
-            splits.add(
-                new FileSplit(
-                    "parquet",
-                    StoragePath.of("file:///split" + (i + 1) + ".parquet"),
-                    0,
-                    100,
-                    "parquet",
-                    Map.of(),
-                    Map.of(),
-                    null,
-                    perSplitStats[i]
-                )
-            );
+        List<ExternalSplit> splits = new ArrayList<>(perSplitStats == null ? 1 : perSplitStats.length);
+        if (perSplitStats == null) {
+            splits.add(fileSplit(0, null));
+            splits.add(fileSplit(1, null));
+        } else {
+            for (int i = 0; i < perSplitStats.length; i++) {
+                splits.add(fileSplit(i, perSplitStats[i]));
+            }
         }
         return new ExternalSourceExec(
             Source.EMPTY,
             "file:///test.parquet",
             "parquet",
-            attrs,
+            defaultAttrs(),
             Map.of(),
             sourceMetadata,
             null,
@@ -607,13 +421,25 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
     }
 
     private static ExternalSourceExec externalSource(Map<String, Object> sourceMetadata) {
-        List<Attribute> attrs = List.of(
-            new ReferenceAttribute(Source.EMPTY, "x", DataType.INTEGER),
-            new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER),
-            new ReferenceAttribute(Source.EMPTY, "score", DataType.DOUBLE),
-            new ReferenceAttribute(Source.EMPTY, "salary", DataType.INTEGER)
+        return new ExternalSourceExec(Source.EMPTY, "file:///test.parquet", "parquet", defaultAttrs(), Map.of(), sourceMetadata, null);
+    }
+
+    private static List<Attribute> defaultAttrs() {
+        return List.of(referenceAttribute("x", DataType.INTEGER), AGE, SCORE, SALARY);
+    }
+
+    private static FileSplit fileSplit(int index, Map<String, Object> stats) {
+        return new FileSplit(
+            "parquet",
+            StoragePath.of("file:///split" + (index + 1) + ".parquet"),
+            0,
+            100,
+            "parquet",
+            Map.of(),
+            Map.of(),
+            null,
+            stats
         );
-        return new ExternalSourceExec(Source.EMPTY, "file:///test.parquet", "parquet", attrs, Map.of(), sourceMetadata, null);
     }
 
     private static AggregateExec aggregateExec(PhysicalPlan child, NamedExpression... aggregates) {
@@ -621,17 +447,15 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
     }
 
     private static EvalExec evalWithSimpleAlias(ExternalSourceExec child, String aliasName, String originalName) {
-        ReferenceAttribute originalRef = new ReferenceAttribute(Source.EMPTY, originalName, DataType.INTEGER);
-        Alias alias = new Alias(Source.EMPTY, aliasName, originalRef);
-        return new EvalExec(Source.EMPTY, child, List.of(alias));
+        return new EvalExec(Source.EMPTY, child, List.of(alias(aliasName, referenceAttribute(originalName, DataType.INTEGER))));
     }
 
     private static Alias countStarAlias() {
-        return new Alias(Source.EMPTY, "c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
+        return alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
     }
 
     private static Alias countFieldAlias(ReferenceAttribute field) {
-        return new Alias(Source.EMPTY, "c", new Count(Source.EMPTY, field));
+        return alias("c", new Count(Source.EMPTY, field));
     }
 
     private static Map<String, Object> splitStatsWithMinMax(String colName, Object min, Object max, long rowCount, long nullCount) {
@@ -656,7 +480,6 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
     }
 
     private static PhysicalPlan applyRule(AggregateExec agg) {
-        PushStatsToExternalSource rule = new PushStatsToExternalSource();
-        return rule.apply(agg);
+        return new PushStatsToExternalSource().apply(agg);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
@@ -29,9 +30,14 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Abs;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
@@ -517,6 +523,49 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
         assertEquals(1000L, ((LongBlock) page.getBlock(0)).getLong(0));
     }
 
+    // --- filter tests ---
+
+    public void testCountPushedThroughOrFilterAllResolve() {
+        Map<String, Object> split1 = splitStatsWithMinMax("age", 30L, 50L, 500L, 0L);
+        Map<String, Object> split2 = splitStatsWithMinMax("age", 60L, 80L, 500L, 0L);
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), split1, split2);
+        ReferenceAttribute ageRef = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
+        Expression filterCondition = new Or(
+            Source.EMPTY,
+            new GreaterThan(Source.EMPTY, ageRef, new Literal(Source.EMPTY, 20L, DataType.LONG), null),
+            new LessThanOrEqual(Source.EMPTY, ageRef, new Literal(Source.EMPTY, 90L, DataType.LONG), null)
+        );
+        FilterExec filter = new FilterExec(Source.EMPTY, ext, filterCondition);
+        AggregateExec agg = aggregateExec(filter, countStarAlias());
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(LocalSourceExec.class));
+        LocalSourceExec local = (LocalSourceExec) result;
+        Page page = local.supplier().get();
+        assertEquals(1000L, ((LongBlock) page.getBlock(0)).getLong(0));
+    }
+
+    public void testCountPushedThroughNotFilter() {
+        Map<String, Object> split1 = splitStatsWithMinMax("age", 30L, 50L, 500L, 0L);
+        Map<String, Object> split2 = splitStatsWithMinMax("age", 60L, 80L, 500L, 0L);
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), split1, split2);
+        ReferenceAttribute ageRef = new ReferenceAttribute(Source.EMPTY, "age", DataType.INTEGER);
+        Expression filterCondition = new Not(
+            Source.EMPTY,
+            new GreaterThan(Source.EMPTY, ageRef, new Literal(Source.EMPTY, 20L, DataType.LONG), null)
+        );
+        FilterExec filter = new FilterExec(Source.EMPTY, ext, filterCondition);
+        AggregateExec agg = aggregateExec(filter, countStarAlias());
+
+        PhysicalPlan result = applyRule(agg);
+
+        assertThat(result, instanceOf(LocalSourceExec.class));
+        LocalSourceExec local = (LocalSourceExec) result;
+        Page page = local.supplier().get();
+        assertEquals(0L, ((LongBlock) page.getBlock(0)).getLong(0));
+    }
+
     // --- helpers ---
 
     @SafeVarargs
@@ -583,6 +632,13 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
 
     private static Alias countFieldAlias(ReferenceAttribute field) {
         return new Alias(Source.EMPTY, "c", new Count(Source.EMPTY, field));
+    }
+
+    private static Map<String, Object> splitStatsWithMinMax(String colName, Object min, Object max, long rowCount, long nullCount) {
+        Map<String, Object> metadata = statsMetadata(rowCount, colName, nullCount, null);
+        metadata.put("_stats.columns." + colName + ".min", min);
+        metadata.put("_stats.columns." + colName + ".max", max);
+        return metadata;
     }
 
     private static Map<String, Object> statsMetadata(Long rowCount, String colName, Long nullCount, Long sizeBytes) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifierTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
@@ -20,223 +19,179 @@ import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.equalsOf;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.greaterThanOf;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.greaterThanOrEqualOf;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.lessThanOf;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.lessThanOrEqualOf;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.notEqualsOf;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.of;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
 import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SplitFilterClassifier.SplitMatch.AMBIGUOUS;
 import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SplitFilterClassifier.SplitMatch.MATCH;
 import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SplitFilterClassifier.SplitMatch.MISS;
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SplitFilterClassifier.classifyExpression;
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SplitFilterClassifier.classifySplit;
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SplitFilterClassifier.compareValues;
 
 public class SplitFilterClassifierTests extends ESTestCase {
+
+    private static final String COL = "age";
+    private static final ReferenceAttribute AGE = referenceAttribute(COL, DataType.LONG);
+
+    /** Standard stats: age in [10, 20], 100 rows, no nulls. */
+    private static final Map<String, Object> STATS_10_20 = colStats(COL, 10L, 20L, 100L, 0L);
+    /** Stats: age in [30, 50], 100 rows, no nulls. */
+    private static final Map<String, Object> STATS_30_50 = colStats(COL, 30L, 50L, 100L, 0L);
+    /** Stats: constant column age = 42, 100 rows, no nulls. */
+    private static final Map<String, Object> STATS_CONST_42 = colStats(COL, 42L, 42L, 100L, 0L);
 
     // --- GreaterThan ---
 
     public void testGreaterThanMatch() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = gt(ref("age"), lit(5L));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(greaterThanOf(AGE, of(5L)), STATS_10_20));
     }
 
     public void testGreaterThanMiss() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = gt(ref("age"), lit(25L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(greaterThanOf(AGE, of(25L)), STATS_10_20));
     }
 
     public void testGreaterThanMissAtBoundary() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = gt(ref("age"), lit(20L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(greaterThanOf(AGE, of(20L)), STATS_10_20));
     }
 
     public void testGreaterThanAmbiguous() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = gt(ref("age"), lit(15L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(greaterThanOf(AGE, of(15L)), STATS_10_20));
     }
 
     public void testGreaterThanAmbiguousWithNulls() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 5L);
-        Expression filter = gt(ref("age"), lit(5L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        var stats = colStats(COL, 10L, 20L, 100L, 5L);
+        assertEquals(AMBIGUOUS, classify(greaterThanOf(AGE, of(5L)), stats));
     }
 
     // --- GreaterThanOrEqual ---
 
     public void testGreaterThanOrEqualMatch() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = gte(ref("age"), lit(10L));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(greaterThanOrEqualOf(AGE, of(10L)), STATS_10_20));
     }
 
     public void testGreaterThanOrEqualMiss() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = gte(ref("age"), lit(21L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(greaterThanOrEqualOf(AGE, of(21L)), STATS_10_20));
     }
 
     public void testGreaterThanOrEqualAmbiguous() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = gte(ref("age"), lit(15L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(greaterThanOrEqualOf(AGE, of(15L)), STATS_10_20));
     }
 
     // --- LessThan ---
 
     public void testLessThanMatch() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = lt(ref("age"), lit(25L));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(lessThanOf(AGE, of(25L)), STATS_10_20));
     }
 
     public void testLessThanMiss() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = lt(ref("age"), lit(5L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(lessThanOf(AGE, of(5L)), STATS_10_20));
     }
 
     public void testLessThanMissAtBoundary() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = lt(ref("age"), lit(10L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(lessThanOf(AGE, of(10L)), STATS_10_20));
     }
 
     public void testLessThanAmbiguous() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = lt(ref("age"), lit(15L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(lessThanOf(AGE, of(15L)), STATS_10_20));
     }
 
     // --- LessThanOrEqual ---
 
     public void testLessThanOrEqualMatch() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = lte(ref("age"), lit(20L));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(lessThanOrEqualOf(AGE, of(20L)), STATS_10_20));
     }
 
     public void testLessThanOrEqualMiss() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = lte(ref("age"), lit(9L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(lessThanOrEqualOf(AGE, of(9L)), STATS_10_20));
     }
 
     // --- Equals ---
 
     public void testEqualsMatch() {
-        Map<String, Object> stats = splitStats(42L, 42L, 100L, 0L);
-        Expression filter = eq(ref("age"), lit(42L));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(equalsOf(AGE, of(42L)), STATS_CONST_42));
     }
 
     public void testEqualsMissBelowRange() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = eq(ref("age"), lit(5L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(equalsOf(AGE, of(5L)), STATS_10_20));
     }
 
     public void testEqualsMissAboveRange() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = eq(ref("age"), lit(25L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(equalsOf(AGE, of(25L)), STATS_10_20));
     }
 
     public void testEqualsAmbiguous() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = eq(ref("age"), lit(15L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(equalsOf(AGE, of(15L)), STATS_10_20));
     }
 
     // --- NotEquals ---
 
     public void testNotEqualsMatch() {
-        Map<String, Object> stats = splitStats(42L, 42L, 100L, 0L);
-        Expression filter = neq(ref("age"), lit(99L));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(notEqualsOf(AGE, of(99L)), STATS_CONST_42));
     }
 
     public void testNotEqualsMiss() {
-        Map<String, Object> stats = splitStats(42L, 42L, 100L, 0L);
-        Expression filter = neq(ref("age"), lit(42L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(notEqualsOf(AGE, of(42L)), STATS_CONST_42));
     }
 
     public void testNotEqualsAmbiguous() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression filter = neq(ref("age"), lit(15L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(notEqualsOf(AGE, of(15L)), STATS_10_20));
     }
 
     // --- Reversed operand order (literal on left) ---
 
     public void testReversedGreaterThan() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        // 25 > age ⟹ age < 25
-        Expression filter = gt(lit(25L), ref("age"));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        // 25 > age => age < 25
+        assertEquals(MATCH, classify(greaterThanOf(of(25L), AGE), STATS_10_20));
     }
 
     public void testReversedLessThan() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        // 5 < age ⟹ age > 5
-        Expression filter = lt(lit(5L), ref("age"));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        // 5 < age => age > 5
+        assertEquals(MATCH, classify(lessThanOf(of(5L), AGE), STATS_10_20));
     }
 
     // --- AND conjunction ---
 
     public void testConjunctionAllMatch() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression f1 = gte(ref("age"), lit(10L));
-        Expression f2 = lte(ref("age"), lit(20L));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(f1, f2), stats));
+        assertEquals(MATCH, classifySplit(List.of(greaterThanOrEqualOf(AGE, of(10L)), lessThanOrEqualOf(AGE, of(20L))), STATS_10_20));
     }
 
     public void testConjunctionOneMiss() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression f1 = gte(ref("age"), lit(10L));
-        Expression f2 = lt(ref("age"), lit(5L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(f1, f2), stats));
+        assertEquals(MISS, classifySplit(List.of(greaterThanOrEqualOf(AGE, of(10L)), lessThanOf(AGE, of(5L))), STATS_10_20));
     }
 
     public void testConjunctionMixedMatchAndAmbiguous() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        Expression f1 = gte(ref("age"), lit(10L));  // MATCH
-        Expression f2 = lt(ref("age"), lit(15L));    // AMBIGUOUS
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(f1, f2), stats));
+        assertEquals(AMBIGUOUS, classifySplit(List.of(greaterThanOrEqualOf(AGE, of(10L)), lessThanOf(AGE, of(15L))), STATS_10_20));
     }
 
     // --- Edge cases ---
 
     public void testEmptyConjuncts() {
-        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(), stats));
+        assertEquals(AMBIGUOUS, classifySplit(List.of(), STATS_10_20));
     }
 
     public void testNullStats() {
-        Expression filter = gt(ref("age"), lit(5L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), null));
+        assertEquals(AMBIGUOUS, classifySplit(List.of(greaterThanOf(AGE, of(5L))), null));
     }
 
     public void testEmptyStats() {
-        Expression filter = gt(ref("age"), lit(5L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), Map.of()));
+        assertEquals(AMBIGUOUS, classifySplit(List.of(greaterThanOf(AGE, of(5L))), Map.of()));
     }
 
     public void testMissingColumnStats() {
-        Map<String, Object> stats = new HashMap<>();
-        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
-        Expression filter = gt(ref("age"), lit(5L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        var stats = Map.<String, Object>of(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        assertEquals(AMBIGUOUS, classify(greaterThanOf(AGE, of(5L)), stats));
     }
 
     public void testMissingNullCount() {
@@ -244,9 +199,7 @@ public class SplitFilterClassifierTests extends ESTestCase {
         stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
         stats.put("_stats.columns.age.min", 10L);
         stats.put("_stats.columns.age.max", 20L);
-        // min > 5, but no null_count → can't confirm MATCH (could have nulls)
-        Expression filter = gt(ref("age"), lit(5L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(greaterThanOf(AGE, of(5L)), stats));
     }
 
     public void testMissDoesNotRequireNullCount() {
@@ -254,141 +207,108 @@ public class SplitFilterClassifierTests extends ESTestCase {
         stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
         stats.put("_stats.columns.age.min", 10L);
         stats.put("_stats.columns.age.max", 20L);
-        // max <= 5, so all non-null rows miss; null rows also miss (NULL > 5 → UNKNOWN → FALSE)
-        Expression filter = gt(ref("age"), lit(25L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(greaterThanOf(AGE, of(25L)), stats));
     }
 
     // --- Type coercion ---
 
     public void testIntegerStatLongLiteral() {
-        Map<String, Object> stats = splitStats(10, 20, 100L, 0L);
-        Expression filter = gt(ref("age"), lit(5L));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        var stats = colStats(COL, 10, 20, 100L, 0L);
+        assertEquals(MATCH, classify(greaterThanOf(AGE, of(5L)), stats));
     }
 
     public void testDoubleStats() {
+        ReferenceAttribute score = referenceAttribute("score", DataType.DOUBLE);
         Map<String, Object> stats = new HashMap<>();
         stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
         stats.put("_stats.columns.score.min", 1.5);
         stats.put("_stats.columns.score.max", 9.5);
         stats.put("_stats.columns.score.null_count", 0L);
-        Expression filter = gt(ref("score"), lit(0.5));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(greaterThanOf(score, of(0.5)), stats));
     }
 
     public void testStringStats() {
+        ReferenceAttribute name = referenceAttribute("name", DataType.KEYWORD);
         Map<String, Object> stats = new HashMap<>();
         stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
         stats.put("_stats.columns.name.min", "alice");
         stats.put("_stats.columns.name.max", "charlie");
         stats.put("_stats.columns.name.null_count", 0L);
-        Expression filter = gt(ref("name"), lit("aaron"));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(greaterThanOf(name, of("aaron")), stats));
     }
 
     // --- Or ---
 
     public void testOrBothMatch() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = or(gt(ref("age"), lit(20L)), lt(ref("age"), lit(60L)));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(or(greaterThanOf(AGE, of(20L)), lessThanOf(AGE, of(60L))), STATS_30_50));
     }
 
     public void testOrLeftMatchRightMiss() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = or(gt(ref("age"), lit(20L)), lt(ref("age"), lit(10L)));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(or(greaterThanOf(AGE, of(20L)), lessThanOf(AGE, of(10L))), STATS_30_50));
     }
 
     public void testOrLeftMissRightMatch() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = or(gt(ref("age"), lit(60L)), lt(ref("age"), lit(60L)));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(or(greaterThanOf(AGE, of(60L)), lessThanOf(AGE, of(60L))), STATS_30_50));
     }
 
     public void testOrBothMiss() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = or(gt(ref("age"), lit(60L)), lt(ref("age"), lit(20L)));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(or(greaterThanOf(AGE, of(60L)), lessThanOf(AGE, of(20L))), STATS_30_50));
     }
 
     public void testOrOneAmbiguous() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = or(gt(ref("age"), lit(40L)), lt(ref("age"), lit(20L)));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(or(greaterThanOf(AGE, of(40L)), lessThanOf(AGE, of(20L))), STATS_30_50));
     }
 
     public void testOrBothAmbiguous() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = or(gt(ref("age"), lit(35L)), lt(ref("age"), lit(45L)));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(or(greaterThanOf(AGE, of(35L)), lessThanOf(AGE, of(45L))), STATS_30_50));
     }
 
     // --- Not ---
 
     public void testNotOfMatchBecomesMiss() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = not(gt(ref("age"), lit(20L)));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(not(greaterThanOf(AGE, of(20L))), STATS_30_50));
     }
 
     public void testNotOfMissBecomesAmbiguous() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = not(gt(ref("age"), lit(60L)));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(not(greaterThanOf(AGE, of(60L))), STATS_30_50));
     }
 
     public void testNotOfAmbiguousStaysAmbiguous() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = not(gt(ref("age"), lit(40L)));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(not(greaterThanOf(AGE, of(40L))), STATS_30_50));
     }
 
     public void testNotNotOfMatch() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = not(not(gt(ref("age"), lit(20L))));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(not(not(greaterThanOf(AGE, of(20L)))), STATS_30_50));
     }
 
-    // --- Nested And Or Not ---
+    // --- Nested And/Or/Not ---
 
     public void testAndInsideOr() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = or(and(gt(ref("age"), lit(20L)), lt(ref("age"), lit(60L))), gt(ref("age"), lit(70L)));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        Expression filter = or(and(greaterThanOf(AGE, of(20L)), lessThanOf(AGE, of(60L))), greaterThanOf(AGE, of(70L)));
+        assertEquals(MATCH, classify(filter, STATS_30_50));
     }
 
     public void testOrInsideAnd() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = and(or(gt(ref("age"), lit(60L)), lt(ref("age"), lit(20L))), gt(ref("age"), lit(20L)));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        Expression filter = and(or(greaterThanOf(AGE, of(60L)), lessThanOf(AGE, of(20L))), greaterThanOf(AGE, of(20L)));
+        assertEquals(MISS, classify(filter, STATS_30_50));
     }
 
     public void testNotInsideOr() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = or(not(gt(ref("age"), lit(60L))), gt(ref("age"), lit(20L)));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(or(not(greaterThanOf(AGE, of(60L))), greaterThanOf(AGE, of(20L))), STATS_30_50));
     }
 
-    // --- IS NULL tests ---
+    // --- IS NULL ---
 
     public void testIsNullMissWhenNoNulls() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = isNull(ref("age"));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(isNull(AGE), STATS_30_50));
     }
 
     public void testIsNullMatchWhenAllNull() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 100L);
-        Expression filter = isNull(ref("age"));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(isNull(AGE), colStats(COL, 30L, 50L, 100L, 100L)));
     }
 
     public void testIsNullAmbiguousWhenSomeNulls() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 50L);
-        Expression filter = isNull(ref("age"));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(isNull(AGE), colStats(COL, 30L, 50L, 100L, 50L)));
     }
 
     public void testIsNullAmbiguousWhenNoNullCount() {
@@ -396,140 +316,86 @@ public class SplitFilterClassifierTests extends ESTestCase {
         stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
         stats.put("_stats.columns.age.min", 30L);
         stats.put("_stats.columns.age.max", 50L);
-        Expression filter = isNull(ref("age"));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(isNull(AGE), stats));
     }
 
-    // --- IS NOT NULL tests ---
+    // --- IS NOT NULL ---
 
     public void testIsNotNullMatchWhenNoNulls() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = isNotNull(ref("age"));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(isNotNull(AGE), STATS_30_50));
     }
 
     public void testIsNotNullMissWhenAllNull() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 100L);
-        Expression filter = isNotNull(ref("age"));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(isNotNull(AGE), colStats(COL, 30L, 50L, 100L, 100L)));
     }
 
     public void testIsNotNullAmbiguousWhenSomeNulls() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 50L);
-        Expression filter = isNotNull(ref("age"));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(isNotNull(AGE), colStats(COL, 30L, 50L, 100L, 50L)));
     }
 
-    // --- IN tests ---
+    // --- IN ---
 
     public void testInMissAllLiteralsOutOfRange() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = in(ref("age"), lit(10L), lit(15L), lit(60L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(in(AGE, of(10L), of(15L), of(60L)), STATS_30_50));
     }
 
     public void testInAmbiguousWhenLiteralInRange() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = in(ref("age"), lit(10L), lit(40L), lit(60L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(in(AGE, of(10L), of(40L), of(60L)), STATS_30_50));
     }
 
     public void testInMatchWhenConstantColumnEqualsLiteral() {
-        Map<String, Object> stats = splitStats(42L, 42L, 100L, 0L);
-        Expression filter = in(ref("age"), lit(10L), lit(42L), lit(60L));
-        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MATCH, classify(in(AGE, of(10L), of(42L), of(60L)), STATS_CONST_42));
     }
 
     public void testInAmbiguousWhenConstantColumnNotInList() {
-        Map<String, Object> stats = splitStats(42L, 42L, 100L, 0L);
-        Expression filter = in(ref("age"), lit(10L), lit(20L), lit(60L));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(MISS, classify(in(AGE, of(10L), of(20L), of(60L)), STATS_CONST_42));
     }
 
     public void testInAmbiguousWithNulls() {
-        Map<String, Object> stats = splitStats(42L, 42L, 100L, 5L);
-        Expression filter = in(ref("age"), lit(42L));
-        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        assertEquals(AMBIGUOUS, classify(in(AGE, of(42L)), colStats(COL, 42L, 42L, 100L, 5L)));
     }
 
     public void testInWithAndFilter() {
-        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
-        Expression filter = and(in(ref("age"), lit(10L), lit(15L)), gt(ref("age"), lit(20L)));
-        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+        Expression filter = and(in(AGE, of(10L), of(15L)), greaterThanOf(AGE, of(20L)));
+        assertEquals(MISS, classify(filter, STATS_30_50));
     }
 
     // --- compareValues ---
 
     public void testCompareValuesLongs() {
-        assertEquals(-1, Integer.signum(SplitFilterClassifier.compareValues(5L, 10L)));
-        assertEquals(0, SplitFilterClassifier.compareValues(10L, 10L));
-        assertEquals(1, Integer.signum(SplitFilterClassifier.compareValues(15L, 10L)));
+        assertEquals(-1, Integer.signum(compareValues(5L, 10L)));
+        assertEquals(0, compareValues(10L, 10L));
+        assertEquals(1, Integer.signum(compareValues(15L, 10L)));
     }
 
     public void testCompareValuesIntAndLong() {
-        assertEquals(0, SplitFilterClassifier.compareValues(10, 10L));
-        assertEquals(-1, Integer.signum(SplitFilterClassifier.compareValues(5, 10L)));
+        assertEquals(0, compareValues(10, 10L));
+        assertEquals(-1, Integer.signum(compareValues(5, 10L)));
     }
 
     public void testCompareValuesDoubles() {
-        assertEquals(-1, Integer.signum(SplitFilterClassifier.compareValues(1.5, 2.5)));
-        assertEquals(0, SplitFilterClassifier.compareValues(1.5, 1.5));
+        assertEquals(-1, Integer.signum(compareValues(1.5, 2.5)));
+        assertEquals(0, compareValues(1.5, 1.5));
     }
 
     public void testCompareValuesNull() {
-        assertEquals(Integer.MIN_VALUE, SplitFilterClassifier.compareValues(null, 10L));
-        assertEquals(Integer.MIN_VALUE, SplitFilterClassifier.compareValues(10L, null));
+        assertEquals(Integer.MIN_VALUE, compareValues(null, 10L));
+        assertEquals(Integer.MIN_VALUE, compareValues(10L, null));
     }
 
     // --- helpers ---
 
-    private static Map<String, Object> splitStats(Object min, Object max, long rowCount, long nullCount) {
+    private static SplitFilterClassifier.SplitMatch classify(Expression filter, Map<String, Object> stats) {
+        return classifyExpression(filter, stats);
+    }
+
+    private static Map<String, Object> colStats(String colName, Object min, Object max, long rowCount, long nullCount) {
         Map<String, Object> stats = new HashMap<>();
         stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, rowCount);
-        stats.put("_stats.columns.age.min", min);
-        stats.put("_stats.columns.age.max", max);
-        stats.put("_stats.columns.age.null_count", nullCount);
+        stats.put("_stats.columns." + colName + ".min", min);
+        stats.put("_stats.columns." + colName + ".max", max);
+        stats.put("_stats.columns." + colName + ".null_count", nullCount);
         return stats;
-    }
-
-    private static ReferenceAttribute ref(String name) {
-        return new ReferenceAttribute(Source.EMPTY, name, DataType.LONG);
-    }
-
-    private static Literal lit(long value) {
-        return new Literal(Source.EMPTY, value, DataType.LONG);
-    }
-
-    private static Literal lit(double value) {
-        return new Literal(Source.EMPTY, value, DataType.DOUBLE);
-    }
-
-    private static Literal lit(String value) {
-        return new Literal(Source.EMPTY, new BytesRef(value), DataType.KEYWORD);
-    }
-
-    private static Expression gt(Expression left, Expression right) {
-        return new GreaterThan(Source.EMPTY, left, right, null);
-    }
-
-    private static Expression gte(Expression left, Expression right) {
-        return new GreaterThanOrEqual(Source.EMPTY, left, right, null);
-    }
-
-    private static Expression lt(Expression left, Expression right) {
-        return new LessThan(Source.EMPTY, left, right, null);
-    }
-
-    private static Expression lte(Expression left, Expression right) {
-        return new LessThanOrEqual(Source.EMPTY, left, right, null);
-    }
-
-    private static Expression eq(Expression left, Expression right) {
-        return new Equals(Source.EMPTY, left, right, null);
-    }
-
-    private static Expression neq(Expression left, Expression right) {
-        return new NotEquals(Source.EMPTY, left, right, null);
     }
 
     private static Expression or(Expression left, Expression right) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifierTests.java
@@ -1,0 +1,558 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SplitFilterClassifier.SplitMatch.AMBIGUOUS;
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SplitFilterClassifier.SplitMatch.MATCH;
+import static org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SplitFilterClassifier.SplitMatch.MISS;
+
+public class SplitFilterClassifierTests extends ESTestCase {
+
+    // --- GreaterThan ---
+
+    public void testGreaterThanMatch() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = gt(ref("age"), lit(5L));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testGreaterThanMiss() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = gt(ref("age"), lit(25L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testGreaterThanMissAtBoundary() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = gt(ref("age"), lit(20L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testGreaterThanAmbiguous() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = gt(ref("age"), lit(15L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testGreaterThanAmbiguousWithNulls() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 5L);
+        Expression filter = gt(ref("age"), lit(5L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- GreaterThanOrEqual ---
+
+    public void testGreaterThanOrEqualMatch() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = gte(ref("age"), lit(10L));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testGreaterThanOrEqualMiss() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = gte(ref("age"), lit(21L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testGreaterThanOrEqualAmbiguous() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = gte(ref("age"), lit(15L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- LessThan ---
+
+    public void testLessThanMatch() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = lt(ref("age"), lit(25L));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testLessThanMiss() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = lt(ref("age"), lit(5L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testLessThanMissAtBoundary() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = lt(ref("age"), lit(10L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testLessThanAmbiguous() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = lt(ref("age"), lit(15L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- LessThanOrEqual ---
+
+    public void testLessThanOrEqualMatch() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = lte(ref("age"), lit(20L));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testLessThanOrEqualMiss() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = lte(ref("age"), lit(9L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- Equals ---
+
+    public void testEqualsMatch() {
+        Map<String, Object> stats = splitStats(42L, 42L, 100L, 0L);
+        Expression filter = eq(ref("age"), lit(42L));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testEqualsMissBelowRange() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = eq(ref("age"), lit(5L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testEqualsMissAboveRange() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = eq(ref("age"), lit(25L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testEqualsAmbiguous() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = eq(ref("age"), lit(15L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- NotEquals ---
+
+    public void testNotEqualsMatch() {
+        Map<String, Object> stats = splitStats(42L, 42L, 100L, 0L);
+        Expression filter = neq(ref("age"), lit(99L));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testNotEqualsMiss() {
+        Map<String, Object> stats = splitStats(42L, 42L, 100L, 0L);
+        Expression filter = neq(ref("age"), lit(42L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testNotEqualsAmbiguous() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression filter = neq(ref("age"), lit(15L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- Reversed operand order (literal on left) ---
+
+    public void testReversedGreaterThan() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        // 25 > age ⟹ age < 25
+        Expression filter = gt(lit(25L), ref("age"));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testReversedLessThan() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        // 5 < age ⟹ age > 5
+        Expression filter = lt(lit(5L), ref("age"));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- AND conjunction ---
+
+    public void testConjunctionAllMatch() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression f1 = gte(ref("age"), lit(10L));
+        Expression f2 = lte(ref("age"), lit(20L));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(f1, f2), stats));
+    }
+
+    public void testConjunctionOneMiss() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression f1 = gte(ref("age"), lit(10L));
+        Expression f2 = lt(ref("age"), lit(5L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(f1, f2), stats));
+    }
+
+    public void testConjunctionMixedMatchAndAmbiguous() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        Expression f1 = gte(ref("age"), lit(10L));  // MATCH
+        Expression f2 = lt(ref("age"), lit(15L));    // AMBIGUOUS
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(f1, f2), stats));
+    }
+
+    // --- Edge cases ---
+
+    public void testEmptyConjuncts() {
+        Map<String, Object> stats = splitStats(10L, 20L, 100L, 0L);
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(), stats));
+    }
+
+    public void testNullStats() {
+        Expression filter = gt(ref("age"), lit(5L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), null));
+    }
+
+    public void testEmptyStats() {
+        Expression filter = gt(ref("age"), lit(5L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), Map.of()));
+    }
+
+    public void testMissingColumnStats() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        Expression filter = gt(ref("age"), lit(5L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testMissingNullCount() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        stats.put("_stats.columns.age.min", 10L);
+        stats.put("_stats.columns.age.max", 20L);
+        // min > 5, but no null_count → can't confirm MATCH (could have nulls)
+        Expression filter = gt(ref("age"), lit(5L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testMissDoesNotRequireNullCount() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        stats.put("_stats.columns.age.min", 10L);
+        stats.put("_stats.columns.age.max", 20L);
+        // max <= 5, so all non-null rows miss; null rows also miss (NULL > 5 → UNKNOWN → FALSE)
+        Expression filter = gt(ref("age"), lit(25L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- Type coercion ---
+
+    public void testIntegerStatLongLiteral() {
+        Map<String, Object> stats = splitStats(10, 20, 100L, 0L);
+        Expression filter = gt(ref("age"), lit(5L));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testDoubleStats() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        stats.put("_stats.columns.score.min", 1.5);
+        stats.put("_stats.columns.score.max", 9.5);
+        stats.put("_stats.columns.score.null_count", 0L);
+        Expression filter = gt(ref("score"), lit(0.5));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testStringStats() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        stats.put("_stats.columns.name.min", "alice");
+        stats.put("_stats.columns.name.max", "charlie");
+        stats.put("_stats.columns.name.null_count", 0L);
+        Expression filter = gt(ref("name"), lit("aaron"));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- Or ---
+
+    public void testOrBothMatch() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = or(gt(ref("age"), lit(20L)), lt(ref("age"), lit(60L)));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testOrLeftMatchRightMiss() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = or(gt(ref("age"), lit(20L)), lt(ref("age"), lit(10L)));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testOrLeftMissRightMatch() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = or(gt(ref("age"), lit(60L)), lt(ref("age"), lit(60L)));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testOrBothMiss() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = or(gt(ref("age"), lit(60L)), lt(ref("age"), lit(20L)));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testOrOneAmbiguous() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = or(gt(ref("age"), lit(40L)), lt(ref("age"), lit(20L)));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testOrBothAmbiguous() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = or(gt(ref("age"), lit(35L)), lt(ref("age"), lit(45L)));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- Not ---
+
+    public void testNotOfMatchBecomesMiss() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = not(gt(ref("age"), lit(20L)));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testNotOfMissBecomesAmbiguous() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = not(gt(ref("age"), lit(60L)));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testNotOfAmbiguousStaysAmbiguous() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = not(gt(ref("age"), lit(40L)));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testNotNotOfMatch() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = not(not(gt(ref("age"), lit(20L))));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- Nested And Or Not ---
+
+    public void testAndInsideOr() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = or(and(gt(ref("age"), lit(20L)), lt(ref("age"), lit(60L))), gt(ref("age"), lit(70L)));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testOrInsideAnd() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = and(or(gt(ref("age"), lit(60L)), lt(ref("age"), lit(20L))), gt(ref("age"), lit(20L)));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testNotInsideOr() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = or(not(gt(ref("age"), lit(60L))), gt(ref("age"), lit(20L)));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- IS NULL tests ---
+
+    public void testIsNullMissWhenNoNulls() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = isNull(ref("age"));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testIsNullMatchWhenAllNull() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 100L);
+        Expression filter = isNull(ref("age"));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testIsNullAmbiguousWhenSomeNulls() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 50L);
+        Expression filter = isNull(ref("age"));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testIsNullAmbiguousWhenNoNullCount() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        stats.put("_stats.columns.age.min", 30L);
+        stats.put("_stats.columns.age.max", 50L);
+        Expression filter = isNull(ref("age"));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- IS NOT NULL tests ---
+
+    public void testIsNotNullMatchWhenNoNulls() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = isNotNull(ref("age"));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testIsNotNullMissWhenAllNull() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 100L);
+        Expression filter = isNotNull(ref("age"));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testIsNotNullAmbiguousWhenSomeNulls() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 50L);
+        Expression filter = isNotNull(ref("age"));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- IN tests ---
+
+    public void testInMissAllLiteralsOutOfRange() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = in(ref("age"), lit(10L), lit(15L), lit(60L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testInAmbiguousWhenLiteralInRange() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = in(ref("age"), lit(10L), lit(40L), lit(60L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testInMatchWhenConstantColumnEqualsLiteral() {
+        Map<String, Object> stats = splitStats(42L, 42L, 100L, 0L);
+        Expression filter = in(ref("age"), lit(10L), lit(42L), lit(60L));
+        assertEquals(MATCH, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testInAmbiguousWhenConstantColumnNotInList() {
+        Map<String, Object> stats = splitStats(42L, 42L, 100L, 0L);
+        Expression filter = in(ref("age"), lit(10L), lit(20L), lit(60L));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testInAmbiguousWithNulls() {
+        Map<String, Object> stats = splitStats(42L, 42L, 100L, 5L);
+        Expression filter = in(ref("age"), lit(42L));
+        assertEquals(AMBIGUOUS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    public void testInWithAndFilter() {
+        Map<String, Object> stats = splitStats(30L, 50L, 100L, 0L);
+        Expression filter = and(in(ref("age"), lit(10L), lit(15L)), gt(ref("age"), lit(20L)));
+        assertEquals(MISS, SplitFilterClassifier.classifySplit(List.of(filter), stats));
+    }
+
+    // --- compareValues ---
+
+    public void testCompareValuesLongs() {
+        assertEquals(-1, Integer.signum(SplitFilterClassifier.compareValues(5L, 10L)));
+        assertEquals(0, SplitFilterClassifier.compareValues(10L, 10L));
+        assertEquals(1, Integer.signum(SplitFilterClassifier.compareValues(15L, 10L)));
+    }
+
+    public void testCompareValuesIntAndLong() {
+        assertEquals(0, SplitFilterClassifier.compareValues(10, 10L));
+        assertEquals(-1, Integer.signum(SplitFilterClassifier.compareValues(5, 10L)));
+    }
+
+    public void testCompareValuesDoubles() {
+        assertEquals(-1, Integer.signum(SplitFilterClassifier.compareValues(1.5, 2.5)));
+        assertEquals(0, SplitFilterClassifier.compareValues(1.5, 1.5));
+    }
+
+    public void testCompareValuesNull() {
+        assertEquals(Integer.MIN_VALUE, SplitFilterClassifier.compareValues(null, 10L));
+        assertEquals(Integer.MIN_VALUE, SplitFilterClassifier.compareValues(10L, null));
+    }
+
+    // --- helpers ---
+
+    private static Map<String, Object> splitStats(Object min, Object max, long rowCount, long nullCount) {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, rowCount);
+        stats.put("_stats.columns.age.min", min);
+        stats.put("_stats.columns.age.max", max);
+        stats.put("_stats.columns.age.null_count", nullCount);
+        return stats;
+    }
+
+    private static ReferenceAttribute ref(String name) {
+        return new ReferenceAttribute(Source.EMPTY, name, DataType.LONG);
+    }
+
+    private static Literal lit(long value) {
+        return new Literal(Source.EMPTY, value, DataType.LONG);
+    }
+
+    private static Literal lit(double value) {
+        return new Literal(Source.EMPTY, value, DataType.DOUBLE);
+    }
+
+    private static Literal lit(String value) {
+        return new Literal(Source.EMPTY, new BytesRef(value), DataType.KEYWORD);
+    }
+
+    private static Expression gt(Expression left, Expression right) {
+        return new GreaterThan(Source.EMPTY, left, right, null);
+    }
+
+    private static Expression gte(Expression left, Expression right) {
+        return new GreaterThanOrEqual(Source.EMPTY, left, right, null);
+    }
+
+    private static Expression lt(Expression left, Expression right) {
+        return new LessThan(Source.EMPTY, left, right, null);
+    }
+
+    private static Expression lte(Expression left, Expression right) {
+        return new LessThanOrEqual(Source.EMPTY, left, right, null);
+    }
+
+    private static Expression eq(Expression left, Expression right) {
+        return new Equals(Source.EMPTY, left, right, null);
+    }
+
+    private static Expression neq(Expression left, Expression right) {
+        return new NotEquals(Source.EMPTY, left, right, null);
+    }
+
+    private static Expression or(Expression left, Expression right) {
+        return new Or(Source.EMPTY, left, right);
+    }
+
+    private static Expression not(Expression child) {
+        return new Not(Source.EMPTY, child);
+    }
+
+    private static Expression and(Expression left, Expression right) {
+        return new And(Source.EMPTY, left, right);
+    }
+
+    private static Expression isNull(Expression child) {
+        return new IsNull(Source.EMPTY, child);
+    }
+
+    private static Expression isNotNull(Expression child) {
+        return new IsNotNull(Source.EMPTY, child);
+    }
+
+    private static Expression in(Expression value, Literal... list) {
+        return new In(Source.EMPTY, value, List.of(list));
+    }
+}


### PR DESCRIPTION
Enable metadata-only aggregate resolution (COUNT, MIN, MAX) for
queries with WHERE clauses. Evaluates filter conditions against
per-block statistics to classify splits as MATCH, MISS, or
AMBIGUOUS, computing aggregates solely from MATCH block stats.

Supports AND, OR, NOT, comparisons, IN lists, IS NULL/IS NOT NULL.

Developed with AI-assisted tooling