### PR TITLE
Add a range query for custom binary doc values

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -41,17 +41,16 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMaxBytesRefsFro
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFromBinaryBlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesRangeQuery;
 import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesTermQuery;
 import org.elasticsearch.script.IpFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
-import org.elasticsearch.script.SortedBinaryDocValuesIpFieldScript;
 import org.elasticsearch.script.field.IpDocValuesField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.elasticsearch.search.runtime.IpScriptFieldRangeQuery;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentString;
 
@@ -418,14 +417,7 @@ public class IpFieldMapper extends FieldMapper {
                 if (lower.bytesEquals(upper)) {
                     return new SlowCustomBinaryDocValuesTermQuery(field, lower);
                 } else {
-                    // TODO: This is likely very slow
-                    return new IpScriptFieldRangeQuery(
-                        new Script(""),
-                        ctx -> new SortedBinaryDocValuesIpFieldScript(pointRangeQuery.getField(), context.lookup(), ctx),
-                        field,
-                        lower,
-                        upper
-                    );
+                    return new SlowCustomBinaryDocValuesRangeQuery(field, lower, upper);
                 }
             } else {
                 return SortedSetDocValuesField.newSlowRangeQuery(field, lower, upper, true, true);

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -42,7 +42,6 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFro
 import org.elasticsearch.index.mapper.blockloader.docvalues.fn.MvMinBytesRefsFromOrdsBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesRangeQuery;
-import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesTermQuery;
 import org.elasticsearch.script.IpFieldScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
@@ -414,11 +413,7 @@ public class IpFieldMapper extends FieldMapper {
             final BytesRef upper = new BytesRef(pointRangeQuery.getUpperPoint());
 
             if (usesBinaryDocValues) {
-                if (lower.bytesEquals(upper)) {
-                    return new SlowCustomBinaryDocValuesTermQuery(field, lower);
-                } else {
-                    return new SlowCustomBinaryDocValuesRangeQuery(field, lower, upper);
-                }
+                return new SlowCustomBinaryDocValuesRangeQuery(field, lower, upper);
             } else {
                 return SortedSetDocValuesField.newSlowRangeQuery(field, lower, upper, true, true);
             }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesRangeQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesRangeQuery.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.network.InetAddresses;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * A query for matching any binary doc value (per document) that falls in an inclusive {@link BytesRef} range.
+ * Values are compared with {@link BytesRef#compareTo}, which matches {@link InetAddressPoint} sort order for IP
+ * fields.
+ * <p>
+ * This implementation is slow, because it potentially scans binary doc values for each document.
+ */
+public final class SlowCustomBinaryDocValuesRangeQuery extends AbstractBinaryDocValuesQuery {
+
+    private final BytesRef lower;
+    private final BytesRef upper;
+
+    public SlowCustomBinaryDocValuesRangeQuery(String fieldName, BytesRef lower, BytesRef upper) {
+        super(fieldName, rangeMatcher(Objects.requireNonNull(lower), Objects.requireNonNull(upper)));
+        assert lower.compareTo(upper) <= 0;
+        this.lower = lower;
+        this.upper = upper;
+    }
+
+    private static Predicate<BytesRef> rangeMatcher(BytesRef lower, BytesRef upper) {
+        return value -> lower.compareTo(value) <= 0 && upper.compareTo(value) >= 0;
+    }
+
+    @Override
+    protected float matchCost() {
+        return 20; // two comparisons per candidate value
+    }
+
+    @Override
+    public String toString(String field) {
+        return "SlowCustomBinaryDocValuesRangeQuery(fieldName="
+            + field
+            + ",lower="
+            + InetAddresses.toAddrString(InetAddressPoint.decode(BytesReference.toBytes(new BytesArray(lower))))
+            + ",upper="
+            + InetAddresses.toAddrString(InetAddressPoint.decode(BytesReference.toBytes(new BytesArray(upper))))
+            + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (sameClassAs(o) == false) {
+            return false;
+        }
+        SlowCustomBinaryDocValuesRangeQuery that = (SlowCustomBinaryDocValuesRangeQuery) o;
+        return Objects.equals(fieldName, that.fieldName) && lower.bytesEquals(that.lower) && upper.bytesEquals(that.upper);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), fieldName, lower, upper);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesRangeQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesRangeQuery.java
@@ -10,11 +10,11 @@
 package org.elasticsearch.lucene.queries;
 
 import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.network.InetAddresses;
 
+import java.io.IOException;
 import java.util.Objects;
 import java.util.function.Predicate;
 
@@ -24,6 +24,9 @@ import java.util.function.Predicate;
  * fields.
  * <p>
  * This implementation is slow, because it potentially scans binary doc values for each document.
+ * <p>
+ * When the lower and upper bound are identical, {@link #rewrite(IndexSearcher)} returns a
+ * {@link SlowCustomBinaryDocValuesTermQuery}.
  */
 public final class SlowCustomBinaryDocValuesRangeQuery extends AbstractBinaryDocValuesQuery {
 
@@ -42,19 +45,21 @@ public final class SlowCustomBinaryDocValuesRangeQuery extends AbstractBinaryDoc
     }
 
     @Override
+    public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+        if (lower.bytesEquals(upper)) {
+            return new SlowCustomBinaryDocValuesTermQuery(fieldName, lower);
+        }
+        return super.rewrite(indexSearcher);
+    }
+
+    @Override
     protected float matchCost() {
         return 20; // two comparisons per candidate value
     }
 
     @Override
     public String toString(String field) {
-        return "SlowCustomBinaryDocValuesRangeQuery(fieldName="
-            + field
-            + ",lower="
-            + InetAddresses.toAddrString(InetAddressPoint.decode(BytesReference.toBytes(new BytesArray(lower))))
-            + ",upper="
-            + InetAddresses.toAddrString(InetAddressPoint.decode(BytesReference.toBytes(new BytesArray(upper))))
-            + ")";
+        return "SlowCustomBinaryDocValuesRangeQuery(fieldName=" + field + ",lower=" + lower.toString() + ",upper=" + upper.toString() + ")";
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
@@ -18,10 +18,9 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesRangeQuery;
 import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesTermQuery;
-import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
-import org.elasticsearch.search.runtime.IpScriptFieldRangeQuery;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -107,9 +106,7 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
         assertEquals(query, ftOnlyIndex.termQuery(prefix, MOCK_CONTEXT));
         assertEquals(convertToDocValuesQuery(query), ftOnlyDocValues.termQuery(prefix, MOCK_CONTEXT));
         assertEquals(
-            new IpScriptFieldRangeQuery(
-                new Script(""),
-                ctx -> null,
+            new SlowCustomBinaryDocValuesRangeQuery(
                 "field",
                 new BytesRef(((PointRangeQuery) query).getLowerPoint()),
                 new BytesRef(((PointRangeQuery) query).getUpperPoint())

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldTypeTests.java
@@ -19,7 +19,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesRangeQuery;
-import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesTermQuery;
 import org.elasticsearch.script.ScriptCompiler;
 
 import java.io.IOException;
@@ -82,8 +81,9 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
         assertEquals(convertToIndexOrDocValuesQuery(query), ftIndexAndDocValues.termQuery(ip, MOCK_CONTEXT));
         assertEquals(query, ftOnlyIndex.termQuery(ip, MOCK_CONTEXT));
         assertEquals(convertToDocValuesQuery(query), ftOnlyDocValues.termQuery(ip, MOCK_CONTEXT));
+        BytesRef encodedIp = new BytesRef(InetAddressPoint.encode(inetIp));
         assertEquals(
-            new SlowCustomBinaryDocValuesTermQuery("field", new BytesRef(InetAddressPoint.encode(inetIp))),
+            new SlowCustomBinaryDocValuesRangeQuery("field", encodedIp, encodedIp),
             ftOnlyBinaryDocValues.termQuery(ip, MOCK_CONTEXT)
         );
 
@@ -93,8 +93,9 @@ public class IpFieldTypeTests extends FieldTypeTestCase {
         assertEquals(convertToIndexOrDocValuesQuery(query), ftIndexAndDocValues.termQuery(ip, MOCK_CONTEXT));
         assertEquals(query, ftOnlyIndex.termQuery(ip, MOCK_CONTEXT));
         assertEquals(convertToDocValuesQuery(query), ftOnlyDocValues.termQuery(ip, MOCK_CONTEXT));
+        encodedIp = new BytesRef(InetAddressPoint.encode(inetIp));
         assertEquals(
-            new SlowCustomBinaryDocValuesTermQuery("field", new BytesRef(InetAddressPoint.encode(inetIp))),
+            new SlowCustomBinaryDocValuesRangeQuery("field", encodedIp, encodedIp),
             ftOnlyBinaryDocValues.termQuery(ip, MOCK_CONTEXT)
         );
 

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesRangeQueryTests.java
@@ -87,4 +87,31 @@ public class SlowCustomBinaryDocValuesRangeQueryTests extends ESTestCase {
             }
         }
     }
+
+    public void testRewriteToTermQueryWhenBoundsEqual() throws Exception {
+        BytesRef term = encodeIp("192.168.1.1");
+        SlowCustomBinaryDocValuesRangeQuery range = new SlowCustomBinaryDocValuesRangeQuery("field", term, term);
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    assertEquals(new SlowCustomBinaryDocValuesTermQuery("field", term), range.rewrite(searcher));
+                }
+            }
+        }
+    }
+
+    public void testRewriteKeepsTrueRange() throws Exception {
+        BytesRef lower = encodeIp("192.168.1.0");
+        BytesRef upper = encodeIp("192.168.1.255");
+        SlowCustomBinaryDocValuesRangeQuery range = new SlowCustomBinaryDocValuesRangeQuery("field", lower, upper);
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    assertSame(range, range.rewrite(searcher));
+                }
+            }
+        }
+    }
 }

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesRangeQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesRangeQueryTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class SlowCustomBinaryDocValuesRangeQueryTests extends ESTestCase {
+
+    private static BytesRef encodeIp(String ip) {
+        return new BytesRef(InetAddressPoint.encode(InetAddresses.forString(ip)));
+    }
+
+    private static Document docWithIps(String... ips) {
+        Document document = new Document();
+        var field = new MultiValuedBinaryDocValuesField.SeparateCount("field", MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE);
+        for (String ip : ips) {
+            field.add(encodeIp(ip));
+        }
+        document.add(field);
+        document.add(new NumericDocValuesField("field.counts", field.count()));
+        return document;
+    }
+
+    public void testRangeMatchesSingleAndMultiValued() throws Exception {
+        String fieldName = "field";
+        BytesRef lower = encodeIp("192.168.1.0");
+        BytesRef upper = encodeIp("192.168.1.255");
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                writer.addDocument(docWithIps("192.168.1.50"));
+                writer.addDocument(docWithIps("10.0.0.1"));
+                writer.addDocument(docWithIps("10.0.0.2", "192.168.1.7"));
+                writer.addDocument(docWithIps("10.0.0.3", "10.0.0.4"));
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new SlowCustomBinaryDocValuesRangeQuery(fieldName, lower, upper);
+                    assertEquals(2, searcher.count(query));
+                }
+            }
+        }
+    }
+
+    public void testNoField() throws IOException {
+        String fieldName = "field";
+        BytesRef lower = encodeIp("192.168.1.0");
+        BytesRef upper = encodeIp("192.168.1.255");
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                writer.addDocument(new Document());
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new SlowCustomBinaryDocValuesRangeQuery(fieldName, lower, upper);
+                    assertEquals(0, searcher.count(query));
+                }
+            }
+        }
+
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                writer.addDocument(docWithIps("192.168.1.1"));
+                writer.commit();
+                writer.addDocument(new Document());
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new SlowCustomBinaryDocValuesRangeQuery(fieldName, lower, upper);
+                    assertEquals(1, searcher.count(query));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the SlowCustomBinaryDocValuesRangeQuery class, which is a range query on the custom binary doc values format used by multivalued binary doc values.

Follow-up to #146321

Developed using Cursor