### PR TITLE
ESQL:DS: run data sourcing on separate thread pool

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -7,16 +7,20 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.IsBlockedResult;
 import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.TimeValue;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Thread-safe buffer for async external source data.
@@ -44,7 +48,8 @@ public final class AsyncExternalSourceBuffer {
     private final Object notEmptyLock = new Object();
     private SubscribableListener<Void> notEmptyFuture = null;
 
-    private final Object notFullLock = new Object();
+    private final ReentrantLock notFullLock = new ReentrantLock();
+    private final Condition notFullCondition = notFullLock.newCondition();
     private SubscribableListener<Void> notFullFuture = null;
 
     private final SubscribableListener<Void> completionFuture = new SubscribableListener<>();
@@ -136,9 +141,13 @@ public final class AsyncExternalSourceBuffer {
 
     private void notifyNotFull() {
         final SubscribableListener<Void> toNotify;
-        synchronized (notFullLock) {
+        notFullLock.lock();
+        try {
             toNotify = notFullFuture;
             notFullFuture = null;
+            notFullCondition.signalAll();
+        } finally {
+            notFullLock.unlock();
         }
         if (toNotify != null) {
             toNotify.onResponse(null);
@@ -153,7 +162,8 @@ public final class AsyncExternalSourceBuffer {
         if (bytesInBuffer.get() < maxBufferBytes || noMoreInputs) {
             return Operator.NOT_BLOCKED;
         }
-        synchronized (notFullLock) {
+        notFullLock.lock();
+        try {
             if (bytesInBuffer.get() < maxBufferBytes || noMoreInputs) {
                 return Operator.NOT_BLOCKED;
             }
@@ -161,6 +171,8 @@ public final class AsyncExternalSourceBuffer {
                 notFullFuture = new SubscribableListener<>();
             }
             return new IsBlockedResult(notFullFuture, "async external source buffer full");
+        } finally {
+            notFullLock.unlock();
         }
     }
 
@@ -177,7 +189,8 @@ public final class AsyncExternalSourceBuffer {
         if (bytesInBuffer.get() < maxBufferBytes || noMoreInputs) {
             return SubscribableListener.newSucceeded(null);
         }
-        synchronized (notFullLock) {
+        notFullLock.lock();
+        try {
             if (bytesInBuffer.get() < maxBufferBytes || noMoreInputs) {
                 return SubscribableListener.newSucceeded(null);
             }
@@ -185,6 +198,34 @@ public final class AsyncExternalSourceBuffer {
                 notFullFuture = new SubscribableListener<>();
             }
             return notFullFuture;
+        } finally {
+            notFullLock.unlock();
+        }
+    }
+
+    /**
+     * Blocks the producer (same condition as {@link #waitForSpace()}) on the same not-full lock
+     * used to install {@code notFullFuture} until there is capacity, {@link #noMoreInputs} is set,
+     * or the wait times out. Used by {@link ExternalSourceDrainUtils} instead of
+     * {@code PlainActionFuture} or {@code SubscribableListener} + latches.
+     */
+    public void awaitSpaceForProducer(TimeValue timeout) {
+        long remainingNanos = timeout.nanos();
+        notFullLock.lock();
+        try {
+            while (bytesInBuffer.get() >= maxBufferBytes && noMoreInputs == false) {
+                if (remainingNanos <= 0) {
+                    throw new ElasticsearchTimeoutException("timeout waiting for async external source buffer space");
+                }
+                try {
+                    remainingNanos = notFullCondition.awaitNanos(remainingNanos);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while waiting for buffer space", e);
+                }
+            }
+        } finally {
+            notFullLock.unlock();
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -61,6 +61,12 @@ import java.util.concurrent.Executor;
  *   <li>ES ThreadPool integration - All executors come from ES, not standalone threads</li>
  *   <li>Backpressure via buffer - Uses {@link AsyncExternalSourceBuffer} with waitForSpace()</li>
  * </ul>
+ * <p>
+ * The {@code executor} passed in runs background file reads: it is typically the {@code generic} pool
+ * (via {@link org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorContext#fileReadExecutor}, set in
+ * {@code LocalExecutionPlanner}) so blocked producers do not starve {@code esql_worker} drivers that
+ * {@link AsyncExternalSourceBuffer#pollPage()}. {@link ExternalSourceDrainUtils} uses
+ * {@link AsyncExternalSourceBuffer#awaitSpaceForProducer} (not {@link org.elasticsearch.action.support.PlainActionFuture}).
  *
  * @see AsyncExternalSourceBuffer
  * @see AsyncExternalSourceOperator

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
@@ -218,7 +218,11 @@ public final class DataSourceModule implements Closeable {
     }
 
     public OperatorFactoryRegistry createOperatorFactoryRegistry(Executor executor) {
-        return new OperatorFactoryRegistry(sourceFactories, pluginFactories, executor);
+        return createOperatorFactoryRegistry(executor, executor);
+    }
+
+    public OperatorFactoryRegistry createOperatorFactoryRegistry(Executor executor, Executor fileReadExecutor) {
+        return new OperatorFactoryRegistry(sourceFactories, pluginFactories, executor, fileReadExecutor);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtils.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.TimeValue;
@@ -17,6 +16,11 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
  * Utility for draining pages from a {@link CloseableIterator} into an {@link AsyncExternalSourceBuffer}
  * with backpressure. Uses blocking wait instead of spin-wait, relying on the buffer's
  * {@code notifyNotFull()} in {@code finish()} to wake producers when no more input is needed.
+ *
+ * <p>Buffer-space blocking uses {@link AsyncExternalSourceBuffer#awaitSpaceForProducer} (a timed condition wait
+ * on the buffer's not-full lock), not {@link org.elasticsearch.action.support.PlainActionFuture}, so a
+ * producer and a consumer on different threads of the same named pool (e.g. {@code esql_worker}) do not
+ * trip {@code PlainActionFuture}'s same-pool completion assertion.
  */
 public final class ExternalSourceDrainUtils {
 
@@ -30,12 +34,7 @@ public final class ExternalSourceDrainUtils {
 
     public static void drainPages(CloseableIterator<Page> pages, AsyncExternalSourceBuffer buffer, TimeValue timeout) {
         while (pages.hasNext() && buffer.noMoreInputs() == false) {
-            var spaceListener = buffer.waitForSpace();
-            if (spaceListener.isDone() == false) {
-                PlainActionFuture<Void> future = new PlainActionFuture<>();
-                spaceListener.addListener(future);
-                future.actionGet(timeout);
-            }
+            buffer.awaitSpaceForProducer(timeout);
             if (buffer.noMoreInputs()) {
                 break;
             }
@@ -64,12 +63,7 @@ public final class ExternalSourceDrainUtils {
             if (rowLimit != FormatReader.NO_LIMIT && totalRows >= rowLimit) {
                 break;
             }
-            var spaceListener = buffer.waitForSpace();
-            if (spaceListener.isDone() == false) {
-                PlainActionFuture<Void> future = new PlainActionFuture<>();
-                spaceListener.addListener(future);
-                future.actionGet(timeout);
-            }
+            buffer.awaitSpaceForProducer(timeout);
             if (buffer.noMoreInputs()) {
                 break;
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 /**
  * Framework-internal factory that bridges the building-block registries
@@ -146,6 +147,7 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 ? format.filterPushdownSupport()
                 : null;
 
+            Executor readExecutor = context.fileReadExecutor() != null ? context.fileReadExecutor() : context.executor();
             return new AsyncExternalSourceOperatorFactory(
                 storage,
                 format,
@@ -154,7 +156,7 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 context.batchSize(),
                 context.maxBufferSize(),
                 context.rowLimit(),
-                context.executor(),
+                readExecutor,
                 context.fileList(),
                 context.partitionColumnNames(),
                 partitionValues,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/OperatorFactoryRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/OperatorFactoryRegistry.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.Connector;
 import org.elasticsearch.xpack.esql.datasources.spi.ConnectorFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
@@ -41,18 +42,28 @@ public class OperatorFactoryRegistry {
     // Once plugins migrate to ExternalSourceFactory.operatorFactory(), remove this field.
     private final Map<String, SourceOperatorFactoryProvider> pluginFactories;
     private final Executor executor;
+    private final Executor fileReadExecutor;
 
     public OperatorFactoryRegistry(
         Map<String, ExternalSourceFactory> sourceFactories,
         Map<String, SourceOperatorFactoryProvider> pluginFactories,
         Executor executor
     ) {
-        if (executor == null) {
-            throw new IllegalArgumentException("executor cannot be null");
-        }
+        this(sourceFactories, pluginFactories, executor, executor);
+    }
+
+    public OperatorFactoryRegistry(
+        Map<String, ExternalSourceFactory> sourceFactories,
+        Map<String, SourceOperatorFactoryProvider> pluginFactories,
+        Executor executor,
+        Executor fileReadExecutor
+    ) {
+        Check.notNull(executor, "executor cannot be null");
+        Check.notNull(fileReadExecutor, "fileReadExecutor cannot be null");
         this.sourceFactories = sourceFactories != null ? Map.copyOf(sourceFactories) : Map.of();
         this.pluginFactories = pluginFactories != null ? Map.copyOf(pluginFactories) : Map.of();
         this.executor = executor;
+        this.fileReadExecutor = fileReadExecutor;
     }
 
     public SourceOperator.SourceOperatorFactory factory(SourceOperatorContext context) {
@@ -104,5 +115,14 @@ public class OperatorFactoryRegistry {
 
     public Executor executor() {
         return executor;
+    }
+
+    /**
+     * Thread pool for file (and similar) background reads. Isolated from {@link #executor} (typically
+     * {@code esql_worker}, which also runs compute drivers) so blocked producers in buffer backpressure
+     * cannot starve the drivers that free buffer space.
+     */
+    public Executor fileReadExecutor() {
+        return fileReadExecutor;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SourceOperatorContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SourceOperatorContext.java
@@ -47,6 +47,7 @@ public record SourceOperatorContext(
     int maxBufferSize,
     int rowLimit,
     Executor executor,
+    @Nullable Executor fileReadExecutor,
     Map<String, Object> config,
     Map<String, Object> sourceMetadata,
     Object pushedFilter,
@@ -103,6 +104,7 @@ public record SourceOperatorContext(
             maxBufferSize,
             FormatReader.NO_LIMIT,
             executor,
+            null,
             config,
             sourceMetadata,
             pushedFilter,
@@ -137,6 +139,7 @@ public record SourceOperatorContext(
             maxBufferSize,
             FormatReader.NO_LIMIT,
             executor,
+            null,
             config,
             sourceMetadata,
             pushedFilter,
@@ -170,6 +173,7 @@ public record SourceOperatorContext(
             maxBufferSize,
             FormatReader.NO_LIMIT,
             executor,
+            null,
             config,
             sourceMetadata,
             pushedFilter,
@@ -201,6 +205,7 @@ public record SourceOperatorContext(
             maxBufferSize,
             FormatReader.NO_LIMIT,
             executor,
+            null,
             config,
             Map.of(),
             null,
@@ -226,6 +231,8 @@ public record SourceOperatorContext(
         private int maxBufferSize = 10;
         private int rowLimit = FormatReader.NO_LIMIT;
         private Executor executor;
+        @Nullable
+        private Executor fileReadExecutor;
         private Map<String, Object> config;
         private Map<String, Object> sourceMetadata;
         private Object pushedFilter;
@@ -273,6 +280,16 @@ public record SourceOperatorContext(
 
         public Builder executor(Executor executor) {
             this.executor = executor;
+            return this;
+        }
+
+        /**
+         * Optional executor for file (and similar) background reads. When set (e.g. to {@code generic}),
+         * async reads and slice-queue drain run here instead of on {@link #executor}, so producers blocked
+         * in buffer backpressure do not starve the {@code esql_worker} drivers that consume the buffer.
+         */
+        public Builder fileReadExecutor(Executor fileReadExecutor) {
+            this.fileReadExecutor = fileReadExecutor;
             return this;
         }
 
@@ -331,6 +348,7 @@ public record SourceOperatorContext(
                 maxBufferSize,
                 rowLimit,
                 executor,
+                fileReadExecutor,
                 config,
                 sourceMetadata,
                 pushedFilter,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -1392,6 +1392,7 @@ public class LocalExecutionPlanner {
             .maxBufferSize(effectiveBufferSize)
             .rowLimit(pushedLimit)
             .executor(operatorFactoryRegistry.executor())
+            .fileReadExecutor(operatorFactoryRegistry.fileReadExecutor())
             .config(externalSource.config())
             .sourceMetadata(externalSource.sourceMetadata())
             .pushedFilter(externalSource.pushedFilter())

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -213,7 +213,10 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
         );
 
         var dataSourceModule = planExecutor.dataSourceModule();
-        OperatorFactoryRegistry operatorFactoryRegistry = dataSourceModule.createOperatorFactoryRegistry(externalSourceExecutor());
+        OperatorFactoryRegistry operatorFactoryRegistry = dataSourceModule.createOperatorFactoryRegistry(
+            externalSourceExecutor(),
+            threadPool.executor(ThreadPool.Names.GENERIC)
+        );
         this.computeService = new ComputeService(
             services,
             enrichLookupService,
@@ -258,9 +261,10 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
     }
 
     /**
-     * Returns the executor used for external source I/O (e.g. {@code EXTERNAL/FROM external_source} operators).
+     * Returns the executor used for external source coordination (e.g. connector handshakes and registry wiring).
+     * File-based async reads and slice-queue drain use {@link ThreadPool.Names#GENERIC} via
+     * {@link OperatorFactoryRegistry#fileReadExecutor} so they do not share the same pool as compute drivers.
      * Isolated from {@link ThreadPool.Names#SEARCH} to prevent heavy external queries from starving regular ES operations.
-     * Currently shares {@code esql_worker} with compute drivers; override this method when a dedicated I/O pool is introduced.
      */
     protected Executor externalSourceExecutor() {
         return threadPool.executor(ESQL_WORKER_THREAD_POOL_NAME);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
@@ -7,20 +7,23 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
-import org.elasticsearch.compute.operator.IsBlockedResult;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
 /**
- * Tests for {@link AsyncExternalSourceBuffer}.
- *
- * Tests the thread-safe buffer for async external source data,
- * including byte-based backpressure via waitForSpace() and waitForWriting().
+ * Unit tests for {@link AsyncExternalSourceBuffer} producer backpressure, including
+ * {@link AsyncExternalSourceBuffer#awaitSpaceForProducer} timeout behavior.
  */
 public class AsyncExternalSourceBufferTests extends ESTestCase {
 
@@ -28,12 +31,7 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         .breaker(new NoopCircuitBreaker("none"))
         .build();
 
-    private Page createTestPage() {
-        IntBlock block = BLOCK_FACTORY.newIntBlockBuilder(1).appendInt(42).build();
-        return new Page(block);
-    }
-
-    private Page createTestPage(int numColumns, int numRows) {
+    private static Page createTestPage(int numColumns, int numRows) {
         IntBlock.Builder[] builders = new IntBlock.Builder[numColumns];
         for (int c = 0; c < numColumns; c++) {
             builders[c] = BLOCK_FACTORY.newIntBlockBuilder(numRows);
@@ -48,321 +46,94 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         return new Page(blocks);
     }
 
-    public void testConstructorValidation() {
-        expectThrows(IllegalArgumentException.class, () -> new AsyncExternalSourceBuffer(0));
-        expectThrows(IllegalArgumentException.class, () -> new AsyncExternalSourceBuffer(-1));
+    /**
+     * When the buffer stays full because no consumer calls {@link AsyncExternalSourceBuffer#pollPage()},
+     * {@link AsyncExternalSourceBuffer#awaitSpaceForProducer} must time out with
+     * {@link ElasticsearchTimeoutException}. The buffer must remain consistent and recover after the
+     * producer gives up (drain pages, {@link AsyncExternalSourceBuffer#finish}).
+     */
+    public void testAwaitSpaceForProducerTimeoutLeavesBufferConsistent() {
+        long maxBufferBytes = 1500;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
 
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1);
-        assertNotNull(buffer);
-        assertEquals(0, buffer.size());
-        assertEquals(0L, buffer.bytesInBuffer());
-        assertFalse(buffer.isFinished());
+        long expectedBytes = 0;
+        while (buffer.bytesInBuffer() < maxBufferBytes) {
+            Page p = createTestPage(2, 50);
+            expectedBytes += p.ramBytesUsedByBlocks();
+            buffer.addPage(p);
+        }
+        assertTrue(buffer.bytesInBuffer() >= maxBufferBytes);
+        int sizeBeforeWait = buffer.size();
+
+        var ex = expectThrows(ElasticsearchTimeoutException.class, () -> buffer.awaitSpaceForProducer(TimeValue.timeValueMillis(50)));
+        assertTrue(ex.getMessage().contains("timeout waiting for async external source buffer space"));
+
+        assertEquals(sizeBeforeWait, buffer.size());
+        assertEquals(expectedBytes, buffer.bytesInBuffer());
         assertFalse(buffer.noMoreInputs());
-    }
 
-    public void testAddAndPollPage() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        Page page = createTestPage();
-
-        buffer.addPage(page);
-        assertEquals(1, buffer.size());
-        assertTrue(buffer.bytesInBuffer() > 0);
-
-        Page polled = buffer.pollPage();
-        assertSame(page, polled);
+        for (int i = 0; i < sizeBeforeWait; i++) {
+            Page p = buffer.pollPage();
+            assertNotNull(p);
+            p.releaseBlocks();
+        }
         assertEquals(0, buffer.size());
-        assertEquals(0L, buffer.bytesInBuffer());
-
-        assertNull(buffer.pollPage());
-
-        page.releaseBlocks();
-    }
-
-    public void testWaitForSpaceWhenNotFull() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        SubscribableListener<Void> listener = buffer.waitForSpace();
-        assertTrue("Listener should be done when buffer has space", listener.isDone());
-    }
-
-    public void testWaitForSpaceWhenFull() {
-        Page page1 = createTestPage();
-        long pageBytes = page1.ramBytesUsedByBlocks();
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(pageBytes * 2);
-
-        Page page2 = createTestPage();
-        buffer.addPage(page1);
-        buffer.addPage(page2);
-        assertEquals(2, buffer.size());
-
-        SubscribableListener<Void> listener = buffer.waitForSpace();
-        assertFalse("Listener should not be done when buffer is full", listener.isDone());
-
-        Page polled = buffer.pollPage();
-        polled.releaseBlocks();
-        assertEquals(1, buffer.size());
-
-        assertTrue("Listener should be done after space is made", listener.isDone());
-
+        assertEquals(0, buffer.bytesInBuffer());
         buffer.finish(true);
     }
 
-    public void testWaitForWritingWhenNotFull() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
+    /**
+     * Same scenario through {@link ExternalSourceDrainUtils}: a tight drain timeout and a stuck consumer
+     * surface {@link ElasticsearchTimeoutException}. Byte accounting for queued pages matches
+     * {@link AsyncExternalSourceBuffer#bytesInBuffer()}, and the buffer is fully recoverable.
+     */
+    public void testExternalSourceDrainUtilsTimeoutWithStuckConsumer() {
+        long maxBufferBytes = 1500;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
 
-        IsBlockedResult result = buffer.waitForWriting();
-        assertTrue("Should not be blocked when buffer has space", result.listener().isDone());
-    }
-
-    public void testWaitForWritingWhenFull() {
-        Page page1 = createTestPage();
-        long pageBytes = page1.ramBytesUsedByBlocks();
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(pageBytes * 2);
-
-        Page page2 = createTestPage();
-        buffer.addPage(page1);
-        buffer.addPage(page2);
-
-        IsBlockedResult result = buffer.waitForWriting();
-        assertFalse("Should be blocked when buffer is full", result.listener().isDone());
-        assertEquals("async external source buffer full", result.reason());
-
-        Page polled = buffer.pollPage();
-        polled.releaseBlocks();
-
-        assertTrue("Should not be blocked after space is made", result.listener().isDone());
-
-        buffer.finish(true);
-    }
-
-    public void testWaitForReadingWhenEmpty() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        IsBlockedResult result = buffer.waitForReading();
-        assertFalse("Should be blocked when buffer is empty", result.listener().isDone());
-        assertEquals("async external source buffer empty", result.reason());
-
-        Page page = createTestPage();
-        buffer.addPage(page);
-
-        assertTrue("Should not be blocked after page is added", result.listener().isDone());
-
-        buffer.finish(true);
-    }
-
-    public void testWaitForReadingWhenNotEmpty() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        Page page = createTestPage();
-        buffer.addPage(page);
-
-        IsBlockedResult result = buffer.waitForReading();
-        assertTrue("Should not be blocked when buffer has data", result.listener().isDone());
-
-        buffer.finish(true);
-    }
-
-    public void testFinish() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        assertFalse(buffer.noMoreInputs());
-        assertFalse(buffer.isFinished());
-
-        buffer.finish(false);
-
-        assertTrue(buffer.noMoreInputs());
-        assertTrue(buffer.isFinished());
-    }
-
-    public void testFinishWithDraining() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        Page page1 = createTestPage();
-        Page page2 = createTestPage();
-        buffer.addPage(page1);
-        buffer.addPage(page2);
-        assertEquals(2, buffer.size());
-
-        buffer.finish(true);
-
-        assertTrue(buffer.noMoreInputs());
-        assertTrue(buffer.isFinished());
-        assertEquals(0, buffer.size());
-        assertEquals(0L, buffer.bytesInBuffer());
-    }
-
-    public void testOnFailure() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        Page page = createTestPage();
-        buffer.addPage(page);
-
-        Exception failure = new RuntimeException("test failure");
-        buffer.onFailure(failure);
-
-        assertTrue(buffer.noMoreInputs());
-        assertFalse("Completion is deferred until queued pages are drained", buffer.isFinished());
-        assertSame(failure, buffer.failure());
-        assertEquals(1, buffer.size());
-
-        Page drained = buffer.pollPage();
-        assertNotNull(drained);
-        drained.releaseBlocks();
-        assertTrue(buffer.isFinished());
-    }
-
-    public void testAddPageAfterFinish() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        buffer.finish(false);
-
-        Page page = createTestPage();
-        buffer.addPage(page);
-    }
-
-    public void testAddPageAfterFailure() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        buffer.onFailure(new RuntimeException("test"));
-
-        Page page = createTestPage();
-        buffer.addPage(page);
-    }
-
-    public void testWaitForSpaceAfterFinish() {
-        Page page1 = createTestPage();
-        long pageBytes = page1.ramBytesUsedByBlocks();
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(pageBytes * 2);
-
-        Page page2 = createTestPage();
-        buffer.addPage(page1);
-        buffer.addPage(page2);
-
-        buffer.finish(true);
-
-        SubscribableListener<Void> listener = buffer.waitForSpace();
-        assertTrue("Listener should be done after finish", listener.isDone());
-    }
-
-    public void testCompletionListener() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        java.util.concurrent.atomic.AtomicBoolean completed = new java.util.concurrent.atomic.AtomicBoolean(false);
-        buffer.addCompletionListener(org.elasticsearch.action.ActionListener.wrap(v -> completed.set(true), e -> fail("Should not fail")));
-
-        assertFalse(completed.get());
-
-        buffer.finish(false);
-
-        assertTrue("Completion listener should be called", completed.get());
-    }
-
-    public void testCompletionListenerOnFailure() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        java.util.concurrent.atomic.AtomicReference<Exception> failureRef = new java.util.concurrent.atomic.AtomicReference<>();
-        buffer.addCompletionListener(org.elasticsearch.action.ActionListener.wrap(v -> fail("Should not succeed"), failureRef::set));
-
-        assertNull(failureRef.get());
-
-        Exception failure = new RuntimeException("test failure");
-        buffer.onFailure(failure);
-
-        assertNotNull("Completion listener should receive failure", failureRef.get());
-        assertEquals("test failure", failureRef.get().getCause().getMessage());
-    }
-
-    public void testByteBasedBackpressure() {
-        Page smallPage = createTestPage(1, 10);
-        long pageBytes = smallPage.ramBytesUsedByBlocks();
-        assertTrue("Test page should have non-zero bytes", pageBytes > 0);
-
-        long maxBytes = pageBytes + pageBytes / 2;
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBytes);
-
-        buffer.addPage(smallPage);
-        assertEquals(pageBytes, buffer.bytesInBuffer());
-
-        SubscribableListener<Void> spaceListener = buffer.waitForSpace();
-        assertTrue("Should have space for one page", spaceListener.isDone());
-
-        Page secondPage = createTestPage(1, 10);
-        buffer.addPage(secondPage);
-        assertTrue("Should exceed byte limit with two pages", buffer.bytesInBuffer() >= maxBytes);
-
-        spaceListener = buffer.waitForSpace();
-        assertFalse("Should be blocked when byte limit exceeded", spaceListener.isDone());
-
-        Page polled = buffer.pollPage();
-        polled.releaseBlocks();
-
-        assertTrue("Should unblock after polling", spaceListener.isDone());
-
-        buffer.finish(true);
-    }
-
-    public void testWidePagesBackpressureSooner() {
-        long maxBytes = 2000;
-        AsyncExternalSourceBuffer narrowBuffer = new AsyncExternalSourceBuffer(maxBytes);
-        AsyncExternalSourceBuffer wideBuffer = new AsyncExternalSourceBuffer(maxBytes);
-
-        int narrowCount = 0;
-        while (narrowBuffer.waitForSpace().isDone()) {
-            narrowBuffer.addPage(createTestPage(1, 10));
-            narrowCount++;
-            if (narrowCount > 100) break;
+        int totalPages = 8;
+        List<Page> sourcePages = new ArrayList<>();
+        for (int i = 0; i < totalPages; i++) {
+            sourcePages.add(createTestPage(2, 50));
         }
 
-        int wideCount = 0;
-        while (wideBuffer.waitForSpace().isDone()) {
-            wideBuffer.addPage(createTestPage(10, 10));
-            wideCount++;
-            if (wideCount > 100) break;
+        CloseableIterator<Page> it = new CloseableIterator<>() {
+            private int index = 0;
+
+            @Override
+            public boolean hasNext() {
+                return index < sourcePages.size();
+            }
+
+            @Override
+            public Page next() {
+                if (index >= sourcePages.size()) {
+                    throw new NoSuchElementException();
+                }
+                return sourcePages.get(index++);
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        var ex = expectThrows(
+            ElasticsearchTimeoutException.class,
+            () -> ExternalSourceDrainUtils.drainPages(it, buffer, TimeValue.timeValueMillis(200))
+        );
+        assertTrue(ex.getMessage().contains("timeout waiting for async external source buffer space"));
+
+        assertTrue(buffer.size() >= 1);
+        long bytesInBuffer = buffer.bytesInBuffer();
+        long sumBytes = 0;
+        for (Page p = buffer.pollPage(); p != null; p = buffer.pollPage()) {
+            sumBytes += p.ramBytesUsedByBlocks();
+            p.releaseBlocks();
         }
-
-        assertTrue("Wide pages should trigger backpressure sooner than narrow pages", wideCount < narrowCount);
-
-        narrowBuffer.finish(true);
-        wideBuffer.finish(true);
-    }
-
-    public void testBytesTrackedCorrectly() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        Page page1 = createTestPage(2, 10);
-        Page page2 = createTestPage(3, 10);
-        long bytes1 = page1.ramBytesUsedByBlocks();
-        long bytes2 = page2.ramBytesUsedByBlocks();
-
-        buffer.addPage(page1);
-        assertEquals(bytes1, buffer.bytesInBuffer());
-
-        buffer.addPage(page2);
-        assertEquals(bytes1 + bytes2, buffer.bytesInBuffer());
-
-        Page polled = buffer.pollPage();
-        polled.releaseBlocks();
-        assertEquals(bytes2, buffer.bytesInBuffer());
-
-        polled = buffer.pollPage();
-        polled.releaseBlocks();
-        assertEquals(0L, buffer.bytesInBuffer());
-    }
-
-    public void testBytesResetOnDrain() {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
-
-        buffer.addPage(createTestPage(2, 10));
-        buffer.addPage(createTestPage(3, 10));
-        assertTrue(buffer.bytesInBuffer() > 0);
-
+        assertEquals(0, buffer.size());
+        assertEquals(0, buffer.bytesInBuffer());
+        assertEquals(bytesInBuffer, sumBytes);
+        assertTrue("drain should not have ingested all pages before timing out", it.hasNext());
         buffer.finish(true);
-
-        assertEquals(0L, buffer.bytesInBuffer());
-    }
-
-    public void testDefaultMaxBufferBytes() {
-        assertEquals(10L * 262144, AsyncExternalSourceBuffer.DEFAULT_MAX_BUFFER_BYTES);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DataSourceModuleTests.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executor;
 
 /**
  * Integration tests for DataSourceModule verifying SPI discovery and registration.
@@ -317,6 +318,22 @@ public class DataSourceModuleTests extends ESTestCase {
         // Create OperatorFactoryRegistry with a simple executor
         OperatorFactoryRegistry operatorRegistry = module.createOperatorFactoryRegistry(Runnable::run);
         assertNotNull("OperatorFactoryRegistry should be created", operatorRegistry);
+    }
+
+    /**
+     * {@link DataSourceModule#createOperatorFactoryRegistry(Executor, Executor)} must preserve both
+     * executors: compute coordination ({@link OperatorFactoryRegistry#executor()}, e.g. {@code esql_worker} in
+     * {@link org.elasticsearch.xpack.esql.plugin.TransportEsqlQueryAction}) and
+     * {@link OperatorFactoryRegistry#fileReadExecutor()} (e.g. {@code generic} for file background reads).
+     */
+    public void testOperatorFactoryRegistryUsesDistinctExecutors() {
+        List<DataSourcePlugin> plugins = List.of(new TestDataSourcePlugin());
+        DataSourceModule module = createModule(plugins, Settings.EMPTY, blockFactory);
+        Executor main = Runnable::run;
+        Executor fileRead = Runnable::run;
+        OperatorFactoryRegistry registry = module.createOperatorFactoryRegistry(main, fileRead);
+        assertSame(main, registry.executor());
+        assertSame(fileRead, registry.fileReadExecutor());
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtilsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
@@ -140,6 +141,68 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
         });
 
         Thread consumeThread = new Thread(() -> {
+            try {
+                barrier.await();
+                int consumed = 0;
+                while (consumed < totalPages) {
+                    Page page = buffer.pollPage();
+                    if (page != null) {
+                        page.releaseBlocks();
+                        consumed++;
+                    } else if (buffer.noMoreInputs() && buffer.size() == 0) {
+                        break;
+                    } else {
+                        Thread.yield();
+                    }
+                }
+            } catch (Exception e) {
+                buffer.finish(true);
+            }
+        });
+
+        drainThread.start();
+        consumeThread.start();
+
+        drainThread.join(30_000);
+        consumeThread.join(30_000);
+
+        assertNull("Drain should not throw", drainError.get());
+    }
+
+    /**
+     * Regression: backpressure used to block on {@code PlainActionFuture#actionGet} on the same named
+     * pool that completes the wait (e.g. two {@code esql_worker} threads), which trips
+     * {@code PlainActionFuture}'s same-pool assertion. Production now uses
+     * {@link AsyncExternalSourceBuffer#awaitSpaceForProducer} ({@code Object#wait} on the buffer's
+     * not-full lock). This test runs producer and consumer on {@link EsExecutors.EsThread} instances
+     * sharing the {@code esql_worker} pool name.
+     */
+    public void testBackpressureWithSameNamedPoolThreads() throws Exception {
+        int totalPages = 20;
+        long maxBufferBytes = 1500;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+
+        List<Page> sourcePages = new ArrayList<>();
+        for (int i = 0; i < totalPages; i++) {
+            sourcePages.add(createTestPage(2, 50));
+        }
+
+        AtomicReference<Exception> drainError = new AtomicReference<>();
+        CyclicBarrier barrier = new CyclicBarrier(2);
+
+        var factory = EsExecutors.daemonThreadFactory("testNode", "esql_worker");
+        Thread drainThread = factory.newThread(() -> {
+            try {
+                barrier.await();
+                ExternalSourceDrainUtils.drainPages(iteratorOf(sourcePages), buffer);
+                buffer.finish(false);
+            } catch (Exception e) {
+                drainError.set(e);
+                buffer.onFailure(e);
+            }
+        });
+
+        Thread consumeThread = factory.newThread(() -> {
             try {
                 barrier.await();
                 int consumed = 0;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -91,12 +91,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class LocalExecutionPlannerTests extends MapperServiceTestCase {
 
@@ -340,6 +342,104 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
         assertThat(captured.get(), notNullValue());
         assertThat(captured.get().sliceQueue(), notNullValue());
         assertThat(captured.get().sliceQueue().totalSlices(), equalTo(1));
+    }
+
+    /**
+     * {@link LocalExecutionPlanner} must pass {@link OperatorFactoryRegistry#executor()} and
+     * {@link OperatorFactoryRegistry#fileReadExecutor()} into {@link SourceOperatorContext} separately.
+     * Production wires the main executor to external-source work and {@code fileReadExecutor} to
+     * {@link org.elasticsearch.threadpool.ThreadPool.Names#GENERIC} via
+     * {@link org.elasticsearch.xpack.esql.plugin.TransportEsqlQueryAction}.
+     */
+    public void testPlanExternalSourcePassesDistinctExecutorsToSourceOperatorContext() throws IOException {
+        AtomicReference<SourceOperatorContext> captured = new AtomicReference<>();
+        SourceOperatorFactoryProvider provider = context -> {
+            captured.set(context);
+            return new SourceOperator.SourceOperatorFactory() {
+                @Override
+                public SourceOperator get(DriverContext driverContext) {
+                    return new SourceOperator() {
+                        @Override
+                        public Page getOutput() {
+                            return null;
+                        }
+
+                        @Override
+                        public boolean isFinished() {
+                            return true;
+                        }
+
+                        @Override
+                        public void finish() {}
+
+                        @Override
+                        public void close() {}
+                    };
+                }
+
+                @Override
+                public String describe() {
+                    return "test-source";
+                }
+            };
+        };
+        Executor mainExecutor = r -> r.run();
+        Executor fileReadExecutor = r -> r.run();
+        OperatorFactoryRegistry operatorFactoryRegistry = new OperatorFactoryRegistry(
+            Map.of(),
+            Map.of("file", provider),
+            mainExecutor,
+            fileReadExecutor
+        );
+
+        List<Attribute> attrs = List.of(
+            new FieldAttribute(Source.EMPTY, "a", new EsField("a", DataType.INTEGER, Map.of(), true, EsField.TimeSeriesFieldType.NONE))
+        );
+        ExternalSplit child1 = new FileSplit(
+            "file",
+            StoragePath.of("s3://test-bucket/warehouse/stress/part-00000.csv"),
+            0,
+            10,
+            ".csv",
+            Map.of(),
+            Map.of()
+        );
+        ExternalSplit child2 = new FileSplit(
+            "file",
+            StoragePath.of("s3://test-bucket/warehouse/stress/part-00001.csv"),
+            0,
+            10,
+            ".csv",
+            Map.of(),
+            Map.of()
+        );
+        ExternalSplit coalesced = new CoalescedSplit("file", List.of(child1, child2));
+
+        ExternalSourceExec exec = new ExternalSourceExec(
+            Source.EMPTY,
+            "s3://test-bucket/warehouse/stress/*.csv",
+            "file",
+            attrs,
+            Map.of(),
+            Map.of(),
+            null,
+            FormatReader.NO_LIMIT,
+            10,
+            null,
+            List.of(coalesced)
+        );
+
+        planner(operatorFactoryRegistry).plan(
+            "test",
+            FoldContext.small(),
+            PlannerSettings.DEFAULTS,
+            exec,
+            EmptyIndexedByShardId.instance()
+        );
+
+        assertThat(captured.get(), notNullValue());
+        assertThat(captured.get().executor(), sameInstance(mainExecutor));
+        assertThat(captured.get().fileReadExecutor(), sameInstance(fileReadExecutor));
     }
 
     public void testPlanUnmappedFieldExtractStoredSource() throws Exception {


### PR DESCRIPTION
This fixes an execution starvation issue:
AsyncExternalSourceOperatorFactory, creates a producer/consumer setup with a bounded buffer. This is unlike the index data-sourced execution, where the drivers pull-drive the reading through the pipeline.

With AsyncExternalSourceOperatorFactory, high splits count and one threads pool it can happen that producers block waiting for space while consumers are thread-pool starved when draining the pages.  When that happens, processing slows down gradually until timeouts in producers fire.

The proposed change is to move data producing onto a different thread pool, the GENERIC one. Consumers remain on the ESQL pool.

🤖-assisted development.
