### PR TITLE
Ensure stable master at the end of testSeqNoCASLinearizability

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -331,9 +331,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
   method: test {csv-spec:inlinestats.filterSometimesMatches}
   issue: https://github.com/elastic/elasticsearch/issues/146545
-- class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
-  method: testSeqNoCASLinearizability
-  issue: https://github.com/elastic/elasticsearch/issues/146568
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeUnmappedLoadIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/145900

--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -12,9 +12,13 @@ import org.apache.logging.log4j.Level;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.coordination.LinearizabilityChecker;
 import org.elasticsearch.cluster.coordination.LinearizabilityChecker.LinearizabilityCheckAborted;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteable;
@@ -119,7 +123,7 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
     // multiple threads doing CAS updates.
     // Wait up to 1 minute (+10s in thread to ensure it does not time out) for threads to complete previous round before initiating next
     // round.
-    public void testSeqNoCASLinearizability() {
+    public void testSeqNoCASLinearizability() throws Exception {
         final int disruptTimeSeconds = scaledRandomIntBetween(1, 8);
 
         assertAcked(
@@ -182,6 +186,31 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
         }
 
         partitions.forEach(Partition::assertLinearizable);
+
+        // ensure master election has stabilized after disruption
+        assertBusy(ConcurrentSeqNoVersioningIT::publishTrivialClusterStateUpdate);
+    }
+
+    private static void publishTrivialClusterStateUpdate() {
+        var processed = new PlainActionFuture<>();
+        internalCluster().getCurrentMasterNodeInstance(ClusterService.class)
+            .submitUnbatchedStateUpdateTask("trivial cluster state update", new ClusterStateUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    return ClusterState.builder(currentState).build();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    processed.onFailure(e);
+                }
+
+                @Override
+                public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
+                    processed.onResponse(null);
+                }
+            });
+        safeGet(processed);
     }
 
     private class CASUpdateThread extends Thread {


### PR DESCRIPTION
An induced network partition can produce more than one round of elections when it is repaired. If
post-test cluster validation runs while this is happening, it may race with the elections and see an inconsistent state.

To avoid the race, the test now publishes a trivial cluster state update before concluding and waits for it to be successfully processed.

Fixes #146568
