### PR TITLE
[ESQL] Replace hadoop-shaded-guava and hadoop-hdfs-client with stub classes for ORC

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -411,63 +411,12 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeRandomMappingIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/146553
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.filterByEmploymentStatus [GCS]}
-  issue: https://github.com/elastic/elasticsearch/issues/146982
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.dropColumn [GCS]}
-  issue: https://github.com/elastic/elasticsearch/issues/146983
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.selectSpecificColumns [HTTP]}
-  issue: https://github.com/elastic/elasticsearch/issues/146985
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.sampleWithStats [HTTP]}
-  issue: https://github.com/elastic/elasticsearch/issues/146990
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.mvCountFromSplit [S3]}
-  issue: https://github.com/elastic/elasticsearch/issues/146991
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.selectAdditionalColumns [GCS]}
-  issue: https://github.com/elastic/elasticsearch/issues/146993
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.convertToDouble [HTTP]}
-  issue: https://github.com/elastic/elasticsearch/issues/146997
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.aggregateByGender [HTTP]}
-  issue: https://github.com/elastic/elasticsearch/issues/146999
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.renameColumn [HTTP]}
-  issue: https://github.com/elastic/elasticsearch/issues/147000
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.enrich [AZURE]}
-  issue: https://github.com/elastic/elasticsearch/issues/147001
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.mvSumFromMvAppend [S3]}
-  issue: https://github.com/elastic/elasticsearch/issues/147004
 - class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
   method: test {yaml=reindex/10_basic/Response format for created}
   issue: https://github.com/elastic/elasticsearch/issues/147005
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.topNSortBySalaryDesc [S3]}
-  issue: https://github.com/elastic/elasticsearch/issues/147006
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.aggregateSalaryStats [HTTP]}
-  issue: https://github.com/elastic/elasticsearch/issues/147007
 - class: org.elasticsearch.xpack.inference.mapper.SemanticInferenceMetadataFieldsMapperTests
   method: testIsEnabled
   issue: https://github.com/elastic/elasticsearch/issues/147009
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.selectHeightVariants [S3]}
-  issue: https://github.com/elastic/elasticsearch/issues/147012
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.filterByEmploymentStatus [S3]}
-  issue: https://github.com/elastic/elasticsearch/issues/147013
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.lookupJoin [AZURE]}
-  issue: https://github.com/elastic/elasticsearch/issues/147015
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.filterByEmployeeNumber [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/147016
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
   method: test {csv-spec:exponential_histogram.All aggs grouped by TBucket and Instance (time series mode)}
   issue: https://github.com/elastic/elasticsearch/issues/147020
@@ -480,42 +429,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
   method: test {csv-spec:unmapped-type-conflicts.noTypeConflictKeepTriggersLoadInlineStatsWithFilter}
   issue: https://github.com/elastic/elasticsearch/issues/147023
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.convertToDouble [AZURE]}
-  issue: https://github.com/elastic/elasticsearch/issues/147027
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.filterByGender [S3]}
-  issue: https://github.com/elastic/elasticsearch/issues/147029
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.filterAndSort [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/147031
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.selectSpecificColumns [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/147035
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.categorizeByFullName [AZURE]}
-  issue: https://github.com/elastic/elasticsearch/issues/147036
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.mvMaxFromSplit [GCS]}
-  issue: https://github.com/elastic/elasticsearch/issues/147037
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.mvDedupeFromSplit [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/147039
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.mvCountFromSplit [GCS]}
-  issue: https://github.com/elastic/elasticsearch/issues/147040
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.enrich [GCS]}
-  issue: https://github.com/elastic/elasticsearch/issues/147044
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.uriPartsFromEval [AZURE]}
-  issue: https://github.com/elastic/elasticsearch/issues/147046
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.selectAdditionalColumns [LOCAL]}
-  issue: https://github.com/elastic/elasticsearch/issues/147047
-- class: org.elasticsearch.xpack.esql.qa.orc.OrcFormatSpecIT
-  method: test {csv-spec:external-basic.renameColumn [AZURE]}
-  issue: https://github.com/elastic/elasticsearch/issues/147048
 
 # Examples:
 #

--- a/x-pack/plugin/esql-datasource-orc/build.gradle
+++ b/x-pack/plugin/esql-datasource-orc/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     // lz4-java is provided by the server (libs/lz4); exclude to prevent jar hell
     exclude group: 'at.yawk.lz4', module: 'lz4-java'
     exclude group: 'com.aayushatharva.brotli4j', module: 'brotli4j'
-    // Replaced by hadoop-common (non-transitive) + woodstox + hadoop-shaded-guava
+    // Replaced by hadoop-common (non-transitive) + woodstox + Strings stub
     exclude group: 'org.apache.hadoop', module: 'hadoop-client-api'
     exclude group: 'org.apache.hadoop', module: 'hadoop-client-runtime'
   }
@@ -57,14 +57,17 @@ dependencies {
   // Instead of the massive hadoop-client-api (19 MB) + hadoop-client-runtime (29 MB)
   // which bundle shaded Jetty, ZooKeeper, Curator, Avro, etc. (and attract CVE flags),
   // we use hadoop-common (4.5 MB, non-transitive) plus only the jars it actually needs
-  // at runtime: Woodstox for Configuration's XML parsing and hadoop-shaded-guava for
-  // Configuration.get() which calls Strings.isNullOrEmpty().
+  // at runtime: Woodstox for Configuration's XML parsing; Configuration.get() calls
+  // Strings.isNullOrEmpty() which is provided by a tiny stub class replacing
+  // the 3.5 MB hadoop-shaded-guava jar.
   implementation("org.apache.hadoop:hadoop-common:${versions.hadoop}") {
     transitive = false
   }
   implementation("com.fasterxml.woodstox:woodstox-core:5.4.0")
   implementation("org.codehaus.woodstox:stax2-api:4.2.1")
-  implementation("org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.5.0")
+  // hadoop-shaded-guava (3.5 MB) replaced by a tiny stub class in
+  // org.apache.hadoop.thirdparty.com.google.common.base.Strings
+  // which is the only class Configuration actually needs at runtime.
   implementation("org.apache.commons:commons-collections4:4.4")
 
   // Re-add slf4j-api at the platform version to avoid jar hell with x-pack-core
@@ -78,12 +81,11 @@ dependencies {
   testImplementation "io.airlift:aircompressor:${versions.aircompressor}"
   testImplementation "com.github.luben:zstd-jni:${versions.zstdJni}"
   testImplementation "org.xerial.snappy:snappy-java:${versions.snappyJava}"
-  // ORC's writer path loads HadoopShimsCurrent which references HdfsDataOutputStream.
-  // Only needed for tests that create ORC files; not needed at production runtime
-  // since we only read ORC. Non-transitive to avoid pulling the Hadoop ecosystem.
-  testImplementation("org.apache.hadoop:hadoop-hdfs-client:${versions.hadoop}") {
-    transitive = false
-  }
+  // ORC's HadoopShimsCurrent references HdfsDataOutputStream$SyncFlag which triggers
+  // NoClassDefFoundError if hadoop-hdfs-client is absent. A stub class in
+  // org.apache.hadoop.hdfs.client.HdfsDataOutputStream provides the type at class-load
+  // time; the instanceof check in HadoopShimsCurrent always returns false so the
+  // HDFS-specific code path is never executed. This eliminates the 5.3 MB hadoop-hdfs-client jar.
 }
 
 // Compression libraries (aircompressor, zstd-jni, snappy-java) are provided by
@@ -117,12 +119,6 @@ tasks.named("thirdPartyAudit").configure {
     'org.apache.hadoop.service.launcher.InterruptEscalator',
     'org.apache.hadoop.service.launcher.IrqHandler',
     'org.apache.hadoop.util.SignalLogger$Handler',
-    // Hadoop thirdparty Guava uses sun.misc.Unsafe
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray',
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$1',
-    'org.apache.hadoop.thirdparty.com.google.common.hash.LittleEndianByteArray$UnsafeByteArray$2',
-    'org.apache.hadoop.thirdparty.com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator',
-    'org.apache.hadoop.thirdparty.com.google.common.util.concurrent.AbstractFutureState$UnsafeAtomicHelper',
     // Protobuf uses sun.misc.Unsafe
     'com.google.protobuf.MessageSchema',
     'com.google.protobuf.UnsafeUtil',

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/hadoop/hdfs/client/HdfsDataOutputStream.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/hadoop/hdfs/client/HdfsDataOutputStream.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.apache.hadoop.hdfs.client;
+
+import java.io.OutputStream;
+import java.util.EnumSet;
+
+/**
+ * Minimal stub replacing the {@code hadoop-hdfs-client} jar (5.3 MB).
+ * <p>
+ * The original class lives in the Apache Hadoop HDFS Client module
+ * ({@code org.apache.hadoop:hadoop-hdfs-client}, Apache License 2.0) and
+ * provides HDFS-specific output stream functionality. ORC's
+ * {@code HadoopShimsCurrent} (in {@code orc-shims}) references this type
+ * statically in its {@code endOutputStreamBlock} method: it checks
+ * {@code stream instanceof HdfsDataOutputStream} and, if true, calls
+ * {@code hsync(EnumSet.of(SyncFlag.END_BLOCK))}.
+ * <p>
+ * When the JVM loads {@code HadoopShimsCurrent} — triggered by the ORC
+ * <b>reader</b> path via {@code RecordReaderUtils.<clinit>()} →
+ * {@code HadoopShimsFactory.get()} — it resolves all class references
+ * including {@code HdfsDataOutputStream} and its inner enum {@code SyncFlag}.
+ * Without this stub, a {@code NoClassDefFoundError} crashes the ES node on
+ * the first ORC read attempt.
+ * <p>
+ * At runtime, no stream is an instance of this stub, so the {@code instanceof}
+ * check in {@code HadoopShimsCurrent} always returns false and the HDFS-specific
+ * code path is never executed. This is an independent stub (not a copy of the
+ * original class); it only provides the type and enum declarations needed for
+ * class loading.
+ */
+public class HdfsDataOutputStream extends OutputStream {
+
+    public enum SyncFlag {
+        UPDATE_LENGTH,
+        END_BLOCK
+    }
+
+    @Override
+    public void write(int b) {
+        throw new UnsupportedOperationException("stub");
+    }
+
+    public void hsync(EnumSet<SyncFlag> syncFlags) {
+        throw new UnsupportedOperationException("stub");
+    }
+}

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/hadoop/thirdparty/com/google/common/base/Strings.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/hadoop/thirdparty/com/google/common/base/Strings.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.apache.hadoop.thirdparty.com.google.common.base;
+
+/**
+ * Minimal stub replacing the {@code hadoop-shaded-guava} jar (3.5 MB).
+ * <p>
+ * The original class lives in Google Guava ({@code com.google.common.base.Strings},
+ * Apache License 2.0) and is shaded by the Hadoop project into the
+ * {@code org.apache.hadoop.thirdparty} package namespace. The bytecode of
+ * {@code org.apache.hadoop.conf.Configuration} (in {@code hadoop-common}) calls
+ * {@code Strings.isNullOrEmpty()} from this shaded package. Rather than shipping
+ * the entire 3.5 MB shaded-guava jar, this stub provides the single method that
+ * {@code Configuration} actually invokes at runtime.
+ * <p>
+ * This is an independent reimplementation (the only possible implementation of
+ * this trivial logic); no code was copied from Guava.
+ */
+public final class Strings {
+
+    private Strings() {}
+
+    public static boolean isNullOrEmpty(String string) {
+        return string == null || string.isEmpty();
+    }
+}

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/hadoop/thirdparty/com/google/common/collect/Interner.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/hadoop/thirdparty/com/google/common/collect/Interner.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.apache.hadoop.thirdparty.com.google.common.collect;
+
+/**
+ * Minimal stub replacing the {@code hadoop-shaded-guava} jar (3.5 MB).
+ * <p>
+ * The original interface lives in Google Guava ({@code com.google.common.collect.Interner},
+ * Apache License 2.0) and is shaded by the Hadoop project into the
+ * {@code org.apache.hadoop.thirdparty} package namespace.
+ * {@code org.apache.hadoop.util.StringInterner} in {@code hadoop-common}
+ * holds a field of this type, populated via {@link Interners#newStrongInterner()}.
+ * <p>
+ * This is a single-method interface whose signature is dictated by the calling
+ * bytecode in {@code hadoop-common}; no code was copied from Guava.
+ */
+public interface Interner<E> {
+    E intern(E sample);
+}

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/hadoop/thirdparty/com/google/common/collect/Interners.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/hadoop/thirdparty/com/google/common/collect/Interners.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.apache.hadoop.thirdparty.com.google.common.collect;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Minimal stub replacing the {@code hadoop-shaded-guava} jar (3.5 MB).
+ * <p>
+ * The original class lives in Google Guava ({@code com.google.common.collect.Interners},
+ * Apache License 2.0) and is shaded by the Hadoop project into the
+ * {@code org.apache.hadoop.thirdparty} package namespace. The static initializer of
+ * {@code org.apache.hadoop.util.StringInterner} (in {@code hadoop-common}) calls
+ * {@code Interners.newStrongInterner()} to create the singleton interner used during
+ * Hadoop {@code Configuration} XML parsing.
+ * <p>
+ * Guava's implementation uses its internal {@code MapMakerInternalMap}; this stub
+ * uses {@link ConcurrentHashMap} instead -- a completely independent implementation
+ * with identical semantics. No code was copied from Guava.
+ */
+public final class Interners {
+
+    private Interners() {}
+
+    @SuppressWarnings("unchecked")
+    public static <E> Interner<E> newStrongInterner() {
+        return new StrongInterner<>();
+    }
+
+    private static final class StrongInterner<E> implements Interner<E> {
+        private final ConcurrentHashMap<E, E> map = new ConcurrentHashMap<>();
+
+        @Override
+        public E intern(E sample) {
+            E existing = map.putIfAbsent(sample, sample);
+            return existing != null ? existing : sample;
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/hadoop/thirdparty/com/google/common/primitives/UnsignedBytes.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/apache/hadoop/thirdparty/com/google/common/primitives/UnsignedBytes.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.apache.hadoop.thirdparty.com.google.common.primitives;
+
+/**
+ * Minimal stub replacing the {@code hadoop-shaded-guava} jar (3.5 MB).
+ * <p>
+ * The original class lives in Google Guava ({@code com.google.common.primitives.UnsignedBytes},
+ * Apache License 2.0) and is shaded by the Hadoop project into the
+ * {@code org.apache.hadoop.thirdparty} package namespace.
+ * {@code org.apache.hadoop.io.FastByteComparisons$LexicographicalComparerHolder$UnsafeComparer}
+ * (in {@code hadoop-common}) calls {@code UnsignedBytes.compare(byte, byte)} as the
+ * fall-through comparison when the unsafe fast path encounters differing bytes.
+ * <p>
+ * Both this implementation and the Guava original use {@code Byte.toUnsignedInt}
+ * (the canonical way to compare bytes as unsigned in Java). This is an independent
+ * reimplementation; no code was copied from Guava.
+ */
+public final class UnsignedBytes {
+
+    private UnsignedBytes() {}
+
+    public static int compare(byte a, byte b) {
+        return Byte.toUnsignedInt(a) - Byte.toUnsignedInt(b);
+    }
+}


### PR DESCRIPTION
Replace hadoop-shaded-guava (3.5 MB) and hadoop-hdfs-client (5.3 MB)
with five tiny stub classes (~140 lines) that provide only the types
and methods actually referenced at runtime by hadoop-common and
orc-shims.

The shaded-guava stubs cover Strings.isNullOrEmpty (Configuration),
Interners/Interner (StringInterner), and UnsignedBytes.compare
(FastByteComparisons). The HdfsDataOutputStream stub prevents a
NoClassDefFoundError that crashes the ES node when ORC's reader path
triggers HadoopShimsCurrent class loading via RecordReaderUtils.

These are independent reimplementations, not copies of the original
Apache-licensed code. ORC plugin size reduced from ~12 MB to ~9 MB.

Developed with AI-assisted tooling