### PR TITLE
Bump replica shard inactive grace period

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
@@ -114,9 +114,9 @@ public abstract class ShardsAvailabilityHealthIndicatorService implements Health
     /// window applies to non-active shards in either unassigned or initializing state.
     public static final Setting<TimeValue> REPLICA_INACTIVE_BUFFER_TIME = Setting.timeSetting(
         "health.shards_availability.replica_unassigned_buffer_time",
-        TimeValue.timeValueSeconds(5),
+        TimeValue.timeValueSeconds(30),
         TimeValue.timeValueSeconds(0),
-        TimeValue.timeValueSeconds(60),
+        TimeValue.timeValueMinutes(2),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
@@ -114,7 +114,7 @@ public abstract class ShardsAvailabilityHealthIndicatorService implements Health
     /// window applies to non-active shards in either unassigned or initializing state.
     public static final Setting<TimeValue> REPLICA_INACTIVE_BUFFER_TIME = Setting.timeSetting(
         "health.shards_availability.replica_unassigned_buffer_time",
-        TimeValue.timeValueSeconds(30),
+        TimeValue.timeValueSeconds(25),
         TimeValue.timeValueSeconds(0),
         TimeValue.timeValueMinutes(2),
         Setting.Property.NodeScope,


### PR DESCRIPTION
Follows: https://github.com/elastic/elasticsearch/pull/144773 and https://github.com/elastic/elasticsearch/pull/145484

Bumps `REPLICA_INACTIVE_BUFFER_TIME` default value to 30 second and max value to 2 minutes.

Relates to ES-14351

Derived the values from the "unassigned -> started" stats from the serverless dashboard: `[inespot] Shard allocation & health` from April 16th to April 21st.
