### PR TITLE
[9.4] Consistent behavior for MMR when docs are missing diversification field (#146005)

### DIFF
--- a/docs/changelog/146005.yaml
+++ b/docs/changelog/146005.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 142939
+pr: 146005
+summary: Fix MMR NPE when initial doc has a null vector
+type: bug

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/result-diversification/10_mmr_result_diversification_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/result-diversification/10_mmr_result_diversification_retriever.yml
@@ -716,9 +716,11 @@ teardown:
 
 ---
 "Test MMR result diversification required field type":
+  - requires:
+      cluster_features: [ "retriever.mmr_null_dense_vector_fix" ]
+      reason: "MMR now drops null-vector docs instead of erroring"
 
   - do:
-      catch: /Failed to retrieve vectors for field \[unknown_field\]. Is it a \[dense_vector\] or \[semantic_text\] field with text embeddings?/
       search:
         index: test-result-diversification-index
         body:
@@ -735,13 +737,10 @@ teardown:
                   k: 6
                   num_candidates: 6
 
-  - match: { status: 400 }
-  - match: { error.type: status_exception }
-  - contains: { error.reason: "[diversify] search failed - retrievers '[diversify]'" }
-  - match: { error.suppressed.0.type: status_exception }
+  - match: { hits.total.value: 6 }
+  - length: { hits.hits: 0 }
 
   - do:
-      catch: /Failed to retrieve vectors for field \[keywordfield\]. Is it a \[dense_vector\] or \[semantic_text\] field with text embeddings?/
       search:
         index: test-result-diversification-index
         body:
@@ -758,13 +757,10 @@ teardown:
                   k: 6
                   num_candidates: 6
 
-  - match: { status: 400 }
-  - match: { error.type: status_exception }
-  - contains: { error.reason: "[diversify] search failed - retrievers '[diversify]'" }
-  - match: { error.suppressed.0.type: status_exception }
+  - match: { hits.total.value: 6 }
+  - length: { hits.hits: 0 }
 
   - do:
-      catch: /Failed to retrieve vectors for field \[textbody\]. Is it a \[dense_vector\] or \[semantic_text\] field with text embeddings?/
       search:
         index: test-result-diversification-index
         body:
@@ -781,10 +777,8 @@ teardown:
                   k: 6
                   num_candidates: 6
 
-  - match: { status: 400 }
-  - match: { error.type: status_exception }
-  - contains: { error.reason: "[diversify] search failed" }
-  - match: { error.suppressed.0.type: status_exception }
+  - match: { hits.total.value: 6 }
+  - length: { hits.hits: 0 }
 
 ---
 "Test MMR result diversification cannot have a string encoded query vector":

--- a/server/src/main/java/org/elasticsearch/search/diversification/DiversifyRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/diversification/DiversifyRetrieverBuilder.java
@@ -63,6 +63,7 @@ public final class DiversifyRetrieverBuilder extends CompoundRetrieverBuilder<Di
     public static final int DEFAULT_SIZE_VALUE = 10;
 
     public static final NodeFeature RETRIEVER_RESULT_DIVERSIFICATION_MMR_FEATURE = new NodeFeature("retriever.result_diversification_mmr");
+    public static final NodeFeature MMR_NULL_DENSE_VECTOR_FIX = new NodeFeature("retriever.mmr_null_dense_vector_fix");
     private static final VectorSimilarityFunction QUERY_VECTOR_SIMILARITY_FUNCTION = VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
 
     public static final String NAME = "diversify";
@@ -399,17 +400,6 @@ public final class DiversifyRetrieverBuilder extends CompoundRetrieverBuilder<Di
             } catch (IOException ioEx) {
                 throw new UncheckedIOException(ioEx);
             }
-        }
-
-        if (fieldVectors.isEmpty()) {
-            throw new ElasticsearchStatusException(
-                String.format(
-                    Locale.ROOT,
-                    "Failed to retrieve vectors for field [%s]. Is it a [dense_vector] or [semantic_text] field with text embeddings?",
-                    diversificationField
-                ),
-                RestStatus.BAD_REQUEST
-            );
         }
 
         diversificationContext.setFieldVectors(fieldVectors);

--- a/server/src/main/java/org/elasticsearch/search/diversification/mmr/MMRResultDiversification.java
+++ b/server/src/main/java/org/elasticsearch/search/diversification/mmr/MMRResultDiversification.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.stream.IntStream;
 
 public class MMRResultDiversification extends ResultDiversification<MMRResultDiversificationContext> {
@@ -47,9 +48,15 @@ public class MMRResultDiversification extends ResultDiversification<MMRResultDiv
 
         // cache the similarity scores for the query vector vs. searchHits
         float[] querySimilarities = getQuerySimilarityForDocs(docs);
-        // always add the highest relevant doc to the list
-        int prevSelectedDocRank = 1 + IntStream.range(0, querySimilarities.length)
-            .reduce(0, (a, b) -> querySimilarities[a] >= querySimilarities[b] ? a : b);
+        OptionalInt bestDocIdx = IntStream.range(0, querySimilarities.length)
+            .filter(i -> context.getFieldVector(i + 1) != null)
+            .reduce((a, b) -> querySimilarities[a] >= querySimilarities[b] ? a : b);
+
+        if (bestDocIdx.isEmpty()) {
+            return new RankDoc[0];
+        }
+
+        int prevSelectedDocRank = 1 + bestDocIdx.getAsInt();
 
         selectedDocRanks.add(prevSelectedDocRank);
         int topDocsSize = context.getSize();

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
@@ -14,6 +14,7 @@ import org.elasticsearch.features.NodeFeature;
 
 import java.util.Set;
 
+import static org.elasticsearch.search.diversification.DiversifyRetrieverBuilder.MMR_NULL_DENSE_VECTOR_FIX;
 import static org.elasticsearch.search.diversification.DiversifyRetrieverBuilder.RETRIEVER_RESULT_DIVERSIFICATION_MMR_FEATURE;
 
 /**
@@ -30,6 +31,6 @@ public class RetrieversFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
-        return Set.of(NEGATIVE_RANK_WINDOW_SIZE_FIX, RETRIEVER_RESULT_DIVERSIFICATION_MMR_FEATURE);
+        return Set.of(NEGATIVE_RANK_WINDOW_SIZE_FIX, RETRIEVER_RESULT_DIVERSIFICATION_MMR_FEATURE, MMR_NULL_DENSE_VECTOR_FIX);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/diversification/DiversifyRetrieverBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/diversification/DiversifyRetrieverBuilderTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.rank.RankDoc;
 import org.elasticsearch.search.retriever.CompoundRetrieverBuilder;
 import org.elasticsearch.search.retriever.RetrieverBuilder;
 import org.elasticsearch.search.retriever.TestRetrieverBuilder;
@@ -332,32 +333,16 @@ public class DiversifyRetrieverBuilderTests extends ESTestCase {
         ScoreDoc[] hits = getTestNonVectorSearchHits();
         docs.add(hits);
 
-        ElasticsearchStatusException badDocFieldEx = assertThrows(
-            ElasticsearchStatusException.class,
-            () -> retriever.combineInnerRetrieverResults(docs, false)
-        );
-        assertEquals(
-            "Failed to retrieve vectors for field [dense_vector_field]. "
-                + "Is it a [dense_vector] or [semantic_text] field with text embeddings?",
-            badDocFieldEx.getMessage()
-        );
-        assertEquals(400, badDocFieldEx.status().getStatus());
+        RankDoc[] results = retriever.combineInnerRetrieverResults(docs, false);
+        assertEquals(0, results.length);
 
         cleanDocsAndHits(docs, hits);
 
         ScoreDoc[] hitsWithNoValues = getTestSearchHitsWithNoValues();
         docs.add(hitsWithNoValues);
 
-        ElasticsearchStatusException docsWithNoValuesEx = assertThrows(
-            ElasticsearchStatusException.class,
-            () -> retriever.combineInnerRetrieverResults(docs, false)
-        );
-        assertEquals(
-            "Failed to retrieve vectors for field [dense_vector_field]. "
-                + "Is it a [dense_vector] or [semantic_text] field with text embeddings?",
-            docsWithNoValuesEx.getMessage()
-        );
-        assertEquals(400, docsWithNoValuesEx.status().getStatus());
+        RankDoc[] resultsWithNoValues = retriever.combineInnerRetrieverResults(docs, false);
+        assertEquals(0, resultsWithNoValues.length);
 
         cleanDocsAndHits(docs, hitsWithNoValues);
     }
@@ -476,6 +461,62 @@ public class DiversifyRetrieverBuilderTests extends ESTestCase {
         // should still not throw an exception
         try {
             retriever.combineInnerRetrieverResults(docs, false);
+        } finally {
+            cleanDocsAndHits(docs, hits);
+        }
+    }
+
+    public void testCombineInnerRetrieverResultsWithAllMissingVectors() {
+        var queryRewriteContext = getQueryRewriteContext();
+        var retriever = new DiversifyRetrieverBuilder(
+            getInnerRetriever(),
+            ResultDiversificationType.MMR,
+            "rgb_vector",
+            10,
+            3,
+            new VectorData(new float[] { 0.5f, 0.2f, 0.4f, 0.4f }),
+            null,
+            0.5f
+        );
+
+        retriever.doRewrite(queryRewriteContext);
+
+        List<ScoreDoc[]> docs = new ArrayList<>();
+        ScoreDoc[] hits = new DiversifyRetrieverBuilder.RankDocWithSearchHit[] { getTestSearchHitWithNoValue(1, 90002, 1.0f) };
+        docs.add(hits);
+
+        try {
+            RankDoc[] results = retriever.combineInnerRetrieverResults(docs, false);
+            assertEquals(0, results.length);
+        } finally {
+            cleanDocsAndHits(docs, hits);
+        }
+    }
+
+    public void testCombineInnerRetrieverResultsDropsMissingVectorDocs() {
+        var queryRewriteContext = getQueryRewriteContext();
+        var retriever = new DiversifyRetrieverBuilder(
+            getInnerRetriever(),
+            ResultDiversificationType.MMR,
+            "dense_vector_field",
+            10,
+            10,
+            new VectorData(new float[] { 0.5f, 0.2f, 0.4f, 0.4f }),
+            null,
+            0.5f
+        );
+
+        retriever.doRewrite(queryRewriteContext);
+
+        List<ScoreDoc[]> docs = new ArrayList<>();
+        ScoreDoc[] hits = new DiversifyRetrieverBuilder.RankDocWithSearchHit[] {
+            getTestSearchHitWithNoValue(1, 90002, 1.0f),
+            getTestSearchHit(2, 4, 4.0f, new float[] { 0.5f, 0.2f, 0.4f, 0.4f }) };
+        docs.add(hits);
+
+        try {
+            RankDoc[] results = retriever.combineInnerRetrieverResults(docs, false);
+            assertEquals(1, results.length);
         } finally {
             cleanDocsAndHits(docs, hits);
         }

--- a/server/src/test/java/org/elasticsearch/search/diversification/mmr/MMRResultDiversificationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/diversification/mmr/MMRResultDiversificationTests.java
@@ -15,49 +15,68 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
 public class MMRResultDiversificationTests extends ESTestCase {
 
-    public void testMMRDiversification() throws IOException {
-        for (int x = 0; x < 10; x++) {
-            List<Integer> expectedDocIds = new ArrayList<>();
-            MMRResultDiversificationContext diversificationContext = getRandomContext(expectedDocIds);
+    public void testMMRDiversificationWithFloatVectors() throws IOException {
+        List<Integer> expectedDocIds = new ArrayList<>();
+        MMRResultDiversificationContext diversificationContext = getFloatContext(expectedDocIds);
 
-            RankDoc[] docs = new RankDoc[] {
-                new RankDoc(1, 2.0f, 1),
-                new RankDoc(2, 1.8f, 1),
-                new RankDoc(3, 1.8f, 1),
-                new RankDoc(4, 1.0f, 1),
-                new RankDoc(5, 0.8f, 1),
-                new RankDoc(6, 0.8f, 1) };
+        RankDoc[] docs = new RankDoc[] {
+            new RankDoc(1, 2.0f, 1),
+            new RankDoc(2, 1.8f, 1),
+            new RankDoc(3, 1.8f, 1),
+            new RankDoc(4, 1.0f, 1),
+            new RankDoc(5, 0.8f, 1),
+            new RankDoc(6, 0.8f, 1) };
 
-            int rankIndex = 1;
-            for (RankDoc doc : docs) {
-                doc.rank = rankIndex++;
-            }
+        int rankIndex = 1;
+        for (RankDoc doc : docs) {
+            doc.rank = rankIndex++;
+        }
 
-            MMRResultDiversification resultDiversification = new MMRResultDiversification(diversificationContext);
-            RankDoc[] diversifiedTopDocs = resultDiversification.diversify(docs);
-            assertNotSame(docs, diversifiedTopDocs);
+        MMRResultDiversification resultDiversification = new MMRResultDiversification(diversificationContext);
+        RankDoc[] diversifiedTopDocs = resultDiversification.diversify(docs);
+        assertNotSame(docs, diversifiedTopDocs);
 
-            assertEquals(expectedDocIds.size(), diversifiedTopDocs.length);
-            for (int i = 0; i < expectedDocIds.size(); i++) {
-                assertEquals((int) expectedDocIds.get(i), diversifiedTopDocs[i].doc);
-            }
+        assertEquals(expectedDocIds.size(), diversifiedTopDocs.length);
+        for (int i = 0; i < expectedDocIds.size(); i++) {
+            assertEquals((int) expectedDocIds.get(i), diversifiedTopDocs[i].doc);
         }
     }
 
-    private MMRResultDiversificationContext getRandomContext(List<Integer> expectedDocIds) {
-        if (randomBoolean()) {
-            return getRandomFloatContext(expectedDocIds);
+    public void testMMRDiversificationWithByteVectors() throws IOException {
+        List<Integer> expectedDocIds = new ArrayList<>();
+        MMRResultDiversificationContext diversificationContext = getByteContext(expectedDocIds);
+
+        RankDoc[] docs = new RankDoc[] {
+            new RankDoc(1, 2.0f, 1),
+            new RankDoc(2, 1.8f, 1),
+            new RankDoc(3, 1.8f, 1),
+            new RankDoc(4, 1.0f, 1),
+            new RankDoc(5, 0.8f, 1),
+            new RankDoc(6, 0.8f, 1) };
+
+        int rankIndex = 1;
+        for (RankDoc doc : docs) {
+            doc.rank = rankIndex++;
         }
-        return getRandomByteContext(expectedDocIds);
+
+        MMRResultDiversification resultDiversification = new MMRResultDiversification(diversificationContext);
+        RankDoc[] diversifiedTopDocs = resultDiversification.diversify(docs);
+        assertNotSame(docs, diversifiedTopDocs);
+
+        assertEquals(expectedDocIds.size(), diversifiedTopDocs.length);
+        for (int i = 0; i < expectedDocIds.size(); i++) {
+            assertEquals((int) expectedDocIds.get(i), diversifiedTopDocs[i].doc);
+        }
     }
 
-    private MMRResultDiversificationContext getRandomFloatContext(List<Integer> expectedDocIds) {
+    private MMRResultDiversificationContext getFloatContext(List<Integer> expectedDocIds) {
 
         Supplier<VectorData> queryVectorData = () -> new VectorData(new float[] { 0.5f, 0.2f, 0.4f, 0.4f });
         var diversificationContext = new MMRResultDiversificationContext("dense_vector_field", 0.3f, 3, queryVectorData);
@@ -83,7 +102,7 @@ public class MMRResultDiversificationTests extends ESTestCase {
         return diversificationContext;
     }
 
-    private MMRResultDiversificationContext getRandomByteContext(List<Integer> expectedDocIds) {
+    private MMRResultDiversificationContext getByteContext(List<Integer> expectedDocIds) {
 
         Supplier<VectorData> queryVectorData = () -> new VectorData(new byte[] { 0x50, 0x20, 0x40, 0x40 });
         var diversificationContext = new MMRResultDiversificationContext("dense_vector_field", 0.3f, 3, queryVectorData);
@@ -107,6 +126,60 @@ public class MMRResultDiversificationTests extends ESTestCase {
         expectedDocIds.addAll(List.of(3, 4, 6));
 
         return diversificationContext;
+    }
+
+    public void testMMRDiversificationWithActualNullVector() throws IOException {
+        Supplier<VectorData> queryVectorData = () -> null;
+        var diversificationContext = new MMRResultDiversificationContext("dense_vector_field", 0.3f, 3, queryVectorData);
+
+        Map<Integer, VectorData> vectors = new HashMap<>();
+        vectors.put(1, null);
+        vectors.put(2, new VectorData(new float[] { 0.4f, 0.2f, 0.4f, 0.4f }));
+        vectors.put(3, new VectorData(new float[] { 0.4f, 0.2f, 0.3f, 0.3f }));
+        vectors.put(4, new VectorData(new float[] { 0.4f, 0.1f, 0.3f, 0.3f }));
+        diversificationContext.setFieldVectors(vectors);
+
+        RankDoc[] docs = new RankDoc[] {
+            new RankDoc(1, 2.0f, 1),
+            new RankDoc(2, 1.8f, 1),
+            new RankDoc(3, 1.0f, 1),
+            new RankDoc(4, 0.8f, 1) };
+
+        int rankIndex = 1;
+        for (RankDoc doc : docs) {
+            doc.rank = rankIndex++;
+        }
+
+        MMRResultDiversification resultDiversification = new MMRResultDiversification(diversificationContext);
+        RankDoc[] diversifiedTopDocs = resultDiversification.diversify(docs);
+
+        assertEquals(3, diversifiedTopDocs.length);
+        for (RankDoc doc : diversifiedTopDocs) {
+            assertNotEquals(1, doc.rank);
+        }
+    }
+
+    public void testMMRDiversificationWithAllNullVectors() throws IOException {
+        Supplier<VectorData> queryVectorData = () -> null;
+        var diversificationContext = new MMRResultDiversificationContext("dense_vector_field", 0.3f, 3, queryVectorData);
+
+        Map<Integer, VectorData> vectors = new HashMap<>();
+        vectors.put(1, null);
+        vectors.put(2, null);
+        vectors.put(3, null);
+        diversificationContext.setFieldVectors(vectors);
+
+        RankDoc[] docs = new RankDoc[] { new RankDoc(1, 2.0f, 1), new RankDoc(2, 1.8f, 1), new RankDoc(3, 1.0f, 1) };
+
+        int rankIndex = 1;
+        for (RankDoc doc : docs) {
+            doc.rank = rankIndex++;
+        }
+
+        MMRResultDiversification resultDiversification = new MMRResultDiversification(diversificationContext);
+        RankDoc[] diversifiedTopDocs = resultDiversification.diversify(docs);
+
+        assertEquals(0, diversifiedTopDocs.length);
     }
 
     public void testMMRDiversificationIfNoSearchHits() throws IOException {

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_semantic_text_diversify_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_semantic_text_diversify_retriever.yml
@@ -330,8 +330,11 @@ setup:
 
 ---
 "Validate diversification does not work with sparse vector data":
+  - requires:
+      cluster_features: [ "retriever.mmr_null_dense_vector_fix" ]
+      reason: "MMR now drops null-vector docs instead of erroring"
+
   - do:
-      catch: /Failed to retrieve vectors for field \[content\]. Is it a \[dense_vector\] or \[semantic_text\] field with text embeddings?/
       search:
         index: test-result-diversification-sparse-semantic-text-index
         body:
@@ -348,10 +351,7 @@ setup:
                     match:
                       content:
                         query: "What causes muscle soreness after running?"
-
-  - match: { status: 400 }
-  - match: { error.type: status_exception }
-
+  - length: { hits.hits: 0 }
 ---
 "Validate query_vector or query_vector_builder but not both":
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Consistent behavior for MMR when docs are missing diversification field (#146005)