### PR TITLE
[8.19] Unmute AccountableQueryCircuitBreakerIT tests

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
@@ -216,7 +216,9 @@ public class AccountableQueryCircuitBreakerIT extends ESIntegTestCase {
     private void assertQueryMemoryReleased(QueryBuilder query) throws Exception {
         long baseline = getRequestBreakerEstimated();
         client().prepareSearch(INDEX_NAME).setQuery(query).get().decRef();
-        long estimated = getRequestBreakerEstimated();
-        assertEquals("Request breaker memory should be released after search completes", baseline, estimated);
+        assertBusy(() -> {
+            long estimated = getRequestBreakerEstimated();
+            assertEquals("Request breaker memory should be released after search completes", baseline, estimated);
+        });
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Unmute AccountableQueryCircuitBreakerIT tests (#145536 

Closes #146764