### PR TITLE
[9.4] Fix terminate_after not honored for aggs when size=0 (#146199)

### DIFF
--- a/docs/changelog/146199.yaml
+++ b/docs/changelog/146199.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 126665
+pr: 146199
+summary: Fix `terminate_after` not honored for aggs when size=0
+type: bug

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhaseCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhaseCollector.java
@@ -157,7 +157,7 @@ public final class QueryPhaseCollector implements TwoPhaseCollector {
         try {
             tdlc = topDocsCollector.getLeafCollector(context);
         } catch (@SuppressWarnings("unused") CollectionTerminatedException e) {
-            // top docs collector does not need this segment, but the aggs collector does.
+            // top docs collector does not need this segment, but the aggs collector may.
         }
         final LeafCollector topDocsLeafCollector = tdlc;
 
@@ -172,9 +172,11 @@ public final class QueryPhaseCollector implements TwoPhaseCollector {
         }
         final LeafCollector aggsLeafCollector = alf;
 
-        if (topDocsLeafCollector == null && minScore == null) {
-            // top docs collector early terminated, we can avoid wrapping as long as we don't need to apply min_score.
-            // post_filter and terminate_after do not matter because they not applied to aggs collection anyways.
+        if (topDocsLeafCollector == null && minScore == null && terminateAfterChecker == NO_OP_TERMINATE_AFTER_CHECKER) {
+            // top docs collector early terminated, we can avoid wrapping as long as we don't need to apply min_score
+            // or check terminate_after. terminate_after must still be enforced via CompositeLeafCollector to limit
+            // the number of documents collected by the aggs collector.
+            // post_filter does not matter because it is not applied to aggs collection anyway.
             // aggs don't support skipping low scoring hits, so we can rely on setMinCompetitiveScore being a no-op already.
             return aggsLeafCollector;
         }

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseCollectorTests.java
@@ -542,6 +542,39 @@ public class QueryPhaseCollectorTests extends ESTestCase {
         }
     }
 
+    public void testTerminateAfterWithAggsAndEarlyTerminatedTopDocs() throws IOException {
+        // When the top docs collector early terminates for every segment (simulating size=0 with track_total_hits disabled,
+        // where PartialHitCountCollector has threshold 0), terminate_after should still be honored for aggs collection.
+        {
+            int terminateAfter = randomIntBetween(1, numDocs - 1);
+            DummyTotalHitCountCollector aggsCollector = new DummyTotalHitCountCollector();
+            QueryPhaseCollector queryPhaseCollector = new QueryPhaseCollector(
+                new TerminateAfterCollector(new DummyTotalHitCountCollector(), 0),
+                null,
+                resolveTerminateAfterChecker(terminateAfter),
+                aggsCollector,
+                null
+            );
+            searcher.search(Queries.ALL_DOCS_INSTANCE, queryPhaseCollector);
+            assertTrue(queryPhaseCollector.isTerminatedAfter());
+            assertEquals(terminateAfter, aggsCollector.getTotalHits());
+        }
+        {
+            // terminate_after equal to numDocs: no early termination
+            DummyTotalHitCountCollector aggsCollector = new DummyTotalHitCountCollector();
+            QueryPhaseCollector queryPhaseCollector = new QueryPhaseCollector(
+                new TerminateAfterCollector(new DummyTotalHitCountCollector(), 0),
+                null,
+                resolveTerminateAfterChecker(numDocs),
+                aggsCollector,
+                null
+            );
+            searcher.search(Queries.ALL_DOCS_INSTANCE, queryPhaseCollector);
+            assertFalse(queryPhaseCollector.isTerminatedAfter());
+            assertEquals(numDocs, aggsCollector.getTotalHits());
+        }
+    }
+
     public void testTerminateAfterTopDocsOnlyWithPostFilter() throws IOException {
         TermQuery termQuery = new TermQuery(new Term("field2", "value"));
         Weight filterWeight = termQuery.createWeight(searcher, ScoreMode.TOP_DOCS, 1f);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix terminate_after not honored for aggs when size=0 (#146199)](https://github.com/elastic/elasticsearch/pull/146199)

<!--- Backport version: 11.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)