### PR TITLE
[ESQL] Cost-based filter evaluation ordering for external sources

### DIFF
--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Check;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
@@ -165,6 +166,7 @@ public class OrcFormatReader implements RangeAwareFormatReader {
             long nullCount = rowCount - totalValues;
             Object minVal = extractOrcMin(cs);
             Object maxVal = extractOrcMax(cs);
+            long bytesOnDisk = cs.getBytesOnDisk();
 
             columnStats.put(name, new SourceStatistics.ColumnStatistics() {
                 @Override
@@ -185,6 +187,11 @@ public class OrcFormatReader implements RangeAwareFormatReader {
                 @Override
                 public Optional<Object> maxValue() {
                     return Optional.ofNullable(maxVal);
+                }
+
+                @Override
+                public OptionalLong sizeInBytes() {
+                    return bytesOnDisk > 0 ? OptionalLong.of(bytesOnDisk) : OptionalLong.empty();
                 }
             });
         }
@@ -274,8 +281,8 @@ public class OrcFormatReader implements RangeAwareFormatReader {
 
     private static Map<String, Object> buildStripeStats(StripeInformation stripe, StripeStatistics stats, TypeDescription schema) {
         Map<String, Object> map = new HashMap<>();
-        map.put("_stats.row_count", stripe.getNumberOfRows());
-        map.put("_stats.size_bytes", stripe.getLength());
+        map.put(SourceStatisticsSerializer.STATS_ROW_COUNT, stripe.getNumberOfRows());
+        map.put(SourceStatisticsSerializer.STATS_SIZE_BYTES, stripe.getLength());
         List<String> fieldNames = schema.getFieldNames();
         List<TypeDescription> children = schema.getChildren();
         ColumnStatistics[] colStats = stats.getColumnStatistics();
@@ -291,14 +298,17 @@ public class OrcFormatReader implements RangeAwareFormatReader {
             }
             long totalValues = cs.getNumberOfValues();
             long nullCount = stripe.getNumberOfRows() - totalValues;
-            map.put("_stats.columns." + colName + ".null_count", nullCount);
+            map.put(SourceStatisticsSerializer.columnNullCountKey(colName), nullCount);
+            if (cs.getBytesOnDisk() > 0) {
+                map.put(SourceStatisticsSerializer.columnSizeBytesKey(colName), cs.getBytesOnDisk());
+            }
             Object minVal = extractOrcMin(cs);
             Object maxVal = extractOrcMax(cs);
             if (minVal != null) {
-                map.put("_stats.columns." + colName + ".min", minVal);
+                map.put(SourceStatisticsSerializer.columnMinKey(colName), minVal);
             }
             if (maxVal != null) {
-                map.put("_stats.columns." + colName + ".max", maxVal);
+                map.put(SourceStatisticsSerializer.columnMaxKey(colName), maxVal);
             }
         }
         return Map.copyOf(map);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -195,12 +195,17 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         Map<String, long[]> nullCounts = new HashMap<>();
         Map<String, Comparable[]> mins = new HashMap<>();
         Map<String, Comparable[]> maxs = new HashMap<>();
+        Map<String, long[]> colSizes = new HashMap<>();
 
         for (BlockMetaData rowGroup : rowGroups) {
             totalRows += rowGroup.getRowCount();
             totalSize += rowGroup.getTotalByteSize();
             for (ColumnChunkMetaData col : rowGroup.getColumns()) {
                 String colName = col.getPath().toDotString();
+                colSizes.merge(colName, new long[] { col.getTotalUncompressedSize() }, (a, b) -> {
+                    a[0] += b[0];
+                    return a;
+                });
                 Statistics stats = col.getStatistics();
                 if (stats == null || stats.isEmpty()) {
                     continue;
@@ -234,10 +239,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             long[] nc = nullCounts.get(name);
             Comparable[] mn = mins.get(name);
             Comparable[] mx = maxs.get(name);
-            if (nc != null || mn != null || mx != null) {
+            long[] cs = colSizes.get(name);
+            if (nc != null || mn != null || mx != null || cs != null) {
                 final long nullCount = nc != null ? nc[0] : 0;
                 final Object minVal = mn != null ? mn[0] : null;
                 final Object maxVal = mx != null ? mx[0] : null;
+                final long colSize = cs != null ? cs[0] : -1;
                 columnStats.put(name, new SourceStatistics.ColumnStatistics() {
                     @Override
                     public OptionalLong nullCount() {
@@ -257,6 +264,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                     @Override
                     public Optional<Object> maxValue() {
                         return Optional.ofNullable(maxVal);
+                    }
+
+                    @Override
+                    public OptionalLong sizeInBytes() {
+                        return colSize >= 0 ? OptionalLong.of(colSize) : OptionalLong.empty();
                     }
                 });
             }
@@ -399,6 +411,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         stats.put(SourceStatisticsSerializer.STATS_SIZE_BYTES, rowGroup.getTotalByteSize());
         for (ColumnChunkMetaData col : rowGroup.getColumns()) {
             String colName = col.getPath().toDotString();
+            stats.put(SourceStatisticsSerializer.columnSizeBytesKey(colName), col.getTotalUncompressedSize());
             Statistics colStats = col.getStatistics();
             if (colStats == null || colStats.isEmpty()) {
                 continue;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimator.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Reorders filter conjuncts by estimated selectivity and cost using column statistics
+ * from source metadata. Most selective predicates (those eliminating the most rows) are
+ * placed first so that downstream readers can skip data earlier.
+ * <p>
+ * Scoring:
+ * <ul>
+ *   <li>Primary: estimated selectivity from min/max range width vs predicate value (lower = more selective = evaluated first)</li>
+ *   <li>Secondary: column size_bytes — smaller column is cheaper to evaluate</li>
+ *   <li>Fallback: original order preserved for predicates without statistics</li>
+ * </ul>
+ */
+public final class FilterEvaluationOrderEstimator {
+
+    static final double UNKNOWN_SELECTIVITY = 0.5;
+    private static final long UNKNOWN_SIZE = Long.MAX_VALUE;
+
+    private FilterEvaluationOrderEstimator() {}
+
+    /**
+     * Returns the conjuncts reordered so the most selective (cheapest) predicates come first.
+     * If metadata is null/empty, contains a single predicate, or all conjuncts score equally,
+     * returns the original list unchanged.
+     */
+    public static List<Expression> orderByEstimatedCost(List<Expression> conjuncts, Map<String, Object> sourceMetadata) {
+        if (conjuncts == null || conjuncts.size() <= 1 || sourceMetadata == null || sourceMetadata.isEmpty()) {
+            return conjuncts;
+        }
+
+        Object rcValue = sourceMetadata.get(SourceStatisticsSerializer.STATS_ROW_COUNT);
+        if (rcValue instanceof Number == false) {
+            return conjuncts;
+        }
+        long rowCount = ((Number) rcValue).longValue();
+        if (rowCount <= 0) {
+            return conjuncts;
+        }
+
+        List<ScoredExpression> scored = new ArrayList<>(conjuncts.size());
+        for (int i = 0; i < conjuncts.size(); i++) {
+            Expression expr = conjuncts.get(i);
+            double selectivity = estimateSelectivity(expr, sourceMetadata, rowCount);
+            long sizeBytes = estimateColumnSize(expr, sourceMetadata);
+            scored.add(new ScoredExpression(expr, selectivity, sizeBytes, i));
+        }
+
+        scored.sort(
+            Comparator.comparingDouble((ScoredExpression s) -> s.selectivity)
+                .thenComparingLong(s -> s.sizeBytes)
+                .thenComparingInt(s -> s.originalIndex)
+        );
+
+        boolean changed = false;
+        for (int i = 0; i < scored.size(); i++) {
+            if (scored.get(i).originalIndex != i) {
+                changed = true;
+                break;
+            }
+        }
+        if (changed == false) {
+            return conjuncts;
+        }
+
+        List<Expression> result = new ArrayList<>(scored.size());
+        for (ScoredExpression s : scored) {
+            result.add(s.expression);
+        }
+        return result;
+    }
+
+    private record ScoredExpression(Expression expression, double selectivity, long sizeBytes, int originalIndex) {}
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    static double estimateSelectivity(Expression expr, Map<String, Object> sourceMetadata, long rowCount) {
+        if (expr instanceof Equals eq) {
+            String col = columnName(eq.left());
+            if (col != null && eq.right().foldable()) {
+                return estimateEqualitySelectivity(col, foldValue(eq.right()), sourceMetadata);
+            }
+        } else if (expr instanceof GreaterThan gt) {
+            String col = columnName(gt.left());
+            if (col != null && gt.right().foldable()) {
+                return estimateRangeSelectivity(col, foldValue(gt.right()), true, sourceMetadata);
+            }
+        } else if (expr instanceof GreaterThanOrEqual gte) {
+            String col = columnName(gte.left());
+            if (col != null && gte.right().foldable()) {
+                return estimateRangeSelectivity(col, foldValue(gte.right()), true, sourceMetadata);
+            }
+        } else if (expr instanceof LessThan lt) {
+            String col = columnName(lt.left());
+            if (col != null && lt.right().foldable()) {
+                return estimateRangeSelectivity(col, foldValue(lt.right()), false, sourceMetadata);
+            }
+        } else if (expr instanceof LessThanOrEqual lte) {
+            String col = columnName(lte.left());
+            if (col != null && lte.right().foldable()) {
+                return estimateRangeSelectivity(col, foldValue(lte.right()), false, sourceMetadata);
+            }
+        } else if (expr instanceof In in) {
+            String col = columnName(in.value());
+            if (col != null) {
+                int count = 0;
+                for (Expression e : in.list()) {
+                    if (e.foldable()) {
+                        count++;
+                    }
+                }
+                return estimateInSelectivity(col, count, sourceMetadata);
+            }
+        } else if (expr instanceof IsNull isNull) {
+            String col = columnName(isNull.field());
+            if (col != null) {
+                return estimateNullSelectivity(col, sourceMetadata, rowCount);
+            }
+        } else if (expr instanceof IsNotNull isNotNull) {
+            String col = columnName(isNotNull.field());
+            if (col != null) {
+                double nullSel = estimateNullSelectivity(col, sourceMetadata, rowCount);
+                return 1.0 - nullSel;
+            }
+        }
+
+        return UNKNOWN_SELECTIVITY;
+    }
+
+    /**
+     * Folds a foldable expression to its runtime value using a small allocator.
+     */
+    private static Object foldValue(Expression expr) {
+        return expr.fold(FoldContext.small());
+    }
+
+    /**
+     * Returns the column name if the expression is a field or reference attribute, null otherwise.
+     */
+    private static String columnName(Expression expr) {
+        if (expr instanceof NamedExpression ne) {
+            return Expressions.name(ne);
+        }
+        return null;
+    }
+
+    /**
+     * Collects all column names referenced by an expression.
+     */
+    private static Set<String> collectColumnNames(Expression expr) {
+        Set<String> names = new LinkedHashSet<>();
+        expr.forEachDown(Attribute.class, attr -> {
+            if (attr instanceof FieldAttribute || attr instanceof ReferenceAttribute) {
+                names.add(Expressions.name(attr));
+            }
+        });
+        return names;
+    }
+
+    // -- selectivity estimators --
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static double estimateEqualitySelectivity(String colName, Object value, Map<String, Object> sourceMetadata) {
+        Object min = sourceMetadata.get(SourceStatisticsSerializer.columnMinKey(colName));
+        Object max = sourceMetadata.get(SourceStatisticsSerializer.columnMaxKey(colName));
+        if (min == null || max == null) {
+            return UNKNOWN_SELECTIVITY;
+        }
+        double rangeWidth = numericRangeWidth(min, max);
+        if (Double.isNaN(rangeWidth)) {
+            return UNKNOWN_SELECTIVITY;
+        }
+        if (rangeWidth <= 0) {
+            if (min instanceof Comparable minC && value instanceof Comparable valC) {
+                return minC.compareTo(valC) == 0 ? 1.0 : 0.0;
+            }
+            return UNKNOWN_SELECTIVITY;
+        }
+        if (min instanceof Comparable minC && max instanceof Comparable maxC && value instanceof Comparable valC) {
+            if (minC.compareTo(valC) > 0 || maxC.compareTo(valC) < 0) {
+                return 0.0;
+            }
+        }
+        return Math.min(1.0, 1.0 / rangeWidth);
+    }
+
+    private static double estimateRangeSelectivity(
+        String colName,
+        Object value,
+        boolean isGreaterThan,
+        Map<String, Object> sourceMetadata
+    ) {
+        Object min = sourceMetadata.get(SourceStatisticsSerializer.columnMinKey(colName));
+        Object max = sourceMetadata.get(SourceStatisticsSerializer.columnMaxKey(colName));
+        if (min == null || max == null) {
+            return UNKNOWN_SELECTIVITY;
+        }
+        double minD = toNumeric(min);
+        double maxD = toNumeric(max);
+        double valD = toNumeric(value);
+        if (Double.isNaN(minD) || Double.isNaN(maxD) || Double.isNaN(valD)) {
+            return UNKNOWN_SELECTIVITY;
+        }
+        double rangeWidth = maxD - minD;
+        if (rangeWidth <= 0) {
+            return UNKNOWN_SELECTIVITY;
+        }
+        double fraction;
+        if (isGreaterThan) {
+            fraction = (maxD - valD) / rangeWidth;
+        } else {
+            fraction = (valD - minD) / rangeWidth;
+        }
+        return clamp(fraction);
+    }
+
+    private static double estimateInSelectivity(String colName, int listSize, Map<String, Object> sourceMetadata) {
+        Object min = sourceMetadata.get(SourceStatisticsSerializer.columnMinKey(colName));
+        Object max = sourceMetadata.get(SourceStatisticsSerializer.columnMaxKey(colName));
+        if (min == null || max == null) {
+            return UNKNOWN_SELECTIVITY;
+        }
+        double rangeWidth = numericRangeWidth(min, max);
+        if (Double.isNaN(rangeWidth) || rangeWidth <= 0) {
+            return UNKNOWN_SELECTIVITY;
+        }
+        return Math.min(1.0, listSize / rangeWidth);
+    }
+
+    private static double estimateNullSelectivity(String colName, Map<String, Object> sourceMetadata, long rowCount) {
+        Object ncValue = sourceMetadata.get(SourceStatisticsSerializer.columnNullCountKey(colName));
+        if (ncValue instanceof Number nc) {
+            return clamp((double) nc.longValue() / rowCount);
+        }
+        return UNKNOWN_SELECTIVITY;
+    }
+
+    /**
+     * Returns the column size in bytes for the smallest column referenced by the expression,
+     * or {@link #UNKNOWN_SIZE} if unavailable.
+     */
+    private static long estimateColumnSize(Expression expr, Map<String, Object> sourceMetadata) {
+        Set<String> columns = collectColumnNames(expr);
+        long minSize = UNKNOWN_SIZE;
+        for (String col : columns) {
+            Object sbValue = sourceMetadata.get(SourceStatisticsSerializer.columnSizeBytesKey(col));
+            if (sbValue instanceof Number n) {
+                minSize = Math.min(minSize, n.longValue());
+            }
+        }
+        return minSize;
+    }
+
+    // -- arithmetic helpers --
+
+    /**
+     * Returns the numeric range width (max - min) or NaN if either value is non-numeric.
+     */
+    private static double numericRangeWidth(Object min, Object max) {
+        double minD = toNumeric(min);
+        double maxD = toNumeric(max);
+        if (Double.isNaN(minD) || Double.isNaN(maxD)) {
+            return Double.NaN;
+        }
+        return maxD - minD;
+    }
+
+    /**
+     * Converts a value to its numeric representation. Returns NaN for non-numeric types.
+     */
+    private static double toNumeric(Object value) {
+        if (value instanceof Number n) {
+            return n.doubleValue();
+        }
+        return Double.NaN;
+    }
+
+    private static double clamp(double value) {
+        return Math.max(0.0, Math.min(1.0, value));
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 
@@ -31,6 +32,7 @@ public final class SourceStatisticsSerializer {
     private static final String NULL_COUNT_SUFFIX = ".null_count";
     private static final String MIN_SUFFIX = ".min";
     private static final String MAX_SUFFIX = ".max";
+    private static final String SIZE_BYTES_SUFFIX = ".size_bytes";
 
     private SourceStatisticsSerializer() {}
 
@@ -52,6 +54,7 @@ public final class SourceStatisticsSerializer {
                 cs.nullCount().ifPresent(nc -> result.put(prefix + NULL_COUNT_SUFFIX, nc));
                 cs.minValue().ifPresent(mv -> result.put(prefix + MIN_SUFFIX, mv));
                 cs.maxValue().ifPresent(mv -> result.put(prefix + MAX_SUFFIX, mv));
+                cs.sizeInBytes().ifPresent(sb -> result.put(prefix + SIZE_BYTES_SUFFIX, sb));
             }
         });
         return result;
@@ -68,12 +71,12 @@ public final class SourceStatisticsSerializer {
         return Optional.of(new SourceStatistics() {
             @Override
             public OptionalLong rowCount() {
-                return toLong(sourceMetadata.get(STATS_ROW_COUNT));
+                return toOptionalLong(asBoxedLong(sourceMetadata.get(STATS_ROW_COUNT)));
             }
 
             @Override
             public OptionalLong sizeInBytes() {
-                return toLong(sourceMetadata.get(STATS_SIZE_BYTES));
+                return toOptionalLong(asBoxedLong(sourceMetadata.get(STATS_SIZE_BYTES)));
             }
 
             @Override
@@ -97,44 +100,39 @@ public final class SourceStatisticsSerializer {
     }
 
     /**
-     * Extracts the row count directly from the sourceMetadata map without constructing a full
-     * SourceStatistics object.
+     * Extracts the row count directly from the sourceMetadata map.
+     * Returns {@code null} if the metadata is null or the row count is absent/non-numeric.
      */
-    public static OptionalLong extractRowCount(Map<String, Object> sourceMetadata) {
-        if (sourceMetadata == null) {
-            return OptionalLong.empty();
-        }
-        return toLong(sourceMetadata.get(STATS_ROW_COUNT));
+    @Nullable
+    public static Long extractRowCount(Map<String, Object> sourceMetadata) {
+        return sourceMetadata != null ? asBoxedLong(sourceMetadata.get(STATS_ROW_COUNT)) : null;
     }
 
     /**
      * Extracts the null count for a specific column directly from the sourceMetadata map.
+     * Returns {@code null} if the metadata is null or the null count is absent/non-numeric.
      */
-    public static OptionalLong extractColumnNullCount(Map<String, Object> sourceMetadata, String columnName) {
-        if (sourceMetadata == null) {
-            return OptionalLong.empty();
-        }
-        return toLong(sourceMetadata.get(columnNullCountKey(columnName)));
+    @Nullable
+    public static Long extractColumnNullCount(Map<String, Object> sourceMetadata, String columnName) {
+        return sourceMetadata != null ? asBoxedLong(sourceMetadata.get(columnNullCountKey(columnName))) : null;
     }
 
     /**
      * Extracts the min value for a specific column directly from the sourceMetadata map.
+     * Returns {@code null} if the metadata is null or the min is absent.
      */
-    public static Optional<Object> extractColumnMin(Map<String, Object> sourceMetadata, String columnName) {
-        if (sourceMetadata == null) {
-            return Optional.empty();
-        }
-        return Optional.ofNullable(sourceMetadata.get(columnMinKey(columnName)));
+    @Nullable
+    public static Object extractColumnMin(Map<String, Object> sourceMetadata, String columnName) {
+        return sourceMetadata != null ? sourceMetadata.get(columnMinKey(columnName)) : null;
     }
 
     /**
      * Extracts the max value for a specific column directly from the sourceMetadata map.
+     * Returns {@code null} if the metadata is null or the max is absent.
      */
-    public static Optional<Object> extractColumnMax(Map<String, Object> sourceMetadata, String columnName) {
-        if (sourceMetadata == null) {
-            return Optional.empty();
-        }
-        return Optional.ofNullable(sourceMetadata.get(columnMaxKey(columnName)));
+    @Nullable
+    public static Object extractColumnMax(Map<String, Object> sourceMetadata, String columnName) {
+        return sourceMetadata != null ? sourceMetadata.get(columnMaxKey(columnName)) : null;
     }
 
     /** Returns the flat key used for a column's null count statistic. */
@@ -150,6 +148,20 @@ public final class SourceStatisticsSerializer {
     /** Returns the flat key used for a column's max statistic. */
     public static String columnMaxKey(String columnName) {
         return STATS_COL_PREFIX + columnName + MAX_SUFFIX;
+    }
+
+    /** Returns the flat key used for a column's size in bytes statistic. */
+    public static String columnSizeBytesKey(String columnName) {
+        return STATS_COL_PREFIX + columnName + SIZE_BYTES_SUFFIX;
+    }
+
+    /**
+     * Extracts the size in bytes for a specific column directly from the sourceMetadata map.
+     * Returns {@code null} if the metadata is null or the size is absent/non-numeric.
+     */
+    @Nullable
+    public static Long extractColumnSizeBytes(Map<String, Object> sourceMetadata, String columnName) {
+        return sourceMetadata != null ? asBoxedLong(sourceMetadata.get(columnSizeBytesKey(columnName))) : null;
     }
 
     /**
@@ -189,6 +201,7 @@ public final class SourceStatisticsSerializer {
         Map<String, long[]> nullCounts = new HashMap<>();
         Map<String, Comparable[]> mins = new HashMap<>();
         Map<String, Comparable[]> maxs = new HashMap<>();
+        Map<String, long[]> colSizeBytes = new HashMap<>();
 
         for (Map<String, Object> stats : splitStats) {
             if (stats == null || stats.containsKey(STATS_ROW_COUNT) == false) {
@@ -223,6 +236,11 @@ public final class SourceStatisticsSerializer {
                         if (cmp < 0) a[0] = b[0];
                         return a;
                     });
+                } else if (key.endsWith(SIZE_BYTES_SUFFIX) && entry.getValue() instanceof Number sbNum) {
+                    colSizeBytes.merge(key, new long[] { sbNum.longValue() }, (a, b) -> {
+                        a[0] += b[0];
+                        return a;
+                    });
                 }
             }
         }
@@ -235,14 +253,17 @@ public final class SourceStatisticsSerializer {
         nullCounts.forEach((k, v) -> merged.put(k, v[0]));
         mins.forEach((k, v) -> merged.put(k, v[0]));
         maxs.forEach((k, v) -> merged.put(k, v[0]));
+        colSizeBytes.forEach((k, v) -> merged.put(k, v[0]));
         return merged;
     }
 
-    private static OptionalLong toLong(Object value) {
-        if (value instanceof Number n) {
-            return OptionalLong.of(n.longValue());
-        }
-        return OptionalLong.empty();
+    @Nullable
+    private static Long asBoxedLong(Object value) {
+        return value instanceof Number n ? n.longValue() : null;
+    }
+
+    private static OptionalLong toOptionalLong(Long value) {
+        return value != null ? OptionalLong.of(value) : OptionalLong.empty();
     }
 
     private static class DeserializedColumnStatistics implements SourceStatistics.ColumnStatistics {
@@ -256,7 +277,7 @@ public final class SourceStatisticsSerializer {
 
         @Override
         public OptionalLong nullCount() {
-            return extractColumnNullCount(map, colName);
+            return toOptionalLong(extractColumnNullCount(map, colName));
         }
 
         @Override
@@ -266,12 +287,17 @@ public final class SourceStatisticsSerializer {
 
         @Override
         public Optional<Object> minValue() {
-            return extractColumnMin(map, colName);
+            return Optional.ofNullable(extractColumnMin(map, colName));
         }
 
         @Override
         public Optional<Object> maxValue() {
-            return extractColumnMax(map, colName);
+            return Optional.ofNullable(extractColumnMax(map, colName));
+        }
+
+        @Override
+        public OptionalLong sizeInBytes() {
+            return toOptionalLong(extractColumnSizeBytes(map, colName));
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SourceStatistics.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SourceStatistics.java
@@ -67,5 +67,13 @@ public interface SourceStatistics {
          * The type depends on the column data type.
          */
         Optional<Object> maxValue();
+
+        /**
+         * Returns the uncompressed size of this column in bytes, if known.
+         * Useful for cost-based filter evaluation ordering.
+         */
+        default OptionalLong sizeInBytes() {
+            return OptionalLong.empty();
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -34,8 +34,6 @@ import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalLong;
 
 /**
  * Replaces {@code AggregateExec → ExternalSourceExec} with {@code LocalSourceExec}
@@ -145,15 +143,13 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
             }
             Expression target = count.field();
             if (target.foldable()) {
-                // COUNT(*)
-                OptionalLong rc = SourceStatisticsSerializer.extractRowCount(sourceMetadata);
-                return rc.isPresent() ? rc.getAsLong() : null;
+                return SourceStatisticsSerializer.extractRowCount(sourceMetadata);
             }
             if (target instanceof Attribute ref) {
-                OptionalLong rc = SourceStatisticsSerializer.extractRowCount(sourceMetadata);
-                OptionalLong nc = SourceStatisticsSerializer.extractColumnNullCount(sourceMetadata, ref.name());
-                if (rc.isPresent() && nc.isPresent()) {
-                    return rc.getAsLong() - nc.getAsLong();
+                Long rc = SourceStatisticsSerializer.extractRowCount(sourceMetadata);
+                Long nc = SourceStatisticsSerializer.extractColumnNullCount(sourceMetadata, ref.name());
+                if (rc != null && nc != null) {
+                    return rc - nc;
                 }
             }
             return null;
@@ -162,8 +158,7 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
                 return null;
             }
             if (min.field() instanceof Attribute ref) {
-                Optional<Object> minVal = SourceStatisticsSerializer.extractColumnMin(sourceMetadata, ref.name());
-                return minVal.orElse(null);
+                return SourceStatisticsSerializer.extractColumnMin(sourceMetadata, ref.name());
             }
             return null;
         } else if (aggFunction instanceof Max max) {
@@ -171,8 +166,7 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
                 return null;
             }
             if (max.field() instanceof Attribute ref) {
-                Optional<Object> maxVal = SourceStatisticsSerializer.extractColumnMax(sourceMetadata, ref.name());
-                return maxVal.orElse(null);
+                return SourceStatisticsSerializer.extractColumnMax(sourceMetadata, ref.name());
             }
             return null;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -18,7 +18,9 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.operator.compariso
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
 import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 import org.elasticsearch.xpack.esql.core.util.Queries;
+import org.elasticsearch.xpack.esql.datasources.FilterEvaluationOrderEstimator;
 import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
@@ -253,8 +255,13 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
             return filterExec;
         }
 
-        // Split filter condition by AND
+        // Split filter condition by AND and reorder by estimated selectivity
         List<Expression> filters = splitAnd(filterExec.condition());
+        Map<String, Object> effectiveMetadata = SourceStatisticsSerializer.resolveEffectiveMetadata(
+            externalExec.splits(),
+            externalExec.sourceMetadata()
+        );
+        filters = FilterEvaluationOrderEstimator.orderByEstimatedCost(filters, effectiveMetadata);
 
         // Use the SPI to push filters
         FilterPushdownSupport.PushdownResult result = pushdownSupport.pushFilters(filters);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -32,8 +32,6 @@ import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalLong;
 
 /**
  * Pushes ungrouped aggregate functions (COUNT, MIN, MAX) to external sources when the
@@ -128,14 +126,13 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         }
         Expression target = count.field();
         if (target.foldable()) {
-            OptionalLong rc = SourceStatisticsSerializer.extractRowCount(sourceMetadata);
-            return rc.isPresent() ? rc.getAsLong() : null;
+            return SourceStatisticsSerializer.extractRowCount(sourceMetadata);
         }
         if (target instanceof ReferenceAttribute ref) {
-            OptionalLong rc = SourceStatisticsSerializer.extractRowCount(sourceMetadata);
-            OptionalLong nc = SourceStatisticsSerializer.extractColumnNullCount(sourceMetadata, ref.name());
-            if (rc.isPresent() && nc.isPresent()) {
-                return rc.getAsLong() - nc.getAsLong();
+            Long rc = SourceStatisticsSerializer.extractRowCount(sourceMetadata);
+            Long nc = SourceStatisticsSerializer.extractColumnNullCount(sourceMetadata, ref.name());
+            if (rc != null && nc != null) {
+                return rc - nc;
             }
         }
         return null;
@@ -147,8 +144,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         }
         Expression target = min.field();
         if (target instanceof ReferenceAttribute ref) {
-            Optional<Object> minVal = SourceStatisticsSerializer.extractColumnMin(sourceMetadata, ref.name());
-            return minVal.orElse(null);
+            return SourceStatisticsSerializer.extractColumnMin(sourceMetadata, ref.name());
         }
         return null;
     }
@@ -159,8 +155,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         }
         Expression target = max.field();
         if (target instanceof ReferenceAttribute ref) {
-            Optional<Object> maxVal = SourceStatisticsSerializer.extractColumnMax(sourceMetadata, ref.name());
-            return maxVal.orElse(null);
+            return SourceStatisticsSerializer.extractColumnMax(sourceMetadata, ref.name());
         }
         return null;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifier.java
@@ -27,8 +27,6 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Not
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalLong;
 
 /**
  * Evaluates filter predicates against per-split (row-group/stripe) statistics to classify
@@ -253,15 +251,15 @@ final class SplitFilterClassifier {
         if (columnName == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        OptionalLong nullCount = SourceStatisticsSerializer.extractColumnNullCount(splitStats, columnName);
-        if (nullCount.isEmpty()) {
+        Long nullCount = SourceStatisticsSerializer.extractColumnNullCount(splitStats, columnName);
+        if (nullCount == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        if (nullCount.getAsLong() == 0) {
+        if (nullCount == 0) {
             return SplitMatch.MISS;
         }
-        OptionalLong rowCount = SourceStatisticsSerializer.extractRowCount(splitStats);
-        if (rowCount.isPresent() && nullCount.getAsLong() == rowCount.getAsLong()) {
+        Long rowCount = SourceStatisticsSerializer.extractRowCount(splitStats);
+        if (rowCount != null && nullCount.equals(rowCount)) {
             return SplitMatch.MATCH;
         }
         return SplitMatch.AMBIGUOUS;
@@ -275,15 +273,15 @@ final class SplitFilterClassifier {
         if (columnName == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        OptionalLong nullCount = SourceStatisticsSerializer.extractColumnNullCount(splitStats, columnName);
-        if (nullCount.isEmpty()) {
+        Long nullCount = SourceStatisticsSerializer.extractColumnNullCount(splitStats, columnName);
+        if (nullCount == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        if (nullCount.getAsLong() == 0) {
+        if (nullCount == 0) {
             return SplitMatch.MATCH;
         }
-        OptionalLong rowCount = SourceStatisticsSerializer.extractRowCount(splitStats);
-        if (rowCount.isPresent() && nullCount.getAsLong() == rowCount.getAsLong()) {
+        Long rowCount = SourceStatisticsSerializer.extractRowCount(splitStats);
+        if (rowCount != null && nullCount.equals(rowCount)) {
             return SplitMatch.MISS;
         }
         return SplitMatch.AMBIGUOUS;
@@ -302,13 +300,11 @@ final class SplitFilterClassifier {
         if (literalValues.stream().anyMatch(v -> v == null)) {
             return SplitMatch.AMBIGUOUS;
         }
-        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
-        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
-        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+        Object min = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Object max = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (min == null || max == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        Object min = minOpt.get();
-        Object max = maxOpt.get();
 
         boolean anyInRange = false;
         for (Object lit : literalValues) {
@@ -344,19 +340,19 @@ final class SplitFilterClassifier {
      * {@code col > lit}: MATCH when min &gt; lit (and no nulls), MISS when max &lt;= lit
      */
     private static SplitMatch classifyGreaterThan(String columnName, Object literalValue, Map<String, Object> splitStats) {
-        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
-        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
-        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+        Object min = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Object max = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (min == null || max == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        int maxCmp = compareValues(maxOpt.get(), literalValue);
+        int maxCmp = compareValues(max, literalValue);
         if (maxCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
         if (maxCmp <= 0) {
             return SplitMatch.MISS;
         }
-        int minCmp = compareValues(minOpt.get(), literalValue);
+        int minCmp = compareValues(min, literalValue);
         if (minCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
@@ -370,19 +366,19 @@ final class SplitFilterClassifier {
      * {@code col >= lit}: MATCH when min &gt;= lit (and no nulls), MISS when max &lt; lit
      */
     private static SplitMatch classifyGreaterThanOrEqual(String columnName, Object literalValue, Map<String, Object> splitStats) {
-        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
-        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
-        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+        Object min = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Object max = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (min == null || max == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        int maxCmp = compareValues(maxOpt.get(), literalValue);
+        int maxCmp = compareValues(max, literalValue);
         if (maxCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
         if (maxCmp < 0) {
             return SplitMatch.MISS;
         }
-        int minCmp = compareValues(minOpt.get(), literalValue);
+        int minCmp = compareValues(min, literalValue);
         if (minCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
@@ -396,19 +392,19 @@ final class SplitFilterClassifier {
      * {@code col < lit}: MATCH when max &lt; lit (and no nulls), MISS when min &gt;= lit
      */
     private static SplitMatch classifyLessThan(String columnName, Object literalValue, Map<String, Object> splitStats) {
-        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
-        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
-        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+        Object min = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Object max = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (min == null || max == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        int minCmp = compareValues(minOpt.get(), literalValue);
+        int minCmp = compareValues(min, literalValue);
         if (minCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
         if (minCmp >= 0) {
             return SplitMatch.MISS;
         }
-        int maxCmp = compareValues(maxOpt.get(), literalValue);
+        int maxCmp = compareValues(max, literalValue);
         if (maxCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
@@ -422,19 +418,19 @@ final class SplitFilterClassifier {
      * {@code col <= lit}: MATCH when max &lt;= lit (and no nulls), MISS when min &gt; lit
      */
     private static SplitMatch classifyLessThanOrEqual(String columnName, Object literalValue, Map<String, Object> splitStats) {
-        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
-        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
-        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+        Object min = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Object max = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (min == null || max == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        int minCmp = compareValues(minOpt.get(), literalValue);
+        int minCmp = compareValues(min, literalValue);
         if (minCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
         if (minCmp > 0) {
             return SplitMatch.MISS;
         }
-        int maxCmp = compareValues(maxOpt.get(), literalValue);
+        int maxCmp = compareValues(max, literalValue);
         if (maxCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
@@ -448,13 +444,13 @@ final class SplitFilterClassifier {
      * {@code col = lit}: MATCH when min == max == lit (and no nulls), MISS when lit outside [min, max]
      */
     private static SplitMatch classifyEquals(String columnName, Object literalValue, Map<String, Object> splitStats) {
-        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
-        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
-        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+        Object min = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Object max = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (min == null || max == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        int minCmp = compareValues(literalValue, minOpt.get());
-        int maxCmp = compareValues(literalValue, maxOpt.get());
+        int minCmp = compareValues(literalValue, min);
+        int maxCmp = compareValues(literalValue, max);
         if (minCmp == Integer.MIN_VALUE || maxCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
@@ -471,17 +467,17 @@ final class SplitFilterClassifier {
      * {@code col != lit}: MATCH when min == max and min != lit (and no nulls), MISS when min == max == lit
      */
     private static SplitMatch classifyNotEquals(String columnName, Object literalValue, Map<String, Object> splitStats) {
-        Optional<Object> minOpt = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
-        Optional<Object> maxOpt = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
-        if (minOpt.isEmpty() || maxOpt.isEmpty()) {
+        Object min = SourceStatisticsSerializer.extractColumnMin(splitStats, columnName);
+        Object max = SourceStatisticsSerializer.extractColumnMax(splitStats, columnName);
+        if (min == null || max == null) {
             return SplitMatch.AMBIGUOUS;
         }
-        int minCmp = compareValues(literalValue, minOpt.get());
-        int maxCmp = compareValues(literalValue, maxOpt.get());
+        int minCmp = compareValues(literalValue, min);
+        int maxCmp = compareValues(literalValue, max);
         if (minCmp == Integer.MIN_VALUE || maxCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
-        int minMaxCmp = compareValues(minOpt.get(), maxOpt.get());
+        int minMaxCmp = compareValues(min, max);
         if (minMaxCmp == Integer.MIN_VALUE) {
             return SplitMatch.AMBIGUOUS;
         }
@@ -499,8 +495,8 @@ final class SplitFilterClassifier {
      * When null_count is unavailable, assumes nulls may exist (conservative).
      */
     private static boolean hasNoNulls(String columnName, Map<String, Object> splitStats) {
-        OptionalLong nullCount = SourceStatisticsSerializer.extractColumnNullCount(splitStats, columnName);
-        return nullCount.isPresent() && nullCount.getAsLong() == 0;
+        Long nullCount = SourceStatisticsSerializer.extractColumnNullCount(splitStats, columnName);
+        return nullCount != null && nullCount == 0;
     }
 
     private static String extractColumnName(Expression expr) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimatorTests.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FilterEvaluationOrderEstimatorTests extends ESTestCase {
+
+    private static final Source SRC = Source.EMPTY;
+
+    public void testNoMetadata_preservesOriginalOrder() {
+        List<Expression> filters = List.of(gt("a", 10), lt("b", 20));
+        assertSame(filters, FilterEvaluationOrderEstimator.orderByEstimatedCost(filters, null));
+        assertSame(filters, FilterEvaluationOrderEstimator.orderByEstimatedCost(filters, Map.of()));
+    }
+
+    public void testSinglePredicate_unchangedOrder() {
+        Map<String, Object> meta = metadata(1000, "a", 0L, 0, 100, 50_000L);
+        List<Expression> filters = List.of(gt("a", 50));
+        assertSame(filters, FilterEvaluationOrderEstimator.orderByEstimatedCost(filters, meta));
+    }
+
+    public void testRangeSelectivity_narrowRangeFirst() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+        putColumnStats(meta, "timestamp", 0L, 0, 1000, 100_000L);
+        putColumnStats(meta, "level", 0L, 0, 5, 10_000L);
+
+        // timestamp > 990 eliminates ~99% of range; level < 3 eliminates ~40%
+        Expression tsFilter = gt("timestamp", 990);
+        Expression levelFilter = lt("level", 3);
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(levelFilter, tsFilter), meta);
+        assertSame(tsFilter, result.get(0));
+        assertSame(levelFilter, result.get(1));
+    }
+
+    public void testEqualitySelectivity_smallDomainFirst() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+        putColumnStats(meta, "status", 0L, 1, 5, 5_000L);
+        putColumnStats(meta, "user_id", 0L, 1, 100000, 50_000L);
+
+        // status == 3 has selectivity 1/4 = 0.25; user_id == 500 has selectivity 1/99999 ≈ 0.00001
+        Expression statusFilter = eq("status", 3);
+        Expression userIdFilter = eq("user_id", 500);
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(statusFilter, userIdFilter), meta);
+        assertSame(userIdFilter, result.get(0));
+        assertSame(statusFilter, result.get(1));
+    }
+
+    public void testNullSelectivity_highNullRatioFirst() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+        putColumnStats(meta, "sparse_col", 9500L, 0, 100, 50_000L);
+        putColumnStats(meta, "dense_col", 10L, 0, 100, 50_000L);
+
+        Expression sparseIsNull = new IsNull(SRC, fieldAttr("sparse_col"));
+        Expression denseIsNull = new IsNull(SRC, fieldAttr("dense_col"));
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(sparseIsNull, denseIsNull), meta);
+        // sparse_col IS NULL has selectivity 0.95 (high), dense_col IS NULL has selectivity 0.001 (low)
+        // Lower selectivity comes first
+        assertSame(denseIsNull, result.get(0));
+        assertSame(sparseIsNull, result.get(1));
+    }
+
+    public void testIsNotNull_ordering() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+        putColumnStats(meta, "sparse_col", 9500L, 0, 100, 50_000L);
+        putColumnStats(meta, "dense_col", 10L, 0, 100, 50_000L);
+
+        Expression sparseNotNull = new IsNotNull(SRC, fieldAttr("sparse_col"));
+        Expression denseNotNull = new IsNotNull(SRC, fieldAttr("dense_col"));
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(denseNotNull, sparseNotNull), meta);
+        // sparse IS NOT NULL = 1 - 0.95 = 0.05 (very selective) -> first
+        assertSame(sparseNotNull, result.get(0));
+        assertSame(denseNotNull, result.get(1));
+    }
+
+    public void testColumnSizeTiebreaker_smallerColumnFirst() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+        putColumnStats(meta, "small_col", 0L, 0, 100, 10_000L);
+        putColumnStats(meta, "big_col", 0L, 0, 100, 1_000_000L);
+
+        // Same range => same selectivity => tiebreak on size_bytes
+        Expression smallFilter = gt("small_col", 50);
+        Expression bigFilter = gt("big_col", 50);
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(bigFilter, smallFilter), meta);
+        assertSame(smallFilter, result.get(0));
+        assertSame(bigFilter, result.get(1));
+    }
+
+    public void testMixedPredicates_selectiveThenCheap() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100000L);
+        putColumnStats(meta, "timestamp", 0L, 0, 1000, 200_000L);
+        putColumnStats(meta, "status", 100L, 1, 5, 10_000L);
+        putColumnStats(meta, "user_id", 0L, 1, 1000000, 80_000L);
+
+        // timestamp > 999: selectivity ~ 0.001 (very selective)
+        // status == 3: selectivity ~ 0.25
+        // user_id > 500000: selectivity ~ 0.5
+        Expression tsFilter = gt("timestamp", 999);
+        Expression statusFilter = eq("status", 3);
+        Expression userFilter = gt("user_id", 500000);
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(userFilter, statusFilter, tsFilter), meta);
+        assertSame(tsFilter, result.get(0));
+        assertSame(statusFilter, result.get(1));
+        assertSame(userFilter, result.get(2));
+    }
+
+    public void testNoStatsPredicates_preserveRelativeOrder() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+
+        Expression a = gt("unknown_a", 50);
+        Expression b = gt("unknown_b", 50);
+        Expression c = gt("unknown_c", 50);
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(a, b, c), meta);
+        assertSame(a, result.get(0));
+        assertSame(b, result.get(1));
+        assertSame(c, result.get(2));
+    }
+
+    public void testAllSameScore_preserveOriginalOrder() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+        putColumnStats(meta, "a", 0L, 0, 100, 50_000L);
+        putColumnStats(meta, "b", 0L, 0, 100, 50_000L);
+
+        Expression filterA = gt("a", 50);
+        Expression filterB = gt("b", 50);
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(filterA, filterB), meta);
+        assertSame(filterA, result.get(0));
+        assertSame(filterB, result.get(1));
+    }
+
+    public void testInSelectivity() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+        putColumnStats(meta, "status", 0L, 1, 1000, 10_000L);
+        putColumnStats(meta, "code", 0L, 1, 100, 10_000L);
+
+        // IN(status, [1, 2, 3]) -> 3/999 ≈ 0.003
+        // code > 90 -> (100-90)/99 ≈ 0.101
+        Expression inFilter = new In(SRC, fieldAttr("status"), List.of(intLiteral(1), intLiteral(2), intLiteral(3)));
+        Expression codeFilter = gt("code", 90);
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(codeFilter, inFilter), meta);
+        assertSame(inFilter, result.get(0));
+        assertSame(codeFilter, result.get(1));
+    }
+
+    public void testEqualityOutsideRange() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+        putColumnStats(meta, "x", 0L, 10, 20, 10_000L);
+        putColumnStats(meta, "y", 0L, 0, 100, 10_000L);
+
+        // x == 99 is outside [10, 20] => selectivity 0
+        // y > 50 => selectivity 0.5
+        Expression xFilter = eq("x", 99);
+        Expression yFilter = gt("y", 50);
+
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(List.of(yFilter, xFilter), meta);
+        assertSame(xFilter, result.get(0));
+        assertSame(yFilter, result.get(1));
+    }
+
+    public void testZeroRangeWidth_equalityMatch() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+        putColumnStats(meta, "const_col", 0L, 42, 42, 10_000L);
+
+        double sel = FilterEvaluationOrderEstimator.estimateSelectivity(eq("const_col", 42), meta, 10000L);
+        assertEquals(1.0, sel, 0.001);
+    }
+
+    public void testZeroRangeWidth_equalityMismatch() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 10000L);
+        putColumnStats(meta, "const_col", 0L, 42, 42, 10_000L);
+
+        double sel = FilterEvaluationOrderEstimator.estimateSelectivity(eq("const_col", 99), meta, 10000L);
+        assertEquals(0.0, sel, 0.001);
+    }
+
+    // -- helpers --
+
+    private static FieldAttribute fieldAttr(String name) {
+        return new FieldAttribute(SRC, name, new EsField(name, DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE));
+    }
+
+    private static Literal intLiteral(int value) {
+        return new Literal(SRC, value, DataType.INTEGER);
+    }
+
+    private static Expression gt(String field, int value) {
+        return new GreaterThan(SRC, fieldAttr(field), intLiteral(value), null);
+    }
+
+    private static Expression lt(String field, int value) {
+        return new LessThan(SRC, fieldAttr(field), intLiteral(value), null);
+    }
+
+    private static Expression eq(String field, int value) {
+        return new Equals(SRC, fieldAttr(field), intLiteral(value), null);
+    }
+
+    private static Map<String, Object> metadata(long rowCount, String col, long nullCount, int min, int max, long sizeBytes) {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, rowCount);
+        putColumnStats(meta, col, nullCount, min, max, sizeBytes);
+        return meta;
+    }
+
+    private static void putColumnStats(Map<String, Object> meta, String col, long nullCount, int min, int max, long sizeBytes) {
+        meta.put(SourceStatisticsSerializer.columnNullCountKey(col), nullCount);
+        meta.put(SourceStatisticsSerializer.columnMinKey(col), min);
+        meta.put(SourceStatisticsSerializer.columnMaxKey(col), max);
+        meta.put(SourceStatisticsSerializer.columnSizeBytesKey(col), sizeBytes);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
@@ -84,4 +84,34 @@ public class SourceStatisticsSerializerTests extends ESTestCase {
 
         assertNull(SourceStatisticsSerializer.mergeStatistics(list));
     }
+
+    public void testColumnSizeBytesRoundTrip() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 1000L);
+        meta.put(SourceStatisticsSerializer.columnSizeBytesKey("age"), 50000L);
+        meta.put(SourceStatisticsSerializer.columnSizeBytesKey("name"), 120000L);
+
+        assertEquals(Long.valueOf(50000L), SourceStatisticsSerializer.extractColumnSizeBytes(meta, "age"));
+        assertEquals(Long.valueOf(120000L), SourceStatisticsSerializer.extractColumnSizeBytes(meta, "name"));
+        assertNull(SourceStatisticsSerializer.extractColumnSizeBytes(meta, "missing"));
+        assertNull(SourceStatisticsSerializer.extractColumnSizeBytes(null, "age"));
+    }
+
+    public void testMergeStatistics_sumsSizeBytes() {
+        Map<String, Object> s1 = new HashMap<>();
+        s1.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        s1.put(SourceStatisticsSerializer.columnSizeBytesKey("age"), 5000L);
+        s1.put(SourceStatisticsSerializer.columnSizeBytesKey("name"), 10000L);
+
+        Map<String, Object> s2 = new HashMap<>();
+        s2.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 200L);
+        s2.put(SourceStatisticsSerializer.columnSizeBytesKey("age"), 8000L);
+        s2.put(SourceStatisticsSerializer.columnSizeBytesKey("name"), 15000L);
+
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(s1, s2));
+        assertNotNull(result);
+        assertEquals(300L, result.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        assertEquals(13000L, result.get(SourceStatisticsSerializer.columnSizeBytesKey("age")));
+        assertEquals(25000L, result.get(SourceStatisticsSerializer.columnSizeBytesKey("name")));
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -243,10 +243,10 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
         assertEquals("value", enriched.get("existing_key"));
         assertEquals(42L, enriched.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
         assertEquals(1024L, enriched.get(SourceStatisticsSerializer.STATS_SIZE_BYTES));
-        assertEquals(OptionalLong.of(42), SourceStatisticsSerializer.extractRowCount(enriched));
-        assertEquals(OptionalLong.of(5), SourceStatisticsSerializer.extractColumnNullCount(enriched, "col1"));
-        assertEquals(Optional.of(10), SourceStatisticsSerializer.extractColumnMin(enriched, "col1"));
-        assertEquals(Optional.of(100), SourceStatisticsSerializer.extractColumnMax(enriched, "col1"));
+        assertEquals(Long.valueOf(42L), SourceStatisticsSerializer.extractRowCount(enriched));
+        assertEquals(Long.valueOf(5L), SourceStatisticsSerializer.extractColumnNullCount(enriched, "col1"));
+        assertEquals(10, SourceStatisticsSerializer.extractColumnMin(enriched, "col1"));
+        assertEquals(100, SourceStatisticsSerializer.extractColumnMax(enriched, "col1"));
     }
 
     // --- EvalExec intermediate node tests ---


### PR DESCRIPTION
Add FilterEvaluationOrderEstimator that reorders filter conjuncts
based on column statistics (min/max range, null count, size).
More selective predicates execute first, reducing I/O for external
sources like Parquet and ORC.

Also removes Optional wrappers from SourceStatisticsSerializer
extract methods in favor of @Nullable returns for cleaner consumer
code.

Depends on #146597.

Developed with AI-assisted tooling