### PR TITLE
[backport] ES|QL: Fix pruning of Project columns in FORK branches (#146473)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
@@ -1011,4 +1011,56 @@ FROM books METADATA _score
 author:text | _fork:keyword | total:long
 ;
 
+forkWithFinalStatsCount
+required_capability: fork_v9
+required_capability: fork_prune_all_columns_fix
 
+from employees
+| stats x = count(*), y = count(*) by emp_no
+| FORK (where emp_no > 10050)
+| stats y = count(*)
+;
+
+y:long
+50
+;
+
+forkWithEmptyBranchOutputs
+required_capability: fork_v9
+required_capability: fork_prune_all_columns_fix
+
+from employees
+| fork ( stats salary = count(*)::int, z = count(*) by gender
+        | where NOT starts_with(gender, "v")
+        | eval gender = gender::keyword )
+       ( stats gender = values(gender), z = count(*) by salary
+        | where salary > 100000 )
+       ( where emp_no > 10050
+        | eval gender = gender::keyword )
+| sort salary
+| stats y = count(*)
+;
+
+y:long
+52
+;
+
+forkWithEmptyBranchOutputsAndNoRows
+required_capability: fork_v9
+required_capability: fork_prune_all_columns_fix
+
+from employees
+| fork ( stats salary = count(*)::int, z = count(*) by gender
+        | where starts_with(gender, "zzz")
+        | eval gender = gender::keyword )
+       ( stats gender = values(gender), z = count(*) by salary
+        | where salary < 0 )
+       ( where emp_no < 0
+        | eval gender = gender::keyword )
+| sort salary
+| stats y = count(*)
+;
+
+y:long
+0
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2495,6 +2495,11 @@ public class EsqlCapabilities {
         FIX_STARTS_WITH_ENDS_WITH_PUSHDOWN_ON_INDEX,
 
         /**
+         * Fix for column pruning in FORK.
+         */
+        FORK_PRUNE_ALL_COLUMNS_FIX,
+
+        /**
          * Fix TBUCKET with a numeric bucket count returning a verification exception instead of empty results
          * when the top-level request filter covers a time range with no matching indices.
          * See https://github.com/elastic/elasticsearch/issues/146354

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -35,9 +35,7 @@ import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneEmptyPlans.skipPlan;
@@ -235,10 +233,9 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
         AttributeSet.Builder builder = AttributeSet.builder();
         // if any of the fork outputs are used, keep them
         // otherwise, prune them based on the rest of the plan's usage
-        Set<String> names = new HashSet<>(used.build().names());
         for (var attr : fork.output()) {
             // we should also ensure to keep any synthetic attributes around as those could still be used for internal processing
-            if (attr.synthetic() || names.contains(attr.name())) {
+            if (attr.synthetic() || used.contains(attr)) {
                 builder.add(attr);
             } else {
                 forkOutputChanged = true;
@@ -258,8 +255,20 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
                 var outputAttrs = localRelation.output().stream().filter(x -> forkOutputNames.contains(x.name())).toList();
                 newSubPlan = new LocalRelation(localRelation.source(), outputAttrs, localRelation.supplier());
             } else {
+                // otherwise, we first prune the projections of the top-level Project of each subplan
                 subPlan.outputSet().stream().filter(x -> forkOutputNames.contains(x.name())).forEach(usedAttrs::add);
-                newSubPlan = pruneColumns(subPlan, usedAttrs, false);
+
+                Holder<Boolean> projectVisited = new Holder<>(false);
+                newSubPlan = subPlan.transformDown(Project.class, p -> {
+                    if (projectVisited.get()) {
+                        return p;
+                    }
+                    projectVisited.set(true);
+                    // filter projections based on fork output attributes
+                    var prunedAttrs = p.projections().stream().filter(x -> forkOutputNames.contains(x.name())).toList();
+                    return new Project(p.source(), p.child(), prunedAttrs);
+                });
+                newSubPlan = pruneColumns(newSubPlan, usedAttrs, false);
             }
             if (false == newSubPlan.equals(subPlan)) {
                 subPlanChanged = true;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/ProjectAwayColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/ProjectAwayColumns.java
@@ -55,6 +55,12 @@ public class ProjectAwayColumns extends Rule<PhysicalPlan, PhysicalPlan> {
             // for non-unary execution plans, we apply the rule for each child
             if (currentPlanNode instanceof MergeExec mergeExec) {
                 keepTraversing.set(FALSE);
+
+                if (mergeExec.output().isEmpty()) {
+                    // we have already pruned all columns, no need to apply the rule further down
+                    return mergeExec;
+                }
+
                 List<PhysicalPlan> newChildren = new ArrayList<>();
                 boolean changed = false;
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -215,7 +215,6 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.util.TestUtils.stripThrough;
-import static org.elasticsearch.xpack.esql.optimizer.rules.physical.ProjectAwayColumns.ALL_FIELDS_PROJECTED;
 import static org.elasticsearch.xpack.esql.parser.ExpressionBuilder.MAX_EXPRESSION_DEPTH;
 import static org.elasticsearch.xpack.esql.parser.LogicalPlanBuilder.MAX_QUERY_DEPTH;
 import static org.elasticsearch.xpack.esql.plan.physical.AbstractPhysicalPlanSerializationTests.randomEstimatedRowSize;
@@ -3793,20 +3792,20 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     }
 
     /**
+     * {@snippet lang="text":
      * LimitExec[1000[INTEGER],8]
-     * \_AggregateExec[[],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS cnt#4],SINGLE,[$$cnt$count{r}#5, $$cnt$seen{r}#6],8]
-     *   \_MergeExec[[&lt;all-fields-projected&gt;{r$}#7]]
-     *     |_ExchangeExec[[&lt;all-fields-projected&gt;{r$}#7],false]
-     *     | \_ProjectExec[[&lt;all-fields-projected&gt;{r$}#7]]
-     *     |   \_EvalExec[[null[NULL] AS &lt;all-fields-projected&gt;#7]]
-     *     |     \_EsQueryExec[no_fields_index]
-     *     \_ExchangeExec[[&lt;all-fields-projected&gt;{r$}#8],false]
-     *       \_ProjectExec[[&lt;all-fields-projected&gt;{r$}#8]]
-     *         \_EvalExec[[null[NULL] AS &lt;all-fields-projected&gt;#8]]
-     *           \_EsQueryExec[no_fields_index]
+     * \_AggregateExec[[],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count()#3],SINGLE,[$$count()$count{r}#4, $$count()$
+     * seen{r}#5],8]
+     *   \_MergeExec[[]]
+     *     |_ExchangeExec[[],false]
+     *     | \_ProjectExec[[]]
+     *     |   \_EsQueryExec[no_fields_index], ...]
+     *     \_ExchangeExec[[],false]
+     *       \_ProjectExec[[]]
+     *         \_EsQueryExec[no_fields_index], ...]
+     * }
      */
     public void testProjectAwayColumnsWithSubqueryCount() {
-        assumeTrue("Prune no-fields in subquery", EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND_PRUNE_NO_FIELDS.isEnabled());
         for (String count : List.of("count()", "count(*)", "count(1)")) {
             String query = LoggerMessageFormat.format(null, """
                 FROM no_fields_index, (FROM no_fields_index)
@@ -3817,22 +3816,15 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             LimitExec limit = as(plan, LimitExec.class);
             AggregateExec agg = as(limit.child(), AggregateExec.class);
             MergeExec merge = as(agg.child(), MergeExec.class);
-            assertEquals(1, merge.output().size());
-            Attribute attribute = merge.output().getFirst();
-            assertEquals(ALL_FIELDS_PROJECTED, attribute.name());
+            assertEquals(0, merge.output().size());
             assertEquals(2, merge.children().size());
 
             for (PhysicalPlan child : merge.children()) {
                 ExchangeExec exchange = as(child, ExchangeExec.class);
-                assertEquals(1, exchange.output().size());
-                Attribute attr = exchange.output().getFirst();
-                assertEquals(ALL_FIELDS_PROJECTED, attr.name());
+                assertEquals(0, exchange.output().size());
                 ProjectExec project = as(exchange.child(), ProjectExec.class);
-                assertEquals(1, project.projections().size());
-                NamedExpression namedExpression = project.projections().get(0);
-                assertEquals(ALL_FIELDS_PROJECTED, namedExpression.name());
-                EvalExec eval = as(project.child(), EvalExec.class);
-                EsQueryExec esQuery = as(eval.child(), EsQueryExec.class);
+                assertEquals(0, project.projections().size());
+                EsQueryExec esQuery = as(project.child(), EsQueryExec.class);
                 assertEquals("no_fields_index", esQuery.indexPattern());
             }
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumnsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumnsTests.java
@@ -1289,6 +1289,113 @@ public class PruneColumnsTests extends AbstractLogicalPlanOptimizerTests {
         }
     }
 
+    /**
+     * {@snippet lang="text":
+     * Limit[1000[INTEGER],false,false]
+     * \_Aggregate[[],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS y#28]]
+     *   \_Fork[[]]
+     *     |_Project[[]]
+     *     | \_Filter[NOT(STARTSWITH(gender{f}#31,v[KEYWORD]))]
+     *     |   \_Aggregate[[gender{f}#31],[gender{f}#31]]
+     *     |     \_EsRelation[employees][_meta_field{f}#35, emp_no{f}#29, first_name{f}#30, ..]
+     *     |_Project[[]]
+     *     | \_Filter[salary{f}#45 > 100000[INTEGER]]
+     *     |   \_Aggregate[[salary{f}#45],[salary{f}#45]]
+     *     |     \_EsRelation[employees][_meta_field{f}#46, emp_no{f}#40, first_name{f}#41, ..]
+     *     \_Project[[]]
+     *       \_Filter[emp_no{f}#51 > 10000[INTEGER]]
+     *         \_EsRelation[employees][_meta_field{f}#57, emp_no{f}#51, first_name{f}#52, ..]
+     * }
+     */
+    public void testPruneColumnsInForkBranchesWithFinalCountStats() {
+        var query = """
+             from employees
+             // reusing the same column name as in the final STATS
+            | FORK ( stats salary = count(*)::int, z = count(*) by gender
+                    | where NOT starts_with(gender, "v")
+                    | eval gender = gender::keyword )
+                   ( stats gender = values(gender), z = count(*) by salary
+                    | where salary > 100000 )
+                   ( where emp_no > 10000
+                    | eval gender = gender::keyword )
+            | sort salary
+            | stats y = count(*) // this removes all existing columns
+            """;
+
+        var plan = optimizedPlan(query);
+        var limit = as(plan, Limit.class);
+        var aggregate = as(limit.child(), Aggregate.class);
+        assertThat(aggregate.aggregates().size(), equalTo(1));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("y"));
+        var fork = as(aggregate.child(), Fork.class);
+
+        assertThat(fork.output().size(), equalTo(0));
+        assertThat(fork.children().size(), equalTo(3));
+
+        var firstBranch = fork.children().getFirst();
+        var firstBranchProject = as(firstBranch, Project.class);
+        var firstBranchFilter = as(firstBranchProject.child(), Filter.class);
+        var firstBranchAggregate = as(firstBranchFilter.child(), Aggregate.class);
+        assertThat(firstBranchAggregate.aggregates().size(), equalTo(1));
+        assertThat(Expressions.names(firstBranchAggregate.aggregates()), contains("gender"));
+        var firstBranchRelation = as(firstBranchAggregate.child(), EsRelation.class);
+        assertThat(firstBranchRelation.output().stream().map(Attribute::name).collect(Collectors.toSet()), hasItems("gender"));
+
+        var secondBranch = fork.children().get(1);
+        var secondBranchProject = as(secondBranch, Project.class);
+        var secondBranchFilter = as(secondBranchProject.child(), Filter.class);
+        var secondBranchAggregate = as(secondBranchFilter.child(), Aggregate.class);
+        assertThat(secondBranchAggregate.aggregates().size(), equalTo(1));
+        assertThat(Expressions.names(secondBranchAggregate.aggregates()), contains("salary"));
+        var secondBranchRelation = as(secondBranchAggregate.child(), EsRelation.class);
+        assertThat(secondBranchRelation.output().stream().map(Attribute::name).collect(Collectors.toSet()), hasItems("salary"));
+
+        var thirdBranch = fork.children().get(2);
+        var thirdBranchProject = as(thirdBranch, Project.class);
+        var thirdBranchFilter = as(thirdBranchProject.child(), Filter.class);
+        var thirdBranchRelation = as(thirdBranchFilter.child(), EsRelation.class);
+        assertThat(thirdBranchRelation.output().stream().map(Attribute::name).collect(Collectors.toSet()), hasItems("emp_no", "gender"));
+    }
+
+    /**
+     * {@snippet lang="text":
+     * Limit[1000[INTEGER],false,false]
+     * \_Aggregate[[],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS y#12]]
+     *   \_Fork[[]]
+     *     \_Project[[]]
+     *       \_Filter[emp_no{f}#13 > 10000[INTEGER]]
+     *         \_Aggregate[[emp_no{f}#13],[emp_no{f}#13]]
+     *           \_EsRelation[employees][_meta_field{f}#19, emp_no{f}#13, first_name{f}#14, ..]
+     * }
+     */
+    public void testPruneColumnsInForkWithSingleBranchAndFinalStats() {
+        var query = """
+                 from employees
+                | stats x = count(*), y = count(*) by emp_no
+                | FORK (where emp_no > 10000)
+                | sort x
+                | stats y = count(*)
+            """;
+
+        var plan = optimizedPlan(query);
+        var limit = as(plan, Limit.class);
+        var aggregate = as(limit.child(), Aggregate.class);
+        assertThat(aggregate.aggregates().size(), equalTo(1));
+        assertThat(Expressions.names(aggregate.aggregates()), contains("y"));
+        var fork = as(aggregate.child(), Fork.class);
+        assertThat(fork.output().size(), equalTo(0));
+        assertThat(fork.children().size(), equalTo(1));
+
+        var project = as(fork.children().getFirst(), Project.class);
+        assertThat(project.projections().size(), equalTo(0));
+        var filter = as(project.child(), Filter.class);
+        var branchAggregate = as(filter.child(), Aggregate.class);
+        assertThat(branchAggregate.aggregates().size(), equalTo(1));
+        assertThat(Expressions.names(branchAggregate.aggregates()), contains("emp_no"));
+        var relation = as(branchAggregate.child(), EsRelation.class);
+        assertThat(relation.output().stream().map(Attribute::name).collect(Collectors.toSet()), hasItems("emp_no"));
+    }
+
     /*
      * Limit[1000[INTEGER],false,false]
      * \_InlineJoin[LEFT,[],[]]


### PR DESCRIPTION
manual backport of #146473