### PR TITLE
PROMQL: Mute GenerativePromQLIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -250,6 +250,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeUnmappedLoadIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/145900
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativePromQLIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/146923
 - class: org.elasticsearch.xpack.eql.qa.ccs_rolling_upgrade.EqlCcsRollingUpgradeIT
   method: testSequences
   issue: https://github.com/elastic/elasticsearch/issues/146263


### PR DESCRIPTION
Mute because of https://github.com/elastic/elasticsearch/issues/146923 which blocks https://github.com/elastic/elasticsearch/pull/146912