### PR TITLE
[ESQL] Parquet reader baseline optimizations

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -37,12 +37,26 @@ public final class BytesRefArray extends AbstractRefCounted implements Accountab
     private long size;
 
     public BytesRefArray(long capacity, BigArrays bigArrays) {
+        this(capacity, bigArrays, 0L);
+    }
+
+    /**
+     * Creates a new {@link BytesRefArray} with pre-allocated byte storage.
+     *
+     * @param capacity  estimated number of entries
+     * @param bigArrays backing big-arrays instance
+     * @param byteHint  expected total byte payload; when positive, the internal byte
+     *                  buffer is pre-sized to this value instead of the default
+     *                  {@code capacity * 3}, reducing grow-on-demand resizes
+     */
+    public BytesRefArray(long capacity, BigArrays bigArrays, long byteHint) {
         this.bigArrays = bigArrays;
         boolean success = false;
         try {
             startOffsets = bigArrays.newLongArray(capacity + 1, false);
             startOffsets.set(0, 0);
-            bytes = bigArrays.newByteArray(capacity * 3, false);
+            long initialBytes = byteHint > 0 ? byteHint : capacity * 3;
+            bytes = bigArrays.newByteArray(initialBytes, false);
             success = true;
         } finally {
             if (false == success) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -295,21 +295,18 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     }
 
     /**
-     * Resolves the record filter for a given Parquet file. When deferred expressions are present,
-     * reads the file footer to obtain the physical schema and builds a schema-aware FilterPredicate.
-     * The footer is read twice when deferred expressions are present (once here for the schema,
-     * once by the main reader) — this overhead is acceptable because Parquet footers are typically
-     * small (KB) and the I/O saving from skipping row groups far outweighs the footer cost.
+     * Resolves the record filter using the schema from an already-open reader, avoiding a
+     * redundant footer read. When deferred expressions are present, builds a schema-aware
+     * FilterPredicate from the provided schema.
      */
-    private FilterCompat.Filter resolveRecordFilter(StorageObject object, InputFile inputFile) {
+    private FilterCompat.Filter resolveRecordFilter(StorageObject object, MessageType schema) {
         if (FilterCompat.isFilteringRequired(pushedFilter)) {
             return pushedFilter;
         }
         if (pushedExpressions == null) {
             return FilterCompat.NOOP;
         }
-        try (ParquetFileReader metadataReader = openParquetFile(object, inputFile, readOptionsBuilder().build())) {
-            MessageType schema = metadataReader.getFileMetaData().getSchema();
+        try {
             FilterPredicate predicate = pushedExpressions.toFilterPredicate(schema);
             return predicate != null ? FilterCompat.get(predicate) : FilterCompat.NOOP;
         } catch (Exception e) {
@@ -325,16 +322,18 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         int rowLimit = context.rowLimit();
 
         InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
-        FilterCompat.Filter recordFilter = resolveRecordFilter(object, parquetInputFile);
-        PlainParquetReadOptions.Builder optionsBuilder = readOptionsBuilder();
-        if (FilterCompat.isFilteringRequired(recordFilter)) {
-            optionsBuilder.withRecordFilter(recordFilter);
-        }
-        ParquetReadOptions options = optionsBuilder.build();
-        ParquetFileReader reader = openParquetFile(object, parquetInputFile, options);
-
+        ParquetFileReader reader = openParquetFile(object, parquetInputFile, readOptionsBuilder().build());
         FileMetaData fileMetaData = reader.getFileMetaData();
         MessageType parquetSchema = fileMetaData.getSchema();
+
+        FilterCompat.Filter recordFilter = resolveRecordFilter(object, parquetSchema);
+        if (FilterCompat.isFilteringRequired(recordFilter)) {
+            reader.close();
+            PlainParquetReadOptions.Builder optionsBuilder = readOptionsBuilder().withRecordFilter(recordFilter);
+            reader = openParquetFile(object, parquetInputFile, optionsBuilder.build());
+            fileMetaData = reader.getFileMetaData();
+            parquetSchema = fileMetaData.getSchema();
+        }
         List<Attribute> attributes = convertParquetSchemaToAttributes(parquetSchema);
 
         List<Attribute> projectedAttributes;
@@ -460,6 +459,17 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             long length = range.length();
             long end = start + length;
 
+            if (length >= targetBytes) {
+                if (groupStart >= 0) {
+                    out.add(new SplitRange(groupStart, groupEnd - groupStart, SourceStatisticsSerializer.mergeStatistics(pendingStats)));
+                    pendingStats.clear();
+                }
+                out.add(new SplitRange(start, length, range.statistics()));
+                groupStart = -1;
+                groupEnd = -1;
+                continue;
+            }
+
             if (groupStart < 0) {
                 groupStart = start;
                 groupEnd = end;
@@ -499,16 +509,19 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         ErrorPolicy errorPolicy
     ) throws IOException {
         InputFile parquetInputFile = ParquetStorageObjectAdapter.forRange(object, rangeEnd - rangeStart);
-        FilterCompat.Filter recordFilter = resolveRecordFilter(object, parquetInputFile);
-        PlainParquetReadOptions.Builder optionsBuilder = readOptionsBuilder().withRange(rangeStart, rangeEnd);
-        if (FilterCompat.isFilteringRequired(recordFilter)) {
-            optionsBuilder.withRecordFilter(recordFilter);
-        }
-        ParquetReadOptions options = optionsBuilder.build();
-        ParquetFileReader reader = openParquetFile(object, parquetInputFile, options);
-
+        ParquetFileReader reader = openParquetFile(object, parquetInputFile, readOptionsBuilder().withRange(rangeStart, rangeEnd).build());
         FileMetaData fileMetaData = reader.getFileMetaData();
         MessageType parquetSchema = fileMetaData.getSchema();
+
+        FilterCompat.Filter recordFilter = resolveRecordFilter(object, parquetSchema);
+        if (FilterCompat.isFilteringRequired(recordFilter)) {
+            reader.close();
+            PlainParquetReadOptions.Builder optionsBuilder = readOptionsBuilder().withRange(rangeStart, rangeEnd)
+                .withRecordFilter(recordFilter);
+            reader = openParquetFile(object, parquetInputFile, optionsBuilder.build());
+            fileMetaData = reader.getFileMetaData();
+            parquetSchema = fileMetaData.getSchema();
+        }
         // The framework passes planning-time resolved attributes for this query (AsyncExternalSourceOperatorFactory).
         // Reuse them to avoid redundant schema conversion work per split. We still read Parquet metadata to drive row groups.
         final List<Attribute> attributes = resolvedAttributes != null && resolvedAttributes.isEmpty() == false
@@ -719,6 +732,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         private PageReadStore rowGroup;
         private ColumnReader[] columnReaders;
+        /** Per-column uncompressed byte size for the current row group (0 if unknown). */
+        private long[] columnUncompressedBytes;
         private long rowsRemainingInGroup;
         private boolean exhausted = false;
         /** Zero-based index of the row group currently being read, or -1 before the first. */
@@ -815,13 +830,30 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 createdBy
             );
             columnReaders = new ColumnReader[columnInfos.length];
+            columnUncompressedBytes = new long[columnInfos.length];
+
+            // Best-effort: rowGroupOrdinal may not match the physical block index when
+            // readNextFilteredRowGroup() skips entire row groups. A wrong hint only affects
+            // pre-sizing (falls back to grow-on-demand), not correctness.
+            List<BlockMetaData> rowGroups = reader.getRowGroups();
+            Map<String, Long> chunkSizes = Map.of();
+            if (rowGroupOrdinal >= 0 && rowGroupOrdinal < rowGroups.size()) {
+                BlockMetaData block = rowGroups.get(rowGroupOrdinal);
+                chunkSizes = new HashMap<>();
+                for (ColumnChunkMetaData chunk : block.getColumns()) {
+                    chunkSizes.put(chunk.getPath().toDotString(), chunk.getTotalUncompressedSize());
+                }
+            }
+
             for (int i = 0; i < columnInfos.length; i++) {
                 if (columnInfos[i] != null) {
                     columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor);
+                    String colPath = String.join(".", columnInfos[i].descriptor.getPath());
+                    Long size = chunkSizes.get(colPath);
+                    columnUncompressedBytes[i] = size != null ? size : 0L;
                 }
             }
             return rowsRemainingInGroup > 0;
-
         }
 
         @Override
@@ -843,7 +875,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                         blocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
                     } else {
                         try {
-                            blocks[col] = readColumnBlock(columnReaders[col], info, rowsToRead);
+                            blocks[col] = readColumnBlock(columnReaders[col], info, rowsToRead, col);
                         } catch (Exception e) {
                             Releasables.closeExpectNoException(blocks);
                             Attribute attr = attributes.get(col);
@@ -890,7 +922,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             return new Page(blocks);
         }
 
-        private Block readColumnBlock(ColumnReader cr, ColumnInfo info, int rowsToRead) {
+        private Block readColumnBlock(ColumnReader cr, ColumnInfo info, int rowsToRead, int colIndex) {
             if (info.maxRepLevel > 0) {
                 return readListColumn(cr, info, rowsToRead);
             }
@@ -904,7 +936,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                     yield readLongColumn(cr, info.maxDefLevel, rowsToRead);
                 }
                 case DOUBLE -> readDoubleColumn(cr, info, rowsToRead);
-                case KEYWORD, TEXT -> readBytesRefColumn(cr, info, rowsToRead);
+                case KEYWORD, TEXT -> {
+                    long totalRows = rowGroup.getRowCount();
+                    long scaledHint = totalRows > 0 ? (columnUncompressedBytes[colIndex] * rowsToRead) / totalRows : 0L;
+                    yield readBytesRefColumn(cr, info, rowsToRead, scaledHint);
+                }
                 case DATETIME -> readDatetimeColumn(cr, info, rowsToRead);
                 default -> {
                     skipValues(cr, rowsToRead);
@@ -1050,9 +1086,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             return ColumnBlockConversions.doubleColumn(blockFactory, values, rows, noNulls, false, isNull);
         }
 
-        private Block readBytesRefColumn(ColumnReader cr, ColumnInfo info, int rows) {
+        private Block readBytesRefColumn(ColumnReader cr, ColumnInfo info, int rows, long byteHint) {
             boolean isUuid = info.logicalType instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
-            try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
+            try (
+                var builder = byteHint > 0
+                    ? blockFactory.newBytesRefBlockBuilder(rows, byteHint)
+                    : blockFactory.newBytesRefBlockBuilder(rows)
+            ) {
                 for (int i = 0; i < rows; i++) {
                     if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
                         builder.appendNull();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetSplitCoalescingTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetSplitCoalescingTests.java
@@ -14,15 +14,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer.STATS_ROW_COUNT;
+
 public class ParquetSplitCoalescingTests extends ESTestCase {
 
     public void testCoalesceProducesFewerRangesAndPreservesCoverage() {
         List<SplitRange> ranges = new ArrayList<>();
-        ranges.add(new SplitRange(0, 10, Map.of("_stats.row_count", 10L)));
-        ranges.add(new SplitRange(10, 10, Map.of("_stats.row_count", 10L)));
-        ranges.add(new SplitRange(20, 10, Map.of("_stats.row_count", 10L)));
-        ranges.add(new SplitRange(30, 10, Map.of("_stats.row_count", 10L)));
-        ranges.add(new SplitRange(40, 10, Map.of("_stats.row_count", 10L)));
+        ranges.add(range(0, 10, 10));
+        ranges.add(range(10, 10, 10));
+        ranges.add(range(20, 10, 10));
+        ranges.add(range(30, 10, 10));
+        ranges.add(range(40, 10, 10));
 
         List<SplitRange> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 25);
         assertTrue(coalesced.size() < ranges.size());
@@ -36,16 +38,13 @@ public class ParquetSplitCoalescingTests extends ESTestCase {
     }
 
     public void testCoalesceWithLargeTargetProducesSingleRange() {
-        List<SplitRange> ranges = List.of(
-            new SplitRange(0, 10, Map.of("_stats.row_count", 5L)),
-            new SplitRange(10, 10, Map.of("_stats.row_count", 5L)),
-            new SplitRange(20, 10, Map.of("_stats.row_count", 5L))
-        );
+        List<SplitRange> ranges = List.of(range(0, 10, 5), range(10, 10, 5), range(20, 10, 5));
         List<SplitRange> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 1024 * 1024);
         assertEquals(1, coalesced.size());
-        assertEquals(0, coalesced.get(0).offset());
-        assertEquals(30, coalesced.get(0).length());
-        assertEquals(15L, coalesced.get(0).statistics().get("_stats.row_count"));
+        SplitRange only = coalesced.get(0);
+        assertEquals(0, only.offset());
+        assertEquals(30, only.length());
+        assertEquals(15L, rowCount(only));
         assertSortedNonOverlapping(coalesced);
     }
 
@@ -57,6 +56,61 @@ public class ParquetSplitCoalescingTests extends ESTestCase {
             assertEquals(ranges.get(i).offset(), coalesced.get(i).offset());
             assertEquals(ranges.get(i).length(), coalesced.get(i).length());
         }
+    }
+
+    public void testCoalesceLargeRangeNotAbsorbedByAccumulator() {
+        List<SplitRange> ranges = List.of(range(0, 10, 5), range(10, 10, 5), range(20, 30, 50));
+        List<SplitRange> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 25);
+        assertEquals(2, coalesced.size());
+
+        SplitRange smalls = coalesced.get(0);
+        assertEquals(0, smalls.offset());
+        assertEquals(20, smalls.length());
+        assertEquals(10L, rowCount(smalls));
+
+        SplitRange large = coalesced.get(1);
+        assertEquals(20, large.offset());
+        assertEquals(30, large.length());
+        assertEquals(50L, rowCount(large));
+
+        assertSortedNonOverlapping(coalesced);
+    }
+
+    public void testCoalesceAllLargeRangesStandAlone() {
+        List<SplitRange> ranges = List.of(range(0, 30, 10), range(30, 40, 20), range(70, 25, 15));
+        List<SplitRange> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 25);
+        assertEquals(3, coalesced.size());
+        for (int i = 0; i < ranges.size(); i++) {
+            assertEquals(ranges.get(i).offset(), coalesced.get(i).offset());
+            assertEquals(ranges.get(i).length(), coalesced.get(i).length());
+        }
+        assertSortedNonOverlapping(coalesced);
+    }
+
+    public void testCoalesceFirstRangeLargeFollowedBySmalls() {
+        List<SplitRange> ranges = List.of(range(0, 50, 30), range(50, 5, 2), range(55, 5, 2));
+        List<SplitRange> coalesced = ParquetFormatReader.coalesceRowGroupRanges(ranges, 25);
+        assertEquals(2, coalesced.size());
+
+        SplitRange large = coalesced.get(0);
+        assertEquals(0, large.offset());
+        assertEquals(50, large.length());
+        assertEquals(30L, rowCount(large));
+
+        SplitRange tail = coalesced.get(1);
+        assertEquals(50, tail.offset());
+        assertEquals(10, tail.length());
+        assertEquals(4L, rowCount(tail));
+
+        assertSortedNonOverlapping(coalesced);
+    }
+
+    private static SplitRange range(long offset, long length, long rowCount) {
+        return new SplitRange(offset, length, Map.of(STATS_ROW_COUNT, rowCount));
+    }
+
+    private static long rowCount(SplitRange range) {
+        return (long) range.statistics().get(STATS_ROW_COUNT);
     }
 
     private static boolean isCoveredByAny(List<SplitRange> coalesced, long start) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
@@ -28,8 +28,12 @@ final class BytesRefBlockBuilder extends AbstractBlockBuilder implements BytesRe
     private BytesRefArray values;
 
     BytesRefBlockBuilder(int estimatedSize, BigArrays bigArrays, BlockFactory blockFactory) {
+        this(estimatedSize, bigArrays, blockFactory, 0L);
+    }
+
+    BytesRefBlockBuilder(int estimatedSize, BigArrays bigArrays, BlockFactory blockFactory, long byteHint) {
         super(blockFactory);
-        values = new BytesRefArray(Math.max(estimatedSize, 2), bigArrays);
+        values = new BytesRefArray(Math.max(estimatedSize, 2), bigArrays, byteHint);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -467,6 +467,15 @@ public class BlockFactory {
         return new BytesRefBlockBuilder(estimatedSize, bigArrays, this);
     }
 
+    /**
+     * Creates a {@link BytesRefBlock.Builder} with a byte-level storage hint. The hint
+     * pre-sizes the internal byte buffer so that columns with known payload size (e.g.
+     * from Parquet column-chunk metadata) avoid repeated grow-on-demand resizes.
+     */
+    public BytesRefBlock.Builder newBytesRefBlockBuilder(int estimatedSize, long byteHint) {
+        return new BytesRefBlockBuilder(estimatedSize, bigArrays, this, byteHint);
+    }
+
     public BytesRefBlock newBytesRefArrayBlock(BytesRefArray values, int pc, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
         var b = new BytesRefArrayBlock(values, pc, firstValueIndexes, nulls, mvOrdering, this);
         adjustBreaker(b.ramBytesUsed() - values.bigArraysRamBytesUsed());

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
@@ -31,8 +31,12 @@ $if(BytesRef)$
     private BytesRefArray values;
 
     BytesRefBlockBuilder(int estimatedSize, BigArrays bigArrays, BlockFactory blockFactory) {
+        this(estimatedSize, bigArrays, blockFactory, 0L);
+    }
+
+    BytesRefBlockBuilder(int estimatedSize, BigArrays bigArrays, BlockFactory blockFactory, long byteHint) {
         super(blockFactory);
-        values = new BytesRefArray(Math.max(estimatedSize, 2), bigArrays);
+        values = new BytesRefArray(Math.max(estimatedSize, 2), bigArrays, byteHint);
     }
 
 $else$


### PR DESCRIPTION
Three standalone performance improvements to the baseline Parquet reader:

- Eliminate a redundant ParquetFileReader open in resolveRecordFilter
  by passing the schema from the already-open reader, saving one footer
  round-trip when pushed expressions don't produce a filter predicate.

- Add a lower-bound check in coalesceRowGroupRanges so that a row group
  already meeting the target split size is emitted standalone instead of
  being absorbed into the previous accumulator.

- Pre-size BytesRefArray byte storage using Parquet column-chunk
  uncompressed size metadata, scaled proportionally to batch size, to
  reduce grow-on-demand resizes for string columns.

Developed with AI-assisted tooling