### PR TITLE
[9.3] Replace IllegalStateException with IllegalArgumentException for conflicting time series metadata (#142370)

### DIFF
--- a/docs/changelog/142370.yaml
+++ b/docs/changelog/142370.yaml
@@ -1,0 +1,6 @@
+area: TSDB
+issues: []
+pr: 142370
+summary: Replace `IllegalStateException` with `IllegalArgumentException` for conflicting
+  time series metadata
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/EsField.java
@@ -51,7 +51,7 @@ public class EsField implements Writeable {
                 if (other != DIMENSION) {
                     return METRIC;
                 }
-                throw new IllegalStateException("Time Series Metadata conflict.  Cannot merge [" + other + "] with [METRIC].");
+                throw new IllegalArgumentException("Time Series Metadata conflict.  Cannot merge [" + other + "] with [METRIC].");
             }
         },
         DIMENSION(3) {
@@ -60,7 +60,7 @@ public class EsField implements Writeable {
                 if (other != METRIC) {
                     return DIMENSION;
                 }
-                throw new IllegalStateException("Time Series Metadata conflict.  Cannot merge [" + other + "] with [DIMENSION].");
+                throw new IllegalArgumentException("Time Series Metadata conflict.  Cannot merge [" + other + "] with [DIMENSION].");
             }
         };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Replace IllegalStateException with IllegalArgumentException for conflicting time series metadata (#142370)](https://github.com/elastic/elasticsearch/pull/142370)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)