### PR TITLE
ESQL: Unmute QuerySettingsTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -463,8 +463,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeUnmappedLoadIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/145900
-- class: org.elasticsearch.xpack.esql.plan.QuerySettingsTests
-  issue: https://github.com/elastic/elasticsearch/issues/146570
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=aggregations/sig_terms/Test background filter count}
   issue: https://github.com/elastic/elasticsearch/issues/146599


### PR DESCRIPTION
Close https://github.com/elastic/elasticsearch/issues/146570.

Already fixed in #146601.