### PR TITLE
Regenerate unmapped_fields docs

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/settings/unmapped_fields.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/settings/unmapped_fields.md
@@ -47,6 +47,9 @@ FROM partial_mapping_sample_data
 
 #### Example
 
+Field `unmapped_message` is not mapped; it doesn't appear in the mapping of index `partial_mapping_sample_data`. It appears,
+however, in the stored `_source` of all documents in this index.
+
 The `LOAD` option will load this field from `_source` and treat it like a `keyword` type field.
 
 


### PR DESCRIPTION
Regenerating missing docs for the LOAD example in the unmapped_fields setting.