### PR TITLE
ESQL: Re-mute testApproximationDisabled

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -442,6 +442,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.PushExpressionToLoadIT
   method: testRoundToLongExactMatch
   issue: https://github.com/elastic/elasticsearch/issues/146615
+- class: org.elasticsearch.xpack.esql.optimizer.ApproximationGoldenTests
+  method: testApproximationDisabled
+  issue: https://github.com/elastic/elasticsearch/issues/146564
 
 # Examples:
 #


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/146564

The mute somehow got removed, but the test is still failing.

Cc @jan-elastic 