### PR TITLE
[9.4] [ES|QL] Pass request context to completion inference (#146577)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceService.java
@@ -21,6 +21,8 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 public class InferenceService {
 
+    public static final String COMPLETION_PRODUCT_USE_CASE = "internal_completion";
+
     private InferenceSettings inferenceSettings;
 
     private final Client client;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/completion/CompletionRequestIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/completion/CompletionRequestIterator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xpack.core.inference.InferenceContext;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceRequestItem;
 import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceRequestItem.PositionValueCountsBuilder;
@@ -22,6 +23,8 @@ import org.elasticsearch.xpack.esql.inference.InputTextReader;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+
+import static org.elasticsearch.xpack.esql.inference.InferenceService.COMPLETION_PRODUCT_USE_CASE;
 
 /**
  * Iterator that converts a block of prompt strings into inference request items.
@@ -96,7 +99,8 @@ class CompletionRequestIterator implements BulkInferenceRequestItemIterator {
         }
 
         InferenceAction.Request.Builder builder = InferenceAction.Request.builder(inferenceId, TaskType.COMPLETION)
-            .setInput(List.of(prompt));
+            .setInput(List.of(prompt))
+            .setContext(new InferenceContext(COMPLETION_PRODUCT_USE_CASE));
 
         // Only set task settings if explicitly provided by the user.
         // This preserves backward compatibility and avoids sending empty

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/completion/CompletionRequestIteratorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/completion/CompletionRequestIteratorTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.inference.InferenceOperator.BulkInferenceReq
 
 import java.util.Map;
 
+import static org.elasticsearch.xpack.esql.inference.InferenceService.COMPLETION_PRODUCT_USE_CASE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -65,6 +66,7 @@ public class CompletionRequestIteratorTests extends ComputeTestCase {
             BulkInferenceRequestItem requestItem1 = requestIterator.next();
             assertThat(requestItem1.inferenceRequest().getInferenceEntityId(), equalTo(inferenceId));
             assertThat(requestItem1.inferenceRequest().getTaskType(), equalTo(TaskType.COMPLETION));
+            assertThat(requestItem1.inferenceRequest().getContext().productUseCase(), equalTo(COMPLETION_PRODUCT_USE_CASE));
             assertThat(requestItem1.inferenceRequest().getInput().getFirst(), equalTo("prompt1"));
             assertThat(requestItem1.positionValueCounts(), equalTo(new int[] { 1, 0, 0 }));
 
@@ -251,6 +253,7 @@ public class CompletionRequestIteratorTests extends ComputeTestCase {
 
                 assertThat(request.getInferenceEntityId(), equalTo(inferenceId));
                 assertThat(request.getTaskType(), equalTo(TaskType.COMPLETION));
+                assertThat(request.getContext().productUseCase(), equalTo(COMPLETION_PRODUCT_USE_CASE));
 
                 scratch = inputBlock.getBytesRef(inputBlock.getFirstValueIndex(iterationCount), scratch);
                 assertThat(request.getInput().getFirst(), equalTo(scratch.utf8ToString()));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[ES|QL] Pass request context to completion inference (#146577)](https://github.com/elastic/elasticsearch/pull/146577)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

---

### Manual conflict resolution

This PR was created manually after the automated backport failed. One conflict in `CompletionRequestIteratorTests.java`: on `main`, the line below the insertion point has a cast — `((InferenceAction.Request) requestItem1.inferenceRequest()).getInput().getFirst()` — that was added in a separate commit not backported to `9.4`. On `9.4` the line has no cast. Resolution: inserted the new `getContext().productUseCase()` assertion and left `9.4`'s existing uncast line alone. Production files cherry-picked cleanly.