### PR TITLE
[ESQL] Embed file-level statistics into sourceMetadata

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -183,6 +183,18 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
     }
 
+    /**
+     * Converts Parquet-specific stat values to JDK types safe for {@code writeGenericValue} serialization.
+     * Parquet's {@code Statistics.genericGetMin/Max()} returns {@link Binary} for BYTE_ARRAY columns;
+     * these must be converted to {@code String} before entering the metadata map.
+     */
+    private static Object normalizeStatValue(Object value) {
+        if (value instanceof Binary binary) {
+            return binary.toStringUsingUTF8();
+        }
+        return value;
+    }
+
     @SuppressWarnings("rawtypes")
     private SourceStatistics extractStatistics(ParquetFileReader reader, MessageType schema) {
         List<BlockMetaData> rowGroups = reader.getRowGroups();
@@ -215,13 +227,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                     return a;
                 });
                 if (stats.hasNonNullValue()) {
-                    mins.merge(colName, new Comparable[] { stats.genericGetMin() }, (a, b) -> {
+                    mins.merge(colName, new Comparable[] { (Comparable) normalizeStatValue(stats.genericGetMin()) }, (a, b) -> {
                         @SuppressWarnings("unchecked")
                         int cmp = a[0].compareTo(b[0]);
                         if (cmp > 0) a[0] = b[0];
                         return a;
                     });
-                    maxs.merge(colName, new Comparable[] { stats.genericGetMax() }, (a, b) -> {
+                    maxs.merge(colName, new Comparable[] { (Comparable) normalizeStatValue(stats.genericGetMax()) }, (a, b) -> {
                         @SuppressWarnings("unchecked")
                         int cmp = a[0].compareTo(b[0]);
                         if (cmp < 0) a[0] = b[0];
@@ -418,8 +430,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             }
             stats.put(SourceStatisticsSerializer.columnNullCountKey(colName), colStats.getNumNulls());
             if (colStats.hasNonNullValue()) {
-                stats.put(SourceStatisticsSerializer.columnMinKey(colName), colStats.genericGetMin());
-                stats.put(SourceStatisticsSerializer.columnMaxKey(colName), colStats.genericGetMax());
+                stats.put(SourceStatisticsSerializer.columnMinKey(colName), normalizeStatValue(colStats.genericGetMin()));
+                stats.put(SourceStatisticsSerializer.columnMaxKey(colName), normalizeStatValue(colStats.genericGetMax()));
             }
         }
         return Map.copyOf(stats);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -57,12 +57,14 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class ParquetFormatReaderTests extends ESTestCase {
 
@@ -1262,6 +1264,57 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertEquals(0L, enriched.get("_stats.columns.score.null_count"));
         assertNotNull("Score min should be present", enriched.get("_stats.columns.score.min"));
         assertNotNull("Score max should be present", enriched.get("_stats.columns.score.max"));
+    }
+
+    public void testStatisticsForStringColumnsAreJdkTypes() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("city")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("pop")
+            .named("string_stats_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (String name : List.of("alpha", "bravo", "charlie", "delta")) {
+                Group g = factory.newGroup();
+                g.add("city", name);
+                g.add("pop", 1000);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        SourceMetadata metadata = reader.metadata(storageObject);
+
+        var stats = metadata.statistics().orElseThrow();
+        var enriched = org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer.embedStatistics(
+            metadata.sourceMetadata(),
+            stats
+        );
+
+        Object minCity = enriched.get("_stats.columns.city.min");
+        Object maxCity = enriched.get("_stats.columns.city.max");
+        assertNotNull("city min should be present", minCity);
+        assertNotNull("city max should be present", maxCity);
+        assertThat("min must be a JDK String, not Parquet Binary", minCity, instanceOf(String.class));
+        assertThat("max must be a JDK String, not Parquet Binary", maxCity, instanceOf(String.class));
+        assertEquals("alpha", minCity);
+        assertEquals("delta", maxCity);
+
+        // Also verify per-split stats if we can force multi-row-group
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        for (RangeAwareFormatReader.SplitRange range : ranges) {
+            for (Map.Entry<String, Object> entry : range.statistics().entrySet()) {
+                assertFalse(
+                    "Split stat value must not be a Parquet Binary: " + entry.getKey(),
+                    entry.getValue() instanceof Binary
+                );
+            }
+        }
     }
 
     public void testDiscoverSplitRangesMultipleRowGroups() throws Exception {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1221,6 +1221,49 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertEquals("parquet", metadata.sourceType());
     }
 
+    public void testStatisticsSurviveEmbedding() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("age")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("score")
+            .named("stats_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("age", 20 + (i % 60));
+                g.add("score", (long) (i * 10));
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        SourceMetadata metadata = reader.metadata(storageObject);
+        assertTrue("statistics() should be present", metadata.statistics().isPresent());
+
+        var stats = metadata.statistics().get();
+        assertTrue("Row count should be present", stats.rowCount().isPresent());
+        assertEquals(100L, stats.rowCount().getAsLong());
+
+        var enriched = org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer.embedStatistics(
+            metadata.sourceMetadata(),
+            stats
+        );
+
+        assertEquals(100L, enriched.get("_stats.row_count"));
+        assertEquals(0L, enriched.get("_stats.columns.age.null_count"));
+        assertEquals(20, enriched.get("_stats.columns.age.min"));
+        assertEquals(79, enriched.get("_stats.columns.age.max"));
+        assertEquals(0L, enriched.get("_stats.columns.score.null_count"));
+        assertNotNull("Score min should be present", enriched.get("_stats.columns.score.min"));
+        assertNotNull("Score max should be present", enriched.get("_stats.columns.score.max"));
+    }
+
     public void testDiscoverSplitRangesMultipleRowGroups() throws Exception {
         byte[] parquetData = createWideMultiRowGroupFile(500);
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1309,10 +1309,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
         for (RangeAwareFormatReader.SplitRange range : ranges) {
             for (Map.Entry<String, Object> entry : range.statistics().entrySet()) {
-                assertFalse(
-                    "Split stat value must not be a Parquet Binary: " + entry.getKey(),
-                    entry.getValue() instanceof Binary
-                );
+                assertFalse("Split stat value must not be a Parquet Binary: " + entry.getKey(), entry.getValue() instanceof Binary);
             }
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -241,7 +241,10 @@ public class ExternalSourceResolver {
             SchemaCacheKey schemaKey = SchemaCacheKey.build(anchorPath.toString(), anchorMtime, formatType, config);
             SchemaCacheEntry schemaEntry = cacheService.getOrComputeSchema(schemaKey, k -> {
                 SourceMetadata meta = resolveSingleSource(anchorPath.toString(), config);
-                return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), meta.sourceMetadata());
+                Map<String, Object> enrichedMeta = meta.statistics()
+                    .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
+                    .orElse(meta.sourceMetadata());
+                return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta);
             });
             List<Attribute> schema = schemaEntry.toAttributes();
             extMetadata = buildMetadataFromCache(schemaEntry, schema, config);
@@ -423,6 +426,9 @@ public class ExternalSourceResolver {
     ) {
         Map<String, Object> mergedConfig = mergeConfigs(referenceMeta.config(), queryConfig);
         List<Attribute> schema = List.copyOf(unifiedSchema);
+        Map<String, Object> enrichedSourceMetadata = referenceMeta.statistics()
+            .map(stats -> SourceStatisticsSerializer.embedStatistics(referenceMeta.sourceMetadata(), stats))
+            .orElse(referenceMeta.sourceMetadata());
         return new ExternalSourceMetadata() {
             @Override
             public String location() {
@@ -441,7 +447,7 @@ public class ExternalSourceResolver {
 
             @Override
             public Map<String, Object> sourceMetadata() {
-                return referenceMeta.sourceMetadata();
+                return enrichedSourceMetadata;
             }
 
             @Override
@@ -647,6 +653,10 @@ public class ExternalSourceResolver {
             mergedConfig = queryConfig;
         }
 
+        Map<String, Object> enrichedSourceMetadata = metadata.statistics()
+            .map(stats -> SourceStatisticsSerializer.embedStatistics(metadata.sourceMetadata(), stats))
+            .orElse(metadata.sourceMetadata());
+
         return new ExternalSourceMetadata() {
             @Override
             public String location() {
@@ -665,7 +675,7 @@ public class ExternalSourceResolver {
 
             @Override
             public Map<String, Object> sourceMetadata() {
-                return metadata.sourceMetadata();
+                return enrichedSourceMetadata;
             }
 
             @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -636,6 +636,10 @@ public class ExternalSourceResolver {
 
         if (metadata instanceof ExternalSourceMetadata extMetadata) {
             if (extMetadata.config() != null && extMetadata.config().isEmpty() == false) {
+                // Stats are embedded into sourceMetadata() below for the general path; for
+                // ExternalSourceMetadata instances that already carry config (e.g. Iceberg),
+                // their factory is responsible for populating sourceMetadata() — statistics()
+                // is typically empty so there is nothing extra to embed.
                 return extMetadata;
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -39,9 +39,10 @@ import java.util.Map;
  * Replaces {@code AggregateExec → ExternalSourceExec} with {@code LocalSourceExec}
  * when ungrouped aggregates (COUNT(*), MIN, MAX) can be computed from file-level statistics.
  * <p>
- * Works in both SINGLE mode (coordinator-only) and INITIAL mode (data node in distributed execution).
- * The coordinator's FINAL AggregateExec is never touched — it merges intermediate values from all
- * data nodes regardless of whether each data node pushed down or scanned.
+ * Only applies in SINGLE mode (coordinator-only, non-distributed execution). INITIAL mode
+ * aggregates require intermediate-format blocks whose layout varies per aggregate function
+ * (e.g. Count produces one channel while Min/Max produce two); producing incorrect intermediate
+ * blocks causes the downstream FINAL aggregation to fail with a verification error.
  * <p>
  * Statistics come from {@code ExternalSourceExec.sourceMetadata()} for single-split queries, or
  * from merged per-split statistics in {@code FileSplit.statistics()} for multi-split queries.
@@ -58,7 +59,10 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
         }
         ExternalSourceExec externalExec = (ExternalSourceExec) aggregateExec.child();
 
-        // Phase 1: Ungrouped only
+        if (aggregateExec.getMode() != AggregatorMode.SINGLE) {
+            return aggregateExec;
+        }
+
         if (aggregateExec.groupings().isEmpty() == false) {
             return aggregateExec;
         }
@@ -95,23 +99,11 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
             return aggregateExec; // Some aggregate couldn't be resolved from metadata
         }
 
-        // Build the output page based on mode
-        AggregatorMode mode = aggregateExec.getMode();
-        List<Attribute> outputAttrs;
-        Block[] blocks;
-
-        if (mode == AggregatorMode.SINGLE) {
-            // Final values — same as PushStatsToExternalSource
-            outputAttrs = new ArrayList<>(aggregateExec.aggregates().size());
-            for (NamedExpression agg : aggregateExec.aggregates()) {
-                outputAttrs.add(agg.toAttribute());
-            }
-            blocks = buildFinalBlocks(values);
-        } else {
-            // Intermediate format — value + seen boolean for each aggregate
-            outputAttrs = aggregateExec.intermediateAttributes();
-            blocks = buildIntermediateBlocks(values);
+        List<Attribute> outputAttrs = new ArrayList<>(aggregateExec.aggregates().size());
+        for (NamedExpression agg : aggregateExec.aggregates()) {
+            outputAttrs.add(agg.toAttribute());
         }
+        Block[] blocks = buildFinalBlocks(values);
 
         return new LocalSourceExec(aggregateExec.source(), outputAttrs, LocalSupplier.of(new Page(blocks)));
     }
@@ -181,20 +173,6 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
         Block[] blocks = new Block[values.size()];
         for (int i = 0; i < values.size(); i++) {
             blocks[i] = buildBlock(blockFactory, values.get(i));
-        }
-        return blocks;
-    }
-
-    /**
-     * Build blocks for INITIAL mode (intermediate format: value + seen boolean per aggregate).
-     */
-    private static Block[] buildIntermediateBlocks(List<Object> values) {
-        var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
-        // Each aggregate produces 2 intermediate channels: value + seen
-        Block[] blocks = new Block[values.size() * 2];
-        for (int i = 0; i < values.size(); i++) {
-            blocks[i * 2] = buildBlock(blockFactory, values.get(i));
-            blocks[i * 2 + 1] = blockFactory.newConstantBooleanBlockWith(true, 1);
         }
         return blocks;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -39,10 +39,14 @@ import java.util.Map;
  * Replaces {@code AggregateExec → ExternalSourceExec} with {@code LocalSourceExec}
  * when ungrouped aggregates (COUNT(*), MIN, MAX) can be computed from file-level statistics.
  * <p>
- * Only applies in SINGLE mode (coordinator-only, non-distributed execution). INITIAL mode
- * aggregates require intermediate-format blocks whose layout varies per aggregate function
- * (e.g. Count produces one channel while Min/Max produce two); producing incorrect intermediate
- * blocks causes the downstream FINAL aggregation to fail with a verification error.
+ * Supports both SINGLE and INITIAL modes. In SINGLE mode the replacement produces final-value
+ * blocks (one block per aggregate). In INITIAL mode the replacement produces intermediate-format
+ * blocks matching {@link AggregateExec#intermediateAttributes()}: for each aggregate, a typed
+ * value block followed by a {@code seen} boolean block (all supported aggregates — Count, Min,
+ * Max — share this two-channel layout).
+ * <p>
+ * FINAL mode is never pushed because the rule matches {@code AggregateExec → ExternalSourceExec}
+ * and a FINAL aggregate's child is always another aggregate or exchange, never an external source.
  * <p>
  * Statistics come from {@code ExternalSourceExec.sourceMetadata()} for single-split queries, or
  * from merged per-split statistics in {@code FileSplit.statistics()} for multi-split queries.
@@ -59,7 +63,8 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
         }
         ExternalSourceExec externalExec = (ExternalSourceExec) aggregateExec.child();
 
-        if (aggregateExec.getMode() != AggregatorMode.SINGLE) {
+        AggregatorMode mode = aggregateExec.getMode();
+        if (mode != AggregatorMode.SINGLE && mode != AggregatorMode.INITIAL) {
             return aggregateExec;
         }
 
@@ -99,11 +104,18 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
             return aggregateExec; // Some aggregate couldn't be resolved from metadata
         }
 
-        List<Attribute> outputAttrs = new ArrayList<>(aggregateExec.aggregates().size());
-        for (NamedExpression agg : aggregateExec.aggregates()) {
-            outputAttrs.add(agg.toAttribute());
+        List<Attribute> outputAttrs;
+        Block[] blocks;
+        if (mode == AggregatorMode.SINGLE) {
+            outputAttrs = new ArrayList<>(aggregateExec.aggregates().size());
+            for (NamedExpression agg : aggregateExec.aggregates()) {
+                outputAttrs.add(agg.toAttribute());
+            }
+            blocks = buildFinalBlocks(values);
+        } else {
+            outputAttrs = aggregateExec.intermediateAttributes();
+            blocks = buildIntermediateBlocks(values);
         }
-        Block[] blocks = buildFinalBlocks(values);
 
         return new LocalSourceExec(aggregateExec.source(), outputAttrs, LocalSupplier.of(new Page(blocks)));
     }
@@ -166,8 +178,20 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
     }
 
     /**
-     * Build blocks for SINGLE mode (final values).
+     * Build intermediate-format blocks: for each aggregate value, a typed value block
+     * followed by a {@code seen=true} boolean block. All supported aggregates (Count,
+     * Min, Max) use this two-channel intermediate layout.
      */
+    private static Block[] buildIntermediateBlocks(List<Object> values) {
+        var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
+        Block[] blocks = new Block[values.size() * 2];
+        for (int i = 0; i < values.size(); i++) {
+            blocks[i * 2] = buildBlock(blockFactory, values.get(i));
+            blocks[i * 2 + 1] = blockFactory.newConstantBooleanBlockWith(true, 1);
+        }
+        return blocks;
+    }
+
     private static Block[] buildFinalBlocks(List<Object> values) {
         var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
         Block[] blocks = new Block[values.size()];

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -7,10 +7,12 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -219,10 +221,10 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
             case LONG, COUNTER_LONG, DATETIME -> blockFactory.newConstantLongBlockWith(((Number) value).longValue(), 1);
             case DOUBLE, COUNTER_DOUBLE -> blockFactory.newConstantDoubleBlockWith(((Number) value).doubleValue(), 1);
             case BOOLEAN -> blockFactory.newConstantBooleanBlockWith(
-                value instanceof Boolean b ? b : Boolean.parseBoolean(value.toString()),
+                value instanceof Boolean b ? b : Booleans.parseBoolean(value.toString()),
                 1
             );
-            case KEYWORD, TEXT -> blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef(value.toString()), 1);
+            case KEYWORD, TEXT -> blockFactory.newConstantBytesRefBlockWith(new BytesRef(value.toString()), 1);
             default -> {
                 if (value instanceof Number n) {
                     yield blockFactory.newConstantLongBlockWith(n.longValue(), 1);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -9,11 +9,13 @@ package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
@@ -99,9 +101,10 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
         if (sourceMetadata == null) {
             return aggregateExec;
         }
-        List<Object> values = resolveAggregateValues(aggregateExec.aggregates(), sourceMetadata);
-        if (values == null) {
-            return aggregateExec; // Some aggregate couldn't be resolved from metadata
+        List<Object> values = new ArrayList<>(aggregateExec.aggregates().size());
+        List<DataType> dataTypes = new ArrayList<>(aggregateExec.aggregates().size());
+        if (resolveAggregateValues(aggregateExec.aggregates(), sourceMetadata, values, dataTypes) == false) {
+            return aggregateExec;
         }
 
         List<Attribute> outputAttrs;
@@ -111,33 +114,39 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
             for (NamedExpression agg : aggregateExec.aggregates()) {
                 outputAttrs.add(agg.toAttribute());
             }
-            blocks = buildFinalBlocks(values);
+            blocks = buildFinalBlocks(values, dataTypes);
         } else {
             outputAttrs = aggregateExec.intermediateAttributes();
-            blocks = buildIntermediateBlocks(values);
+            blocks = buildIntermediateBlocks(values, dataTypes);
         }
 
         return new LocalSourceExec(aggregateExec.source(), outputAttrs, LocalSupplier.of(new Page(blocks)));
     }
 
     /**
-     * Resolve aggregate values from sourceMetadata. Returns null if any value can't be resolved.
+     * Resolve aggregate values and their expected data types from sourceMetadata.
+     * Returns false if any value can't be resolved.
      */
-    private List<Object> resolveAggregateValues(List<? extends NamedExpression> aggregates, Map<String, Object> sourceMetadata) {
-        List<Object> values = new ArrayList<>(aggregates.size());
+    private boolean resolveAggregateValues(
+        List<? extends NamedExpression> aggregates,
+        Map<String, Object> sourceMetadata,
+        List<Object> values,
+        List<DataType> dataTypes
+    ) {
         for (int i = 0; i < aggregates.size(); i++) {
             NamedExpression agg = aggregates.get(i);
             if (agg instanceof Alias == false) {
-                return null;
+                return false;
             }
             Expression child = ((Alias) agg).child();
             Object value = resolveFromMetadata(child, sourceMetadata);
             if (value == null) {
-                return null;
+                return false;
             }
             values.add(value);
+            dataTypes.add(child instanceof AggregateFunction af ? af.dataType() : DataType.LONG);
         }
-        return values;
+        return true;
     }
 
     private Object resolveFromMetadata(Expression aggFunction, Map<String, Object> sourceMetadata) {
@@ -177,46 +186,50 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
         return null;
     }
 
-    /**
-     * Build intermediate-format blocks: for each aggregate value, a typed value block
-     * followed by a {@code seen=true} boolean block. All supported aggregates (Count,
-     * Min, Max) use this two-channel intermediate layout.
-     */
-    private static Block[] buildIntermediateBlocks(List<Object> values) {
+    private static Block[] buildFinalBlocks(List<Object> values, List<DataType> dataTypes) {
+        var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
+        Block[] blocks = new Block[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            blocks[i] = buildBlock(blockFactory, values.get(i), dataTypes.get(i));
+        }
+        return blocks;
+    }
+
+    private static Block[] buildIntermediateBlocks(List<Object> values, List<DataType> dataTypes) {
         var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
         Block[] blocks = new Block[values.size() * 2];
         for (int i = 0; i < values.size(); i++) {
-            blocks[i * 2] = buildBlock(blockFactory, values.get(i));
+            blocks[i * 2] = buildBlock(blockFactory, values.get(i), dataTypes.get(i));
             blocks[i * 2 + 1] = blockFactory.newConstantBooleanBlockWith(true, 1);
         }
         return blocks;
     }
 
-    private static Block[] buildFinalBlocks(List<Object> values) {
-        var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
-        Block[] blocks = new Block[values.size()];
-        for (int i = 0; i < values.size(); i++) {
-            blocks[i] = buildBlock(blockFactory, values.get(i));
-        }
-        return blocks;
-    }
-
-    private static Block buildBlock(org.elasticsearch.compute.data.BlockFactory blockFactory, Object value) {
-        if (value instanceof Long l) {
-            return blockFactory.newConstantLongBlockWith(l, 1);
-        } else if (value instanceof Integer n) {
-            return blockFactory.newConstantIntBlockWith(n, 1);
-        } else if (value instanceof Double d) {
-            return blockFactory.newConstantDoubleBlockWith(d, 1);
-        } else if (value instanceof Boolean b) {
-            return blockFactory.newConstantBooleanBlockWith(b, 1);
-        } else if (value instanceof String s) {
-            return blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef(s), 1);
-        } else if (value instanceof Number n) {
-            return blockFactory.newConstantLongBlockWith(n.longValue(), 1);
-        } else {
+    /**
+     * Builds a single-value constant block, coercing the stat value to match the expected ESQL
+     * data type. Format readers may return stats in wider Java types than the column's ESQL type
+     * (e.g. ORC returns {@code long} for all integer stats including INT32 columns).
+     */
+    static Block buildBlock(BlockFactory blockFactory, Object value, DataType dataType) {
+        if (value == null) {
             return blockFactory.newConstantNullBlock(1);
         }
+        return switch (dataType) {
+            case INTEGER -> blockFactory.newConstantIntBlockWith(((Number) value).intValue(), 1);
+            case LONG, COUNTER_LONG, DATETIME -> blockFactory.newConstantLongBlockWith(((Number) value).longValue(), 1);
+            case DOUBLE, COUNTER_DOUBLE -> blockFactory.newConstantDoubleBlockWith(((Number) value).doubleValue(), 1);
+            case BOOLEAN -> blockFactory.newConstantBooleanBlockWith(
+                value instanceof Boolean b ? b : Boolean.parseBoolean(value.toString()),
+                1
+            );
+            case KEYWORD, TEXT -> blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef(value.toString()), 1);
+            default -> {
+                if (value instanceof Number n) {
+                    yield blockFactory.newConstantLongBlockWith(n.longValue(), 1);
+                }
+                yield blockFactory.newConstantNullBlock(1);
+            }
+        };
     }
 
     private List<Expression> extractAggregateFunctions(List<? extends NamedExpression> aggregates) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -17,8 +16,10 @@ import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.FileSplit;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
@@ -97,6 +98,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         List<? extends NamedExpression> aggregates = aggregateExec.aggregates();
 
         List<Object> values = new ArrayList<>(aggregates.size());
+        List<DataType> dataTypes = new ArrayList<>(aggregates.size());
 
         for (NamedExpression agg : aggregates) {
             if (agg instanceof Alias == false) {
@@ -112,6 +114,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
                 return aggregateExec;
             }
             values.add(value);
+            dataTypes.add(aggExpr instanceof AggregateFunction af ? af.dataType() : DataType.LONG);
         }
 
         List<Attribute> outputAttrs;
@@ -121,10 +124,10 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
             for (NamedExpression agg : aggregates) {
                 outputAttrs.add(agg.toAttribute());
             }
-            blocks = buildBlocks(values);
+            blocks = buildBlocks(values, dataTypes);
         } else {
             outputAttrs = aggregateExec.intermediateAttributes();
-            blocks = buildIntermediateBlocks(values);
+            blocks = buildIntermediateBlocks(values, dataTypes);
         }
 
         return new LocalSourceExec(aggregateExec.source(), outputAttrs, LocalSupplier.of(new Page(blocks)));
@@ -181,49 +184,21 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         return null;
     }
 
-    private static Block[] buildIntermediateBlocks(List<Object> values) {
-        BlockFactory blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
+    private static Block[] buildIntermediateBlocks(List<Object> values, List<DataType> dataTypes) {
+        var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
         Block[] blocks = new Block[values.size() * 2];
         for (int i = 0; i < values.size(); i++) {
-            Object value = values.get(i);
-            if (value instanceof Long l) {
-                blocks[i * 2] = blockFactory.newConstantLongBlockWith(l, 1);
-            } else if (value instanceof Integer n) {
-                blocks[i * 2] = blockFactory.newConstantIntBlockWith(n, 1);
-            } else if (value instanceof Double d) {
-                blocks[i * 2] = blockFactory.newConstantDoubleBlockWith(d, 1);
-            } else if (value instanceof String s) {
-                blocks[i * 2] = blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef(s), 1);
-            } else if (value instanceof Number n) {
-                blocks[i * 2] = blockFactory.newConstantLongBlockWith(n.longValue(), 1);
-            } else {
-                blocks[i * 2] = blockFactory.newConstantNullBlock(1);
-            }
+            blocks[i * 2] = PushAggregatesToExternalSource.buildBlock(blockFactory, values.get(i), dataTypes.get(i));
             blocks[i * 2 + 1] = blockFactory.newConstantBooleanBlockWith(true, 1);
         }
         return blocks;
     }
 
-    private static Block[] buildBlocks(List<Object> values) {
-        BlockFactory blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
+    private static Block[] buildBlocks(List<Object> values, List<DataType> dataTypes) {
+        var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
         Block[] blocks = new Block[values.size()];
         for (int i = 0; i < values.size(); i++) {
-            Object value = values.get(i);
-            if (value instanceof Long l) {
-                blocks[i] = blockFactory.newConstantLongBlockWith(l, 1);
-            } else if (value instanceof Integer n) {
-                blocks[i] = blockFactory.newConstantIntBlockWith(n, 1);
-            } else if (value instanceof Double d) {
-                blocks[i] = blockFactory.newConstantDoubleBlockWith(d, 1);
-            } else if (value instanceof Boolean b) {
-                blocks[i] = blockFactory.newConstantBooleanBlockWith(b, 1);
-            } else if (value instanceof String s) {
-                blocks[i] = blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef(s), 1);
-            } else if (value instanceof Number n) {
-                blocks[i] = blockFactory.newConstantLongBlockWith(n.longValue(), 1);
-            } else {
-                blocks[i] = blockFactory.newConstantNullBlock(1);
-            }
+            blocks[i] = PushAggregatesToExternalSource.buildBlock(blockFactory, values.get(i), dataTypes.get(i));
         }
         return blocks;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
+import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
@@ -38,6 +39,11 @@ import java.util.Map;
  * required statistics are available in the file metadata. Replaces the AggregateExec +
  * ExternalSourceExec subtree with a LocalSourceExec containing pre-computed results.
  * <p>
+ * Supports both SINGLE and INITIAL modes. In SINGLE mode the replacement produces final-value
+ * blocks (one block per aggregate). In INITIAL mode the replacement produces intermediate-format
+ * blocks matching {@link AggregateExec#intermediateAttributes()}: for each aggregate, a typed
+ * value block followed by a {@code seen} boolean block.
+ * <p>
  * Handles intermediate EvalExec (from EVAL), ProjectExec (from RENAME), and FilterExec
  * nodes between the aggregate and external source by resolving aliased attribute names
  * back to the original column names before metadata lookup, and by classifying filters
@@ -65,6 +71,11 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         AttributeMap<Attribute> aliasReplacedBy = info.aliasReplacedBy();
         Expression filterCondition = info.filterCondition();
 
+        AggregatorMode mode = aggregateExec.getMode();
+        if (mode != AggregatorMode.SINGLE && mode != AggregatorMode.INITIAL) {
+            return aggregateExec;
+        }
+
         if (aggregateExec.groupings().isEmpty() == false) {
             return aggregateExec;
         }
@@ -86,7 +97,6 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         List<? extends NamedExpression> aggregates = aggregateExec.aggregates();
 
         List<Object> values = new ArrayList<>(aggregates.size());
-        List<Attribute> outputAttrs = new ArrayList<>(aggregates.size());
 
         for (NamedExpression agg : aggregates) {
             if (agg instanceof Alias == false) {
@@ -102,10 +112,21 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
                 return aggregateExec;
             }
             values.add(value);
-            outputAttrs.add(agg.toAttribute());
         }
 
-        Block[] blocks = buildBlocks(values);
+        List<Attribute> outputAttrs;
+        Block[] blocks;
+        if (mode == AggregatorMode.SINGLE) {
+            outputAttrs = new ArrayList<>(aggregates.size());
+            for (NamedExpression agg : aggregates) {
+                outputAttrs.add(agg.toAttribute());
+            }
+            blocks = buildBlocks(values);
+        } else {
+            outputAttrs = aggregateExec.intermediateAttributes();
+            blocks = buildIntermediateBlocks(values);
+        }
+
         return new LocalSourceExec(aggregateExec.source(), outputAttrs, LocalSupplier.of(new Page(blocks)));
     }
 
@@ -158,6 +179,29 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
             return SourceStatisticsSerializer.extractColumnMax(sourceMetadata, ref.name());
         }
         return null;
+    }
+
+    private static Block[] buildIntermediateBlocks(List<Object> values) {
+        BlockFactory blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
+        Block[] blocks = new Block[values.size() * 2];
+        for (int i = 0; i < values.size(); i++) {
+            Object value = values.get(i);
+            if (value instanceof Long l) {
+                blocks[i * 2] = blockFactory.newConstantLongBlockWith(l, 1);
+            } else if (value instanceof Integer n) {
+                blocks[i * 2] = blockFactory.newConstantIntBlockWith(n, 1);
+            } else if (value instanceof Double d) {
+                blocks[i * 2] = blockFactory.newConstantDoubleBlockWith(d, 1);
+            } else if (value instanceof String s) {
+                blocks[i * 2] = blockFactory.newConstantBytesRefBlockWith(new org.apache.lucene.util.BytesRef(s), 1);
+            } else if (value instanceof Number n) {
+                blocks[i * 2] = blockFactory.newConstantLongBlockWith(n.longValue(), 1);
+            } else {
+                blocks[i * 2] = blockFactory.newConstantNullBlock(1);
+            }
+            blocks[i * 2 + 1] = blockFactory.newConstantBooleanBlockWith(true, 1);
+        }
+        return blocks;
     }
 
     private static Block[] buildBlocks(List<Object> values) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.alias;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.greaterThanOf;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.of;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
+
+public class PushAggregatesToExternalSourceTests extends ESTestCase {
+
+    private static final ReferenceAttribute AGE = referenceAttribute("age", DataType.INTEGER);
+    private static final ReferenceAttribute SCORE = referenceAttribute("score", DataType.DOUBLE);
+
+    // --- SINGLE mode tests ---
+
+    public void testCountStarPushedInSingleMode() {
+        var agg = aggregateExec(AggregatorMode.SINGLE, externalSource(statsMetadata(1000L, null, null)), countStarAlias());
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(1, local.output().size());
+        Page page = local.supplier().get();
+        assertNotNull(page);
+        assertEquals(1, page.getPositionCount());
+        assertEquals(1000L, as(page.getBlock(0), LongBlock.class).getLong(0));
+    }
+
+    public void testCountFieldPushedInSingleMode() {
+        var agg = aggregateExec(AggregatorMode.SINGLE, externalSource(statsMetadata(1000L, "age", 50L)), countFieldAlias(AGE));
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(950L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
+    }
+
+    public void testMinPushedInSingleMode() {
+        Map<String, Object> metadata = statsMetadata(100L, "age", 0L);
+        metadata.put("_stats.columns.age.min", 18);
+        var agg = aggregateExec(AggregatorMode.SINGLE, externalSource(metadata), alias("m", new Min(Source.EMPTY, AGE)));
+
+        as(applyRule(agg), LocalSourceExec.class);
+    }
+
+    public void testMaxPushedInSingleMode() {
+        Map<String, Object> metadata = statsMetadata(100L, "age", 0L);
+        metadata.put("_stats.columns.age.max", 99);
+        var agg = aggregateExec(AggregatorMode.SINGLE, externalSource(metadata), alias("m", new Max(Source.EMPTY, AGE)));
+
+        as(applyRule(agg), LocalSourceExec.class);
+    }
+
+    // --- INITIAL mode tests ---
+
+    public void testCountStarPushedInInitialMode() {
+        var agg = aggregateExec(AggregatorMode.INITIAL, externalSource(statsMetadata(500L, null, null)), countStarAlias());
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        Page page = local.supplier().get();
+        assertNotNull(page);
+        assertEquals(1, page.getPositionCount());
+        assertEquals(2, page.getBlockCount());
+        assertEquals(500L, as(page.getBlock(0), LongBlock.class).getLong(0));
+        assertTrue(as(page.getBlock(1), BooleanBlock.class).getBoolean(0));
+    }
+
+    public void testMinPushedInInitialMode() {
+        Map<String, Object> metadata = statsMetadata(100L, "age", 0L);
+        metadata.put("_stats.columns.age.min", 25);
+        var agg = aggregateExec(AggregatorMode.INITIAL, externalSource(metadata), alias("m", new Min(Source.EMPTY, AGE)));
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        Page page = local.supplier().get();
+        assertNotNull(page);
+        assertEquals(2, page.getBlockCount());
+        assertEquals(25, as(page.getBlock(0), IntBlock.class).getInt(0));
+        assertTrue(as(page.getBlock(1), BooleanBlock.class).getBoolean(0));
+    }
+
+    // --- Not-pushed cases ---
+
+    public void testNotPushedWithGroupings() {
+        ExternalSourceExec ext = externalSource(statsMetadata(1000L, null, null));
+        ReferenceAttribute groupField = referenceAttribute("dept", DataType.KEYWORD);
+        var agg = new AggregateExec(
+            Source.EMPTY,
+            ext,
+            List.of(groupField),
+            List.of(countStarAlias()),
+            AggregatorMode.SINGLE,
+            List.of(),
+            null
+        );
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
+    public void testNotPushedWithoutStats() {
+        var agg = aggregateExec(AggregatorMode.SINGLE, externalSource(Map.of()), countStarAlias());
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
+    public void testNotPushedWithUnsupportedFormat() {
+        ExternalSourceExec ext = new ExternalSourceExec(
+            Source.EMPTY,
+            "file:///test.csv",
+            "csv",
+            defaultAttrs(),
+            Map.of(),
+            statsMetadata(1000L, null, null),
+            null
+        );
+        var agg = aggregateExec(AggregatorMode.SINGLE, ext, countStarAlias());
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
+    public void testNotPushedWithUnsupportedAggregation() {
+        var agg = aggregateExec(
+            AggregatorMode.SINGLE,
+            externalSource(statsMetadata(1000L, "age", 0L)),
+            alias("s", new Sum(Source.EMPTY, AGE))
+        );
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
+    public void testNotPushedWhenChildIsNotExternalSourceExec() {
+        ExternalSourceExec ext = externalSource(statsMetadata(1000L, null, null));
+        Expression filterCondition = greaterThanOf(AGE, of(20L));
+        FilterExec filter = new FilterExec(Source.EMPTY, ext, filterCondition);
+        var agg = aggregateExec(AggregatorMode.SINGLE, filter, countStarAlias());
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
+    public void testNotPushedWithNullFormatReaderRegistry() {
+        ExternalSourceExec ext = externalSource(statsMetadata(1000L, null, null));
+        var agg = aggregateExec(AggregatorMode.SINGLE, ext, countStarAlias());
+
+        PhysicalPlan result = new PushAggregatesToExternalSource().apply(agg, nullRegistryContext());
+        as(result, AggregateExec.class);
+    }
+
+    public void testCountFieldWithoutNullCountNotPushed() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 1000L);
+        var agg = aggregateExec(AggregatorMode.SINGLE, externalSource(metadata), countFieldAlias(AGE));
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
+    public void testMinWithoutColumnStatsNotPushed() {
+        var agg = aggregateExec(
+            AggregatorMode.SINGLE,
+            externalSource(statsMetadata(100L, null, null)),
+            alias("m", new Min(Source.EMPTY, AGE))
+        );
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
+    public void testMaxWithoutColumnStatsNotPushed() {
+        var agg = aggregateExec(
+            AggregatorMode.SINGLE,
+            externalSource(statsMetadata(100L, null, null)),
+            alias("m", new Max(Source.EMPTY, AGE))
+        );
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
+    public void testMultipleAggsPushedDown() {
+        Map<String, Object> metadata = statsMetadata(500L, "score", 10L);
+        metadata.put("_stats.columns.score.min", 1.0);
+        metadata.put("_stats.columns.score.max", 100.0);
+
+        var agg = aggregateExec(
+            AggregatorMode.SINGLE,
+            externalSource(metadata),
+            countStarAlias(),
+            alias("mn", new Min(Source.EMPTY, SCORE)),
+            alias("mx", new Max(Source.EMPTY, SCORE))
+        );
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(3, local.output().size());
+    }
+
+    public void testNotPushedWithMixedSplitStats() {
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), statsMetadata(100L, null, null), null);
+        var agg = aggregateExec(AggregatorMode.SINGLE, ext, countStarAlias());
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
+    // --- Multi-split tests ---
+
+    public void testPushedWithMultipleSplitsWithStats() {
+        ExternalSourceExec ext = externalSourceWithSplits(
+            Map.of(),
+            statsMetadata(100L, null, null),
+            statsMetadata(200L, null, null),
+            statsMetadata(300L, null, null)
+        );
+        var agg = aggregateExec(AggregatorMode.SINGLE, ext, countStarAlias());
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(600L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
+    }
+
+    public void testNotPushedWithMultipleSplitsWithoutStats() {
+        ExternalSourceExec ext = externalSourceWithSplits(statsMetadata(1000L, null, null), (Map<String, Object>[]) null);
+        var agg = aggregateExec(AggregatorMode.SINGLE, ext, countStarAlias());
+
+        as(applyRule(agg), AggregateExec.class);
+    }
+
+    // --- helpers ---
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    private static ExternalSourceExec externalSourceWithSplits(Map<String, Object> sourceMetadata, Map<String, Object>... perSplitStats) {
+        List<ExternalSplit> splits = new ArrayList<>(perSplitStats == null ? 1 : perSplitStats.length);
+        if (perSplitStats == null) {
+            splits.add(fileSplit(0, null));
+            splits.add(fileSplit(1, null));
+        } else {
+            for (int i = 0; i < perSplitStats.length; i++) {
+                splits.add(fileSplit(i, perSplitStats[i]));
+            }
+        }
+        return new ExternalSourceExec(
+            Source.EMPTY,
+            "file:///test.parquet",
+            "parquet",
+            defaultAttrs(),
+            Map.of(),
+            sourceMetadata,
+            null,
+            -1,
+            null,
+            null,
+            splits
+        );
+    }
+
+    private static ExternalSourceExec externalSource(Map<String, Object> sourceMetadata) {
+        return new ExternalSourceExec(Source.EMPTY, "file:///test.parquet", "parquet", defaultAttrs(), Map.of(), sourceMetadata, null);
+    }
+
+    private static List<Attribute> defaultAttrs() {
+        return List.of(referenceAttribute("x", DataType.INTEGER), AGE, SCORE);
+    }
+
+    private static FileSplit fileSplit(int index, Map<String, Object> stats) {
+        return new FileSplit(
+            "parquet",
+            StoragePath.of("file:///split" + (index + 1) + ".parquet"),
+            0,
+            100,
+            "parquet",
+            Map.of(),
+            Map.of(),
+            null,
+            stats
+        );
+    }
+
+    private static AggregateExec aggregateExec(AggregatorMode mode, PhysicalPlan child, NamedExpression... aggregates) {
+        return new AggregateExec(Source.EMPTY, child, List.of(), List.of(aggregates), mode, List.of(), null);
+    }
+
+    private static Alias countStarAlias() {
+        return alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
+    }
+
+    private static Alias countFieldAlias(ReferenceAttribute field) {
+        return alias("c", new Count(Source.EMPTY, field));
+    }
+
+    private static Map<String, Object> statsMetadata(Long rowCount, String colName, Long nullCount) {
+        Map<String, Object> metadata = new HashMap<>();
+        if (rowCount != null) {
+            metadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, rowCount);
+        }
+        if (colName != null && nullCount != null) {
+            metadata.put("_stats.columns." + colName + ".null_count", nullCount);
+        }
+        return metadata;
+    }
+
+    private static FormatReaderRegistry buildParquetRegistry() {
+        FormatReaderRegistry registry = new FormatReaderRegistry(null);
+        AggregatePushdownSupport parquetSupport = (aggregates, groupings) -> {
+            if (groupings.isEmpty() == false) {
+                return AggregatePushdownSupport.Pushability.NO;
+            }
+            for (Expression agg : aggregates) {
+                if (agg instanceof Count || agg instanceof Min || agg instanceof Max) {
+                    continue;
+                }
+                return AggregatePushdownSupport.Pushability.NO;
+            }
+            return AggregatePushdownSupport.Pushability.YES;
+        };
+        registry.registerLazy("parquet", (settings, blockFactory) -> new StubFormatReader(parquetSupport), null, null);
+        return registry;
+    }
+
+    private static LocalPhysicalOptimizerContext buildContext(FormatReaderRegistry registry) {
+        return new LocalPhysicalOptimizerContext(null, null, null, null, null, registry);
+    }
+
+    private static LocalPhysicalOptimizerContext nullRegistryContext() {
+        return new LocalPhysicalOptimizerContext(null, null, null, null, null, null);
+    }
+
+    private static PhysicalPlan applyRule(AggregateExec agg) {
+        return new PushAggregatesToExternalSource().apply(agg, buildContext(buildParquetRegistry()));
+    }
+
+    /**
+     * Minimal FormatReader stub that only provides aggregate pushdown support.
+     */
+    private static class StubFormatReader implements FormatReader {
+        private final AggregatePushdownSupport support;
+
+        StubFormatReader(AggregatePushdownSupport support) {
+            this.support = support;
+        }
+
+        @Override
+        public org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata metadata(
+            org.elasticsearch.xpack.esql.datasources.spi.StorageObject object
+        ) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public org.elasticsearch.compute.operator.CloseableIterator<org.elasticsearch.compute.data.Page> read(
+            org.elasticsearch.xpack.esql.datasources.spi.StorageObject object,
+            org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext context
+        ) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String formatName() {
+            return "parquet";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public AggregatePushdownSupport aggregatePushdownSupport() {
+            return support;
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
@@ -33,11 +33,11 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
-import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -152,16 +152,8 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
         List<Attribute> expectedOutput = agg.output();
 
         LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
-        assertEquals(
-            "LocalSourceExec output must match AggregateExec.output() for INITIAL mode",
-            expectedOutput,
-            local.output()
-        );
-        assertEquals(
-            "Block count must match output attribute count",
-            local.output().size(),
-            local.supplier().get().getBlockCount()
-        );
+        assertEquals("LocalSourceExec output must match AggregateExec.output() for INITIAL mode", expectedOutput, local.output());
+        assertEquals("Block count must match output attribute count", local.output().size(), local.supplier().get().getBlockCount());
     }
 
     public void testInitialModeMultiAggOutputMatchesAggregateExecOutput() {
@@ -196,16 +188,8 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
         List<Attribute> expectedOutput = agg.output();
 
         LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
-        assertEquals(
-            "LocalSourceExec output must match AggregateExec.output() for SINGLE mode",
-            expectedOutput,
-            local.output()
-        );
-        assertEquals(
-            "Block count must match output attribute count",
-            local.output().size(),
-            local.supplier().get().getBlockCount()
-        );
+        assertEquals("LocalSourceExec output must match AggregateExec.output() for SINGLE mode", expectedOutput, local.output());
+        assertEquals("Block count must match output attribute count", local.output().size(), local.supplier().get().getBlockCount());
     }
 
     // --- Not-pushed cases ---
@@ -342,11 +326,7 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
     }
 
     public void testPushedWithMultipleSplitsInInitialMode() {
-        ExternalSourceExec ext = externalSourceWithSplits(
-            Map.of(),
-            statsMetadata(100L, null, null),
-            statsMetadata(200L, null, null)
-        );
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), statsMetadata(100L, null, null), statsMetadata(200L, null, null));
         var agg = aggregateExec(AggregatorMode.INITIAL, ext, countStarAlias());
 
         LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
@@ -32,6 +33,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
@@ -89,18 +91,121 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
         as(applyRule(agg), LocalSourceExec.class);
     }
 
-    // --- INITIAL mode is NOT pushed (intermediate block layout varies per agg type) ---
+    // --- INITIAL mode tests (intermediate blocks: value + seen) ---
 
-    public void testNotPushedInInitialMode() {
+    public void testCountStarPushedInInitialMode() {
         var agg = aggregateExec(AggregatorMode.INITIAL, externalSource(statsMetadata(500L, null, null)), countStarAlias());
 
-        as(applyRule(agg), AggregateExec.class);
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(agg.intermediateAttributes(), local.output());
+        Page page = local.supplier().get();
+        assertNotNull(page);
+        assertEquals(2, page.getBlockCount());
+        assertEquals(500L, as(page.getBlock(0), LongBlock.class).getLong(0));
+        assertTrue(as(page.getBlock(1), BooleanBlock.class).getBoolean(0));
+    }
+
+    public void testMinPushedInInitialMode() {
+        Map<String, Object> metadata = statsMetadata(100L, "age", 0L);
+        metadata.put("_stats.columns.age.min", 18);
+        var agg = aggregateExec(AggregatorMode.INITIAL, externalSource(metadata), alias("m", new Min(Source.EMPTY, AGE)));
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        Page page = local.supplier().get();
+        assertEquals(2, page.getBlockCount());
+        assertTrue(as(page.getBlock(1), BooleanBlock.class).getBoolean(0));
+    }
+
+    public void testMultipleAggsPushedInInitialMode() {
+        Map<String, Object> metadata = statsMetadata(500L, "score", 10L);
+        metadata.put("_stats.columns.score.min", 1.0);
+        metadata.put("_stats.columns.score.max", 100.0);
+
+        var agg = aggregateExec(
+            AggregatorMode.INITIAL,
+            externalSource(metadata),
+            countStarAlias(),
+            alias("mn", new Min(Source.EMPTY, SCORE)),
+            alias("mx", new Max(Source.EMPTY, SCORE))
+        );
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(agg.intermediateAttributes(), local.output());
+        Page page = local.supplier().get();
+        assertEquals(6, page.getBlockCount());
+        assertEquals(500L, as(page.getBlock(0), LongBlock.class).getLong(0));
+        assertTrue(as(page.getBlock(1), BooleanBlock.class).getBoolean(0));
+        assertTrue(as(page.getBlock(3), BooleanBlock.class).getBoolean(0));
+        assertTrue(as(page.getBlock(5), BooleanBlock.class).getBoolean(0));
     }
 
     public void testNotPushedInFinalMode() {
         var agg = aggregateExec(AggregatorMode.FINAL, externalSource(statsMetadata(500L, null, null)), countStarAlias());
 
         as(applyRule(agg), AggregateExec.class);
+    }
+
+    // --- Output schema consistency (regression for VerificationException) ---
+
+    public void testInitialModeOutputMatchesAggregateExecOutput() {
+        var agg = aggregateExec(AggregatorMode.INITIAL, externalSource(statsMetadata(1000L, null, null)), countStarAlias());
+        List<Attribute> expectedOutput = agg.output();
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(
+            "LocalSourceExec output must match AggregateExec.output() for INITIAL mode",
+            expectedOutput,
+            local.output()
+        );
+        assertEquals(
+            "Block count must match output attribute count",
+            local.output().size(),
+            local.supplier().get().getBlockCount()
+        );
+    }
+
+    public void testInitialModeMultiAggOutputMatchesAggregateExecOutput() {
+        Map<String, Object> metadata = statsMetadata(500L, "score", 10L);
+        metadata.put("_stats.columns.score.min", 1.0);
+        metadata.put("_stats.columns.score.max", 100.0);
+
+        var agg = aggregateExec(
+            AggregatorMode.INITIAL,
+            externalSource(metadata),
+            countStarAlias(),
+            alias("mn", new Min(Source.EMPTY, SCORE)),
+            alias("mx", new Max(Source.EMPTY, SCORE))
+        );
+        List<Attribute> expectedOutput = agg.output();
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(
+            "LocalSourceExec output must match AggregateExec.output() for INITIAL mode with multiple aggs",
+            expectedOutput,
+            local.output()
+        );
+        assertEquals(
+            "Block count must match output attribute count for multiple aggs",
+            local.output().size(),
+            local.supplier().get().getBlockCount()
+        );
+    }
+
+    public void testSingleModeOutputMatchesAggregateExecOutput() {
+        var agg = aggregateExec(AggregatorMode.SINGLE, externalSource(statsMetadata(1000L, null, null)), countStarAlias());
+        List<Attribute> expectedOutput = agg.output();
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(
+            "LocalSourceExec output must match AggregateExec.output() for SINGLE mode",
+            expectedOutput,
+            local.output()
+        );
+        assertEquals(
+            "Block count must match output attribute count",
+            local.output().size(),
+            local.supplier().get().getBlockCount()
+        );
     }
 
     // --- Not-pushed cases ---
@@ -236,6 +341,21 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
         assertEquals(600L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
     }
 
+    public void testPushedWithMultipleSplitsInInitialMode() {
+        ExternalSourceExec ext = externalSourceWithSplits(
+            Map.of(),
+            statsMetadata(100L, null, null),
+            statsMetadata(200L, null, null)
+        );
+        var agg = aggregateExec(AggregatorMode.INITIAL, ext, countStarAlias());
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        Page page = local.supplier().get();
+        assertEquals(2, page.getBlockCount());
+        assertEquals(300L, as(page.getBlock(0), LongBlock.class).getLong(0));
+        assertTrue(as(page.getBlock(1), BooleanBlock.class).getBoolean(0));
+    }
+
     public void testNotPushedWithMultipleSplitsWithoutStats() {
         ExternalSourceExec ext = externalSourceWithSplits(statsMetadata(1000L, null, null), (Map<String, Object>[]) null);
         var agg = aggregateExec(AggregatorMode.SINGLE, ext, countStarAlias());
@@ -295,7 +415,8 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
     }
 
     private static AggregateExec aggregateExec(AggregatorMode mode, PhysicalPlan child, NamedExpression... aggregates) {
-        return new AggregateExec(Source.EMPTY, child, List.of(), List.of(aggregates), mode, List.of(), null);
+        List<Attribute> intermediateAttrs = AbstractPhysicalOperationProviders.intermediateAttributes(List.of(aggregates), List.of());
+        return new AggregateExec(Source.EMPTY, child, List.of(), List.of(aggregates), mode, intermediateAttrs, null);
     }
 
     private static Alias countStarAlias() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSourceTests.java
@@ -8,8 +8,6 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.compute.aggregation.AggregatorMode;
-import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
@@ -91,31 +89,18 @@ public class PushAggregatesToExternalSourceTests extends ESTestCase {
         as(applyRule(agg), LocalSourceExec.class);
     }
 
-    // --- INITIAL mode tests ---
+    // --- INITIAL mode is NOT pushed (intermediate block layout varies per agg type) ---
 
-    public void testCountStarPushedInInitialMode() {
+    public void testNotPushedInInitialMode() {
         var agg = aggregateExec(AggregatorMode.INITIAL, externalSource(statsMetadata(500L, null, null)), countStarAlias());
 
-        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
-        Page page = local.supplier().get();
-        assertNotNull(page);
-        assertEquals(1, page.getPositionCount());
-        assertEquals(2, page.getBlockCount());
-        assertEquals(500L, as(page.getBlock(0), LongBlock.class).getLong(0));
-        assertTrue(as(page.getBlock(1), BooleanBlock.class).getBoolean(0));
+        as(applyRule(agg), AggregateExec.class);
     }
 
-    public void testMinPushedInInitialMode() {
-        Map<String, Object> metadata = statsMetadata(100L, "age", 0L);
-        metadata.put("_stats.columns.age.min", 25);
-        var agg = aggregateExec(AggregatorMode.INITIAL, externalSource(metadata), alias("m", new Min(Source.EMPTY, AGE)));
+    public void testNotPushedInFinalMode() {
+        var agg = aggregateExec(AggregatorMode.FINAL, externalSource(statsMetadata(500L, null, null)), countStarAlias());
 
-        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
-        Page page = local.supplier().get();
-        assertNotNull(page);
-        assertEquals(2, page.getBlockCount());
-        assertEquals(25, as(page.getBlock(0), IntBlock.class).getInt(0));
-        assertTrue(as(page.getBlock(1), BooleanBlock.class).getBoolean(0));
+        as(applyRule(agg), AggregateExec.class);
     }
 
     // --- Not-pushed cases ---

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
@@ -54,6 +55,7 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.greaterThanOf;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.lessThanOrEqualOf;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.of;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class PushStatsToExternalSourceTests extends ESTestCase {
 
@@ -101,6 +103,21 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
         var agg = aggregateExec(externalSource(metadata), alias("m", new Max(Source.EMPTY, AGE)));
 
         as(applyRule(agg), LocalSourceExec.class);
+    }
+
+    /**
+     * ORC's IntegerColumnStatistics returns {@code long} for all integer stats, even for INT32 columns.
+     * The block type must match the ESQL column type (INTEGER -> IntBlock), not the Java stat type.
+     */
+    public void testMaxWithLongStatForIntegerColumnProducesIntBlock() {
+        Map<String, Object> metadata = statsMetadata(100L, "salary", 0L, null);
+        metadata.put("_stats.columns.salary.max", 150000L);
+        var agg = aggregateExec(externalSource(metadata), alias("m", new Max(Source.EMPTY, SALARY)));
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        Block block = local.supplier().get().getBlock(0);
+        assertThat("Long stat for INTEGER column must produce IntBlock", block, instanceOf(IntBlock.class));
+        assertEquals(150000, ((IntBlock) block).getInt(0));
     }
 
     public void testMultipleAggsPushedDown() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -33,13 +33,13 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.math.Abs;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
-import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -32,6 +33,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.math.Abs;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
@@ -115,6 +117,45 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
 
         LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
         assertEquals(3, local.output().size());
+    }
+
+    // --- INITIAL mode: output schema must match AggregateExec.output() (regression for VerificationException) ---
+
+    public void testCountStarPushedInInitialMode() {
+        var agg = aggregateExec(AggregatorMode.INITIAL, externalSource(statsMetadata(1000L, null, null, null)), countStarAlias());
+        List<Attribute> expectedOutput = agg.output();
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals("output must match AggregateExec.output() for INITIAL mode", expectedOutput, local.output());
+        assertEquals("block count must match attribute count", local.output().size(), local.supplier().get().getBlockCount());
+        Page page = local.supplier().get();
+        assertEquals(1000L, as(page.getBlock(0), LongBlock.class).getLong(0));
+        assertTrue(as(page.getBlock(1), BooleanBlock.class).getBoolean(0));
+    }
+
+    public void testMultiAggPushedInInitialMode() {
+        Map<String, Object> metadata = statsMetadata(500L, "score", 10L, null);
+        metadata.put("_stats.columns.score.min", 1.0);
+        metadata.put("_stats.columns.score.max", 100.0);
+
+        var agg = aggregateExec(
+            AggregatorMode.INITIAL,
+            externalSource(metadata),
+            countStarAlias(),
+            alias("mn", new Min(Source.EMPTY, SCORE)),
+            alias("mx", new Max(Source.EMPTY, SCORE))
+        );
+        List<Attribute> expectedOutput = agg.output();
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals("output must match AggregateExec.output() for INITIAL mode", expectedOutput, local.output());
+        assertEquals("block count must match attribute count", local.output().size(), local.supplier().get().getBlockCount());
+    }
+
+    public void testNotPushedInFinalMode() {
+        var agg = aggregateExec(AggregatorMode.FINAL, externalSource(statsMetadata(500L, null, null, null)), countStarAlias());
+
+        as(applyRule(agg), AggregateExec.class);
     }
 
     public void testNotPushedWithGroupings() {
@@ -443,7 +484,12 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
     }
 
     private static AggregateExec aggregateExec(PhysicalPlan child, NamedExpression... aggregates) {
-        return new AggregateExec(Source.EMPTY, child, List.of(), List.of(aggregates), AggregatorMode.SINGLE, List.of(), null);
+        return aggregateExec(AggregatorMode.SINGLE, child, aggregates);
+    }
+
+    private static AggregateExec aggregateExec(AggregatorMode mode, PhysicalPlan child, NamedExpression... aggregates) {
+        List<Attribute> intermediateAttrs = AbstractPhysicalOperationProviders.intermediateAttributes(List.of(aggregates), List.of());
+        return new AggregateExec(Source.EMPTY, child, List.of(), List.of(aggregates), mode, intermediateAttrs, null);
     }
 
     private static EvalExec evalWithSimpleAlias(ExternalSourceExec child, String aliasName, String originalName) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelationSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelationSerializationTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -21,9 +22,23 @@ public class ExternalRelationSerializationTests extends AbstractLogicalPlanSeria
         String sourceType = randomFrom("parquet", "csv", "file", "iceberg");
         List<Attribute> output = randomFieldAttributes(1, 5, false);
         Map<String, Object> config = randomBoolean() ? Map.of() : Map.of("endpoint", "https://s3.example.com");
-        Map<String, Object> sourceMetadata = randomBoolean() ? Map.of() : Map.of("schema_version", 1);
+        Map<String, Object> sourceMetadata = randomBoolean() ? Map.of() : randomSourceMetadataWithStats();
         SimpleSourceMetadata metadata = new SimpleSourceMetadata(output, sourceType, sourcePath, null, null, sourceMetadata, config);
         return new ExternalRelation(randomSource(), sourcePath, metadata, output);
+    }
+
+    private static Map<String, Object> randomSourceMetadataWithStats() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("schema_version", 1);
+        if (randomBoolean()) {
+            map.put("_stats.row_count", randomLongBetween(0, 100_000));
+            map.put("_stats.size_bytes", randomLongBetween(1000, 10_000_000));
+            String colName = randomAlphaOfLength(5);
+            map.put("_stats.columns." + colName + ".null_count", randomLongBetween(0, 1000));
+            map.put("_stats.columns." + colName + ".min", randomIntBetween(0, 100));
+            map.put("_stats.columns." + colName + ".max", randomIntBetween(100, 1000));
+        }
+        return map;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelationSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/ExternalRelationSerializationTests.java
@@ -33,10 +33,14 @@ public class ExternalRelationSerializationTests extends AbstractLogicalPlanSeria
         if (randomBoolean()) {
             map.put("_stats.row_count", randomLongBetween(0, 100_000));
             map.put("_stats.size_bytes", randomLongBetween(1000, 10_000_000));
-            String colName = randomAlphaOfLength(5);
-            map.put("_stats.columns." + colName + ".null_count", randomLongBetween(0, 1000));
-            map.put("_stats.columns." + colName + ".min", randomIntBetween(0, 100));
-            map.put("_stats.columns." + colName + ".max", randomIntBetween(100, 1000));
+            String intCol = randomAlphaOfLength(5);
+            map.put("_stats.columns." + intCol + ".null_count", randomLongBetween(0, 1000));
+            map.put("_stats.columns." + intCol + ".min", randomIntBetween(0, 100));
+            map.put("_stats.columns." + intCol + ".max", randomIntBetween(100, 1000));
+            String strCol = randomAlphaOfLength(5);
+            map.put("_stats.columns." + strCol + ".null_count", randomLongBetween(0, 100));
+            map.put("_stats.columns." + strCol + ".min", randomAlphaOfLength(5));
+            map.put("_stats.columns." + strCol + ".max", randomAlphaOfLength(5));
         }
         return map;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExecSerializationTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,7 +28,7 @@ public class ExternalSourceExecSerializationTests extends AbstractPhysicalPlanSe
         String sourceType = randomFrom("parquet", "csv", "file");
         List<Attribute> attributes = randomFieldAttributes(1, 5, false);
         Map<String, Object> config = randomBoolean() ? Map.of() : Map.of("endpoint", "https://s3.example.com");
-        Map<String, Object> sourceMetadata = randomBoolean() ? Map.of() : Map.of("schema_version", 1);
+        Map<String, Object> sourceMetadata = randomBoolean() ? Map.of() : randomSourceMetadataWithStats();
         Integer estimatedRowSize = randomEstimatedRowSize();
         List<ExternalSplit> splits = randomSplits();
         return new ExternalSourceExec(
@@ -45,6 +46,20 @@ public class ExternalSourceExecSerializationTests extends AbstractPhysicalPlanSe
         );
     }
 
+    private static Map<String, Object> randomSourceMetadataWithStats() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("schema_version", 1);
+        if (randomBoolean()) {
+            map.put("_stats.row_count", randomLongBetween(0, 100_000));
+            map.put("_stats.size_bytes", randomLongBetween(1000, 10_000_000));
+            String colName = randomAlphaOfLength(5);
+            map.put("_stats.columns." + colName + ".null_count", randomLongBetween(0, 1000));
+            map.put("_stats.columns." + colName + ".min", randomIntBetween(0, 100));
+            map.put("_stats.columns." + colName + ".max", randomIntBetween(100, 1000));
+        }
+        return map;
+    }
+
     static List<ExternalSplit> randomSplits() {
         int count = between(0, 4);
         List<ExternalSplit> splits = new ArrayList<>();
@@ -56,9 +71,21 @@ public class ExternalSourceExecSerializationTests extends AbstractPhysicalPlanSe
 
     static FileSplit randomFileSplit() {
         StoragePath path = StoragePath.of("s3://bucket/data/" + randomAlphaOfLength(6) + ".parquet");
-        Map<String, Object> statistics = randomBoolean()
-            ? null
-            : Map.of("_stats.row_count", (long) randomIntBetween(100, 10000), "_stats.size_bytes", (long) randomIntBetween(1000, 100000));
+        Map<String, Object> statistics;
+        if (randomBoolean()) {
+            statistics = null;
+        } else {
+            Map<String, Object> stats = new HashMap<>();
+            stats.put("_stats.row_count", randomLongBetween(100, 10000));
+            stats.put("_stats.size_bytes", randomLongBetween(1000, 100000));
+            if (randomBoolean()) {
+                String colName = randomAlphaOfLength(4);
+                stats.put("_stats.columns." + colName + ".null_count", randomLongBetween(0, 100));
+                stats.put("_stats.columns." + colName + ".min", randomIntBetween(0, 50));
+                stats.put("_stats.columns." + colName + ".max", randomIntBetween(50, 200));
+            }
+            statistics = Map.copyOf(stats);
+        }
         return new FileSplit(
             "file",
             path,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExecSerializationTests.java
@@ -52,10 +52,14 @@ public class ExternalSourceExecSerializationTests extends AbstractPhysicalPlanSe
         if (randomBoolean()) {
             map.put("_stats.row_count", randomLongBetween(0, 100_000));
             map.put("_stats.size_bytes", randomLongBetween(1000, 10_000_000));
-            String colName = randomAlphaOfLength(5);
-            map.put("_stats.columns." + colName + ".null_count", randomLongBetween(0, 1000));
-            map.put("_stats.columns." + colName + ".min", randomIntBetween(0, 100));
-            map.put("_stats.columns." + colName + ".max", randomIntBetween(100, 1000));
+            String intCol = randomAlphaOfLength(5);
+            map.put("_stats.columns." + intCol + ".null_count", randomLongBetween(0, 1000));
+            map.put("_stats.columns." + intCol + ".min", randomIntBetween(0, 100));
+            map.put("_stats.columns." + intCol + ".max", randomIntBetween(100, 1000));
+            String strCol = randomAlphaOfLength(5);
+            map.put("_stats.columns." + strCol + ".null_count", randomLongBetween(0, 100));
+            map.put("_stats.columns." + strCol + ".min", randomAlphaOfLength(5));
+            map.put("_stats.columns." + strCol + ".max", randomAlphaOfLength(5));
         }
         return map;
     }
@@ -83,6 +87,12 @@ public class ExternalSourceExecSerializationTests extends AbstractPhysicalPlanSe
                 stats.put("_stats.columns." + colName + ".null_count", randomLongBetween(0, 100));
                 stats.put("_stats.columns." + colName + ".min", randomIntBetween(0, 50));
                 stats.put("_stats.columns." + colName + ".max", randomIntBetween(50, 200));
+            }
+            if (randomBoolean()) {
+                String strCol = randomAlphaOfLength(4);
+                stats.put("_stats.columns." + strCol + ".null_count", randomLongBetween(0, 50));
+                stats.put("_stats.columns." + strCol + ".min", randomAlphaOfLength(4));
+                stats.put("_stats.columns." + strCol + ".max", randomAlphaOfLength(4));
             }
             statistics = Map.copyOf(stats);
         }


### PR DESCRIPTION
File-level statistics from format readers were silently dropped when
ExternalSourceResolver wrapped SourceMetadata into ExternalSourceMetadata.
The anonymous wrappers delegated sourceMetadata() but not statistics(),
so _stats.* keys never reached the optimizer for aggregate pushdown.

Fix by calling SourceStatisticsSerializer.embedStatistics() at the three
wrapping points: wrapAsExternalSourceMetadata, cache entry creation, and
buildUnifiedMetadata.

Developed with AI-assisted tooling