### PR TITLE
[9.3][ML] fix/datafeed timing stats delete race

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -8,205 +8,50 @@ tests:
 - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
   method: testTracingCrossCluster
   issue: https://github.com/elastic/elasticsearch/issues/112731
-- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/115528
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
-  issue: https://github.com/elastic/elasticsearch/issues/115808
-- class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
-  issue: https://github.com/elastic/elasticsearch/issues/116087
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start already started transform}
-  issue: https://github.com/elastic/elasticsearch/issues/98802
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
-  issue: https://github.com/elastic/elasticsearch/issues/116775
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/10_apm/Test template reinstallation}
   issue: https://github.com/elastic/elasticsearch/issues/116445
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_reset/Test reset running transform}
-  issue: https://github.com/elastic/elasticsearch/issues/117473
 - class: org.elasticsearch.packaging.test.ArchiveTests
   method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
   issue: https://github.com/elastic/elasticsearch/issues/118208
 - class: org.elasticsearch.packaging.test.ArchiveTests
   method: test51AutoConfigurationWithPasswordProtectedKeystore
   issue: https://github.com/elastic/elasticsearch/issues/118212
-- class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
-  method: testShardChangesNoOperation
-  issue: https://github.com/elastic/elasticsearch/issues/118800
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
-  issue: https://github.com/elastic/elasticsearch/issues/119508
 - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/119983
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_unattended/Test unattended put and start}
-  issue: https://github.com/elastic/elasticsearch/issues/120019
 - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
   method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
   issue: https://github.com/elastic/elasticsearch/issues/120127
-- class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
-  method: testCleanShardFollowTaskAfterDeleteFollower
-  issue: https://github.com/elastic/elasticsearch/issues/120339
-- class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
-  method: testAuthenticateShouldNotFallThroughInCaseOfFailure
-  issue: https://github.com/elastic/elasticsearch/issues/120902
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
-  issue: https://github.com/elastic/elasticsearch/issues/120950
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
-  issue: https://github.com/elastic/elasticsearch/issues/122102
 - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
   method: testChildrenTasksCancelledOnTimeout
   issue: https://github.com/elastic/elasticsearch/issues/123568
-- class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
-  method: testCreateAndRestorePartialSearchableSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/123773
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
-  issue: https://github.com/elastic/elasticsearch/issues/122755
-- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-  method: testDeploymentSurvivesRestart {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/124160
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
-  issue: https://github.com/elastic/elasticsearch/issues/120720
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
-  issue: https://github.com/elastic/elasticsearch/issues/125854
-- class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
-  method: testRecreateTemplateWhenDeleted
-  issue: https://github.com/elastic/elasticsearch/issues/123232
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_reset/Test force reseting a running transform}
-  issue: https://github.com/elastic/elasticsearch/issues/126240
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
-  issue: https://github.com/elastic/elasticsearch/issues/126466
-- class: org.elasticsearch.repositories.blobstore.testkit.rest.SnapshotRepoTestKitClientYamlTestSuiteIT
-  method: test {p0=/10_analyze/Analysis without details}
-  issue: https://github.com/elastic/elasticsearch/issues/126569
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
-  issue: https://github.com/elastic/elasticsearch/issues/126755
 - class: org.elasticsearch.index.engine.CompletionStatsCacheTests
   method: testCompletionStatsCache
   issue: https://github.com/elastic/elasticsearch/issues/126910
-- class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
-  method: testFeatureImportanceValues
-  issue: https://github.com/elastic/elasticsearch/issues/124341
-- class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
-  method: testStdinWithMultipleValues
-  issue: https://github.com/elastic/elasticsearch/issues/126882
-- class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
-  method: testChangeFollowerHistoryUUID
-  issue: https://github.com/elastic/elasticsearch/issues/127680
-- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
-  method: testKnnVectors
-  issue: https://github.com/elastic/elasticsearch/issues/127689
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search/350_point_in_time/point-in-time with index filter}
-  issue: https://github.com/elastic/elasticsearch/issues/127741
-- class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
-  method: testSearchWhileRelocating
-  issue: https://github.com/elastic/elasticsearch/issues/128500
-- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-  method: testWindowsMixedCaseAccess
-  issue: https://github.com/elastic/elasticsearch/issues/129167
-- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-  method: testWindowsAbsolutPathAccess
-  issue: https://github.com/elastic/elasticsearch/issues/129168
 - class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
   method: testWaitsUntilResourcesAreCreated
   issue: https://github.com/elastic/elasticsearch/issues/129486
-- class: org.elasticsearch.search.query.VectorIT
-  method: testFilteredQueryStrategy
-  issue: https://github.com/elastic/elasticsearch/issues/129517
 - class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
   method: testUpdatingFileBasedRoleAffectsAllProjects
   issue: https://github.com/elastic/elasticsearch/issues/129775
-- class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
-  method: testManyInitialManyPartialFinalRunnerThrowing
-  issue: https://github.com/elastic/elasticsearch/issues/130145
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
   method: testNodesCachesStats
   issue: https://github.com/elastic/elasticsearch/issues/129863
-- class: org.elasticsearch.index.IndexingPressureIT
-  method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
-  issue: https://github.com/elastic/elasticsearch/issues/130281
-- class: org.elasticsearch.indices.stats.IndexStatsIT
-  method: testFilterCacheStats
-  issue: https://github.com/elastic/elasticsearch/issues/124447
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
-  issue: https://github.com/elastic/elasticsearch/issues/122414
-- class: org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreTests
-  method: testSerializationOfSimple {TestCase=<boolean>}
-  issue: https://github.com/elastic/elasticsearch/issues/131334
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testWatcherWithApiKey {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/131964
-- class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
-  method: testNullsOrderWithMissingOrderSupportQueryingNewNode
-  issue: https://github.com/elastic/elasticsearch/issues/132249
 - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
   method: test40VerifyAutogeneratedCredentials
   issue: https://github.com/elastic/elasticsearch/issues/132877
 - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
   method: test50CredentialAutogenerationOnlyOnce
   issue: https://github.com/elastic/elasticsearch/issues/132878
-- class: org.elasticsearch.xpack.eql.planner.QueryTranslatorTests
-  method: testMatchOptimization
-  issue: https://github.com/elastic/elasticsearch/issues/132894
-- class: org.elasticsearch.xpack.security.authc.AuthenticationServiceTests
-  method: testInvalidToken
-  issue: https://github.com/elastic/elasticsearch/issues/133328
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testWithCustomFeatureProcessors
-  issue: https://github.com/elastic/elasticsearch/issues/134001
-- class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
-  method: testAliasFilters
-  issue: https://github.com/elastic/elasticsearch/issues/134512
 - class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
   method: testCBTrippingOnReduction
   issue: https://github.com/elastic/elasticsearch/issues/134667
-- class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
-  method: testCancelSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/134865
-- class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
-  method: testSettingsApplied
-  issue: https://github.com/elastic/elasticsearch/issues/126748
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
-  issue: https://github.com/elastic/elasticsearch/issues/135135
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null double values}
-  issue: https://github.com/elastic/elasticsearch/issues/135159
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null integer values}
-  issue: https://github.com/elastic/elasticsearch/issues/135162
 - class: org.elasticsearch.gradle.TestClustersPluginFuncTest
   method: override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities
   issue: https://github.com/elastic/elasticsearch/issues/135413
 - class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
   method: testConcurrentAuthentication
   issue: https://github.com/elastic/elasticsearch/issues/135777
-- class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
-  method: test {p0=field_caps/10_basic/Field caps for number field with only doc values}
-  issue: https://github.com/elastic/elasticsearch/issues/136244
-- class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
-  method: test {p0=search.vectors/200_dense_vector_docvalue_fields/Enable docvalue_fields parameter for dense_vector fields}
-  issue: https://github.com/elastic/elasticsearch/issues/136443
-- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
-  method: testMultipleInferencesTriggeringDownloadAndDeploy
-  issue: https://github.com/elastic/elasticsearch/issues/117208
-- class: org.elasticsearch.smoketest.SmokeTestIngestWithAllDepsClientYamlTestSuiteIT
-  method: test {yaml=ingest/100_sampling_with_reroute/Test get sample with multiple reroutes}
-  issue: https://github.com/elastic/elasticsearch/issues/137457
 - class: org.elasticsearch.xpack.ilm.CCRIndexLifecycleIT
   method: testTsdbLeaderIndexRolloverAndSyncAfterWaitUntilEndTime {targetCluster=FOLLOWER}
   issue: https://github.com/elastic/elasticsearch/issues/137565
@@ -216,141 +61,381 @@ tests:
 - class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
   method: testLicenseInvalidForInference {p0=false}
   issue: https://github.com/elastic/elasticsearch/issues/137691
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/70_text_similarity_rank_retriever/Text similarity reranker with min_score zero includes all docs}
-  issue: https://github.com/elastic/elasticsearch/issues/137732
-- class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
-  method: testUpdateMappingConcurrently
-  issue: https://github.com/elastic/elasticsearch/issues/137758
-- class: org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceTests
-  method: testChangingCapacity_DoesNotRejectsOverflowTasks_BecauseOfQueueFull
-  issue: https://github.com/elastic/elasticsearch/issues/137823
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/138128
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/138311
-- class: org.elasticsearch.xpack.ml.integration.RegressionIT
-  method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
-  issue: https://github.com/elastic/elasticsearch/issues/138319
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=termvectors/30_realtime/Realtime Term Vectors}
   issue: https://github.com/elastic/elasticsearch/issues/138370
-- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
-  method: testRevertModelSnapshot_DeleteInterveningResults
-  issue: https://github.com/elastic/elasticsearch/issues/132349
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
-  issue: https://github.com/elastic/elasticsearch/issues/138409
-- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
-  method: testRevertModelSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/132733
-- class: org.elasticsearch.xpack.inference.services.jinaai.JinaAIServiceTests
-  method: test_Embedding_ChunkedInfer_LateChunkingEnabled
-  issue: https://github.com/elastic/elasticsearch/issues/138451
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=index/100_field_name_length_limit/Test field name length limit synthetic source}
-  issue: https://github.com/elastic/elasticsearch/issues/138471
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLookupJoinIT
-  method: testLookupExplosionBigString
-  issue: https://github.com/elastic/elasticsearch/issues/138510
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=index/100_field_name_length_limit/Test field name length limit}
-  issue: https://github.com/elastic/elasticsearch/issues/138768
-- class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
-  method: testDatafeedTimingStats_DatafeedRecreated
-  issue: https://github.com/elastic/elasticsearch/issues/138348
-- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1EnrichUnavailableRemotesIT
-  method: testEsqlEnrichWithSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/138793
-- class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
-  method: testStopLookback_closeJobFalse
-  issue: https://github.com/elastic/elasticsearch/issues/139024
-- class: org.elasticsearch.xpack.core.security.authc.AuthenticationTests
-  method: testMaybeRewriteForOlderVersionWithCrossClusterAccessRewritesAuthenticationInMetadata
-  issue: https://github.com/elastic/elasticsearch/issues/139167
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=index/100_field_name_length_limit/Test field name length limit array synthetic source}
-  issue: https://github.com/elastic/elasticsearch/issues/139300
-- class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
-  method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
-  issue: https://github.com/elastic/elasticsearch/issues/139490
-- class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
-  method: testReductionPlanForTopNWithPushedDownFunctions
-  issue: https://github.com/elastic/elasticsearch/issues/139491
-- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
-  method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
-  issue: https://github.com/elastic/elasticsearch/issues/139492
-- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
-  method: testReductionPlanForTopNWithPushedDownFunctions
-  issue: https://github.com/elastic/elasticsearch/issues/139493
-- class: org.elasticsearch.xpack.core.action.XPackUsageResponseTests
-  method: testVersionDependentSerializationWriteToOldStream
-  issue: https://github.com/elastic/elasticsearch/issues/139576
-- class: org.elasticsearch.smoketest.WatcherYamlRestIT
-  method: test {p0=mustache/10_webhook/Test webhook action with mustache integration}
-  issue: https://github.com/elastic/elasticsearch/issues/139663
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/40_unsupported_types/unsupported}
-  issue: https://github.com/elastic/elasticsearch/issues/139701
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/40_unsupported_types/unsupported with sort}
-  issue: https://github.com/elastic/elasticsearch/issues/139702
-- class: org.elasticsearch.persistent.PersistentTasksCustomMetadataTests
-  method: testMinVersionSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/139740
-- class: org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadataTests
-  method: testMinVersionSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/139741
-- class: org.elasticsearch.xpack.esql.session.EsqlResolvedIndexExpressionIT
-  method: testLocalDateMathExpression
-  issue: https://github.com/elastic/elasticsearch/issues/140106
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-  method: test {csv-spec:unmapped-nullify.TsWithAggsByMissing}
-  issue: https://github.com/elastic/elasticsearch/issues/142762
-- class: org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceTests
-  method: testExecute_Throws_WhenRateLimitedQueueIsFull
-  issue: https://github.com/elastic/elasticsearch/issues/141231
-- class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
-  method: testQuantizedXY
-  issue: https://github.com/elastic/elasticsearch/issues/141234
-- class: org.elasticsearch.compute.operator.topn.TopNOomRaceTests
-  method: testRace {repeats = 15}
-  issue: https://github.com/elastic/elasticsearch/issues/141471
-- class: org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingServiceTests
-  method: testExpiredModelsAreEvictedBeforeLoading
-  issue: https://github.com/elastic/elasticsearch/issues/141589
+- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+  method: test {csv-spec:spatial.convertFromStringParseError}
+  issue: https://github.com/elastic/elasticsearch/issues/139213
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:boolean.convertFromIntAndLong}
+  issue: https://github.com/elastic/elasticsearch/issues/141375
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:keep.whereWithEvalGeneratedValue}
+  issue: https://github.com/elastic/elasticsearch/issues/141375
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:topN.sortingOnNumbersFromStrings}
+  issue: https://github.com/elastic/elasticsearch/issues/141375
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:drop.whereWithEvalGeneratedValue_DropHeight}
+  issue: https://github.com/elastic/elasticsearch/issues/141375
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:rename.renameIntertwinedWithSort}
+  issue: https://github.com/elastic/elasticsearch/issues/141375
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:ints.convertStringToBaseIndexGroup7}
+  issue: https://github.com/elastic/elasticsearch/issues/141375
+- class: org.elasticsearch.indices.recovery.IndexRecoveryIT
+  method: testSourceThrottling
+  issue: https://github.com/elastic/elasticsearch/issues/141548
 - class: org.elasticsearch.search.aggregations.metrics.TopHitsIT
   method: testMixedSortFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/142077
 - class: org.elasticsearch.xpack.analytics.cumulativecardinality.CumulativeCardinalityAggregatorTests
   method: testSimple
   issue: https://github.com/elastic/elasticsearch/issues/142408
-- class: org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorTests
-  method: testOrderByCardinality
-  issue: https://github.com/elastic/elasticsearch/issues/142484
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/144161
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/144159
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/30_semantic_text_inference_bwc/Calculates embeddings using the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/144160
-- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
-  method: testInferDeploysDefaultRerank
-  issue: https://github.com/elastic/elasticsearch/issues/144162
-- class: org.elasticsearch.indices.IndicesRequestCacheIT
-  method: testCanCache
-  issue: https://github.com/elastic/elasticsearch/issues/144526
-- class: org.elasticsearch.repositories.s3.S3BlobStoreRepositoryTimeoutTests
-  method: testSnapshotWithLargeSegmentFiles
-  issue: https://github.com/elastic/elasticsearch/issues/146156
-- class: org.elasticsearch.xpack.ssl.SSLReloadDuringStartupIntegTests
-  method: testReloadDuringStartup
-  issue: https://github.com/elastic/elasticsearch/issues/146645
+- class: org.elasticsearch.xpack.esql.common.spatial.H3SphericalGeometryTests
+  method: testIndexPoints
+  issue: https://github.com/elastic/elasticsearch/issues/142439
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
+  method: test {p0=esql/160_union_types/suggested_type}
+  issue: https://github.com/elastic/elasticsearch/issues/142525
+- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
+  method: test {p0=esql/160_union_types/suggested_type}
+  issue: https://github.com/elastic/elasticsearch/issues/142525
+- class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
+  method: testQuantizedXY
+  issue: https://github.com/elastic/elasticsearch/issues/141234
+- class: org.elasticsearch.packaging.test.DebMetadataTests
+  method: test05CheckLintian
+  issue: https://github.com/elastic/elasticsearch/issues/142819
+- class: org.elasticsearch.xpack.security.support.MetadataFlattenedMigrationIntegTests
+  method: testMigrationWithConcurrentUpdates
+  issue: https://github.com/elastic/elasticsearch/issues/143674
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/143697
+- class: org.elasticsearch.upgrades.FullClusterRestartIT
+  method: testClusterState {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/143800
+- class: org.elasticsearch.upgrades.FullClusterRestartIT
+  method: testOperationBasedRecovery {cluster=OLD}
+  issue: https://github.com/elastic/elasticsearch/issues/143801
+- class: org.elasticsearch.upgrades.FullClusterRestartIT
+  method: testOperationBasedRecovery {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/143802
+- class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
+  method: testWriteBlobWithRetries
+  issue: https://github.com/elastic/elasticsearch/issues/144025
+- class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
+  method: testOpenAiEmbeddings {upgradedNodes=3}
+  issue: https://github.com/elastic/elasticsearch/issues/144440
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:spatial.convertCartesianFromStringParseError}
+  issue: https://github.com/elastic/elasticsearch/issues/144580
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
+  method: test {csv-spec:spatial_shapes.convertFromStringParseError}
+  issue: https://github.com/elastic/elasticsearch/issues/144672
+- class: org.elasticsearch.xpack.transform.transforms.ClientTransformIndexerTests
+  method: testDisablePitWhenCrossProjectSearchIsEnabled
+  issue: https://github.com/elastic/elasticsearch/issues/144822
+- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
+  method: testLookupMissingField
+  issue: https://github.com/elastic/elasticsearch/issues/144697
+- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
+  method: testLookupMatchTypeWrong
+  issue: https://github.com/elastic/elasticsearch/issues/144694
+- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
+  method: testLookup
+  issue: https://github.com/elastic/elasticsearch/issues/144696
+- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
+  method: testLookupMissingTable
+  issue: https://github.com/elastic/elasticsearch/issues/144695
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
+  method: test {csv-spec:external-basic.scoreFunction}
+  issue: https://github.com/elastic/elasticsearch/issues/145352
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
+  method: test {csv-spec:external-basic.topSnippetsFunction}
+  issue: https://github.com/elastic/elasticsearch/issues/145353
+- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
+  method: testKnnVectors
+  issue: https://github.com/elastic/elasticsearch/issues/145377
+- class: org.elasticsearch.compute.aggregation.SumLongGroupingAggregatorFunctionTests
+  method: testOverflowInGroupingProducesNullAndWarning
+  issue: https://github.com/elastic/elasticsearch/issues/145438
+- class: org.elasticsearch.xpack.ml.integration.RegressionIT
+  method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
+  issue: https://github.com/elastic/elasticsearch/issues/145519
+- class: org.elasticsearch.xpack.esql.CsvIT
+  method: test {csv-spec:spatial_shapes.convertFromStringParseError}
+  issue: https://github.com/elastic/elasticsearch/issues/145655
+- class: org.elasticsearch.xpack.autoscaling.storage.ReactiveStorageIT
+  method: testScaleWhileShrinking
+  issue: https://github.com/elastic/elasticsearch/issues/145669
+- class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
+  method: testAverageWriteLoadMetricIsPublished
+  issue: https://github.com/elastic/elasticsearch/issues/145855
+- class: org.elasticsearch.xpack.esql.spatial.SpatialCentroidAggregationIT
+  method: testStCentroidAggregationWithShapes
+  issue: https://github.com/elastic/elasticsearch/issues/145883
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryAllCombinationsSkipUnavailableIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/145884
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
+  method: "testEvaluateBlockWithNulls {TestCase=field: <random mv DEDUPLICATED_UNORDERD doubles>, percentile: <positive int>}"
+  issue: https://github.com/elastic/elasticsearch/issues/145886
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
+  method: "testEvaluateBlockWithNulls {TestCase=field: <random mv DEDUPLICATED_AND_SORTED_ASCENDING doubles>, percentile: <positive int>}"
+  issue: https://github.com/elastic/elasticsearch/issues/145887
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
+  method: "testEvaluateBlockWithNulls {TestCase=field: <random mv SORTED_ASCENDING doubles>, percentile: <positive int>}"
+  issue: https://github.com/elastic/elasticsearch/issues/145888
+- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
+  method: "testEvaluateBlockWithNulls {TestCase=field: <random mv UNORDERED doubles>, percentile: <positive int>}"
+  issue: https://github.com/elastic/elasticsearch/issues/145889
+- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
+  method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromLeftSide}
+  issue: https://github.com/elastic/elasticsearch/issues/145904
+- class: org.elasticsearch.xpack.security.failurestore.FailureStoreSecurityRestIT
+  method: testWatcher
+  issue: https://github.com/elastic/elasticsearch/issues/145928
+- class: org.elasticsearch.reindex.management.ReindexGetRelocationIT
+  method: testGetWaitForCompletionDuringRelocation
+  issue: https://github.com/elastic/elasticsearch/issues/145931
+- class: org.elasticsearch.reindex.management.ReindexGetRelocationIT
+  method: testGetReindexFollowsRelocation
+  issue: https://github.com/elastic/elasticsearch/issues/144364
+- class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcWarningsIT
+  method: testSingleDeprecationWarning
+  issue: https://github.com/elastic/elasticsearch/issues/145933
+- class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
+  method: testGettingValidNumbersWithCastingFromUnsignedLong
+  issue: https://github.com/elastic/elasticsearch/issues/145934
+- class: org.elasticsearch.xpack.ml.integration.DatafeedCcsIT
+  method: testDatafeedWithCcsRemoteUnavailable
+  issue: https://github.com/elastic/elasticsearch/issues/145948
+- class: org.elasticsearch.action.RejectionActionIT
+  method: testSimulatedSearchRejectionLoad
+  issue: https://github.com/elastic/elasticsearch/issues/146022
+- class: org.elasticsearch.cluster.remote.test.RemoteClustersIT
+  method: testHAProxyModeConnectionWithSNIToCluster1Works
+  issue: https://github.com/elastic/elasticsearch/issues/139170
+- class: org.elasticsearch.cluster.remote.test.RemoteClustersIT
+  method: testHAProxyModeConnectionWithSNIToCluster2Works
+  issue: https://github.com/elastic/elasticsearch/issues/139172
+- class: org.elasticsearch.cluster.remote.test.RemoteClustersIT
+  method: testHAProxyModeConnectionWorks
+  issue: https://github.com/elastic/elasticsearch/issues/139171
+- class: org.elasticsearch.search.fetch.FetchPhaseDocsIteratorTests
+  method: testIterateAsyncVisitsLeavesInDocIdOrder
+  issue: https://github.com/elastic/elasticsearch/issues/146078
+- class: org.elasticsearch.xpack.security.transport.filter.IpFilteringIntegrationTests
+  method: testThatIpFilteringIsIntegratedIntoNettyPipelineViaHttp
+  issue: https://github.com/elastic/elasticsearch/issues/146102
+- class: org.elasticsearch.xpack.entsearch.EnterpriseSearchRestIT
+  method: test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type}
+  issue: https://github.com/elastic/elasticsearch/issues/146106
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {csv-spec:embedding.embedding with multiple knn queries in fork}
+  issue: https://github.com/elastic/elasticsearch/issues/146130
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
+  method: test {csv-spec:embedding.embedding with multiple knn queries in fork}
+  issue: https://github.com/elastic/elasticsearch/issues/146130
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
+  method: test {csv-spec:embedding.embedding with multiple knn queries in fork}
+  issue: https://github.com/elastic/elasticsearch/issues/146137
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=tsdb/25_id_generation/*}
+  issue: https://github.com/elastic/elasticsearch/issues/146177
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=delete/70_tsdb/basic tsdb delete}
+  issue: https://github.com/elastic/elasticsearch/issues/146177
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeUnmappedLoadIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/145900
+- class: org.elasticsearch.indices.stats.IndexStatsIT
+  method: testFilterCacheStats
+  issue: https://github.com/elastic/elasticsearch/issues/124447
+- class: org.elasticsearch.xpack.eql.qa.ccs_rolling_upgrade.EqlCcsRollingUpgradeIT
+  method: testSequences
+  issue: https://github.com/elastic/elasticsearch/issues/146263
+- class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
+  method: testMaxQueueLatencyMetricIsPublished
+  issue: https://github.com/elastic/elasticsearch/issues/146283
+- class: org.elasticsearch.xpack.sql.qa.multi_node.RestSqlIT
+  method: testAsyncTextPaginated
+  issue: https://github.com/elastic/elasticsearch/issues/80089
+- class: org.elasticsearch.xpack.sql.qa.single_node.RestSqlIT
+  method: testAsyncTextPaginated
+  issue: https://github.com/elastic/elasticsearch/issues/80089
+- class: org.elasticsearch.xpack.sql.qa.security.RestSqlIT
+  method: testAsyncTextPaginated
+  issue: https://github.com/elastic/elasticsearch/issues/80089
+- class: org.elasticsearch.xpack.sql.qa.multi_cluster_with_security.RestSqlIT
+  method: testAsyncTextPaginated
+  issue: https://github.com/elastic/elasticsearch/issues/80089
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=indices.resolve_cluster/20_resolve_system_index/Resolve system index via resolve/cluster}
+  issue: https://github.com/elastic/elasticsearch/issues/146312
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {csv-spec:stats.sumAsSurrogateWithOverflowGroupingRow}
+  issue: https://github.com/elastic/elasticsearch/issues/146376
+- class: org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT
+  method: testForceSleepsProfile {SYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/146377
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=mget/60_realtime_refresh/Realtime Refresh}
+  issue: https://github.com/elastic/elasticsearch/issues/146410
+- class: org.elasticsearch.xpack.diskbbq.DiskBbqTrialLicenseIT
+  method: testDefaultIndexOptionsForDenseVector
+  issue: https://github.com/elastic/elasticsearch/issues/146415
+- class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
+  method: test {yaml=reindex/10_basic/Response format for version conflict with conflicts=proceed}
+  issue: https://github.com/elastic/elasticsearch/issues/146419
+- class: org.elasticsearch.repositories.blobstore.testkit.analyze.AzureRepositoryAnalysisRestIT
+  method: testRepositoryAnalysis
+  issue: https://github.com/elastic/elasticsearch/issues/146430
+- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToGoldenTests
+  method: testDateTruncNotTransformToQueryAndTags
+  issue: https://github.com/elastic/elasticsearch/issues/146458
+- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToTests
+  method: testBlockLoaderFallbackForDate {default}
+  issue: https://github.com/elastic/elasticsearch/issues/146459
+- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToTests
+  method: testBlockLoaderFallbackForLong {default}
+  issue: https://github.com/elastic/elasticsearch/issues/146460
+- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToTests
+  method: testBlockLoaderFallbackForDateNanos {default}
+  issue: https://github.com/elastic/elasticsearch/issues/146461
+- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToTests
+  method: testDateTruncNotTransformToQueryAndTags {default}
+  issue: https://github.com/elastic/elasticsearch/issues/146462
+- class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
+  method: test {yaml=rrf/310_rrf_retriever_simplified/Expansion to equivalent custom sub-retrievers returns the same results}
+  issue: https://github.com/elastic/elasticsearch/issues/146464
+- class: org.elasticsearch.reindex.ReindexBasicTests
+  method: testReindexFailsWhenSourceIndexIsClosed
+  issue: https://github.com/elastic/elasticsearch/issues/146466
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/145901
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
+  method: test {csv-spec:inlinestats.filterSometimesMatches}
+  issue: https://github.com/elastic/elasticsearch/issues/146545
+- class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
+  method: testSeqNoCASLinearizability
+  issue: https://github.com/elastic/elasticsearch/issues/146568
+- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeUnmappedLoadIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/145900
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=aggregations/sig_terms/Test background filter count}
+  issue: https://github.com/elastic/elasticsearch/issues/146599
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=reindex/10_basic/Response format for updated}
+  issue: https://github.com/elastic/elasticsearch/issues/146607
+- class: org.elasticsearch.xpack.esql.qa.single_node.PushExpressionToLoadIT
+  method: testRoundToLong
+  issue: https://github.com/elastic/elasticsearch/issues/146614
+- class: org.elasticsearch.xpack.esql.qa.single_node.PushExpressionToLoadIT
+  method: testRoundToLongExactMatch
+  issue: https://github.com/elastic/elasticsearch/issues/146615
+- class: org.elasticsearch.xpack.esql.optimizer.ApproximationGoldenTests
+  method: testApproximationDisabled
+  issue: https://github.com/elastic/elasticsearch/issues/146564
+- class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
+  method: testReindexFailsWhenPitRelocationFails
+  issue: https://github.com/elastic/elasticsearch/issues/146650
+- class: org.elasticsearch.transport.ClusterConnectionManagerTests
+  method: testConcurrentConnectsAndDisconnects
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.RemoteClusterClientTests
+  method: testQuicklySkipUnavailableClusters
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.TransportHandshakerTests
+  method: testHandshakeRequestFutureVersionsCompatibility
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.simdvec.ESVectorUtilTests
+  method: testPow2DiffAndScale
+  issue: https://github.com/elastic/elasticsearch/issues/146690
+- class: org.elasticsearch.transport.TransportHandshakerTests
+  method: testHandshakeRequestAndResponse
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.RemoteClusterClientTests
+  method: testConnectAndExecuteRequest
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.synonyms.SynonymsManagementAPIServiceTests
+  method: testBulkUpdateEmptySet
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeRandomMappingIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/146553
+- class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
+  method: testReindexTaskRelocatesOnNodeShutdown
+  issue: https://github.com/elastic/elasticsearch/issues/146696
+- class: org.elasticsearch.transport.TransportHandshakerTests
+  method: testHandshakeError
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.ClusterConnectionManagerTests
+  method: testDisconnectLogging
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.RemoteClusterClientTests
+  method: testEnsureWeReconnect
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.simdvec.ESVectorUtilTests
+  method: testLogSumExpDiff
+  issue: https://github.com/elastic/elasticsearch/issues/146700
+- class: org.elasticsearch.transport.TransportHandshakerTests
+  method: testHandshakeResponseFromOlderNodeWithPatchedProtocol
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.TransportHandshakerTests
+  method: testHandshakeResponseFromOlderNode
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.ClusterConnectionManagerTests
+  method: testConnectAfterClose
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.ClusterConnectionManagerTests
+  method: testConnectFailsDuringValidation
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.TransportHandshakerTests
+  method: testIncompatibleHandshakeRequest
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.TransportHandshakerTests
+  method: testReadV8HandshakeRequest
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.RemoteClusterClientTests
+  method: testRemoteClusterServiceNotEnabled
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
+  method: test {csv-spec:stats_sparkline.sparklineComplexWithGrouping}
+  issue: https://github.com/elastic/elasticsearch/issues/146729
+- class: org.elasticsearch.synonyms.SynonymsManagementAPIServiceTests
+  method: testTransportVersionGateRejectsLargeSetsOnOldCluster
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.transport.ClusterConnectionManagerTests
+  method: testConcurrentConnectsDuringClose
+  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
+  method: test {csv-spec:inlinestats.pushDown_OneGroupingFilter_PastInlineJoinWithInnerFilterAndOuterFilter}
+  issue: https://github.com/elastic/elasticsearch/issues/146737
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
+  method: test {csv-spec:floats.signumWithEvalWhereAndStats}
+  issue: https://github.com/elastic/elasticsearch/issues/146738
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
+  method: test {csv-spec:match-operator.testFTFWithLookupJoin}
+  issue: https://github.com/elastic/elasticsearch/issues/146739
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
+  method: test {csv-spec:inlinestats.multiIndexIpInlinestats_NonPushableCountWithFilter}
+  issue: https://github.com/elastic/elasticsearch/issues/146740
+- class: org.elasticsearch.reindex.ReindexBasicTests
+  method: testCopyManyWithAutoSlicing
+  issue: https://github.com/elastic/elasticsearch/issues/146741
+- class: org.elasticsearch.synonyms.SynonymsManagementAPIServiceTests
+  method: testPutSynonymRuleUpgradeGuardRejectsOnOldCluster
+  issue: https://github.com/elastic/elasticsearch/issues/146743
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -8,50 +8,205 @@ tests:
 - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
   method: testTracingCrossCluster
   issue: https://github.com/elastic/elasticsearch/issues/112731
+- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/115528
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
+  issue: https://github.com/elastic/elasticsearch/issues/115808
+- class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
+  issue: https://github.com/elastic/elasticsearch/issues/116087
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start already started transform}
+  issue: https://github.com/elastic/elasticsearch/issues/98802
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
+  issue: https://github.com/elastic/elasticsearch/issues/116775
 - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
   method: test {yaml=/10_apm/Test template reinstallation}
   issue: https://github.com/elastic/elasticsearch/issues/116445
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_reset/Test reset running transform}
+  issue: https://github.com/elastic/elasticsearch/issues/117473
 - class: org.elasticsearch.packaging.test.ArchiveTests
   method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
   issue: https://github.com/elastic/elasticsearch/issues/118208
 - class: org.elasticsearch.packaging.test.ArchiveTests
   method: test51AutoConfigurationWithPasswordProtectedKeystore
   issue: https://github.com/elastic/elasticsearch/issues/118212
+- class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
+  method: testShardChangesNoOperation
+  issue: https://github.com/elastic/elasticsearch/issues/118800
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
+  issue: https://github.com/elastic/elasticsearch/issues/119508
 - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/119983
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_unattended/Test unattended put and start}
+  issue: https://github.com/elastic/elasticsearch/issues/120019
 - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
   method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
   issue: https://github.com/elastic/elasticsearch/issues/120127
+- class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
+  method: testCleanShardFollowTaskAfterDeleteFollower
+  issue: https://github.com/elastic/elasticsearch/issues/120339
+- class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
+  method: testAuthenticateShouldNotFallThroughInCaseOfFailure
+  issue: https://github.com/elastic/elasticsearch/issues/120902
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
+  issue: https://github.com/elastic/elasticsearch/issues/120950
+- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
+  method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
+  issue: https://github.com/elastic/elasticsearch/issues/122102
 - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
   method: testChildrenTasksCancelledOnTimeout
   issue: https://github.com/elastic/elasticsearch/issues/123568
+- class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
+  method: testCreateAndRestorePartialSearchableSnapshot
+  issue: https://github.com/elastic/elasticsearch/issues/123773
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
+  issue: https://github.com/elastic/elasticsearch/issues/122755
+- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+  method: testDeploymentSurvivesRestart {cluster=OLD}
+  issue: https://github.com/elastic/elasticsearch/issues/124160
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
+  issue: https://github.com/elastic/elasticsearch/issues/120720
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
+  issue: https://github.com/elastic/elasticsearch/issues/125854
+- class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
+  method: testRecreateTemplateWhenDeleted
+  issue: https://github.com/elastic/elasticsearch/issues/123232
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_reset/Test force reseting a running transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126240
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126466
+- class: org.elasticsearch.repositories.blobstore.testkit.rest.SnapshotRepoTestKitClientYamlTestSuiteIT
+  method: test {p0=/10_analyze/Analysis without details}
+  issue: https://github.com/elastic/elasticsearch/issues/126569
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126755
 - class: org.elasticsearch.index.engine.CompletionStatsCacheTests
   method: testCompletionStatsCache
   issue: https://github.com/elastic/elasticsearch/issues/126910
+- class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
+  method: testFeatureImportanceValues
+  issue: https://github.com/elastic/elasticsearch/issues/124341
+- class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
+  method: testStdinWithMultipleValues
+  issue: https://github.com/elastic/elasticsearch/issues/126882
+- class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
+  method: testChangeFollowerHistoryUUID
+  issue: https://github.com/elastic/elasticsearch/issues/127680
+- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
+  method: testKnnVectors
+  issue: https://github.com/elastic/elasticsearch/issues/127689
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=search/350_point_in_time/point-in-time with index filter}
+  issue: https://github.com/elastic/elasticsearch/issues/127741
+- class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
+  method: testSearchWhileRelocating
+  issue: https://github.com/elastic/elasticsearch/issues/128500
+- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
+  method: testWindowsMixedCaseAccess
+  issue: https://github.com/elastic/elasticsearch/issues/129167
+- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
+  method: testWindowsAbsolutPathAccess
+  issue: https://github.com/elastic/elasticsearch/issues/129168
 - class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
   method: testWaitsUntilResourcesAreCreated
   issue: https://github.com/elastic/elasticsearch/issues/129486
+- class: org.elasticsearch.search.query.VectorIT
+  method: testFilteredQueryStrategy
+  issue: https://github.com/elastic/elasticsearch/issues/129517
 - class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
   method: testUpdatingFileBasedRoleAffectsAllProjects
   issue: https://github.com/elastic/elasticsearch/issues/129775
+- class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
+  method: testManyInitialManyPartialFinalRunnerThrowing
+  issue: https://github.com/elastic/elasticsearch/issues/130145
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
   method: testNodesCachesStats
   issue: https://github.com/elastic/elasticsearch/issues/129863
+- class: org.elasticsearch.index.IndexingPressureIT
+  method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
+  issue: https://github.com/elastic/elasticsearch/issues/130281
+- class: org.elasticsearch.indices.stats.IndexStatsIT
+  method: testFilterCacheStats
+  issue: https://github.com/elastic/elasticsearch/issues/124447
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
+  issue: https://github.com/elastic/elasticsearch/issues/122414
+- class: org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreTests
+  method: testSerializationOfSimple {TestCase=<boolean>}
+  issue: https://github.com/elastic/elasticsearch/issues/131334
+- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
+  method: testWatcherWithApiKey {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/131964
+- class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
+  method: testNullsOrderWithMissingOrderSupportQueryingNewNode
+  issue: https://github.com/elastic/elasticsearch/issues/132249
 - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
   method: test40VerifyAutogeneratedCredentials
   issue: https://github.com/elastic/elasticsearch/issues/132877
 - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
   method: test50CredentialAutogenerationOnlyOnce
   issue: https://github.com/elastic/elasticsearch/issues/132878
+- class: org.elasticsearch.xpack.eql.planner.QueryTranslatorTests
+  method: testMatchOptimization
+  issue: https://github.com/elastic/elasticsearch/issues/132894
+- class: org.elasticsearch.xpack.security.authc.AuthenticationServiceTests
+  method: testInvalidToken
+  issue: https://github.com/elastic/elasticsearch/issues/133328
+- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
+  method: testWithCustomFeatureProcessors
+  issue: https://github.com/elastic/elasticsearch/issues/134001
+- class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
+  method: testAliasFilters
+  issue: https://github.com/elastic/elasticsearch/issues/134512
 - class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
   method: testCBTrippingOnReduction
   issue: https://github.com/elastic/elasticsearch/issues/134667
+- class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
+  method: testCancelSkipUnavailable
+  issue: https://github.com/elastic/elasticsearch/issues/134865
+- class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
+  method: testSettingsApplied
+  issue: https://github.com/elastic/elasticsearch/issues/126748
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
+  issue: https://github.com/elastic/elasticsearch/issues/135135
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null double values}
+  issue: https://github.com/elastic/elasticsearch/issues/135159
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null integer values}
+  issue: https://github.com/elastic/elasticsearch/issues/135162
 - class: org.elasticsearch.gradle.TestClustersPluginFuncTest
   method: override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities
   issue: https://github.com/elastic/elasticsearch/issues/135413
 - class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
   method: testConcurrentAuthentication
   issue: https://github.com/elastic/elasticsearch/issues/135777
+- class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
+  method: test {p0=field_caps/10_basic/Field caps for number field with only doc values}
+  issue: https://github.com/elastic/elasticsearch/issues/136244
+- class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
+  method: test {p0=search.vectors/200_dense_vector_docvalue_fields/Enable docvalue_fields parameter for dense_vector fields}
+  issue: https://github.com/elastic/elasticsearch/issues/136443
+- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
+  method: testMultipleInferencesTriggeringDownloadAndDeploy
+  issue: https://github.com/elastic/elasticsearch/issues/117208
+- class: org.elasticsearch.smoketest.SmokeTestIngestWithAllDepsClientYamlTestSuiteIT
+  method: test {yaml=ingest/100_sampling_with_reroute/Test get sample with multiple reroutes}
+  issue: https://github.com/elastic/elasticsearch/issues/137457
 - class: org.elasticsearch.xpack.ilm.CCRIndexLifecycleIT
   method: testTsdbLeaderIndexRolloverAndSyncAfterWaitUntilEndTime {targetCluster=FOLLOWER}
   issue: https://github.com/elastic/elasticsearch/issues/137565
@@ -61,381 +216,138 @@ tests:
 - class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
   method: testLicenseInvalidForInference {p0=false}
   issue: https://github.com/elastic/elasticsearch/issues/137691
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/70_text_similarity_rank_retriever/Text similarity reranker with min_score zero includes all docs}
+  issue: https://github.com/elastic/elasticsearch/issues/137732
+- class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
+  method: testUpdateMappingConcurrently
+  issue: https://github.com/elastic/elasticsearch/issues/137758
+- class: org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceTests
+  method: testChangingCapacity_DoesNotRejectsOverflowTasks_BecauseOfQueueFull
+  issue: https://github.com/elastic/elasticsearch/issues/137823
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/138128
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/138311
+- class: org.elasticsearch.xpack.ml.integration.RegressionIT
+  method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
+  issue: https://github.com/elastic/elasticsearch/issues/138319
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=termvectors/30_realtime/Realtime Term Vectors}
   issue: https://github.com/elastic/elasticsearch/issues/138370
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:spatial.convertFromStringParseError}
-  issue: https://github.com/elastic/elasticsearch/issues/139213
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:boolean.convertFromIntAndLong}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:keep.whereWithEvalGeneratedValue}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:topN.sortingOnNumbersFromStrings}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:drop.whereWithEvalGeneratedValue_DropHeight}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:rename.renameIntertwinedWithSort}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:ints.convertStringToBaseIndexGroup7}
-  issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.indices.recovery.IndexRecoveryIT
-  method: testSourceThrottling
-  issue: https://github.com/elastic/elasticsearch/issues/141548
+- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
+  method: testRevertModelSnapshot_DeleteInterveningResults
+  issue: https://github.com/elastic/elasticsearch/issues/132349
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
+  issue: https://github.com/elastic/elasticsearch/issues/138409
+- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
+  method: testRevertModelSnapshot
+  issue: https://github.com/elastic/elasticsearch/issues/132733
+- class: org.elasticsearch.xpack.inference.services.jinaai.JinaAIServiceTests
+  method: test_Embedding_ChunkedInfer_LateChunkingEnabled
+  issue: https://github.com/elastic/elasticsearch/issues/138451
+- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=index/100_field_name_length_limit/Test field name length limit synthetic source}
+  issue: https://github.com/elastic/elasticsearch/issues/138471
+- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLookupJoinIT
+  method: testLookupExplosionBigString
+  issue: https://github.com/elastic/elasticsearch/issues/138510
+- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=index/100_field_name_length_limit/Test field name length limit}
+  issue: https://github.com/elastic/elasticsearch/issues/138768
+- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1EnrichUnavailableRemotesIT
+  method: testEsqlEnrichWithSkipUnavailable
+  issue: https://github.com/elastic/elasticsearch/issues/138793
+- class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
+  method: testStopLookback_closeJobFalse
+  issue: https://github.com/elastic/elasticsearch/issues/139024
+- class: org.elasticsearch.xpack.core.security.authc.AuthenticationTests
+  method: testMaybeRewriteForOlderVersionWithCrossClusterAccessRewritesAuthenticationInMetadata
+  issue: https://github.com/elastic/elasticsearch/issues/139167
+- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=index/100_field_name_length_limit/Test field name length limit array synthetic source}
+  issue: https://github.com/elastic/elasticsearch/issues/139300
+- class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
+  method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
+  issue: https://github.com/elastic/elasticsearch/issues/139490
+- class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
+  method: testReductionPlanForTopNWithPushedDownFunctions
+  issue: https://github.com/elastic/elasticsearch/issues/139491
+- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
+  method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
+  issue: https://github.com/elastic/elasticsearch/issues/139492
+- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
+  method: testReductionPlanForTopNWithPushedDownFunctions
+  issue: https://github.com/elastic/elasticsearch/issues/139493
+- class: org.elasticsearch.xpack.core.action.XPackUsageResponseTests
+  method: testVersionDependentSerializationWriteToOldStream
+  issue: https://github.com/elastic/elasticsearch/issues/139576
+- class: org.elasticsearch.smoketest.WatcherYamlRestIT
+  method: test {p0=mustache/10_webhook/Test webhook action with mustache integration}
+  issue: https://github.com/elastic/elasticsearch/issues/139663
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=esql/40_unsupported_types/unsupported}
+  issue: https://github.com/elastic/elasticsearch/issues/139701
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=esql/40_unsupported_types/unsupported with sort}
+  issue: https://github.com/elastic/elasticsearch/issues/139702
+- class: org.elasticsearch.persistent.PersistentTasksCustomMetadataTests
+  method: testMinVersionSerialization
+  issue: https://github.com/elastic/elasticsearch/issues/139740
+- class: org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadataTests
+  method: testMinVersionSerialization
+  issue: https://github.com/elastic/elasticsearch/issues/139741
+- class: org.elasticsearch.xpack.esql.session.EsqlResolvedIndexExpressionIT
+  method: testLocalDateMathExpression
+  issue: https://github.com/elastic/elasticsearch/issues/140106
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
+  method: test {csv-spec:unmapped-nullify.TsWithAggsByMissing}
+  issue: https://github.com/elastic/elasticsearch/issues/142762
+- class: org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceTests
+  method: testExecute_Throws_WhenRateLimitedQueueIsFull
+  issue: https://github.com/elastic/elasticsearch/issues/141231
+- class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
+  method: testQuantizedXY
+  issue: https://github.com/elastic/elasticsearch/issues/141234
+- class: org.elasticsearch.compute.operator.topn.TopNOomRaceTests
+  method: testRace {repeats = 15}
+  issue: https://github.com/elastic/elasticsearch/issues/141471
+- class: org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingServiceTests
+  method: testExpiredModelsAreEvictedBeforeLoading
+  issue: https://github.com/elastic/elasticsearch/issues/141589
 - class: org.elasticsearch.search.aggregations.metrics.TopHitsIT
   method: testMixedSortFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/142077
 - class: org.elasticsearch.xpack.analytics.cumulativecardinality.CumulativeCardinalityAggregatorTests
   method: testSimple
   issue: https://github.com/elastic/elasticsearch/issues/142408
-- class: org.elasticsearch.xpack.esql.common.spatial.H3SphericalGeometryTests
-  method: testIndexPoints
-  issue: https://github.com/elastic/elasticsearch/issues/142439
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
-  method: test {p0=esql/160_union_types/suggested_type}
-  issue: https://github.com/elastic/elasticsearch/issues/142525
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/160_union_types/suggested_type}
-  issue: https://github.com/elastic/elasticsearch/issues/142525
-- class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
-  method: testQuantizedXY
-  issue: https://github.com/elastic/elasticsearch/issues/141234
-- class: org.elasticsearch.packaging.test.DebMetadataTests
-  method: test05CheckLintian
-  issue: https://github.com/elastic/elasticsearch/issues/142819
-- class: org.elasticsearch.xpack.security.support.MetadataFlattenedMigrationIntegTests
-  method: testMigrationWithConcurrentUpdates
-  issue: https://github.com/elastic/elasticsearch/issues/143674
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/143697
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testClusterState {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/143800
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testOperationBasedRecovery {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/143801
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testOperationBasedRecovery {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/143802
-- class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
-  method: testWriteBlobWithRetries
-  issue: https://github.com/elastic/elasticsearch/issues/144025
-- class: org.elasticsearch.xpack.application.OpenAiServiceUpgradeIT
-  method: testOpenAiEmbeddings {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/144440
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:spatial.convertCartesianFromStringParseError}
-  issue: https://github.com/elastic/elasticsearch/issues/144580
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:spatial_shapes.convertFromStringParseError}
-  issue: https://github.com/elastic/elasticsearch/issues/144672
-- class: org.elasticsearch.xpack.transform.transforms.ClientTransformIndexerTests
-  method: testDisablePitWhenCrossProjectSearchIsEnabled
-  issue: https://github.com/elastic/elasticsearch/issues/144822
-- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
-  method: testLookupMissingField
-  issue: https://github.com/elastic/elasticsearch/issues/144697
-- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
-  method: testLookupMatchTypeWrong
-  issue: https://github.com/elastic/elasticsearch/issues/144694
-- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
-  method: testLookup
-  issue: https://github.com/elastic/elasticsearch/issues/144696
-- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
-  method: testLookupMissingTable
-  issue: https://github.com/elastic/elasticsearch/issues/144695
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:external-basic.scoreFunction}
-  issue: https://github.com/elastic/elasticsearch/issues/145352
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:external-basic.topSnippetsFunction}
-  issue: https://github.com/elastic/elasticsearch/issues/145353
-- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
-  method: testKnnVectors
-  issue: https://github.com/elastic/elasticsearch/issues/145377
-- class: org.elasticsearch.compute.aggregation.SumLongGroupingAggregatorFunctionTests
-  method: testOverflowInGroupingProducesNullAndWarning
-  issue: https://github.com/elastic/elasticsearch/issues/145438
-- class: org.elasticsearch.xpack.ml.integration.RegressionIT
-  method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
-  issue: https://github.com/elastic/elasticsearch/issues/145519
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:spatial_shapes.convertFromStringParseError}
-  issue: https://github.com/elastic/elasticsearch/issues/145655
-- class: org.elasticsearch.xpack.autoscaling.storage.ReactiveStorageIT
-  method: testScaleWhileShrinking
-  issue: https://github.com/elastic/elasticsearch/issues/145669
-- class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
-  method: testAverageWriteLoadMetricIsPublished
-  issue: https://github.com/elastic/elasticsearch/issues/145855
-- class: org.elasticsearch.xpack.esql.spatial.SpatialCentroidAggregationIT
-  method: testStCentroidAggregationWithShapes
-  issue: https://github.com/elastic/elasticsearch/issues/145883
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryAllCombinationsSkipUnavailableIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/145884
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
-  method: "testEvaluateBlockWithNulls {TestCase=field: <random mv DEDUPLICATED_UNORDERD doubles>, percentile: <positive int>}"
-  issue: https://github.com/elastic/elasticsearch/issues/145886
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
-  method: "testEvaluateBlockWithNulls {TestCase=field: <random mv DEDUPLICATED_AND_SORTED_ASCENDING doubles>, percentile: <positive int>}"
-  issue: https://github.com/elastic/elasticsearch/issues/145887
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
-  method: "testEvaluateBlockWithNulls {TestCase=field: <random mv SORTED_ASCENDING doubles>, percentile: <positive int>}"
-  issue: https://github.com/elastic/elasticsearch/issues/145888
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvPercentileTests
-  method: "testEvaluateBlockWithNulls {TestCase=field: <random mv UNORDERED doubles>, percentile: <positive int>}"
-  issue: https://github.com/elastic/elasticsearch/issues/145889
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:lookup-join.mvKeywordFieldJoinWarningsFromLeftSide}
-  issue: https://github.com/elastic/elasticsearch/issues/145904
-- class: org.elasticsearch.xpack.security.failurestore.FailureStoreSecurityRestIT
-  method: testWatcher
-  issue: https://github.com/elastic/elasticsearch/issues/145928
-- class: org.elasticsearch.reindex.management.ReindexGetRelocationIT
-  method: testGetWaitForCompletionDuringRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/145931
-- class: org.elasticsearch.reindex.management.ReindexGetRelocationIT
-  method: testGetReindexFollowsRelocation
-  issue: https://github.com/elastic/elasticsearch/issues/144364
-- class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcWarningsIT
-  method: testSingleDeprecationWarning
-  issue: https://github.com/elastic/elasticsearch/issues/145933
-- class: org.elasticsearch.xpack.sql.qa.jdbc.single_node.SingleNodeJdbcResultSetIT
-  method: testGettingValidNumbersWithCastingFromUnsignedLong
-  issue: https://github.com/elastic/elasticsearch/issues/145934
-- class: org.elasticsearch.xpack.ml.integration.DatafeedCcsIT
-  method: testDatafeedWithCcsRemoteUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/145948
-- class: org.elasticsearch.action.RejectionActionIT
-  method: testSimulatedSearchRejectionLoad
-  issue: https://github.com/elastic/elasticsearch/issues/146022
-- class: org.elasticsearch.cluster.remote.test.RemoteClustersIT
-  method: testHAProxyModeConnectionWithSNIToCluster1Works
-  issue: https://github.com/elastic/elasticsearch/issues/139170
-- class: org.elasticsearch.cluster.remote.test.RemoteClustersIT
-  method: testHAProxyModeConnectionWithSNIToCluster2Works
-  issue: https://github.com/elastic/elasticsearch/issues/139172
-- class: org.elasticsearch.cluster.remote.test.RemoteClustersIT
-  method: testHAProxyModeConnectionWorks
-  issue: https://github.com/elastic/elasticsearch/issues/139171
-- class: org.elasticsearch.search.fetch.FetchPhaseDocsIteratorTests
-  method: testIterateAsyncVisitsLeavesInDocIdOrder
-  issue: https://github.com/elastic/elasticsearch/issues/146078
-- class: org.elasticsearch.xpack.security.transport.filter.IpFilteringIntegrationTests
-  method: testThatIpFilteringIsIntegratedIntoNettyPipelineViaHttp
-  issue: https://github.com/elastic/elasticsearch/issues/146102
-- class: org.elasticsearch.xpack.entsearch.EnterpriseSearchRestIT
-  method: test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type}
-  issue: https://github.com/elastic/elasticsearch/issues/146106
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:embedding.embedding with multiple knn queries in fork}
-  issue: https://github.com/elastic/elasticsearch/issues/146130
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
-  method: test {csv-spec:embedding.embedding with multiple knn queries in fork}
-  issue: https://github.com/elastic/elasticsearch/issues/146130
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:embedding.embedding with multiple knn queries in fork}
-  issue: https://github.com/elastic/elasticsearch/issues/146137
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=tsdb/25_id_generation/*}
-  issue: https://github.com/elastic/elasticsearch/issues/146177
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=delete/70_tsdb/basic tsdb delete}
-  issue: https://github.com/elastic/elasticsearch/issues/146177
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeUnmappedLoadIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/145900
-- class: org.elasticsearch.indices.stats.IndexStatsIT
-  method: testFilterCacheStats
-  issue: https://github.com/elastic/elasticsearch/issues/124447
-- class: org.elasticsearch.xpack.eql.qa.ccs_rolling_upgrade.EqlCcsRollingUpgradeIT
-  method: testSequences
-  issue: https://github.com/elastic/elasticsearch/issues/146263
-- class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
-  method: testMaxQueueLatencyMetricIsPublished
-  issue: https://github.com/elastic/elasticsearch/issues/146283
-- class: org.elasticsearch.xpack.sql.qa.multi_node.RestSqlIT
-  method: testAsyncTextPaginated
-  issue: https://github.com/elastic/elasticsearch/issues/80089
-- class: org.elasticsearch.xpack.sql.qa.single_node.RestSqlIT
-  method: testAsyncTextPaginated
-  issue: https://github.com/elastic/elasticsearch/issues/80089
-- class: org.elasticsearch.xpack.sql.qa.security.RestSqlIT
-  method: testAsyncTextPaginated
-  issue: https://github.com/elastic/elasticsearch/issues/80089
-- class: org.elasticsearch.xpack.sql.qa.multi_cluster_with_security.RestSqlIT
-  method: testAsyncTextPaginated
-  issue: https://github.com/elastic/elasticsearch/issues/80089
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=indices.resolve_cluster/20_resolve_system_index/Resolve system index via resolve/cluster}
-  issue: https://github.com/elastic/elasticsearch/issues/146312
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:stats.sumAsSurrogateWithOverflowGroupingRow}
-  issue: https://github.com/elastic/elasticsearch/issues/146376
-- class: org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT
-  method: testForceSleepsProfile {SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/146377
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mget/60_realtime_refresh/Realtime Refresh}
-  issue: https://github.com/elastic/elasticsearch/issues/146410
-- class: org.elasticsearch.xpack.diskbbq.DiskBbqTrialLicenseIT
-  method: testDefaultIndexOptionsForDenseVector
-  issue: https://github.com/elastic/elasticsearch/issues/146415
-- class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
-  method: test {yaml=reindex/10_basic/Response format for version conflict with conflicts=proceed}
-  issue: https://github.com/elastic/elasticsearch/issues/146419
-- class: org.elasticsearch.repositories.blobstore.testkit.analyze.AzureRepositoryAnalysisRestIT
-  method: testRepositoryAnalysis
-  issue: https://github.com/elastic/elasticsearch/issues/146430
-- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToGoldenTests
-  method: testDateTruncNotTransformToQueryAndTags
-  issue: https://github.com/elastic/elasticsearch/issues/146458
-- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToTests
-  method: testBlockLoaderFallbackForDate {default}
-  issue: https://github.com/elastic/elasticsearch/issues/146459
-- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToTests
-  method: testBlockLoaderFallbackForLong {default}
-  issue: https://github.com/elastic/elasticsearch/issues/146460
-- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToTests
-  method: testBlockLoaderFallbackForDateNanos {default}
-  issue: https://github.com/elastic/elasticsearch/issues/146461
-- class: org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SubstituteRoundToTests
-  method: testDateTruncNotTransformToQueryAndTags {default}
-  issue: https://github.com/elastic/elasticsearch/issues/146462
-- class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
-  method: test {yaml=rrf/310_rrf_retriever_simplified/Expansion to equivalent custom sub-retrievers returns the same results}
-  issue: https://github.com/elastic/elasticsearch/issues/146464
-- class: org.elasticsearch.reindex.ReindexBasicTests
-  method: testReindexFailsWhenSourceIndexIsClosed
-  issue: https://github.com/elastic/elasticsearch/issues/146466
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/145901
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
-  method: test {csv-spec:inlinestats.filterSometimesMatches}
-  issue: https://github.com/elastic/elasticsearch/issues/146545
-- class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
-  method: testSeqNoCASLinearizability
-  issue: https://github.com/elastic/elasticsearch/issues/146568
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeUnmappedLoadIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/145900
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=aggregations/sig_terms/Test background filter count}
-  issue: https://github.com/elastic/elasticsearch/issues/146599
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=reindex/10_basic/Response format for updated}
-  issue: https://github.com/elastic/elasticsearch/issues/146607
-- class: org.elasticsearch.xpack.esql.qa.single_node.PushExpressionToLoadIT
-  method: testRoundToLong
-  issue: https://github.com/elastic/elasticsearch/issues/146614
-- class: org.elasticsearch.xpack.esql.qa.single_node.PushExpressionToLoadIT
-  method: testRoundToLongExactMatch
-  issue: https://github.com/elastic/elasticsearch/issues/146615
-- class: org.elasticsearch.xpack.esql.optimizer.ApproximationGoldenTests
-  method: testApproximationDisabled
-  issue: https://github.com/elastic/elasticsearch/issues/146564
-- class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
-  method: testReindexFailsWhenPitRelocationFails
-  issue: https://github.com/elastic/elasticsearch/issues/146650
-- class: org.elasticsearch.transport.ClusterConnectionManagerTests
-  method: testConcurrentConnectsAndDisconnects
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.RemoteClusterClientTests
-  method: testQuicklySkipUnavailableClusters
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.TransportHandshakerTests
-  method: testHandshakeRequestFutureVersionsCompatibility
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.simdvec.ESVectorUtilTests
-  method: testPow2DiffAndScale
-  issue: https://github.com/elastic/elasticsearch/issues/146690
-- class: org.elasticsearch.transport.TransportHandshakerTests
-  method: testHandshakeRequestAndResponse
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.RemoteClusterClientTests
-  method: testConnectAndExecuteRequest
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.synonyms.SynonymsManagementAPIServiceTests
-  method: testBulkUpdateEmptySet
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeRandomMappingIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/146553
-- class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
-  method: testReindexTaskRelocatesOnNodeShutdown
-  issue: https://github.com/elastic/elasticsearch/issues/146696
-- class: org.elasticsearch.transport.TransportHandshakerTests
-  method: testHandshakeError
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.ClusterConnectionManagerTests
-  method: testDisconnectLogging
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.RemoteClusterClientTests
-  method: testEnsureWeReconnect
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.simdvec.ESVectorUtilTests
-  method: testLogSumExpDiff
-  issue: https://github.com/elastic/elasticsearch/issues/146700
-- class: org.elasticsearch.transport.TransportHandshakerTests
-  method: testHandshakeResponseFromOlderNodeWithPatchedProtocol
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.TransportHandshakerTests
-  method: testHandshakeResponseFromOlderNode
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.ClusterConnectionManagerTests
-  method: testConnectAfterClose
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.ClusterConnectionManagerTests
-  method: testConnectFailsDuringValidation
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.TransportHandshakerTests
-  method: testIncompatibleHandshakeRequest
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.TransportHandshakerTests
-  method: testReadV8HandshakeRequest
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.RemoteClusterClientTests
-  method: testRemoteClusterServiceNotEnabled
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-  method: test {csv-spec:stats_sparkline.sparklineComplexWithGrouping}
-  issue: https://github.com/elastic/elasticsearch/issues/146729
-- class: org.elasticsearch.synonyms.SynonymsManagementAPIServiceTests
-  method: testTransportVersionGateRejectsLargeSetsOnOldCluster
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.ClusterConnectionManagerTests
-  method: testConcurrentConnectsDuringClose
-  issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
-  method: test {csv-spec:inlinestats.pushDown_OneGroupingFilter_PastInlineJoinWithInnerFilterAndOuterFilter}
-  issue: https://github.com/elastic/elasticsearch/issues/146737
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
-  method: test {csv-spec:floats.signumWithEvalWhereAndStats}
-  issue: https://github.com/elastic/elasticsearch/issues/146738
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
-  method: test {csv-spec:match-operator.testFTFWithLookupJoin}
-  issue: https://github.com/elastic/elasticsearch/issues/146739
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
-  method: test {csv-spec:inlinestats.multiIndexIpInlinestats_NonPushableCountWithFilter}
-  issue: https://github.com/elastic/elasticsearch/issues/146740
-- class: org.elasticsearch.reindex.ReindexBasicTests
-  method: testCopyManyWithAutoSlicing
-  issue: https://github.com/elastic/elasticsearch/issues/146741
-- class: org.elasticsearch.synonyms.SynonymsManagementAPIServiceTests
-  method: testPutSynonymRuleUpgradeGuardRejectsOnOldCluster
-  issue: https://github.com/elastic/elasticsearch/issues/146743
+- class: org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorTests
+  method: testOrderByCardinality
+  issue: https://github.com/elastic/elasticsearch/issues/142484
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/144161
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/144159
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/30_semantic_text_inference_bwc/Calculates embeddings using the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/144160
+- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
+  method: testInferDeploysDefaultRerank
+  issue: https://github.com/elastic/elasticsearch/issues/144162
+- class: org.elasticsearch.indices.IndicesRequestCacheIT
+  method: testCanCache
+  issue: https://github.com/elastic/elasticsearch/issues/144526
+- class: org.elasticsearch.repositories.s3.S3BlobStoreRepositoryTimeoutTests
+  method: testSnapshotWithLargeSegmentFiles
+  issue: https://github.com/elastic/elasticsearch/issues/146156
+- class: org.elasticsearch.xpack.ssl.SSLReloadDuringStartupIntegTests
+  method: testReloadDuringStartup
+  issue: https://github.com/elastic/elasticsearch/issues/146645
 
 # Examples:
 #

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleter.java
@@ -17,12 +17,15 @@ import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.TransportDeleteAction;
 import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.TransportMultiSearchAction;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
@@ -311,7 +314,10 @@ public class JobDataDeleter {
     }
 
     /**
-     * Delete the datafeed timing stats document from all the job results indices
+     * Delete the datafeed timing stats document from the job results index.
+     * Uses a direct delete-by-ID rather than delete-by-query to avoid the two-phase
+     * search-then-delete race where an un-refreshed document can be missed by the
+     * search phase.
      *
      * @param listener Response listener
      */
@@ -323,14 +329,17 @@ public class JobDataDeleter {
             () -> listener.onResponse(emptyBulkByScrollResponse())
         );
         if (indicesToQuery.length == 0) return;
-        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(indicesToQuery).setRefresh(true)
-            .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-            .setQuery(QueryBuilders.idsQuery().addIds(DatafeedTimingStats.documentId(jobId)));
 
-        // _doc is the most efficient sort order and will also disable scoring
-        deleteByQueryRequest.getSearchRequest().source().sort(ElasticsearchMappings.ES_DOC);
+        DeleteRequest deleteRequest = new DeleteRequest(indicesToQuery[0], DatafeedTimingStats.documentId(jobId));
+        deleteRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
-        executeAsyncWithOrigin(client, ML_ORIGIN, DeleteByQueryAction.INSTANCE, deleteByQueryRequest, listener);
+        executeAsyncWithOrigin(
+            client,
+            ML_ORIGIN,
+            TransportDeleteAction.TYPE,
+            deleteRequest,
+            listener.delegateFailureAndWrap((l, deleteResponse) -> l.onResponse(emptyBulkByScrollResponse()))
+        );
     }
 
     /**

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
@@ -6,7 +6,10 @@
  */
 package org.elasticsearch.xpack.ml.job.persistence;
 
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.TransportDeleteAction;
 import org.elasticsearch.action.support.ActionTestUtils;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -17,6 +20,7 @@ import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.ml.job.retention.MockWritableIndexExpander;
 import org.junit.After;
@@ -166,19 +170,21 @@ public class JobDataDeleterTests extends ESTestCase {
 
     public void testDeleteDatafeedTimingStats() {
         MockWritableIndexExpander.create(true);
+        ArgumentCaptor<DeleteRequest> deleteCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
+        // deleteDatafeedTimingStats does not use the deleteUserAnnotations flag, so both iterations
+        // produce identical client calls; we verify the cumulative counts after the loop.
         Arrays.asList(false, true).forEach(deleteUserAnnotations -> {
             JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID, deleteUserAnnotations);
             jobDataDeleter.deleteDatafeedTimingStats(ActionTestUtils.assertNoFailureListener(deleteResponse -> {}));
-
-            if (deleteUserAnnotations) {
-                verify(client, times(2)).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any());
-            } else {
-                verify(client).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any());
-            }
-
-            DeleteByQueryRequest deleteRequest = deleteRequestCaptor.getValue();
-            assertThat(deleteRequest.indices(), is(arrayContaining(AnomalyDetectorsIndex.jobResultsAliasedName(JOB_ID))));
         });
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(), any());
+        verify(client, times(2)).execute(eq(TransportDeleteAction.TYPE), deleteCaptor.capture(), any());
+
+        DeleteRequest deleteRequest = deleteCaptor.getValue();
+        assertThat(deleteRequest.index(), is(AnomalyDetectorsIndex.jobResultsAliasedName(JOB_ID)));
+        assertThat(deleteRequest.id(), is(DatafeedTimingStats.documentId(JOB_ID)));
+        assertThat(deleteRequest.getRefreshPolicy(), is(WriteRequest.RefreshPolicy.IMMEDIATE));
+
         verify(client, times(2)).threadPool();
     }
 
@@ -187,15 +193,7 @@ public class JobDataDeleterTests extends ESTestCase {
         Arrays.asList(false, true).forEach(deleteUserAnnotations -> {
             JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID, deleteUserAnnotations);
             jobDataDeleter.deleteDatafeedTimingStats(ActionTestUtils.assertNoFailureListener(deleteResponse -> {}));
-
-            if (deleteUserAnnotations) {
-                verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any());
-                client.threadPool();
-            } else {
-                verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any());
-                client.threadPool();
-            }
         });
-        verify(client, times(2)).threadPool();
+        verify(client, never()).execute(eq(TransportDeleteAction.TYPE), any(DeleteRequest.class), any());
     }
 }


### PR DESCRIPTION
Fixes the flaky DatafeedJobsIT.testDatafeedTimingStats_DatafeedRecreated test (https://github.com/elastic/elasticsearch/issues/138348) by replacing the DeleteByQuery in JobDataDeleter.deleteDatafeedTimingStats() with a direct DeleteRequest by document ID.

Backports https://github.com/elastic/elasticsearch/pull/146442
