### PR TITLE
[9.2] Collapse pathological regex quantifier stacking to prevent NFA construction (#145452)

### DIFF
--- a/docs/changelog/145452.yaml
+++ b/docs/changelog/145452.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues: []
+pr: 145452
+summary: Collapse pathological regex quantifier stacking to prevent NFA construction
+  OOM
+type: bug

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/30_limits.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/30_limits.yml
@@ -189,3 +189,29 @@ setup:
                     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
                     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
                     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+---
+"Regexp stacked quantifiers are collapsed":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_1
+        body:
+          query:
+            regexp:
+              foo.keyword:
+                value: "b.+++++r"
+  - match: {hits.total: 1}
+  - match: {hits.hits.0._id: "1"}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_1
+        body:
+          query:
+            query_string:
+              default_field: foo.keyword
+              query: "/b.+++++r/"
+  - match: {hits.total: 1}
+  - match: {hits.hits.0._id: "1"}

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/AutomatonQueries.java
@@ -23,6 +23,7 @@ import org.elasticsearch.lucene.util.automaton.CircuitBreakingOperations;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Helper functions for creating various forms of {@link AutomatonQuery}
@@ -210,9 +211,85 @@ public class AutomatonQueries {
         return a;
     }
 
+    /**
+     * Collapses consecutive repetition operators ({@code +}, {@code *}, {@code ?}) in a Lucene regex
+     * pattern down to a single, language-equivalent operator. Stacking quantifiers is always
+     * semantically redundant (e.g. {@code x+++} = {@code x+}, {@code x+?} = {@code x*}) and causes
+     * exponential NFA state growth in {@link org.apache.lucene.util.automaton.RegExp#toAutomaton()},
+     * leading to OOM.
+     * <p>
+     * The scan respects escape sequences ({@code \+}), character classes ({@code [+*?]}), and
+     * Lucene quoted strings ({@code "+++"}) where these characters are literals.
+     *
+     * @param pattern the raw regex pattern string
+     * @return the pattern with redundant consecutive quantifiers collapsed
+     * @throws NullPointerException if {@code pattern} is {@code null}
+     */
+    public static String collapseConsecutiveQuantifiers(String pattern) {
+        Objects.requireNonNull(pattern, "pattern must not be null");
+        final int length = pattern.length();
+        StringBuilder sb = new StringBuilder(length);
+        boolean inCharClass = false;
+        boolean inQuotedString = false;
+        boolean prevWasQuantifier = false;
+        for (int i = 0; i < length; i++) {
+            char c = pattern.charAt(i);
+            if (c == '\\' && i + 1 < length) {
+                sb.append(c);
+                sb.append(pattern.charAt(i + 1));
+                i++;
+                prevWasQuantifier = false;
+            } else if (inQuotedString) {
+                sb.append(c);
+                if (c == '"') {
+                    inQuotedString = false;
+                }
+                prevWasQuantifier = false;
+            } else if (inCharClass) {
+                sb.append(c);
+                if (c == ']') {
+                    inCharClass = false;
+                }
+                prevWasQuantifier = false;
+            } else if (c == '"') {
+                sb.append(c);
+                inQuotedString = true;
+                prevWasQuantifier = false;
+            } else if (c == '[') {
+                sb.append(c);
+                inCharClass = true;
+                prevWasQuantifier = false;
+            } else if (c == '+' || c == '*' || c == '?') {
+                if (prevWasQuantifier == false) {
+                    sb.append(c);
+                    prevWasQuantifier = true;
+                } else {
+                    int previousQuantifierIndex = sb.length() - 1;
+                    sb.setCharAt(previousQuantifierIndex, collapseConsecutiveQuantifierPair(sb.charAt(previousQuantifierIndex), c));
+                }
+            } else {
+                sb.append(c);
+                prevWasQuantifier = false;
+            }
+        }
+        return sb.toString();
+    }
+
+    private static char collapseConsecutiveQuantifierPair(char existing, char incoming) {
+        assert isRepetitionOperator(existing) && isRepetitionOperator(incoming)
+            : "expected repetition operators but got [" + existing + "] and [" + incoming + "]";
+        if (existing == incoming) {
+            return existing;
+        }
+        return '*';
+    }
+
+    private static boolean isRepetitionOperator(char c) {
+        return c == '+' || c == '*' || c == '?';
+    }
+
     public static Automaton toCaseInsensitiveChar(int codepoint) {
         Automaton case1 = Automata.makeChar(codepoint);
-        // For now we only work with ASCII characters
         if (codepoint > 128) {
             return case1;
         }
@@ -220,7 +297,6 @@ public class AutomatonQueries {
         Automaton result;
         if (altCase != codepoint) {
             result = Operations.union(case1, Automata.makeChar(altCase));
-            // this automaton should always be deterministic, no need to determinize
             assert result.isDeterministic();
         } else {
             result = case1;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1047,6 +1047,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (isIndexed()) {
                 return super.regexpQuery(value, syntaxFlags, matchFlags, maxDeterminizedStates, method, context);
             } else {
+                value = AutomatonQueries.collapseConsecutiveQuantifiers(value);
                 if (matchFlags != 0) {
                     throw new IllegalArgumentException("Match flags not yet implemented [" + matchFlags + "]");
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringFieldType.java
@@ -230,6 +230,7 @@ public abstract class StringFieldType extends TermBasedFieldType {
         }
         failIfNotIndexed();
 
+        value = AutomatonQueries.collapseConsecutiveQuantifiers(value);
         AutomatonQuery query;
         Term term = new Term(name(), indexedValueForSearch(value));
         CircuitBreaker circuitBreaker = context.getCircuitBreaker();

--- a/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RegexpQueryBuilder.java
@@ -289,7 +289,8 @@ public class RegexpQueryBuilder extends AbstractQueryBuilder<RegexpQueryBuilder>
             }
         }
         AutomatonQuery query;
-        Term term = new Term(fieldName, BytesRefs.toBytesRef(value));
+        String safeValue = AutomatonQueries.collapseConsecutiveQuantifiers(value);
+        Term term = new Term(fieldName, BytesRefs.toBytesRef(safeValue));
         if (context.getCircuitBreaker() != null) {
             Automaton dfa = AutomatonQueries.toRegexpAutomaton(
                 term,

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -34,6 +34,7 @@ import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -732,6 +733,7 @@ public class QueryStringQueryParser extends QueryParser {
                     + "] index level setting."
             );
         }
+        termStr = AutomatonQueries.collapseConsecutiveQuantifiers(termStr);
         Map<String, Float> fields = extractMultiFields(field, false);
         if (fields.isEmpty()) {
             return newUnmappedFieldQuery(termStr);

--- a/server/src/test/java/org/elasticsearch/common/lucene/search/AutomatonQueriesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/search/AutomatonQueriesTests.java
@@ -9,9 +9,12 @@
 
 package org.elasticsearch.common.lucene.search;
 
+import org.apache.lucene.tests.util.automaton.AutomatonTestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Locale;
@@ -86,4 +89,118 @@ public class AutomatonQueriesTests extends ESTestCase {
         br = new BytesRef(s + randomRealisticUnicodeOfLengthBetween(10, 20));
         assertTrue(runAutomaton.run(br.bytes, br.offset, br.length));
     }
+
+    public void testCollapseConsecutiveQuantifierStacksUpToThree() {
+        // Generates all +/*/? stacks of length 1..3 and verifies collapse and language equivalence
+        // (e.g. a++ -> a+, a+? -> a*, a+*? -> a*).
+        char[] quantifiers = new char[] { '+', '*', '?' };
+        for (int length = 1; length <= 3; length++) {
+            int combinations = (int) Math.pow(quantifiers.length, length);
+            for (int i = 0; i < combinations; i++) {
+                String stack = toQuantifierStack(i, length, quantifiers);
+                char collapsedQuantifier = expectedCollapsedQuantifier(stack);
+                assertCollapsedAndLanguagePreserved("a" + stack, "a" + collapsedQuantifier);
+            }
+        }
+    }
+
+    public void testCollapseConsecutiveQuantifiersPathologicalPattern() {
+        assertCollapsedAndLanguagePreserved("(ab)+++.+.???.*", "(ab)+.+.?.*");
+        assertCollapsedAndLanguagePreserved("(ab)+++++??*", "(ab)*");
+        assertCollapsedAndLanguagePreserved("(.[^A-Za-z0-9_])?Ben+++++.?", "(.[^A-Za-z0-9_])?Ben+.?");
+    }
+
+    public void testCollapseConsecutiveQuantifiersHandlesEscapes() {
+        assertCollapsedAndLanguagePreserved("a\\+\\+\\+", "a\\+\\+\\+");
+        assertCollapsedAndLanguagePreserved("a+\\++", "a+\\++");
+        assertCollapsedAndLanguagePreserved("\\+\\*\\?", "\\+\\*\\?");
+    }
+
+    public void testCollapseConsecutiveQuantifiersHandlesCharClasses() {
+        assertCollapsedAndLanguagePreserved("[+*?]+", "[+*?]+");
+        assertCollapsedAndLanguagePreserved("[+++]+", "[+++]+");
+        assertCollapsedAndLanguagePreserved("[^+*?]++", "[^+*?]+");
+    }
+
+    public void testCollapseConsecutiveQuantifiersHandlesQuotedStrings() {
+        assertCollapsedAndLanguagePreserved("\"+++\"a+", "\"+++\"a+");
+        assertCollapsedAndLanguagePreserved("\"***\"b+", "\"***\"b+");
+        assertCollapsedAndLanguagePreserved("a+\"+++\"b+", "a+\"+++\"b+");
+    }
+
+    public void testCollapseConsecutiveQuantifiersEmptyAndSimplePatterns() {
+        assertCollapsedAndLanguagePreserved("", "");
+        assertCollapsedAndLanguagePreserved("abc", "abc");
+        assertCollapsedAndLanguagePreserved(".", ".");
+    }
+
+    public void testCollapseConsecutiveQuantifiersTrailingBackslash() {
+        assertCollapsedAndInvalidRegexHandled("a\\", "a\\");
+    }
+
+    public void testCollapseConsecutiveQuantifiersResetsOnNonQuantifier() {
+        assertCollapsedAndLanguagePreserved("a++b++", "a+b+");
+        assertCollapsedAndLanguagePreserved("a??z**", "a?z*");
+    }
+
+    public void testCollapseConsecutiveQuantifiersUnclosedQuoteOrClass() {
+        assertCollapsedAndInvalidRegexHandled("\"+++", "\"+++");
+        assertCollapsedAndInvalidRegexHandled("[+++", "[+++");
+    }
+
+    public void testCollapseConsecutiveQuantifiersNullPattern() {
+        expectThrows(NullPointerException.class, () -> AutomatonQueries.collapseConsecutiveQuantifiers(null));
+    }
+
+    private static void assertCollapsed(String input, String expected) {
+        assertEquals(expected, AutomatonQueries.collapseConsecutiveQuantifiers(input));
+    }
+
+    private static void assertCollapsedAndLanguagePreserved(String pattern, String collapsed) {
+        assertCollapsed(pattern, collapsed);
+        Automaton originalAutomaton = Operations.determinize(new RegExp(pattern).toAutomaton(), 10_000);
+        Automaton collapsedAutomaton = Operations.determinize(new RegExp(collapsed).toAutomaton(), 10_000);
+        assertTrue(
+            "collapsed regex must accept the same language, pattern=[" + pattern + "], collapsed=[" + collapsed + "]",
+            AutomatonTestUtil.sameLanguage(originalAutomaton, collapsedAutomaton)
+        );
+    }
+
+    private void assertCollapsedAndInvalidRegexHandled(String pattern, String expectedCollapsed) {
+        assertCollapsed(pattern, expectedCollapsed);
+        Exception original = expectThrows(IllegalArgumentException.class, () -> new RegExp(pattern).toAutomaton());
+        Exception reduced = expectThrows(IllegalArgumentException.class, () -> new RegExp(expectedCollapsed).toAutomaton());
+        assertEquals(original.getMessage(), reduced.getMessage());
+    }
+
+    private static String toQuantifierStack(int value, int length, char[] quantifiers) {
+        char[] stack = new char[length];
+        for (int i = length - 1; i >= 0; i--) {
+            stack[i] = quantifiers[value % quantifiers.length];
+            value /= quantifiers.length;
+        }
+        return new String(stack);
+    }
+
+    private static char expectedCollapsedQuantifier(String stack) {
+        boolean seenPlus = false;
+        boolean seenStar = false;
+        boolean seenQuestion = false;
+        for (char c : stack.toCharArray()) {
+            switch (c) {
+                case '+' -> seenPlus = true;
+                case '*' -> seenStar = true;
+                case '?' -> seenQuestion = true;
+                default -> throw new IllegalArgumentException("unexpected quantifier [" + c + "]");
+            }
+        }
+        if (seenStar || (seenPlus && seenQuestion)) {
+            return '*';
+        }
+        if (seenPlus) {
+            return '+';
+        }
+        return '?';
+    }
+
 }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Collapse pathological regex quantifier stacking to prevent NFA construction (#145452)