### PR TITLE
Revise title for Elasticsearch REST APIs

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/index.md
+++ b/docs/reference/elasticsearch/rest-apis/index.md
@@ -5,9 +5,10 @@ mapped_pages:
 applies_to:
   stack: ga
   serverless: ga
+navigation_title: REST APIs
 ---
 
-# REST APIs
+# Elasticsearch REST APIs
 
 Elasticsearch exposes REST APIs that are used by the UI components and can be called directly to configure and access Elasticsearch features.
 


### PR DESCRIPTION
Updated the REST APIs title and navigation title for clarity and to optimize for SEO.

New navigation title = REST APIs
New page title = Elasticsearch REST APIs
