### PR TITLE
Expose `DesiredBalanceStats` as metrics

### DIFF
--- a/docs/changelog/146928.yaml
+++ b/docs/changelog/146928.yaml
@@ -1,0 +1,5 @@
+area: Allocation
+issues: []
+pr: 146928
+summary: Expose `DesiredBalanceStats` as metrics
+type: enhancement

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerMetricsIT.java
@@ -77,12 +77,12 @@ public class DesiredBalanceReconcilerMetricsIT extends ESIntegTestCase {
         assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.TOTAL_SHARDS_METRIC_NAME), not(empty()));
         assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.UNDESIRED_ALLOCATION_COUNT_METRIC_NAME), not(empty()));
         assertThat(telemetryPlugin.getDoubleGaugeMeasurement(DesiredBalanceMetrics.UNDESIRED_ALLOCATION_RATIO_METRIC_NAME), not(empty()));
-        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_SUBMITTED_METRIC_NAME), not(empty()));
-        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_EXECUTED_METRIC_NAME), not(empty()));
-        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_CONVERGED_METRIC_NAME), not(empty()));
-        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_ITERATIONS_METRIC_NAME), not(empty()));
-        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_TIME_METRIC_NAME), not(empty()));
-        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.RECONCILIATIONS_TIME_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.COMPUTATIONS_SUBMITTED_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.COMPUTATIONS_EXECUTED_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.COMPUTATIONS_CONVERGED_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.COMPUTATIONS_ITERATIONS_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.COMPUTATIONS_TIME_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.RECONCILIATIONS_TIME_METRIC_NAME), not(empty()));
 
         var nodeIds = internalCluster().clusterService().state().nodes().stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
         var nodeNames = internalCluster().clusterService().state().nodes().stream().map(DiscoveryNode::getName).collect(Collectors.toSet());
@@ -198,12 +198,12 @@ public class DesiredBalanceReconcilerMetricsIT extends ESIntegTestCase {
         assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.TOTAL_SHARDS_METRIC_NAME), matcher);
         assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.UNDESIRED_ALLOCATION_COUNT_METRIC_NAME), matcher);
         assertThat(testTelemetryPlugin.getDoubleGaugeMeasurement(DesiredBalanceMetrics.UNDESIRED_ALLOCATION_RATIO_METRIC_NAME), matcher);
-        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_SUBMITTED_METRIC_NAME), matcher);
-        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_EXECUTED_METRIC_NAME), matcher);
-        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_CONVERGED_METRIC_NAME), matcher);
-        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_ITERATIONS_METRIC_NAME), matcher);
-        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_TIME_METRIC_NAME), matcher);
-        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.RECONCILIATIONS_TIME_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.COMPUTATIONS_SUBMITTED_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.COMPUTATIONS_EXECUTED_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.COMPUTATIONS_CONVERGED_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.COMPUTATIONS_ITERATIONS_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.COMPUTATIONS_TIME_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongAsyncCounterMeasurement(DesiredBalanceMetrics.RECONCILIATIONS_TIME_METRIC_NAME), matcher);
         assertThat(testTelemetryPlugin.getDoubleGaugeMeasurement(DesiredBalanceMetrics.DESIRED_BALANCE_NODE_WEIGHT_METRIC_NAME), matcher);
         assertThat(
             testTelemetryPlugin.getDoubleGaugeMeasurement(DesiredBalanceMetrics.DESIRED_BALANCE_NODE_WRITE_LOAD_METRIC_NAME),

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerMetricsIT.java
@@ -77,6 +77,12 @@ public class DesiredBalanceReconcilerMetricsIT extends ESIntegTestCase {
         assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.TOTAL_SHARDS_METRIC_NAME), not(empty()));
         assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.UNDESIRED_ALLOCATION_COUNT_METRIC_NAME), not(empty()));
         assertThat(telemetryPlugin.getDoubleGaugeMeasurement(DesiredBalanceMetrics.UNDESIRED_ALLOCATION_RATIO_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_SUBMITTED_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_EXECUTED_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_CONVERGED_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_ITERATIONS_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_TIME_METRIC_NAME), not(empty()));
+        assertThat(telemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.RECONCILIATIONS_TIME_METRIC_NAME), not(empty()));
 
         var nodeIds = internalCluster().clusterService().state().nodes().stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
         var nodeNames = internalCluster().clusterService().state().nodes().stream().map(DiscoveryNode::getName).collect(Collectors.toSet());
@@ -192,6 +198,12 @@ public class DesiredBalanceReconcilerMetricsIT extends ESIntegTestCase {
         assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.TOTAL_SHARDS_METRIC_NAME), matcher);
         assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.UNDESIRED_ALLOCATION_COUNT_METRIC_NAME), matcher);
         assertThat(testTelemetryPlugin.getDoubleGaugeMeasurement(DesiredBalanceMetrics.UNDESIRED_ALLOCATION_RATIO_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_SUBMITTED_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_EXECUTED_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_CONVERGED_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_ITERATIONS_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.COMPUTATIONS_TIME_METRIC_NAME), matcher);
+        assertThat(testTelemetryPlugin.getLongGaugeMeasurement(DesiredBalanceMetrics.RECONCILIATIONS_TIME_METRIC_NAME), matcher);
         assertThat(testTelemetryPlugin.getDoubleGaugeMeasurement(DesiredBalanceMetrics.DESIRED_BALANCE_NODE_WEIGHT_METRIC_NAME), matcher);
         assertThat(
             testTelemetryPlugin.getDoubleGaugeMeasurement(DesiredBalanceMetrics.DESIRED_BALANCE_NODE_WRITE_LOAD_METRIC_NAME),

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceMetrics.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceMetrics.java
@@ -107,6 +107,14 @@ public class DesiredBalanceMetrics {
     /** {@link #UNDESIRED_ALLOCATION_COUNT_METRIC_NAME} / {@link #TOTAL_SHARDS_METRIC_NAME} */
     public static final String UNDESIRED_ALLOCATION_RATIO_METRIC_NAME = "es.allocator.desired_balance.allocations.undesired.ratio";
 
+    // Desired balance computation metrics (from {@link DesiredBalanceStats}).
+    public static final String COMPUTATIONS_SUBMITTED_METRIC_NAME = "es.allocator.desired_balance.computations.submitted.total";
+    public static final String COMPUTATIONS_EXECUTED_METRIC_NAME = "es.allocator.desired_balance.computations.executed.total";
+    public static final String COMPUTATIONS_CONVERGED_METRIC_NAME = "es.allocator.desired_balance.computations.converged.total";
+    public static final String COMPUTATIONS_ITERATIONS_METRIC_NAME = "es.allocator.desired_balance.computations.iterations.total";
+    public static final String COMPUTATIONS_TIME_METRIC_NAME = "es.allocator.desired_balance.computations.time";
+    public static final String RECONCILIATIONS_TIME_METRIC_NAME = "es.allocator.desired_balance.reconciliations.time";
+
     // Desired balance node metrics.
     public static final String DESIRED_BALANCE_NODE_WEIGHT_METRIC_NAME = "es.allocator.desired_balance.allocations.node_weight.current";
     public static final String DESIRED_BALANCE_NODE_SHARD_COUNT_METRIC_NAME =
@@ -145,10 +153,13 @@ public class DesiredBalanceMetrics {
         Map.of()
     );
 
+    private volatile DesiredBalanceStats desiredBalanceStats = DesiredBalanceStats.ZERO;
+
     public void updateMetrics(
         AllocationStats allocationStats,
         Map<DiscoveryNode, NodeWeightStats> weightStatsPerNode,
-        Map<DiscoveryNode, NodeAllocationStatsAndWeight> nodeAllocationStats
+        Map<DiscoveryNode, NodeAllocationStatsAndWeight> nodeAllocationStats,
+        DesiredBalanceStats desiredBalanceStats
     ) {
         assert allocationStats != null : "allocation stats cannot be null";
         assert weightStatsPerNode != null : "node balance weight stats cannot be null";
@@ -157,6 +168,7 @@ public class DesiredBalanceMetrics {
         }
         weightStatsPerNodeRef.set(weightStatsPerNode);
         allocationStatsPerNodeRef.set(nodeAllocationStats);
+        this.desiredBalanceStats = desiredBalanceStats;
     }
 
     public DesiredBalanceMetrics(MeterRegistry meterRegistry) {
@@ -179,6 +191,43 @@ public class DesiredBalanceMetrics {
             "Ratio of undesired allocations to shard count excluding shutting down nodes",
             "1",
             this::getUndesiredAllocationsRatioMetrics
+        );
+
+        meterRegistry.registerLongsGauge(
+            COMPUTATIONS_SUBMITTED_METRIC_NAME,
+            "Total number of desired balance computations submitted on this elected master",
+            "unit",
+            this::getComputationSubmittedMetrics
+        );
+        meterRegistry.registerLongsGauge(
+            COMPUTATIONS_EXECUTED_METRIC_NAME,
+            "Total number of desired balance computations executed on this elected master",
+            "unit",
+            this::getComputationExecutedMetrics
+        );
+        meterRegistry.registerLongsGauge(
+            COMPUTATIONS_CONVERGED_METRIC_NAME,
+            "Total number of desired balance computations that converged on this elected master",
+            "unit",
+            this::getComputationConvergedMetrics
+        );
+        meterRegistry.registerLongsGauge(
+            COMPUTATIONS_ITERATIONS_METRIC_NAME,
+            "Total iterations across desired balance computations on this elected master",
+            "unit",
+            this::getComputationIterationsMetrics
+        );
+        meterRegistry.registerLongsGauge(
+            COMPUTATIONS_TIME_METRIC_NAME,
+            "Cumulative wall-clock time spent in desired balance computation on this elected master",
+            "ms",
+            this::getCumulativeComputationTimeMillisMetrics
+        );
+        meterRegistry.registerLongsGauge(
+            RECONCILIATIONS_TIME_METRIC_NAME,
+            "Cumulative wall-clock time spent reconciling toward the desired balance on this elected master",
+            "ms",
+            this::getCumulativeReconciliationTimeMillisMetrics
         );
 
         meterRegistry.registerDoublesGauge(
@@ -430,6 +479,37 @@ public class DesiredBalanceMetrics {
         return List.of();
     }
 
+    private List<LongWithAttributes> getComputationSubmittedMetrics() {
+        return getIfPublishingDesiredBalanceStats(DesiredBalanceStats::computationSubmitted);
+    }
+
+    private List<LongWithAttributes> getComputationExecutedMetrics() {
+        return getIfPublishingDesiredBalanceStats(DesiredBalanceStats::computationExecuted);
+    }
+
+    private List<LongWithAttributes> getComputationConvergedMetrics() {
+        return getIfPublishingDesiredBalanceStats(DesiredBalanceStats::computationConverged);
+    }
+
+    private List<LongWithAttributes> getComputationIterationsMetrics() {
+        return getIfPublishingDesiredBalanceStats(DesiredBalanceStats::computationIterations);
+    }
+
+    private List<LongWithAttributes> getCumulativeComputationTimeMillisMetrics() {
+        return getIfPublishingDesiredBalanceStats(DesiredBalanceStats::cumulativeComputationTime);
+    }
+
+    private List<LongWithAttributes> getCumulativeReconciliationTimeMillisMetrics() {
+        return getIfPublishingDesiredBalanceStats(DesiredBalanceStats::cumulativeReconciliationTime);
+    }
+
+    private List<LongWithAttributes> getIfPublishingDesiredBalanceStats(ToLongFunction<DesiredBalanceStats> value) {
+        if (nodeIsMaster && lastReconciliationAllocationStats != EMPTY_ALLOCATION_STATS) {
+            return List.of(new LongWithAttributes(value.applyAsLong(desiredBalanceStats)));
+        }
+        return List.of();
+    }
+
     /**
      * Sets all the internal class fields to zero/empty. Typically used in conjunction with {@link #setNodeIsMaster}.
      * This is best-effort because it is possible for {@link #updateMetrics} to race with this method.
@@ -438,5 +518,6 @@ public class DesiredBalanceMetrics {
         lastReconciliationAllocationStats = EMPTY_ALLOCATION_STATS;
         weightStatsPerNodeRef.set(Map.of());
         allocationStatsPerNodeRef.set(Map.of());
+        desiredBalanceStats = DesiredBalanceStats.ZERO;
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceMetrics.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceMetrics.java
@@ -193,37 +193,37 @@ public class DesiredBalanceMetrics {
             this::getUndesiredAllocationsRatioMetrics
         );
 
-        meterRegistry.registerLongsGauge(
+        meterRegistry.registerLongsAsyncCounter(
             COMPUTATIONS_SUBMITTED_METRIC_NAME,
             "Total number of desired balance computations submitted on this elected master",
             "unit",
             this::getComputationSubmittedMetrics
         );
-        meterRegistry.registerLongsGauge(
+        meterRegistry.registerLongsAsyncCounter(
             COMPUTATIONS_EXECUTED_METRIC_NAME,
             "Total number of desired balance computations executed on this elected master",
             "unit",
             this::getComputationExecutedMetrics
         );
-        meterRegistry.registerLongsGauge(
+        meterRegistry.registerLongsAsyncCounter(
             COMPUTATIONS_CONVERGED_METRIC_NAME,
             "Total number of desired balance computations that converged on this elected master",
             "unit",
             this::getComputationConvergedMetrics
         );
-        meterRegistry.registerLongsGauge(
+        meterRegistry.registerLongsAsyncCounter(
             COMPUTATIONS_ITERATIONS_METRIC_NAME,
             "Total iterations across desired balance computations on this elected master",
             "unit",
             this::getComputationIterationsMetrics
         );
-        meterRegistry.registerLongsGauge(
+        meterRegistry.registerLongsAsyncCounter(
             COMPUTATIONS_TIME_METRIC_NAME,
             "Cumulative wall-clock time spent in desired balance computation on this elected master",
             "ms",
             this::getCumulativeComputationTimeMillisMetrics
         );
-        meterRegistry.registerLongsGauge(
+        meterRegistry.registerLongsAsyncCounter(
             RECONCILIATIONS_TIME_METRIC_NAME,
             "Cumulative wall-clock time spent reconciling toward the desired balance on this elected master",
             "ms",

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -377,8 +377,9 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
             logger.debug("Reconciling desired balance for [{}]", desiredBalance.lastConvergedIndex());
         }
         recordTime(cumulativeReconciliationTime, () -> {
-            DesiredBalanceMetrics.AllocationStats allocationStats = desiredBalanceReconciler.reconcile(desiredBalance, allocation);
-            updateDesireBalanceMetrics(desiredBalance, allocation, allocationStats);
+            final var allocationStats = desiredBalanceReconciler.reconcile(desiredBalance, allocation);
+            final var desiredBalanceStats = getStats();
+            updateDesireBalanceMetrics(desiredBalance, allocation, allocationStats, desiredBalanceStats);
         });
 
         if (logger.isTraceEnabled()) {
@@ -424,7 +425,8 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
     private void updateDesireBalanceMetrics(
         DesiredBalance desiredBalance,
         RoutingAllocation routingAllocation,
-        DesiredBalanceMetrics.AllocationStats allocationStats
+        DesiredBalanceMetrics.AllocationStats allocationStats,
+        DesiredBalanceStats desiredBalanceStats
     ) {
         var nodesStatsAndWeights = nodeAllocationStatsAndWeightsCalculator.nodesAllocationStatsAndWeights(
             routingAllocation.metadata(),
@@ -441,7 +443,12 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
                 filteredNodeAllocationStatsAndWeights.put(node, nodeStatsAndWeight.getValue());
             }
         }
-        desiredBalanceMetrics.updateMetrics(allocationStats, desiredBalance.weightsPerNode(), filteredNodeAllocationStatsAndWeights);
+        desiredBalanceMetrics.updateMetrics(
+            allocationStats,
+            desiredBalance.weightsPerNode(),
+            filteredNodeAllocationStatsAndWeights,
+            desiredBalanceStats
+        );
     }
 
     public DesiredBalanceStats getStats() {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceStats.java
@@ -40,6 +40,8 @@ public record DesiredBalanceStats(
         }
     }
 
+    public static final DesiredBalanceStats ZERO = new DesiredBalanceStats(0, false, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
     public static DesiredBalanceStats readFrom(StreamInput in) throws IOException {
         return new DesiredBalanceStats(
             in.readVLong(),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceMetricsTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.Map;
 
+import static org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceStatsTests.randomDesiredBalanceStats;
 import static org.elasticsearch.telemetry.RecordingMeterRegistry.measures;
 import static org.hamcrest.Matchers.empty;
 
@@ -27,7 +28,12 @@ public class DesiredBalanceMetricsTests extends ESTestCase {
         long unassignedShards = randomNonNegativeLong();
         long totalAllocations = randomNonNegativeLong();
         long undesiredAllocations = randomNonNegativeLong();
-        metrics.updateMetrics(new AllocationStats(unassignedShards, totalAllocations, undesiredAllocations), Map.of(), Map.of());
+        metrics.updateMetrics(
+            new AllocationStats(unassignedShards, totalAllocations, undesiredAllocations),
+            Map.of(),
+            Map.of(),
+            DesiredBalanceStats.ZERO
+        );
         assertEquals(totalAllocations, metrics.totalAllocations());
         assertEquals(unassignedShards, metrics.unassignedShards());
         assertEquals(undesiredAllocations, metrics.undesiredAllocations());
@@ -44,7 +50,13 @@ public class DesiredBalanceMetricsTests extends ESTestCase {
         long unassignedShards = randomNonNegativeLong();
         long totalAllocations = randomLongBetween(100, 10000000);
         long undesiredAllocations = randomLongBetween(0, totalAllocations);
-        metrics.updateMetrics(new AllocationStats(unassignedShards, totalAllocations, undesiredAllocations), Map.of(), Map.of());
+        DesiredBalanceStats desiredBalanceStats = randomDesiredBalanceStats();
+        metrics.updateMetrics(
+            new AllocationStats(unassignedShards, totalAllocations, undesiredAllocations),
+            Map.of(),
+            Map.of(),
+            desiredBalanceStats
+        );
 
         // Collect when not master
         meterRegistry.getRecorder().collect();
@@ -64,6 +76,33 @@ public class DesiredBalanceMetricsTests extends ESTestCase {
         assertThat(
             meterRegistry.getRecorder()
                 .getMeasurements(InstrumentType.DOUBLE_GAUGE, DesiredBalanceMetrics.UNDESIRED_ALLOCATION_RATIO_METRIC_NAME),
+            empty()
+        );
+        assertThat(
+            meterRegistry.getRecorder()
+                .getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_SUBMITTED_METRIC_NAME),
+            empty()
+        );
+        assertThat(
+            meterRegistry.getRecorder().getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_EXECUTED_METRIC_NAME),
+            empty()
+        );
+        assertThat(
+            meterRegistry.getRecorder()
+                .getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_CONVERGED_METRIC_NAME),
+            empty()
+        );
+        assertThat(
+            meterRegistry.getRecorder()
+                .getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_ITERATIONS_METRIC_NAME),
+            empty()
+        );
+        assertThat(
+            meterRegistry.getRecorder().getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_TIME_METRIC_NAME),
+            empty()
+        );
+        assertThat(
+            meterRegistry.getRecorder().getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.RECONCILIATIONS_TIME_METRIC_NAME),
             empty()
         );
 
@@ -88,13 +127,40 @@ public class DesiredBalanceMetricsTests extends ESTestCase {
                 .getMeasurements(InstrumentType.DOUBLE_GAUGE, DesiredBalanceMetrics.UNDESIRED_ALLOCATION_RATIO_METRIC_NAME),
             measures((double) undesiredAllocations / totalAllocations)
         );
+        assertThat(
+            meterRegistry.getRecorder()
+                .getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_SUBMITTED_METRIC_NAME),
+            measures(desiredBalanceStats.computationSubmitted())
+        );
+        assertThat(
+            meterRegistry.getRecorder().getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_EXECUTED_METRIC_NAME),
+            measures(desiredBalanceStats.computationExecuted())
+        );
+        assertThat(
+            meterRegistry.getRecorder()
+                .getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_CONVERGED_METRIC_NAME),
+            measures(desiredBalanceStats.computationConverged())
+        );
+        assertThat(
+            meterRegistry.getRecorder()
+                .getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_ITERATIONS_METRIC_NAME),
+            measures(desiredBalanceStats.computationIterations())
+        );
+        assertThat(
+            meterRegistry.getRecorder().getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_TIME_METRIC_NAME),
+            measures(desiredBalanceStats.cumulativeComputationTime())
+        );
+        assertThat(
+            meterRegistry.getRecorder().getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.RECONCILIATIONS_TIME_METRIC_NAME),
+            measures(desiredBalanceStats.cumulativeReconciliationTime())
+        );
     }
 
     public void testUndesiredAllocationRatioIsZeroWhenTotalShardsIsZero() {
         RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
         DesiredBalanceMetrics metrics = new DesiredBalanceMetrics(meterRegistry);
         long unassignedShards = randomNonNegativeLong();
-        metrics.updateMetrics(new AllocationStats(unassignedShards, 0, 0), Map.of(), Map.of());
+        metrics.updateMetrics(new AllocationStats(unassignedShards, 0, 0), Map.of(), Map.of(), DesiredBalanceStats.ZERO);
 
         metrics.setNodeIsMaster(true);
         meterRegistry.getRecorder().collect();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceMetricsTests.java
@@ -129,29 +129,32 @@ public class DesiredBalanceMetricsTests extends ESTestCase {
         );
         assertThat(
             meterRegistry.getRecorder()
-                .getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_SUBMITTED_METRIC_NAME),
+                .getMeasurements(InstrumentType.LONG_ASYNC_COUNTER, DesiredBalanceMetrics.COMPUTATIONS_SUBMITTED_METRIC_NAME),
             measures(desiredBalanceStats.computationSubmitted())
         );
         assertThat(
-            meterRegistry.getRecorder().getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_EXECUTED_METRIC_NAME),
+            meterRegistry.getRecorder()
+                .getMeasurements(InstrumentType.LONG_ASYNC_COUNTER, DesiredBalanceMetrics.COMPUTATIONS_EXECUTED_METRIC_NAME),
             measures(desiredBalanceStats.computationExecuted())
         );
         assertThat(
             meterRegistry.getRecorder()
-                .getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_CONVERGED_METRIC_NAME),
+                .getMeasurements(InstrumentType.LONG_ASYNC_COUNTER, DesiredBalanceMetrics.COMPUTATIONS_CONVERGED_METRIC_NAME),
             measures(desiredBalanceStats.computationConverged())
         );
         assertThat(
             meterRegistry.getRecorder()
-                .getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_ITERATIONS_METRIC_NAME),
+                .getMeasurements(InstrumentType.LONG_ASYNC_COUNTER, DesiredBalanceMetrics.COMPUTATIONS_ITERATIONS_METRIC_NAME),
             measures(desiredBalanceStats.computationIterations())
         );
         assertThat(
-            meterRegistry.getRecorder().getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.COMPUTATIONS_TIME_METRIC_NAME),
+            meterRegistry.getRecorder()
+                .getMeasurements(InstrumentType.LONG_ASYNC_COUNTER, DesiredBalanceMetrics.COMPUTATIONS_TIME_METRIC_NAME),
             measures(desiredBalanceStats.cumulativeComputationTime())
         );
         assertThat(
-            meterRegistry.getRecorder().getMeasurements(InstrumentType.LONG_GAUGE, DesiredBalanceMetrics.RECONCILIATIONS_TIME_METRIC_NAME),
+            meterRegistry.getRecorder()
+                .getMeasurements(InstrumentType.LONG_ASYNC_COUNTER, DesiredBalanceMetrics.RECONCILIATIONS_TIME_METRIC_NAME),
             measures(desiredBalanceStats.cumulativeReconciliationTime())
         );
     }


### PR DESCRIPTION
It's useful to watch these values over time, but today they are only
visible in API outputs. With this commit we expose them as metrics too.