### PR TITLE
Extend yaml assertion message

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/MatchAssertion.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/MatchAssertion.java
@@ -97,6 +97,6 @@ public class MatchAssertion extends Assertion {
             assertThat(actualValue, instanceOf(List.class));
             assertMap((List<?>) actualValue, matchesList((List<?>) expectedValue));
         }
-        assertThat(actualValue, equalTo(expectedValue));
+        assertThat("field [" + getField() + "] does not match the expected value", actualValue, equalTo(expectedValue));
     }
 }


### PR DESCRIPTION
We miss which match clause is not expected and this does not give us much info on what is wrong.

So extending the assertion message with which field was not matched so we can understand more.

Relates #146607