### PR TITLE
[9.4] ESQL: Fix COUNT+query push down losing aggs (#146555)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -5729,10 +5729,91 @@ from employees
 | limit 5
 ;
 
-   languages:i |    emp_no:i   |    gender:s   |     w_avg:d   |   w:i       
-2              |10001          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]      
-5              |10002          |F              |[1.0, 1.0, 1.0]|[1, 2, 3]      
-4              |10003          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]      
-5              |10004          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]      
-1              |10005          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]      
+   languages:i |    emp_no:i   |    gender:s   |     w_avg:d   |   w:i
+2              |10001          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]
+5              |10002          |F              |[1.0, 1.0, 1.0]|[1, 2, 3]
+4              |10003          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]
+5              |10004          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]
+1              |10005          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]
+;
+
+inlineStatsAbsentOnTopWithDateTrunc
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM date_nanos
+| STATS a = COUNT(*), y = TOP(DATE_TRUNC(1 year, millis), 2, "desc") BY num
+| INLINE STATS x = COUNT(*), z = ABSENT(y)
+| KEEP x, z, a
+;
+ignoreOrder:true
+
+x:long | z:boolean | a:long
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 2
+8      | false     | 2
+;
+
+inlineStatsAbsentOnMaxWithDateTrunc
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM date_nanos
+| STATS a = COUNT(*), y = MAX(DATE_TRUNC(1 year, millis)) BY num
+| INLINE STATS x = COUNT(*), z = ABSENT(y)
+| KEEP x, z, a
+;
+ignoreOrder:true
+
+x:long | z:boolean | a:long
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 2
+8      | false     | 2
+;
+
+inlineStatsAbsentOnTopHireDateByLanguages
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| STATS a = COUNT(*), y = TOP(DATE_TRUNC(1 year, hire_date), 2, "desc") BY languages
+| INLINE STATS x = COUNT(*), z = ABSENT(y)
+| KEEP x, z, a
+;
+ignoreOrder:true
+
+x:long | z:boolean | a:long
+6      | false     | 10
+6      | false     | 15
+6      | false     | 17
+6      | false     | 18
+6      | false     | 19
+6      | false     | 21
+;
+
+inlineStatsSumCountWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS a = COUNT(*), y = MAX(salary) BY x
+| INLINE STATS total = SUM(a)
+| KEEP a, y, total
+| SORT a ASC, y ASC
+| LIMIT 5
+;
+
+a:long | y:integer | total:long
+1      | 45656     | 100
+1      | 64675     | 100
+1      | 73717     | 100
+3      | 58715     | 100
+4      | 67492     | 100
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -4185,5 +4185,160 @@ from employees
 ;
 
     max(c):l   |    min(c):l   |    min(s):d   |    avg(s):d
-null           |null           |null           |null           
+null           |null           |null           |null
+;
+
+statsCountAndMaxWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS a = COUNT(*), y = MAX(salary) BY x
+| DROP x
+;
+ignoreOrder:true
+
+a:long | y:integer
+1      | 45656
+1      | 64675
+1      | 73717
+3      | 58715
+4      | 67492
+5      | 65367
+6      | 65030
+8      | 60781
+9      | 73578
+11     | 61805
+11     | 74999
+12     | 71165
+13     | 74970
+15     | 70011
+;
+
+statsCountOnlyWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS a = COUNT(*) BY x
+| DROP x
+;
+ignoreOrder:true
+
+a:long
+1
+1
+1
+3
+4
+5
+6
+8
+9
+11
+11
+12
+13
+15
+;
+
+statsDuplicateCountAndMaxWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS y = COUNT(*), a = MAX(salary), y = COUNT(*) BY x
+| DROP x
+;
+ignoreOrder:true
+warning:Line 3:9: Field 'y' shadowed by field at line 3:40
+
+a:integer | y:long
+45656     | 1
+64675     | 1
+73717     | 1
+58715     | 3
+67492     | 4
+65367     | 5
+65030     | 6
+60781     | 8
+73578     | 9
+61805     | 11
+74999     | 11
+71165     | 12
+74970     | 13
+70011     | 15
+;
+
+statsTwoCountsAndMaxWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS y = COUNT(*), a = MAX(salary), z = COUNT(*) BY x
+| DROP x
+;
+ignoreOrder:true
+
+y:long | a:integer | z:long
+1      | 45656     | 1
+1      | 64675     | 1
+1      | 73717     | 1
+3      | 58715     | 3
+4      | 67492     | 4
+5      | 65367     | 5
+6      | 65030     | 6
+8      | 60781     | 8
+9      | 73578     | 9
+11     | 61805     | 11
+11     | 74999     | 11
+12     | 71165     | 12
+13     | 74970     | 13
+15     | 70011     | 15
+;
+
+statsMaxAndCountWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS a = MAX(salary), y = COUNT(*) BY x
+| DROP x
+;
+ignoreOrder:true
+
+a:integer | y:long
+45656     | 1
+64675     | 1
+73717     | 1
+58715     | 3
+67492     | 4
+65367     | 5
+65030     | 6
+60781     | 8
+73578     | 9
+61805     | 11
+74999     | 11
+71165     | 12
+74970     | 13
+70011     | 15
+;
+
+statsCountWithDateTruncAndLanguagesDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS a = COUNT(*) BY x, languages
+| DROP x
+| SORT languages, a
+| LIMIT 5
+;
+
+a:long | languages:integer
+1      | 1
+1      | 1
+1      | 1
+2      | 1
+2      | 1
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2495,6 +2495,17 @@ public class EsqlCapabilities {
         FIX_STARTS_WITH_ENDS_WITH_PUSHDOWN_ON_INDEX,
 
         /**
+         * Fix for {@link org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushCountQueryAndTagsToSource} incorrectly
+         * replacing an {@code AggregateExec} that has multiple aggregate functions (e.g. COUNT + MAX) with an
+         * {@code EsStatsQueryExec} that only handles COUNT, when {@code CombineProjections} had removed the grouping key
+         * from the aggregates list.
+         * <p>
+         *     See <a href="https://github.com/elastic/elasticsearch/issues/146479">#146479</a>
+         * </p>
+         */
+        FIX_PUSH_COUNT_QUERY_AND_TAGS_WITH_MULTIPLE_AGGS,
+
+        /**
          * Fix for column pruning in FORK.
          */
         FORK_PRUNE_ALL_COLUMNS_FIX,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushCountQueryAndTagsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushCountQueryAndTagsToSource.java
@@ -15,6 +15,7 @@ import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -62,10 +63,17 @@ import java.util.Optional;
 public class PushCountQueryAndTagsToSource extends PhysicalOptimizerRules.OptimizerRule<AggregateExec> {
     @Override
     protected PhysicalPlan rule(AggregateExec aggregateExec) {
-        // There should be exactly one grouping field (hence 2 aggregates: agg + group by field).
-        // The aggregation should be Count(*) or CountApproximate(*), without a filter on the count
-        // itself.
-        if (aggregateExec.aggregates().size() == 2
+        // The rule applies only when the aggregate has:
+        // - exactly one grouping key
+        // - exactly one aggregate (the COUNT itself)
+        // This rejects multi-grouping queries and multi-aggregate queries (e.g. COUNT + MAX).
+        // The COUNT must be Count(*) or CountApproximate(*), without a filter on the count itself.
+        if (aggregateExec.groupings().size() == 1
+            && (aggregateExec.aggregates().size() == 1
+                // The second "aggregate" must be the grouping itself.
+                // Sometimes CombineProjections or other rules may remove it, so we check for both 1 and 2 aggs
+                || aggregateExec.aggregates().size() == 2
+                    && Expressions.equalsAsAttribute(Alias.unwrap(aggregateExec.aggregates().get(1)), aggregateExec.groupings().getFirst()))
             && aggregateExec.aggregates().getFirst() instanceof Alias alias
             && ((alias.child() instanceof Count count && count.hasFilter() == false && count.field() instanceof Literal)
                 || (alias.child() instanceof CountApproximate ca && ca.hasFilter() == false && ca.field() instanceof Literal))

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SubstituteRoundToGoldenTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SubstituteRoundToGoldenTests.java
@@ -73,6 +73,47 @@ public class SubstituteRoundToGoldenTests extends GoldenTestCase {
         }
     }
 
+    // https://github.com/elastic/elasticsearch/issues/146479
+    // When the grouping key is dropped and COUNT(*) is the only agg, CombineProjections removes
+    // the grouping key from aggregates leaving [COUNT] (size 1). But it should still be pushed down.
+    public void testDateTruncCountOnlyPushedWhenGroupingKeyDropped() {
+        for (var queryAndName : dateHistograms) {
+            String query = LoggerMessageFormat.format(null, """
+                from all_types
+                | stats count(*) by x = {}
+                | drop x
+                """, queryAndName.query());
+            runGoldenTest(query, EnumSet.of(Stage.LOCAL_PHYSICAL_OPTIMIZATION), STATS, queryAndName.name());
+        }
+    }
+
+    // https://github.com/elastic/elasticsearch/issues/146479
+    // When the grouping key is dropped (e.g. via DROP/KEEP), CombineProjections removes it from
+    // aggregates, leaving [COUNT, MAX] (size 2). PushCountQueryAndTagsToSource must not mistake
+    // this for [COUNT, grouping_key] and must not push down.
+    public void testDateTruncBucketNotPushedWhenGroupingKeyDropped() {
+        for (var queryAndName : dateHistograms) {
+            String query = LoggerMessageFormat.format(null, """
+                from all_types
+                | stats count(*), max(long) by x = {}
+                | drop x
+                """, queryAndName.query());
+            runGoldenTest(query, EnumSet.of(Stage.LOCAL_PHYSICAL_OPTIMIZATION), STATS, queryAndName.name());
+        }
+    }
+
+    // With multiple groupings the optimization does not apply: [COUNT, grouping_1, grouping_2] has
+    // size 3, so the rule's guard (aggregates().size() == 2) keeps it from firing.
+    public void testDateTruncBucketNotPushedWithMultipleGroupings() {
+        for (var queryAndName : dateHistograms) {
+            String query = LoggerMessageFormat.format(null, """
+                from all_types
+                | stats count(*) by x = {}, long
+                """, queryAndName.query());
+            runGoldenTest(query, EnumSet.of(Stage.LOCAL_PHYSICAL_OPTIMIZATION), STATS, queryAndName.name());
+        }
+    }
+
     // DateTrunc is transformed to RoundTo first but cannot be transformed to QueryAndTags, when the TopN is pushed down to EsQueryExec
     public void testDateTruncNotTransformToQueryAndTags() {
         for (var queryAndName : dateHistograms) {

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/bucket/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/bucket/local_physical_optimization.expected
@@ -1,0 +1,81 @@
+LimitExec[1000[INTEGER],null]
+\_AggregateExec[[x{r}#0],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#1, MAX(long{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS max(long)#3],FINAL,[x{r}#0, $$count(*)$count{r}#4, $$count(*)$seen{r}#5, $$max(long)$max{r}#6, $$max(long)$seen{r}#7],null]
+  \_ExchangeExec[[x{r}#0, $$count(*)$count{r}#4, $$count(*)$seen{r}#5, $$max(long)$max{r}#6, $$max(long)$seen{r}#7],true]
+    \_AggregateExec[[x{r}#0],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#1, MAX(long{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS max(long)#3],INITIAL,[x{r}#0, $$count(*)$count{r}#8, $$count(*)$seen{r}#9, $$max(long)$max{r}#10, $$max(long)$seen{r}#11],16]
+      \_FieldExtractExec[long{f}#2]<[],[],[]>
+        \_EvalExec[[$$date$round_to$datetime{f}#12 AS x#0]]
+          \_EsQueryExec[all_types], indexMode[standard], [_doc{f}#13, $$date$round_to$datetime{f}#12], limit[], sort[] estimatedRowSize[20] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "lt" : "2023-10-21T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:36"
+  }
+}, tags=[1697760000000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-21T00:00:00.000Z",
+          "lt" : "2023-10-22T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:36"
+  }
+}, tags=[1697846400000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-22T00:00:00.000Z",
+          "lt" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:36"
+  }
+}, tags=[1697932800000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:36"
+  }
+}, tags=[1698019200000]], QueryBuilderAndTags[query={
+  "bool" : {
+    "must_not" : [
+      {
+        "exists" : {
+          "field" : "date",
+          "boost" : 0.0
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[null]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/bucket/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/bucket/query.esql
@@ -1,0 +1,3 @@
+from all_types
+| stats count(*), max(long) by x = bucket(date, 1 day)
+| drop x

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/date_trunc/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/date_trunc/local_physical_optimization.expected
@@ -1,0 +1,81 @@
+LimitExec[1000[INTEGER],null]
+\_AggregateExec[[x{r}#0],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#1, MAX(long{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS max(long)#3],FINAL,[x{r}#0, $$count(*)$count{r}#4, $$count(*)$seen{r}#5, $$max(long)$max{r}#6, $$max(long)$seen{r}#7],null]
+  \_ExchangeExec[[x{r}#0, $$count(*)$count{r}#4, $$count(*)$seen{r}#5, $$max(long)$max{r}#6, $$max(long)$seen{r}#7],true]
+    \_AggregateExec[[x{r}#0],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#1, MAX(long{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS max(long)#3],INITIAL,[x{r}#0, $$count(*)$count{r}#8, $$count(*)$seen{r}#9, $$max(long)$max{r}#10, $$max(long)$seen{r}#11],16]
+      \_FieldExtractExec[long{f}#2]<[],[],[]>
+        \_EvalExec[[$$date$round_to$datetime{f}#12 AS x#0]]
+          \_EsQueryExec[all_types], indexMode[standard], [_doc{f}#13, $$date$round_to$datetime{f}#12], limit[], sort[] estimatedRowSize[20] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "lt" : "2023-10-21T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:36"
+  }
+}, tags=[1697760000000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-21T00:00:00.000Z",
+          "lt" : "2023-10-22T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:36"
+  }
+}, tags=[1697846400000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-22T00:00:00.000Z",
+          "lt" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:36"
+  }
+}, tags=[1697932800000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:36"
+  }
+}, tags=[1698019200000]], QueryBuilderAndTags[query={
+  "bool" : {
+    "must_not" : [
+      {
+        "exists" : {
+          "field" : "date",
+          "boost" : 0.0
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[null]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/date_trunc/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/date_trunc/query.esql
@@ -1,0 +1,3 @@
+from all_types
+| stats count(*), max(long) by x = date_trunc(1 day, date)
+| drop x

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/round_to/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/round_to/local_physical_optimization.expected
@@ -1,0 +1,81 @@
+LimitExec[1000[INTEGER],null]
+\_AggregateExec[[x{r}#0],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#1, MAX(long{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS max(long)#3],FINAL,[x{r}#0, $$count(*)$count{r}#4, $$count(*)$seen{r}#5, $$max(long)$max{r}#6, $$max(long)$seen{r}#7],null]
+  \_ExchangeExec[[x{r}#0, $$count(*)$count{r}#4, $$count(*)$seen{r}#5, $$max(long)$max{r}#6, $$max(long)$seen{r}#7],true]
+    \_AggregateExec[[x{r}#0],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#1, MAX(long{f}#2,true[BOOLEAN],PT0S[TIME_DURATION]) AS max(long)#3],INITIAL,[x{r}#0, $$count(*)$count{r}#8, $$count(*)$seen{r}#9, $$max(long)$max{r}#10, $$max(long)$seen{r}#11],16]
+      \_FieldExtractExec[long{f}#2]<[],[],[]>
+        \_EvalExec[[$$date$round_to$datetime{f}#12 AS x#0]]
+          \_EsQueryExec[all_types], indexMode[standard], [_doc{f}#13, $$date$round_to$datetime{f}#12], limit[], sort[] estimatedRowSize[20] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "lt" : "2023-10-21T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:36"
+  }
+}, tags=[1697760000000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-21T00:00:00.000Z",
+          "lt" : "2023-10-22T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:36"
+  }
+}, tags=[1697846400000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-22T00:00:00.000Z",
+          "lt" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:36"
+  }
+}, tags=[1697932800000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:36"
+  }
+}, tags=[1698019200000]], QueryBuilderAndTags[query={
+  "bool" : {
+    "must_not" : [
+      {
+        "exists" : {
+          "field" : "date",
+          "boost" : 0.0
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[null]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/round_to/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWhenGroupingKeyDropped/round_to/query.esql
@@ -1,0 +1,3 @@
+from all_types
+| stats count(*), max(long) by x = round_to(date, "2023-10-20", "2023-10-21", "2023-10-22", "2023-10-23")
+| drop x

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/bucket/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/bucket/local_physical_optimization.expected
@@ -1,0 +1,81 @@
+LimitExec[1000[INTEGER],null]
+\_AggregateExec[[x{r}#0, long{f}#1],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#2, x{r}#0, long{f}#1],FINAL,[x{r}#0, long{f}#1, $$count(*)$count{r}#3, $$count(*)$seen{r}#4],null]
+  \_ExchangeExec[[x{r}#0, long{f}#1, $$count(*)$count{r}#3, $$count(*)$seen{r}#4],true]
+    \_AggregateExec[[x{r}#0, long{f}#1],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#2, x{r}#0, long{f}#1],INITIAL,[x{r}#0, long{f}#1, $$count(*)$count{r}#5, $$count(*)$seen{r}#6],24]
+      \_FieldExtractExec[long{f}#1]<[],[],[]>
+        \_EvalExec[[$$date$round_to$datetime{f}#7 AS x#0]]
+          \_EsQueryExec[all_types], indexMode[standard], [_doc{f}#8, $$date$round_to$datetime{f}#7], limit[], sort[] estimatedRowSize[20] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "lt" : "2023-10-21T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:25"
+  }
+}, tags=[1697760000000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-21T00:00:00.000Z",
+          "lt" : "2023-10-22T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:25"
+  }
+}, tags=[1697846400000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-22T00:00:00.000Z",
+          "lt" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:25"
+  }
+}, tags=[1697932800000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:25"
+  }
+}, tags=[1698019200000]], QueryBuilderAndTags[query={
+  "bool" : {
+    "must_not" : [
+      {
+        "exists" : {
+          "field" : "date",
+          "boost" : 0.0
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[null]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/bucket/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/bucket/query.esql
@@ -1,0 +1,2 @@
+from all_types
+| stats count(*) by x = bucket(date, 1 day), long

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/date_trunc/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/date_trunc/local_physical_optimization.expected
@@ -1,0 +1,81 @@
+LimitExec[1000[INTEGER],null]
+\_AggregateExec[[x{r}#0, long{f}#1],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#2, x{r}#0, long{f}#1],FINAL,[x{r}#0, long{f}#1, $$count(*)$count{r}#3, $$count(*)$seen{r}#4],null]
+  \_ExchangeExec[[x{r}#0, long{f}#1, $$count(*)$count{r}#3, $$count(*)$seen{r}#4],true]
+    \_AggregateExec[[x{r}#0, long{f}#1],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#2, x{r}#0, long{f}#1],INITIAL,[x{r}#0, long{f}#1, $$count(*)$count{r}#5, $$count(*)$seen{r}#6],24]
+      \_FieldExtractExec[long{f}#1]<[],[],[]>
+        \_EvalExec[[$$date$round_to$datetime{f}#7 AS x#0]]
+          \_EsQueryExec[all_types], indexMode[standard], [_doc{f}#8, $$date$round_to$datetime{f}#7], limit[], sort[] estimatedRowSize[20] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "lt" : "2023-10-21T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:25"
+  }
+}, tags=[1697760000000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-21T00:00:00.000Z",
+          "lt" : "2023-10-22T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:25"
+  }
+}, tags=[1697846400000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-22T00:00:00.000Z",
+          "lt" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:25"
+  }
+}, tags=[1697932800000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:25"
+  }
+}, tags=[1698019200000]], QueryBuilderAndTags[query={
+  "bool" : {
+    "must_not" : [
+      {
+        "exists" : {
+          "field" : "date",
+          "boost" : 0.0
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[null]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/date_trunc/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/date_trunc/query.esql
@@ -1,0 +1,2 @@
+from all_types
+| stats count(*) by x = date_trunc(1 day, date), long

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/round_to/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/round_to/local_physical_optimization.expected
@@ -1,0 +1,81 @@
+LimitExec[1000[INTEGER],null]
+\_AggregateExec[[x{r}#0, long{f}#1],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#2, x{r}#0, long{f}#1],FINAL,[x{r}#0, long{f}#1, $$count(*)$count{r}#3, $$count(*)$seen{r}#4],null]
+  \_ExchangeExec[[x{r}#0, long{f}#1, $$count(*)$count{r}#3, $$count(*)$seen{r}#4],true]
+    \_AggregateExec[[x{r}#0, long{f}#1],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#2, x{r}#0, long{f}#1],INITIAL,[x{r}#0, long{f}#1, $$count(*)$count{r}#5, $$count(*)$seen{r}#6],24]
+      \_FieldExtractExec[long{f}#1]<[],[],[]>
+        \_EvalExec[[$$date$round_to$datetime{f}#7 AS x#0]]
+          \_EsQueryExec[all_types], indexMode[standard], [_doc{f}#8, $$date$round_to$datetime{f}#7], limit[], sort[] estimatedRowSize[20] queryBuilderAndTags [[QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "lt" : "2023-10-21T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:25"
+  }
+}, tags=[1697760000000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-21T00:00:00.000Z",
+          "lt" : "2023-10-22T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:25"
+  }
+}, tags=[1697846400000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-22T00:00:00.000Z",
+          "lt" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:25"
+  }
+}, tags=[1697932800000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:25"
+  }
+}, tags=[1698019200000]], QueryBuilderAndTags[query={
+  "bool" : {
+    "must_not" : [
+      {
+        "exists" : {
+          "field" : "date",
+          "boost" : 0.0
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[null]]]]

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/round_to/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncBucketNotPushedWithMultipleGroupings/round_to/query.esql
@@ -1,0 +1,2 @@
+from all_types
+| stats count(*) by x = round_to(date, "2023-10-20", "2023-10-21", "2023-10-22", "2023-10-23"), long

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/bucket/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/bucket/local_physical_optimization.expected
@@ -1,0 +1,79 @@
+LimitExec[1000[INTEGER],null]
+\_AggregateExec[[x{r}#0],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#1],FINAL,[x{r}#0, $$count(*)$count{r}#2, $$count(*)$seen{r}#3],null]
+  \_ExchangeExec[[x{r}#0, $$count(*)$count{r}#2, $$count(*)$seen{r}#3],true]
+    \_FilterExec[$$count(*)$count{r}#4 > 0[LONG]]
+      \_EsStatsQueryExec[all_types], stats[ByStat{queryBuilderAndTags=[QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "lt" : "2023-10-21T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:25"
+  }
+}, tags=[1697760000000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-21T00:00:00.000Z",
+          "lt" : "2023-10-22T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:25"
+  }
+}, tags=[1697846400000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-22T00:00:00.000Z",
+          "lt" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:25"
+  }
+}, tags=[1697932800000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "bucket(date, 1 day)@2:25"
+  }
+}, tags=[1698019200000]], QueryBuilderAndTags[query={
+  "bool" : {
+    "must_not" : [
+      {
+        "exists" : {
+          "field" : "date",
+          "boost" : 0.0
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[null]]]}], query[][x{r}#0, $$count(*)$count{r}#4, $$count(*)$seen{r}#5], limit[], 

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/bucket/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/bucket/query.esql
@@ -1,0 +1,3 @@
+from all_types
+| stats count(*) by x = bucket(date, 1 day)
+| drop x

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/date_trunc/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/date_trunc/local_physical_optimization.expected
@@ -1,0 +1,79 @@
+LimitExec[1000[INTEGER],null]
+\_AggregateExec[[x{r}#0],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#1],FINAL,[x{r}#0, $$count(*)$count{r}#2, $$count(*)$seen{r}#3],null]
+  \_ExchangeExec[[x{r}#0, $$count(*)$count{r}#2, $$count(*)$seen{r}#3],true]
+    \_FilterExec[$$count(*)$count{r}#4 > 0[LONG]]
+      \_EsStatsQueryExec[all_types], stats[ByStat{queryBuilderAndTags=[QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "lt" : "2023-10-21T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:25"
+  }
+}, tags=[1697760000000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-21T00:00:00.000Z",
+          "lt" : "2023-10-22T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:25"
+  }
+}, tags=[1697846400000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-22T00:00:00.000Z",
+          "lt" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:25"
+  }
+}, tags=[1697932800000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "date_trunc(1 day, date)@2:25"
+  }
+}, tags=[1698019200000]], QueryBuilderAndTags[query={
+  "bool" : {
+    "must_not" : [
+      {
+        "exists" : {
+          "field" : "date",
+          "boost" : 0.0
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[null]]]}], query[][x{r}#0, $$count(*)$count{r}#4, $$count(*)$seen{r}#5], limit[], 

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/date_trunc/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/date_trunc/query.esql
@@ -1,0 +1,3 @@
+from all_types
+| stats count(*) by x = date_trunc(1 day, date)
+| drop x

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/round_to/local_physical_optimization.expected
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/round_to/local_physical_optimization.expected
@@ -1,0 +1,79 @@
+LimitExec[1000[INTEGER],null]
+\_AggregateExec[[x{r}#0],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS count(*)#1],FINAL,[x{r}#0, $$count(*)$count{r}#2, $$count(*)$seen{r}#3],null]
+  \_ExchangeExec[[x{r}#0, $$count(*)$count{r}#2, $$count(*)$seen{r}#3],true]
+    \_FilterExec[$$count(*)$count{r}#4 > 0[LONG]]
+      \_EsStatsQueryExec[all_types], stats[ByStat{queryBuilderAndTags=[QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "lt" : "2023-10-21T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:25"
+  }
+}, tags=[1697760000000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-21T00:00:00.000Z",
+          "lt" : "2023-10-22T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:25"
+  }
+}, tags=[1697846400000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-22T00:00:00.000Z",
+          "lt" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:25"
+  }
+}, tags=[1697932800000]], QueryBuilderAndTags[query={
+  "esql_single_value" : {
+    "field" : "date",
+    "next" : {
+      "range" : {
+        "date" : {
+          "gte" : "2023-10-23T00:00:00.000Z",
+          "time_zone" : "Z",
+          "format" : "strict_date_optional_time",
+          "boost" : 0.0
+        }
+      }
+    },
+    "source" : "round_to(date, \"2023-10-20\", \"2023-10-21\", \"2023-10-22\", \"2023-10-23\")@2:25"
+  }
+}, tags=[1698019200000]], QueryBuilderAndTags[query={
+  "bool" : {
+    "must_not" : [
+      {
+        "exists" : {
+          "field" : "date",
+          "boost" : 0.0
+        }
+      }
+    ],
+    "boost" : 1.0
+  }
+}, tags=[null]]]}], query[][x{r}#0, $$count(*)$count{r}#4, $$count(*)$seen{r}#5], limit[], 

--- a/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/round_to/query.esql
+++ b/x-pack/plugin/esql/src/test/resources/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/golden_tests/SubstituteRoundToGoldenTests/testDateTruncCountOnlyPushedWhenGroupingKeyDropped/round_to/query.esql
@@ -1,0 +1,3 @@
+from all_types
+| stats count(*) by x = round_to(date, "2023-10-20", "2023-10-21", "2023-10-22", "2023-10-23")
+| drop x


### PR DESCRIPTION
Manual 9.4 backport of https://github.com/elastic/elasticsearch/pull/146555