### PR TITLE
ESQL: Disable TERM tests if not enabled

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/TermIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/TermIT.java
@@ -23,6 +23,7 @@ public class TermIT extends AbstractEsqlIntegTestCase {
 
     @Before
     public void setupIndex() {
+        assumeTrue("term function is enabled", EsqlCapabilities.Cap.TERM_FUNCTION.isEnabled());
         createAndPopulateIndex(this::ensureYellow);
     }
 


### PR DESCRIPTION
If the TERM function is not enabled, like in release builds, then we skip the tests.

Closes #146706
