### PR TITLE
[9.3] ES|QL: Fix rate/increase single-value bucket handling for delta temporality (#146518)

### DIFF
--- a/docs/changelog/146518.yaml
+++ b/docs/changelog/146518.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 146518
+summary: Fix rate/increase single-value bucket handling for delta temporality
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -698,8 +698,8 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
-                firstTsSec = state.intervals[0].t1 / dateFactor;
-                firstValue = state.intervals[0].v1;
+                firstTsSec = state.intervals[0].t2 / dateFactor;
+                firstValue = state.intervals[0].v2;
             } else {
                 firstValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, true);
             }
@@ -712,7 +712,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
                 lastTsSec = state.intervals[0].t1 / dateFactor;
-                lastValue = state.intervals[0].v1;
+                lastValue = state.intervals[0].v1 + state.resets;
             } else {
                 lastValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, false);
             }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -698,8 +698,8 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
-                firstTsSec = state.intervals[0].t1 / dateFactor;
-                firstValue = state.intervals[0].v1;
+                firstTsSec = state.intervals[0].t2 / dateFactor;
+                firstValue = state.intervals[0].v2;
             } else {
                 firstValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, true);
             }
@@ -712,7 +712,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
                 lastTsSec = state.intervals[0].t1 / dateFactor;
-                lastValue = state.intervals[0].v1;
+                lastValue = state.intervals[0].v1 + state.resets;
             } else {
                 lastValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, false);
             }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -698,8 +698,8 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
-                firstTsSec = state.intervals[0].t1 / dateFactor;
-                firstValue = state.intervals[0].v1;
+                firstTsSec = state.intervals[0].t2 / dateFactor;
+                firstValue = state.intervals[0].v2;
             } else {
                 firstValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, true);
             }
@@ -712,7 +712,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
                 lastTsSec = state.intervals[0].t1 / dateFactor;
-                lastValue = state.intervals[0].v1;
+                lastValue = state.intervals[0].v1 + state.resets;
             } else {
                 lastValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, false);
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
@@ -698,8 +698,8 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
-                firstTsSec = state.intervals[0].t1 / dateFactor;
-                firstValue = state.intervals[0].v1;
+                firstTsSec = state.intervals[0].t2 / dateFactor;
+                firstValue = state.intervals[0].v2;
             } else {
                 firstValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, true);
             }
@@ -712,7 +712,7 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
                 lastTsSec = state.intervals[0].t1 / dateFactor;
-                lastValue = state.intervals[0].v1;
+                lastValue = state.intervals[0].v1 + state.resets;
             } else {
                 lastValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, false);
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [ES|QL: Fix rate/increase single-value bucket handling for delta temporality (#146518)](https://github.com/elastic/elasticsearch/pull/146518)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)