### PR TITLE
[9.4] Fix pipeline resolution cache for bulk requests (#144648)

### DIFF
--- a/docs/changelog/144648.yaml
+++ b/docs/changelog/144648.yaml
@@ -1,0 +1,5 @@
+area: Ingest Node
+issues: []
+pr: 144648
+summary: Fix pipeline resolution cache for bulk requests
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
@@ -272,15 +272,15 @@ public abstract class TransportAbstractBulkAction extends HandledTransportAction
             project = state.metadata().getProject(projectId);
         }
 
-        Map<String, IngestService.Pipelines> resolvedPipelineCache = new HashMap<>();
+        final long pipelineResolutionTimeMillis = threadPool.absoluteTimeInMillis();
+        Map<PipelineCacheKey, IngestService.Pipelines> resolvedPipelineCache = new HashMap<>();
         for (DocWriteRequest<?> actionRequest : bulkRequest.requests) {
             IndexRequest indexRequest = getIndexWriteRequest(actionRequest);
             if (indexRequest != null) {
                 if (indexRequest.isPipelineResolved() == false) {
                     var pipeline = resolvedPipelineCache.computeIfAbsent(
-                        indexRequest.index(),
-                        // TODO perhaps this should use `threadPool.absoluteTimeInMillis()`, but leaving as is for now.
-                        (index) -> IngestService.resolvePipelines(actionRequest, indexRequest, project, System.currentTimeMillis())
+                        new PipelineCacheKey(actionRequest.index(), indexRequest.index()),
+                        (index) -> IngestService.resolvePipelines(actionRequest, indexRequest, project, pipelineResolutionTimeMillis)
                     );
                     IngestService.setPipelineOnRequest(indexRequest, pipeline);
                 }
@@ -389,6 +389,8 @@ public abstract class TransportAbstractBulkAction extends HandledTransportAction
      *     doesn't correspond to a data stream.
      */
     protected abstract Boolean resolveFailureStore(String indexName, ProjectMetadata metadata, long epochMillis);
+
+    private record PipelineCacheKey(String originalIndex, String embeddedIndex) {}
 
     /**
      * Retrieves the {@link IndexRequest} from the provided {@link DocWriteRequest} for index or upsert actions.  Upserts are

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -640,6 +640,29 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         validatePipelineWithBulkUpsert(indexRequestName, WITH_DEFAULT_PIPELINE_ALIAS);
     }
 
+    public void testBulkUpsertsDoNotReusePipelinesForDifferentIndices() throws Exception {
+        BulkRequest bulkRequest = new BulkRequest();
+        IndexRequest firstUpsert = new IndexRequest().id("id1").source(Collections.emptyMap());
+        IndexRequest secondUpsert = new IndexRequest().id("id2").source(Collections.emptyMap());
+        bulkRequest.add(new UpdateRequest(WITH_DEFAULT_PIPELINE_ALIAS, "id1").doc(firstUpsert).docAsUpsert(true));
+        bulkRequest.add(new UpdateRequest("index_without_pipeline", "id2").doc(secondUpsert).docAsUpsert(true));
+
+        ActionTestUtils.execute(action, null, bulkRequest, ActionTestUtils.assertNoFailureListener(response -> {}));
+
+        verify(ingestService).executeBulkRequest(
+            eq(projectId),
+            eq(bulkRequest.numberOfActions()),
+            bulkDocsItr.capture(),
+            any(),
+            any(),
+            any(),
+            failureHandler.capture(),
+            listener.capture()
+        );
+        assertEquals("default_pipeline", firstUpsert.getPipeline());
+        assertEquals(IngestService.NOOP_PIPELINE_NAME, secondUpsert.getPipeline());
+    }
+
     private void validatePipelineWithBulkUpsert(@Nullable String indexRequestIndexName, String updateRequestIndexName) throws Exception {
         Exception exception = new Exception("fake exception");
         BulkRequest bulkRequest = new BulkRequest();


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix pipeline resolution cache for bulk requests (#144648)