### PR TITLE
[ESQL] Grant file read entitlement for Snappy musl detection

### DIFF
--- a/docs/changelog/146718.yaml
+++ b/docs/changelog/146718.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 146717
+pr: 146718
+summary: Grant file read entitlement for Snappy musl detection
+type: bug

--- a/x-pack/plugin/esql-datasource-compression-libs/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/esql-datasource-compression-libs/src/main/plugin-metadata/entitlement-policy.yaml
@@ -3,5 +3,3 @@ ALL-UNNAMED:
   - files:
     - path: "/lib/ld-musl-x86_64.so.1"
       mode: "read"
-    - path: "/lib/ld-musl-aarch64.so.1"
-      mode: "read"

--- a/x-pack/plugin/esql-datasource-compression-libs/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/esql-datasource-compression-libs/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,2 +1,7 @@
 ALL-UNNAMED:
   - load_native_libraries
+  - files:
+    - path: "/lib/ld-musl-x86_64.so.1"
+      mode: "read"
+    - path: "/lib/ld-musl-aarch64.so.1"
+      mode: "read"


### PR DESCRIPTION
Snappy's OSInfo.isX64Musl() probes /lib/ld-musl-x86_64.so.1 via
File.exists() during native library initialization to select the
correct native library variant for musl-based Linux. The entitlement
checker denies this because esql-datasource-compression-libs only
granted load_native_libraries.

Add files read entitlements for the musl linker paths (x86_64 and
aarch64) so the OS detection works without triggering a WARN log.

Closes #146717

Developed with AI-assisted tooling