### PR TITLE
[Test] Unmute ClusterConnectionManagerTests.testDisconnectLogging

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -376,9 +376,6 @@ tests:
 - class: org.elasticsearch.transport.TransportHandshakerTests
   method: testHandshakeError
   issue: https://github.com/elastic/elasticsearch/issues/146743
-- class: org.elasticsearch.transport.ClusterConnectionManagerTests
-  method: testDisconnectLogging
-  issue: https://github.com/elastic/elasticsearch/issues/146743
 - class: org.elasticsearch.transport.RemoteClusterClientTests
   method: testEnsureWeReconnect
   issue: https://github.com/elastic/elasticsearch/issues/146743


### PR DESCRIPTION
It was a fallout due to #146743. It can now be unmuted since the actual test causing the failure is muted.

Relates #146698
