### PR TITLE
[ML] Fix flaky sparse_vector pruning test (#146447) [backport 9.4]

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -79,9 +79,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=termvectors/30_realtime/Realtime Term Vectors}
   issue: https://github.com/elastic/elasticsearch/issues/138370
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
-  issue: https://github.com/elastic/elasticsearch/issues/139196
 - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
   method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
   issue: https://github.com/elastic/elasticsearch/issues/139654

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
@@ -81,6 +81,17 @@ setup:
           {"index": { "_id": 6 }}
           {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
 
+  # Force merge to a single segment so that term statistics used by token pruning
+  # (averageTokenFreqRatio) are deterministic regardless of how many segments the
+  # bulk index produced. Without this, the per-segment max unique token count varies
+  # and borderline pruning decisions can flip between runs.
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      indices.forcemerge:
+        index: index-with-sparse-vector
+        max_num_segments: 1
+
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser


### PR DESCRIPTION
Backport of #146447 to 9.4.

Force merge the sparse_vector test index to a single segment so that term statistics used by token pruning are deterministic regardless of segment count.

Made with [Cursor](https://cursor.com)