### PR TITLE
Normalize automata before subset checks in CircuitBreakingOperationsT…

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/lucene/search/AutomatonQueriesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/search/AutomatonQueriesTests.java
@@ -171,7 +171,9 @@ public class AutomatonQueriesTests extends ESTestCase {
         if (a1 == a2) {
             return true;
         }
-        return subsetOf(a2, a1) && subsetOf(a1, a2);
+        Automaton normalizedA1 = Operations.removeDeadStates(a1);
+        Automaton normalizedA2 = Operations.removeDeadStates(a2);
+        return subsetOf(normalizedA2, normalizedA1) && subsetOf(normalizedA1, normalizedA2);
     }
 
     private void assertCollapsedAndInvalidRegexHandled(String pattern, String expectedCollapsed) {

--- a/server/src/test/java/org/elasticsearch/lucene/util/automaton/CircuitBreakingOperationsTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/util/automaton/CircuitBreakingOperationsTests.java
@@ -126,9 +126,11 @@ public class CircuitBreakingOperationsTests extends ESTestCase {
     }
 
     private static void assertAcceptSameStrings(Automaton expected, Automaton actual) {
+        Automaton normalizedExpected = Operations.removeDeadStates(expected);
+        Automaton normalizedActual = Operations.removeDeadStates(actual);
         assertTrue(
             "Circuit-breaking determinize should produce the same language as Lucene's determinize",
-            Operations.subsetOf(expected, actual) && Operations.subsetOf(actual, expected)
+            Operations.subsetOf(normalizedExpected, normalizedActual) && Operations.subsetOf(normalizedActual, normalizedExpected)
         );
     }
 }


### PR DESCRIPTION
Fixes a flaky test failure caused by `subsetOf` assertions on random automata with dead states.

Before comparing language equivalence, the tests now normalize both automata with `Operations.removeDeadStates(...)` and then perform the same bidirectional `subsetOf` checks.

Lucene’s `subsetOf` test helpers require deterministic, dead-state-free inputs.  The randomized test input can violate that precondition, causing assertion failures unrelated to actual language mismatch.

Closes #146029