### PR TITLE
Fixes two test failures #146415 and #146464

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -295,9 +295,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=mget/60_realtime_refresh/Realtime Refresh}
   issue: https://github.com/elastic/elasticsearch/issues/146410
-- class: org.elasticsearch.xpack.diskbbq.DiskBbqTrialLicenseIT
-  method: testDefaultIndexOptionsForDenseVector
-  issue: https://github.com/elastic/elasticsearch/issues/146415
 - class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
   method: test {yaml=reindex/10_basic/Response format for version conflict with conflicts=proceed}
   issue: https://github.com/elastic/elasticsearch/issues/146419
@@ -319,9 +316,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToTests
   method: testDateTruncNotTransformToQueryAndTags {default}
   issue: https://github.com/elastic/elasticsearch/issues/146462
-- class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
-  method: test {yaml=rrf/310_rrf_retriever_simplified/Expansion to equivalent custom sub-retrievers returns the same results}
-  issue: https://github.com/elastic/elasticsearch/issues/146464
 - class: org.elasticsearch.reindex.ReindexBasicTests
   method: testReindexFailsWhenSourceIndexIsClosed
   issue: https://github.com/elastic/elasticsearch/issues/146466

--- a/x-pack/plugin/diskbbq/qa/diskbbq-licensing/src/javaRestTest/java/org/elasticsearch/xpack/diskbbq/DiskBbqTrialLicenseIT.java
+++ b/x-pack/plugin/diskbbq/qa/diskbbq-licensing/src/javaRestTest/java/org/elasticsearch/xpack/diskbbq/DiskBbqTrialLicenseIT.java
@@ -39,7 +39,7 @@ public class DiskBbqTrialLicenseIT extends ESRestTestCase {
     }
 
     /**
-     * The default index type for dense_vector is bbq_disk when licenced.
+     * The default index type for dense_vector on stateful clusters is int8_hnsw.
      */
     public void testDefaultIndexOptionsForDenseVector() throws IOException {
         final String index = "test_default_index_options";
@@ -68,6 +68,6 @@ public class DiskBbqTrialLicenseIT extends ESRestTestCase {
         assertEquals("cosine", vector.get("similarity"));
         @SuppressWarnings("unchecked")
         Map<String, Object> indexOptions = (Map<String, Object>) vector.get("index_options");
-        assertEquals("bbq_disk", indexOptions.get("type"));
+        assertEquals("int8_hnsw", indexOptions.get("type"));
     }
 }

--- a/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperTests.java
+++ b/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperTests.java
@@ -69,7 +69,7 @@ public class DiskBBQDenseVectorFieldMapperTests extends MapperServiceTestCase {
         }
     }
 
-    public void testDefaultsToBBQDiskWhenLicensed() throws IOException {
+    public void testDefaultsToBBQDiskWhenLicensedOnStatelessNode() throws IOException {
         final int dims = randomIntBetween(1, 4096);
         MapperService mapperService = createMapperService(getVersion(), Settings.EMPTY, () -> true, fieldMapping(b -> {
             b.field("type", "dense_vector");

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/310_rrf_retriever_simplified.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/310_rrf_retriever_simplified.yml
@@ -1,6 +1,6 @@
 setup:
   - requires:
-      cluster_features: [ "rrf_retriever.multi_fields_query_format_support" ]
+      cluster_features: [ "rrf_retriever.multi_fields_query_format_support", "semantic_text.index_options" ]
       reason: "RRF retriever multi-fields query format support"
       test_runner_features: [ "contains" ]
 
@@ -77,6 +77,9 @@ setup:
               dense_inference:
                 type: semantic_text
                 inference_id: dense-inference-id
+                index_options:
+                  dense_vector:
+                    type: int8_hnsw
               sparse_inference:
                 type: semantic_text
                 inference_id: sparse-inference-id
@@ -151,12 +154,18 @@ setup:
               dense_inference:
                 type: semantic_text
                 inference_id: dense-inference-id
+                index_options:
+                  dense_vector:
+                    type: int8_hnsw
               sparse_inference:
                 type: semantic_text
                 inference_id: sparse-inference-another-id
               text_1:
                 type: semantic_text
                 inference_id: dense-inference-another-id
+                index_options:
+                  dense_vector:
+                    type: int8_hnsw
               text_2:
                 type: text
               sparse_vector:


### PR DESCRIPTION
Fixes two test failures related to default index options behavior for dense_vector

closes: #146415, #146464