### PR TITLE
Fix the default index type for dense vector tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -295,9 +295,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=mget/60_realtime_refresh/Realtime Refresh}
   issue: https://github.com/elastic/elasticsearch/issues/146410
-- class: org.elasticsearch.xpack.diskbbq.DiskBbqTrialLicenseIT
-  method: testDefaultIndexOptionsForDenseVector
-  issue: https://github.com/elastic/elasticsearch/issues/146415
 - class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
   method: test {yaml=reindex/10_basic/Response format for version conflict with conflicts=proceed}
   issue: https://github.com/elastic/elasticsearch/issues/146419

--- a/x-pack/plugin/diskbbq/src/main/java/org/elasticsearch/xpack/diskbbq/DiskBBQPlugin.java
+++ b/x-pack/plugin/diskbbq/src/main/java/org/elasticsearch/xpack/diskbbq/DiskBBQPlugin.java
@@ -53,8 +53,9 @@ public class DiskBBQPlugin extends Plugin implements InternalVectorFormatProvide
             @Override
             public boolean isVectorIndexTypeAllowed(IndexVersion indexVersionCreated, DenseVectorFieldMapper.VectorIndexType indexType) {
                 return indexType != DenseVectorFieldMapper.VectorIndexType.BBQ_DISK
-                    || indexVersionCreated.onOrAfter(IndexVersions.DISK_BBQ_LICENSE_ENFORCEMENT) == false
-                    || (statelessNode && DISK_BBQ_FEATURE.check(getLicenseState()));
+                    || indexVersionCreated.before(IndexVersions.DISK_BBQ_LICENSE_ENFORCEMENT)
+                    || statelessNode
+                    || DISK_BBQ_FEATURE.check(getLicenseState());
             }
 
             @Override

--- a/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperServerlessDefaultsTests.java
+++ b/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperServerlessDefaultsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.diskbbq;
 
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
@@ -19,11 +20,12 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.instanceOf;
 
-public class DiskBBQDenseVectorFieldMapperUnlicensedDefaultsTests extends MapperServiceTestCase {
+public class DiskBBQDenseVectorFieldMapperServerlessDefaultsTests extends MapperServiceTestCase {
 
     @Override
     protected Collection<? extends Plugin> getPlugins() {
-        return List.of(new BasicLicenseStateDiskBBQPlugin(Settings.EMPTY));
+        Settings statelessSettings = Settings.builder().put(DiscoveryNode.STATELESS_ENABLED_SETTING_NAME, true).build();
+        return List.of(new BasicLicenseStateDiskBBQPlugin(statelessSettings));
     }
 
     public void testDoesNotDefaultToBBQDiskWhenUnlicensed() throws IOException {
@@ -36,7 +38,7 @@ public class DiskBBQDenseVectorFieldMapperUnlicensedDefaultsTests extends Mapper
 
         DenseVectorFieldMapper mapper = (DenseVectorFieldMapper) mapperService.mappingLookup().getMapper("field");
         assertNotNull(mapper);
-        assertThat(mapper.fieldType().getIndexOptions(), instanceOf(DenseVectorFieldMapper.BBQHnswIndexOptions.class));
-        assertEquals(DenseVectorFieldMapper.VectorIndexType.BBQ_HNSW, mapper.fieldType().getIndexOptions().getType());
+        assertThat(mapper.fieldType().getIndexOptions(), instanceOf(DenseVectorFieldMapper.BBQIVFIndexOptions.class));
+        assertEquals(DenseVectorFieldMapper.VectorIndexType.BBQ_DISK, mapper.fieldType().getIndexOptions().getType());
     }
 }


### PR DESCRIPTION
Use disk_bbq if:
- The index was created before enforcement was added
- **Or** we are in stateless
- **Or** there is a compliant licence 

Closes #146415