### PR TITLE
[9.4] ESQL - Fix source loader filter when vectors are excluded (#146223)

### DIFF
--- a/docs/changelog/146223.yaml
+++ b/docs/changelog/146223.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 145799
+pr: 146223
+summary: ESQL - Fix performance loading source when vectors are excluded
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -639,15 +639,21 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
 
         @Override
         public SourceLoader newSourceLoader(Set<String> sourcePaths) {
+            var filter = buildSourceFilter(sourcePaths, ctx.getMappingLookup(), ctx.getIndexSettings());
+            return ctx.newSourceLoader(filter, false);
+        }
+
+        static SourceFilter buildSourceFilter(Set<String> sourcePaths, MappingLookup mappingLookup, IndexSettings indexSettings) {
             var filter = sourcePaths != null ? new SourceFilter(sourcePaths.toArray(new String[0]), null) : null;
             // Apply vector exclusion logic similar to ShardGetService
             var fetchSourceContext = filter != null ? FetchSourceContext.of(true, null, filter.getIncludes(), filter.getExcludes()) : null;
-            var result = maybeExcludeVectorFields(ctx.getMappingLookup(), ctx.getIndexSettings(), fetchSourceContext, null);
+            var result = maybeExcludeVectorFields(mappingLookup, indexSettings, fetchSourceContext, null);
             var vectorFilter = result.v2();
             if (vectorFilter != null) {
-                filter = vectorFilter;
+                var includes = filter != null ? filter.getIncludes() : new String[0];
+                filter = new SourceFilter(includes, vectorFilter.getExcludes());
             }
-            return ctx.newSourceLoader(filter, false);
+            return filter;
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProvidersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProvidersTests.java
@@ -44,7 +44,9 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.SearchExecutionContextHelper;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.internal.AliasFilter;
+import org.elasticsearch.search.lookup.SourceFilter;
 import org.elasticsearch.test.IndexSettingsModule;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.TemporalityAttribute;
@@ -59,6 +61,7 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 
 import static java.util.Collections.emptyMap;
@@ -357,6 +360,43 @@ public class EsPhysicalOperationProvidersTests extends MapperServiceTestCase {
             "Line -1:-1: java.lang.IllegalArgumentException: configured temporality field [metric_temporality] must be a time-series "
                 + "dimension; assuming default temporality for all values"
         );
+    }
+
+    /**
+     * Verifies that when {@code index.mapping.exclude_source_vectors} is enabled,
+     * the source filter retains the original field includes from the ES|QL projection
+     * instead of replacing them with an include-all filter.
+     */
+    public void testSourceFilterPreservesIncludesWhenVectorFieldsExcluded() throws IOException {
+        var indexSettings = Settings.builder().put("index.mapping.exclude_source_vectors", true).build();
+        var mapperService = createMapperService(indexSettings, mapping(b -> {
+            b.startObject("text_field").field("type", "text").endObject();
+            b.startObject("keyword_field").field("type", "keyword").endObject();
+            b.startObject("other_field").field("type", "keyword").endObject();
+            b.startObject("embedding").field("type", "dense_vector").field("dims", 3).endObject();
+        }));
+        var searchExecutionContext = createSearchExecutionContext(mapperService, null);
+
+        SourceFilter filter = EsPhysicalOperationProviders.DefaultShardContext.buildSourceFilter(
+            Set.of("text_field", "keyword_field"),
+            searchExecutionContext.getMappingLookup(),
+            searchExecutionContext.getIndexSettings()
+        );
+
+        assertNotNull("filter must not be null", filter);
+
+        var docSource = org.elasticsearch.search.lookup.Source.fromMap(
+            Map.of("text_field", "hello", "keyword_field", "world", "other_field", "extra", "embedding", List.of(1, 2, 3)),
+            XContentType.JSON
+        );
+        var filtered = filter.filterMap(docSource);
+        var result = filtered.source();
+
+        assertThat("text_field must be present", result.containsKey("text_field"), equalTo(true));
+        assertThat("keyword_field must be present", result.containsKey("keyword_field"), equalTo(true));
+        assertThat("other_field must be excluded", result.containsKey("other_field"), equalTo(false));
+        assertThat("embedding must be excluded", result.containsKey("embedding"), equalTo(false));
+        assertThat("exactly 2 fields survive", result.size(), equalTo(2));
     }
 
     private ValuesSourceReaderOperator.LoaderAndConverter temporalityLoader(EsPhysicalOperationProviders provider) {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ESQL - Fix source loader filter when vectors are excluded (#146223)