### PR TITLE
[9.2] [ES|QL] Pass request context to completion inference (#146577)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/InferenceService.java
@@ -13,6 +13,9 @@ import org.elasticsearch.xpack.esql.inference.bulk.BulkInferenceRunner;
 import org.elasticsearch.xpack.esql.inference.bulk.BulkInferenceRunnerConfig;
 
 public class InferenceService {
+
+    public static final String COMPLETION_PRODUCT_USE_CASE = "internal_completion";
+
     private final InferenceResolver.Factory inferenceResolverFactory;
 
     private final BulkInferenceRunner.Factory bulkInferenceRunnerFactory;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/completion/CompletionOperatorRequestIterator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/completion/CompletionOperatorRequestIterator.java
@@ -10,12 +10,15 @@ package org.elasticsearch.xpack.esql.inference.completion;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.xpack.core.inference.InferenceContext;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.esql.inference.InputTextReader;
 import org.elasticsearch.xpack.esql.inference.bulk.BulkInferenceRequestIterator;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+
+import static org.elasticsearch.xpack.esql.inference.InferenceService.COMPLETION_PRODUCT_USE_CASE;
 
 /**
  *  This iterator reads prompts from a {@link BytesRefBlock} and converts them into individual {@link InferenceAction.Request} instances
@@ -62,7 +65,10 @@ class CompletionOperatorRequestIterator implements BulkInferenceRequestIterator 
             return null;
         }
 
-        return InferenceAction.Request.builder(inferenceId, TaskType.COMPLETION).setInput(List.of(prompt)).build();
+        return InferenceAction.Request.builder(inferenceId, TaskType.COMPLETION)
+            .setInput(List.of(prompt))
+            .setContext(new InferenceContext(COMPLETION_PRODUCT_USE_CASE))
+            .build();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/completion/CompletionOperatorRequestIteratorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/completion/CompletionOperatorRequestIteratorTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.test.ComputeTestCase;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 
+import static org.elasticsearch.xpack.esql.inference.InferenceService.COMPLETION_PRODUCT_USE_CASE;
 import static org.hamcrest.Matchers.equalTo;
 
 public class CompletionOperatorRequestIteratorTests extends ComputeTestCase {
@@ -34,6 +35,7 @@ public class CompletionOperatorRequestIteratorTests extends ComputeTestCase {
             for (int currentPos = 0; requestIterator.hasNext(); currentPos++) {
                 InferenceAction.Request request = requestIterator.next();
                 assertThat(request.getInferenceEntityId(), equalTo(inferenceId));
+                assertThat(request.getContext().productUseCase(), equalTo(COMPLETION_PRODUCT_USE_CASE));
                 scratch = inputBlock.getBytesRef(inputBlock.getFirstValueIndex(currentPos), scratch);
                 assertThat(request.getInput().getFirst(), equalTo(scratch.utf8ToString()));
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ES|QL] Pass request context to completion inference (#146577)](https://github.com/elastic/elasticsearch/pull/146577)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)