### PR TITLE
Remove mapping serialization assertions

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -73,48 +73,12 @@ public class DocumentMapper {
         this.indexVersion = version;
         this.logger = Loggers.getLogger(getClass(), indexName);
         this.indexName = indexName;
-
-        assert mapping.toCompressedXContent().equals(source)
-            || isSyntheticSourceMalformed(source, version)
-            || hasConfidenceIntervalDifference(source, mapping.toCompressedXContent())
-            : "provided source [" + source + "] differs from mapping [" + mapping.toCompressedXContent() + "]";
     }
 
     private void maybeLog(Exception ex) {
         if (logger.isDebugEnabled()) {
             logger.debug("Error while parsing document for index [" + indexName + "]: " + ex.getMessage(), ex);
         }
-    }
-
-    /**
-     * Indexes built at v.8.7 were missing an explicit entry for synthetic_source.
-     * This got restored in v.8.10 to avoid confusion. The change is only restricted to mapping printout, it has no
-     * functional effect as the synthetic source already applies.
-     */
-    boolean isSyntheticSourceMalformed(CompressedXContent source, IndexVersion version) {
-        return sourceMapper().isSynthetic()
-            && source.string().contains("\"_source\":{\"mode\":\"synthetic\"}") == false
-            && version.onOrBefore(IndexVersions.V_8_10_0);
-    }
-
-    /**
-     * The confidence_interval dense vector mapping parameter was deprecated on upgrade to Lucene 10.4.
-     * Previously it was default to 0.0 and always visible in the mapping, now it is hidden unless
-     * explicitly set. The check allows the mappings to differ if one contains "confidence_interval:0.0"
-     * but the other doesn't.
-     * Strips out confidence_interval fields from both sources and compares them.
-     */
-    boolean hasConfidenceIntervalDifference(CompressedXContent source1, CompressedXContent source2) {
-        String s1 = stripConfidenceInterval(source1.string());
-        String s2 = stripConfidenceInterval(source2.string());
-        return s1.equals(s2);
-    }
-
-    private String stripConfidenceInterval(String json) {
-        // Remove "confidence_interval":0.0 and the comma before it if present
-        return json.replaceAll(",\"confidence_interval\":0\\.0", "")
-            // Remove "confidence_interval":0.0 and the comma after it if present
-            .replaceAll("\"confidence_interval\":0\\.0,", "");
     }
 
     public Mapping mapping() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -37,7 +37,6 @@ import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
@@ -50,7 +49,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -379,7 +377,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             : "index mismatch: expected " + index() + " but was " + newIndexMetadata.getIndex();
 
         if (currentIndexMetadata != null && currentIndexMetadata.getMappingVersion() == newIndexMetadata.getMappingVersion()) {
-            assert assertNoUpdateRequired(newIndexMetadata);
             return;
         }
 
@@ -391,7 +388,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             DocumentMapper previousMapper;
             synchronized (this) {
                 previousMapper = this.mapper;
-                assert assertRefreshIsNotNeeded(type, incomingBuilder);
                 Mapping incomingMapping = buildMapping(incomingBuilder, MergeReason.MAPPING_RECOVERY);
                 this.mapper = newDocumentMapper(incomingMapping, MergeReason.MAPPING_RECOVERY, incomingMappingSource);
                 this.mappingVersion = newIndexMetadata.getMappingVersion();
@@ -405,58 +401,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
                 logger.debug("[{}] {} mapping (source suppressed due to length, use TRACE level if needed)", index(), op);
             }
         }
-    }
-
-    private boolean assertRefreshIsNotNeeded(String type, MappingBuilder incomingBuilder) {
-        Mapping mergedMapping = mergeBuilders(incomingBuilder, MergeReason.MAPPING_RECOVERY);
-        Mapping incomingMapping = incomingBuilder.build(MergeReason.MAPPING_RECOVERY);
-        // skip the runtime section or removed runtime fields will make the assertion fail
-        ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap(RootObjectMapper.TOXCONTENT_SKIP_RUNTIME, "true"));
-        CompressedXContent mergedMappingSource;
-        try {
-            mergedMappingSource = new CompressedXContent(mergedMapping, params);
-        } catch (Exception e) {
-            throw new AssertionError("failed to serialize source for type [" + type + "]", e);
-        }
-        CompressedXContent incomingMappingSource;
-        try {
-            incomingMappingSource = new CompressedXContent(incomingMapping, params);
-        } catch (Exception e) {
-            throw new AssertionError("failed to serialize source for type [" + type + "]", e);
-        }
-        // we used to ask the master to refresh its mappings whenever the result of merging the incoming mappings with the
-        // current mappings differs from the incoming mappings. We now rather assert that this situation never happens.
-        assert mergedMappingSource.equals(incomingMappingSource)
-            : "["
-                + index()
-                + "] parsed mapping, and got different sources\n"
-                + "incoming:\n"
-                + incomingMappingSource
-                + "\nmerged:\n"
-                + mergedMappingSource;
-        return true;
-    }
-
-    boolean assertNoUpdateRequired(final IndexMetadata newIndexMetadata) {
-        MappingMetadata mapping = newIndexMetadata.mapping();
-        if (mapping != null) {
-            // mapping representations may change between versions (eg text field mappers
-            // used to always explicitly serialize analyzers), so we cannot simply check
-            // that the incoming mappings are the same as the current ones: we need to
-            // parse the incoming mappings into a DocumentMapper and check that its
-            // serialization is the same as the existing mapper
-            Mapping newMapping = parseMapping(mapping.type(), MergeReason.MAPPING_UPDATE, mapping.source());
-            final CompressedXContent currentSource = this.mapper.mappingSource();
-            final CompressedXContent newSource = newMapping.toCompressedXContent();
-            if (Objects.equals(currentSource, newSource) == false
-                && mapper.isSyntheticSourceMalformed(currentSource, indexVersionCreated) == false) {
-                throw new IllegalStateException(
-                    "expected current mapping [" + currentSource + "] to be the same as new mapping [" + newSource + "]"
-                );
-            }
-        }
-        return true;
-
     }
 
     public void merge(IndexMetadata indexMetadata, MergeReason reason) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -46,16 +46,6 @@ public class RootObjectMapper extends ObjectMapper {
     private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(RootObjectMapper.class);
     private static final int MAX_NESTING_LEVEL_FOR_PASS_THROUGH_OBJECTS = 20;
 
-    /**
-     * Parameter used when serializing {@link RootObjectMapper} and request that the runtime section is skipped.
-     * This is only needed internally when we compare different versions of mappings and assert that they are the same.
-     * Runtime fields break these assertions as they can be removed: the master node sends the merged mappings without the runtime fields
-     * that needed to be removed. Then each local node as part of its assertions merges the incoming mapping with the current mapping,
-     *  and the previously removed runtime fields appear again, which is not desirable. The expectation is that those two versions of the
-     *  mappings are the same, besides runtime fields.
-     */
-    static final String TOXCONTENT_SKIP_RUNTIME = "skip_runtime";
-
     public static class Defaults {
         public static final Explicit<DateFormatter[]> DYNAMIC_DATE_TIME_FORMATTERS = new Explicit<>(
             new DateFormatter[] {
@@ -318,7 +308,7 @@ public class RootObjectMapper extends ObjectMapper {
             builder.field("numeric_detection", numericDetection.value());
         }
 
-        if (runtimeFields.size() > 0 && params.paramAsBoolean(TOXCONTENT_SKIP_RUNTIME, false) == false) {
+        if (runtimeFields.isEmpty() == false) {
             builder.startObject("runtime");
             List<RuntimeField> sortedRuntimeFields = runtimeFields.values()
                 .stream()

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -512,42 +512,4 @@ public class DocumentMapperTests extends MapperServiceTestCase {
             )
         );
     }
-
-    public void testHasConfidenceIntervalDifference() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(mapping(b -> b.startObject("field").field("type", "keyword").endObject()));
-
-        // Test with confidence_interval:0.0 in one source but not the other
-        String sourceWithConfidenceInterval = "{\"_doc\":{\"properties\":{\"vector\":{\"type\":\"dense_vector\",\"dims\":4,"
-            + "\"index\":true,\"similarity\":\"l2_norm\",\"index_options\":{\"type\":\"int4_flat\",\"confidence_interval\":0.0}}}}}";
-        String sourceWithoutConfidenceInterval = "{\"_doc\":{\"properties\":{\"vector\":{\"type\":\"dense_vector\",\"dims\":4,"
-            + "\"index\":true,\"similarity\":\"l2_norm\",\"index_options\":{\"type\":\"int4_flat\"}}}}}";
-
-        CompressedXContent compressed1 = new CompressedXContent(sourceWithConfidenceInterval);
-        CompressedXContent compressed2 = new CompressedXContent(sourceWithoutConfidenceInterval);
-
-        assertTrue(mapper.hasConfidenceIntervalDifference(compressed1, compressed2));
-
-        // Test with confidence_interval:0.0 appearing multiple times
-        String sourceWithMultipleConfidenceIntervals = "{\"_doc\":{\"properties\":{\"vector\":{\"type\":\"dense_vector\",\"dims\":4,"
-            + "\"index\":true,\"similarity\":\"l2_norm\",\"index_options\":{\"type\":\"int4_flat\",\"confidence_interval\":0.0}},"
-            + "\"another_vector\":{\"type\":\"dense_vector\",\"dims\":4,\"index\":true,\"similarity\":\"l2_norm\","
-            + "\"index_options\":{\"type\":\"int4_flat\",\"confidence_interval\":0.0}}}}}";
-        String sourceWithoutMultipleConfidenceIntervals = "{\"_doc\":{\"properties\":{\"vector\":{\"type\":\"dense_vector\","
-            + "\"dims\":4,\"index\":true,\"similarity\":\"l2_norm\",\"index_options\":{\"type\":\"int4_flat\"}},"
-            + "\"another_vector\":{\"type\":\"dense_vector\",\"dims\":4,\"index\":true,\"similarity\":\"l2_norm\","
-            + "\"index_options\":{\"type\":\"int4_flat\"}}}}}";
-
-        CompressedXContent compressed3 = new CompressedXContent(sourceWithMultipleConfidenceIntervals);
-        CompressedXContent compressed4 = new CompressedXContent(sourceWithoutMultipleConfidenceIntervals);
-
-        assertTrue(mapper.hasConfidenceIntervalDifference(compressed3, compressed4));
-
-        // Test with non-zero confidence_interval (should not match)
-        String sourceWithNonZeroConfidenceInterval = "{\"_doc\":{\"properties\":{\"vector\":{\"type\":\"dense_vector\",\"dims\":4,"
-            + "\"index\":true,\"similarity\":\"l2_norm\",\"index_options\":{\"type\":\"int4_flat\",\"confidence_interval\":0.5}}}}}";
-
-        CompressedXContent compressed5 = new CompressedXContent(sourceWithNonZeroConfidenceInterval);
-
-        assertFalse(mapper.hasConfidenceIntervalDifference(compressed5, compressed2));
-    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -364,34 +364,6 @@ public class MapperServiceTests extends MapperServiceTestCase {
         }
     }
 
-    public void testMappingUpdateChecks() throws IOException {
-        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "text")));
-
-        {
-            IndexMetadata.Builder builder = new IndexMetadata.Builder("test");
-            builder.settings(indexSettings(IndexVersion.current(), 1, 0));
-
-            // Text fields are not stored by default, so an incoming update that is identical but
-            // just has `stored:false` should not require an update
-            builder.putMapping("""
-                {"properties":{"field":{"type":"text","store":"false"}}}""");
-            assertTrue(mapperService.assertNoUpdateRequired(builder.build()));
-        }
-
-        {
-            IndexMetadata.Builder builder = new IndexMetadata.Builder("test");
-            builder.settings(indexSettings(IndexVersion.current(), 1, 0));
-
-            // However, an update that really does need a rebuild will throw an exception
-            builder.putMapping("""
-                {"properties":{"field":{"type":"text","store":"true"}}}""");
-            Exception e = expectThrows(IllegalStateException.class, () -> mapperService.assertNoUpdateRequired(builder.build()));
-
-            assertThat(e.getMessage(), containsString("expected current mapping ["));
-            assertThat(e.getMessage(), containsString("to be the same as new mapping"));
-        }
-    }
-
     public void testEagerGlobalOrdinals() throws IOException {
         MapperService mapperService = createMapperService(mapping(b -> {
             b.startObject("eager1").field("type", "keyword").field("eager_global_ordinals", true).endObject();


### PR DESCRIPTION
We have three places where we assert on mapping serializations on a data node:
- When we receive a mapping update with the same version as the current mappings, we assert that the serialized incoming mappings are the same as our current mapping.  This was added as part of the move to use mapping versions to ensure that there weren't any other update paths. We assert in both the MapperService and the DocumentMapper.
- When a mapping update comes in after a dynamic mapping change, we assert that merging the new mappings into the current mapping serializes in the same way as the new mappings do by themselves.  This was added when the mapping refresh mechanism was removed, to ensure that we weren't missing an update path.

Both of these assertions have been in place for several versions, and we can be reasonable confident that there are no other update paths for mappings.  Updates all happen on the master, and merges on data nodes are only done via MapperService.updateMapping().

There is a considerable downside associated with these assertions, in that they mean we cannot change serialization across versions. Any change in serialization will trip these assertions in mixed-version clusters, even though the mappings themselves are perfectly well-formed and can be parsed without issue.  This can be seen by the exclusions that have had to be added to these assertions to handle some changes that managed to pass BWC tests in CI, before failing once they landed in main, as well as special handling for runtime fields.  We have comprehensive unit tests for serialization which will catch real errors.

This commit removes the assertions entirely, and can be backported to all versions that support mixed clusters.  It will allow us to freely change things like the order of serialization and handling of default values in the future.

Relates to #142753 