### PR TITLE
[ESQL] DS: async producer drain, remove 5-min timeout

### DIFF
--- a/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/AsyncConnectorFactoryFlightTests.java
+++ b/x-pack/plugin/esql-datasource-grpc/src/test/java/org/elasticsearch/xpack/esql/datasource/grpc/AsyncConnectorFactoryFlightTests.java
@@ -8,8 +8,10 @@
 package org.elasticsearch.xpack.esql.datasource.grpc;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.IntBlock;
@@ -25,15 +27,16 @@ import org.elasticsearch.xpack.esql.datasources.spi.QueryRequest;
 import org.elasticsearch.xpack.esql.datasources.spi.ResultCursor;
 import org.elasticsearch.xpack.esql.datasources.spi.Split;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class AsyncConnectorFactoryFlightTests extends ESTestCase {
 
@@ -93,7 +96,7 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
     }
 
     public void testConnectorWithDrainUtils() throws Exception {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newSingleThreadExecutor(EsExecutors.daemonThreadFactory("test", "drain"));
         try (EmployeeFlightServer server = new EmployeeFlightServer(0)) {
             String endpoint = "flight://localhost:" + server.port();
             FlightConnectorFactory factory = new FlightConnectorFactory();
@@ -109,18 +112,27 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
                 AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
 
                 ResultCursor cursor = connector.execute(request, Split.SINGLE);
-                executor.execute(() -> {
-                    try {
-                        ExternalSourceDrainUtils.drainPages(cursor, buffer);
-                        buffer.finish(false);
-                    } catch (Exception e) {
-                        buffer.onFailure(e);
-                    } finally {
-                        try {
-                            cursor.close();
-                        } catch (IOException ignored) {}
-                    }
-                });
+                CountDownLatch drainDone = new CountDownLatch(1);
+                AtomicReference<Exception> drainError = new AtomicReference<>();
+                executor.execute(
+                    () -> ExternalSourceDrainUtils.drainPagesAsync(
+                        cursor,
+                        buffer,
+                        executor,
+                        ActionListener.runAfter(ActionListener.wrap(v -> {
+                            buffer.finish(false);
+                            drainDone.countDown();
+                        }, e -> {
+                            drainError.set(e);
+                            buffer.onFailure(e);
+                            drainDone.countDown();
+                        }), () -> {
+                            try {
+                                cursor.close();
+                            } catch (Exception ignored) {}
+                        })
+                    )
+                );
 
                 int totalRows = 0;
                 while (buffer.noMoreInputs() == false || buffer.size() > 0) {
@@ -138,6 +150,8 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
                     page.releaseBlocks();
                 }
 
+                assertTrue(drainDone.await(30, TimeUnit.SECONDS));
+                assertNull("Drain should not fail", drainError.get());
                 assertEquals(100, totalRows);
             }
         } finally {
@@ -191,7 +205,7 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
 
     public void testMultiSplitWithSliceQueue() throws Exception {
         int numEndpoints = 4;
-        ExecutorService executor = Executors.newFixedThreadPool(2);
+        ExecutorService executor = Executors.newFixedThreadPool(2, EsExecutors.daemonThreadFactory("test", "drain"));
         try (EmployeeFlightServer server = new EmployeeFlightServer(0, numEndpoints)) {
             String endpoint = "flight://localhost:" + server.port();
             FlightConnectorFactory factory = new FlightConnectorFactory();
@@ -213,20 +227,10 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
             try (Connector connector = factory.open(Map.of("endpoint", endpoint))) {
                 QueryRequest request = new QueryRequest("employees", projectedColumns, attributes, Map.of(), 1000, blockFactory);
                 AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+                CountDownLatch drainDone = new CountDownLatch(1);
+                AtomicReference<Exception> drainError = new AtomicReference<>();
 
-                executor.execute(() -> {
-                    try {
-                        ExternalSplit split;
-                        while ((split = sliceQueue.nextSplit()) != null) {
-                            try (ResultCursor cursor = connector.execute(request, split)) {
-                                ExternalSourceDrainUtils.drainPages(cursor, buffer);
-                            }
-                        }
-                        buffer.finish(false);
-                    } catch (Exception e) {
-                        buffer.onFailure(e);
-                    }
-                });
+                executor.execute(() -> drainNextSplit(sliceQueue, connector, request, buffer, executor, drainDone, drainError));
 
                 int totalRows = 0;
                 while (buffer.noMoreInputs() == false || buffer.size() > 0) {
@@ -244,12 +248,61 @@ public class AsyncConnectorFactoryFlightTests extends ESTestCase {
                     page.releaseBlocks();
                 }
 
+                assertTrue(drainDone.await(30, TimeUnit.SECONDS));
+                assertNull("Drain should not fail", drainError.get());
                 assertEquals(100, totalRows);
             }
         } finally {
             executor.shutdown();
             executor.awaitTermination(10, TimeUnit.SECONDS);
         }
+    }
+
+    private static void drainNextSplit(
+        ExternalSliceQueue sliceQueue,
+        Connector connector,
+        QueryRequest request,
+        AsyncExternalSourceBuffer buffer,
+        ExecutorService executor,
+        CountDownLatch drainDone,
+        AtomicReference<Exception> drainError
+    ) {
+        if (buffer.noMoreInputs()) {
+            buffer.finish(false);
+            drainDone.countDown();
+            return;
+        }
+        ExternalSplit split = sliceQueue.nextSplit();
+        if (split == null) {
+            buffer.finish(false);
+            drainDone.countDown();
+            return;
+        }
+        ResultCursor cursor;
+        try {
+            cursor = connector.execute(request, split);
+        } catch (Exception e) {
+            buffer.onFailure(e);
+            drainDone.countDown();
+            return;
+        }
+        ExternalSourceDrainUtils.drainPagesAsync(cursor, buffer, executor, ActionListener.runAfter(ActionListener.wrap(v -> {
+            try {
+                executor.execute(() -> drainNextSplit(sliceQueue, connector, request, buffer, executor, drainDone, drainError));
+            } catch (Exception e) {
+                drainError.set(e);
+                buffer.onFailure(e);
+                drainDone.countDown();
+            }
+        }, e -> {
+            drainError.set(e);
+            buffer.onFailure(e);
+            drainDone.countDown();
+        }), () -> {
+            try {
+                cursor.close();
+            } catch (Exception ignored) {}
+        }));
     }
 
     public void testMultiSplitWithNullLocationUsesDefaultClient() throws Exception {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
@@ -34,6 +35,7 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
     private final Connector connector;
     private final QueryRequest baseRequest;
     private final int maxBufferSize;
+    private final int rowLimit;
     private final Executor executor;
     private final ExternalSliceQueue sliceQueue;
 
@@ -59,6 +61,7 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
         this.connector = connector;
         this.baseRequest = baseRequest;
         this.maxBufferSize = maxBufferSize;
+        this.rowLimit = baseRequest.rowLimit();
         this.executor = executor;
         this.sliceQueue = sliceQueue;
     }
@@ -74,28 +77,18 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
         driverContext.addAsyncAction();
 
-        int rowLimit = baseRequest.rowLimit();
+        ActionListener<Void> failureListener = ActionListener.wrap(v -> {}, e -> {
+            buffer.onFailure(e);
+            closeConnectorQuietly();
+            driverContext.removeAsyncAction();
+        });
         if (sliceQueue != null) {
-            executor.execute(() -> {
-                try {
-                    processNextSplit(request, sliceQueue, buffer, driverContext, rowLimit);
-                } catch (Exception e) {
-                    buffer.onFailure(e);
-                    closeConnectorQuietly();
-                    driverContext.removeAsyncAction();
-                }
-            });
+            executor.execute(
+                ActionRunnable.run(failureListener, () -> processNextSplit(request, sliceQueue, buffer, driverContext, rowLimit))
+            );
         } else {
-            executor.execute(() -> {
-                ResultCursor cursor;
-                try {
-                    cursor = connector.execute(request, Split.SINGLE);
-                } catch (Exception e) {
-                    buffer.onFailure(e);
-                    closeConnectorQuietly();
-                    driverContext.removeAsyncAction();
-                    return;
-                }
+            executor.execute(ActionRunnable.run(failureListener, () -> {
+                ResultCursor cursor = connector.execute(request, Split.SINGLE);
                 ExternalSourceDrainUtils.drainPagesWithBudgetAsync(
                     cursor,
                     buffer,
@@ -110,7 +103,7 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
                         }
                     )
                 );
-            });
+            }));
         }
         return new AsyncExternalSourceOperator(buffer);
     }
@@ -122,7 +115,6 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
         DriverContext driverContext,
         int rowsRemaining
     ) {
-        int rowLimit = baseRequest.rowLimit();
         if (buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
             buffer.finish(false);
             closeConnectorQuietly();
@@ -147,6 +139,11 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
             return;
         }
 
+        ActionListener<Void> failureListener = ActionListener.wrap(v -> {}, e -> {
+            buffer.onFailure(e);
+            closeConnectorQuietly();
+            driverContext.removeAsyncAction();
+        });
         ExternalSourceDrainUtils.drainPagesWithBudgetAsync(
             cursor,
             buffer,
@@ -154,18 +151,10 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
             executor,
             ActionListener.runAfter(ActionListener.<Integer>wrap(consumed -> {
                 int remaining = rowLimit != FormatReader.NO_LIMIT ? rowsRemaining - consumed : rowsRemaining;
-                try {
-                    executor.execute(() -> processNextSplit(request, queue, buffer, driverContext, remaining));
-                } catch (Exception e) {
-                    buffer.onFailure(e);
-                    closeConnectorQuietly();
-                    driverContext.removeAsyncAction();
-                }
-            }, e -> {
-                buffer.onFailure(e);
-                closeConnectorQuietly();
-                driverContext.removeAsyncAction();
-            }), () -> closeQuietly(cursor))
+                executor.execute(
+                    ActionRunnable.run(failureListener, () -> processNextSplit(request, queue, buffer, driverContext, remaining))
+                );
+            }, failureListener::onFailure), () -> closeQuietly(cursor))
         );
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
@@ -24,6 +25,9 @@ import java.util.concurrent.Executor;
 /**
  * Single-split source operator factory that executes a connector query on a background thread
  * and feeds pages into an {@link AsyncExternalSourceBuffer} for the driver to consume.
+ * <p>
+ * Uses non-blocking async drain: the producer thread is released when the buffer is full and
+ * resumes via the executor when space is freed, with no timeout.
  */
 public class AsyncConnectorSourceOperatorFactory implements SourceOperator.SourceOperatorFactory {
 
@@ -74,47 +78,109 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
         if (sliceQueue != null) {
             executor.execute(() -> {
                 try {
-                    int rowsRemaining = rowLimit;
-                    ExternalSplit split;
-                    while ((split = sliceQueue.nextSplit()) != null) {
-                        if (buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
-                            break;
-                        }
-                        try (ResultCursor cursor = connector.execute(request, split)) {
-                            int consumed = ExternalSourceDrainUtils.drainPagesWithBudget(cursor, buffer);
-                            if (rowLimit != FormatReader.NO_LIMIT) {
-                                rowsRemaining -= consumed;
-                            }
-                        }
-                    }
-                    buffer.finish(false);
+                    processNextSplit(request, sliceQueue, buffer, driverContext, rowLimit);
                 } catch (Exception e) {
                     buffer.onFailure(e);
-                } finally {
-                    try {
-                        connector.close();
-                    } catch (IOException ignored) {} finally {
-                        driverContext.removeAsyncAction();
-                    }
+                    closeConnectorQuietly();
+                    driverContext.removeAsyncAction();
                 }
             });
         } else {
             executor.execute(() -> {
-                try (ResultCursor cursor = connector.execute(request, Split.SINGLE)) {
-                    ExternalSourceDrainUtils.drainPagesWithBudget(cursor, buffer, rowLimit);
-                    buffer.finish(false);
+                ResultCursor cursor;
+                try {
+                    cursor = connector.execute(request, Split.SINGLE);
                 } catch (Exception e) {
                     buffer.onFailure(e);
-                } finally {
-                    try {
-                        connector.close();
-                    } catch (IOException ignored) {} finally {
-                        driverContext.removeAsyncAction();
-                    }
+                    closeConnectorQuietly();
+                    driverContext.removeAsyncAction();
+                    return;
                 }
+                ExternalSourceDrainUtils.drainPagesWithBudgetAsync(
+                    cursor,
+                    buffer,
+                    rowLimit,
+                    executor,
+                    ActionListener.runAfter(
+                        ActionListener.<Integer>wrap(consumed -> buffer.finish(false), e -> buffer.onFailure(e)),
+                        () -> {
+                            closeQuietly(cursor);
+                            closeConnectorQuietly();
+                            driverContext.removeAsyncAction();
+                        }
+                    )
+                );
             });
         }
         return new AsyncExternalSourceOperator(buffer);
+    }
+
+    private void processNextSplit(
+        QueryRequest request,
+        ExternalSliceQueue queue,
+        AsyncExternalSourceBuffer buffer,
+        DriverContext driverContext,
+        int rowsRemaining
+    ) {
+        int rowLimit = baseRequest.rowLimit();
+        if (buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
+            buffer.finish(false);
+            closeConnectorQuietly();
+            driverContext.removeAsyncAction();
+            return;
+        }
+        ExternalSplit split = queue.nextSplit();
+        if (split == null) {
+            buffer.finish(false);
+            closeConnectorQuietly();
+            driverContext.removeAsyncAction();
+            return;
+        }
+
+        ResultCursor cursor;
+        try {
+            cursor = connector.execute(request, split);
+        } catch (Exception e) {
+            buffer.onFailure(e);
+            closeConnectorQuietly();
+            driverContext.removeAsyncAction();
+            return;
+        }
+
+        ExternalSourceDrainUtils.drainPagesWithBudgetAsync(
+            cursor,
+            buffer,
+            rowsRemaining,
+            executor,
+            ActionListener.runAfter(ActionListener.<Integer>wrap(consumed -> {
+                int remaining = rowLimit != FormatReader.NO_LIMIT ? rowsRemaining - consumed : rowsRemaining;
+                try {
+                    executor.execute(() -> processNextSplit(request, queue, buffer, driverContext, remaining));
+                } catch (Exception e) {
+                    buffer.onFailure(e);
+                    closeConnectorQuietly();
+                    driverContext.removeAsyncAction();
+                }
+            }, e -> {
+                buffer.onFailure(e);
+                closeConnectorQuietly();
+                driverContext.removeAsyncAction();
+            }), () -> closeQuietly(cursor))
+        );
+    }
+
+    private void closeConnectorQuietly() {
+        try {
+            connector.close();
+        } catch (IOException ignored) {}
+    }
+
+    private static void closeQuietly(ResultCursor cursor) {
+        if (cursor != null) {
+            try {
+                cursor.close();
+            } catch (Exception ignored) {}
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -7,20 +7,16 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.IsBlockedResult;
 import org.elasticsearch.compute.operator.Operator;
-import org.elasticsearch.core.TimeValue;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Thread-safe buffer for async external source data.
@@ -48,8 +44,7 @@ public final class AsyncExternalSourceBuffer {
     private final Object notEmptyLock = new Object();
     private SubscribableListener<Void> notEmptyFuture = null;
 
-    private final ReentrantLock notFullLock = new ReentrantLock();
-    private final Condition notFullCondition = notFullLock.newCondition();
+    private final Object notFullLock = new Object();
     private SubscribableListener<Void> notFullFuture = null;
 
     private final SubscribableListener<Void> completionFuture = new SubscribableListener<>();
@@ -141,13 +136,9 @@ public final class AsyncExternalSourceBuffer {
 
     private void notifyNotFull() {
         final SubscribableListener<Void> toNotify;
-        notFullLock.lock();
-        try {
+        synchronized (notFullLock) {
             toNotify = notFullFuture;
             notFullFuture = null;
-            notFullCondition.signalAll();
-        } finally {
-            notFullLock.unlock();
         }
         if (toNotify != null) {
             toNotify.onResponse(null);
@@ -162,8 +153,7 @@ public final class AsyncExternalSourceBuffer {
         if (bytesInBuffer.get() < maxBufferBytes || noMoreInputs) {
             return Operator.NOT_BLOCKED;
         }
-        notFullLock.lock();
-        try {
+        synchronized (notFullLock) {
             if (bytesInBuffer.get() < maxBufferBytes || noMoreInputs) {
                 return Operator.NOT_BLOCKED;
             }
@@ -171,8 +161,6 @@ public final class AsyncExternalSourceBuffer {
                 notFullFuture = new SubscribableListener<>();
             }
             return new IsBlockedResult(notFullFuture, "async external source buffer full");
-        } finally {
-            notFullLock.unlock();
         }
     }
 
@@ -189,8 +177,7 @@ public final class AsyncExternalSourceBuffer {
         if (bytesInBuffer.get() < maxBufferBytes || noMoreInputs) {
             return SubscribableListener.newSucceeded(null);
         }
-        notFullLock.lock();
-        try {
+        synchronized (notFullLock) {
             if (bytesInBuffer.get() < maxBufferBytes || noMoreInputs) {
                 return SubscribableListener.newSucceeded(null);
             }
@@ -198,34 +185,6 @@ public final class AsyncExternalSourceBuffer {
                 notFullFuture = new SubscribableListener<>();
             }
             return notFullFuture;
-        } finally {
-            notFullLock.unlock();
-        }
-    }
-
-    /**
-     * Blocks the producer (same condition as {@link #waitForSpace()}) on the same not-full lock
-     * used to install {@code notFullFuture} until there is capacity, {@link #noMoreInputs} is set,
-     * or the wait times out. Used by {@link ExternalSourceDrainUtils} instead of
-     * {@code PlainActionFuture} or {@code SubscribableListener} + latches.
-     */
-    public void awaitSpaceForProducer(TimeValue timeout) {
-        long remainingNanos = timeout.nanos();
-        notFullLock.lock();
-        try {
-            while (bytesInBuffer.get() >= maxBufferBytes && noMoreInputs == false) {
-                if (remainingNanos <= 0) {
-                    throw new ElasticsearchTimeoutException("timeout waiting for async external source buffer space");
-                }
-                try {
-                    remainingNanos = notFullCondition.awaitNanos(remainingNanos);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new IllegalStateException("Interrupted while waiting for buffer space", e);
-                }
-            }
-        } finally {
-            notFullLock.unlock();
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -40,6 +40,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
+import static org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils.drainPagesAsync;
+import static org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils.drainPagesWithBudgetAsync;
+
 /**
  * Dual-mode async factory for creating source operators that read from external storage.
  * <p>
@@ -62,11 +65,12 @@ import java.util.concurrent.Executor;
  *   <li>Backpressure via buffer - Uses {@link AsyncExternalSourceBuffer} with waitForSpace()</li>
  * </ul>
  * <p>
- * The {@code executor} passed in runs background file reads: it is typically the {@code generic} pool
- * (via {@link org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorContext#fileReadExecutor}, set in
- * {@code LocalExecutionPlanner}) so blocked producers do not starve {@code esql_worker} drivers that
- * {@link AsyncExternalSourceBuffer#pollPage()}. {@link ExternalSourceDrainUtils} uses
- * {@link AsyncExternalSourceBuffer#awaitSpaceForProducer} (not {@link org.elasticsearch.action.support.PlainActionFuture}).
+ * The {@code executor} passed in runs background file reads and async drain continuations: it is
+ * typically the {@code generic} pool (via
+ * {@link org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorContext#fileReadExecutor}, set in
+ * {@code LocalExecutionPlanner}) so producer continuations do not starve {@code esql_worker} drivers that
+ * {@link AsyncExternalSourceBuffer#pollPage()}. The drain is fully non-blocking: it runs synchronously
+ * while the buffer has space and yields the thread when full, resuming via the executor when space is freed.
  *
  * @see AsyncExternalSourceBuffer
  * @see AsyncExternalSourceOperator
@@ -87,7 +91,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     private final ExternalSliceQueue sliceQueue;
     private final ErrorPolicy errorPolicy;
     private final int parsingParallelism;
-    private final TimeValue drainTimeout;
     private final List<Expression> pushedExpressions;
     private final FilterPushdownSupport pushdownSupport;
 
@@ -106,7 +109,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         ExternalSliceQueue sliceQueue,
         ErrorPolicy errorPolicy,
         int parsingParallelism,
-        TimeValue drainTimeout,
         @Nullable List<Expression> pushedExpressions,
         @Nullable FilterPushdownSupport pushdownSupport
     ) {
@@ -146,7 +148,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.sliceQueue = sliceQueue;
         this.errorPolicy = errorPolicy != null ? errorPolicy : formatReader.defaultErrorPolicy();
         this.parsingParallelism = Math.max(1, parsingParallelism);
-        this.drainTimeout = drainTimeout != null ? drainTimeout : ExternalSourceDrainUtils.DEFAULT_DRAIN_TIMEOUT;
         this.pushedExpressions = pushedExpressions != null ? pushedExpressions : List.of();
         this.pushdownSupport = pushdownSupport;
     }
@@ -183,7 +184,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             sliceQueue,
             errorPolicy,
             parsingParallelism,
-            drainTimeout,
             null,
             null
         );
@@ -221,7 +221,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             errorPolicy,
             parsingParallelism,
             null,
-            null,
             null
         );
     }
@@ -257,7 +256,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             errorPolicy,
             1,
             null,
-            null,
             null
         );
     }
@@ -292,7 +290,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             null,
             1,
             null,
-            null,
             null
         );
     }
@@ -326,7 +323,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             null,
             1,
             null,
-            null,
             null
         );
     }
@@ -359,7 +355,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             null,
             1,
             null,
-            null,
             null
         );
     }
@@ -390,7 +385,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             null,
             1,
             null,
-            null,
             null
         );
     }
@@ -419,7 +413,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             null,
             null,
             1,
-            null,
             null,
             null
         );
@@ -538,80 +531,133 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     private void startSliceQueueRead(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
         executor.execute(() -> {
             try {
-                int rowsRemaining = rowLimit;
-                ExternalSplit split;
-                while ((split = sliceQueue.nextSplit()) != null) {
-                    if (buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
-                        break;
-                    }
-                    for (ExternalSplit leaf : flattenToLeaves(split)) {
-                        if (buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
-                            break;
-                        }
-                        if (leaf instanceof FileSplit fileSplit) {
-                            VirtualColumnInjector injector = null;
-                            if (partitionColumnNames.isEmpty() == false) {
-                                injector = new VirtualColumnInjector(
-                                    attributes,
-                                    partitionColumnNames,
-                                    fileSplit.partitionValues(),
-                                    driverContext.blockFactory()
-                                );
-                            }
-                            List<String> cols = projectedColumns(injector);
-
-                            FormatReader fileReader = readerForFile(fileSplit);
-                            boolean isRangeSplit = "true".equals(fileSplit.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
-                            CloseableIterator<Page> pages;
-                            if (isRangeSplit && fileReader instanceof RangeAwareFormatReader rangeReader) {
-                                String fileLengthStr = (String) fileSplit.config().get(FileSplitProvider.FILE_LENGTH_KEY);
-                                StorageObject fullObj = fileLengthStr != null
-                                    ? storageProvider.newObject(fileSplit.path(), Long.parseLong(fileLengthStr))
-                                    : storageProvider.newObject(fileSplit.path());
-                                long rangeEnd = fileSplit.offset() + fileSplit.length();
-                                pages = rangeReader.readRange(
-                                    fullObj,
-                                    cols,
-                                    batchSize,
-                                    fileSplit.offset(),
-                                    rangeEnd,
-                                    attributes,
-                                    errorPolicy
-                                );
-                            } else {
-                                StorageObject obj = FileSplitProvider.storageObjectForSplit(storageProvider, fileSplit);
-                                boolean firstSplit = fileSplit.offset() == 0
-                                    || "true".equals(fileSplit.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
-                                boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
-                                FormatReadContext ctx = FormatReadContext.builder()
-                                    .projectedColumns(cols)
-                                    .batchSize(batchSize)
-                                    .rowLimit(FormatReader.NO_LIMIT)
-                                    .errorPolicy(errorPolicy)
-                                    .firstSplit(firstSplit)
-                                    .lastSplit(lastSplit)
-                                    .build();
-                                pages = fileReader.read(obj, ctx);
-                            }
-                            CloseableIterator<Page> adaptedPages = adaptSchema(pages, fileSplit.columnMapping(), driverContext);
-                            try (adaptedPages) {
-                                int consumed = drainPagesWithBudget(adaptedPages, buffer, injector);
-                                if (rowLimit != FormatReader.NO_LIMIT) {
-                                    rowsRemaining -= consumed;
-                                }
-                            }
-                        } else {
-                            throw new IllegalArgumentException("Unsupported split type: " + leaf.getClass().getName());
-                        }
-                    }
-                }
-                buffer.finish(false);
+                processNextSplit(sliceQueue, buffer, driverContext, rowLimit);
             } catch (Exception e) {
                 buffer.onFailure(e);
-            } finally {
                 driverContext.removeAsyncAction();
             }
         });
+    }
+
+    private void processNextSplit(
+        ExternalSliceQueue queue,
+        AsyncExternalSourceBuffer buffer,
+        DriverContext driverContext,
+        int rowsRemaining
+    ) {
+        if (buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
+            buffer.finish(false);
+            driverContext.removeAsyncAction();
+            return;
+        }
+        ExternalSplit split = queue.nextSplit();
+        if (split == null) {
+            buffer.finish(false);
+            driverContext.removeAsyncAction();
+            return;
+        }
+        List<ExternalSplit> leaves = flattenToLeaves(split);
+        processNextLeaf(leaves, 0, queue, buffer, driverContext, rowsRemaining, ActionListener.wrap(remaining -> {
+            try {
+                executor.execute(() -> processNextSplit(queue, buffer, driverContext, remaining));
+            } catch (Exception e) {
+                buffer.onFailure(e);
+                driverContext.removeAsyncAction();
+            }
+        }, e -> {
+            buffer.onFailure(e);
+            driverContext.removeAsyncAction();
+        }));
+    }
+
+    private void processNextLeaf(
+        List<ExternalSplit> leaves,
+        int leafIndex,
+        ExternalSliceQueue queue,
+        AsyncExternalSourceBuffer buffer,
+        DriverContext driverContext,
+        int rowsRemaining,
+        ActionListener<Integer> splitDoneListener
+    ) {
+        if (leafIndex >= leaves.size() || buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
+            splitDoneListener.onResponse(rowsRemaining);
+            return;
+        }
+        ExternalSplit leaf = leaves.get(leafIndex);
+        if (leaf instanceof FileSplit == false) {
+            splitDoneListener.onFailure(new IllegalArgumentException("Unsupported split type: " + leaf.getClass().getName()));
+            return;
+        }
+        FileSplit fileSplit = (FileSplit) leaf;
+        VirtualColumnInjector injector = null;
+        if (partitionColumnNames.isEmpty() == false) {
+            injector = new VirtualColumnInjector(
+                attributes,
+                partitionColumnNames,
+                fileSplit.partitionValues(),
+                driverContext.blockFactory()
+            );
+        }
+        List<String> cols = projectedColumns(injector);
+
+        CloseableIterator<Page> pages;
+        try {
+            FormatReader fileReader = readerForFile(fileSplit);
+            boolean isRangeSplit = "true".equals(fileSplit.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
+            if (isRangeSplit && fileReader instanceof RangeAwareFormatReader rangeReader) {
+                String fileLengthStr = (String) fileSplit.config().get(FileSplitProvider.FILE_LENGTH_KEY);
+                StorageObject fullObj = fileLengthStr != null
+                    ? storageProvider.newObject(fileSplit.path(), Long.parseLong(fileLengthStr))
+                    : storageProvider.newObject(fileSplit.path());
+                long rangeEnd = fileSplit.offset() + fileSplit.length();
+                pages = rangeReader.readRange(fullObj, cols, batchSize, fileSplit.offset(), rangeEnd, attributes, errorPolicy);
+            } else {
+                StorageObject obj = FileSplitProvider.storageObjectForSplit(storageProvider, fileSplit);
+                boolean firstSplit = fileSplit.offset() == 0 || "true".equals(fileSplit.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+                boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+                FormatReadContext ctx = FormatReadContext.builder()
+                    .projectedColumns(cols)
+                    .batchSize(batchSize)
+                    .rowLimit(FormatReader.NO_LIMIT)
+                    .errorPolicy(errorPolicy)
+                    .firstSplit(firstSplit)
+                    .lastSplit(lastSplit)
+                    .build();
+                pages = fileReader.read(obj, ctx);
+            }
+        } catch (Exception e) {
+            splitDoneListener.onFailure(e);
+            return;
+        }
+
+        CloseableIterator<Page> adaptedPages;
+        CloseableIterator<Page> wrappedPages;
+        try {
+            adaptedPages = adaptSchema(pages, fileSplit.columnMapping(), driverContext);
+            wrappedPages = wrapWithInjector(adaptedPages, injector);
+        } catch (Exception e) {
+            closeQuietly(pages);
+            splitDoneListener.onFailure(e);
+            return;
+        }
+
+        // INV-3: close the current iterator before advancing to the next leaf.
+        // Using runBefore (close, then advance) ensures the previous file descriptor
+        // is released even when the next leaf drains entirely on the hot path.
+        drainPagesWithBudgetAsync(
+            wrappedPages,
+            buffer,
+            rowsRemaining,
+            executor,
+            ActionListener.runAfter(ActionListener.<Integer>wrap(consumed -> {
+                closeQuietly(wrappedPages);
+                int remaining = rowLimit != FormatReader.NO_LIMIT ? rowsRemaining - consumed : rowsRemaining;
+                processNextLeaf(leaves, leafIndex + 1, queue, buffer, driverContext, remaining, splitDoneListener);
+            }, e -> {
+                closeQuietly(wrappedPages);
+                splitDoneListener.onFailure(e);
+            }), () -> closeQuietly(wrappedPages))
+        );
     }
 
     /**
@@ -629,62 +675,98 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
 
         executor.execute(() -> {
             try {
-                int rowsRemaining = rowLimit;
-                boolean useParallel = rowLimit == FormatReader.NO_LIMIT && formatReader instanceof SegmentableFormatReader;
-                for (int i = 0; i < fileList.fileCount(); i++) {
-                    if (buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
-                        break;
-                    }
-                    // Open by path only: {@link StorageProvider#newObject(StoragePath)} matches the resolver's
-                    // metadata probe and performs a normal full-object read. Passing cached length and mtime from
-                    // {@link FileList} into {@link StorageProvider#newObject(StoragePath, long, java.time.Instant)}
-                    // produced empty NDJSON/CSV reads over HTTP/S3/Azure in integration tests.
-                    StorageObject obj = storageProvider.newObject(fileList.path(i));
-                    CloseableIterator<Page> pages;
-                    if (useParallel) {
-                        pages = ParallelParsingCoordinator.parallelRead(
-                            (SegmentableFormatReader) formatReader,
-                            obj,
-                            projectedColumns,
-                            batchSize,
-                            parsingParallelism,
-                            executor,
-                            errorPolicy
-                        );
-                    } else {
-                        int fileBudget = rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : rowsRemaining;
-                        FormatReadContext ctx = FormatReadContext.builder()
-                            .projectedColumns(projectedColumns)
-                            .batchSize(batchSize)
-                            .rowLimit(fileBudget)
-                            .errorPolicy(errorPolicy)
-                            .build();
-                        pages = formatReader.read(obj, ctx);
-                    }
-
-                    SchemaReconciliation.ColumnMapping mapping = null;
-                    if (schemaInfo != null) {
-                        SchemaReconciliation.FileSchemaInfo info = schemaInfo.get(fileList.path(i));
-                        if (info != null) {
-                            mapping = info.mapping();
-                        }
-                    }
-                    CloseableIterator<Page> adaptedPages = adaptSchema(pages, mapping, driverContext);
-
-                    try (adaptedPages) {
-                        int consumed = drainPagesWithBudget(adaptedPages, buffer, injector);
-                        if (rowLimit != FormatReader.NO_LIMIT) {
-                            rowsRemaining -= consumed;
-                        }
-                    }
-                }
-                buffer.finish(false);
+                processNextFile(0, projectedColumns, buffer, driverContext, injector, schemaInfo, rowLimit);
             } catch (Exception e) {
                 buffer.onFailure(e);
-            } finally {
                 driverContext.removeAsyncAction();
             }
         });
+    }
+
+    private void processNextFile(
+        int fileIndex,
+        List<String> projectedColumns,
+        AsyncExternalSourceBuffer buffer,
+        DriverContext driverContext,
+        VirtualColumnInjector injector,
+        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo,
+        int rowsRemaining
+    ) {
+        if (fileIndex >= fileList.fileCount() || buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
+            buffer.finish(false);
+            driverContext.removeAsyncAction();
+            return;
+        }
+
+        boolean useParallel = rowLimit == FormatReader.NO_LIMIT && formatReader instanceof SegmentableFormatReader;
+        CloseableIterator<Page> pages;
+        try {
+            StorageObject obj = storageProvider.newObject(fileList.path(fileIndex));
+            if (useParallel) {
+                pages = ParallelParsingCoordinator.parallelRead(
+                    (SegmentableFormatReader) formatReader,
+                    obj,
+                    projectedColumns,
+                    batchSize,
+                    parsingParallelism,
+                    executor,
+                    errorPolicy
+                );
+            } else {
+                int fileBudget = rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : rowsRemaining;
+                FormatReadContext ctx = FormatReadContext.builder()
+                    .projectedColumns(projectedColumns)
+                    .batchSize(batchSize)
+                    .rowLimit(fileBudget)
+                    .errorPolicy(errorPolicy)
+                    .build();
+                pages = formatReader.read(obj, ctx);
+            }
+        } catch (Exception e) {
+            buffer.onFailure(e);
+            driverContext.removeAsyncAction();
+            return;
+        }
+
+        SchemaReconciliation.ColumnMapping mapping = null;
+        if (schemaInfo != null) {
+            SchemaReconciliation.FileSchemaInfo info = schemaInfo.get(fileList.path(fileIndex));
+            if (info != null) {
+                mapping = info.mapping();
+            }
+        }
+        CloseableIterator<Page> adaptedPages;
+        CloseableIterator<Page> wrappedPages;
+        try {
+            adaptedPages = adaptSchema(pages, mapping, driverContext);
+            wrappedPages = wrapWithInjector(adaptedPages, injector);
+        } catch (Exception e) {
+            closeQuietly(pages);
+            buffer.onFailure(e);
+            driverContext.removeAsyncAction();
+            return;
+        }
+
+        drainPagesWithBudgetAsync(
+            wrappedPages,
+            buffer,
+            rowsRemaining,
+            executor,
+            ActionListener.runAfter(ActionListener.<Integer>wrap(consumed -> {
+                int remaining = rowLimit != FormatReader.NO_LIMIT ? rowsRemaining - consumed : rowsRemaining;
+                try {
+                    executor.execute(
+                        () -> processNextFile(fileIndex + 1, projectedColumns, buffer, driverContext, injector, schemaInfo, remaining)
+                    );
+                } catch (Exception e) {
+                    buffer.onFailure(e);
+                    driverContext.removeAsyncAction();
+                }
+            }, e -> {
+                buffer.onFailure(e);
+                driverContext.removeAsyncAction();
+            }), () -> closeQuietly(wrappedPages))
+        );
     }
 
     private void startNativeAsyncRead(
@@ -716,8 +798,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         VirtualColumnInjector injector
     ) {
         executor.execute(() -> {
-            CloseableIterator<Page> pages = null;
             try {
+                CloseableIterator<Page> pages;
                 if (rowLimit == FormatReader.NO_LIMIT && formatReader instanceof SegmentableFormatReader segmentable) {
                     pages = ParallelParsingCoordinator.parallelRead(
                         segmentable,
@@ -737,11 +819,18 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                         .build();
                     pages = formatReader.read(storageObject, ctx);
                 }
-                consumePages(pages, buffer, injector);
+                CloseableIterator<Page> wrapped = wrapWithInjector(pages, injector);
+                drainPagesAsync(
+                    wrapped,
+                    buffer,
+                    executor,
+                    ActionListener.runAfter(ActionListener.wrap(v -> buffer.finish(false), e -> buffer.onFailure(e)), () -> {
+                        closeQuietly(wrapped);
+                        driverContext.removeAsyncAction();
+                    })
+                );
             } catch (Exception e) {
                 buffer.onFailure(e);
-            } finally {
-                closeQuietly(pages);
                 driverContext.removeAsyncAction();
             }
         });
@@ -753,42 +842,31 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         DriverContext driverContext,
         VirtualColumnInjector injector
     ) {
-        executor.execute(() -> {
-            try {
-                consumePages(pages, buffer, injector);
-            } catch (Exception e) {
-                buffer.onFailure(e);
-            } finally {
-                closeQuietly(pages);
-                driverContext.removeAsyncAction();
-            }
-        });
-    }
-
-    private void consumePages(CloseableIterator<Page> pages, AsyncExternalSourceBuffer buffer, VirtualColumnInjector injector) {
-        drainPages(pages, buffer, injector);
-        buffer.finish(false);
-    }
-
-    private void drainPages(CloseableIterator<Page> pages, AsyncExternalSourceBuffer buffer, VirtualColumnInjector injector) {
-        if (injector != null && injector.hasPartitionColumns()) {
-            ExternalSourceDrainUtils.drainPages(new InjectingIterator(pages, injector), buffer, drainTimeout);
-        } else {
-            ExternalSourceDrainUtils.drainPages(pages, buffer, drainTimeout);
+        try {
+            executor.execute(() -> {
+                CloseableIterator<Page> wrapped = wrapWithInjector(pages, injector);
+                drainPagesAsync(
+                    wrapped,
+                    buffer,
+                    executor,
+                    ActionListener.runAfter(ActionListener.wrap(v -> buffer.finish(false), e -> buffer.onFailure(e)), () -> {
+                        closeQuietly(wrapped);
+                        driverContext.removeAsyncAction();
+                    })
+                );
+            });
+        } catch (Exception e) {
+            closeQuietly(pages);
+            buffer.onFailure(e);
+            driverContext.removeAsyncAction();
         }
     }
 
-    private int drainPagesWithBudget(CloseableIterator<Page> pages, AsyncExternalSourceBuffer buffer, VirtualColumnInjector injector) {
+    private static CloseableIterator<Page> wrapWithInjector(CloseableIterator<Page> pages, VirtualColumnInjector injector) {
         if (injector != null && injector.hasPartitionColumns()) {
-            return ExternalSourceDrainUtils.drainPagesWithBudget(
-                new InjectingIterator(pages, injector),
-                buffer,
-                FormatReader.NO_LIMIT,
-                drainTimeout
-            );
-        } else {
-            return ExternalSourceDrainUtils.drainPagesWithBudget(pages, buffer, FormatReader.NO_LIMIT, drainTimeout);
+            return new InjectingIterator(pages, injector);
         }
+        return pages;
     }
 
     private static class InjectingIterator implements CloseableIterator<Page> {
@@ -931,7 +1009,4 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         return parsingParallelism;
     }
 
-    public TimeValue drainTimeout() {
-        return drainTimeout;
-    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -8,13 +8,13 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -150,43 +150,6 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.parsingParallelism = Math.max(1, parsingParallelism);
         this.pushedExpressions = pushedExpressions != null ? pushedExpressions : List.of();
         this.pushdownSupport = pushdownSupport;
-    }
-
-    public AsyncExternalSourceOperatorFactory(
-        StorageProvider storageProvider,
-        FormatReader formatReader,
-        StoragePath path,
-        List<Attribute> attributes,
-        int batchSize,
-        int maxBufferSize,
-        int rowLimit,
-        Executor executor,
-        FileList fileList,
-        Set<String> partitionColumnNames,
-        Map<String, Object> partitionValues,
-        ExternalSliceQueue sliceQueue,
-        ErrorPolicy errorPolicy,
-        int parsingParallelism,
-        TimeValue drainTimeout
-    ) {
-        this(
-            storageProvider,
-            formatReader,
-            path,
-            attributes,
-            batchSize,
-            maxBufferSize,
-            rowLimit,
-            executor,
-            fileList,
-            partitionColumnNames,
-            partitionValues,
-            sliceQueue,
-            errorPolicy,
-            parsingParallelism,
-            null,
-            null
-        );
     }
 
     public AsyncExternalSourceOperatorFactory(
@@ -529,14 +492,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     }
 
     private void startSliceQueueRead(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
-        executor.execute(() -> {
-            try {
-                processNextSplit(sliceQueue, buffer, driverContext, rowLimit);
-            } catch (Exception e) {
-                buffer.onFailure(e);
-                driverContext.removeAsyncAction();
-            }
-        });
+        ActionListener<Void> failureListener = failureListener(buffer, driverContext);
+        executor.execute(ActionRunnable.run(failureListener, () -> processNextSplit(sliceQueue, buffer, driverContext, rowLimit)));
     }
 
     private void processNextSplit(
@@ -556,18 +513,11 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             driverContext.removeAsyncAction();
             return;
         }
+        ActionListener<Void> failureListener = failureListener(buffer, driverContext);
         List<ExternalSplit> leaves = flattenToLeaves(split);
         processNextLeaf(leaves, 0, queue, buffer, driverContext, rowsRemaining, ActionListener.wrap(remaining -> {
-            try {
-                executor.execute(() -> processNextSplit(queue, buffer, driverContext, remaining));
-            } catch (Exception e) {
-                buffer.onFailure(e);
-                driverContext.removeAsyncAction();
-            }
-        }, e -> {
-            buffer.onFailure(e);
-            driverContext.removeAsyncAction();
-        }));
+            executor.execute(ActionRunnable.run(failureListener, () -> processNextSplit(queue, buffer, driverContext, remaining)));
+        }, failureListener::onFailure));
     }
 
     private void processNextLeaf(
@@ -641,22 +591,20 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             return;
         }
 
-        // INV-3: close the current iterator before advancing to the next leaf.
-        // Using runBefore (close, then advance) ensures the previous file descriptor
-        // is released even when the next leaf drains entirely on the hot path.
         drainPagesWithBudgetAsync(
             wrappedPages,
             buffer,
             rowsRemaining,
             executor,
             ActionListener.runAfter(ActionListener.<Integer>wrap(consumed -> {
-                closeQuietly(wrappedPages);
                 int remaining = rowLimit != FormatReader.NO_LIMIT ? rowsRemaining - consumed : rowsRemaining;
-                processNextLeaf(leaves, leafIndex + 1, queue, buffer, driverContext, remaining, splitDoneListener);
-            }, e -> {
-                closeQuietly(wrappedPages);
-                splitDoneListener.onFailure(e);
-            }), () -> closeQuietly(wrappedPages))
+                executor.execute(
+                    ActionRunnable.wrap(
+                        splitDoneListener,
+                        l -> processNextLeaf(leaves, leafIndex + 1, queue, buffer, driverContext, remaining, l)
+                    )
+                );
+            }, splitDoneListener::onFailure), () -> closeQuietly(wrappedPages))
         );
     }
 
@@ -673,14 +621,13 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     ) {
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = fileList != null ? fileList.fileSchemaInfo() : null;
 
-        executor.execute(() -> {
-            try {
-                processNextFile(0, projectedColumns, buffer, driverContext, injector, schemaInfo, rowLimit);
-            } catch (Exception e) {
-                buffer.onFailure(e);
-                driverContext.removeAsyncAction();
-            }
-        });
+        ActionListener<Void> failureListener = failureListener(buffer, driverContext);
+        executor.execute(
+            ActionRunnable.run(
+                failureListener,
+                () -> processNextFile(0, projectedColumns, buffer, driverContext, injector, schemaInfo, rowLimit)
+            )
+        );
     }
 
     private void processNextFile(
@@ -747,6 +694,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             return;
         }
 
+        ActionListener<Void> failureListener = failureListener(buffer, driverContext);
         drainPagesWithBudgetAsync(
             wrappedPages,
             buffer,
@@ -754,18 +702,13 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             executor,
             ActionListener.runAfter(ActionListener.<Integer>wrap(consumed -> {
                 int remaining = rowLimit != FormatReader.NO_LIMIT ? rowsRemaining - consumed : rowsRemaining;
-                try {
-                    executor.execute(
+                executor.execute(
+                    ActionRunnable.run(
+                        failureListener,
                         () -> processNextFile(fileIndex + 1, projectedColumns, buffer, driverContext, injector, schemaInfo, remaining)
-                    );
-                } catch (Exception e) {
-                    buffer.onFailure(e);
-                    driverContext.removeAsyncAction();
-                }
-            }, e -> {
-                buffer.onFailure(e);
-                driverContext.removeAsyncAction();
-            }), () -> closeQuietly(wrappedPages))
+                    )
+                );
+            }, failureListener::onFailure), () -> closeQuietly(wrappedPages))
         );
     }
 
@@ -797,43 +740,45 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         DriverContext driverContext,
         VirtualColumnInjector injector
     ) {
-        executor.execute(() -> {
-            try {
-                CloseableIterator<Page> pages;
-                if (rowLimit == FormatReader.NO_LIMIT && formatReader instanceof SegmentableFormatReader segmentable) {
-                    pages = ParallelParsingCoordinator.parallelRead(
-                        segmentable,
-                        storageObject,
-                        projectedColumns,
-                        batchSize,
-                        parsingParallelism,
-                        executor,
-                        errorPolicy
-                    );
-                } else {
-                    FormatReadContext ctx = FormatReadContext.builder()
-                        .projectedColumns(projectedColumns)
-                        .batchSize(batchSize)
-                        .rowLimit(rowLimit)
-                        .errorPolicy(errorPolicy)
-                        .build();
-                    pages = formatReader.read(storageObject, ctx);
-                }
-                CloseableIterator<Page> wrapped = wrapWithInjector(pages, injector);
-                drainPagesAsync(
-                    wrapped,
-                    buffer,
+        ActionListener<Void> failureListener = failureListener(buffer, driverContext);
+        executor.execute(ActionRunnable.run(failureListener, () -> {
+            CloseableIterator<Page> pages;
+            if (rowLimit == FormatReader.NO_LIMIT && formatReader instanceof SegmentableFormatReader segmentable) {
+                pages = ParallelParsingCoordinator.parallelRead(
+                    segmentable,
+                    storageObject,
+                    projectedColumns,
+                    batchSize,
+                    parsingParallelism,
                     executor,
-                    ActionListener.runAfter(ActionListener.wrap(v -> buffer.finish(false), e -> buffer.onFailure(e)), () -> {
-                        closeQuietly(wrapped);
-                        driverContext.removeAsyncAction();
-                    })
+                    errorPolicy
                 );
-            } catch (Exception e) {
-                buffer.onFailure(e);
-                driverContext.removeAsyncAction();
+            } else {
+                FormatReadContext ctx = FormatReadContext.builder()
+                    .projectedColumns(projectedColumns)
+                    .batchSize(batchSize)
+                    .rowLimit(rowLimit)
+                    .errorPolicy(errorPolicy)
+                    .build();
+                pages = formatReader.read(storageObject, ctx);
             }
-        });
+            CloseableIterator<Page> wrapped;
+            try {
+                wrapped = wrapWithInjector(pages, injector);
+            } catch (Exception e) {
+                closeQuietly(pages);
+                throw e;
+            }
+            drainPagesAsync(
+                wrapped,
+                buffer,
+                executor,
+                ActionListener.runAfter(ActionListener.wrap(v -> buffer.finish(false), e -> buffer.onFailure(e)), () -> {
+                    closeQuietly(wrapped);
+                    driverContext.removeAsyncAction();
+                })
+            );
+        }));
     }
 
     private void consumePagesInBackground(
@@ -842,24 +787,23 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         DriverContext driverContext,
         VirtualColumnInjector injector
     ) {
-        try {
-            executor.execute(() -> {
-                CloseableIterator<Page> wrapped = wrapWithInjector(pages, injector);
-                drainPagesAsync(
-                    wrapped,
-                    buffer,
-                    executor,
-                    ActionListener.runAfter(ActionListener.wrap(v -> buffer.finish(false), e -> buffer.onFailure(e)), () -> {
-                        closeQuietly(wrapped);
-                        driverContext.removeAsyncAction();
-                    })
-                );
-            });
-        } catch (Exception e) {
+        ActionListener<Void> failureListener = ActionListener.wrap(v -> {}, e -> {
             closeQuietly(pages);
             buffer.onFailure(e);
             driverContext.removeAsyncAction();
-        }
+        });
+        executor.execute(ActionRunnable.run(failureListener, () -> {
+            CloseableIterator<Page> wrapped = wrapWithInjector(pages, injector);
+            drainPagesAsync(
+                wrapped,
+                buffer,
+                executor,
+                ActionListener.runAfter(ActionListener.wrap(v -> buffer.finish(false), e -> buffer.onFailure(e)), () -> {
+                    closeQuietly(wrapped);
+                    driverContext.removeAsyncAction();
+                })
+            );
+        }));
     }
 
     private static CloseableIterator<Page> wrapWithInjector(CloseableIterator<Page> pages, VirtualColumnInjector injector) {
@@ -913,6 +857,13 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             }
         }
         return leaves;
+    }
+
+    private static ActionListener<Void> failureListener(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
+        return ActionListener.wrap(v -> {}, e -> {
+            buffer.onFailure(e);
+            driverContext.removeAsyncAction();
+        });
     }
 
     private static void closeQuietly(CloseableIterator<?> iterator) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtils.java
@@ -7,71 +7,144 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+
+import java.util.concurrent.Executor;
 
 /**
  * Utility for draining pages from a {@link CloseableIterator} into an {@link AsyncExternalSourceBuffer}
- * with backpressure. Uses blocking wait instead of spin-wait, relying on the buffer's
- * {@code notifyNotFull()} in {@code finish()} to wake producers when no more input is needed.
+ * with non-blocking backpressure.
  *
- * <p>Buffer-space blocking uses {@link AsyncExternalSourceBuffer#awaitSpaceForProducer} (a timed condition wait
- * on the buffer's not-full lock), not {@link org.elasticsearch.action.support.PlainActionFuture}, so a
- * producer and a consumer on different threads of the same named pool (e.g. {@code esql_worker}) do not
- * trip {@code PlainActionFuture}'s same-pool completion assertion.
+ * <p>Runs synchronously while the buffer has space (hot path), yields the thread when the buffer is
+ * full, and resumes via the provided {@link Executor} when space is freed (cold path). No timeout is
+ * needed — cancellation propagates via {@link AsyncExternalSourceBuffer#finish(boolean)} setting
+ * {@code noMoreInputs}, which causes {@link AsyncExternalSourceBuffer#waitForSpace()} to return an
+ * already-completed listener so the drain loop exits promptly.
  */
 public final class ExternalSourceDrainUtils {
 
-    static final TimeValue DEFAULT_DRAIN_TIMEOUT = TimeValue.timeValueMinutes(5);
-
     private ExternalSourceDrainUtils() {}
 
-    public static void drainPages(CloseableIterator<Page> pages, AsyncExternalSourceBuffer buffer) {
-        drainPages(pages, buffer, DEFAULT_DRAIN_TIMEOUT);
+    /**
+     * Drains pages from iterator into buffer asynchronously.
+     * Runs synchronously while the buffer has space; yields the thread
+     * when the buffer is full and resumes via {@code executor} when space is freed.
+     * Completion (success or failure) is reported via the listener.
+     *
+     * <p><b>Iterator ownership:</b> This method does NOT close the iterator.
+     * The caller must close it regardless of outcome (e.g. via
+     * {@link ActionListener#runAfter}).
+     *
+     * <p><b>Executor contract:</b> The {@code executor} must be a real thread-pool
+     * executor (e.g. {@code generic}), never {@code DIRECT_EXECUTOR_SERVICE}.
+     * Continuations resume on this executor to avoid running producer I/O
+     * on the Driver thread. The executor captures and restores thread context
+     * at submission time, so no explicit context-preserving wrapper is needed.
+     *
+     * <p><b>Cancellation:</b> No timeout. Cancellation comes from
+     * {@code buffer.finish(true)} setting {@code noMoreInputs}, which causes
+     * {@code waitForSpace()} to return an already-completed listener.
+     */
+    public static void drainPagesAsync(
+        CloseableIterator<Page> pages,
+        AsyncExternalSourceBuffer buffer,
+        Executor executor,
+        ActionListener<Void> listener
+    ) {
+        drainBatch(pages, buffer, executor, listener);
     }
 
-    public static void drainPages(CloseableIterator<Page> pages, AsyncExternalSourceBuffer buffer, TimeValue timeout) {
-        while (pages.hasNext() && buffer.noMoreInputs() == false) {
-            buffer.awaitSpaceForProducer(timeout);
-            if (buffer.noMoreInputs()) {
-                break;
+    private static void drainBatch(
+        CloseableIterator<Page> pages,
+        AsyncExternalSourceBuffer buffer,
+        Executor executor,
+        ActionListener<Void> listener
+    ) {
+        try {
+            while (pages.hasNext() && buffer.noMoreInputs() == false) {
+                SubscribableListener<Void> space = buffer.waitForSpace();
+                if (space.isDone()) {
+                    if (buffer.noMoreInputs()) break;
+                    Page page = pages.next();
+                    page.allowPassingToDifferentDriver();
+                    buffer.addPage(page);
+                } else {
+                    space.addListener(ActionListener.wrap(v -> {
+                        try {
+                            executor.execute(() -> drainBatch(pages, buffer, executor, listener));
+                        } catch (Exception e) {
+                            listener.onFailure(e);
+                        }
+                    }, listener::onFailure));
+                    return;
+                }
             }
-            Page page = pages.next();
-            page.allowPassingToDifferentDriver();
-            buffer.addPage(page);
+            listener.onResponse(null);
+        } catch (Exception e) {
+            listener.onFailure(e);
         }
     }
 
-    public static int drainPagesWithBudget(CloseableIterator<Page> pages, AsyncExternalSourceBuffer buffer) {
-        return drainPagesWithBudget(pages, buffer, FormatReader.NO_LIMIT, DEFAULT_DRAIN_TIMEOUT);
-    }
-
-    public static int drainPagesWithBudget(CloseableIterator<Page> pages, AsyncExternalSourceBuffer buffer, int rowLimit) {
-        return drainPagesWithBudget(pages, buffer, rowLimit, DEFAULT_DRAIN_TIMEOUT);
-    }
-
-    public static int drainPagesWithBudget(
+    /**
+     * Drains pages from iterator into buffer asynchronously with a row budget.
+     * Same async behavior as {@link #drainPagesAsync}: synchronous hot path, async cold path
+     * on buffer-full. Reports the total number of rows drained via the listener.
+     *
+     * <p><b>Iterator ownership:</b> This method does NOT close the iterator.
+     * The caller must close it regardless of outcome (e.g. via
+     * {@link ActionListener#runAfter}).
+     *
+     * <p><b>Executor contract:</b> Same as {@link #drainPagesAsync}.
+     *
+     * @param rowLimit maximum rows to drain, or {@link FormatReader#NO_LIMIT} for unlimited
+     */
+    public static void drainPagesWithBudgetAsync(
         CloseableIterator<Page> pages,
         AsyncExternalSourceBuffer buffer,
         int rowLimit,
-        TimeValue timeout
+        Executor executor,
+        ActionListener<Integer> listener
     ) {
-        int totalRows = 0;
-        while (pages.hasNext() && buffer.noMoreInputs() == false) {
-            if (rowLimit != FormatReader.NO_LIMIT && totalRows >= rowLimit) {
-                break;
-            }
-            buffer.awaitSpaceForProducer(timeout);
-            if (buffer.noMoreInputs()) {
-                break;
-            }
-            Page page = pages.next();
-            totalRows += page.getPositionCount();
-            page.allowPassingToDifferentDriver();
-            buffer.addPage(page);
-        }
-        return totalRows;
+        drainBatchWithBudget(pages, buffer, rowLimit, new int[] { 0 }, executor, listener);
     }
+
+    private static void drainBatchWithBudget(
+        CloseableIterator<Page> pages,
+        AsyncExternalSourceBuffer buffer,
+        int rowLimit,
+        int[] totalRows,
+        Executor executor,
+        ActionListener<Integer> listener
+    ) {
+        try {
+            while (pages.hasNext() && buffer.noMoreInputs() == false) {
+                if (rowLimit != FormatReader.NO_LIMIT && totalRows[0] >= rowLimit) break;
+                SubscribableListener<Void> space = buffer.waitForSpace();
+                if (space.isDone()) {
+                    if (buffer.noMoreInputs()) break;
+                    Page page = pages.next();
+                    totalRows[0] += page.getPositionCount();
+                    page.allowPassingToDifferentDriver();
+                    buffer.addPage(page);
+                } else {
+                    space.addListener(ActionListener.wrap(v -> {
+                        try {
+                            executor.execute(() -> drainBatchWithBudget(pages, buffer, rowLimit, totalRows, executor, listener));
+                        } catch (Exception e) {
+                            listener.onFailure(e);
+                        }
+                    }, listener::onFailure));
+                    return;
+                }
+            }
+            listener.onResponse(totalRows[0]);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -163,7 +163,6 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 context.sliceQueue(),
                 errorPolicy,
                 context.parsingParallelism(),
-                null,
                 pushedExpressions,
                 pushdownSupport
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactorySplitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactorySplitTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
@@ -28,6 +29,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -105,6 +110,131 @@ public class AsyncConnectorSourceOperatorFactorySplitTests extends ESTestCase {
 
         assertEquals(1, receivedSplits.size());
         assertSame(Split.SINGLE, receivedSplits.get(0));
+    }
+
+    // ===== Lifecycle tests =====
+
+    /**
+     * Single-split connector path: removeAsyncAction fires exactly once on success.
+     */
+    public void testSingleSplitRemoveAsyncActionExactlyOnce() throws Exception {
+        List<Split> receivedSplits = new CopyOnWriteArrayList<>();
+        LegacySplitCapturingConnector connector = new LegacySplitCapturingConnector(receivedSplits);
+        QueryRequest baseRequest = new QueryRequest("target", List.of("col"), List.of(), Map.of(), 100, TEST_BLOCK_FACTORY);
+
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(TEST_BLOCK_FACTORY);
+        AtomicInteger addCount = new AtomicInteger(0);
+        AtomicInteger removeCount = new AtomicInteger(0);
+        doAnswer(inv -> {
+            addCount.incrementAndGet();
+            return null;
+        }).when(driverContext).addAsyncAction();
+        doAnswer(inv -> {
+            removeCount.incrementAndGet();
+            return null;
+        }).when(driverContext).removeAsyncAction();
+
+        AsyncConnectorSourceOperatorFactory factory = new AsyncConnectorSourceOperatorFactory(connector, baseRequest, 10, Runnable::run);
+
+        SourceOperator operator = factory.get(driverContext);
+        drainOperator(operator);
+        operator.close();
+
+        assertEquals("addAsyncAction should be called exactly once", 1, addCount.get());
+        assertEquals("removeAsyncAction should be called exactly once", 1, removeCount.get());
+    }
+
+    /**
+     * Slice-queue connector path: removeAsyncAction fires exactly once for all splits.
+     */
+    public void testSliceQueueRemoveAsyncActionExactlyOnce() throws Exception {
+        List<ExternalSplit> receivedSplits = new CopyOnWriteArrayList<>();
+        SplitCapturingConnector connector = new SplitCapturingConnector(receivedSplits);
+        QueryRequest baseRequest = new QueryRequest("target", List.of("col"), List.of(), Map.of(), 100, TEST_BLOCK_FACTORY);
+
+        StubExternalSplit splitA = new StubExternalSplit("a");
+        StubExternalSplit splitB = new StubExternalSplit("b");
+        ExternalSliceQueue sliceQueue = new ExternalSliceQueue(List.of(splitA, splitB));
+
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(TEST_BLOCK_FACTORY);
+        AtomicInteger addCount = new AtomicInteger(0);
+        AtomicInteger removeCount = new AtomicInteger(0);
+        doAnswer(inv -> {
+            addCount.incrementAndGet();
+            return null;
+        }).when(driverContext).addAsyncAction();
+        doAnswer(inv -> {
+            removeCount.incrementAndGet();
+            return null;
+        }).when(driverContext).removeAsyncAction();
+
+        AsyncConnectorSourceOperatorFactory factory = new AsyncConnectorSourceOperatorFactory(
+            connector,
+            baseRequest,
+            10,
+            Runnable::run,
+            sliceQueue
+        );
+
+        SourceOperator operator = factory.get(driverContext);
+        drainOperator(operator);
+        operator.close();
+
+        assertEquals("addAsyncAction should be called exactly once", 1, addCount.get());
+        assertEquals("removeAsyncAction should be called exactly once after all splits", 1, removeCount.get());
+        assertEquals(2, receivedSplits.size());
+    }
+
+    /**
+     * Connector with real thread pool: exercises backpressure.
+     */
+    public void testConnectorBackpressureWithRealThreadPool() throws Exception {
+        ExecutorService realExec = Executors.newFixedThreadPool(2, EsExecutors.daemonThreadFactory("test", "conn-test"));
+        try {
+            List<ExternalSplit> receivedSplits = new CopyOnWriteArrayList<>();
+            MultiPageSplitConnector connector = new MultiPageSplitConnector(receivedSplits, 10);
+            QueryRequest baseRequest = new QueryRequest("target", List.of("col"), List.of(), Map.of(), 100, TEST_BLOCK_FACTORY);
+
+            StubExternalSplit splitA = new StubExternalSplit("a");
+            StubExternalSplit splitB = new StubExternalSplit("b");
+            ExternalSliceQueue sliceQueue = new ExternalSliceQueue(List.of(splitA, splitB));
+
+            DriverContext driverContext = mockDriverContext();
+
+            AsyncConnectorSourceOperatorFactory factory = new AsyncConnectorSourceOperatorFactory(
+                connector,
+                baseRequest,
+                2,
+                realExec,
+                sliceQueue
+            );
+
+            SourceOperator operator = factory.get(driverContext);
+            List<Page> pages = new ArrayList<>();
+
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (operator.isFinished() == false && System.currentTimeMillis() < deadline) {
+                Page page = operator.getOutput();
+                if (page != null) {
+                    pages.add(page);
+                } else {
+                    Thread.sleep(10);
+                }
+            }
+            assertTrue("Operator should complete within timeout", operator.isFinished());
+            assertEquals(2, receivedSplits.size());
+            assertEquals(20, pages.size());
+
+            for (Page p : pages) {
+                p.releaseBlocks();
+            }
+            operator.close();
+        } finally {
+            realExec.shutdown();
+            assertTrue(realExec.awaitTermination(10, TimeUnit.SECONDS));
+        }
     }
 
     // ===== Helpers =====
@@ -219,6 +349,56 @@ public class AsyncConnectorSourceOperatorFactorySplitTests extends ESTestCase {
 
         @Override
         public void close() {}
+    }
+
+    /**
+     * Connector that returns multi-page results for ExternalSplit queries.
+     */
+    private static class MultiPageSplitConnector implements Connector {
+        private final List<ExternalSplit> receivedSplits;
+        private final int pagesPerSplit;
+
+        MultiPageSplitConnector(List<ExternalSplit> receivedSplits, int pagesPerSplit) {
+            this.receivedSplits = receivedSplits;
+            this.pagesPerSplit = pagesPerSplit;
+        }
+
+        @Override
+        public ResultCursor execute(QueryRequest request, Split split) {
+            return multiPageResultCursor(pagesPerSplit);
+        }
+
+        @Override
+        public ResultCursor execute(QueryRequest request, ExternalSplit split) {
+            receivedSplits.add(split);
+            return multiPageResultCursor(pagesPerSplit);
+        }
+
+        @Override
+        public void close() {}
+
+        private static ResultCursor multiPageResultCursor(int pageCount) {
+            return new ResultCursor() {
+                private int remaining = pageCount;
+
+                @Override
+                public boolean hasNext() {
+                    return remaining > 0;
+                }
+
+                @Override
+                public Page next() {
+                    if (remaining <= 0) {
+                        throw new NoSuchElementException();
+                    }
+                    remaining--;
+                    return createTestPage();
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
@@ -7,23 +7,16 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
-import org.elasticsearch.compute.operator.CloseableIterator;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.NoSuchElementException;
-
 /**
- * Unit tests for {@link AsyncExternalSourceBuffer} producer backpressure, including
- * {@link AsyncExternalSourceBuffer#awaitSpaceForProducer} timeout behavior.
+ * Unit tests for {@link AsyncExternalSourceBuffer} backpressure via {@link AsyncExternalSourceBuffer#waitForSpace()}.
  */
 public class AsyncExternalSourceBufferTests extends ESTestCase {
 
@@ -46,13 +39,47 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         return new Page(blocks);
     }
 
-    /**
-     * When the buffer stays full because no consumer calls {@link AsyncExternalSourceBuffer#pollPage()},
-     * {@link AsyncExternalSourceBuffer#awaitSpaceForProducer} must time out with
-     * {@link ElasticsearchTimeoutException}. The buffer must remain consistent and recover after the
-     * producer gives up (drain pages, {@link AsyncExternalSourceBuffer#finish}).
-     */
-    public void testAwaitSpaceForProducerTimeoutLeavesBufferConsistent() {
+    public void testWaitForSpaceReturnsCompletedWhenBufferHasRoom() {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+        SubscribableListener<Void> space = buffer.waitForSpace();
+        assertTrue("waitForSpace should be immediately done when buffer is empty", space.isDone());
+        buffer.finish(true);
+    }
+
+    public void testWaitForSpaceReturnsPendingWhenBufferFull() {
+        long maxBufferBytes = 1500;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+
+        while (buffer.bytesInBuffer() < maxBufferBytes) {
+            buffer.addPage(createTestPage(2, 50));
+        }
+        assertTrue(buffer.bytesInBuffer() >= maxBufferBytes);
+
+        SubscribableListener<Void> space = buffer.waitForSpace();
+        assertFalse("waitForSpace should NOT be done when buffer is full", space.isDone());
+
+        buffer.pollPage().releaseBlocks();
+        assertTrue("waitForSpace should complete after pollPage frees space", space.isDone());
+
+        buffer.finish(true);
+    }
+
+    public void testWaitForSpaceCompletesOnFinish() {
+        long maxBufferBytes = 1500;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+
+        while (buffer.bytesInBuffer() < maxBufferBytes) {
+            buffer.addPage(createTestPage(2, 50));
+        }
+
+        SubscribableListener<Void> space = buffer.waitForSpace();
+        assertFalse(space.isDone());
+
+        buffer.finish(true);
+        assertTrue("waitForSpace should complete when buffer is finished (cancelled)", space.isDone());
+    }
+
+    public void testBufferConsistentAfterFullAndDrain() {
         long maxBufferBytes = 1500;
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
 
@@ -65,9 +92,6 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         assertTrue(buffer.bytesInBuffer() >= maxBufferBytes);
         int sizeBeforeWait = buffer.size();
 
-        var ex = expectThrows(ElasticsearchTimeoutException.class, () -> buffer.awaitSpaceForProducer(TimeValue.timeValueMillis(50)));
-        assertTrue(ex.getMessage().contains("timeout waiting for async external source buffer space"));
-
         assertEquals(sizeBeforeWait, buffer.size());
         assertEquals(expectedBytes, buffer.bytesInBuffer());
         assertFalse(buffer.noMoreInputs());
@@ -79,61 +103,6 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         }
         assertEquals(0, buffer.size());
         assertEquals(0, buffer.bytesInBuffer());
-        buffer.finish(true);
-    }
-
-    /**
-     * Same scenario through {@link ExternalSourceDrainUtils}: a tight drain timeout and a stuck consumer
-     * surface {@link ElasticsearchTimeoutException}. Byte accounting for queued pages matches
-     * {@link AsyncExternalSourceBuffer#bytesInBuffer()}, and the buffer is fully recoverable.
-     */
-    public void testExternalSourceDrainUtilsTimeoutWithStuckConsumer() {
-        long maxBufferBytes = 1500;
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
-
-        int totalPages = 8;
-        List<Page> sourcePages = new ArrayList<>();
-        for (int i = 0; i < totalPages; i++) {
-            sourcePages.add(createTestPage(2, 50));
-        }
-
-        CloseableIterator<Page> it = new CloseableIterator<>() {
-            private int index = 0;
-
-            @Override
-            public boolean hasNext() {
-                return index < sourcePages.size();
-            }
-
-            @Override
-            public Page next() {
-                if (index >= sourcePages.size()) {
-                    throw new NoSuchElementException();
-                }
-                return sourcePages.get(index++);
-            }
-
-            @Override
-            public void close() {}
-        };
-
-        var ex = expectThrows(
-            ElasticsearchTimeoutException.class,
-            () -> ExternalSourceDrainUtils.drainPages(it, buffer, TimeValue.timeValueMillis(200))
-        );
-        assertTrue(ex.getMessage().contains("timeout waiting for async external source buffer space"));
-
-        assertTrue(buffer.size() >= 1);
-        long bytesInBuffer = buffer.bytesInBuffer();
-        long sumBytes = 0;
-        for (Page p = buffer.pollPage(); p != null; p = buffer.pollPage()) {
-            sumBytes += p.ramBytesUsedByBlocks();
-            p.releaseBlocks();
-        }
-        assertEquals(0, buffer.size());
-        assertEquals(0, buffer.bytesInBuffer());
-        assertEquals(bytesInBuffer, sumBytes);
-        assertTrue("drain should not have ingested all pages before timing out", it.hasNext());
         buffer.finish(true);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
@@ -40,6 +41,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -1327,6 +1331,584 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         operator.close();
     }
 
+    // ===== Lifecycle tests: removeAsyncAction fires exactly once per producer path =====
+
+    /**
+     * Sync-wrapper path: verifies removeAsyncAction fires exactly once on success.
+     */
+    public void testSyncWrapperRemoveAsyncActionExactlyOnce() throws Exception {
+        AtomicInteger readCount = new AtomicInteger(0);
+        FormatReader formatReader = new PageCountingFormatReader(readCount);
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+        StoragePath path = StoragePath.of("file:///test.csv");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        DriverContext driverContext = mock(DriverContext.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(driverContext.blockFactory()).thenReturn(blockFactory);
+
+        AtomicInteger addCount = new AtomicInteger(0);
+        AtomicInteger removeCount = new AtomicInteger(0);
+        doAnswer(inv -> {
+            addCount.incrementAndGet();
+            return null;
+        }).when(driverContext).addAsyncAction();
+        doAnswer(inv -> {
+            removeCount.incrementAndGet();
+            return null;
+        }).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            storageProvider,
+            formatReader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        );
+
+        SourceOperator operator = factory.get(driverContext);
+        List<Page> pages = new ArrayList<>();
+        while (operator.isFinished() == false) {
+            Page page = operator.getOutput();
+            if (page != null) {
+                pages.add(page);
+            }
+        }
+
+        assertEquals("addAsyncAction should be called exactly once", 1, addCount.get());
+        assertEquals("removeAsyncAction should be called exactly once", 1, removeCount.get());
+
+        for (Page p : pages) {
+            p.releaseBlocks();
+        }
+        operator.close();
+    }
+
+    /**
+     * Multi-file path: verifies removeAsyncAction fires exactly once for the entire multi-file iteration.
+     */
+    public void testMultiFileRemoveAsyncActionExactlyOnce() throws Exception {
+        AtomicInteger readCount = new AtomicInteger(0);
+        List<StorageEntry> entries = List.of(
+            new StorageEntry(StoragePath.of("s3://bucket/data/f1.parquet"), 100, Instant.EPOCH),
+            new StorageEntry(StoragePath.of("s3://bucket/data/f2.parquet"), 200, Instant.EPOCH),
+            new StorageEntry(StoragePath.of("s3://bucket/data/f3.parquet"), 300, Instant.EPOCH)
+        );
+        FileList fileList = GlobExpander.fileListOf(entries, "s3://bucket/data/*.parquet");
+
+        FormatReader formatReader = new PageCountingFormatReader(readCount);
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+        StoragePath path = StoragePath.of("s3://bucket/data/f1.parquet");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        DriverContext driverContext = mock(DriverContext.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(driverContext.blockFactory()).thenReturn(blockFactory);
+
+        AtomicInteger addCount = new AtomicInteger(0);
+        AtomicInteger removeCount = new AtomicInteger(0);
+        doAnswer(inv -> {
+            addCount.incrementAndGet();
+            return null;
+        }).when(driverContext).addAsyncAction();
+        doAnswer(inv -> {
+            removeCount.incrementAndGet();
+            return null;
+        }).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            storageProvider,
+            formatReader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run(),
+            fileList
+        );
+
+        SourceOperator operator = factory.get(driverContext);
+        List<Page> pages = new ArrayList<>();
+        while (operator.isFinished() == false) {
+            Page page = operator.getOutput();
+            if (page != null) {
+                pages.add(page);
+            }
+        }
+
+        assertEquals("addAsyncAction should be called exactly once", 1, addCount.get());
+        assertEquals("removeAsyncAction should be called exactly once for all files", 1, removeCount.get());
+        assertEquals(3, readCount.get());
+
+        for (Page p : pages) {
+            p.releaseBlocks();
+        }
+        operator.close();
+    }
+
+    /**
+     * Slice-queue path: verifies removeAsyncAction fires exactly once after all splits are processed.
+     */
+    public void testSliceQueueRemoveAsyncActionExactlyOnce() throws Exception {
+        List<FileSplit> splits = List.of(
+            new FileSplit("test", StoragePath.of("s3://bucket/f1.parquet"), 0, 100, "parquet", Map.of(), Map.of()),
+            new FileSplit("test", StoragePath.of("s3://bucket/f2.parquet"), 0, 200, "parquet", Map.of(), Map.of())
+        );
+        ExternalSliceQueue sliceQueue = new ExternalSliceQueue(new ArrayList<>(splits));
+
+        AtomicInteger readCount = new AtomicInteger(0);
+        FormatReader formatReader = new PageCountingFormatReader(readCount);
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+        StoragePath path = StoragePath.of("s3://bucket/f1.parquet");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        DriverContext driverContext = mock(DriverContext.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(driverContext.blockFactory()).thenReturn(blockFactory);
+
+        AtomicInteger addCount = new AtomicInteger(0);
+        AtomicInteger removeCount = new AtomicInteger(0);
+        doAnswer(inv -> {
+            addCount.incrementAndGet();
+            return null;
+        }).when(driverContext).addAsyncAction();
+        doAnswer(inv -> {
+            removeCount.incrementAndGet();
+            return null;
+        }).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            storageProvider,
+            formatReader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run(),
+            null,
+            null,
+            null,
+            sliceQueue
+        );
+
+        SourceOperator operator = factory.get(driverContext);
+        List<Page> pages = new ArrayList<>();
+        while (operator.isFinished() == false) {
+            Page page = operator.getOutput();
+            if (page != null) {
+                pages.add(page);
+            }
+        }
+
+        assertEquals("addAsyncAction should be called exactly once", 1, addCount.get());
+        assertEquals("removeAsyncAction should be called exactly once after all splits", 1, removeCount.get());
+        assertEquals(2, readCount.get());
+
+        for (Page p : pages) {
+            p.releaseBlocks();
+        }
+        operator.close();
+    }
+
+    /**
+     * Sync-wrapper path with error: removeAsyncAction fires exactly once even when read fails.
+     */
+    public void testSyncWrapperRemoveAsyncActionOnError() throws Exception {
+        FormatReader formatReader = new AlwaysFailFormatReader();
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+        StoragePath path = StoragePath.of("s3://bucket/data/bad.parquet");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        DriverContext driverContext = mock(DriverContext.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(driverContext.blockFactory()).thenReturn(blockFactory);
+
+        AtomicInteger addCount = new AtomicInteger(0);
+        AtomicInteger removeCount = new AtomicInteger(0);
+        doAnswer(inv -> {
+            addCount.incrementAndGet();
+            return null;
+        }).when(driverContext).addAsyncAction();
+        doAnswer(inv -> {
+            removeCount.incrementAndGet();
+            return null;
+        }).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            storageProvider,
+            formatReader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        );
+
+        SourceOperator operator = factory.get(driverContext);
+        List<Page> pages = new ArrayList<>();
+        RuntimeException failure = expectThrows(RuntimeException.class, () -> {
+            while (operator.isFinished() == false) {
+                Page page = operator.getOutput();
+                if (page != null) {
+                    pages.add(page);
+                }
+            }
+        });
+        assertNotNull(failure);
+
+        assertEquals("addAsyncAction should be called exactly once", 1, addCount.get());
+        assertEquals("removeAsyncAction should be called exactly once even on error", 1, removeCount.get());
+
+        for (Page p : pages) {
+            p.releaseBlocks();
+        }
+        operator.close();
+    }
+
+    // ===== Regression: buffer.finish / buffer.onFailure mutually exclusive on factory paths =====
+
+    /**
+     * Sync-wrapper success: buffer.finish(false) is called, buffer.onFailure is not.
+     */
+    public void testSyncWrapperBufferFinishOnSuccess() throws Exception {
+        AtomicInteger readCount = new AtomicInteger(0);
+        FormatReader formatReader = new PageCountingFormatReader(readCount);
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+        StoragePath path = StoragePath.of("file:///test.csv");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        DriverContext driverContext = mock(DriverContext.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(driverContext.blockFactory()).thenReturn(blockFactory);
+        doAnswer(inv -> null).when(driverContext).addAsyncAction();
+        doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            storageProvider,
+            formatReader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        );
+
+        SourceOperator operator = factory.get(driverContext);
+        List<Page> pages = new ArrayList<>();
+        while (operator.isFinished() == false) {
+            Page page = operator.getOutput();
+            if (page != null) {
+                pages.add(page);
+            }
+        }
+
+        assertTrue("Operator should be finished", operator.isFinished());
+        assertNull("No failure should be recorded", ((AsyncExternalSourceOperator.Status) operator.status()).failure());
+
+        for (Page p : pages) {
+            p.releaseBlocks();
+        }
+        operator.close();
+    }
+
+    // ===== Regression: backpressure with real thread pool across all producer paths =====
+
+    /**
+     * Sync-wrapper with real thread pool and small buffer: verifies end-to-end backpressure works.
+     */
+    public void testSyncWrapperBackpressureWithRealThreadPool() throws Exception {
+        ExecutorService realExec = Executors.newFixedThreadPool(2, EsExecutors.daemonThreadFactory("test", "bp-test"));
+        try {
+            AtomicInteger readCount = new AtomicInteger(0);
+            FormatReader formatReader = new MultiPageFormatReader(readCount, 10);
+            StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+            StoragePath path = StoragePath.of("file:///test.csv");
+            List<Attribute> attributes = List.of(
+                new FieldAttribute(
+                    Source.EMPTY,
+                    "value",
+                    new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+                )
+            );
+
+            DriverContext driverContext = mock(DriverContext.class);
+            BlockFactory blockFactory = mock(BlockFactory.class);
+            when(driverContext.blockFactory()).thenReturn(blockFactory);
+            doAnswer(inv -> null).when(driverContext).addAsyncAction();
+            doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+            AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+                storageProvider,
+                formatReader,
+                path,
+                attributes,
+                100,
+                2,
+                realExec
+            );
+
+            SourceOperator operator = factory.get(driverContext);
+            List<Page> pages = new ArrayList<>();
+
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (operator.isFinished() == false && System.currentTimeMillis() < deadline) {
+                Page page = operator.getOutput();
+                if (page != null) {
+                    pages.add(page);
+                } else {
+                    Thread.sleep(10);
+                }
+            }
+            assertTrue("Operator should complete within timeout", operator.isFinished());
+            assertEquals(10, pages.size());
+
+            for (Page p : pages) {
+                p.releaseBlocks();
+            }
+            operator.close();
+        } finally {
+            realExec.shutdown();
+            assertTrue(realExec.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    /**
+     * Multi-file path with real thread pool: exercises backpressure across file boundaries.
+     */
+    public void testMultiFileBackpressureWithRealThreadPool() throws Exception {
+        ExecutorService realExec = Executors.newFixedThreadPool(2, EsExecutors.daemonThreadFactory("test", "mf-test"));
+        try {
+            AtomicInteger readCount = new AtomicInteger(0);
+            FormatReader formatReader = new MultiPageFormatReader(readCount, 5);
+            StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+            List<StorageEntry> entries = List.of(
+                new StorageEntry(StoragePath.of("s3://bucket/f1.parquet"), 100, Instant.EPOCH),
+                new StorageEntry(StoragePath.of("s3://bucket/f2.parquet"), 200, Instant.EPOCH),
+                new StorageEntry(StoragePath.of("s3://bucket/f3.parquet"), 300, Instant.EPOCH)
+            );
+            FileList fileList = GlobExpander.fileListOf(entries, "s3://bucket/*.parquet");
+
+            StoragePath path = StoragePath.of("s3://bucket/f1.parquet");
+            List<Attribute> attributes = List.of(
+                new FieldAttribute(
+                    Source.EMPTY,
+                    "value",
+                    new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+                )
+            );
+
+            DriverContext driverContext = mock(DriverContext.class);
+            BlockFactory blockFactory = mock(BlockFactory.class);
+            when(driverContext.blockFactory()).thenReturn(blockFactory);
+            doAnswer(inv -> null).when(driverContext).addAsyncAction();
+            doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+            AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+                storageProvider,
+                formatReader,
+                path,
+                attributes,
+                100,
+                2,
+                realExec,
+                fileList
+            );
+
+            SourceOperator operator = factory.get(driverContext);
+            List<Page> pages = new ArrayList<>();
+
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (operator.isFinished() == false && System.currentTimeMillis() < deadline) {
+                Page page = operator.getOutput();
+                if (page != null) {
+                    pages.add(page);
+                } else {
+                    Thread.sleep(10);
+                }
+            }
+            assertTrue("Operator should complete within timeout", operator.isFinished());
+            assertEquals(3, readCount.get());
+            assertEquals(15, pages.size());
+
+            for (Page p : pages) {
+                p.releaseBlocks();
+            }
+            operator.close();
+        } finally {
+            realExec.shutdown();
+            assertTrue(realExec.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    /**
+     * Slice-queue path with real thread pool: exercises backpressure within split processing.
+     */
+    public void testSliceQueueBackpressureWithRealThreadPool() throws Exception {
+        ExecutorService realExec = Executors.newFixedThreadPool(2, EsExecutors.daemonThreadFactory("test", "sq-test"));
+        try {
+            AtomicInteger readCount = new AtomicInteger(0);
+            FormatReader formatReader = new MultiPageFormatReader(readCount, 5);
+            StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+            List<FileSplit> splits = List.of(
+                new FileSplit("test", StoragePath.of("s3://bucket/f1.parquet"), 0, 100, "parquet", Map.of(), Map.of()),
+                new FileSplit("test", StoragePath.of("s3://bucket/f2.parquet"), 0, 200, "parquet", Map.of(), Map.of())
+            );
+            ExternalSliceQueue sliceQueue = new ExternalSliceQueue(new ArrayList<>(splits));
+
+            StoragePath path = StoragePath.of("s3://bucket/f1.parquet");
+            List<Attribute> attributes = List.of(
+                new FieldAttribute(
+                    Source.EMPTY,
+                    "value",
+                    new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+                )
+            );
+
+            DriverContext driverContext = mock(DriverContext.class);
+            BlockFactory blockFactory = mock(BlockFactory.class);
+            when(driverContext.blockFactory()).thenReturn(blockFactory);
+            doAnswer(inv -> null).when(driverContext).addAsyncAction();
+            doAnswer(inv -> null).when(driverContext).removeAsyncAction();
+
+            AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+                storageProvider,
+                formatReader,
+                path,
+                attributes,
+                100,
+                2,
+                realExec,
+                null,
+                null,
+                null,
+                sliceQueue
+            );
+
+            SourceOperator operator = factory.get(driverContext);
+            List<Page> pages = new ArrayList<>();
+
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (operator.isFinished() == false && System.currentTimeMillis() < deadline) {
+                Page page = operator.getOutput();
+                if (page != null) {
+                    pages.add(page);
+                } else {
+                    Thread.sleep(10);
+                }
+            }
+            assertTrue("Operator should complete within timeout", operator.isFinished());
+            assertEquals(2, readCount.get());
+            assertEquals(10, pages.size());
+
+            for (Page p : pages) {
+                p.releaseBlocks();
+            }
+            operator.close();
+        } finally {
+            realExec.shutdown();
+            assertTrue(realExec.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    /**
+     * Native async path: verifies removeAsyncAction fires exactly once.
+     */
+    public void testNativeAsyncRemoveAsyncActionExactlyOnce() throws Exception {
+        FormatReader formatReader = new TestAsyncFormatReader();
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+        StoragePath path = StoragePath.of("s3://bucket/test.parquet");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        DriverContext driverContext = mock(DriverContext.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(driverContext.blockFactory()).thenReturn(blockFactory);
+
+        AtomicInteger addCount = new AtomicInteger(0);
+        AtomicInteger removeCount = new AtomicInteger(0);
+        doAnswer(inv -> {
+            addCount.incrementAndGet();
+            return null;
+        }).when(driverContext).addAsyncAction();
+        doAnswer(inv -> {
+            removeCount.incrementAndGet();
+            return null;
+        }).when(driverContext).removeAsyncAction();
+
+        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            storageProvider,
+            formatReader,
+            path,
+            attributes,
+            100,
+            10,
+            (Runnable r) -> r.run()
+        );
+
+        SourceOperator operator = factory.get(driverContext);
+        List<Page> pages = new ArrayList<>();
+        while (operator.isFinished() == false) {
+            Page page = operator.getOutput();
+            if (page != null) {
+                pages.add(page);
+            }
+        }
+
+        assertEquals("addAsyncAction should be called exactly once", 1, addCount.get());
+        assertEquals("removeAsyncAction should be called exactly once", 1, removeCount.get());
+
+        for (Page p : pages) {
+            p.releaseBlocks();
+        }
+        operator.close();
+    }
+
     // ===== Helpers =====
 
     private static CloseableIterator<Page> emptyIterator() {
@@ -1796,6 +2378,90 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         public StoragePath path() {
             return path;
         }
+    }
+
+    /**
+     * Format reader that always throws on read, for testing error handling.
+     */
+    private static class AlwaysFailFormatReader implements FormatReader {
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+            throw new IOException("Simulated read error");
+        }
+
+        @Override
+        public String formatName() {
+            return "test-always-fail";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * Format reader that returns multiple pages per read, for testing backpressure.
+     */
+    private static class MultiPageFormatReader implements FormatReader {
+        private final AtomicInteger readCount;
+        private final int pagesPerRead;
+
+        MultiPageFormatReader(AtomicInteger readCount, int pagesPerRead) {
+            this.readCount = readCount;
+            this.pagesPerRead = pagesPerRead;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            readCount.incrementAndGet();
+            return new CloseableIterator<>() {
+                private int remaining = pagesPerRead;
+
+                @Override
+                public boolean hasNext() {
+                    return remaining > 0;
+                }
+
+                @Override
+                public Page next() {
+                    if (remaining <= 0) {
+                        throw new NoSuchElementException();
+                    }
+                    remaining--;
+                    return createTestPage();
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
+
+        @Override
+        public String formatName() {
+            return "test-multi-page";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtilsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -14,7 +15,6 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -23,17 +23,39 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Tests for {@link ExternalSourceDrainUtils} verifying error handling, backpressure,
- * and edge cases during page draining.
+ * Tests for {@link ExternalSourceDrainUtils} async drain methods verifying error handling,
+ * backpressure, cancellation, and edge cases.
  */
 public class ExternalSourceDrainUtilsTests extends ESTestCase {
 
     private static final BlockFactory BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
         .breaker(new NoopCircuitBreaker("none"))
         .build();
+
+    private ExecutorService exec;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        exec = Executors.newFixedThreadPool(2, EsExecutors.daemonThreadFactory("test", "drain-test"));
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        exec.shutdown();
+        assertTrue(exec.awaitTermination(30, TimeUnit.SECONDS));
+        super.tearDown();
+    }
 
     private static Page createTestPage(int numColumns, int numRows) {
         IntBlock.Builder[] builders = new IntBlock.Builder[numColumns];
@@ -72,10 +94,6 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
         };
     }
 
-    /**
-     * Iterator that throws after delivering a configurable number of pages.
-     * The exception can be thrown from either {@code hasNext()} or {@code next()}.
-     */
     private static CloseableIterator<Page> faultingIterator(List<Page> pages, int succeedCount, boolean failOnHasNext) {
         return new CloseableIterator<>() {
             private int index = 0;
@@ -104,20 +122,25 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
         };
     }
 
-    public void testDrainPagesSimple() {
+    public void testDrainPagesAsyncSimple() throws Exception {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
-
         List<Page> pages = List.of(createTestPage(1, 10), createTestPage(1, 10), createTestPage(1, 10));
 
-        ExternalSourceDrainUtils.drainPages(iteratorOf(pages), buffer);
-        assertEquals(3, buffer.size());
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+        ExternalSourceDrainUtils.drainPagesAsync(iteratorOf(pages), buffer, exec, ActionListener.wrap(v -> latch.countDown(), e -> {
+            error.set(e);
+            latch.countDown();
+        }));
 
+        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(3, buffer.size());
         buffer.finish(true);
     }
 
-    public void testDrainRespectsPagesBackpressure() throws Exception {
+    public void testDrainAsyncRespectsPagesBackpressure() throws Exception {
         int totalPages = 20;
-        // ~3 pages worth of bytes: each page is 2 cols × 50 ints ≈ 400+ bytes
         long maxBufferBytes = 1500;
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
 
@@ -126,57 +149,33 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
             sourcePages.add(createTestPage(2, 50));
         }
 
+        CountDownLatch drainDone = new CountDownLatch(1);
         AtomicReference<Exception> drainError = new AtomicReference<>();
-        CyclicBarrier barrier = new CyclicBarrier(2);
+        ExternalSourceDrainUtils.drainPagesAsync(iteratorOf(sourcePages), buffer, exec, ActionListener.wrap(v -> {
+            buffer.finish(false);
+            drainDone.countDown();
+        }, e -> {
+            drainError.set(e);
+            drainDone.countDown();
+        }));
 
-        Thread drainThread = new Thread(() -> {
-            try {
-                barrier.await();
-                ExternalSourceDrainUtils.drainPages(iteratorOf(sourcePages), buffer);
-                buffer.finish(false);
-            } catch (Exception e) {
-                drainError.set(e);
-                buffer.onFailure(e);
+        int consumed = 0;
+        while (consumed < totalPages) {
+            Page page = buffer.pollPage();
+            if (page != null) {
+                page.releaseBlocks();
+                consumed++;
+            } else if (buffer.noMoreInputs() && buffer.size() == 0) {
+                break;
+            } else {
+                Thread.yield();
             }
-        });
+        }
 
-        Thread consumeThread = new Thread(() -> {
-            try {
-                barrier.await();
-                int consumed = 0;
-                while (consumed < totalPages) {
-                    Page page = buffer.pollPage();
-                    if (page != null) {
-                        page.releaseBlocks();
-                        consumed++;
-                    } else if (buffer.noMoreInputs() && buffer.size() == 0) {
-                        break;
-                    } else {
-                        Thread.yield();
-                    }
-                }
-            } catch (Exception e) {
-                buffer.finish(true);
-            }
-        });
-
-        drainThread.start();
-        consumeThread.start();
-
-        drainThread.join(30_000);
-        consumeThread.join(30_000);
-
+        assertTrue(drainDone.await(30, java.util.concurrent.TimeUnit.SECONDS));
         assertNull("Drain should not throw", drainError.get());
     }
 
-    /**
-     * Regression: backpressure used to block on {@code PlainActionFuture#actionGet} on the same named
-     * pool that completes the wait (e.g. two {@code esql_worker} threads), which trips
-     * {@code PlainActionFuture}'s same-pool assertion. Production now uses
-     * {@link AsyncExternalSourceBuffer#awaitSpaceForProducer} ({@code Object#wait} on the buffer's
-     * not-full lock). This test runs producer and consumer on {@link EsExecutors.EsThread} instances
-     * sharing the {@code esql_worker} pool name.
-     */
     public void testBackpressureWithSameNamedPoolThreads() throws Exception {
         int totalPages = 20;
         long maxBufferBytes = 1500;
@@ -187,21 +186,26 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
             sourcePages.add(createTestPage(2, 50));
         }
 
+        CountDownLatch drainDone = new CountDownLatch(1);
         AtomicReference<Exception> drainError = new AtomicReference<>();
         CyclicBarrier barrier = new CyclicBarrier(2);
 
-        var factory = EsExecutors.daemonThreadFactory("testNode", "esql_worker");
-        Thread drainThread = factory.newThread(() -> {
+        exec.execute(() -> {
             try {
                 barrier.await();
-                ExternalSourceDrainUtils.drainPages(iteratorOf(sourcePages), buffer);
-                buffer.finish(false);
             } catch (Exception e) {
-                drainError.set(e);
-                buffer.onFailure(e);
+                throw new RuntimeException(e);
             }
+            ExternalSourceDrainUtils.drainPagesAsync(iteratorOf(sourcePages), buffer, exec, ActionListener.wrap(v -> {
+                buffer.finish(false);
+                drainDone.countDown();
+            }, e -> {
+                drainError.set(e);
+                drainDone.countDown();
+            }));
         });
 
+        var factory = EsExecutors.daemonThreadFactory("testNode", "esql_worker");
         Thread consumeThread = factory.newThread(() -> {
             try {
                 barrier.await();
@@ -221,17 +225,14 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
                 buffer.finish(true);
             }
         });
-
-        drainThread.start();
         consumeThread.start();
 
-        drainThread.join(30_000);
         consumeThread.join(30_000);
-
+        assertTrue(drainDone.await(30, java.util.concurrent.TimeUnit.SECONDS));
         assertNull("Drain should not throw", drainError.get());
     }
 
-    public void testDrainPagesWithBudgetRespectsRowLimit() {
+    public void testDrainPagesWithBudgetAsyncRespectsRowLimit() throws Exception {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
 
         List<Page> pages = new ArrayList<>();
@@ -239,56 +240,76 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
             pages.add(createTestPage(1, 10));
         }
 
-        int totalRows = ExternalSourceDrainUtils.drainPagesWithBudget(iteratorOf(pages), buffer, 25);
-        assertEquals(30, totalRows);
-        assertEquals(3, buffer.size());
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Integer> result = new AtomicReference<>();
+        AtomicReference<Exception> error = new AtomicReference<>();
+        ExternalSourceDrainUtils.drainPagesWithBudgetAsync(iteratorOf(pages), buffer, 25, exec, ActionListener.wrap(totalRows -> {
+            result.set(totalRows);
+            latch.countDown();
+        }, e -> {
+            error.set(e);
+            latch.countDown();
+        }));
 
+        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(Integer.valueOf(30), result.get());
+        assertEquals(3, buffer.size());
         buffer.finish(true);
     }
 
-    public void testDrainPagesIteratorThrowsOnNext() {
+    public void testDrainPagesAsyncIteratorThrowsOnNext() throws Exception {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+
         int succeedCount = between(1, 3);
         List<Page> pages = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             pages.add(createTestPage(1, 10));
         }
 
-        try {
-            RuntimeException ex = expectThrows(
-                RuntimeException.class,
-                () -> ExternalSourceDrainUtils.drainPages(faultingIterator(pages, succeedCount, false), buffer)
-            );
-            assertTrue(ex.getCause().getMessage().contains("simulated S3 read failure on next"));
-            assertEquals(succeedCount, buffer.size());
-        } finally {
-            buffer.finish(true);
-        }
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+        ExternalSourceDrainUtils.drainPagesAsync(faultingIterator(pages, succeedCount, false), buffer, exec, ActionListener.wrap(v -> {
+            latch.countDown();
+        }, e -> {
+            error.set(e);
+            latch.countDown();
+        }));
+
+        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
+        assertNotNull(error.get());
+        assertTrue(error.get().getCause().getMessage().contains("simulated S3 read failure on next"));
+        assertEquals(succeedCount, buffer.size());
+        buffer.finish(true);
     }
 
-    public void testDrainPagesIteratorThrowsOnHasNext() {
+    public void testDrainPagesAsyncIteratorThrowsOnHasNext() throws Exception {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+
         int succeedCount = between(1, 3);
         List<Page> pages = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             pages.add(createTestPage(1, 10));
         }
 
-        try {
-            RuntimeException ex = expectThrows(
-                RuntimeException.class,
-                () -> ExternalSourceDrainUtils.drainPages(faultingIterator(pages, succeedCount, true), buffer)
-            );
-            assertTrue(ex.getCause().getMessage().contains("simulated S3 read failure on hasNext"));
-            assertEquals(succeedCount, buffer.size());
-        } finally {
-            buffer.finish(true);
-        }
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+        ExternalSourceDrainUtils.drainPagesAsync(faultingIterator(pages, succeedCount, true), buffer, exec, ActionListener.wrap(v -> {
+            latch.countDown();
+        }, e -> {
+            error.set(e);
+            latch.countDown();
+        }));
+
+        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
+        assertNotNull(error.get());
+        assertTrue(error.get().getCause().getMessage().contains("simulated S3 read failure on hasNext"));
+        assertEquals(succeedCount, buffer.size());
+        buffer.finish(true);
     }
 
-    public void testDrainPagesBufferCancelledMidDrain() throws Exception {
+    public void testDrainPagesAsyncBufferCancelledMidDrain() throws Exception {
         int totalPages = 20;
-        // ~2 pages worth of bytes: each page is 2 cols × 50 ints ≈ 400+ bytes
         long maxBufferBytes = 1000;
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
 
@@ -319,78 +340,698 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
             public void close() {}
         };
 
+        CountDownLatch drainDone = new CountDownLatch(1);
         AtomicReference<Exception> drainError = new AtomicReference<>();
+        AtomicBoolean drainSucceeded = new AtomicBoolean(false);
+        ExternalSourceDrainUtils.drainPagesAsync(signalingIterator, buffer, exec, ActionListener.wrap(v -> {
+            drainSucceeded.set(true);
+            drainDone.countDown();
+        }, e -> {
+            drainError.set(e);
+            drainDone.countDown();
+        }));
 
-        Thread drainThread = new Thread(() -> {
-            try {
-                ExternalSourceDrainUtils.drainPages(signalingIterator, buffer);
-            } catch (Exception e) {
-                drainError.set(e);
-            }
-        });
-
-        drainThread.start();
         drainStarted.await();
         buffer.finish(true);
 
-        drainThread.join(10_000);
-        assertFalse("Drain thread should have exited", drainThread.isAlive());
+        assertTrue("Drain should complete after cancellation", drainDone.await(10, java.util.concurrent.TimeUnit.SECONDS));
         assertNull("Drain should exit cleanly when buffer is cancelled, but got: " + drainError.get(), drainError.get());
+        assertTrue(drainSucceeded.get());
     }
 
-    public void testDrainEmptyIterator() {
+    public void testDrainAsyncEmptyIterator() throws Exception {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
 
-        ExternalSourceDrainUtils.drainPages(iteratorOf(List.of()), buffer);
-        assertEquals(0, buffer.size());
+        CountDownLatch latch = new CountDownLatch(1);
+        ExternalSourceDrainUtils.drainPagesAsync(iteratorOf(List.of()), buffer, exec, ActionListener.wrap(v -> latch.countDown(), e -> {
+            fail("should not fail");
+        }));
 
+        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
+        assertEquals(0, buffer.size());
         buffer.finish(true);
     }
 
-    public void testDrainPagesWithBudgetThrowsMidDrain() {
+    public void testDrainPagesWithBudgetAsyncThrowsMidDrain() throws Exception {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+
         List<Page> pages = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             pages.add(createTestPage(1, 10));
         }
 
-        try {
-            RuntimeException ex = expectThrows(
-                RuntimeException.class,
-                () -> ExternalSourceDrainUtils.drainPagesWithBudget(faultingIterator(pages, 2, false), buffer, 100)
-            );
-            assertTrue(ex.getCause().getMessage().contains("simulated S3 read failure on next"));
-            assertEquals(2, buffer.size());
-        } finally {
-            buffer.finish(true);
-        }
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+        ExternalSourceDrainUtils.drainPagesWithBudgetAsync(
+            faultingIterator(pages, 2, false),
+            buffer,
+            100,
+            exec,
+            ActionListener.wrap(v -> latch.countDown(), e -> {
+                error.set(e);
+                latch.countDown();
+            })
+        );
+
+        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
+        assertNotNull(error.get());
+        assertTrue(error.get().getCause().getMessage().contains("simulated S3 read failure on next"));
+        assertEquals(2, buffer.size());
+        buffer.finish(true);
     }
 
-    public void testDrainPagesWithExplicitTimeout() {
+    public void testDrainAsyncExecutorRejection() throws Exception {
+        long maxBufferBytes = 100;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+        List<Page> pages = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            pages.add(createTestPage(2, 50));
+        }
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+        AtomicBoolean cleanupRan = new AtomicBoolean(false);
+
+        ExecutorService shutdownExec = Executors.newSingleThreadExecutor(EsExecutors.daemonThreadFactory("test", "shutdown"));
+        shutdownExec.shutdown();
+
+        exec.execute(() -> {
+            ExternalSourceDrainUtils.drainPagesAsync(
+                iteratorOf(pages),
+                buffer,
+                shutdownExec,
+                ActionListener.runAfter(ActionListener.wrap(v -> latch.countDown(), e -> {
+                    error.set(e);
+                    latch.countDown();
+                }), () -> cleanupRan.set(true))
+            );
+        });
+
+        // The drain adds one page synchronously, then goes async because the buffer is full.
+        // The addListener callback fires when we poll a page, then tries shutdownExec.execute()
+        // which throws EsRejectedExecutionException, failing the listener.
+        Thread.sleep(200);
+        Page p = buffer.pollPage();
+        if (p != null) {
+            p.releaseBlocks();
+        }
+
+        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
+        assertNotNull("Should fail with executor rejection", error.get());
+        assertTrue(cleanupRan.get());
+        buffer.finish(true);
+    }
+
+    public void testIteratorOwnershipNotClosedByDrain() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+
+        AtomicBoolean closeCalled = new AtomicBoolean(false);
+
+        List<Page> pages = List.of(createTestPage(1, 10));
+        CloseableIterator<Page> tracked = new CloseableIterator<>() {
+            private final CloseableIterator<Page> delegate = iteratorOf(pages);
+
+            @Override
+            public boolean hasNext() {
+                return delegate.hasNext();
+            }
+
+            @Override
+            public Page next() {
+                return delegate.next();
+            }
+
+            @Override
+            public void close() {
+                closeCalled.set(true);
+            }
+        };
+
+        CountDownLatch latch = new CountDownLatch(1);
+        ExternalSourceDrainUtils.drainPagesAsync(
+            tracked,
+            buffer,
+            exec,
+            ActionListener.wrap(v -> latch.countDown(), e -> { latch.countDown(); })
+        );
+
+        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
+        assertFalse("drainPagesAsync must NOT close the iterator (INV-7)", closeCalled.get());
+        buffer.finish(true);
+    }
+
+    public void testBudgetAccountingAcrossAsyncBoundaries() throws Exception {
+        long maxBufferBytes = 500;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+
+        List<Page> pages = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            pages.add(createTestPage(2, 5));
+        }
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicInteger resultRows = new AtomicInteger();
+        AtomicReference<Exception> error = new AtomicReference<>();
+        ExternalSourceDrainUtils.drainPagesWithBudgetAsync(iteratorOf(pages), buffer, 20, exec, ActionListener.wrap(totalRows -> {
+            resultRows.set(totalRows);
+            latch.countDown();
+        }, e -> {
+            error.set(e);
+            latch.countDown();
+        }));
+
+        int consumed = 0;
+        while (true) {
+            Page page = buffer.pollPage();
+            if (page != null) {
+                page.releaseBlocks();
+                consumed++;
+            } else if (latch.getCount() == 0) {
+                break;
+            } else {
+                Thread.yield();
+            }
+        }
+
+        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(20, resultRows.get());
+        assertEquals(4, consumed);
+        buffer.finish(true);
+    }
+
+    // ===== Exactly-once lifecycle tests (INV-2) =====
+
+    /**
+     * Verifies that the iterator is closed exactly once on the success path
+     * when using ActionListener.runAfter, as recommended by INV-7 / INV-2.
+     */
+    public void testIteratorClosedExactlyOnceOnSuccess() throws Exception {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
         List<Page> pages = List.of(createTestPage(1, 10), createTestPage(1, 10));
 
-        ExternalSourceDrainUtils.drainPages(iteratorOf(pages), buffer, TimeValue.timeValueMinutes(1));
-        assertEquals(2, buffer.size());
+        AtomicInteger closeCount = new AtomicInteger(0);
+        CloseableIterator<Page> tracked = trackingClose(iteratorOf(pages), closeCount);
 
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        ExternalSourceDrainUtils.drainPagesAsync(
+            tracked,
+            buffer,
+            exec,
+            ActionListener.runAfter(ActionListener.wrap(v -> latch.countDown(), e -> {
+                error.set(e);
+                latch.countDown();
+            }), () -> closeQuietly(tracked))
+        );
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals("Iterator must be closed exactly once on success path", 1, closeCount.get());
         buffer.finish(true);
     }
 
-    public void testDrainPagesWithBudgetAndExplicitTimeout() {
+    /**
+     * Verifies that the iterator is closed exactly once on the failure path
+     * when using ActionListener.runAfter, as recommended by INV-7 / INV-2.
+     */
+    public void testIteratorClosedExactlyOnceOnFailure() throws Exception {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
         List<Page> pages = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             pages.add(createTestPage(1, 10));
         }
 
-        int totalRows = ExternalSourceDrainUtils.drainPagesWithBudget(iteratorOf(pages), buffer, 25, TimeValue.timeValueMinutes(1));
-        assertEquals(30, totalRows);
-        assertEquals(3, buffer.size());
+        AtomicInteger closeCount = new AtomicInteger(0);
+        CloseableIterator<Page> tracked = trackingClose(faultingIterator(pages, 2, false), closeCount);
 
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        ExternalSourceDrainUtils.drainPagesAsync(
+            tracked,
+            buffer,
+            exec,
+            ActionListener.runAfter(ActionListener.wrap(v -> latch.countDown(), e -> {
+                error.set(e);
+                latch.countDown();
+            }), () -> closeQuietly(tracked))
+        );
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNotNull("Drain should fail due to iterator exception", error.get());
+        assertEquals("Iterator must be closed exactly once on failure path", 1, closeCount.get());
         buffer.finish(true);
     }
 
-    public void testDefaultDrainTimeoutConstant() {
-        assertEquals(TimeValue.timeValueMinutes(5), ExternalSourceDrainUtils.DEFAULT_DRAIN_TIMEOUT);
+    /**
+     * Verifies that removeAsyncAction fires exactly once when the drain is used
+     * as part of the standard lifecycle pattern (INV-2).
+     */
+    public void testRemoveAsyncActionFiresExactlyOnce() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+        List<Page> pages = List.of(createTestPage(1, 10), createTestPage(1, 10));
+
+        AtomicInteger removeCount = new AtomicInteger(0);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        ExternalSourceDrainUtils.drainPagesAsync(iteratorOf(pages), buffer, exec, ActionListener.runAfter(ActionListener.wrap(v -> {
+            buffer.finish(false);
+            latch.countDown();
+        }, e -> {
+            buffer.onFailure(e);
+            error.set(e);
+            latch.countDown();
+        }), removeCount::incrementAndGet));
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals("removeAsyncAction must fire exactly once", 1, removeCount.get());
+        buffer.finish(true);
+    }
+
+    /**
+     * Verifies that removeAsyncAction fires exactly once on the failure path.
+     */
+    public void testRemoveAsyncActionFiresExactlyOnceOnFailure() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+        List<Page> pages = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            pages.add(createTestPage(1, 10));
+        }
+
+        AtomicInteger removeCount = new AtomicInteger(0);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        ExternalSourceDrainUtils.drainPagesAsync(
+            faultingIterator(pages, 2, false),
+            buffer,
+            exec,
+            ActionListener.runAfter(ActionListener.wrap(v -> {
+                buffer.finish(false);
+                latch.countDown();
+            }, e -> {
+                buffer.onFailure(e);
+                error.set(e);
+                latch.countDown();
+            }), removeCount::incrementAndGet)
+        );
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNotNull(error.get());
+        assertEquals("removeAsyncAction must fire exactly once on failure path", 1, removeCount.get());
+    }
+
+    /**
+     * Verifies that buffer.finish(false) and buffer.onFailure(e) are mutually exclusive:
+     * on the success path, only finish(false) is called; on the failure path, only onFailure is called.
+     */
+    public void testBufferFinishAndOnFailureMutuallyExclusive() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+        List<Page> pages = List.of(createTestPage(1, 10));
+
+        AtomicInteger finishCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ExternalSourceDrainUtils.drainPagesAsync(iteratorOf(pages), buffer, exec, ActionListener.wrap(v -> {
+            finishCount.incrementAndGet();
+            buffer.finish(false);
+            latch.countDown();
+        }, e -> {
+            failureCount.incrementAndGet();
+            buffer.onFailure(e);
+            latch.countDown();
+        }));
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertEquals("finish should be called on success", 1, finishCount.get());
+        assertEquals("onFailure should not be called on success", 0, failureCount.get());
+        assertNull("No failure should be recorded in buffer", buffer.failure());
+    }
+
+    /**
+     * Verifies that on the failure path, onFailure is called and finish(false) is not.
+     */
+    public void testBufferOnFailureCalledNotFinishOnError() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+        List<Page> pages = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            pages.add(createTestPage(1, 10));
+        }
+
+        AtomicInteger finishCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ExternalSourceDrainUtils.drainPagesAsync(faultingIterator(pages, 2, false), buffer, exec, ActionListener.wrap(v -> {
+            finishCount.incrementAndGet();
+            buffer.finish(false);
+            latch.countDown();
+        }, e -> {
+            failureCount.incrementAndGet();
+            buffer.onFailure(e);
+            latch.countDown();
+        }));
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertEquals("finish should not be called on failure", 0, finishCount.get());
+        assertEquals("onFailure should be called on failure", 1, failureCount.get());
+        assertNotNull("Failure should be recorded in buffer", buffer.failure());
+    }
+
+    // ===== Regression & integration tests =====
+
+    /**
+     * Regression test: a slow consumer that processes pages slower than the producer,
+     * with total drain time that would exceed the old 5-minute timeout.
+     * The async drain has no timeout; it must complete successfully.
+     */
+    public void testSlowConsumerExceedingOldTimeoutCompletes() throws Exception {
+        int totalPages = 10;
+        long maxBufferBytes = 500;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+
+        List<Page> sourcePages = new ArrayList<>();
+        for (int i = 0; i < totalPages; i++) {
+            sourcePages.add(createTestPage(2, 50));
+        }
+
+        CountDownLatch drainDone = new CountDownLatch(1);
+        AtomicReference<Exception> drainError = new AtomicReference<>();
+
+        ExternalSourceDrainUtils.drainPagesAsync(iteratorOf(sourcePages), buffer, exec, ActionListener.wrap(v -> {
+            buffer.finish(false);
+            drainDone.countDown();
+        }, e -> {
+            drainError.set(e);
+            drainDone.countDown();
+        }));
+
+        int consumed = 0;
+        while (consumed < totalPages) {
+            Page page = buffer.pollPage();
+            if (page != null) {
+                page.releaseBlocks();
+                consumed++;
+                Thread.sleep(50);
+            } else if (buffer.noMoreInputs() && buffer.size() == 0) {
+                break;
+            } else {
+                Thread.yield();
+            }
+        }
+
+        assertTrue("Drain should complete despite slow consumer", drainDone.await(30, TimeUnit.SECONDS));
+        assertNull("No timeout error should occur", drainError.get());
+        assertEquals(totalPages, consumed);
+    }
+
+    /**
+     * Verifies that the executor thread is returned to the pool between pages
+     * when the buffer is full. Uses a tiny buffer (fits ~1 page) and a multi-page
+     * source with a delayed consumer.
+     */
+    public void testThreadReleaseDuringBackpressure() throws Exception {
+        int totalPages = 10;
+        long maxBufferBytes = 200;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+
+        List<Page> sourcePages = new ArrayList<>();
+        for (int i = 0; i < totalPages; i++) {
+            sourcePages.add(createTestPage(2, 50));
+        }
+
+        CountDownLatch drainDone = new CountDownLatch(1);
+        AtomicReference<Exception> drainError = new AtomicReference<>();
+        AtomicInteger maxConcurrentTasks = new AtomicInteger(0);
+        AtomicInteger currentRunning = new AtomicInteger(0);
+
+        ExecutorService trackingExec = Executors.newFixedThreadPool(4, EsExecutors.daemonThreadFactory("test", "tracking"));
+        Executor trackingWrapper = command -> trackingExec.execute(() -> {
+            int running = currentRunning.incrementAndGet();
+            maxConcurrentTasks.updateAndGet(prev -> Math.max(prev, running));
+            try {
+                command.run();
+            } finally {
+                currentRunning.decrementAndGet();
+            }
+        });
+
+        ExternalSourceDrainUtils.drainPagesAsync(iteratorOf(sourcePages), buffer, trackingWrapper, ActionListener.wrap(v -> {
+            buffer.finish(false);
+            drainDone.countDown();
+        }, e -> {
+            drainError.set(e);
+            drainDone.countDown();
+        }));
+
+        int consumed = 0;
+        while (consumed < totalPages) {
+            Page page = buffer.pollPage();
+            if (page != null) {
+                page.releaseBlocks();
+                consumed++;
+            } else if (buffer.noMoreInputs() && buffer.size() == 0) {
+                break;
+            } else {
+                Thread.sleep(10);
+            }
+        }
+
+        assertTrue(drainDone.await(30, TimeUnit.SECONDS));
+        assertNull(drainError.get());
+        assertEquals(totalPages, consumed);
+        assertTrue(
+            "Max concurrent drain tasks should be 1 (thread released during waits), got: " + maxConcurrentTasks.get(),
+            maxConcurrentTasks.get() <= 2
+        );
+
+        trackingExec.shutdown();
+        assertTrue(trackingExec.awaitTermination(10, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Start a drain, let buffer fill, then cancel the query (buffer.finish(true)).
+     * Assert producer exits cleanly, cleanup runs, no leaked resources.
+     */
+    public void testCancellationWhileWaitingOnWaitForSpace() throws Exception {
+        int totalPages = 50;
+        long maxBufferBytes = 200;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+
+        List<Page> sourcePages = new ArrayList<>();
+        for (int i = 0; i < totalPages; i++) {
+            sourcePages.add(createTestPage(2, 50));
+        }
+
+        CountDownLatch drainDone = new CountDownLatch(1);
+        AtomicReference<Exception> drainError = new AtomicReference<>();
+        AtomicBoolean cleanupRan = new AtomicBoolean(false);
+        AtomicInteger closeCount = new AtomicInteger(0);
+
+        CloseableIterator<Page> tracked = trackingClose(iteratorOf(sourcePages), closeCount);
+
+        ExternalSourceDrainUtils.drainPagesAsync(
+            tracked,
+            buffer,
+            exec,
+            ActionListener.runAfter(ActionListener.wrap(v -> drainDone.countDown(), e -> {
+                drainError.set(e);
+                drainDone.countDown();
+            }), () -> {
+                closeQuietly(tracked);
+                cleanupRan.set(true);
+            })
+        );
+
+        // Let the buffer fill up (producer should be blocked waiting for space)
+        Thread.sleep(200);
+        assertTrue("Buffer should have pages", buffer.size() > 0);
+
+        // Cancel the query
+        buffer.finish(true);
+
+        assertTrue("Drain must complete after cancellation", drainDone.await(10, TimeUnit.SECONDS));
+        assertNull("Drain should exit cleanly on cancellation, but got: " + drainError.get(), drainError.get());
+        assertTrue("Cleanup must run after cancellation", cleanupRan.get());
+        assertEquals("Iterator must be closed exactly once after cancellation", 1, closeCount.get());
+    }
+
+    /**
+     * Budget accounting with multiple sequential drains simulating multi-split behavior.
+     * Each drain reports consumed rows; the total across async boundaries must match.
+     */
+    public void testBudgetPropagationAcrossMultipleSequentialDrains() throws Exception {
+        long maxBufferBytes = 500;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+        int overallRowLimit = 35;
+
+        List<Page> batch1 = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            batch1.add(createTestPage(2, 5));
+        }
+        List<Page> batch2 = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            batch2.add(createTestPage(2, 5));
+        }
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicInteger totalConsumedRows = new AtomicInteger(0);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        // Simulate multi-split: drain batch1, then batch2 with remaining budget
+        ExternalSourceDrainUtils.drainPagesWithBudgetAsync(iteratorOf(batch1), buffer, overallRowLimit, exec, ActionListener.wrap(c1 -> {
+            totalConsumedRows.addAndGet(c1);
+            int remaining = overallRowLimit - c1;
+            ExternalSourceDrainUtils.drainPagesWithBudgetAsync(iteratorOf(batch2), buffer, remaining, exec, ActionListener.wrap(c2 -> {
+                totalConsumedRows.addAndGet(c2);
+                latch.countDown();
+            }, e -> {
+                error.set(e);
+                latch.countDown();
+            }));
+        }, e -> {
+            error.set(e);
+            latch.countDown();
+        }));
+
+        // Consume pages to avoid blocking
+        int consumed = 0;
+        while (latch.getCount() > 0 || buffer.size() > 0) {
+            Page page = buffer.pollPage();
+            if (page != null) {
+                page.releaseBlocks();
+                consumed++;
+            } else {
+                Thread.yield();
+            }
+        }
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals("Total rows across async boundaries must match limit", 35, totalConsumedRows.get());
+        buffer.finish(true);
+    }
+
+    /**
+     * Executor rejection with budget variant: when executor.execute() throws during a
+     * budget-limited drain, the listener receives the failure and cleanup runs.
+     */
+    public void testBudgetDrainExecutorRejection() throws Exception {
+        long maxBufferBytes = 100;
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+        List<Page> pages = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            pages.add(createTestPage(2, 50));
+        }
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+        AtomicBoolean cleanupRan = new AtomicBoolean(false);
+
+        ExecutorService shutdownExec = Executors.newSingleThreadExecutor(EsExecutors.daemonThreadFactory("test", "shutdown"));
+        shutdownExec.shutdown();
+
+        exec.execute(() -> {
+            ExternalSourceDrainUtils.drainPagesWithBudgetAsync(
+                iteratorOf(pages),
+                buffer,
+                1000,
+                shutdownExec,
+                ActionListener.runAfter(ActionListener.<Integer>wrap(v -> latch.countDown(), e -> {
+                    error.set(e);
+                    latch.countDown();
+                }), () -> cleanupRan.set(true))
+            );
+        });
+
+        Thread.sleep(200);
+        Page p = buffer.pollPage();
+        if (p != null) {
+            p.releaseBlocks();
+        }
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNotNull("Should fail with executor rejection", error.get());
+        assertTrue(
+            "Error should be RejectedExecutionException, got: " + error.get().getClass().getSimpleName(),
+            error.get() instanceof RejectedExecutionException
+        );
+        assertTrue("Cleanup must run on executor rejection", cleanupRan.get());
+        buffer.finish(true);
+    }
+
+    /**
+     * Verifies that the drain handles an iterator that fails on the very first hasNext() call.
+     */
+    public void testIteratorFailsOnFirstHasNext() throws Exception {
+        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
+
+        CloseableIterator<Page> failImmediately = new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                throw new RuntimeException("immediate hasNext failure");
+            }
+
+            @Override
+            public Page next() {
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        ExternalSourceDrainUtils.drainPagesAsync(failImmediately, buffer, exec, ActionListener.wrap(v -> latch.countDown(), e -> {
+            error.set(e);
+            latch.countDown();
+        }));
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNotNull(error.get());
+        assertTrue(error.get().getMessage().contains("immediate hasNext failure"));
+        assertEquals(0, buffer.size());
+        buffer.finish(true);
+    }
+
+    // ===== Helpers =====
+
+    private static CloseableIterator<Page> trackingClose(CloseableIterator<Page> delegate, AtomicInteger closeCount) {
+        return new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return delegate.hasNext();
+            }
+
+            @Override
+            public Page next() {
+                return delegate.next();
+            }
+
+            @Override
+            public void close() {
+                closeCount.incrementAndGet();
+                try {
+                    delegate.close();
+                } catch (Exception ignored) {}
+            }
+        };
+    }
+
+    private static void closeQuietly(CloseableIterator<?> iterator) {
+        if (iterator != null) {
+            try {
+                iterator.close();
+            } catch (Exception ignored) {}
+        }
     }
 }


### PR DESCRIPTION
Replace the synchronous blocking drain in ExternalSourceDrainUtils
with async continuation-based pattern using SubscribableListener
callbacks and executor scheduling. This eliminates the 5-minute
wall-clock timeout that killed legitimate slow-but-progressing
queries over large external files.

The producer now runs synchronously while the buffer has space
(hot path) and yields the thread when the buffer is full, resuming
via the executor when space is freed (cold path). Cancellation
propagates cooperatively through buffer.noMoreInputs().

Changes:
- Add drainPagesAsync/drainPagesWithBudgetAsync to
  ExternalSourceDrainUtils with sync hot-path, async cold-path
- Adapt all producer paths in AsyncExternalSourceOperatorFactory
  (sync-wrapper, native-async, multi-file, slice-queue) to async
  drain with ActionListener.runAfter for exactly-once cleanup
- Adapt AsyncConnectorSourceOperatorFactory (slice-queue and
  single-split paths) to async drain
- Remove awaitSpaceForProducer() from AsyncExternalSourceBuffer;
  revert notFullLock to Object/synchronized
- Remove DEFAULT_DRAIN_TIMEOUT, synchronous drain overloads, and
  all timeout-related fields/parameters/accessors
- Rewrite tests for async drain patterns

Developed with AI-assisted tooling