### PR TITLE
Flaky test: Add more logs to confirm a hypothesis of stale global CP

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -382,7 +382,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
             logShardStatus(indexName);
             IndicesStatsResponse stats = indicesAdmin().prepareStats(indexName).clear().setTranslog(true).get();
             assertThat(stats.getIndex(indexName), notNullValue());
-            var translogStats = stats.getIndex(indexName).getPrimaries().getTranslog();
+            final var translogStats = stats.getIndex(indexName).getPrimaries().getTranslog();
             logTranslogStats(translogStats, uncommittedTranslogOps);
             assertThat(translogStats.estimatedNumberOfOperations(), equalTo(uncommittedTranslogOps));
             assertThat(translogStats.getUncommittedOperations(), equalTo(uncommittedTranslogOps));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -402,11 +402,12 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     }
 
     /**
-     * @see <a href="https://github.com/elastic/elasticsearch/issues/146604">#45801</a>
+     * @see <a href="https://github.com/elastic/elasticsearch/issues/146604">#146604</a>
      */
     private void logShardStatus(String indexName) {
-        for (IndicesService indicesService : internalCluster().getDataNodeInstances(IndicesService.class)) {
-            final var index = internalCluster().clusterService().state().metadata().getProject().index(indexName).getIndex();
+        final var index = internalCluster().clusterService().state().metadata().getProject().index(indexName).getIndex();
+        for (String nodeName : internalCluster().nodesInclude(indexName)) {
+            IndicesService indicesService = internalCluster().getInstance(IndicesService.class, nodeName);
             IndexService indexService = indicesService.indexServiceSafe(index);
             for (IndexShard shard : indexService) {
                 if (shard.routingEntry().primary()) {
@@ -426,7 +427,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
 
     /**
      *
-     * @see <a href="https://github.com/elastic/elasticsearch/issues/146604">#45801</a>
+     * @see <a href="https://github.com/elastic/elasticsearch/issues/146604">#146604</a>
      */
     private void logTranslogStats(TranslogStats translogStats, int uncommittedTranslogOps) {
         logger.info(

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -23,7 +23,11 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.translog.TranslogStats;
+import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -373,14 +377,15 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         }
 
         final int uncommittedTranslogOps = uncommittedOps;
+
         assertBusy(() -> {
+            logShardStatus(indexName);
             IndicesStatsResponse stats = indicesAdmin().prepareStats(indexName).clear().setTranslog(true).get();
             assertThat(stats.getIndex(indexName), notNullValue());
-            assertThat(
-                stats.getIndex(indexName).getPrimaries().getTranslog().estimatedNumberOfOperations(),
-                equalTo(uncommittedTranslogOps)
-            );
-            assertThat(stats.getIndex(indexName).getPrimaries().getTranslog().getUncommittedOperations(), equalTo(uncommittedTranslogOps));
+            var translogStats = stats.getIndex(indexName).getPrimaries().getTranslog();
+            logTranslogStats(translogStats, uncommittedTranslogOps);
+            assertThat(translogStats.estimatedNumberOfOperations(), equalTo(uncommittedTranslogOps));
+            assertThat(translogStats.getUncommittedOperations(), equalTo(uncommittedTranslogOps));
         });
 
         assertAcked(indicesAdmin().prepareClose("test"));
@@ -394,5 +399,41 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         assertThat(stats.getIndex(indexName), notNullValue());
         assertThat(stats.getIndex(indexName).getPrimaries().getTranslog().estimatedNumberOfOperations(), equalTo(0));
         assertThat(stats.getIndex(indexName).getPrimaries().getTranslog().getUncommittedOperations(), equalTo(0));
+    }
+
+    /**
+     * @see <a href="https://github.com/elastic/elasticsearch/issues/146604">#45801</a>
+     */
+    private void logShardStatus(String indexName) {
+        for (IndicesService indicesService : internalCluster().getDataNodeInstances(IndicesService.class)) {
+            final var index = internalCluster().clusterService().state().metadata().getProject().index(indexName).getIndex();
+            IndexService indexService = indicesService.indexServiceSafe(index);
+            for (IndexShard shard : indexService) {
+                if (shard.routingEntry().primary()) {
+                    logger.info(
+                        "Shard [{}] status: lastKnownGlobalCheckpoint={}, lastSyncedGlobalCheckpoint={}, "
+                            + "localCheckpoint={}, maxSeqNo={}",
+                        shard.shardId(),
+                        shard.getLastKnownGlobalCheckpoint(),
+                        shard.getLastSyncedGlobalCheckpoint(),
+                        shard.seqNoStats().getLocalCheckpoint(),
+                        shard.seqNoStats().getMaxSeqNo()
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     *
+     * @see <a href="https://github.com/elastic/elasticsearch/issues/146604">#45801</a>
+     */
+    private void logTranslogStats(TranslogStats translogStats, int uncommittedTranslogOps) {
+        logger.info(
+            "TranslogStats: estimatedOps={}, uncommittedOps={}, expected={}",
+            translogStats.estimatedNumberOfOperations(),
+            translogStats.getUncommittedOperations(),
+            uncommittedTranslogOps
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -379,9 +379,9 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         final int uncommittedTranslogOps = uncommittedOps;
 
         assertBusy(() -> {
-            logShardStatus(indexName);
             IndicesStatsResponse stats = indicesAdmin().prepareStats(indexName).clear().setTranslog(true).get();
             assertThat(stats.getIndex(indexName), notNullValue());
+            logShardStatus(indexName);
             final var translogStats = stats.getIndex(indexName).getPrimaries().getTranslog();
             logTranslogStats(translogStats, uncommittedTranslogOps);
             assertThat(translogStats.estimatedNumberOfOperations(), equalTo(uncommittedTranslogOps));


### PR DESCRIPTION
The hypothesis is, the outdated synced global CP is causing some committed operations not to be trimmed. If this is the case, the logs could confirm it.

On the other hand, that's pretty strange we started observing in-memory vs synced global checkpoint causing failures recently. I wonder if there has been something else introduced to the production/test code that made it more likely to happen.

Relates: #146604 