### PR TITLE
[ESQL] Support numeric range expansion in glob patterns

### DIFF
--- a/docs/changelog/146811.yaml
+++ b/docs/changelog/146811.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 146811
+summary: Support numeric range expansion in glob patterns
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/BraceExpander.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/BraceExpander.java
@@ -55,6 +55,8 @@ final class BraceExpander {
 
     /**
      * Expands all brace groups in the glob into a list of concrete path candidates.
+     * Supports both comma-separated alternatives ({@code {a,b,c}}) and numeric
+     * range expressions ({@code {N..M}}) with leading-zero preservation.
      * Returns {@code null} if the Cartesian product exceeds {@code maxExpansion},
      * signaling that the caller should fall back to listing.
      * Returns a single-element list containing the input if no braces are found.
@@ -71,8 +73,13 @@ final class BraceExpander {
         }
 
         String prefix = glob.substring(0, braceStart);
-        String[] alternatives = glob.substring(braceStart + 1, braceEnd).split(",", -1);
+        String braceContent = glob.substring(braceStart + 1, braceEnd);
         String suffix = glob.substring(braceEnd + 1);
+
+        String[] alternatives = expandBraceContent(braceContent);
+        if (alternatives == null || alternatives.length > maxExpansion) {
+            return null;
+        }
 
         List<String> result = new ArrayList<>();
         for (String alt : alternatives) {
@@ -89,5 +96,82 @@ final class BraceExpander {
             }
         }
         return result;
+    }
+
+    /**
+     * Interprets brace content as either a numeric range ({@code N..M}) or
+     * comma-separated alternatives. For ranges, both ascending and descending
+     * sequences are supported, and leading zeros are preserved when either operand
+     * has a leading zero (matching bash semantics: {@code {01..03}} pads, {@code {1..3}} does not).
+     * Returns {@code null} if the range exceeds the internal safety cap (100,000 elements).
+     */
+    private static String[] expandBraceContent(String content) {
+        int dotDot = content.indexOf("..");
+        if (dotDot > 0 && dotDot < content.length() - 2 && content.indexOf(',') < 0) {
+            String startStr = content.substring(0, dotDot);
+            String endStr = content.substring(dotDot + 2);
+            if (isNumeric(startStr) && isNumeric(endStr)) {
+                String[] rangeResult = expandNumericRange(startStr, endStr);
+                if (rangeResult != null) {
+                    return rangeResult;
+                }
+                return null;
+            }
+        }
+        return content.split(",", -1);
+    }
+
+    private static boolean isNumeric(String s) {
+        if (s.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < s.length(); i++) {
+            if (Character.isDigit(s.charAt(i)) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Nullable
+    private static String[] expandNumericRange(String startStr, String endStr) {
+        long start;
+        long end;
+        try {
+            start = Long.parseLong(startStr);
+            end = Long.parseLong(endStr);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+
+        int width = Math.max(startStr.length(), endStr.length());
+        boolean zeroPad = (startStr.length() > 1 && startStr.charAt(0) == '0') || (endStr.length() > 1 && endStr.charAt(0) == '0');
+
+        long count = (start <= end ? end - start : start - end) + 1;
+        if (count > 100_000) {
+            return null;
+        }
+
+        String[] result = new String[(int) count];
+        long step = start <= end ? 1 : -1;
+        long current = start;
+        for (int i = 0; i < count; i++) {
+            result[i] = zeroPad ? padWithZeros(current, width) : Long.toString(current);
+            current += step;
+        }
+        return result;
+    }
+
+    private static String padWithZeros(long value, int width) {
+        String str = Long.toString(value);
+        if (str.length() >= width) {
+            return str;
+        }
+        StringBuilder sb = new StringBuilder(width);
+        for (int i = str.length(); i < width; i++) {
+            sb.append('0');
+        }
+        sb.append(str);
+        return sb.toString();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/BraceExpander.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/BraceExpander.java
@@ -76,7 +76,7 @@ final class BraceExpander {
         String braceContent = glob.substring(braceStart + 1, braceEnd);
         String suffix = glob.substring(braceEnd + 1);
 
-        String[] alternatives = expandBraceContent(braceContent);
+        String[] alternatives = expandBraceContent(braceContent, maxExpansion);
         if (alternatives == null || alternatives.length > maxExpansion) {
             return null;
         }
@@ -103,15 +103,15 @@ final class BraceExpander {
      * comma-separated alternatives. For ranges, both ascending and descending
      * sequences are supported, and leading zeros are preserved when either operand
      * has a leading zero (matching bash semantics: {@code {01..03}} pads, {@code {1..3}} does not).
-     * Returns {@code null} if the range exceeds the internal safety cap (100,000 elements).
+     * Returns {@code null} if the range exceeds {@code maxExpansion}.
      */
-    private static String[] expandBraceContent(String content) {
+    private static String[] expandBraceContent(String content, int maxExpansion) {
         int dotDot = content.indexOf("..");
         if (dotDot > 0 && dotDot < content.length() - 2 && content.indexOf(',') < 0) {
             String startStr = content.substring(0, dotDot);
             String endStr = content.substring(dotDot + 2);
             if (isNumeric(startStr) && isNumeric(endStr)) {
-                String[] rangeResult = expandNumericRange(startStr, endStr);
+                String[] rangeResult = expandNumericRange(startStr, endStr, maxExpansion);
                 if (rangeResult != null) {
                     return rangeResult;
                 }
@@ -134,7 +134,7 @@ final class BraceExpander {
     }
 
     @Nullable
-    private static String[] expandNumericRange(String startStr, String endStr) {
+    private static String[] expandNumericRange(String startStr, String endStr, int maxExpansion) {
         long start;
         long end;
         try {
@@ -147,8 +147,13 @@ final class BraceExpander {
         int width = Math.max(startStr.length(), endStr.length());
         boolean zeroPad = (startStr.length() > 1 && startStr.charAt(0) == '0') || (endStr.length() > 1 && endStr.charAt(0) == '0');
 
-        long count = (start <= end ? end - start : start - end) + 1;
-        if (count > 100_000) {
+        long count;
+        if (start <= end) {
+            count = end - start + 1;
+        } else {
+            count = start - end + 1;
+        }
+        if (count < 0 || count > maxExpansion) {
             return null;
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/package-info.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/package-info.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Glob pattern matching and expansion for ES|QL external datasources.
+ *
+ * <p>This package handles path resolution for external data sources (S3, GCS, Azure, HTTP,
+ * local filesystem) by expanding user-supplied patterns into concrete object paths.
+ *
+ * <h2>Supported Patterns</h2>
+ *
+ * <table border="1">
+ * <caption>Glob pattern syntax reference</caption>
+ * <tr>
+ *   <th>Pattern</th>
+ *   <th>Description</th>
+ *   <th>Example</th>
+ *   <th>Matches</th>
+ * </tr>
+ * <tr>
+ *   <td>{@code *}</td>
+ *   <td>Matches zero or more characters within a single path segment (does not cross {@code /}).</td>
+ *   <td>{@code data/*.parquet}</td>
+ *   <td>{@code data/sales.parquet}, {@code data/orders.parquet}</td>
+ * </tr>
+ * <tr>
+ *   <td><code>**</code></td>
+ *   <td>Matches zero or more path segments, including nested directories.</td>
+ *   <td><code>data/&#42;&#42;/*.parquet</code></td>
+ *   <td>{@code data/2024/01/file.parquet}, {@code data/file.parquet}</td>
+ * </tr>
+ * <tr>
+ *   <td>{@code ?}</td>
+ *   <td>Matches exactly one character (not {@code /}).</td>
+ *   <td>{@code file-?.csv}</td>
+ *   <td>{@code file-A.csv}, {@code file-1.csv}</td>
+ * </tr>
+ * <tr>
+ *   <td>{@code [abc]}</td>
+ *   <td>Matches one character from the set. Supports ranges ({@code [0-9]}) and
+ *       negation ({@code [!abc]} or {@code [^abc]}).</td>
+ *   <td>{@code file-[0-9].csv}</td>
+ *   <td>{@code file-0.csv} through {@code file-9.csv}</td>
+ * </tr>
+ * <tr>
+ *   <td>{@code {a,b,c}}</td>
+ *   <td>Expands into one candidate per comma-separated alternative.
+ *       Multiple groups produce the Cartesian product.</td>
+ *   <td>{@code {sales,orders}/year={2024,2025}/*.parquet}</td>
+ *   <td>{@code sales/year=2024/*.parquet}, {@code sales/year=2025/*.parquet},
+ *       {@code orders/year=2024/*.parquet}, {@code orders/year=2025/*.parquet}</td>
+ * </tr>
+ * <tr>
+ *   <td>{@code {N..M}}</td>
+ *   <td>Numeric range expansion. Generates one candidate per integer in the range
+ *       (inclusive, ascending or descending). Leading zeros on either operand enable
+ *       zero-padded output using the wider operand's width (bash semantics).</td>
+ *   <td>{@code shard-{000..099}.parquet}</td>
+ *   <td>{@code shard-000.parquet}, {@code shard-001.parquet}, &hellip; {@code shard-099.parquet}</td>
+ * </tr>
+ * </table>
+ *
+ * <h2>Resolution Strategy</h2>
+ *
+ * <p>Patterns are resolved through one of two paths, chosen automatically:
+ * <ul>
+ *   <li><b>Brace-only fast path</b> &mdash; When the pattern contains only brace groups
+ *       ({@code {a,b}} or {@code {N..M}}) and no other metacharacters, each expanded candidate
+ *       is checked individually via {@code exists()} (HEAD request on cloud storage), avoiding
+ *       a potentially expensive listing operation.</li>
+ *   <li><b>Listing path</b> &mdash; When the pattern contains {@code *}, {@code ?}, or
+ *       {@code [...]}, objects are listed under the longest non-pattern prefix and filtered
+ *       through regex-based matching.</li>
+ * </ul>
+ *
+ * <p>Both paths respect the {@code esql.external.max_glob_expansion} cluster setting (default 100)
+ * which caps the number of expanded candidates from brace/range groups before falling back to listing,
+ * and the {@code esql.external.max_discovered_files} setting which caps total discovered files.
+ *
+ * @see org.elasticsearch.xpack.esql.datasources.glob.GlobExpander
+ * @see org.elasticsearch.xpack.esql.datasources.glob.BraceExpander
+ * @see org.elasticsearch.xpack.esql.datasources.glob.GlobMatcher
+ */
+package org.elasticsearch.xpack.esql.datasources.glob;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/BraceExpanderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/BraceExpanderTests.java
@@ -132,4 +132,127 @@ public class BraceExpanderTests extends ESTestCase {
     public void testExpandCapExceededByOneReturnsNull() {
         assertNull(BraceExpander.expand("{a,b}/{c,d}/{e,f}", 7));
     }
+
+    // -- numeric range expansion --
+
+    public void testExpandNumericRangeSimple() {
+        List<String> result = BraceExpander.expand("file-{1..5}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("file-1.parquet", "file-2.parquet", "file-3.parquet", "file-4.parquet", "file-5.parquet"), result);
+    }
+
+    public void testExpandNumericRangeZeroPadded() {
+        List<String> result = BraceExpander.expand("file-{000..003}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("file-000.parquet", "file-001.parquet", "file-002.parquet", "file-003.parquet"), result);
+    }
+
+    public void testExpandNumericRangeZeroPaddedMixedWidths() {
+        List<String> result = BraceExpander.expand("file-{08..12}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("file-08.parquet", "file-09.parquet", "file-10.parquet", "file-11.parquet", "file-12.parquet"), result);
+    }
+
+    public void testExpandNumericRangeDescending() {
+        List<String> result = BraceExpander.expand("file-{5..1}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("file-5.parquet", "file-4.parquet", "file-3.parquet", "file-2.parquet", "file-1.parquet"), result);
+    }
+
+    public void testExpandNumericRangeSingleValue() {
+        List<String> result = BraceExpander.expand("file-{7..7}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("file-7.parquet"), result);
+    }
+
+    public void testExpandNumericRangeExceedsCap() {
+        assertNull(BraceExpander.expand("file-{1..200}.parquet", 100));
+    }
+
+    public void testExpandNumericRangeCombinedWithCommaGroup() {
+        List<String> result = BraceExpander.expand("{a,b}/file-{1..3}.csv", 100);
+        assertNotNull(result);
+        assertEquals(6, result.size());
+        assertTrue(result.contains("a/file-1.csv"));
+        assertTrue(result.contains("a/file-2.csv"));
+        assertTrue(result.contains("a/file-3.csv"));
+        assertTrue(result.contains("b/file-1.csv"));
+        assertTrue(result.contains("b/file-2.csv"));
+        assertTrue(result.contains("b/file-3.csv"));
+    }
+
+    public void testExpandNumericRangeFromZero() {
+        List<String> result = BraceExpander.expand("part-{0..2}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("part-0.parquet", "part-1.parquet", "part-2.parquet"), result);
+    }
+
+    public void testExpandNumericRangeNoPaddingWithoutLeadingZero() {
+        List<String> result = BraceExpander.expand("file-{9..11}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("file-9.parquet", "file-10.parquet", "file-11.parquet"), result);
+    }
+
+    public void testExpandNumericRangePaddingWithLeadingZeroOnStart() {
+        List<String> result = BraceExpander.expand("file-{09..11}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("file-09.parquet", "file-10.parquet", "file-11.parquet"), result);
+    }
+
+    public void testIsBraceOnlyWithNumericRange() {
+        assertTrue(BraceExpander.isBraceOnly("file-{0..9}.parquet"));
+    }
+
+    public void testIsBraceOnlyWithNumericRangeAndStar() {
+        assertFalse(BraceExpander.isBraceOnly("dir/*/file-{0..9}.parquet"));
+    }
+
+    public void testExpandNumericRangeNotNumeric() {
+        List<String> result = BraceExpander.expand("{a..b}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("a..b.parquet"), result);
+    }
+
+    public void testExpandNumericRangeLargeZeroPadded() {
+        List<String> result = BraceExpander.expand("shard-{000..099}.parquet", 200);
+        assertNotNull(result);
+        assertEquals(100, result.size());
+        assertEquals("shard-000.parquet", result.get(0));
+        assertEquals("shard-050.parquet", result.get(50));
+        assertEquals("shard-099.parquet", result.get(99));
+    }
+
+    public void testExpandNumericRangeDescendingWithPadding() {
+        List<String> result = BraceExpander.expand("file-{003..001}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("file-003.parquet", "file-002.parquet", "file-001.parquet"), result);
+    }
+
+    public void testExpandNumericRangeExactlyAtCap() {
+        List<String> result = BraceExpander.expand("file-{1..100}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(100, result.size());
+        assertEquals("file-1.parquet", result.get(0));
+        assertEquals("file-100.parquet", result.get(99));
+    }
+
+    public void testExpandCommaWinsOverRange() {
+        List<String> result = BraceExpander.expand("{1,2..3}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("1.parquet", result.get(0));
+        assertEquals("2..3.parquet", result.get(1));
+    }
+
+    public void testExpandNumericRangeZeroToZero() {
+        List<String> result = BraceExpander.expand("file-{0..0}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("file-0.parquet"), result);
+    }
+
+    public void testExpandNumericRangeDoubleZeroPadded() {
+        List<String> result = BraceExpander.expand("file-{00..00}.parquet", 100);
+        assertNotNull(result);
+        assertEquals(List.of("file-00.parquet"), result);
+    }
 }


### PR DESCRIPTION
Extend BraceExpander to recognise {N..M} numeric range syntax
and expand it into concrete candidates, with leading-zero
preservation matching bash semantics. The existing max_glob_expansion
safety cap applies, so large ranges fall back to listing.

Developed with AI-assisted tooling