### PR TITLE
Fix PromQL hour/minute CSV tests for BWC

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -399,45 +399,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
   method: test {csv-spec:mv_expand.explosionStats}
   issue: https://github.com/elastic/elasticsearch/issues/146939
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:k8s-timeseries-promql.day_of_week_sunday}
-  issue: https://github.com/elastic/elasticsearch/issues/146947
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:k8s-timeseries-promql.hour_scalar}
-  issue: https://github.com/elastic/elasticsearch/issues/146948
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-promql.hour_scalar}
-  issue: https://github.com/elastic/elasticsearch/issues/146949
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:k8s-timeseries-promql.minute_scalar}
-  issue: https://github.com/elastic/elasticsearch/issues/146951
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-promql.day_of_week_sunday}
-  issue: https://github.com/elastic/elasticsearch/issues/146952
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-promql.minute_scalar}
-  issue: https://github.com/elastic/elasticsearch/issues/146953
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_forceTrue_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/146955
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
-  method: test {csv-spec:k8s-timeseries-promql.day_of_week_sunday}
-  issue: https://github.com/elastic/elasticsearch/issues/146947
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
-  method: test {csv-spec:k8s-timeseries-promql.hour_scalar}
-  issue: https://github.com/elastic/elasticsearch/issues/146948
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
-  method: test {csv-spec:k8s-timeseries-promql.minute_scalar}
-  issue: https://github.com/elastic/elasticsearch/issues/146951
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:k8s-timeseries-promql.minute_scalar}
-  issue: https://github.com/elastic/elasticsearch/issues/146956
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:k8s-timeseries-promql.hour_scalar}
-  issue: https://github.com/elastic/elasticsearch/issues/146957
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
-  method: test {csv-spec:k8s-timeseries-promql.day_of_week_sunday}
-  issue: https://github.com/elastic/elasticsearch/issues/146958
 - class: org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapperTests
   method: testMinimalToMaximal {p0=true p1=ENTERPRISE}
   issue: https://github.com/elastic/elasticsearch/issues/146966

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -547,10 +547,10 @@ result:double | step:datetime
 day_of_week_sunday
 required_capability: promql_command_v0
 required_capability: promql_time_functions
-PROMQL index=k8s step=1h start="2024-05-12T00:00:00.000Z" end="2024-05-12T01:00:00.000Z" result=(day_of_week());
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(day_of_week(vector(1715472000)));
 
 result:double | step:datetime
-0.0           | 2024-05-12T00:00:00.000Z
+0.0           | 2024-05-10T00:00:00.000Z
 ;
 
 day_of_year_scalar
@@ -565,19 +565,19 @@ result:double | step:datetime
 hour_scalar
 required_capability: promql_command_v0
 required_capability: promql_time_functions
-PROMQL index=k8s step=1h start="2024-05-10T14:00:00.000Z" end="2024-05-10T15:00:00.000Z" result=(hour());
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(hour());
 
 result:double | step:datetime
-14.0          | 2024-05-10T14:00:00.000Z
+0.0           | 2024-05-10T00:00:00.000Z
 ;
 
 minute_scalar
 required_capability: promql_command_v0
 required_capability: promql_time_functions
-PROMQL index=k8s step=1h start="2024-05-10T14:30:00.000Z" end="2024-05-10T15:30:00.000Z" result=(minute());
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z" result=(minute());
 
 result:double | step:datetime
-30.0          | 2024-05-10T14:30:00.000Z
+0.0           | 2024-05-10T00:00:00.000Z
 ;
 
 time_in_arithmetic


### PR DESCRIPTION
## Summary

The `hour_scalar`, `minute_scalar`, and `day_of_week_sunday` CSV tests used timestamps outside the k8s test data range, returning empty results in CI.

- `hour_scalar` / `minute_scalar`: changed to use `00:00` within the data range
- `day_of_week_sunday`: use `vector(1715472000)` (2024-05-12 = Sunday) as argument within the `2024-05-10` data range window

Unmutes all affected tests.

Closes #146947 #146948 #146949 #146951 #146952 #146953 #146956 #146957 #146958

Thanks @nik9000 for reporting the issue. 

## Test plan

- [x] Fixes `minute_scalar`, `hour_scalar`, `day_of_week_sunday` CSV tests