### PR TITLE
DLM Frozen Tier Plugin Disabled On Stateless

### DIFF
--- a/x-pack/plugin/dlm-frozen-transition/build.gradle
+++ b/x-pack/plugin/dlm-frozen-transition/build.gradle
@@ -14,6 +14,7 @@ esplugin {
   description = 'A plugin for the frozen tier functionality of DLM'
   classname = 'org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionPlugin'
   extendedPlugins = ['data-streams', 'x-pack-core']
+  deploymentTarget = "STATEFUL_ONLY"
 }
 base {
   archivesName = 'x-pack-dlm-frozen-transition'


### PR DESCRIPTION
This PR specifies that the DLM Frozen Tier plugin should only be loaded in stateful environments