### PR TITLE
Set graph degree on IVF_PQ CAGRA params (#146670)

### DIFF
--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
@@ -344,11 +344,13 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 var ivfPqIndexParams = cagraIndexParams.getCuVSIvfPqParams().getIndexParams();
                 logger.debug(
                     "Building CAGRA graph: numVectors=[{}], dims=[{}], algorithm=[{}], similarity=[{}], "
-                        + "pqDim=[{}], pqBits=[{}], nLists=[{}], dataType=[{}]",
+                        + "graphDegree=[{}], intermediateGraphDegree=[{}], pqDim=[{}], pqBits=[{}], nLists=[{}], dataType=[{}]",
                     dataset.size(),
                     dataset.columns(),
                     algorithm,
                     fieldInfo.getVectorSimilarityFunction(),
+                    cagraIndexParams.getGraphDegree(),
+                    cagraIndexParams.getIntermediateGraphDegree(),
                     ivfPqIndexParams.getPqDim(),
                     ivfPqIndexParams.getPqBits(),
                     ivfPqIndexParams.getnLists(),
@@ -380,6 +382,9 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         CuVSMatrix.DataType dataType,
         long totalDeviceMemory
     ) {
+        // CAGRA requires the intermediate graph degree to be strictly larger than the graph degree
+        intermediateGraphDegree = Math.max(graphDegree + 1, intermediateGraphDegree);
+
         CagraIndexParams.CuvsDistanceType distanceType = switch (similarityFunction) {
             case COSINE -> CagraIndexParams.CuvsDistanceType.CosineExpanded;
             case EUCLIDEAN -> CagraIndexParams.CuvsDistanceType.L2Expanded;
@@ -421,6 +426,9 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
             params = new CagraIndexParams.Builder().withNumWriterThreads(numCPUThreads)
                 .withCagraGraphBuildAlgo(CagraIndexParams.CagraGraphBuildAlgo.IVF_PQ)
                 .withCuVSIvfPqParams(ivfPqParams)
+                .withGraphDegree(graphDegree)
+                .withIntermediateGraphDegree(intermediateGraphDegree)
+                .withNNDescentNumIterations(5)
                 .withMetric(distanceType)
                 .build();
         } else {

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/CagraParameterTranslationTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/CagraParameterTranslationTests.java
@@ -105,6 +105,13 @@ public class CagraParameterTranslationTests extends ESTestCase {
         assertEquals(CagraIndexParams.CagraGraphBuildAlgo.IVF_PQ, largeParams.getCagraGraphBuildAlgo());
     }
 
+    public void testIvfPqGraphDegreeIsSet() {
+        var params = translateAndBuild(24, 200, 4_000_000, 1024, L4_GPU_MEMORY);
+        assertEquals(CagraIndexParams.CagraGraphBuildAlgo.IVF_PQ, params.getCagraGraphBuildAlgo());
+        assertEquals(18, params.getGraphDegree());
+        assertEquals(42, params.getIntermediateGraphDegree());
+    }
+
     public void testRtxPro6000AlgorithmSelection() {
         var params = translateAndBuild(24, 200, 4_000_000, 1024, RTX_PRO_6000_GPU_MEMORY);
         assertEquals(CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT, params.getCagraGraphBuildAlgo());


### PR DESCRIPTION
Set graph degree on IVF_PQ CAGRA params.

Pass graphDegree and intermediateGraphDegree to the  CagraIndexParams
builder on the IVF_PQ path so the graph  construction honors the values
translated from (m,  ef_construction). Also include both in the IVF_PQ
debug log.

Backport for https://github.com/elastic/elasticsearch/pull/146670