### PR TITLE
Prepare binary doc values read path for single value enforcement

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -816,7 +816,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                     return (cache, breaker) -> new BytesBinaryIndexFieldData(
                         syntheticSourceFallbackFieldName(),
                         CoreValuesSourceType.KEYWORD,
-                        TextDocValuesField::new
+                        TextDocValuesField::new,
+                        indexVersion
                     );
                 }
                 // For older indexes, fallback data is stored in stored fields
@@ -847,7 +848,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
         private IndexFieldData.Builder fieldDataFromDocValues() {
             if (usesBinaryDocValues) {
-                return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, TextDocValuesField::new);
+                return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, TextDocValuesField::new, indexVersion);
             } else {
                 return new SortedSetOrdinalsIndexFieldData.Builder(
                     name(),
@@ -1000,7 +1001,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     private CompositeSyntheticFieldLoader syntheticFieldLoaderFromDocValues() {
         var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>();
         if (fieldType().usesBinaryDocValues()) {
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath()));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexCreatedVersion));
         } else {
             layers.add(new SortedSetDocValuesSyntheticFieldLoaderLayer(fullPath()) {
                 @Override
@@ -1027,7 +1028,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             });
 
             // also load from fallback field for values that exceeded MAX_TERM_LENGTH
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().syntheticSourceFallbackFieldName()));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().syntheticSourceFallbackFieldName(), indexCreatedVersion));
         }
         return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
     }
@@ -1038,7 +1039,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
         // layer for loading from a fallback field created during indexing by this text field mapper
         final String fallbackFieldName = fieldType().syntheticSourceFallbackFieldName();
         if (usesBinaryDocValuesForFallbackFields) {
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fallbackFieldName));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fallbackFieldName, indexCreatedVersion));
         } else {
             // for bwc - fallback fields were originally stored in StoredFields
             layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(fallbackFieldName) {

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -107,7 +107,8 @@ public class QueryBuilderStoreTests extends ESTestCase {
             BytesBinaryIndexFieldData fieldData = new BytesBinaryIndexFieldData(
                 fieldMapper.fullPath(),
                 CoreValuesSourceType.KEYWORD,
-                BinaryDocValuesField::new
+                BinaryDocValuesField::new,
+                indexVersion
             );
             BiFunction<MappedFieldType, FieldDataContext, IndexFieldData<?>> indexFieldDataLookup = (mft, fdc) -> fieldData;
             Settings indexSettingsSettings = indexSettings(indexVersion, 1, 1).build();
@@ -224,7 +225,8 @@ public class QueryBuilderStoreTests extends ESTestCase {
             BytesBinaryIndexFieldData fieldData = new BytesBinaryIndexFieldData(
                 fieldMapper.fullPath(),
                 CoreValuesSourceType.KEYWORD,
-                BinaryDocValuesField::new
+                BinaryDocValuesField::new,
+                indexVersion
             );
             BiFunction<MappedFieldType, FieldDataContext, IndexFieldData<?>> indexFieldDataLookup = (mft, fdc) -> fieldData;
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValues.java
@@ -35,13 +35,13 @@ public abstract class MultiValuedSortedBinaryDocValues extends SortedBinaryDocVa
     }
 
     /**
-     * Reads binary doc values written in the current format ({@link SeparateCounts} or {@link PlainBinary}).
+     * Reads binary doc values written in the ({@link SeparateCounts} or {@link PlainBinary}) formats (as of April 2026).
      * <ul>
      *   <li>{@code .counts} present &rarr; {@link SeparateCounts} (multi-valued)</li>
      *   <li>{@code .counts} absent &rarr; {@link PlainBinary} (single-valued)</li>
      * </ul>
-     * For indices created before {@code DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES}, use {@link #fromLegacy(LeafReader, String)}
-     * instead.
+     * For indices created before {@code DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES}, use {@link #fromMultiValued(LeafReader, String)}
+     * instead, which also handles the deprecated {@link IntegratedCounts} format.
      */
     public static SortedBinaryDocValues from(LeafReader leafReader, String valuesFieldName) throws IOException {
         BinaryDocValues values = DocValues.getBinary(leafReader, valuesFieldName);
@@ -54,21 +54,23 @@ public abstract class MultiValuedSortedBinaryDocValues extends SortedBinaryDocVa
     }
 
     /**
-     * Legacy reader for callers that read inherently multi-valued internal fields (ex. {@code _ignored_source}) that may contain data in
-     * the deprecated {@link IntegratedCounts} format.
-     * <p>
-     * Falls back to {@link IntegratedCounts} when no {@code .counts} companion field is present. New callers should use
-     * {@link #from(LeafReader, String)}.
+     * Reader for callers that read inherently multi-valued fields (ex. {@code _ignored_source}). These fields always use either the
+     * {@link SeparateCounts} or {@link IntegratedCounts} format, so the single-valued fast path in {@link #from(LeafReader, String)} does
+     * not apply.
+     * <ul>
+     *   <li>{@code .counts} present &rarr; {@link SeparateCounts}</li>
+     *   <li>{@code .counts} absent &rarr; {@link IntegratedCounts}</li>
+     * </ul>
      */
-    public static MultiValuedSortedBinaryDocValues fromLegacy(LeafReader leafReader, String valuesFieldName) throws IOException {
+    public static MultiValuedSortedBinaryDocValues fromMultiValued(LeafReader leafReader, String valuesFieldName) throws IOException {
         BinaryDocValues values = DocValues.getBinary(leafReader, valuesFieldName);
-        return fromLegacy(leafReader, valuesFieldName, values);
+        return fromMultiValued(leafReader, valuesFieldName, values);
     }
 
     /**
-     * Legacy reader variant that accepts pre-loaded {@link BinaryDocValues}.
+     * Variant of {@link #fromMultiValued(LeafReader, String)} that accepts pre-loaded {@link BinaryDocValues}.
      */
-    public static MultiValuedSortedBinaryDocValues fromLegacy(LeafReader leafReader, String valuesFieldName, BinaryDocValues values)
+    public static MultiValuedSortedBinaryDocValues fromMultiValued(LeafReader leafReader, String valuesFieldName, BinaryDocValues values)
         throws IOException {
         String countsFieldName = valuesFieldName + MultiValuedBinaryDocValuesField.SeparateCount.COUNT_FIELD_SUFFIX;
         NumericDocValues counts = leafReader.getNumericDocValues(countsFieldName);

--- a/server/src/main/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValues.java
@@ -34,32 +34,67 @@ public abstract class MultiValuedSortedBinaryDocValues extends SortedBinaryDocVa
         this.values = values;
     }
 
-    public static MultiValuedSortedBinaryDocValues from(LeafReader leafReader, String valuesFieldName) throws IOException {
+    /**
+     * Reads binary doc values written in the current format ({@link SeparateCounts} or {@link PlainBinary}).
+     * <ul>
+     *   <li>{@code .counts} present &rarr; {@link SeparateCounts} (multi-valued)</li>
+     *   <li>{@code .counts} absent &rarr; {@link PlainBinary} (single-valued)</li>
+     * </ul>
+     * For indices created before {@code DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES}, use {@link #fromLegacy(LeafReader, String)}
+     * instead.
+     */
+    public static SortedBinaryDocValues from(LeafReader leafReader, String valuesFieldName) throws IOException {
         BinaryDocValues values = DocValues.getBinary(leafReader, valuesFieldName);
-
-        // Obtain counts directly from leafReader so that null is returned rather than an empty doc values.
-        // Whether counts is null allows us to determine which multivalued format was used.
-        return from(leafReader, valuesFieldName, values);
+        String countsFieldName = valuesFieldName + MultiValuedBinaryDocValuesField.SeparateCount.COUNT_FIELD_SUFFIX;
+        NumericDocValues counts = leafReader.getNumericDocValues(countsFieldName);
+        if (counts != null) {
+            return buildSeparateCounts(leafReader, countsFieldName, values, counts);
+        }
+        return new PlainBinary(values);
     }
 
-    public static MultiValuedSortedBinaryDocValues from(LeafReader leafReader, String valuesFieldName, BinaryDocValues values)
+    /**
+     * Legacy reader for callers that read inherently multi-valued internal fields (ex. {@code _ignored_source}) that may contain data in
+     * the deprecated {@link IntegratedCounts} format.
+     * <p>
+     * Falls back to {@link IntegratedCounts} when no {@code .counts} companion field is present. New callers should use
+     * {@link #from(LeafReader, String)}.
+     */
+    public static MultiValuedSortedBinaryDocValues fromLegacy(LeafReader leafReader, String valuesFieldName) throws IOException {
+        BinaryDocValues values = DocValues.getBinary(leafReader, valuesFieldName);
+        return fromLegacy(leafReader, valuesFieldName, values);
+    }
+
+    /**
+     * Legacy reader variant that accepts pre-loaded {@link BinaryDocValues}.
+     */
+    public static MultiValuedSortedBinaryDocValues fromLegacy(LeafReader leafReader, String valuesFieldName, BinaryDocValues values)
         throws IOException {
         String countsFieldName = valuesFieldName + MultiValuedBinaryDocValuesField.SeparateCount.COUNT_FIELD_SUFFIX;
         NumericDocValues counts = leafReader.getNumericDocValues(countsFieldName);
         if (counts == null) {
             return new IntegratedCounts(values);
         } else {
-            Sparsity sparsity = Sparsity.UNKNOWN;
-            ValueMode valueMode = ValueMode.UNKNOWN;
-
-            DocValuesSkipper countsSkipper = leafReader.getDocValuesSkipper(countsFieldName);
-            if (countsSkipper != null) {
-                sparsity = countsSkipper.docCount() == leafReader.maxDoc() ? Sparsity.DENSE : Sparsity.SPARSE;
-                valueMode = countsSkipper.maxValue() == 1 ? ValueMode.SINGLE_VALUED : ValueMode.MULTI_VALUED;
-            }
-
-            return new SeparateCounts(values, counts, sparsity, valueMode);
+            return buildSeparateCounts(leafReader, countsFieldName, values, counts);
         }
+    }
+
+    private static SeparateCounts buildSeparateCounts(
+        LeafReader leafReader,
+        String countsFieldName,
+        BinaryDocValues values,
+        NumericDocValues counts
+    ) throws IOException {
+        Sparsity sparsity = Sparsity.UNKNOWN;
+        ValueMode valueMode = ValueMode.UNKNOWN;
+
+        DocValuesSkipper countsSkipper = leafReader.getDocValuesSkipper(countsFieldName);
+        if (countsSkipper != null) {
+            sparsity = countsSkipper.docCount() == leafReader.maxDoc() ? Sparsity.DENSE : Sparsity.SPARSE;
+            valueMode = countsSkipper.maxValue() == 1 ? ValueMode.SINGLE_VALUED : ValueMode.MULTI_VALUED;
+        }
+
+        return new SeparateCounts(values, counts, sparsity, valueMode);
     }
 
     @Override
@@ -166,6 +201,37 @@ public abstract class MultiValuedSortedBinaryDocValues extends SortedBinaryDocVa
         @Override
         public ValueMode getValueMode() {
             return valueMode;
+        }
+    }
+
+    /**
+     * Single-valued binary doc values written as a plain {@link org.apache.lucene.document.BinaryDocValuesField}.
+     * No companion {@code .counts} field exists; each document has at most one value.
+     */
+    private static class PlainBinary extends MultiValuedSortedBinaryDocValues {
+        PlainBinary(BinaryDocValues values) {
+            super(values);
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+            if (values.advanceExact(doc)) {
+                count = 1;
+                return true;
+            } else {
+                count = 0;
+                return false;
+            }
+        }
+
+        @Override
+        public BytesRef nextValue() throws IOException {
+            return values.binaryValue();
+        }
+
+        @Override
+        public ValueMode getValueMode() {
+            return ValueMode.SINGLE_VALUED;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryIndexFieldData.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
@@ -31,15 +32,18 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
     protected final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
+    protected final IndexVersion indexVersion;
 
     public BytesBinaryIndexFieldData(
         String fieldName,
         ValuesSourceType valuesSourceType,
-        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory
+        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
+        IndexVersion indexVersion
     ) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.toScriptFieldFactory = toScriptFieldFactory;
+        this.indexVersion = indexVersion;
     }
 
     @Override
@@ -75,7 +79,7 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
 
     @Override
     public MultiValuedBinaryDVLeafFieldData load(LeafReaderContext context) {
-        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory);
+        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory, indexVersion);
     }
 
     @Override
@@ -87,17 +91,24 @@ public class BytesBinaryIndexFieldData implements IndexFieldData<MultiValuedBina
         private final String name;
         private final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
         private final ValuesSourceType valuesSourceType;
+        private final IndexVersion indexVersion;
 
-        public Builder(String name, ValuesSourceType valuesSourceType, ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory) {
+        public Builder(
+            String name,
+            ValuesSourceType valuesSourceType,
+            ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
+            IndexVersion indexVersion
+        ) {
             this.name = name;
             this.valuesSourceType = valuesSourceType;
             this.toScriptFieldFactory = toScriptFieldFactory;
+            this.indexVersion = indexVersion;
         }
 
         @Override
         public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
             // Ignore breaker
-            return new BytesBinaryIndexFieldData(name, valuesSourceType, toScriptFieldFactory);
+            return new BytesBinaryIndexFieldData(name, valuesSourceType, toScriptFieldFactory, indexVersion);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDVLeafFieldData.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.index.fielddata.plain;
 
 import org.apache.lucene.index.LeafReader;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
@@ -19,21 +21,24 @@ import org.elasticsearch.script.field.ToScriptFieldFactory;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-public final class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
+public class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
 
     private final String fieldName;
     private final LeafReader leafReader;
     private final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
+    private final IndexVersion indexVersion;
 
-    MultiValuedBinaryDVLeafFieldData(
+    protected MultiValuedBinaryDVLeafFieldData(
         String fieldName,
         LeafReader leafReader,
-        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory
+        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
+        IndexVersion indexVersion
     ) {
         super();
         this.fieldName = fieldName;
         this.leafReader = leafReader;
         this.toScriptFieldFactory = toScriptFieldFactory;
+        this.indexVersion = indexVersion;
     }
 
     @Override
@@ -46,7 +51,10 @@ public final class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
         try {
             // Need to return a new instance each time this gets invoked,
             // otherwise a positioned or exhausted instance can be returned:
-            return MultiValuedSortedBinaryDocValues.from(leafReader, fieldName);
+            if (indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)) {
+                return MultiValuedSortedBinaryDocValues.from(leafReader, fieldName);
+            }
+            return MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, fieldName);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/MultiValuedBinaryDVLeafFieldData.java
@@ -46,6 +46,11 @@ public class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
         return 0; // not exposed by Lucene
     }
 
+    /**
+     * Returns the binary doc values associated with this field.
+     * <p>
+     * Switches formats between legacy and current version (as of April 2026) based on {@link IndexVersion}.
+     */
     @Override
     public SortedBinaryDocValues getBytesValues() {
         try {
@@ -54,7 +59,9 @@ public class MultiValuedBinaryDVLeafFieldData implements LeafFieldData {
             if (indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)) {
                 return MultiValuedSortedBinaryDocValues.from(leafReader, fieldName);
             }
-            return MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, fieldName);
+            // Pre-DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES indices may use the deprecated IntegratedCounts format, which
+            // fromMultiValued() handles as a fallback when the .counts field is absent.
+            return MultiValuedSortedBinaryDocValues.fromMultiValued(leafReader, fieldName);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/StringBinaryIndexFieldData.java
@@ -12,6 +12,7 @@ package org.elasticsearch.index.fielddata.plain;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
@@ -28,15 +29,18 @@ public class StringBinaryIndexFieldData implements IndexFieldData<MultiValuedBin
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
     protected final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
+    protected final IndexVersion indexVersion;
 
     public StringBinaryIndexFieldData(
         String fieldName,
         ValuesSourceType valuesSourceType,
-        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory
+        ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
+        IndexVersion indexVersion
     ) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.toScriptFieldFactory = toScriptFieldFactory;
+        this.indexVersion = indexVersion;
     }
 
     @Override
@@ -57,7 +61,7 @@ public class StringBinaryIndexFieldData implements IndexFieldData<MultiValuedBin
 
     @Override
     public MultiValuedBinaryDVLeafFieldData load(LeafReaderContext context) {
-        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory);
+        return new MultiValuedBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory, indexVersion);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoaderLayer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoaderLayer.java
@@ -45,9 +45,11 @@ public class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSynthe
             return null;
         }
 
+        // Pre-DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES indices may use the deprecated IntegratedCounts format, which
+        // fromMultiValued() handles as a fallback when the .counts field is absent.
         bytesValues = indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)
             ? MultiValuedSortedBinaryDocValues.from(leafReader, name)
-            : MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, name, docValues);
+            : MultiValuedSortedBinaryDocValues.fromMultiValued(leafReader, name, docValues);
 
         return docId -> {
             hasValue = bytesValues.advanceExact(docId);

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoaderLayer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryDocValuesSyntheticFieldLoaderLayer.java
@@ -11,6 +11,8 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -20,11 +22,13 @@ import java.io.IOException;
 public class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSyntheticFieldLoader.DocValuesLayer {
 
     private final String name;
+    private final IndexVersion indexVersion;
     private SortedBinaryDocValues bytesValues;
     private boolean hasValue;
 
-    public BinaryDocValuesSyntheticFieldLoaderLayer(String name) {
+    public BinaryDocValuesSyntheticFieldLoaderLayer(String name, IndexVersion indexVersion) {
         this.name = name;
+        this.indexVersion = indexVersion;
     }
 
     @Override
@@ -41,7 +45,9 @@ public class BinaryDocValuesSyntheticFieldLoaderLayer implements CompositeSynthe
             return null;
         }
 
-        bytesValues = MultiValuedSortedBinaryDocValues.from(leafReader, name, docValues);
+        bytesValues = indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)
+            ? MultiValuedSortedBinaryDocValues.from(leafReader, name)
+            : MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, name, docValues);
 
         return docId -> {
             hasValue = bytesValues.advanceExact(docId);

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -262,7 +262,7 @@ public class BinaryFieldMapper extends FieldMapper {
         @Override
         public SortedBinaryDocValues getBytesValues() {
             try {
-                return MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, fieldName);
+                return MultiValuedSortedBinaryDocValues.fromMultiValued(leafReader, fieldName);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
@@ -18,17 +20,23 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.plain.BytesBinaryIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.MultiValuedBinaryDVLeafFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.field.BinaryDocValuesField;
+import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -133,7 +141,7 @@ public class BinaryFieldMapper extends FieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(FieldDataContext fieldDataContext) {
             failIfNoDocValues();
-            return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, BinaryDocValuesField::new);
+            return (cache, breakerService) -> new CustomBinaryIndexFieldData(name(), BinaryDocValuesField::new);
         }
 
         @Override
@@ -231,6 +239,45 @@ public class BinaryFieldMapper extends FieldMapper {
         }
 
         return super.syntheticSourceSupport();
+    }
+
+    /**
+     * This class is necessary because BinaryFieldMapper uses its own binary encoding format, matching that of
+     * {@link MultiValuedBinaryDocValuesField.IntegratedCount}.
+     */
+    private static final class CustomBinaryDVLeafFieldData extends MultiValuedBinaryDVLeafFieldData {
+        private final LeafReader leafReader;
+        private final String fieldName;
+
+        CustomBinaryDVLeafFieldData(
+            String fieldName,
+            LeafReader leafReader,
+            ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory
+        ) {
+            super(fieldName, leafReader, toScriptFieldFactory, IndexVersion.current());
+            this.leafReader = leafReader;
+            this.fieldName = fieldName;
+        }
+
+        @Override
+        public SortedBinaryDocValues getBytesValues() {
+            try {
+                return MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, fieldName);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    private static final class CustomBinaryIndexFieldData extends BytesBinaryIndexFieldData {
+        CustomBinaryIndexFieldData(String fieldName, ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory) {
+            super(fieldName, CoreValuesSourceType.KEYWORD, toScriptFieldFactory, IndexVersion.current());
+        }
+
+        @Override
+        public MultiValuedBinaryDVLeafFieldData load(LeafReaderContext context) {
+            return new CustomBinaryDVLeafFieldData(fieldName, context.reader(), toScriptFieldFactory);
+        }
     }
 
     public static final class CustomBinaryDocValuesField extends CustomDocValuesField {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -61,7 +62,7 @@ final class BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer implements Compo
 
     @Override
     public SourceLoader.SyntheticFieldLoader.DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {
-        MultiValuedSortedBinaryDocValues valueDocValues = MultiValuedSortedBinaryDocValues.from(leafReader, name);
+        SortedBinaryDocValues valueDocValues = MultiValuedSortedBinaryDocValues.from(leafReader, name);
         return docValues = ValuesWithOffsetsDocValuesLoader.binaryLoader(
             valueDocValues,
             DocValues.getSorted(leafReader, offsetsFieldName),

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompositeSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompositeSyntheticFieldLoader.java
@@ -180,7 +180,7 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
      */
     public static Layer malformedValuesLayer(String fieldName, IndexVersion indexVersion) {
         if (indexVersion.onOrAfter(IndexVersions.STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES)) {
-            return new MalformedValuesBinaryDocValuesLayer(fieldName);
+            return new MalformedValuesBinaryDocValuesLayer(fieldName, indexVersion);
         } else {
             return new MalformedValuesStoredFieldLayer(fieldName);
         }
@@ -209,8 +209,8 @@ public class CompositeSyntheticFieldLoader implements SourceLoader.SyntheticFiel
      * Layer that loads malformed values from binary doc values for synthetic source.
      */
     private static class MalformedValuesBinaryDocValuesLayer extends BinaryDocValuesSyntheticFieldLoaderLayer {
-        MalformedValuesBinaryDocValuesLayer(String fieldName) {
-            super(IgnoreMalformedStoredValues.name(fieldName));
+        MalformedValuesBinaryDocValuesLayer(String fieldName, IndexVersion indexVersion) {
+            super(IgnoreMalformedStoredValues.name(fieldName), indexVersion);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
@@ -136,7 +136,7 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
             this.ignoredSourceFormat = ignoredSourceFormat;
             if (ignoredSourceFormat == IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE) {
                 this.ignoredSourceDocValues = Objects.requireNonNull(
-                    MultiValuedSortedBinaryDocValues.from(leafReader, IgnoredSourceFieldMapper.NAME)
+                    MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, IgnoredSourceFieldMapper.NAME)
                 );
             } else {
                 this.ignoredSourceDocValues = null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
@@ -136,7 +136,7 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
             this.ignoredSourceFormat = ignoredSourceFormat;
             if (ignoredSourceFormat == IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE) {
                 this.ignoredSourceDocValues = Objects.requireNonNull(
-                    MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, IgnoredSourceFieldMapper.NAME)
+                    MultiValuedSortedBinaryDocValues.fromMultiValued(leafReader, IgnoredSourceFieldMapper.NAME)
                 );
             } else {
                 this.ignoredSourceDocValues = null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValues.java
@@ -143,7 +143,7 @@ public abstract class IgnoreMalformedStoredValues {
      */
     public static IgnoreMalformedStoredValues forSyntheticSource(String fieldName, IndexVersion indexVersion) {
         if (indexVersion.onOrAfter(IndexVersions.STORE_IGNORED_MALFORMED_IN_BINARY_DOC_VALUES)) {
-            return new DocValues(fieldName);
+            return new DocValues(fieldName, indexVersion);
         } else {
             return new Stored(fieldName);
         }
@@ -239,8 +239,8 @@ public abstract class IgnoreMalformedStoredValues {
 
         private final BinaryDocValuesSyntheticFieldLoaderLayer delegate;
 
-        DocValues(String fieldName) {
-            this.delegate = new BinaryDocValuesSyntheticFieldLoaderLayer(name(fieldName)) {
+        DocValues(String fieldName, IndexVersion indexVersion) {
+            this.delegate = new BinaryDocValuesSyntheticFieldLoaderLayer(name(fieldName), indexVersion) {
                 @Override
                 protected void writeValue(XContentBuilder b, BytesRef value) throws IOException {
                     XContentDataHelper.decodeAndWrite(b, value);

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -174,7 +174,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
         @Override
         public void setNextReader(LeafReaderContext context) {
             try {
-                docValues = MultiValuedSortedBinaryDocValues.fromLegacy(context.reader(), NAME);
+                docValues = MultiValuedSortedBinaryDocValues.fromMultiValued(context.reader(), NAME);
             } catch (IOException e) {
                 throw new ElasticsearchException("Failed to load doc values for " + NAME, e);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -174,7 +174,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
         @Override
         public void setNextReader(LeafReaderContext context) {
             try {
-                docValues = MultiValuedSortedBinaryDocValues.from(context.reader(), NAME);
+                docValues = MultiValuedSortedBinaryDocValues.fromLegacy(context.reader(), NAME);
             } catch (IOException e) {
                 throw new ElasticsearchException("Failed to load doc values for " + NAME, e);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -807,7 +807,7 @@ public class IpFieldMapper extends FieldMapper {
                             new BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer(fullPath(), offsetsFieldName, IpFieldMapper::convert)
                         );
                     } else {
-                        layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath()) {
+                        layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexSettings.getIndexVersionCreated()) {
                             @Override
                             protected void writeValue(XContentBuilder b, BytesRef value) throws IOException {
                                 BytesRef converted = IpFieldMapper.convert(value);

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -573,6 +573,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         private final boolean isDimension;
         private final boolean usesBinaryDocValues;
         private final boolean usesBinaryDocValuesForIgnoredFields;
+        private final IndexVersion indexVersion;
 
         public KeywordFieldType(
             String name,
@@ -603,6 +604,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.isDimension = builder.dimension.getValue();
             this.usesBinaryDocValues = builder.usesBinaryDocValues();
             this.usesBinaryDocValuesForIgnoredFields = builder.storeIgnoredFieldsInBinaryDocValues;
+            this.indexVersion = builder.indexSettings.getIndexVersionCreated();
         }
 
         public KeywordFieldType(String name) {
@@ -629,6 +631,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.isDimension = false;
             this.usesBinaryDocValues = usesBinaryDocValues;
             this.usesBinaryDocValuesForIgnoredFields = false;
+            this.indexVersion = IndexVersion.current();
         }
 
         public KeywordFieldType(String name, FieldType fieldType, boolean isSyntheticSource) {
@@ -649,6 +652,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.isDimension = false;
             this.usesBinaryDocValues = false;
             this.usesBinaryDocValuesForIgnoredFields = false;
+            this.indexVersion = IndexVersion.current();
         }
 
         public KeywordFieldType(String name, NamedAnalyzer analyzer) {
@@ -669,6 +673,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.isDimension = false;
             this.usesBinaryDocValues = false;
             this.usesBinaryDocValuesForIgnoredFields = false;
+            this.indexVersion = IndexVersion.current();
         }
 
         public boolean usesBinaryDocValues() {
@@ -724,7 +729,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 return new StringScriptFieldRangeQuery(
                     new Script(""),
-                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                     name(),
                     lowerTerm == null ? null : indexedValueForSearch(lowerTerm).utf8ToString(),
                     upperTerm == null ? null : indexedValueForSearch(upperTerm).utf8ToString(),
@@ -758,7 +763,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 return StringScriptFieldFuzzyQuery.build(
                     new Script(""),
-                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                     name(),
                     indexedValueForSearch(value).utf8ToString(),
                     fuzziness.asDistance(BytesRefs.toString(value)),
@@ -790,7 +795,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 return new StringScriptFieldPrefixQuery(
                     new Script(""),
-                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                     name(),
                     indexedValueForSearch(value).utf8ToString(),
                     caseInsensitive
@@ -818,7 +823,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             } else if (usesBinaryDocValues) {
                 return new StringScriptFieldTermQuery(
                     new Script(""),
-                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                    ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                     name(),
                     indexedValueForSearch(value).utf8ToString(),
                     true
@@ -1038,7 +1043,12 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         private IndexFieldData.Builder fieldDataFromDocValues() {
             if (usesBinaryDocValues) {
-                return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, KeywordDocValuesField::new);
+                return new BytesBinaryIndexFieldData.Builder(
+                    name(),
+                    CoreValuesSourceType.KEYWORD,
+                    KeywordDocValuesField::new,
+                    indexVersion
+                );
             } else {
                 return new SortedSetOrdinalsIndexFieldData.Builder(
                     name(),
@@ -1160,7 +1170,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 if (usesBinaryDocValues) {
                     return new StringScriptFieldWildcardQuery(
                         new Script(""),
-                        ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                        ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                         name(),
                         value,
                         false
@@ -1197,7 +1207,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 if (usesBinaryDocValues) {
                     return new StringScriptFieldRegexpQuery(
                         new Script(""),
-                        ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx),
+                        ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx, indexVersion),
                         name(),
                         value,
                         syntaxFlags,
@@ -1597,7 +1607,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 if (offsetsFieldName != null) {
                     layers.add(new BinaryWithOffsetsDocValuesSyntheticFieldLoaderLayer(fullPath(), offsetsFieldName));
                 } else {
-                    layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().name()));
+                    layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().name(), indexCreatedVersion));
                 }
             }
         }
@@ -1608,7 +1618,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             final String fieldName = fieldType().syntheticSourceFallbackFieldName();
 
             if (storeIgnoredFieldsInBinaryDocValues) {
-                layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldName));
+                layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldName, indexCreatedVersion));
             } else {
                 // old indices, stored ignored values in stored fields
                 layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(fieldName) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -213,7 +213,7 @@ public interface SourceLoader {
                 this.ignoredSourceFormat = ignoredSourceFormat;
                 if (ignoredSourceFormat == IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE) {
                     this.ignoredSourcedocValues = Objects.requireNonNull(
-                        MultiValuedSortedBinaryDocValues.from(leafReader, IgnoredSourceFieldMapper.NAME)
+                        MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, IgnoredSourceFieldMapper.NAME)
                     );
                 } else {
                     this.ignoredSourcedocValues = null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -213,7 +213,7 @@ public interface SourceLoader {
                 this.ignoredSourceFormat = ignoredSourceFormat;
                 if (ignoredSourceFormat == IgnoredSourceFieldMapper.IgnoredSourceFormat.DOC_VALUES_IGNORED_SOURCE) {
                     this.ignoredSourcedocValues = Objects.requireNonNull(
-                        MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, IgnoredSourceFieldMapper.NAME)
+                        MultiValuedSortedBinaryDocValues.fromMultiValued(leafReader, IgnoredSourceFieldMapper.NAME)
                     );
                 } else {
                     this.ignoredSourcedocValues = null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1486,7 +1486,12 @@ public final class TextFieldMapper extends FieldMapper {
 
         private IndexFieldData.Builder fieldDataFromDocValues() {
             if (usesBinaryDocValues()) {
-                return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, TextDocValuesField::new);
+                return new BytesBinaryIndexFieldData.Builder(
+                    name(),
+                    CoreValuesSourceType.KEYWORD,
+                    TextDocValuesField::new,
+                    indexCreatedVersion
+                );
             } else {
                 return new SortedSetOrdinalsIndexFieldData.Builder(
                     name(),
@@ -1979,7 +1984,7 @@ public final class TextFieldMapper extends FieldMapper {
         // layer for loading from a fallback field created during indexing by this text field mapper
         final String fallbackFieldName = fieldType().syntheticSourceFallbackFieldName();
         if (usesBinaryDocValuesForFallbackFields) {
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fallbackFieldName));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fallbackFieldName, indexCreatedVersion));
         } else {
             // for bwc - fallback fields were originally stored in StoredFields
             layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(fallbackFieldName) {
@@ -2003,7 +2008,7 @@ public final class TextFieldMapper extends FieldMapper {
     private CompositeSyntheticFieldLoader syntheticFieldLoaderFromDocValues() {
         var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>();
         if (fieldType().usesBinaryDocValues()) {
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath()));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexCreatedVersion));
         } else {
             layers.add(new SortedSetDocValuesSyntheticFieldLoaderLayer(fullPath()) {
                 @Override
@@ -2029,7 +2034,7 @@ public final class TextFieldMapper extends FieldMapper {
             });
 
             // also load from fallback field for values that exceeded MAX_TERM_LENGTH
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().syntheticSourceFallbackFieldName()));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fieldType().syntheticSourceFallbackFieldName(), indexCreatedVersion));
         }
         return new CompositeSyntheticFieldLoader(leafName(), fullPath(), layers);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ValuesWithOffsetsDocValuesLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ValuesWithOffsetsDocValuesLoader.java
@@ -13,7 +13,7 @@ import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
-import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -35,7 +35,7 @@ final class ValuesWithOffsetsDocValuesLoader implements SourceLoader.SyntheticFi
     }
 
     static ValuesWithOffsetsDocValuesLoader binaryLoader(
-        MultiValuedSortedBinaryDocValues valueDocValues,
+        SortedBinaryDocValues valueDocValues,
         SortedDocValues offsetDocValues,
         Function<BytesRef, BytesRef> converter
     ) {
@@ -104,8 +104,8 @@ final class ValuesWithOffsetsDocValuesLoader implements SourceLoader.SyntheticFi
         }
     }
 
-    private record MultivaluedBinarySortedValuesSource(MultiValuedSortedBinaryDocValues valueDocValues) implements SortedValuesSource {
-        private MultivaluedBinarySortedValuesSource(MultiValuedSortedBinaryDocValues valueDocValues) {
+    private record MultivaluedBinarySortedValuesSource(SortedBinaryDocValues valueDocValues) implements SortedValuesSource {
+        private MultivaluedBinarySortedValuesSource(SortedBinaryDocValues valueDocValues) {
             this.valueDocValues = Objects.requireNonNull(valueDocValues);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedDocValuesSyntheticFieldLoader.java
@@ -110,7 +110,7 @@ class FlattenedDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFi
         if (usesBinaryDocValues) {
             var binaryDv = reader.getBinaryDocValues(keyedFieldFullPath);
             if (binaryDv != null) {
-                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromLegacy(reader, keyedFieldFullPath, binaryDv);
+                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromMultiValued(reader, keyedFieldFullPath, binaryDv);
                 docValues = new MultiValuedBinaryFlattenedDocValues(dv);
                 allLoaders.add(docValues);
             } else {
@@ -148,7 +148,11 @@ class FlattenedDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFi
         if (storeIgnoredFieldsInBinaryDocValues && keyedIgnoredValuesFieldFullPath != null) {
             var binaryDv = reader.getBinaryDocValues(keyedIgnoredValuesFieldFullPath);
             if (binaryDv != null) {
-                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromLegacy(reader, keyedIgnoredValuesFieldFullPath, binaryDv);
+                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromMultiValued(
+                    reader,
+                    keyedIgnoredValuesFieldFullPath,
+                    binaryDv
+                );
                 ignoredDocValues = new MultiValuedBinaryFlattenedDocValues(dv);
                 allLoaders.add(ignoredDocValues);
             } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedDocValuesSyntheticFieldLoader.java
@@ -110,7 +110,7 @@ class FlattenedDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFi
         if (usesBinaryDocValues) {
             var binaryDv = reader.getBinaryDocValues(keyedFieldFullPath);
             if (binaryDv != null) {
-                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.from(reader, keyedFieldFullPath, binaryDv);
+                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromLegacy(reader, keyedFieldFullPath, binaryDv);
                 docValues = new MultiValuedBinaryFlattenedDocValues(dv);
                 allLoaders.add(docValues);
             } else {
@@ -129,7 +129,7 @@ class FlattenedDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFi
         {
             var binaryDv = reader.getBinaryDocValues(offsetsFieldName);
             if (binaryDv != null) {
-                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.from(reader, offsetsFieldName, binaryDv);
+                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.from(reader, offsetsFieldName);
                 offsetsDocValues = new MultiValuedBinaryFlattenedDocValues(dv);
                 allLoaders.add(offsetsDocValues);
             } else {
@@ -148,7 +148,7 @@ class FlattenedDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFi
         if (storeIgnoredFieldsInBinaryDocValues && keyedIgnoredValuesFieldFullPath != null) {
             var binaryDv = reader.getBinaryDocValues(keyedIgnoredValuesFieldFullPath);
             if (binaryDv != null) {
-                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.from(reader, keyedIgnoredValuesFieldFullPath, binaryDv);
+                SortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromLegacy(reader, keyedIgnoredValuesFieldFullPath, binaryDv);
                 ignoredDocValues = new MultiValuedBinaryFlattenedDocValues(dv);
                 allLoaders.add(ignoredDocValues);
             } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.FieldData;
@@ -427,7 +428,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 context.isSourceSynthetic(),
                 mappedSubFields,
                 storeIgnoredFieldsInBinaryDocValues,
-                preserveLeafArrays.get()
+                preserveLeafArrays.get(),
+                indexSettings.getIndexVersionCreated()
             );
             return new FlattenedFieldMapper(leafName(), ft, builderParams(this, context), this, mappedSubFields);
         }
@@ -541,6 +543,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
         protected final boolean usesBinaryDocValues;
         protected final boolean hasRootDocValues;
         protected final String nullValue;
+        protected final IndexVersion indexVersion;
 
         BaseFlattenedFieldType(
             String name,
@@ -551,13 +554,15 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             IgnoreAbove ignoreAbove,
             boolean usesBinaryDocValues,
             boolean hasRootDocValues,
-            String nullValue
+            String nullValue,
+            IndexVersion indexVersion
         ) {
             super(name, indexType, isStored, textSearchInfo, meta);
             this.ignoreAbove = ignoreAbove;
             this.usesBinaryDocValues = usesBinaryDocValues;
             this.hasRootDocValues = hasRootDocValues;
             this.nullValue = nullValue;
+            this.indexVersion = indexVersion;
         }
 
         protected Mapper.IgnoreAbove ignoreAbove() {
@@ -611,7 +616,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             IgnoreAbove ignoreAbove,
             boolean usesBinaryDocValues,
             boolean hasRootDocValues,
-            String nullValue
+            String nullValue,
+            IndexVersion indexVersion
         ) {
             super(
                 rootName + KEYED_FIELD_SUFFIX,
@@ -622,7 +628,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 ignoreAbove,
                 usesBinaryDocValues,
                 hasRootDocValues,
-                nullValue
+                nullValue,
+                indexVersion
             );
             this.key = key;
             this.rootName = rootName;
@@ -647,7 +654,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 ignoreAbove,
                 usesBinaryDocValues,
                 ref.hasRootDocValues,
-                nullValue
+                nullValue,
+                ref.indexVersion
             );
         }
 
@@ -780,7 +788,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             failIfNoDocValues();
 
             if (usesBinaryDocValues) {
-                return new BinaryKeyedFlattenedFieldData.Builder(name(), key, FlattenedDocValuesField::new);
+                return new BinaryKeyedFlattenedFieldData.Builder(name(), key, FlattenedDocValuesField::new, indexVersion);
             } else {
                 return new KeyedFlattenedFieldData.Builder(name(), key, (dv, n) -> new FlattenedDocValuesField(FieldData.toString(dv), n));
             }
@@ -1108,16 +1116,23 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             private final String fieldName;
             private final String key;
             private final ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory;
+            private final IndexVersion indexVersion;
 
-            Builder(String fieldName, String key, ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory) {
+            Builder(
+                String fieldName,
+                String key,
+                ToScriptFieldFactory<SortedBinaryDocValues> toScriptFieldFactory,
+                IndexVersion indexVersion
+            ) {
                 this.fieldName = fieldName;
                 this.key = key;
                 this.toScriptFieldFactory = toScriptFieldFactory;
+                this.indexVersion = indexVersion;
             }
 
             @Override
             public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
-                var delegate = new BytesBinaryIndexFieldData(fieldName, CoreValuesSourceType.KEYWORD, toScriptFieldFactory);
+                var delegate = new BytesBinaryIndexFieldData(fieldName, CoreValuesSourceType.KEYWORD, toScriptFieldFactory, indexVersion);
                 return new BinaryKeyedFlattenedFieldData(key, delegate, toScriptFieldFactory);
             }
         }
@@ -1164,7 +1179,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 isSyntheticSourceEnabled,
                 Collections.emptyMap(),
                 false,
-                preserveLeafArrays
+                preserveLeafArrays,
+                IndexVersion.current()
             );
         }
 
@@ -1182,7 +1198,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             boolean isSyntheticSourceEnabled,
             Map<String, FieldMapper> mappedSubFields,
             boolean storeIgnoredFieldsInBinaryDocValues,
-            PreserveLeafArrays preserveLeafArrays
+            PreserveLeafArrays preserveLeafArrays,
+            IndexVersion indexVersion
         ) {
             super(
                 name,
@@ -1193,7 +1210,8 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                 ignoreAbove,
                 usesBinaryDocValues,
                 hasRootDocValues,
-                nullValue
+                nullValue,
+                indexVersion
             );
             this.splitQueriesOnWhitespace = splitQueriesOnWhitespace;
             this.eagerGlobalOrdinals = eagerGlobalOrdinals;
@@ -1278,7 +1296,12 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
 
             if (hasRootDocValues) {
                 if (usesBinaryDocValues) {
-                    return new BytesBinaryIndexFieldData.Builder(name(), CoreValuesSourceType.KEYWORD, FlattenedDocValuesField::new);
+                    return new BytesBinaryIndexFieldData.Builder(
+                        name(),
+                        CoreValuesSourceType.KEYWORD,
+                        FlattenedDocValuesField::new,
+                        indexVersion
+                    );
                 } else {
                     return new SortedSetOrdinalsIndexFieldData.Builder(
                         name(),
@@ -1287,7 +1310,7 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
                     );
                 }
             }
-            return new RootFlattenedFromKeyedFieldData.Builder(name(), name() + KEYED_FIELD_SUFFIX, usesBinaryDocValues);
+            return new RootFlattenedFromKeyedFieldData.Builder(name(), name() + KEYED_FIELD_SUFFIX, usesBinaryDocValues, indexVersion);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedDocValuesBlockLoader.java
@@ -35,7 +35,7 @@ public class KeyedFlattenedDocValuesBlockLoader extends BlockDocValuesReader.Doc
     @Override
     public ColumnAtATimeReader reader(CircuitBreaker breaker, LeafReaderContext context) throws IOException {
         if (usesBinaryDocValues) {
-            MultiValuedSortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromLegacy(context.reader(), keyedFieldName);
+            MultiValuedSortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromMultiValued(context.reader(), keyedFieldName);
             SortedBinaryDocValues filtered = BinaryKeyedFlattenedLeafFieldData.getKeyFilteredSortedBinaryDocValues(dv, key);
             return new BinaryKeyedBlockDocValuesReader(breaker, filtered);
         } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedDocValuesBlockLoader.java
@@ -35,7 +35,7 @@ public class KeyedFlattenedDocValuesBlockLoader extends BlockDocValuesReader.Doc
     @Override
     public ColumnAtATimeReader reader(CircuitBreaker breaker, LeafReaderContext context) throws IOException {
         if (usesBinaryDocValues) {
-            MultiValuedSortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.from(context.reader(), keyedFieldName);
+            MultiValuedSortedBinaryDocValues dv = MultiValuedSortedBinaryDocValues.fromLegacy(context.reader(), keyedFieldName);
             SortedBinaryDocValues filtered = BinaryKeyedFlattenedLeafFieldData.getKeyFilteredSortedBinaryDocValues(dv, key);
             return new BinaryKeyedBlockDocValuesReader(breaker, filtered);
         } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFromKeyedFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFromKeyedFieldData.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.LeafFieldData;
@@ -177,18 +178,25 @@ public final class RootFlattenedFromKeyedFieldData implements IndexFieldData<Lea
         private final String rootFieldName;
         private final String keyedFieldName;
         private final boolean usesBinaryDocValues;
+        private final IndexVersion indexVersion;
 
-        public Builder(String rootFieldName, String keyedFieldName, boolean usesBinaryDocValues) {
+        public Builder(String rootFieldName, String keyedFieldName, boolean usesBinaryDocValues, IndexVersion indexVersion) {
             this.rootFieldName = rootFieldName;
             this.keyedFieldName = keyedFieldName;
             this.usesBinaryDocValues = usesBinaryDocValues;
+            this.indexVersion = indexVersion;
         }
 
         @Override
         public IndexFieldData<?> build(IndexFieldDataCache cache, CircuitBreakerService breakerService) {
             IndexFieldData<?> keyedDelegate;
             if (usesBinaryDocValues) {
-                keyedDelegate = new BytesBinaryIndexFieldData(keyedFieldName, CoreValuesSourceType.KEYWORD, FlattenedDocValuesField::new);
+                keyedDelegate = new BytesBinaryIndexFieldData(
+                    keyedFieldName,
+                    CoreValuesSourceType.KEYWORD,
+                    FlattenedDocValuesField::new,
+                    indexVersion
+                );
             } else {
                 keyedDelegate = new SortedSetOrdinalsIndexFieldData(
                     cache,

--- a/server/src/main/java/org/elasticsearch/script/SortedBinaryDocValuesStringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/SortedBinaryDocValuesStringFieldScript.java
@@ -11,6 +11,8 @@ package org.elasticsearch.script;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fielddata.MultiValuedSortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.mapper.OnScriptError;
@@ -23,10 +25,17 @@ public class SortedBinaryDocValuesStringFieldScript extends StringFieldScript {
     private final SortedBinaryDocValues sortedBinaryDocValues;
     boolean hasValue = false;
 
-    public SortedBinaryDocValuesStringFieldScript(String fieldName, SearchLookup searchLookup, LeafReaderContext ctx) {
+    public SortedBinaryDocValuesStringFieldScript(
+        String fieldName,
+        SearchLookup searchLookup,
+        LeafReaderContext ctx,
+        IndexVersion indexVersion
+    ) {
         super(fieldName, Map.of(), searchLookup, OnScriptError.FAIL, ctx);
         try {
-            sortedBinaryDocValues = MultiValuedSortedBinaryDocValues.from(ctx.reader(), fieldName);
+            sortedBinaryDocValues = indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)
+                ? MultiValuedSortedBinaryDocValues.from(ctx.reader(), fieldName)
+                : MultiValuedSortedBinaryDocValues.fromLegacy(ctx.reader(), fieldName);
         } catch (IOException e) {
             throw new IllegalStateException("Cannot load doc values", e);
         }

--- a/server/src/main/java/org/elasticsearch/script/SortedBinaryDocValuesStringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/SortedBinaryDocValuesStringFieldScript.java
@@ -33,9 +33,11 @@ public class SortedBinaryDocValuesStringFieldScript extends StringFieldScript {
     ) {
         super(fieldName, Map.of(), searchLookup, OnScriptError.FAIL, ctx);
         try {
+            // Pre-DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES indices may use the deprecated IntegratedCounts format, which
+            // fromMultiValued() handles as a fallback when the .counts field is absent.
             sortedBinaryDocValues = indexVersion.onOrAfter(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES)
                 ? MultiValuedSortedBinaryDocValues.from(ctx.reader(), fieldName)
-                : MultiValuedSortedBinaryDocValues.fromLegacy(ctx.reader(), fieldName);
+                : MultiValuedSortedBinaryDocValues.fromMultiValued(ctx.reader(), fieldName);
         } catch (IOException e) {
             throw new IllegalStateException("Cannot load doc values", e);
         }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValuesTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.fielddata;
 
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.store.Directory;
@@ -47,7 +48,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
 
                 // then
                 assertTrue(values.advanceExact(0));
@@ -90,7 +91,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
 
                 // then
                 assertTrue(values.advanceExact(0));
@@ -122,7 +123,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
 
                 // then
                 assertTrue(values.advanceExact(0));
@@ -159,9 +160,72 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
 
                 // then
+                assertTrue(values.advanceExact(0));
+                assertEquals(1, values.docValueCount());
+                assertEquals(expected, values.nextValue());
+            }
+        }
+    }
+
+    /**
+     * Verifies that the PlainBinary reader correctly reads single-valued binary doc values
+     * written as a plain {@link BinaryDocValuesField} via auto-detection.
+     */
+    public void testReadSingleValuedBinaryDocValues() throws IOException {
+        // given
+        BytesRef expected = new BytesRef("potato");
+
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                LuceneDocument doc = new LuceneDocument();
+                doc.addWithKey("field", new BinaryDocValuesField("field", expected));
+                iw.addDocument(doc);
+            }
+
+            // when
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(leafReader, "field");
+
+                // then
+                assertNotNull(values);
+                assertTrue(values.advanceExact(0));
+                assertEquals(1, values.docValueCount());
+                assertEquals(expected, values.nextValue());
+                assertEquals(SortedBinaryDocValues.ValueMode.SINGLE_VALUED, values.getValueMode());
+            }
+        }
+    }
+
+    /**
+     * Verifies that fromLegacy() falls back to IntegratedCounts when .counts is absent.
+     */
+    public void testFromLegacyFallsBackToIntegratedCounts() throws IOException {
+        IndexVersion oldVersion = IndexVersionUtils.getPreviousVersion(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES);
+
+        // Write an IntegratedCount value using the old index version
+        BytesRef expected = new BytesRef("potato");
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+                LuceneDocument doc = new LuceneDocument();
+                MultiValuedBinaryDocValuesField.addToBinaryFieldInDoc(
+                    doc,
+                    "field",
+                    expected,
+                    MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE,
+                    oldVersion
+                );
+                iw.addDocument(doc);
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
+
+                // IntegratedCounts reader should decode correctly
                 assertTrue(values.advanceExact(0));
                 assertEquals(1, values.docValueCount());
                 assertEquals(expected, values.nextValue());

--- a/server/src/test/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/MultiValuedSortedBinaryDocValuesTests.java
@@ -25,8 +25,17 @@ import org.elasticsearch.test.index.IndexVersionUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TreeSet;
 
 public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
+
+    private static List<BytesRef> randomSortedUniqueBytesRefs(int count) {
+        TreeSet<BytesRef> sorted = new TreeSet<>();
+        while (sorted.size() < count) {
+            sorted.add(new BytesRef(randomAlphanumericOfLength(10)));
+        }
+        return new ArrayList<>(sorted);
+    }
 
     /**
      * Verifies that {@link MultiValuedSortedBinaryDocValues} correctly reads multi-valued binary doc values written by
@@ -34,7 +43,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
      */
     public void testReadValuesFromSeparateCount() throws IOException {
         // given
-        List<BytesRef> expected = List.of(new BytesRef("aaa"), new BytesRef("bbb"), new BytesRef("ccc"));
+        List<BytesRef> expected = randomSortedUniqueBytesRefs(3);
 
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
@@ -48,7 +57,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromMultiValued(leafReader, "field");
 
                 // then
                 assertTrue(values.advanceExact(0));
@@ -68,7 +77,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
      */
     public void testReadValuesFromSeparateCountWithPreviousIndexVersion() throws IOException {
         // given
-        List<BytesRef> expected = List.of(new BytesRef("aaa"), new BytesRef("bbb"), new BytesRef("ccc"));
+        List<BytesRef> expected = randomSortedUniqueBytesRefs(3);
 
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
@@ -91,7 +100,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromMultiValued(leafReader, "field");
 
                 // then
                 assertTrue(values.advanceExact(0));
@@ -111,7 +120,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
      */
     public void testReadSingleValueFromSeparateCount() throws IOException {
         // given
-        BytesRef expected = new BytesRef("single");
+        BytesRef expected = new BytesRef(randomAlphanumericOfLength(10));
 
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
@@ -123,7 +132,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromMultiValued(leafReader, "field");
 
                 // then
                 assertTrue(values.advanceExact(0));
@@ -137,9 +146,9 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
      * Verifies that {@link MultiValuedSortedBinaryDocValues} correctly reads a single value written by
      * {@link MultiValuedBinaryDocValuesField.IntegratedCount}.
      */
-    public void testReadSingleValueFromSeparateCountWothPreviousIndexVersion() throws IOException {
+    public void testReadSingleValueFromSeparateCountWithPreviousIndexVersion() throws IOException {
         // given
-        BytesRef expected = new BytesRef("single");
+        BytesRef expected = new BytesRef(randomAlphanumericOfLength(10));
 
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
@@ -160,7 +169,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
             // when
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
+                MultiValuedSortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromMultiValued(leafReader, "field");
 
                 // then
                 assertTrue(values.advanceExact(0));
@@ -176,7 +185,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
      */
     public void testReadSingleValuedBinaryDocValues() throws IOException {
         // given
-        BytesRef expected = new BytesRef("potato");
+        BytesRef expected = new BytesRef(randomAlphanumericOfLength(10));
 
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
@@ -201,13 +210,13 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
     }
 
     /**
-     * Verifies that fromLegacy() falls back to IntegratedCounts when .counts is absent.
+     * Verifies that fromMultiValued() falls back to IntegratedCounts when .counts is absent.
      */
-    public void testFromLegacyFallsBackToIntegratedCounts() throws IOException {
+    public void testFromMultiValuedFallsBackToIntegratedCounts() throws IOException {
         IndexVersion oldVersion = IndexVersionUtils.getPreviousVersion(IndexVersions.DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES);
 
         // Write an IntegratedCount value using the old index version
-        BytesRef expected = new BytesRef("potato");
+        BytesRef expected = new BytesRef(randomAlphanumericOfLength(10));
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
                 LuceneDocument doc = new LuceneDocument();
@@ -223,7 +232,7 @@ public class MultiValuedSortedBinaryDocValuesTests extends ESTestCase {
 
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = reader.leaves().get(0).reader();
-                SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(leafReader, "field");
+                SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromMultiValued(leafReader, "field");
 
                 // IntegratedCounts reader should decode correctly
                 assertTrue(values.advanceExact(0));

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.IndexType;
 import org.elasticsearch.index.mapper.Mapper;
@@ -57,7 +58,8 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
             IGNORE_ABOVE,
             true,
             false,
-            null
+            null,
+            IndexVersion.current()
         );
     }
 
@@ -93,7 +95,8 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
             IGNORE_ABOVE,
             true,
             false,
-            null
+            null,
+            IndexVersion.current()
         );
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("field", null));
         assertEquals("Cannot search on field [" + ft.name() + "] since it is not indexed.", e.getMessage());

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFromKeyedFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/RootFlattenedFromKeyedFieldDataTests.java
@@ -20,6 +20,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
@@ -242,7 +243,7 @@ public class RootFlattenedFromKeyedFieldDataTests extends ESTestCase {
     }
 
     private static SortedBinaryDocValues loadRootValues(IndexReader reader, boolean binary) {
-        var builder = new RootFlattenedFromKeyedFieldData.Builder(ROOT_FIELD, KEYED_FIELD, binary);
+        var builder = new RootFlattenedFromKeyedFieldData.Builder(ROOT_FIELD, KEYED_FIELD, binary, IndexVersion.current());
         IndexFieldData<?> fieldData = builder.build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService());
         return fieldData.load(reader.leaves().get(0)).getBytesValues();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
@@ -372,7 +372,7 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
             this.ignoredSourceFormat = ignoredSourceFormat;
             this.filter = filter;
             // convert incoming binary doc values to reuse the code provided by MultiValuedSortedBinaryDocValues
-            this.multiValues = MultiValuedSortedBinaryDocValues.fromLegacy(reader, IgnoredSourceFieldMapper.NAME, dv);
+            this.multiValues = MultiValuedSortedBinaryDocValues.fromMultiValued(reader, IgnoredSourceFieldMapper.NAME, dv);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
@@ -372,7 +372,7 @@ public final class FieldSubsetReader extends SequentialStoredFieldsLeafReader {
             this.ignoredSourceFormat = ignoredSourceFormat;
             this.filter = filter;
             // convert incoming binary doc values to reuse the code provided by MultiValuedSortedBinaryDocValues
-            this.multiValues = MultiValuedSortedBinaryDocValues.from(reader, IgnoredSourceFieldMapper.NAME, dv);
+            this.multiValues = MultiValuedSortedBinaryDocValues.fromLegacy(reader, IgnoredSourceFieldMapper.NAME, dv);
         }
 
         @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
@@ -150,7 +150,7 @@ abstract class BinaryDvConfirmedQuery extends Query {
                     // No matches to be had
                     return null;
                 }
-                final SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.from(context.reader(), field);
+                final SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(context.reader(), field);
                 return new ScorerSupplier() {
                     @Override
                     public Scorer get(long leadCost) throws IOException {

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/BinaryDvConfirmedQuery.java
@@ -150,7 +150,7 @@ abstract class BinaryDvConfirmedQuery extends Query {
                     // No matches to be had
                     return null;
                 }
-                final SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromLegacy(context.reader(), field);
+                final SortedBinaryDocValues values = MultiValuedSortedBinaryDocValues.fromMultiValued(context.reader(), field);
                 return new ScorerSupplier() {
                     @Override
                     public Scorer get(long leadCost) throws IOException {

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -991,7 +991,8 @@ public class WildcardFieldMapper extends FieldMapper {
             return (cache, breakerService) -> new StringBinaryIndexFieldData(
                 name(),
                 CoreValuesSourceType.KEYWORD,
-                WildcardDocValuesField::new
+                WildcardDocValuesField::new,
+                indexVersion
             );
         }
 
@@ -1139,10 +1140,10 @@ public class WildcardFieldMapper extends FieldMapper {
     protected SyntheticSourceSupport syntheticSourceSupport() {
         return new SyntheticSourceSupport.Native(() -> {
             var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>();
-            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath()));
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fullPath(), indexVersionCreated));
             if (ignoreAbove.valuesPotentiallyIgnored()) {
                 if (storeIgnoredFieldsInBinaryDocValues) {
-                    layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(originalName()));
+                    layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(originalName(), indexVersionCreated));
                 } else {
                     layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(originalName()) {
                         @Override


### PR DESCRIPTION
The [original PR](https://github.com/elastic/elasticsearch/pull/146417) for enforcing `multi_value=no` was getting quite large, so I've decided to split it up into multiple ones:
1. Changes to `MultiValuedSortedBinaryDocValues` to make it read from a plain `BinaryDocValuesField` whenever `.count` field is missing. Also changes to `BinaryFieldMapper` to decouple it from binary doc values encoding formats.
2. Introduction of `DocValuesFieldFactory`, which will serve as the one place responsible for creating doc values fields. Its `multi_value` and `skippers` aware and will branch to depending on their configurations. For example, if `multi_value=no`, then `SortedNumericDocValuesField` is replaced with `NumericDocValuesField`.
3. Single value enforcement for text-family of fields and ip fields.
4. Single value enforcement for numeric-family of fields.
5. Single value enforcement for flattented fields.

Changes 1-4 have already passed CI.

Note, most of the changes here are from passing around `IndexVersion`.