### PR TITLE
[9.2] Set lucene upper Java feature version for unit tests (#141461)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -143,6 +143,8 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
                     return List.of();
                 }
             });
+            test.getJvmArgumentProviders()
+                .add(() -> List.of("-Dorg.apache.lucene.vectorization.upperJavaFeatureVersion=" + test.getJavaVersion().getMajorVersion()));
 
             String argline = System.getProperty("tests.jvm.argline");
             if (argline != null) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Set lucene upper Java feature version for unit tests (#141461)](https://github.com/elastic/elasticsearch/pull/141461)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)