### PR TITLE
Migrate percolator highlight sub-fetch to pooled SearchHit

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
@@ -97,39 +97,44 @@ final class PercolatorHighlightSubFetchPhase implements FetchSubPhase {
                             int slot = (int) matchedSlot;
                             BytesReference document = percolateQuery.getDocuments().get(slot);
                             leafStoredFields.advanceTo(slot);
-                            HitContext subContext = new HitContext(
-                                SearchHit.unpooled(slot, "unknown"),
-                                percolatorLeafReaderContext,
-                                slot,
-                                leafStoredFields.storedFields(),
-                                Source.fromBytes(document),
-                                null
-                            );
-                            processor.process(subContext);
-                            for (Map.Entry<String, HighlightField> entry : subContext.hit().getHighlightFields().entrySet()) {
-                                if (percolateQuery.getDocuments().size() == 1) {
-                                    String hlFieldName;
-                                    if (singlePercolateQuery) {
-                                        hlFieldName = entry.getKey();
+                            SearchHit subHit = new SearchHit(slot, "unknown");
+                            try {
+                                HitContext subContext = new HitContext(
+                                    subHit,
+                                    percolatorLeafReaderContext,
+                                    slot,
+                                    leafStoredFields.storedFields(),
+                                    Source.fromBytes(document),
+                                    null
+                                );
+                                processor.process(subContext);
+                                for (Map.Entry<String, HighlightField> entry : subContext.hit().getHighlightFields().entrySet()) {
+                                    if (percolateQuery.getDocuments().size() == 1) {
+                                        String hlFieldName;
+                                        if (singlePercolateQuery) {
+                                            hlFieldName = entry.getKey();
+                                        } else {
+                                            hlFieldName = percolateQuery.getName() + "_" + entry.getKey();
+                                        }
+                                        hit.hit()
+                                            .getHighlightFields()
+                                            .put(hlFieldName, new HighlightField(hlFieldName, entry.getValue().fragments()));
                                     } else {
-                                        hlFieldName = percolateQuery.getName() + "_" + entry.getKey();
+                                        // In case multiple documents are being percolated we need to identify to which document
+                                        // a highlight belongs to.
+                                        String hlFieldName;
+                                        if (singlePercolateQuery) {
+                                            hlFieldName = slot + "_" + entry.getKey();
+                                        } else {
+                                            hlFieldName = percolateQuery.getName() + "_" + slot + "_" + entry.getKey();
+                                        }
+                                        hit.hit()
+                                            .getHighlightFields()
+                                            .put(hlFieldName, new HighlightField(hlFieldName, entry.getValue().fragments()));
                                     }
-                                    hit.hit()
-                                        .getHighlightFields()
-                                        .put(hlFieldName, new HighlightField(hlFieldName, entry.getValue().fragments()));
-                                } else {
-                                    // In case multiple documents are being percolated we need to identify to which document
-                                    // a highlight belongs to.
-                                    String hlFieldName;
-                                    if (singlePercolateQuery) {
-                                        hlFieldName = slot + "_" + entry.getKey();
-                                    } else {
-                                        hlFieldName = percolateQuery.getName() + "_" + slot + "_" + entry.getKey();
-                                    }
-                                    hit.hit()
-                                        .getHighlightFields()
-                                        .put(hlFieldName, new HighlightField(hlFieldName, entry.getValue().fragments()));
                                 }
+                            } finally {
+                                subHit.decRef();
                             }
                         }
                     }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorMatchedSlotSubFetchPhaseTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorMatchedSlotSubFetchPhaseTests.java
@@ -56,93 +56,108 @@ public class PercolatorMatchedSlotSubFetchPhaseTests extends ESTestCase {
                 LeafReaderContext context = reader.leaves().get(0);
                 // A match:
                 {
-                    HitContext hit = new HitContext(SearchHit.unpooled(0), context, 0, Map.of(), Source.empty(null), null);
-                    PercolateQuery.QueryStore queryStore = ctx -> docId -> new TermQuery(new Term("field", "value"));
-                    MemoryIndex memoryIndex = new MemoryIndex();
-                    memoryIndex.addField("field", "value", new WhitespaceAnalyzer());
-                    memoryIndex.addField(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, 0), null);
-                    PercolateQuery percolateQuery = new PercolateQuery(
-                        "_name",
-                        queryStore,
-                        Collections.emptyList(),
-                        Queries.ALL_DOCS_INSTANCE,
-                        memoryIndex.createSearcher(),
-                        null,
-                        Queries.NO_DOCS_INSTANCE
-                    );
+                    SearchHit sh = new SearchHit(0);
+                    try {
+                        HitContext hit = new HitContext(sh, context, 0, Map.of(), Source.empty(null), null);
+                        PercolateQuery.QueryStore queryStore = ctx -> docId -> new TermQuery(new Term("field", "value"));
+                        MemoryIndex memoryIndex = new MemoryIndex();
+                        memoryIndex.addField("field", "value", new WhitespaceAnalyzer());
+                        memoryIndex.addField(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, 0), null);
+                        PercolateQuery percolateQuery = new PercolateQuery(
+                            "_name",
+                            queryStore,
+                            Collections.emptyList(),
+                            Queries.ALL_DOCS_INSTANCE,
+                            memoryIndex.createSearcher(),
+                            null,
+                            Queries.NO_DOCS_INSTANCE
+                        );
 
-                    FetchContext sc = mock(FetchContext.class);
-                    when(sc.query()).thenReturn(percolateQuery);
-                    SearchExecutionContext sec = mock(SearchExecutionContext.class);
-                    when(sc.getSearchExecutionContext()).thenReturn(sec);
-                    when(sec.indexVersionCreated()).thenReturn(IndexVersion.current());
+                        FetchContext sc = mock(FetchContext.class);
+                        when(sc.query()).thenReturn(percolateQuery);
+                        SearchExecutionContext sec = mock(SearchExecutionContext.class);
+                        when(sc.getSearchExecutionContext()).thenReturn(sec);
+                        when(sec.indexVersionCreated()).thenReturn(IndexVersion.current());
 
-                    FetchSubPhaseProcessor processor = phase.getProcessor(sc);
-                    assertNotNull(processor);
-                    processor.process(hit);
+                        FetchSubPhaseProcessor processor = phase.getProcessor(sc);
+                        assertNotNull(processor);
+                        processor.process(hit);
 
-                    assertNotNull(hit.hit().field(PercolatorMatchedSlotSubFetchPhase.FIELD_NAME_PREFIX));
-                    assertEquals(0, (int) hit.hit().field(PercolatorMatchedSlotSubFetchPhase.FIELD_NAME_PREFIX).getValue());
+                        assertNotNull(hit.hit().field(PercolatorMatchedSlotSubFetchPhase.FIELD_NAME_PREFIX));
+                        assertEquals(0, (int) hit.hit().field(PercolatorMatchedSlotSubFetchPhase.FIELD_NAME_PREFIX).getValue());
+                    } finally {
+                        sh.decRef();
+                    }
                 }
 
                 // No match:
                 {
-                    HitContext hit = new HitContext(SearchHit.unpooled(0), context, 0, Map.of(), Source.empty(null), null);
-                    PercolateQuery.QueryStore queryStore = ctx -> docId -> new TermQuery(new Term("field", "value"));
-                    MemoryIndex memoryIndex = new MemoryIndex();
-                    memoryIndex.addField("field", "value1", new WhitespaceAnalyzer());
-                    memoryIndex.addField(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, 0), null);
-                    PercolateQuery percolateQuery = new PercolateQuery(
-                        "_name",
-                        queryStore,
-                        Collections.emptyList(),
-                        Queries.ALL_DOCS_INSTANCE,
-                        memoryIndex.createSearcher(),
-                        null,
-                        Queries.NO_DOCS_INSTANCE
-                    );
+                    SearchHit sh = new SearchHit(0);
+                    try {
+                        HitContext hit = new HitContext(sh, context, 0, Map.of(), Source.empty(null), null);
+                        PercolateQuery.QueryStore queryStore = ctx -> docId -> new TermQuery(new Term("field", "value"));
+                        MemoryIndex memoryIndex = new MemoryIndex();
+                        memoryIndex.addField("field", "value1", new WhitespaceAnalyzer());
+                        memoryIndex.addField(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, 0), null);
+                        PercolateQuery percolateQuery = new PercolateQuery(
+                            "_name",
+                            queryStore,
+                            Collections.emptyList(),
+                            Queries.ALL_DOCS_INSTANCE,
+                            memoryIndex.createSearcher(),
+                            null,
+                            Queries.NO_DOCS_INSTANCE
+                        );
 
-                    FetchContext sc = mock(FetchContext.class);
-                    when(sc.query()).thenReturn(percolateQuery);
-                    SearchExecutionContext sec = mock(SearchExecutionContext.class);
-                    when(sc.getSearchExecutionContext()).thenReturn(sec);
-                    when(sec.indexVersionCreated()).thenReturn(IndexVersion.current());
+                        FetchContext sc = mock(FetchContext.class);
+                        when(sc.query()).thenReturn(percolateQuery);
+                        SearchExecutionContext sec = mock(SearchExecutionContext.class);
+                        when(sc.getSearchExecutionContext()).thenReturn(sec);
+                        when(sec.indexVersionCreated()).thenReturn(IndexVersion.current());
 
-                    FetchSubPhaseProcessor processor = phase.getProcessor(sc);
-                    assertNotNull(processor);
-                    processor.process(hit);
+                        FetchSubPhaseProcessor processor = phase.getProcessor(sc);
+                        assertNotNull(processor);
+                        processor.process(hit);
 
-                    assertNull(hit.hit().field(PercolatorMatchedSlotSubFetchPhase.FIELD_NAME_PREFIX));
+                        assertNull(hit.hit().field(PercolatorMatchedSlotSubFetchPhase.FIELD_NAME_PREFIX));
+                    } finally {
+                        sh.decRef();
+                    }
                 }
 
                 // No query:
                 {
-                    HitContext hit = new HitContext(SearchHit.unpooled(0), context, 0, Map.of(), Source.empty(null), null);
-                    PercolateQuery.QueryStore queryStore = ctx -> docId -> null;
-                    MemoryIndex memoryIndex = new MemoryIndex();
-                    memoryIndex.addField("field", "value", new WhitespaceAnalyzer());
-                    memoryIndex.addField(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, 0), null);
-                    PercolateQuery percolateQuery = new PercolateQuery(
-                        "_name",
-                        queryStore,
-                        Collections.emptyList(),
-                        Queries.ALL_DOCS_INSTANCE,
-                        memoryIndex.createSearcher(),
-                        null,
-                        Queries.NO_DOCS_INSTANCE
-                    );
+                    SearchHit sh = new SearchHit(0);
+                    try {
+                        HitContext hit = new HitContext(sh, context, 0, Map.of(), Source.empty(null), null);
+                        PercolateQuery.QueryStore queryStore = ctx -> docId -> null;
+                        MemoryIndex memoryIndex = new MemoryIndex();
+                        memoryIndex.addField("field", "value", new WhitespaceAnalyzer());
+                        memoryIndex.addField(new NumericDocValuesField(SeqNoFieldMapper.PRIMARY_TERM_NAME, 0), null);
+                        PercolateQuery percolateQuery = new PercolateQuery(
+                            "_name",
+                            queryStore,
+                            Collections.emptyList(),
+                            Queries.ALL_DOCS_INSTANCE,
+                            memoryIndex.createSearcher(),
+                            null,
+                            Queries.NO_DOCS_INSTANCE
+                        );
 
-                    FetchContext sc = mock(FetchContext.class);
-                    when(sc.query()).thenReturn(percolateQuery);
-                    SearchExecutionContext sec = mock(SearchExecutionContext.class);
-                    when(sc.getSearchExecutionContext()).thenReturn(sec);
-                    when(sec.indexVersionCreated()).thenReturn(IndexVersion.current());
+                        FetchContext sc = mock(FetchContext.class);
+                        when(sc.query()).thenReturn(percolateQuery);
+                        SearchExecutionContext sec = mock(SearchExecutionContext.class);
+                        when(sc.getSearchExecutionContext()).thenReturn(sec);
+                        when(sec.indexVersionCreated()).thenReturn(IndexVersion.current());
 
-                    FetchSubPhaseProcessor processor = phase.getProcessor(sc);
-                    assertNotNull(processor);
-                    processor.process(hit);
+                        FetchSubPhaseProcessor processor = phase.getProcessor(sc);
+                        assertNotNull(processor);
+                        processor.process(hit);
 
-                    assertNull(hit.hit().field(PercolatorMatchedSlotSubFetchPhase.FIELD_NAME_PREFIX));
+                        assertNull(hit.hit().field(PercolatorMatchedSlotSubFetchPhase.FIELD_NAME_PREFIX));
+                    } finally {
+                        sh.decRef();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Replaces `SearchHit.unpooled(slot, "unknown")` with `new SearchHit(slot, "unknown")` in `PercolatorHighlightSubFetchPhase`, wrapping the per-slot work in try/finally to ensure `subHit.decRef()` runs on both success and failure.

Updates the three `SearchHit.unpooled(0)` usages in `PercolatorMatchedSlotSubFetchPhaseTests` to `new SearchHit(0)` with the same try/finally + local `sh.decRef()` pattern.

Makes progress on https://github.com/elastic/elasticsearch/issues/99590.