### PR TITLE
ESQL: Adjust text field creation and usage in generative random mapping testing

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -325,9 +325,6 @@ tests:
 - class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
   method: testReindexFailsWhenPitRelocationFails
   issue: https://github.com/elastic/elasticsearch/issues/146650
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeRandomMappingIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/146553
 - class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
   method: testReindexTaskRelocatesOnNodeShutdown
   issue: https://github.com/elastic/elasticsearch/issues/146696

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/RandomMappingGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/RandomMappingGenerator.java
@@ -281,8 +281,7 @@ public final class RandomMappingGenerator {
                 boolean indexed = Boolean.FALSE.equals(s.get("index")) == false;
                 Object indexOpts = s.get("index_options");
                 // omitted index_options defaults to "positions" (see TextParams.textIndexOptions)
-                boolean positionsEnabled = indexed
-                    && (indexOpts == null || "positions".equals(indexOpts) || "offsets".equals(indexOpts));
+                boolean positionsEnabled = indexed && (indexOpts == null || "positions".equals(indexOpts) || "offsets".equals(indexOpts));
                 if (positionsEnabled) {
                     optionalSet(s, 1, "index_phrases", true);
                     optionalSet(s, 1, "position_increment_gap", randomFrom(100, 0, 50, 200));

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/RandomMappingGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/RandomMappingGenerator.java
@@ -278,12 +278,21 @@ public final class RandomMappingGenerator {
                 optionalSet(s, 1, "index", randomBoolean());
                 optionalSet(s, 1, "index_options", randomFrom("docs", "freqs", "positions", "offsets"));
                 optionalSet(s, 1, "norms", randomBoolean());
-                optionalSet(s, 1, "index_phrases", true);
-                optionalSet(s, 1, "position_increment_gap", randomFrom(100, 0, 50, 200));
+                boolean indexed = Boolean.FALSE.equals(s.get("index")) == false;
+                Object indexOpts = s.get("index_options");
+                // omitted index_options defaults to "positions" (see TextParams.textIndexOptions)
+                boolean positionsEnabled = indexed
+                    && (indexOpts == null || "positions".equals(indexOpts) || "offsets".equals(indexOpts));
+                if (positionsEnabled) {
+                    optionalSet(s, 1, "index_phrases", true);
+                    optionalSet(s, 1, "position_increment_gap", randomFrom(100, 0, 50, 200));
+                }
                 optionalSet(s, 1, "similarity", randomFrom("BM25", "boolean"));
                 optionalSet(s, 1, "term_vector", randomFrom("no", "yes", "with_positions", "with_offsets", "with_positions_offsets"));
                 optionalSet(s, 1, "eager_global_ordinals", true);
-                optionalSet(s, 1, "fielddata", true);
+                if (indexed) {
+                    optionalSet(s, 1, "fielddata", true);
+                }
             }
             case "match_only_text" -> {
             }


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/146553