### PR TITLE
[9.3] ESQL: Fix COUNT+query push down losing aggs (#146555)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -5728,10 +5728,91 @@ from employees
 | limit 5
 ;
 
-   languages:i |    emp_no:i   |    gender:s   |     w_avg:d   |   w:i       
-2              |10001          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]      
-5              |10002          |F              |[1.0, 1.0, 1.0]|[1, 2, 3]      
-4              |10003          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]      
-5              |10004          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]      
-1              |10005          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]      
+   languages:i |    emp_no:i   |    gender:s   |     w_avg:d   |   w:i
+2              |10001          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]
+5              |10002          |F              |[1.0, 1.0, 1.0]|[1, 2, 3]
+4              |10003          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]
+5              |10004          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]
+1              |10005          |M              |[1.0, 1.0, 1.0]|[1, 2, 3]
+;
+
+inlineStatsAbsentOnTopWithDateTrunc
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM date_nanos
+| STATS a = COUNT(*), y = TOP(DATE_TRUNC(1 year, millis), 2, "desc") BY num
+| INLINE STATS x = COUNT(*), z = ABSENT(y)
+| KEEP x, z, a
+;
+ignoreOrder:true
+
+x:long | z:boolean | a:long
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 2
+8      | false     | 2
+;
+
+inlineStatsAbsentOnMaxWithDateTrunc
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM date_nanos
+| STATS a = COUNT(*), y = MAX(DATE_TRUNC(1 year, millis)) BY num
+| INLINE STATS x = COUNT(*), z = ABSENT(y)
+| KEEP x, z, a
+;
+ignoreOrder:true
+
+x:long | z:boolean | a:long
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 1
+8      | false     | 2
+8      | false     | 2
+;
+
+inlineStatsAbsentOnTopHireDateByLanguages
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| STATS a = COUNT(*), y = TOP(DATE_TRUNC(1 year, hire_date), 2, "desc") BY languages
+| INLINE STATS x = COUNT(*), z = ABSENT(y)
+| KEEP x, z, a
+;
+ignoreOrder:true
+
+x:long | z:boolean | a:long
+6      | false     | 10
+6      | false     | 15
+6      | false     | 17
+6      | false     | 18
+6      | false     | 19
+6      | false     | 21
+;
+
+inlineStatsSumCountWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS a = COUNT(*), y = MAX(salary) BY x
+| INLINE STATS total = SUM(a)
+| KEEP a, y, total
+| SORT a ASC, y ASC
+| LIMIT 5
+;
+
+a:long | y:integer | total:long
+1      | 45656     | 100
+1      | 64675     | 100
+1      | 73717     | 100
+3      | 58715     | 100
+4      | 67492     | 100
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -3779,3 +3779,283 @@ SUM(salary_change):double   | salary_change:double
 14.69                       | 1.92           
 6.000000000000001           | 1.98           
 ;
+
+multiStatsAfterFalseFilter_ByComputedValues
+from employees
+| where false
+| stats c = count(*), s = avg(salary)
+| stats max(c), min(s) by s, c
+;
+
+  max(c):l     |    min(s):d   |       s:d     |       c:l
+0              |null           |null           |0              
+;
+
+multiStatsAfterFalseFilter_ByLiteralValue
+from employees
+| where false
+| stats c = count(*), s = avg(salary)
+| stats max(c), min(s) by x = "abc"
+;
+
+    max(c):l   |    min(s):d   |       x:keyword       
+0              |null           |abc            
+;
+
+multiStatsAfterFalseFilter_ByField
+from employees
+| where false
+| stats c = count(gender), s = avg(salary) by gender
+| stats max(c), min(c), min(s), avg(s)
+;
+
+    max(c):l   |    min(c):l   |    min(s):d   |    avg(s):d
+null           |null           |null           |null           
+;
+
+whereNullBeforeStats
+from employees
+| where null
+| stats c = count(*)
+;
+
+c:long
+0
+;
+
+whereNullBeforeMixedStats
+from employees
+| where null
+| stats c = count(*), s = sum(salary), a = avg(salary)
+;
+
+c:long | s:long | a:double
+0      | null   | null
+;
+
+evalNullFilterBeforeStats
+from employees
+| eval x = null
+| where x::int > 0
+| stats c = count(*)
+;
+
+c:long
+0
+;
+
+nullArithmeticFilterBeforeStats
+from employees
+| where 1 + null > 0
+| stats c = count(*), mn = min(salary), mx = max(salary)
+;
+
+c:long | mn:integer | mx:integer
+0      | null       | null
+;
+
+whereNullConjunctionBeforeStats
+from employees
+| where null and salary > 0
+| stats c = count(*)
+;
+
+c:long
+0
+;
+
+whereNullBeforeGroupedStats
+from employees
+| where null
+| stats c = count(*) by gender
+;
+
+c:long | gender:keyword
+;
+
+evalNullFilterBeforeGroupedStats
+from employees
+| eval x = null
+| where x::int > 0
+| stats c = count(*), s = avg(salary) by gender
+;
+
+c:long | s:double | gender:keyword
+;
+
+multiStatsAfterNullFilter_ByComputedValues
+from employees
+| where null
+| stats c = count(*), s = avg(salary)
+| stats max(c), min(s) by s, c
+;
+
+ max(c):l | min(s):d | s:d | c:l
+0         |null      |null |0
+;
+
+multiStatsAfterNullFilter_ByField
+from employees
+| where null
+| stats c = count(gender), s = avg(salary) by gender
+| stats max(c), min(c), min(s), avg(s)
+;
+
+    max(c):l   |    min(c):l   |    min(s):d   |    avg(s):d
+null           |null           |null           |null
+;
+
+statsCountAndMaxWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS a = COUNT(*), y = MAX(salary) BY x
+| DROP x
+;
+ignoreOrder:true
+
+a:long | y:integer
+1      | 45656
+1      | 64675
+1      | 73717
+3      | 58715
+4      | 67492
+5      | 65367
+6      | 65030
+8      | 60781
+9      | 73578
+11     | 61805
+11     | 74999
+12     | 71165
+13     | 74970
+15     | 70011
+;
+
+statsCountOnlyWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS a = COUNT(*) BY x
+| DROP x
+;
+ignoreOrder:true
+
+a:long
+1
+1
+1
+3
+4
+5
+6
+8
+9
+11
+11
+12
+13
+15
+;
+
+statsDuplicateCountAndMaxWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS y = COUNT(*), a = MAX(salary), y = COUNT(*) BY x
+| DROP x
+;
+ignoreOrder:true
+warning:Line 3:9: Field 'y' shadowed by field at line 3:40
+
+a:integer | y:long
+45656     | 1
+64675     | 1
+73717     | 1
+58715     | 3
+67492     | 4
+65367     | 5
+65030     | 6
+60781     | 8
+73578     | 9
+61805     | 11
+74999     | 11
+71165     | 12
+74970     | 13
+70011     | 15
+;
+
+statsTwoCountsAndMaxWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS y = COUNT(*), a = MAX(salary), z = COUNT(*) BY x
+| DROP x
+;
+ignoreOrder:true
+
+y:long | a:integer | z:long
+1      | 45656     | 1
+1      | 64675     | 1
+1      | 73717     | 1
+3      | 58715     | 3
+4      | 67492     | 4
+5      | 65367     | 5
+6      | 65030     | 6
+8      | 60781     | 8
+9      | 73578     | 9
+11     | 61805     | 11
+11     | 74999     | 11
+12     | 71165     | 12
+13     | 74970     | 13
+15     | 70011     | 15
+;
+
+statsMaxAndCountWithDateTruncDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS a = MAX(salary), y = COUNT(*) BY x
+| DROP x
+;
+ignoreOrder:true
+
+a:integer | y:long
+45656     | 1
+64675     | 1
+73717     | 1
+58715     | 3
+67492     | 4
+65367     | 5
+65030     | 6
+60781     | 8
+73578     | 9
+61805     | 11
+74999     | 11
+71165     | 12
+74970     | 13
+70011     | 15
+;
+
+statsCountWithDateTruncAndLanguagesDropGroupingKey
+required_capability: fix_push_count_query_and_tags_with_multiple_aggs
+
+FROM employees
+| EVAL x = DATE_TRUNC(1 year, hire_date)
+| STATS a = COUNT(*) BY x, languages
+| DROP x
+| SORT languages, a
+| LIMIT 5
+;
+
+a:long | languages:integer
+1      | 1
+1      | 1
+1      | 1
+2      | 1
+2      | 1
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1978,6 +1978,17 @@ public class EsqlCapabilities {
          * fields.
          */
         FIX_STARTS_WITH_ENDS_WITH_PUSHDOWN_ON_INDEX,
+
+        /**
+         * Fix for {@link org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushCountQueryAndTagsToSource} incorrectly
+         * replacing an {@code AggregateExec} that has multiple aggregate functions (e.g. COUNT + MAX) with an
+         * {@code EsStatsQueryExec} that only handles COUNT, when {@code CombineProjections} had removed the grouping key
+         * from the aggregates list.
+         * <p>
+         *     See <a href="https://github.com/elastic/elasticsearch/issues/146479">#146479</a>
+         * </p>
+         */
+        FIX_PUSH_COUNT_QUERY_AND_TAGS_WITH_MULTIPLE_AGGS,
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushCountQueryAndTagsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushCountQueryAndTagsToSource.java
@@ -15,6 +15,7 @@ import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -57,9 +58,17 @@ import java.util.Optional;
 public class PushCountQueryAndTagsToSource extends PhysicalOptimizerRules.OptimizerRule<AggregateExec> {
     @Override
     protected PhysicalPlan rule(AggregateExec aggregateExec) {
-        if (
-        // Ensures we are only grouping by one field (2 aggregates: count + group by field).
-        aggregateExec.aggregates().size() == 2
+        // The rule applies only when the aggregate has:
+        // - exactly one grouping key
+        // - exactly one aggregate (the COUNT itself)
+        // This rejects multi-grouping queries and multi-aggregate queries (e.g. COUNT + MAX).
+        // The COUNT must be Count(*) or CountApproximate(*), without a filter on the count itself.
+        if (aggregateExec.groupings().size() == 1
+            && (aggregateExec.aggregates().size() == 1
+                // The second "aggregate" must be the grouping itself.
+                // Sometimes CombineProjections or other rules may remove it, so we check for both 1 and 2 aggs
+                || aggregateExec.aggregates().size() == 2
+                    && Expressions.equalsAsAttribute(Alias.unwrap(aggregateExec.aggregates().get(1)), aggregateExec.groupings().getFirst()))
             && aggregateExec.aggregates().getFirst() instanceof Alias alias
             && alias.child() instanceof Count count
             && count.hasFilter() == false // We don't support pushing down counts where the filter is *on the count itself*.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushCountQueryAndTagsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushCountQueryAndTagsToSource.java
@@ -62,7 +62,7 @@ public class PushCountQueryAndTagsToSource extends PhysicalOptimizerRules.Optimi
         // - exactly one grouping key
         // - exactly one aggregate (the COUNT itself)
         // This rejects multi-grouping queries and multi-aggregate queries (e.g. COUNT + MAX).
-        // The COUNT must be Count(*) or CountApproximate(*), without a filter on the count itself.
+        // The COUNT must be Count(*), without a filter on the count itself.
         if (aggregateExec.groupings().size() == 1
             && (aggregateExec.aggregates().size() == 1
                 // The second "aggregate" must be the grouping itself.


### PR DESCRIPTION
Manual 9.3 backport of https://github.com/elastic/elasticsearch/pull/146555