### PR TITLE
[ESQL] Parquet page-level batch column reader

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnInfo.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnInfo.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+/**
+ * Per-column metadata used by the Parquet column iterators. Holds the Parquet column descriptor
+ * alongside the ESQL type mapping and definition/repetition levels.
+ */
+record ColumnInfo(
+    ColumnDescriptor descriptor,
+    PrimitiveType.PrimitiveTypeName parquetType,
+    DataType esqlType,
+    int maxDefLevel,
+    int maxRepLevel,
+    LogicalTypeAnnotation logicalType
+) {}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ConstantBlockDetection.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ConstantBlockDetection.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+
+import java.util.BitSet;
+
+/**
+ * Post-decode constant detection for Parquet column batches. After values are decoded into arrays,
+ * these methods check whether all non-null values are identical and, if so, return a constant
+ * {@link Block} instead of an array-backed block. This turns O(n) downstream consumers into O(1)
+ * for partition columns and other repeated-value scenarios common in Parquet files.
+ *
+ * <p>Returns {@code null} when the values are not constant, signaling the caller to fall through
+ * to the normal array-block path.
+ */
+final class ConstantBlockDetection {
+
+    private ConstantBlockDetection() {}
+
+    static Block tryConstantBoolean(boolean[] values, int rows, BlockFactory blockFactory) {
+        if (rows <= 1) {
+            return blockFactory.newConstantBooleanBlockWith(rows == 0 ? false : values[0], rows);
+        }
+        boolean first = values[0];
+        for (int i = 1; i < rows; i++) {
+            if (values[i] != first) {
+                return null;
+            }
+        }
+        return blockFactory.newConstantBooleanBlockWith(first, rows);
+    }
+
+    static Block tryConstantInt(int[] values, int rows, BlockFactory blockFactory) {
+        if (rows <= 1) {
+            return blockFactory.newConstantIntBlockWith(rows == 0 ? 0 : values[0], rows);
+        }
+        int first = values[0];
+        for (int i = 1; i < rows; i++) {
+            if (values[i] != first) {
+                return null;
+            }
+        }
+        return blockFactory.newConstantIntBlockWith(first, rows);
+    }
+
+    static Block tryConstantLong(long[] values, int rows, BlockFactory blockFactory) {
+        if (rows <= 1) {
+            return blockFactory.newConstantLongBlockWith(rows == 0 ? 0L : values[0], rows);
+        }
+        long first = values[0];
+        for (int i = 1; i < rows; i++) {
+            if (values[i] != first) {
+                return null;
+            }
+        }
+        return blockFactory.newConstantLongBlockWith(first, rows);
+    }
+
+    /**
+     * Uses {@code Double.doubleToRawLongBits} for bitwise comparison to handle NaN correctly.
+     */
+    static Block tryConstantDouble(double[] values, int rows, BlockFactory blockFactory) {
+        if (rows <= 1) {
+            return blockFactory.newConstantDoubleBlockWith(rows == 0 ? 0.0 : values[0], rows);
+        }
+        long firstBits = Double.doubleToRawLongBits(values[0]);
+        for (int i = 1; i < rows; i++) {
+            if (Double.doubleToRawLongBits(values[i]) != firstBits) {
+                return null;
+            }
+        }
+        return blockFactory.newConstantDoubleBlockWith(values[0], rows);
+    }
+
+    static Block tryConstantBytesRef(BytesRef[] values, int rows, BlockFactory blockFactory) {
+        if (rows <= 1) {
+            return blockFactory.newConstantBytesRefBlockWith(rows == 0 ? new BytesRef() : values[0], rows);
+        }
+        BytesRef first = values[0];
+        for (int i = 1; i < rows; i++) {
+            if (first.bytesEquals(values[i]) == false) {
+                return null;
+            }
+        }
+        return blockFactory.newConstantBytesRefBlockWith(new BytesRef(first.bytes, first.offset, first.length), rows);
+    }
+
+    static Block tryAllNull(BitSet nulls, int rows, BlockFactory blockFactory) {
+        if (nulls.cardinality() == rows) {
+            return blockFactory.newConstantNullBlock(rows);
+        }
+        return null;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DecodeBuffers.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DecodeBuffers.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import java.util.BitSet;
+
+/**
+ * Reusable decode buffers for {@link PageColumnReader} batch operations. Eliminates per-batch
+ * allocation of primitive arrays by keeping warm arrays that are reused across batches.
+ *
+ * <p>Each buffer type is lazily allocated and grown as needed. {@code BlockFactory.newXxxArrayVector}
+ * wraps arrays by reference (no copy), so each {@link PageColumnReader} must own its own
+ * {@code DecodeBuffers} instance. Within a single column, the {@link #takeLongs()} and
+ * {@link #takeDoubles()} methods alternate between two slots so the previous batch's array can
+ * be handed off to a Block while the next batch decodes into the alternate slot.
+ *
+ * <p><b>Important:</b> each {@link PageColumnReader} must own its own {@code DecodeBuffers} instance.
+ * Sharing across columns causes block corruption because {@code BlockFactory.newXxxArrayVector()}
+ * wraps arrays by reference. When two columns share a buffer, the second column's decode overwrites
+ * the first column's live block data. The double-buffering for longs/doubles (slot A/B via
+ * {@link #takeLongs()}/{@link #takeDoubles()}) handles at most 2 consumers but fails with 3+.
+ *
+ * <p>TODO: when {@code ColumnBlockConversions} gains an {@code ownsArray=true} overload (zero-copy
+ * handoff), revisit sharing: a single DecodeBuffers per row group would reduce object overhead if
+ * blocks take ownership and the buffer is immediately recycled.
+ */
+final class DecodeBuffers {
+
+    private int[] intBuf;
+    private long[] longBufA;
+    private long[] longBufB;
+    private boolean longSlotA = true;
+    private double[] doubleBufA;
+    private double[] doubleBufB;
+    private boolean doubleSlotA = true;
+    private boolean[] boolBuf;
+    private BitSet nullsBuf;
+
+    DecodeBuffers() {}
+
+    int[] ints(int minSize) {
+        if (intBuf == null || intBuf.length < minSize) {
+            intBuf = new int[minSize];
+        }
+        return intBuf;
+    }
+
+    long[] longs(int minSize) {
+        if (longSlotA) {
+            if (longBufA == null || longBufA.length < minSize) {
+                longBufA = new long[minSize];
+            }
+            return longBufA;
+        } else {
+            if (longBufB == null || longBufB.length < minSize) {
+                longBufB = new long[minSize];
+            }
+            return longBufB;
+        }
+    }
+
+    /**
+     * Returns the current long buffer and swaps to the alternate slot. The caller takes
+     * exclusive ownership of the returned array (e.g., to hand off to a Block without copying).
+     * The next call to {@link #longs(int)} will use the alternate slot, avoiding reallocation
+     * as long as the previous buffer is released before the one after next is taken.
+     */
+    long[] takeLongs() {
+        if (longSlotA) {
+            longSlotA = false;
+            return longBufA;
+        } else {
+            longSlotA = true;
+            return longBufB;
+        }
+    }
+
+    double[] doubles(int minSize) {
+        if (doubleSlotA) {
+            if (doubleBufA == null || doubleBufA.length < minSize) {
+                doubleBufA = new double[minSize];
+            }
+            return doubleBufA;
+        } else {
+            if (doubleBufB == null || doubleBufB.length < minSize) {
+                doubleBufB = new double[minSize];
+            }
+            return doubleBufB;
+        }
+    }
+
+    /**
+     * Returns the current double buffer and swaps to the alternate slot. The caller takes
+     * exclusive ownership of the returned array (e.g., to hand off to a Block without copying).
+     * The next call to {@link #doubles(int)} will use the alternate slot, avoiding reallocation
+     * as long as the previous buffer is released before the one after next is taken.
+     */
+    double[] takeDoubles() {
+        if (doubleSlotA) {
+            doubleSlotA = false;
+            return doubleBufA;
+        } else {
+            doubleSlotA = true;
+            return doubleBufB;
+        }
+    }
+
+    boolean[] booleans(int minSize) {
+        if (boolBuf == null || boolBuf.length < minSize) {
+            boolBuf = new boolean[minSize];
+        }
+        return boolBuf;
+    }
+
+    /**
+     * Returns a reusable {@link BitSet} cleared to all-false.
+     */
+    BitSet nulls(int minSize) {
+        if (nullsBuf == null) {
+            nullsBuf = new BitSet(minSize);
+        } else {
+            nullsBuf.clear();
+        }
+        return nullsBuf;
+    }
+
+    private WordMask nullsMask;
+    private WordMask valueSelMask;
+
+    WordMask nullsMask(int numBits) {
+        if (nullsMask == null) nullsMask = new WordMask();
+        nullsMask.reset(numBits);
+        return nullsMask;
+    }
+
+    WordMask valueSelection(int numBits) {
+        if (valueSelMask == null) valueSelMask = new WordMask();
+        valueSelMask.reset(numBits);
+        return valueSelMask;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.BitSet;
+
+/**
+ * Bulk decoder for Parquet definition levels, producing a {@link BitSet} of null positions
+ * for nullable flat columns. Delegates to parquet-java's {@link RunLengthBitPackingHybridDecoder}
+ * for the actual RLE hybrid stream decoding.
+ *
+ * <p>For non-nullable columns ({@code maxDefLevel == 0}), no def-level section exists in the
+ * page and all operations are no-ops.
+ */
+final class DefinitionLevelDecoder {
+
+    private boolean nonNullable;
+    private int maxDefLevel;
+    private RunLengthBitPackingHybridDecoder rleDecoder;
+
+    DefinitionLevelDecoder() {}
+
+    void init(ByteBuffer defLevelBytes, int valueCount, int maxDefLevel, boolean hasLengthPrefix) {
+        this.maxDefLevel = maxDefLevel;
+        if (maxDefLevel <= 0) {
+            this.nonNullable = true;
+            this.rleDecoder = null;
+            return;
+        }
+        this.nonNullable = false;
+        int bitWidth = 32 - Integer.numberOfLeadingZeros(maxDefLevel);
+        ByteBuffer source = defLevelBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        if (hasLengthPrefix) {
+            int payloadLen = source.getInt();
+            byte[] payload = new byte[payloadLen];
+            source.get(payload);
+            this.rleDecoder = new RunLengthBitPackingHybridDecoder(bitWidth, new ByteArrayInputStream(payload));
+        } else {
+            byte[] data = new byte[source.remaining()];
+            source.get(data);
+            this.rleDecoder = new RunLengthBitPackingHybridDecoder(bitWidth, new ByteArrayInputStream(data));
+        }
+    }
+
+    /**
+     * Decodes the next {@code count} definition levels, setting null positions in {@code nulls}
+     * starting at {@code offset}. Returns the number of non-null values.
+     */
+    int readBatch(int count, BitSet nulls, int offset) {
+        if (nonNullable) {
+            return count;
+        }
+        if (count == 0) {
+            return 0;
+        }
+        int nonNull = 0;
+        try {
+            for (int i = 0; i < count; i++) {
+                int def = rleDecoder.readInt();
+                if (def < maxDefLevel) {
+                    nulls.set(offset + i);
+                } else {
+                    nonNull++;
+                }
+            }
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to read definition levels: " + e.getMessage(), e);
+        }
+        return nonNull;
+    }
+
+    int readBatch(int count, WordMask nulls, int offset) {
+        if (nonNullable) {
+            return count;
+        }
+        if (count == 0) {
+            return 0;
+        }
+        int nonNull = 0;
+        try {
+            for (int i = 0; i < count; i++) {
+                int def = rleDecoder.readInt();
+                if (def < maxDefLevel) {
+                    nulls.set(offset + i);
+                } else {
+                    nonNull++;
+                }
+            }
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to read definition levels: " + e.getMessage(), e);
+        }
+        return nonNull;
+    }
+
+    /**
+     * Skips {@code count} definition levels without materializing values.
+     * Returns the number of non-null values that were skipped.
+     */
+    int skip(int count) {
+        if (nonNullable || count == 0) {
+            return count;
+        }
+        int nonNull = 0;
+        try {
+            for (int i = 0; i < count; i++) {
+                int def = rleDecoder.readInt();
+                if (def >= maxDefLevel) {
+                    nonNull++;
+                }
+            }
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to skip definition levels: " + e.getMessage(), e);
+        }
+        return nonNull;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.io.api.Binary;
+import org.elasticsearch.xpack.esql.core.util.Check;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+/**
+ * Bulk decoder for RLE_DICTIONARY-encoded Parquet values. Reads a 1-byte bit width header,
+ * then decodes RLE hybrid-encoded dictionary indices and gathers typed values from the
+ * {@link Dictionary}.
+ */
+final class DictionaryValueDecoder {
+
+    private ByteBuffer in;
+    private int bitWidth;
+
+    private boolean rleMode;
+    private int rleLeft;
+    private int rleValue;
+
+    private byte[] packedBytes;
+    private int packedByteOffset;
+    private int packedRemaining;
+    private final int[] groupValues = new int[8];
+    private int groupNext = 8;
+
+    void init(ByteBuffer valueBytes) {
+        ByteBuffer dup = valueBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        bitWidth = dup.get() & 0xFF;
+        Check.isTrue(bitWidth <= 32, "Dictionary index bit width must be <= 32, got [{}]", bitWidth);
+        in = dup.slice().order(ByteOrder.LITTLE_ENDIAN);
+        rleMode = true;
+        rleLeft = 0;
+        rleValue = 0;
+        packedByteOffset = 0;
+        packedRemaining = 0;
+        groupNext = 8;
+    }
+
+    void readInts(int[] values, int offset, int count, Dictionary dict) {
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = dict.decodeToInt(nextIndex());
+        }
+    }
+
+    void readLongs(long[] values, int offset, int count, Dictionary dict) {
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = dict.decodeToLong(nextIndex());
+        }
+    }
+
+    void readFloats(double[] values, int offset, int count, Dictionary dict) {
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = dict.decodeToFloat(nextIndex());
+        }
+    }
+
+    void readDoubles(double[] values, int offset, int count, Dictionary dict) {
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = dict.decodeToDouble(nextIndex());
+        }
+    }
+
+    void readBooleans(boolean[] values, int offset, int count, Dictionary dict) {
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = dict.decodeToBoolean(nextIndex());
+        }
+    }
+
+    void readBinaries(BytesRef[] values, int offset, int count, Dictionary dict) {
+        for (int i = 0; i < count; i++) {
+            Binary bin = dict.decodeToBinary(nextIndex());
+            byte[] bytes = bin.getBytes();
+            values[offset + i] = new BytesRef(bytes, 0, bytes.length);
+        }
+    }
+
+    void skip(int count) {
+        int remaining = count;
+        while (remaining > 0) {
+            ensureRunLoaded();
+            if (rleMode) {
+                int take = Math.min(remaining, rleLeft);
+                rleLeft -= take;
+                remaining -= take;
+            } else {
+                remaining -= skipPackedValues(remaining);
+            }
+        }
+    }
+
+    private int skipPackedValues(int remaining) {
+        int skipped = 0;
+        while (skipped < remaining) {
+            if (packedRemaining == 0) {
+                return skipped;
+            }
+            if (groupNext >= 8) {
+                if (packedRemaining == 0) {
+                    return skipped;
+                }
+                loadPackedGroup();
+            }
+            int inGroupAvail = 8 - groupNext;
+            int take = Math.min(inGroupAvail, remaining - skipped);
+            groupNext += take;
+            packedRemaining -= take;
+            skipped += take;
+        }
+        return skipped;
+    }
+
+    int nextIndex() {
+        while (true) {
+            ensureRunLoaded();
+            if (rleMode) {
+                if (rleLeft > 0) {
+                    rleLeft--;
+                    return rleValue;
+                }
+                startNextRun();
+                continue;
+            }
+            if (packedRemaining > 0) {
+                if (groupNext >= 8) {
+                    loadPackedGroup();
+                }
+                int v = groupValues[groupNext++];
+                packedRemaining--;
+                return v;
+            }
+            startNextRun();
+        }
+    }
+
+    private void ensureRunLoaded() {
+        if (rleMode && rleLeft > 0) {
+            return;
+        }
+        if (rleMode == false && packedRemaining > 0) {
+            return;
+        }
+        startNextRun();
+    }
+
+    private void startNextRun() {
+        Check.isTrue(in.hasRemaining(), "Truncated dictionary index stream");
+        int header = readUnsignedVarInt();
+        if ((header & 1) == 0) {
+            rleMode = true;
+            rleLeft = header >>> 1;
+            rleValue = readIntLittleEndianPadded();
+            packedRemaining = 0;
+            groupNext = 8;
+        } else {
+            rleMode = false;
+            int numGroups = header >>> 1;
+            packedRemaining = numGroups * 8;
+            int byteLen = numGroups * bitWidth;
+            Check.isTrue(in.remaining() >= byteLen, "Truncated bit-packed dictionary index data");
+            if (packedBytes == null || packedBytes.length < byteLen) {
+                packedBytes = new byte[byteLen];
+            }
+            in.get(packedBytes, 0, byteLen);
+            packedByteOffset = 0;
+            groupNext = 8;
+            rleLeft = 0;
+        }
+    }
+
+    private void loadPackedGroup() {
+        if (bitWidth == 0) {
+            Arrays.fill(groupValues, 0);
+        } else {
+            unpack8Values(packedBytes, packedByteOffset, groupValues, 0, bitWidth);
+            packedByteOffset += bitWidth;
+        }
+        groupNext = 0;
+    }
+
+    private int readUnsignedVarInt() {
+        int shift = 0;
+        int result = 0;
+        while (true) {
+            Check.isTrue(in.hasRemaining(), "Truncated varint in dictionary index stream");
+            int b = in.get() & 0xFF;
+            result |= (b & 0x7F) << shift;
+            if ((b & 0x80) == 0) {
+                return result;
+            }
+            shift += 7;
+            Check.isTrue(shift <= 35, "Varint overflow in dictionary index stream");
+        }
+    }
+
+    private int readIntLittleEndianPadded() {
+        int n = (bitWidth + 7) >>> 3;
+        if (n == 0) {
+            return 0;
+        }
+        Check.isTrue(in.remaining() >= n, "Truncated padded dictionary index value");
+        int v = 0;
+        for (int i = 0; i < n; i++) {
+            v |= (in.get() & 0xFF) << (8 * i);
+        }
+        return v;
+    }
+
+    @SuppressWarnings("fallthrough")
+    private static void unpack8Values(byte[] packed, int byteOffset, int[] out, int outOffset, int bitWidth) {
+        switch (bitWidth) {
+            case 0 -> {
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = 0;
+                }
+            }
+            case 1 -> {
+                int b = packed[byteOffset] & 0xFF;
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = (b >>> i) & 1;
+                }
+            }
+            case 2 -> {
+                int word = (packed[byteOffset] & 0xFF) | ((packed[byteOffset + 1] & 0xFF) << 8);
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = (word >>> (i * 2)) & 0x3;
+                }
+            }
+            case 4 -> {
+                int word = (packed[byteOffset] & 0xFF) | ((packed[byteOffset + 1] & 0xFF) << 8) | ((packed[byteOffset + 2] & 0xFF) << 16)
+                    | ((packed[byteOffset + 3] & 0xFF) << 24);
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = (word >>> (i * 4)) & 0xF;
+                }
+            }
+            case 8 -> {
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = packed[byteOffset + i] & 0xFF;
+                }
+            }
+            case 16 -> {
+                for (int i = 0; i < 8; i++) {
+                    int base = byteOffset + i * 2;
+                    out[outOffset + i] = (packed[base] & 0xFF) | ((packed[base + 1] & 0xFF) << 8);
+                }
+            }
+            default -> {
+                int bitBase = byteOffset * 8;
+                for (int i = 0; i < 8; i++) {
+                    out[outOffset + i] = readBitsLE(packed, bitBase + i * bitWidth, bitWidth);
+                }
+            }
+        }
+    }
+
+    private static int readBitsLE(byte[] data, int bitOffset, int width) {
+        int byteIdx = bitOffset >>> 3;
+        int bitInByte = bitOffset & 7;
+        long word = 0;
+        int bytesNeeded = ((bitInByte + width) + 7) >>> 3;
+        for (int i = 0; i < bytesNeeded && (byteIdx + i) < data.length; i++) {
+            word |= (long) (data[byteIdx + i] & 0xFF) << (i * 8);
+        }
+        return (int) ((word >>> bitInByte) & (width == 32 ? 0xFFFFFFFFL : ((1L << width) - 1)));
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -1,0 +1,1134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.ValuesType;
+import org.apache.parquet.column.page.DataPage;
+import org.apache.parquet.column.page.DataPageV1;
+import org.apache.parquet.column.page.DataPageV2;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Duration;
+import java.util.BitSet;
+
+/**
+ * Page-level batch column reader that bypasses {@code ColumnReadStoreImpl} and works directly
+ * with {@link PageReader} and {@link DataPage} objects. For each batch request, it:
+ * <ol>
+ *   <li>Reads data pages from the {@link PageReader}</li>
+ *   <li>Splits V1/V2 pages into def-level and value streams</li>
+ *   <li>Bulk-decodes def levels via {@link DefinitionLevelDecoder} → null {@link BitSet}</li>
+ *   <li>Bulk-decodes values via {@link PlainValueDecoder} or {@link DictionaryValueDecoder}</li>
+ *   <li>Assembles into ESQL {@link Block}s</li>
+ * </ol>
+ *
+ * <p>Only handles flat columns (maxRepLevel == 0). List columns must use the row-at-a-time path.
+ * When a Parquet record filter is active, this reader is bypassed entirely (see
+ * {@code ParquetFormatReader.ParquetColumnIterator#advanceRowGroup}) because page-index filtering
+ * changes the semantics of pages returned by {@link PageReader}.
+ *
+ * <p>TODO: selective reading (RowSelection + PredicateEvaluator) is blocked on Stage 7 of the
+ * performance backport plan. When added, readBatch should gain a predicate parameter that applies
+ * per-page filtering via RowRanges, enabling page skipping for filtered queries without falling
+ * back to the ColumnReader path.
+ */
+final class PageColumnReader {
+
+    private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0).asReadOnlyBuffer();
+    private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
+    private static final long NANOS_PER_MILLI = 1_000_000L;
+    private static final int JULIAN_EPOCH_OFFSET = 2_440_588;
+
+    private final PageReader pageReader;
+    private final ColumnDescriptor descriptor;
+    private final ColumnInfo info;
+    private final RowRanges rowRanges;
+    private final int maxDefLevel;
+
+    private Dictionary dictionary;
+    private boolean dictionaryLoaded;
+
+    private final DefinitionLevelDecoder defDecoder = new DefinitionLevelDecoder();
+    private final PlainValueDecoder plainDecoder = new PlainValueDecoder();
+    private final DictionaryValueDecoder dictDecoder = new DictionaryValueDecoder();
+    private ValuesReader fallbackReader;
+    private boolean useFallbackReader;
+
+    private final DecodeBuffers buffers;
+
+    private ByteBuffer currentDefLevelBytes;
+    private ByteBuffer currentValueBytes;
+    private Encoding currentEncoding;
+    private int currentPageValueCount;
+    private int physicalPageValueCount;
+    private int currentPageConsumed;
+    private boolean currentPageIsV1;
+    private long rowPositionInRowGroup;
+    private boolean columnExhausted;
+
+    PageColumnReader(PageReader pageReader, ColumnDescriptor descriptor, ColumnInfo info, RowRanges rowRanges) {
+        this.pageReader = pageReader;
+        this.descriptor = descriptor;
+        this.info = info;
+        this.rowRanges = rowRanges;
+        this.maxDefLevel = descriptor.getMaxDefinitionLevel();
+        this.columnExhausted = false;
+        this.rowPositionInRowGroup = 0;
+        this.currentPageConsumed = 0;
+        this.currentPageValueCount = 0;
+        this.physicalPageValueCount = 0;
+        this.buffers = new DecodeBuffers();
+    }
+
+    Block readBatch(int maxRows, BlockFactory blockFactory) {
+        loadDictionaryIfNeeded();
+        return switch (info.esqlType()) {
+            case BOOLEAN -> readBooleanBatch(maxRows, blockFactory);
+            case INTEGER -> readIntBatch(maxRows, blockFactory);
+            case LONG -> {
+                if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
+                    yield readInt32AsLongBatch(maxRows, blockFactory);
+                }
+                yield readLongBatch(maxRows, blockFactory);
+            }
+            case DOUBLE -> readDoubleBatch(maxRows, blockFactory);
+            case KEYWORD, TEXT -> readBytesBatch(maxRows, blockFactory);
+            case DATETIME -> readDatetimeBatch(maxRows, blockFactory);
+            default -> {
+                skipRows(maxRows);
+                yield blockFactory.newConstantNullBlock(maxRows);
+            }
+        };
+    }
+
+    private void loadDictionaryIfNeeded() {
+        if (dictionaryLoaded) {
+            return;
+        }
+        dictionaryLoaded = true;
+        DictionaryPage dictPage = pageReader.readDictionaryPage();
+        if (dictPage != null) {
+            dictionary = dictPage.decode(descriptor);
+        }
+    }
+
+    private boolean ensurePage() {
+        if (columnExhausted) {
+            return false;
+        }
+        if (currentPageConsumed < currentPageValueCount) {
+            return true;
+        }
+        return loadNextPage();
+    }
+
+    private boolean loadNextPage() {
+        if (physicalPageValueCount > 0 && currentPageConsumed < physicalPageValueCount) {
+            int remainder = physicalPageValueCount - currentPageConsumed;
+            if (remainder > 0) {
+                int nonNullSkipped = defDecoder.skip(remainder);
+                skipValues(nonNullSkipped);
+                rowPositionInRowGroup += remainder;
+                currentPageConsumed = physicalPageValueCount;
+            }
+        }
+        while (true) {
+            DataPage page = pageReader.readPage();
+            if (page == null) {
+                columnExhausted = true;
+                physicalPageValueCount = 0;
+                return false;
+            }
+
+            page.getFirstRowIndex().ifPresent(firstRow -> {
+                if (firstRow > rowPositionInRowGroup) {
+                    rowPositionInRowGroup = firstRow;
+                }
+            });
+
+            int pageRowCount = page.getValueCount();
+
+            if (rowRanges != null && rowRanges.overlaps(rowPositionInRowGroup, rowPositionInRowGroup + pageRowCount) == false) {
+                rowPositionInRowGroup += pageRowCount;
+                continue;
+            }
+
+            currentPageValueCount = pageRowCount;
+            physicalPageValueCount = pageRowCount;
+            currentPageConsumed = 0;
+
+            if (page instanceof DataPageV1 v1) {
+                currentPageIsV1 = true;
+                currentEncoding = v1.getValueEncoding();
+                splitV1Page(v1);
+            } else if (page instanceof DataPageV2 v2) {
+                currentPageIsV1 = false;
+                currentEncoding = v2.getDataEncoding();
+                splitV2Page(v2);
+            } else {
+                throw new QlIllegalArgumentException("Unexpected page type: " + page.getClass().getName());
+            }
+
+            initDecoders();
+            return true;
+        }
+    }
+
+    private void splitV1Page(DataPageV1 v1) {
+        try {
+            ByteBuffer pageBytes = v1.getBytes().toByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
+
+            if (maxDefLevel > 0) {
+                int dlStart = pageBytes.position();
+                int dlLength = pageBytes.getInt();
+                currentDefLevelBytes = pageBytes.slice(dlStart, Integer.BYTES + dlLength).order(ByteOrder.LITTLE_ENDIAN);
+
+                int valueStart = dlStart + Integer.BYTES + dlLength;
+                int valueLen = pageBytes.limit() - valueStart;
+                currentValueBytes = pageBytes.slice(valueStart, valueLen).order(ByteOrder.LITTLE_ENDIAN);
+            } else {
+                currentDefLevelBytes = null;
+                currentValueBytes = pageBytes;
+            }
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to read V1 page bytes: " + e.getMessage(), e);
+        }
+    }
+
+    private void splitV2Page(DataPageV2 v2) {
+        try {
+            if (maxDefLevel > 0) {
+                BytesInput dlInput = v2.getDefinitionLevels();
+                currentDefLevelBytes = dlInput.toByteBuffer();
+            } else {
+                currentDefLevelBytes = null;
+            }
+            currentValueBytes = v2.getData().toByteBuffer();
+        } catch (IOException e) {
+            throw new QlIllegalArgumentException("Failed to read V2 page bytes: " + e.getMessage(), e);
+        }
+    }
+
+    private void initDecoders() {
+        if (maxDefLevel > 0 && currentDefLevelBytes != null) {
+            defDecoder.init(currentDefLevelBytes, currentPageValueCount, maxDefLevel, currentPageIsV1);
+        } else {
+            defDecoder.init(EMPTY_BYTE_BUFFER.duplicate(), currentPageValueCount, 0, false);
+        }
+
+        if (currentEncoding.usesDictionary()) {
+            useFallbackReader = false;
+            dictDecoder.init(currentValueBytes);
+        } else if (currentEncoding == Encoding.PLAIN || currentEncoding == Encoding.BIT_PACKED) {
+            useFallbackReader = false;
+            plainDecoder.init(currentValueBytes);
+        } else {
+            useFallbackReader = true;
+            try {
+                fallbackReader = currentEncoding.getValuesReader(descriptor, ValuesType.VALUES);
+                byte[] bytes = new byte[currentValueBytes.remaining()];
+                currentValueBytes.duplicate().get(bytes);
+                fallbackReader.initFromPage(currentPageValueCount, bytes, 0);
+            } catch (IOException e) {
+                throw new QlIllegalArgumentException(
+                    "Failed to init fallback decoder for encoding " + currentEncoding + ": " + e.getMessage(),
+                    e
+                );
+            }
+        }
+    }
+
+    private int availableInPage() {
+        return currentPageValueCount - currentPageConsumed;
+    }
+
+    private void advancePosition(int count) {
+        currentPageConsumed += count;
+        rowPositionInRowGroup += count;
+    }
+
+    void skipRows(int count) {
+        int remaining = count;
+        while (remaining > 0) {
+            if (ensurePage() == false) {
+                break;
+            }
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNullSkipped = defDecoder.skip(fromPage);
+            skipValues(nonNullSkipped);
+            advancePosition(fromPage);
+            remaining -= fromPage;
+        }
+    }
+
+    private void skipValues(int nonNullCount) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.skip(nonNullCount);
+        } else if (useFallbackReader) {
+            fallbackReader.skip(nonNullCount);
+        } else {
+            skipPlainValues(nonNullCount);
+        }
+    }
+
+    private void skipPlainValues(int count) {
+        switch (info.parquetType()) {
+            case INT32 -> plainDecoder.skipInts(count);
+            case INT64 -> plainDecoder.skipLongs(count);
+            case FLOAT -> plainDecoder.skipFloats(count);
+            case DOUBLE -> plainDecoder.skipDoubles(count);
+            case BOOLEAN -> plainDecoder.skipBooleans(count);
+            case BINARY -> plainDecoder.skipBinaries(count);
+            case FIXED_LEN_BYTE_ARRAY -> plainDecoder.skipFixedBinaries(count, descriptor.getPrimitiveType().getTypeLength());
+            case INT96 -> plainDecoder.skipFixedBinaries(count, 12);
+            default -> throw new QlIllegalArgumentException("Unsupported Parquet type for skip: " + info.parquetType());
+        }
+    }
+
+    private void readIntsDispatch(int[] values, int offset, int count) {
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readInts(values, offset, count, dictionary);
+        } else if (useFallbackReader) {
+            for (int i = 0; i < count; i++) {
+                values[offset + i] = fallbackReader.readInteger();
+            }
+        } else {
+            plainDecoder.readInts(values, offset, count);
+        }
+    }
+
+    private void readLongsDispatch(long[] values, int offset, int count) {
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readLongs(values, offset, count, dictionary);
+        } else if (useFallbackReader) {
+            for (int i = 0; i < count; i++) {
+                values[offset + i] = fallbackReader.readLong();
+            }
+        } else {
+            plainDecoder.readLongs(values, offset, count);
+        }
+    }
+
+    private void readFloatsDispatch(double[] values, int offset, int count) {
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readFloats(values, offset, count, dictionary);
+        } else if (useFallbackReader) {
+            for (int i = 0; i < count; i++) {
+                values[offset + i] = fallbackReader.readFloat();
+            }
+        } else {
+            plainDecoder.readFloats(values, offset, count);
+        }
+    }
+
+    private void readDoublesDispatch(double[] values, int offset, int count) {
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readDoubles(values, offset, count, dictionary);
+        } else if (useFallbackReader) {
+            for (int i = 0; i < count; i++) {
+                values[offset + i] = fallbackReader.readDouble();
+            }
+        } else {
+            plainDecoder.readDoubles(values, offset, count);
+        }
+    }
+
+    private void readBooleansDispatch(boolean[] values, int offset, int count) {
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readBooleans(values, offset, count, dictionary);
+        } else if (useFallbackReader) {
+            for (int i = 0; i < count; i++) {
+                values[offset + i] = fallbackReader.readBoolean();
+            }
+        } else {
+            plainDecoder.readBooleans(values, offset, count);
+        }
+    }
+
+    private void readBinariesDispatch(BytesRef[] values, int offset, int count) {
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readBinaries(values, offset, count, dictionary);
+        } else if (useFallbackReader) {
+            for (int i = 0; i < count; i++) {
+                org.apache.parquet.io.api.Binary bin = fallbackReader.readBytes();
+                byte[] bytes = bin.getBytes();
+                values[offset + i] = new BytesRef(bytes, 0, bytes.length);
+            }
+        } else if (descriptor.getPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+            plainDecoder.readFixedBinaries(values, offset, count, descriptor.getPrimitiveType().getTypeLength());
+        } else {
+            plainDecoder.readBinaries(values, offset, count);
+        }
+    }
+
+    // --- Boolean ---
+
+    private Block readBooleanBatch(int maxRows, BlockFactory blockFactory) {
+        boolean[] values = buffers.booleans(maxRows);
+        if (maxDefLevel == 0) {
+            int produced = readNonNullBooleans(values, 0, maxRows);
+            Block constant = ConstantBlockDetection.tryConstantBoolean(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return blockFactory.newBooleanArrayVector(values, produced).asBlock();
+        }
+        WordMask nulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            readBooleanValues(values, nulls, produced, fromPage, nonNull);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            Block constant = ConstantBlockDetection.tryConstantBoolean(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return blockFactory.newBooleanArrayVector(values, produced).asBlock();
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
+        }
+        return blockFactory.newBooleanArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
+    }
+
+    private int readNonNullBooleans(boolean[] values, int offset, int maxRows) {
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            readBooleansDispatch(values, offset + produced, fromPage);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        return produced;
+    }
+
+    private void readBooleanValues(boolean[] values, WordMask nulls, int offset, int totalRows, int nonNullCount) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        if (nonNullCount == totalRows) {
+            readBooleansDispatch(values, offset, nonNullCount);
+            return;
+        }
+        boolean[] packed = new boolean[nonNullCount];
+        readBooleansDispatch(packed, 0, nonNullCount);
+        scatter(packed, values, nulls, offset, totalRows);
+    }
+
+    // --- Int ---
+
+    private Block readIntBatch(int maxRows, BlockFactory blockFactory) {
+        int[] values = buffers.ints(maxRows);
+        if (maxDefLevel == 0) {
+            int produced = readNonNullInts(values, 0, maxRows);
+            Block constant = ConstantBlockDetection.tryConstantInt(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return blockFactory.newIntArrayVector(values, produced).asBlock();
+        }
+        WordMask nulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            readIntValues(values, nulls, produced, fromPage, nonNull);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            Block constant = ConstantBlockDetection.tryConstantInt(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return blockFactory.newIntArrayVector(values, produced).asBlock();
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
+        }
+        return blockFactory.newIntArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
+    }
+
+    private int readNonNullInts(int[] values, int offset, int maxRows) {
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            readIntsDispatch(values, offset + produced, fromPage);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        return produced;
+    }
+
+    private void readIntValues(int[] values, WordMask nulls, int offset, int totalRows, int nonNullCount) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        if (nonNullCount == totalRows) {
+            readIntsDispatch(values, offset, nonNullCount);
+            return;
+        }
+        int[] packed = new int[nonNullCount];
+        readIntsDispatch(packed, 0, nonNullCount);
+        scatter(packed, values, nulls, offset, totalRows);
+    }
+
+    // --- Long ---
+
+    private Block readLongBatch(int maxRows, BlockFactory blockFactory) {
+        long[] values = buffers.longs(maxRows);
+        if (maxDefLevel == 0) {
+            int produced = readNonNullLongs(values, 0, maxRows);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeLongBlock(blockFactory, produced, true, null);
+        }
+        WordMask nulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            readLongValues(values, nulls, produced, fromPage, nonNull);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeLongBlock(blockFactory, produced, true, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
+        }
+        return takeLongBlock(blockFactory, produced, false, nulls.toBitSet());
+    }
+
+    private int readNonNullLongs(long[] values, int offset, int maxRows) {
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            if (currentEncoding.usesDictionary()) {
+                dictDecoder.readLongs(values, offset + produced, fromPage, dictionary);
+            } else if (useFallbackReader) {
+                for (int i = 0; i < fromPage; i++) {
+                    values[offset + produced + i] = fallbackReader.readLong();
+                }
+            } else {
+                plainDecoder.readLongs(values, offset + produced, fromPage);
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        return produced;
+    }
+
+    private void readLongValues(long[] values, WordMask nulls, int offset, int totalRows, int nonNullCount) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        if (nonNullCount == totalRows) {
+            readLongsDispatch(values, offset, nonNullCount);
+            return;
+        }
+        long[] packed = new long[nonNullCount];
+        readLongsDispatch(packed, 0, nonNullCount);
+        scatter(packed, values, nulls, offset, totalRows);
+    }
+
+    // --- Int32 widened to Long ---
+
+    private Block readInt32AsLongBatch(int maxRows, BlockFactory blockFactory) {
+        long[] values = buffers.longs(maxRows);
+        if (maxDefLevel == 0) {
+            int produced = readNonNullInt32AsLong(values, 0, maxRows);
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeLongBlock(blockFactory, produced, true, null);
+        }
+        WordMask nulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            readInt32AsLongValues(values, nulls, produced, fromPage, nonNull);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeLongBlock(blockFactory, produced, true, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
+        }
+        return takeLongBlock(blockFactory, produced, false, nulls.toBitSet());
+    }
+
+    private int readNonNullInt32AsLong(long[] values, int offset, int maxRows) {
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int[] intValues = buffers.ints(fromPage);
+            readIntsDispatch(intValues, 0, fromPage);
+            for (int i = 0; i < fromPage; i++) {
+                values[offset + produced + i] = intValues[i];
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        return produced;
+    }
+
+    private void readInt32AsLongValues(long[] values, WordMask nulls, int offset, int totalRows, int nonNullCount) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        int[] intPacked = buffers.ints(nonNullCount);
+        readIntsDispatch(intPacked, 0, nonNullCount);
+        if (nonNullCount == totalRows) {
+            for (int i = 0; i < nonNullCount; i++) {
+                values[offset + i] = intPacked[i];
+            }
+        } else {
+            int pi = 0;
+            for (int i = 0; i < totalRows; i++) {
+                if (nulls.get(offset + i) == false) {
+                    values[offset + i] = intPacked[pi++];
+                }
+            }
+        }
+    }
+
+    // --- Double ---
+
+    private Block readDoubleBatch(int maxRows, BlockFactory blockFactory) {
+        LogicalTypeAnnotation logical = info.logicalType();
+        if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal) {
+            return readDecimalAsDoubleBatch(maxRows, decimal.getScale(), blockFactory);
+        }
+        if (logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
+            return readFloat16Batch(maxRows, blockFactory);
+        }
+        boolean isFloat = info.parquetType() == PrimitiveType.PrimitiveTypeName.FLOAT;
+        double[] values = buffers.doubles(maxRows);
+        if (maxDefLevel == 0) {
+            int produced = readNonNullDoubles(values, 0, maxRows, isFloat);
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeDoubleBlock(blockFactory, produced, true, null);
+        }
+        WordMask nulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            readDoubleValues(values, nulls, produced, fromPage, nonNull, isFloat);
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeDoubleBlock(blockFactory, produced, true, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
+        }
+        return takeDoubleBlock(blockFactory, produced, false, nulls.toBitSet());
+    }
+
+    private int readNonNullDoubles(double[] values, int offset, int maxRows, boolean isFloat) {
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            if (isFloat) {
+                readFloatsDispatch(values, offset + produced, fromPage);
+            } else {
+                readDoublesDispatch(values, offset + produced, fromPage);
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        return produced;
+    }
+
+    private void readDoubleValues(double[] values, WordMask nulls, int offset, int totalRows, int nonNullCount, boolean isFloat) {
+        if (nonNullCount == 0) {
+            return;
+        }
+        if (nonNullCount == totalRows) {
+            if (isFloat) {
+                readFloatsDispatch(values, offset, nonNullCount);
+            } else {
+                readDoublesDispatch(values, offset, nonNullCount);
+            }
+            return;
+        }
+        double[] packed = new double[nonNullCount];
+        if (isFloat) {
+            readFloatsDispatch(packed, 0, nonNullCount);
+        } else {
+            readDoublesDispatch(packed, 0, nonNullCount);
+        }
+        scatter(packed, values, nulls, offset, totalRows);
+    }
+
+    private Block readDecimalAsDoubleBatch(int maxRows, int scale, BlockFactory blockFactory) {
+        double[] values = buffers.doubles(maxRows);
+        if (maxDefLevel == 0) {
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                readDecimalValues(values, produced, fromPage, scale);
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeDoubleBlock(blockFactory, produced, true, null);
+        }
+        WordMask nulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            if (nonNull > 0) {
+                if (nonNull == fromPage) {
+                    readDecimalValues(values, produced, nonNull, scale);
+                } else {
+                    double[] packed = new double[nonNull];
+                    readDecimalValues(packed, 0, nonNull, scale);
+                    scatter(packed, values, nulls, produced, fromPage);
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeDoubleBlock(blockFactory, produced, true, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
+        }
+        return takeDoubleBlock(blockFactory, produced, false, nulls.toBitSet());
+    }
+
+    private void readDecimalValues(double[] values, int offset, int count, int scale) {
+        int[] intScratch = (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) ? new int[1] : null;
+        long[] longScratch = (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT64) ? new long[1] : null;
+        BytesRef[] binScratch = (intScratch == null && longScratch == null) ? new BytesRef[1] : null;
+        for (int i = 0; i < count; i++) {
+            BigInteger unscaled = switch (info.parquetType()) {
+                case INT32 -> {
+                    readIntsDispatch(intScratch, 0, 1);
+                    yield BigInteger.valueOf(intScratch[0]);
+                }
+                case INT64 -> {
+                    readLongsDispatch(longScratch, 0, 1);
+                    yield BigInteger.valueOf(longScratch[0]);
+                }
+                case BINARY, FIXED_LEN_BYTE_ARRAY -> {
+                    readBinariesDispatch(binScratch, 0, 1);
+                    yield new BigInteger(binScratch[0].bytes, binScratch[0].offset, binScratch[0].length);
+                }
+                default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType());
+            };
+            values[offset + i] = new BigDecimal(unscaled, scale).doubleValue();
+        }
+    }
+
+    private Block readFloat16Batch(int maxRows, BlockFactory blockFactory) {
+        double[] values = buffers.doubles(maxRows);
+        if (maxDefLevel == 0) {
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                readFloat16Values(values, produced, fromPage);
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeDoubleBlock(blockFactory, produced, true, null);
+        }
+        WordMask nulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            if (nonNull > 0) {
+                if (nonNull == fromPage) {
+                    readFloat16Values(values, produced, nonNull);
+                } else {
+                    double[] packed = new double[nonNull];
+                    readFloat16Values(packed, 0, nonNull);
+                    scatter(packed, values, nulls, produced, fromPage);
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeDoubleBlock(blockFactory, produced, true, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
+        }
+        return takeDoubleBlock(blockFactory, produced, false, nulls.toBitSet());
+    }
+
+    private void readFloat16Values(double[] values, int offset, int count) {
+        BytesRef[] binaries = new BytesRef[count];
+        readBinariesDispatch(binaries, 0, count);
+        for (int i = 0; i < count; i++) {
+            byte[] bytes = binaries[i].bytes;
+            int off = binaries[i].offset;
+            short float16Bits = (short) ((bytes[off + 1] & 0xFF) << 8 | (bytes[off] & 0xFF));
+            values[offset + i] = Float.float16ToFloat(float16Bits);
+        }
+    }
+
+    // --- BytesRef (KEYWORD/TEXT) ---
+
+    private Block readBytesBatch(int maxRows, BlockFactory blockFactory) {
+        boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+        if (maxDefLevel == 0) {
+            BytesRef[] allValues = new BytesRef[maxRows];
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                BytesRef[] vals = readBinaryValues(fromPage);
+                for (int i = 0; i < fromPage; i++) {
+                    allValues[produced + i] = isUuid ? new BytesRef(ParquetFormatReader.formatUuid(vals[i].bytes)) : vals[i];
+                }
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            Block constant = ConstantBlockDetection.tryConstantBytesRef(allValues, produced, blockFactory);
+            if (constant != null) {
+                return constant;
+            }
+            try (var builder = blockFactory.newBytesRefBlockBuilder(produced)) {
+                for (int i = 0; i < produced; i++) {
+                    builder.appendBytesRef(allValues[i]);
+                }
+                return builder.build();
+            }
+        }
+        BytesRef[] allValues = new BytesRef[maxRows];
+        WordMask allNulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            WordMask pageNulls = buffers.valueSelection(fromPage);
+            int nonNull = defDecoder.readBatch(fromPage, pageNulls, 0);
+            BytesRef[] vals = nonNull > 0 ? readBinaryValues(nonNull) : null;
+            int valIdx = 0;
+            for (int i = 0; i < fromPage; i++) {
+                if (pageNulls.get(i)) {
+                    allNulls.set(produced + i);
+                } else if (isUuid) {
+                    allValues[produced + i] = new BytesRef(ParquetFormatReader.formatUuid(vals[valIdx++].bytes));
+                } else {
+                    allValues[produced + i] = vals[valIdx++];
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (allNulls.isEmpty() == false) {
+            Block allNull = ConstantBlockDetection.tryAllNull(allNulls.toBitSet(), produced, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+        }
+        try (var builder = blockFactory.newBytesRefBlockBuilder(produced)) {
+            for (int i = 0; i < produced; i++) {
+                if (allNulls.get(i)) {
+                    builder.appendNull();
+                } else {
+                    builder.appendBytesRef(allValues[i]);
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private BytesRef[] readBinaryValues(int count) {
+        BytesRef[] values = new BytesRef[count];
+        readBinariesDispatch(values, 0, count);
+        return values;
+    }
+
+    // --- Datetime ---
+
+    private Block readDatetimeBatch(int maxRows, BlockFactory blockFactory) {
+        if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT96) {
+            return readInt96Batch(maxRows, blockFactory);
+        }
+        boolean isDate = info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32;
+        long[] values = buffers.longs(maxRows);
+        if (maxDefLevel == 0) {
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                readDatetimeValues(values, produced, fromPage, isDate);
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeLongBlock(blockFactory, produced, true, null);
+        }
+        WordMask nulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            if (nonNull > 0) {
+                if (nonNull == fromPage) {
+                    readDatetimeValues(values, produced, nonNull, isDate);
+                } else {
+                    long[] packed = new long[nonNull];
+                    readDatetimeValues(packed, 0, nonNull, isDate);
+                    scatter(packed, values, nulls, produced, fromPage);
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeLongBlock(blockFactory, produced, true, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
+        }
+        return takeLongBlock(blockFactory, produced, false, nulls.toBitSet());
+    }
+
+    private void readDatetimeValues(long[] values, int offset, int count, boolean isDate) {
+        if (isDate) {
+            int[] intValues = buffers.ints(count);
+            readIntsDispatch(intValues, 0, count);
+            for (int i = 0; i < count; i++) {
+                values[offset + i] = intValues[i] * MILLIS_PER_DAY;
+            }
+        } else {
+            readLongsDispatch(values, offset, count);
+            LogicalTypeAnnotation logicalType = info.logicalType();
+            if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+                switch (ts.getUnit()) {
+                    case MILLIS -> {
+                    }
+                    case MICROS -> {
+                        for (int i = 0; i < count; i++) {
+                            values[offset + i] = values[offset + i] / 1_000;
+                        }
+                    }
+                    case NANOS -> {
+                        for (int i = 0; i < count; i++) {
+                            values[offset + i] = values[offset + i] / 1_000_000;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private Block readInt96Batch(int maxRows, BlockFactory blockFactory) {
+        long[] values = buffers.longs(maxRows);
+        if (maxDefLevel == 0) {
+            int produced = 0;
+            int remaining = maxRows;
+            while (remaining > 0 && ensurePage()) {
+                int fromPage = Math.min(remaining, availableInPage());
+                readInt96Values(values, produced, fromPage);
+                advancePosition(fromPage);
+                produced += fromPage;
+                remaining -= fromPage;
+            }
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeLongBlock(blockFactory, produced, true, null);
+        }
+        WordMask nulls = buffers.nullsMask(maxRows);
+        int produced = 0;
+        int remaining = maxRows;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+            if (nonNull > 0) {
+                if (nonNull == fromPage) {
+                    readInt96Values(values, produced, nonNull);
+                } else {
+                    long[] packed = new long[nonNull];
+                    readInt96Values(packed, 0, nonNull);
+                    scatter(packed, values, nulls, produced, fromPage);
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (nulls.isEmpty()) {
+            Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
+            if (constant != null) return constant;
+            return takeLongBlock(blockFactory, produced, true, null);
+        }
+        Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
+        if (allNull != null) {
+            return allNull;
+        }
+        return takeLongBlock(blockFactory, produced, false, nulls.toBitSet());
+    }
+
+    private void readInt96Values(long[] values, int offset, int count) {
+        BytesRef[] binaries = new BytesRef[count];
+        if (currentEncoding.usesDictionary()) {
+            dictDecoder.readBinaries(binaries, 0, count, dictionary);
+        } else if (useFallbackReader) {
+            for (int i = 0; i < count; i++) {
+                org.apache.parquet.io.api.Binary bin = fallbackReader.readBytes();
+                byte[] bytes = bin.getBytes();
+                binaries[i] = new BytesRef(bytes, 0, bytes.length);
+            }
+        } else {
+            plainDecoder.readFixedBinaries(binaries, 0, count, 12);
+        }
+        for (int i = 0; i < count; i++) {
+            ByteBuffer buf = ByteBuffer.wrap(binaries[i].bytes, binaries[i].offset, binaries[i].length).order(ByteOrder.LITTLE_ENDIAN);
+            long nanosOfDay = buf.getLong();
+            int julianDay = buf.getInt();
+            long epochDay = julianDay - JULIAN_EPOCH_OFFSET;
+            values[offset + i] = epochDay * MILLIS_PER_DAY + nanosOfDay / NANOS_PER_MILLI;
+        }
+    }
+
+    // --- Block construction helpers ---
+
+    private Block takeLongBlock(BlockFactory blockFactory, int rowCount, boolean noNulls, BitSet nullBitSet) {
+        long[] owned = buffers.takeLongs();
+        if (noNulls) {
+            return blockFactory.newLongArrayVector(owned, rowCount).asBlock();
+        }
+        return blockFactory.newLongArrayBlock(owned, rowCount, null, nullBitSet, Block.MvOrdering.UNORDERED);
+    }
+
+    private Block takeDoubleBlock(BlockFactory blockFactory, int rowCount, boolean noNulls, BitSet nullBitSet) {
+        double[] owned = buffers.takeDoubles();
+        if (noNulls) {
+            return blockFactory.newDoubleArrayVector(owned, rowCount).asBlock();
+        }
+        return blockFactory.newDoubleArrayBlock(owned, rowCount, null, nullBitSet, Block.MvOrdering.UNORDERED);
+    }
+
+    // --- Scatter utilities ---
+
+    private static void scatter(boolean[] packed, boolean[] output, WordMask nulls, int offset, int totalRows) {
+        int pi = 0;
+        for (int i = 0; i < totalRows; i++) {
+            if (nulls.get(offset + i) == false) {
+                output[offset + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static void scatter(int[] packed, int[] output, WordMask nulls, int offset, int totalRows) {
+        int pi = 0;
+        for (int i = 0; i < totalRows; i++) {
+            if (nulls.get(offset + i) == false) {
+                output[offset + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static void scatter(long[] packed, long[] output, WordMask nulls, int offset, int totalRows) {
+        int pi = 0;
+        for (int i = 0; i < totalRows; i++) {
+            if (nulls.get(offset + i) == false) {
+                output[offset + i] = packed[pi++];
+            }
+        }
+    }
+
+    private static void scatter(double[] packed, double[] output, WordMask nulls, int offset, int totalRows) {
+        int pi = 0;
+        for (int i = 0; i < totalRows; i++) {
+            if (nulls.get(offset + i) == false) {
+                output[offset + i] = packed[pi++];
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -14,6 +14,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
@@ -95,26 +96,42 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     private final BlockFactory blockFactory;
     private final FilterCompat.Filter pushedFilter;
     private final ParquetPushedExpressions pushedExpressions;
+    private final boolean forceBaselinePath;
 
     static final long DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES = 32L * 1024 * 1024;
 
     public ParquetFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, FilterCompat.NOOP, null);
+        this(blockFactory, FilterCompat.NOOP, null, false);
     }
 
-    private ParquetFormatReader(BlockFactory blockFactory, FilterCompat.Filter pushedFilter, ParquetPushedExpressions pushedExpressions) {
+    private ParquetFormatReader(
+        BlockFactory blockFactory,
+        FilterCompat.Filter pushedFilter,
+        ParquetPushedExpressions pushedExpressions,
+        boolean forceBaselinePath
+    ) {
         this.blockFactory = blockFactory;
         this.pushedFilter = pushedFilter;
         this.pushedExpressions = pushedExpressions;
+        this.forceBaselinePath = forceBaselinePath;
+    }
+
+    /**
+     * Returns a reader that always uses the row-at-a-time {@code ColumnReader} path,
+     * bypassing {@link PageColumnReader}. Package-private; intended for correctness
+     * testing against the optimized path.
+     */
+    ParquetFormatReader withBaselinePath() {
+        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, true);
     }
 
     @Override
     public ParquetFormatReader withPushedFilter(Object pushedFilter) {
         if (pushedFilter instanceof FilterCompat.Filter filter) {
-            return new ParquetFormatReader(blockFactory, filter, null);
+            return new ParquetFormatReader(blockFactory, filter, null, forceBaselinePath);
         }
         if (pushedFilter instanceof ParquetPushedExpressions exprs) {
-            return new ParquetFormatReader(blockFactory, FilterCompat.NOOP, exprs);
+            return new ParquetFormatReader(blockFactory, FilterCompat.NOOP, exprs, forceBaselinePath);
         }
         return this;
     }
@@ -354,6 +371,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         MessageType projectedSchema = buildProjectedSchema(parquetSchema, projectedAttributes);
         String createdBy = fileMetaData.getCreatedBy();
+        boolean hasRecordFilter = forceBaselinePath || FilterCompat.isFilteringRequired(recordFilter);
         return new ParquetColumnIterator(
             reader,
             projectedSchema,
@@ -362,7 +380,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             blockFactory,
             rowLimit,
             createdBy,
-            object.path().toString()
+            object.path().toString(),
+            hasRecordFilter
         );
     }
 
@@ -546,6 +565,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         MessageType projectedSchema = buildProjectedSchema(parquetSchema, projectedAttributes);
         String createdBy = fileMetaData.getCreatedBy();
+        boolean hasRecordFilter = forceBaselinePath || FilterCompat.isFilteringRequired(recordFilter);
         return new ParquetColumnIterator(
             reader,
             projectedSchema,
@@ -554,7 +574,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             blockFactory,
             NO_LIMIT,
             createdBy,
-            object.path().toString()
+            object.path().toString(),
+            hasRecordFilter
         );
     }
 
@@ -713,9 +734,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     }
 
     /**
-     * Column-at-a-time Parquet iterator. Uses {@link ColumnReadStoreImpl} and {@link ColumnReader}
-     * to decode each column independently into typed arrays, eliminating Group object materialization
-     * and per-row type dispatch. Primitive columns are converted via {@link ColumnBlockConversions}.
+     * Column-at-a-time Parquet iterator. Flat columns (maxRepLevel == 0) are decoded via
+     * {@link PageColumnReader} which bulk-decodes definition levels and values directly from
+     * page bytes, bypassing parquet-mr's row-at-a-time {@link ColumnReader}. List columns
+     * (maxRepLevel > 0) continue using {@link ColumnReadStoreImpl} and {@link ColumnReader}
+     * since they require stateful multi-value handling via repetition levels.
      */
     private static class ParquetColumnIterator implements CloseableIterator<Page> {
         private final ParquetFileReader reader;
@@ -725,20 +748,21 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         private final BlockFactory blockFactory;
         private final String createdBy;
         private final String fileLocation;
+        private final boolean hasRecordFilter;
         private int rowBudget;
 
         /** Per-attribute column metadata; null for attributes not present in the file. */
         private final ColumnInfo[] columnInfos;
+        private final boolean hasListColumns;
 
         private PageReadStore rowGroup;
+        private PageColumnReader[] pageColumnReaders;
         private ColumnReader[] columnReaders;
         /** Per-column uncompressed byte size for the current row group (0 if unknown). */
         private long[] columnUncompressedBytes;
         private long rowsRemainingInGroup;
         private boolean exhausted = false;
-        /** Zero-based index of the row group currently being read, or -1 before the first. */
         private int rowGroupOrdinal = -1;
-        /** Pages yielded for the current row group (reset when advancing row groups). */
         private int pageBatchIndexInRowGroup = 0;
 
         ParquetColumnIterator(
@@ -749,7 +773,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             BlockFactory blockFactory,
             int rowLimit,
             String createdBy,
-            String fileLocation
+            String fileLocation,
+            boolean hasRecordFilter
         ) {
             this.reader = reader;
             this.projectedSchema = projectedSchema;
@@ -759,6 +784,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             this.rowBudget = rowLimit;
             this.createdBy = createdBy != null ? createdBy : "";
             this.fileLocation = fileLocation;
+            this.hasRecordFilter = hasRecordFilter;
 
             reader.setRequestedSchema(projectedSchema);
 
@@ -767,6 +793,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             for (ColumnDescriptor desc : projectedSchema.getColumns()) {
                 descByName.put(desc.getPath()[0], desc);
             }
+            boolean foundListCol = false;
             for (int i = 0; i < attributes.size(); i++) {
                 Attribute attr = attributes.get(i);
                 if (attr.dataType() == DataType.NULL || attr.dataType() == DataType.UNSUPPORTED) {
@@ -783,8 +810,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                         desc.getMaxRepetitionLevel(),
                         logicalType
                     );
+                    if (desc.getMaxRepetitionLevel() > 0) {
+                        foundListCol = true;
+                    }
                 }
             }
+            this.hasListColumns = foundListCol;
             validatePlannerTypesAgainstFile(logger, fileLocation, reader, attributes, columnInfos);
         }
 
@@ -823,35 +854,63 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             rowGroupOrdinal++;
             pageBatchIndexInRowGroup = 0;
             rowsRemainingInGroup = rowGroup.getRowCount();
-            ColumnReadStoreImpl store = new ColumnReadStoreImpl(
-                rowGroup,
-                new NoOpGroupConverter(projectedSchema),
-                projectedSchema,
-                createdBy
-            );
-            columnReaders = new ColumnReader[columnInfos.length];
-            columnUncompressedBytes = new long[columnInfos.length];
 
-            // Best-effort: rowGroupOrdinal may not match the physical block index when
-            // readNextFilteredRowGroup() skips entire row groups. A wrong hint only affects
-            // pre-sizing (falls back to grow-on-demand), not correctness.
-            List<BlockMetaData> rowGroups = reader.getRowGroups();
-            Map<String, Long> chunkSizes = Map.of();
-            if (rowGroupOrdinal >= 0 && rowGroupOrdinal < rowGroups.size()) {
-                BlockMetaData block = rowGroups.get(rowGroupOrdinal);
-                chunkSizes = new HashMap<>();
-                for (ColumnChunkMetaData chunk : block.getColumns()) {
-                    chunkSizes.put(chunk.getPath().toDotString(), chunk.getTotalUncompressedSize());
+            // TODO: when selective reading (Stage 7) is implemented, pass filter-derived RowRanges
+            // instead of RowRanges.all(), and remove the hasRecordFilter bypass so PageColumnReader
+            // handles page-index filtering natively.
+            if (hasRecordFilter == false) {
+                RowRanges allRows = RowRanges.all(rowsRemainingInGroup);
+                pageColumnReaders = new PageColumnReader[columnInfos.length];
+                for (int i = 0; i < columnInfos.length; i++) {
+                    ColumnInfo ci = columnInfos[i];
+                    if (ci != null && ci.maxRepLevel() == 0) {
+                        PageReader pageReader = rowGroup.getPageReader(ci.descriptor());
+                        pageColumnReaders[i] = new PageColumnReader(pageReader, ci.descriptor(), ci, allRows);
+                    }
                 }
+            } else {
+                pageColumnReaders = null;
             }
 
-            for (int i = 0; i < columnInfos.length; i++) {
-                if (columnInfos[i] != null) {
-                    columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor);
-                    String colPath = String.join(".", columnInfos[i].descriptor.getPath());
-                    Long size = chunkSizes.get(colPath);
-                    columnUncompressedBytes[i] = size != null ? size : 0L;
+            if (hasRecordFilter || hasListColumns) {
+                ColumnReadStoreImpl store = new ColumnReadStoreImpl(
+                    rowGroup,
+                    new NoOpGroupConverter(projectedSchema),
+                    projectedSchema,
+                    createdBy
+                );
+                columnReaders = new ColumnReader[columnInfos.length];
+                columnUncompressedBytes = new long[columnInfos.length];
+
+                // Best-effort: rowGroupOrdinal may not match the physical block index when
+                // readNextFilteredRowGroup() skips entire row groups. A wrong hint only affects
+                // pre-sizing (falls back to grow-on-demand), not correctness.
+                List<BlockMetaData> rowGroups = reader.getRowGroups();
+                Map<String, Long> chunkSizes = Map.of();
+                if (rowGroupOrdinal >= 0 && rowGroupOrdinal < rowGroups.size()) {
+                    BlockMetaData block = rowGroups.get(rowGroupOrdinal);
+                    chunkSizes = new HashMap<>();
+                    for (ColumnChunkMetaData chunk : block.getColumns()) {
+                        chunkSizes.put(chunk.getPath().toDotString(), chunk.getTotalUncompressedSize());
+                    }
                 }
+
+                for (int i = 0; i < columnInfos.length; i++) {
+                    if (columnInfos[i] != null) {
+                        boolean needColumnReader = hasRecordFilter
+                            ? (pageColumnReaders == null || pageColumnReaders[i] == null)
+                            : columnInfos[i].maxRepLevel() > 0;
+                        if (needColumnReader) {
+                            columnReaders[i] = store.getColumnReader(columnInfos[i].descriptor());
+                            String colPath = String.join(".", columnInfos[i].descriptor().getPath());
+                            Long size = chunkSizes.get(colPath);
+                            columnUncompressedBytes[i] = size != null ? size : 0L;
+                        }
+                    }
+                }
+            } else {
+                columnReaders = null;
+                columnUncompressedBytes = null;
             }
             return rowsRemainingInGroup > 0;
         }
@@ -875,7 +934,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                         blocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
                     } else {
                         try {
-                            blocks[col] = readColumnBlock(columnReaders[col], info, rowsToRead, col);
+                            if (pageColumnReaders != null && pageColumnReaders[col] != null) {
+                                blocks[col] = pageColumnReaders[col].readBatch(rowsToRead, blockFactory);
+                            } else {
+                                blocks[col] = readColumnBlock(columnReaders[col], info, rowsToRead, col);
+                            }
                         } catch (Exception e) {
                             Releasables.closeExpectNoException(blocks);
                             Attribute attr = attributes.get(col);
@@ -923,17 +986,17 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         private Block readColumnBlock(ColumnReader cr, ColumnInfo info, int rowsToRead, int colIndex) {
-            if (info.maxRepLevel > 0) {
+            if (info.maxRepLevel() > 0) {
                 return readListColumn(cr, info, rowsToRead);
             }
-            return switch (info.esqlType) {
-                case BOOLEAN -> readBooleanColumn(cr, info.maxDefLevel, rowsToRead);
-                case INTEGER -> readIntColumn(cr, info.maxDefLevel, rowsToRead);
+            return switch (info.esqlType()) {
+                case BOOLEAN -> readBooleanColumn(cr, info.maxDefLevel(), rowsToRead);
+                case INTEGER -> readIntColumn(cr, info.maxDefLevel(), rowsToRead);
                 case LONG -> {
-                    if (info.parquetType == PrimitiveType.PrimitiveTypeName.INT32) {
-                        yield readInt32WidenedToLongColumn(cr, info.maxDefLevel, rowsToRead);
+                    if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32) {
+                        yield readInt32WidenedToLongColumn(cr, info.maxDefLevel(), rowsToRead);
                     }
-                    yield readLongColumn(cr, info.maxDefLevel, rowsToRead);
+                    yield readLongColumn(cr, info.maxDefLevel(), rowsToRead);
                 }
                 case DOUBLE -> readDoubleColumn(cr, info, rowsToRead);
                 case KEYWORD, TEXT -> {
@@ -1023,19 +1086,19 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         private Block readDoubleColumn(ColumnReader cr, ColumnInfo info, int rows) {
-            LogicalTypeAnnotation logical = info.logicalType;
+            LogicalTypeAnnotation logical = info.logicalType();
             if (logical instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal) {
                 return readDecimalAsDoubleColumn(cr, info, decimal.getScale(), rows);
             }
             if (logical instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation) {
-                return readFloat16Column(cr, info.maxDefLevel, rows);
+                return readFloat16Column(cr, info.maxDefLevel(), rows);
             }
             double[] values = new double[rows];
-            boolean[] isNull = info.maxDefLevel > 0 ? new boolean[rows] : null;
+            boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
             boolean noNulls = true;
-            boolean isFloat = info.parquetType == PrimitiveType.PrimitiveTypeName.FLOAT;
+            boolean isFloat = info.parquetType() == PrimitiveType.PrimitiveTypeName.FLOAT;
             for (int i = 0; i < rows; i++) {
-                if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
+                if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
                     isNull[i] = true;
                     noNulls = false;
                 } else {
@@ -1048,18 +1111,18 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         private Block readDecimalAsDoubleColumn(ColumnReader cr, ColumnInfo info, int scale, int rows) {
             double[] values = new double[rows];
-            boolean[] isNull = info.maxDefLevel > 0 ? new boolean[rows] : null;
+            boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
             boolean noNulls = true;
             for (int i = 0; i < rows; i++) {
-                if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
+                if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
                     isNull[i] = true;
                     noNulls = false;
                 } else {
-                    BigInteger unscaled = switch (info.parquetType) {
+                    BigInteger unscaled = switch (info.parquetType()) {
                         case INT32 -> BigInteger.valueOf(cr.getInteger());
                         case INT64 -> BigInteger.valueOf(cr.getLong());
                         case BINARY, FIXED_LEN_BYTE_ARRAY -> new BigInteger(cr.getBinary().getBytes());
-                        default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType);
+                        default -> throw new QlIllegalArgumentException("Unexpected DECIMAL backing type: " + info.parquetType());
                     };
                     values[i] = new java.math.BigDecimal(unscaled, scale).doubleValue();
                 }
@@ -1087,14 +1150,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         private Block readBytesRefColumn(ColumnReader cr, ColumnInfo info, int rows, long byteHint) {
-            boolean isUuid = info.logicalType instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+            boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
             try (
                 var builder = byteHint > 0
                     ? blockFactory.newBytesRefBlockBuilder(rows, byteHint)
                     : blockFactory.newBytesRefBlockBuilder(rows)
             ) {
                 for (int i = 0; i < rows; i++) {
-                    if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
+                    if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
                         builder.appendNull();
                     } else if (isUuid) {
                         builder.appendBytesRef(new BytesRef(formatUuid(cr.getBinary().getBytes())));
@@ -1108,22 +1171,22 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
 
         private Block readDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
-            if (info.parquetType == PrimitiveType.PrimitiveTypeName.INT96) {
-                return readInt96TimestampColumn(cr, info.maxDefLevel, rows);
+            if (info.parquetType() == PrimitiveType.PrimitiveTypeName.INT96) {
+                return readInt96TimestampColumn(cr, info.maxDefLevel(), rows);
             }
             long[] values = new long[rows];
-            boolean[] isNull = info.maxDefLevel > 0 ? new boolean[rows] : null;
+            boolean[] isNull = info.maxDefLevel() > 0 ? new boolean[rows] : null;
             boolean noNulls = true;
-            boolean isDate = info.parquetType == PrimitiveType.PrimitiveTypeName.INT32;
+            boolean isDate = info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32;
             for (int i = 0; i < rows; i++) {
-                if (info.maxDefLevel > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel) {
+                if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
                     isNull[i] = true;
                     noNulls = false;
                 } else if (isDate) {
                     values[i] = cr.getInteger() * MILLIS_PER_DAY;
                 } else {
                     long raw = cr.getLong();
-                    values[i] = convertTimestampToMillis(raw, info.logicalType);
+                    values[i] = convertTimestampToMillis(raw, info.logicalType());
                 }
                 cr.consume();
             }
@@ -1172,8 +1235,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
          * null elements within lists correctly.
          */
         private Block readListColumn(ColumnReader cr, ColumnInfo info, int rows) {
-            DataType elementType = info.esqlType;
-            int maxDef = info.maxDefLevel;
+            DataType elementType = info.esqlType();
+            int maxDef = info.maxDefLevel();
             return switch (elementType) {
                 case INTEGER -> readListIntColumn(cr, maxDef, rows);
                 case LONG -> readListLongColumn(cr, maxDef, rows);
@@ -1398,16 +1461,16 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         private Block readListDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
             try (var builder = blockFactory.newLongBlockBuilder(rows)) {
-                int maxDef = info.maxDefLevel;
+                int maxDef = info.maxDefLevel();
                 for (int row = 0; row < rows; row++) {
                     int def = cr.getCurrentDefinitionLevel();
                     if (def >= maxDef) {
                         builder.beginPositionEntry();
-                        builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType));
+                        builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
                         cr.consume();
                         while (cr.getCurrentRepetitionLevel() > 0) {
                             if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType));
+                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
                             }
                             cr.consume();
                         }
@@ -1421,7 +1484,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                                     builder.beginPositionEntry();
                                     hasValues = true;
                                 }
-                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType));
+                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
                             }
                             cr.consume();
                         }
@@ -1463,15 +1526,6 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             }
         }
     }
-
-    private record ColumnInfo(
-        ColumnDescriptor descriptor,
-        PrimitiveType.PrimitiveTypeName parquetType,
-        DataType esqlType,
-        int maxDefLevel,
-        int maxRepLevel,
-        LogicalTypeAnnotation logicalType
-    ) {}
 
     /**
      * Minimal GroupConverter that satisfies {@link ColumnReadStoreImpl}'s constructor.

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Bulk PLAIN decoder over a little-endian value {@link ByteBuffer} for page-level Parquet reads.
+ * Fixed-width types (INT32, INT64, FLOAT, DOUBLE) are read contiguously; BOOLEAN uses 1 byte
+ * per value; BINARY is length-prefixed; FIXED_LEN_BYTE_ARRAY uses a fixed stride.
+ */
+final class PlainValueDecoder {
+
+    private ByteBuffer buffer;
+
+    void init(ByteBuffer valueBytes) {
+        this.buffer = valueBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    void readInts(int[] values, int offset, int count) {
+        buffer.asIntBuffer().get(values, offset, count);
+        buffer.position(buffer.position() + (count << 2));
+    }
+
+    void readLongs(long[] values, int offset, int count) {
+        buffer.asLongBuffer().get(values, offset, count);
+        buffer.position(buffer.position() + (count << 3));
+    }
+
+    // TODO: consider adding a reusable float[] to DecodeBuffers to avoid per-batch allocation
+    void readFloats(double[] values, int offset, int count) {
+        float[] tmp = new float[count];
+        buffer.asFloatBuffer().get(tmp, 0, count);
+        buffer.position(buffer.position() + (count << 2));
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = tmp[i];
+        }
+    }
+
+    void readDoubles(double[] values, int offset, int count) {
+        buffer.asDoubleBuffer().get(values, offset, count);
+        buffer.position(buffer.position() + (count << 3));
+    }
+
+    void readBooleans(boolean[] values, int offset, int count) {
+        int basePos = buffer.position();
+        for (int i = 0; i < count; i++) {
+            int pos = basePos + (i / 8);
+            values[offset + i] = ((buffer.get(pos) >>> (i % 8)) & 1) != 0;
+        }
+        buffer.position(basePos + (count + 7) / 8);
+    }
+
+    void readBinaries(BytesRef[] values, int offset, int count) {
+        for (int i = 0; i < count; i++) {
+            int length = buffer.getInt();
+            byte[] copy = new byte[length];
+            buffer.get(copy);
+            values[offset + i] = new BytesRef(copy);
+        }
+    }
+
+    void readFixedBinaries(BytesRef[] values, int offset, int count, int fixedLength) {
+        for (int i = 0; i < count; i++) {
+            byte[] copy = new byte[fixedLength];
+            buffer.get(copy);
+            values[offset + i] = new BytesRef(copy);
+        }
+    }
+
+    double readOneDouble() {
+        return buffer.getDouble();
+    }
+
+    float readOneFloat() {
+        return buffer.getFloat();
+    }
+
+    long readOneLong() {
+        return buffer.getLong();
+    }
+
+    int readOneInt() {
+        return buffer.getInt();
+    }
+
+    void skipInts(int count) {
+        buffer.position(buffer.position() + (count << 2));
+    }
+
+    void skipLongs(int count) {
+        buffer.position(buffer.position() + (count << 3));
+    }
+
+    void skipFloats(int count) {
+        buffer.position(buffer.position() + (count << 2));
+    }
+
+    void skipDoubles(int count) {
+        buffer.position(buffer.position() + (count << 3));
+    }
+
+    void skipBooleans(int count) {
+        buffer.position(buffer.position() + (count + 7) / 8);
+    }
+
+    void skipBinaries(int count) {
+        for (int i = 0; i < count; i++) {
+            int length = buffer.getInt();
+            buffer.position(buffer.position() + length);
+        }
+    }
+
+    void skipFixedBinaries(int count, int fixedLength) {
+        buffer.position(buffer.position() + count * fixedLength);
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRanges.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRanges.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Represents a set of selected row ranges within a row group as sorted, non-overlapping
+ * {@code [start, end)} intervals. Used for page-level skipping: after evaluating ColumnIndex
+ * min/max per data page, only pages whose row ranges intersect with the selected ranges
+ * need to be decoded.
+ *
+ * <p>Supports set operations (intersect, union) across predicate columns that may have
+ * different page boundaries, plus an anti-fragmentation check to avoid excessive range
+ * transitions that would negate the benefit of page skipping.
+ */
+final class RowRanges {
+
+    static final double DEFAULT_DENSITY_THRESHOLD = 0.8;
+    static final int DEFAULT_MAX_TRANSITIONS = 32;
+
+    private final long[] starts;
+    private final long[] ends;
+    private final long totalRows;
+
+    private RowRanges(long[] starts, long[] ends, long totalRows) {
+        assert starts.length == ends.length;
+        this.starts = starts;
+        this.ends = ends;
+        this.totalRows = totalRows;
+    }
+
+    static RowRanges all(long rowCount) {
+        if (rowCount <= 0) {
+            return new RowRanges(new long[0], new long[0], 0);
+        }
+        return new RowRanges(new long[] { 0 }, new long[] { rowCount }, rowCount);
+    }
+
+    static RowRanges of(long start, long end, long totalRows) {
+        if (start >= end) {
+            return new RowRanges(new long[0], new long[0], totalRows);
+        }
+        return new RowRanges(new long[] { start }, new long[] { end }, totalRows);
+    }
+
+    static RowRanges ofSorted(long[] starts, long[] ends, long totalRows) {
+        return new RowRanges(starts.clone(), ends.clone(), totalRows);
+    }
+
+    static RowRanges fromUnsorted(List<long[]> ranges, long totalRows) {
+        if (ranges.isEmpty()) {
+            return new RowRanges(new long[0], new long[0], totalRows);
+        }
+        ranges.sort((a, b) -> Long.compare(a[0], b[0]));
+
+        List<long[]> merged = new ArrayList<>();
+        long[] current = ranges.get(0);
+        for (int i = 1; i < ranges.size(); i++) {
+            long[] next = ranges.get(i);
+            if (next[0] <= current[1]) {
+                current = new long[] { current[0], Math.max(current[1], next[1]) };
+            } else {
+                merged.add(current);
+                current = next;
+            }
+        }
+        merged.add(current);
+
+        long[] s = new long[merged.size()];
+        long[] e = new long[merged.size()];
+        for (int i = 0; i < merged.size(); i++) {
+            s[i] = merged.get(i)[0];
+            e[i] = merged.get(i)[1];
+        }
+        return new RowRanges(s, e, totalRows);
+    }
+
+    RowRanges intersect(RowRanges other) {
+        if (isEmpty() || other.isEmpty()) {
+            return new RowRanges(new long[0], new long[0], totalRows);
+        }
+
+        List<long[]> result = new ArrayList<>();
+        int i = 0, j = 0;
+        while (i < starts.length && j < other.starts.length) {
+            long overlapStart = Math.max(starts[i], other.starts[j]);
+            long overlapEnd = Math.min(ends[i], other.ends[j]);
+            if (overlapStart < overlapEnd) {
+                result.add(new long[] { overlapStart, overlapEnd });
+            }
+            if (ends[i] < other.ends[j]) {
+                i++;
+            } else {
+                j++;
+            }
+        }
+
+        long[] rs = new long[result.size()];
+        long[] re = new long[result.size()];
+        for (int k = 0; k < result.size(); k++) {
+            rs[k] = result.get(k)[0];
+            re[k] = result.get(k)[1];
+        }
+        return new RowRanges(rs, re, totalRows);
+    }
+
+    RowRanges union(RowRanges other) {
+        if (isEmpty()) {
+            return other;
+        }
+        if (other.isEmpty()) {
+            return this;
+        }
+
+        List<long[]> all = new ArrayList<>(starts.length + other.starts.length);
+        for (int i = 0; i < starts.length; i++) {
+            all.add(new long[] { starts[i], ends[i] });
+        }
+        for (int i = 0; i < other.starts.length; i++) {
+            all.add(new long[] { other.starts[i], other.ends[i] });
+        }
+        return fromUnsorted(all, totalRows);
+    }
+
+    RowRanges complement() {
+        if (isEmpty()) {
+            return all(totalRows);
+        }
+
+        List<long[]> gaps = new ArrayList<>();
+        long prev = 0;
+        for (int i = 0; i < starts.length; i++) {
+            if (prev < starts[i]) {
+                gaps.add(new long[] { prev, starts[i] });
+            }
+            prev = ends[i];
+        }
+        if (prev < totalRows) {
+            gaps.add(new long[] { prev, totalRows });
+        }
+
+        long[] rs = new long[gaps.size()];
+        long[] re = new long[gaps.size()];
+        for (int k = 0; k < gaps.size(); k++) {
+            rs[k] = gaps.get(k)[0];
+            re[k] = gaps.get(k)[1];
+        }
+        return new RowRanges(rs, re, totalRows);
+    }
+
+    long selectedRowCount() {
+        long count = 0;
+        for (int i = 0; i < starts.length; i++) {
+            count += ends[i] - starts[i];
+        }
+        return count;
+    }
+
+    double density() {
+        if (totalRows <= 0) {
+            return 1.0;
+        }
+        return (double) selectedRowCount() / totalRows;
+    }
+
+    int transitionCount() {
+        return starts.length;
+    }
+
+    boolean isEmpty() {
+        return starts.length == 0;
+    }
+
+    boolean isAll() {
+        return starts.length == 1 && starts[0] == 0 && ends[0] == totalRows;
+    }
+
+    int rangeCount() {
+        return starts.length;
+    }
+
+    long rangeStart(int index) {
+        return starts[index];
+    }
+
+    long rangeEnd(int index) {
+        return ends[index];
+    }
+
+    long totalRows() {
+        return totalRows;
+    }
+
+    boolean shouldDiscard() {
+        return shouldDiscard(DEFAULT_DENSITY_THRESHOLD, DEFAULT_MAX_TRANSITIONS);
+    }
+
+    boolean shouldDiscard(double densityThreshold, int maxTransitions) {
+        if (isEmpty()) {
+            return false;
+        }
+        return density() > densityThreshold || transitionCount() > maxTransitions;
+    }
+
+    /**
+     * Returns true if any selected range overlaps the half-open interval {@code [pageStart, pageEnd)}.
+     * O(log n) via binary search, allocation-free.
+     */
+    boolean overlaps(long pageStart, long pageEnd) {
+        if (starts.length == 0 || pageStart >= pageEnd) {
+            return false;
+        }
+        int idx = Arrays.binarySearch(starts, pageStart);
+        if (idx >= 0) {
+            return true;
+        }
+        int insertionPoint = -idx - 1;
+        if (insertionPoint > 0 && ends[insertionPoint - 1] > pageStart) {
+            return true;
+        }
+        return insertionPoint < starts.length && starts[insertionPoint] < pageEnd;
+    }
+
+    long firstSelectedInRange(long rangeStart, long rangeEnd) {
+        if (starts.length == 0 || rangeStart >= rangeEnd) {
+            return -1;
+        }
+        int idx = Arrays.binarySearch(starts, rangeStart);
+        int i;
+        if (idx >= 0) {
+            i = idx;
+        } else {
+            int insertionPoint = -idx - 1;
+            if (insertionPoint > 0 && ends[insertionPoint - 1] > rangeStart) {
+                return rangeStart;
+            }
+            i = insertionPoint;
+        }
+        if (i < starts.length && starts[i] < rangeEnd) {
+            return Math.max(starts[i], rangeStart);
+        }
+        return -1;
+    }
+
+    long lastSelectedInRange(long rangeStart, long rangeEnd) {
+        if (starts.length == 0 || rangeStart >= rangeEnd) {
+            return -1;
+        }
+        int idx = Arrays.binarySearch(starts, rangeEnd);
+        int i;
+        if (idx >= 0) {
+            i = idx - 1;
+        } else {
+            i = -idx - 2;
+        }
+        while (i >= 0) {
+            if (ends[i] > rangeStart && starts[i] < rangeEnd) {
+                return Math.min(ends[i], rangeEnd) - 1;
+            }
+            if (ends[i] <= rangeStart) {
+                break;
+            }
+            i--;
+        }
+        return -1;
+    }
+
+    /**
+     * Finds the next contiguous run of selected rows starting from {@code pageOffset},
+     * within the next {@code maxRows} rows. Returns a {@link Run} describing how many
+     * rows to skip before the run and the run length.
+     *
+     * <p>If no selected rows remain in the window, returns a run with
+     * {@code skipBefore == maxRows} and {@code length == 0}.
+     */
+    Run nextRunInPage(long pageOffset, int maxRows) {
+        if (starts.length == 0 || maxRows <= 0) {
+            return new Run(maxRows, 0);
+        }
+        long windowEnd = pageOffset + maxRows;
+        long first = firstSelectedInRange(pageOffset, windowEnd);
+        if (first < 0) {
+            return new Run(maxRows, 0);
+        }
+        int skipBefore = (int) (first - pageOffset);
+
+        int idx = Arrays.binarySearch(starts, first);
+        int rangeIdx;
+        if (idx >= 0) {
+            rangeIdx = idx;
+        } else {
+            rangeIdx = -idx - 2;
+        }
+        long runEnd = Math.min(ends[rangeIdx], windowEnd);
+        int length = (int) (runEnd - first);
+        return new Run(skipBefore, length);
+    }
+
+    record Run(int skipBefore, int length) {}
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("RowRanges{");
+        for (int i = 0; i < starts.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append('[').append(starts[i]).append(", ").append(ends[i]).append(')');
+        }
+        sb.append(", total=").append(totalRows).append('}');
+        return sb.toString();
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import java.util.Arrays;
+import java.util.BitSet;
+
+/**
+ * Reusable fixed-width bit mask backed by a {@code long[]} word array. Unlike {@link BitSet},
+ * this class supports explicit reset-and-reuse semantics with zero allocation after warmup,
+ * making it suitable for per-batch null tracking in tight decode loops.
+ */
+final class WordMask {
+    private long[] words;
+    private int numBits;
+
+    WordMask() {}
+
+    void reset(int numBits) {
+        this.numBits = numBits;
+        int numWords = (numBits + 63) >>> 6;
+        if (words == null || words.length < numWords) {
+            words = new long[numWords];
+        } else {
+            Arrays.fill(words, 0, numWords, 0L);
+        }
+    }
+
+    void set(int index) {
+        words[index >>> 6] |= 1L << index;
+    }
+
+    boolean get(int index) {
+        return (words[index >>> 6] & (1L << index)) != 0;
+    }
+
+    boolean isEmpty() {
+        for (int i = 0; i < wordCount(); i++) {
+            if (words[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    int wordCount() {
+        return (numBits + 63) >>> 6;
+    }
+
+    BitSet toBitSet() {
+        return BitSet.valueOf(Arrays.copyOf(words, wordCount()));
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+
+/**
+ * Compares the optimized {@link PageColumnReader} path against the baseline row-at-a-time
+ * {@code ColumnReader} path to verify they produce identical results.
+ * <p>
+ * For each test, an in-memory Parquet file is written and read by two readers:
+ * the default (optimized) reader and a {@link ParquetFormatReader#withBaselinePath() baseline}
+ * reader. Pages from both are compared block-by-block, position-by-position.
+ * <p>
+ * Explicit tests cover the V1/V2 x compression matrix. A randomized test generates schemas
+ * with random column counts and null patterns, catching edge cases in buffer management
+ * and encoding dispatch that fixed schemas cannot cover.
+ */
+public class PageColumnReaderCorrectnessTests extends ESTestCase {
+
+    private static final int NUM_ROWS = 500;
+    private static final int BATCH_SIZE = 1000;
+
+    private static final MessageType SCHEMA = Types.buildMessage()
+        .required(INT32)
+        .named("id")
+        .required(INT64)
+        .named("big_id")
+        .required(DOUBLE)
+        .named("score")
+        .required(FLOAT)
+        .named("weight")
+        .required(BOOLEAN)
+        .named("flag")
+        .required(BINARY)
+        .as(LogicalTypeAnnotation.stringType())
+        .named("name")
+        .required(INT64)
+        .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+        .named("ts")
+        .optional(INT32)
+        .named("opt_int")
+        .optional(INT64)
+        .named("opt_long")
+        .optional(DOUBLE)
+        .named("opt_double")
+        .optional(BINARY)
+        .as(LogicalTypeAnnotation.stringType())
+        .named("opt_str")
+        .named("correctness_test");
+
+    private static final List<String> COLUMNS = SCHEMA.getFields().stream().map(Type::getName).toList();
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    // --- Explicit V1/V2 x compression matrix ---
+
+    public void testV1Uncompressed() throws IOException {
+        assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_1_0, CompressionCodecName.UNCOMPRESSED);
+    }
+
+    public void testV1Snappy() throws IOException {
+        assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_1_0, CompressionCodecName.SNAPPY);
+    }
+
+    public void testV1Zstd() throws IOException {
+        assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_1_0, CompressionCodecName.ZSTD);
+    }
+
+    public void testV2Uncompressed() throws IOException {
+        assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_2_0, CompressionCodecName.UNCOMPRESSED);
+    }
+
+    public void testV2Snappy() throws IOException {
+        assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_2_0, CompressionCodecName.SNAPPY);
+    }
+
+    public void testV2Zstd() throws IOException {
+        assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_2_0, CompressionCodecName.ZSTD);
+    }
+
+    private void assertReadersMatch(ParquetProperties.WriterVersion version, CompressionCodecName codec) throws IOException {
+        byte[] data = writeTestFile(version, codec, SCHEMA, NUM_ROWS, PageColumnReaderCorrectnessTests::populateFixedRow);
+        assertOptimizedMatchesBaseline(data, COLUMNS);
+    }
+
+    // --- Randomized test ---
+
+    public void testRandomSchema() throws IOException {
+        int numIntCols = between(1, 4);
+        int numLongCols = between(1, 4);
+        int numDoubleCols = between(1, 3);
+        int numBoolCols = between(0, 2);
+        int numStrCols = between(1, 3);
+        int numRows = between(100, 2000);
+
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        List<ColSpec> specs = new ArrayList<>();
+
+        addColumns(builder, specs, "i", INT32, null, numIntCols);
+        addColumns(builder, specs, "l", INT64, null, numLongCols);
+        addColumns(builder, specs, "d", DOUBLE, null, numDoubleCols);
+        addColumns(builder, specs, "b", BOOLEAN, null, numBoolCols);
+        addColumns(builder, specs, "s", BINARY, LogicalTypeAnnotation.stringType(), numStrCols);
+
+        MessageType schema = builder.named("random_test");
+        List<String> columns = schema.getFields().stream().map(Type::getName).toList();
+
+        ParquetProperties.WriterVersion version = randomFrom(
+            ParquetProperties.WriterVersion.PARQUET_1_0,
+            ParquetProperties.WriterVersion.PARQUET_2_0
+        );
+        CompressionCodecName codec = randomFrom(CompressionCodecName.UNCOMPRESSED, CompressionCodecName.SNAPPY, CompressionCodecName.ZSTD);
+
+        byte[] data = writeTestFile(version, codec, schema, numRows, (group, row) -> {
+            for (ColSpec spec : specs) {
+                if (spec.optional && row % spec.nullFreq == 0) {
+                    continue;
+                }
+                switch (spec.type) {
+                    case INT32 -> group.append(spec.name, row * spec.seed);
+                    case INT64 -> group.append(spec.name, (long) row * spec.seed);
+                    case DOUBLE -> group.append(spec.name, row * spec.seed * 0.1);
+                    case BOOLEAN -> group.append(spec.name, (row + spec.seed) % 3 == 0);
+                    case BINARY -> group.append(spec.name, spec.name + "_" + row);
+                    default -> throw new IllegalStateException("unexpected type: " + spec.type);
+                }
+            }
+        });
+
+        assertOptimizedMatchesBaseline(data, columns);
+    }
+
+    // --- Column spec for randomized tests ---
+
+    private record ColSpec(
+        String name,
+        org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName type,
+        boolean optional,
+        int nullFreq,
+        int seed
+    ) {}
+
+    private void addColumns(
+        Types.MessageTypeBuilder builder,
+        List<ColSpec> specs,
+        String prefix,
+        org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName type,
+        LogicalTypeAnnotation logicalType,
+        int count
+    ) {
+        for (int i = 0; i < count; i++) {
+            boolean optional = randomBoolean();
+            String name = prefix + "_" + i;
+            var col = optional ? Types.optional(type) : Types.required(type);
+            if (logicalType != null) {
+                col.as(logicalType);
+            }
+            builder.addField(col.named(name));
+            specs.add(new ColSpec(name, type, optional, optional ? between(2, 7) : 0, between(1, 100)));
+        }
+    }
+
+    // --- Core comparison logic ---
+
+    private void assertOptimizedMatchesBaseline(byte[] data, List<String> columns) throws IOException {
+        List<Page> optimized = readAll(new ParquetFormatReader(blockFactory), data, columns);
+        List<Page> baseline = readAll(new ParquetFormatReader(blockFactory).withBaselinePath(), data, columns);
+
+        try {
+            assertEquals("page count", baseline.size(), optimized.size());
+
+            int totalRows = 0;
+            for (int p = 0; p < baseline.size(); p++) {
+                Page opt = optimized.get(p);
+                Page base = baseline.get(p);
+                assertEquals("position count at page " + p, base.getPositionCount(), opt.getPositionCount());
+                assertEquals("block count at page " + p, base.getBlockCount(), opt.getBlockCount());
+
+                for (int col = 0; col < base.getBlockCount(); col++) {
+                    assertBlocksEqual(columns.get(col), p, opt.getBlock(col), base.getBlock(col));
+                }
+                totalRows += opt.getPositionCount();
+            }
+            assertTrue("expected rows > 0", totalRows > 0);
+        } finally {
+            optimized.forEach(Page::releaseBlocks);
+            baseline.forEach(Page::releaseBlocks);
+        }
+    }
+
+    // --- Block comparison ---
+
+    private static void assertBlocksEqual(String column, int pageIdx, Block actual, Block expected) {
+        String ctx = "[" + column + "] page " + pageIdx;
+        assertEquals(ctx + " positions", expected.getPositionCount(), actual.getPositionCount());
+
+        for (int pos = 0; pos < expected.getPositionCount(); pos++) {
+            boolean expNull = expected.isNull(pos);
+            assertEquals(ctx + " null@" + pos, expNull, actual.isNull(pos));
+            if (expNull) continue;
+
+            switch (expected) {
+                case IntBlock ei when actual instanceof IntBlock ai -> assertEquals(ctx + "@" + pos, ei.getInt(pos), ai.getInt(pos));
+                case LongBlock el when actual instanceof LongBlock al -> assertEquals(ctx + "@" + pos, el.getLong(pos), al.getLong(pos));
+                case DoubleBlock ed when actual instanceof DoubleBlock ad -> assertEquals(
+                    ctx + "@" + pos,
+                    ed.getDouble(pos),
+                    ad.getDouble(pos),
+                    0.0
+                );
+                case BooleanBlock eb when actual instanceof BooleanBlock ab -> assertEquals(
+                    ctx + "@" + pos,
+                    eb.getBoolean(pos),
+                    ab.getBoolean(pos)
+                );
+                case BytesRefBlock exb when actual instanceof BytesRefBlock acb -> assertEquals(
+                    ctx + "@" + pos,
+                    exb.getBytesRef(pos, new BytesRef()),
+                    acb.getBytesRef(pos, new BytesRef())
+                );
+                default -> fail(
+                    ctx + " type mismatch: " + expected.getClass().getSimpleName() + " vs " + actual.getClass().getSimpleName()
+                );
+            }
+        }
+    }
+
+    // --- Read helpers ---
+
+    private List<Page> readAll(ParquetFormatReader reader, byte[] data, List<String> columns) throws IOException {
+        StorageObject so = storageObject(data);
+        List<Page> pages = new ArrayList<>();
+        try (CloseableIterator<Page> iter = reader.read(so, FormatReadContext.of(columns, BATCH_SIZE))) {
+            while (iter.hasNext()) {
+                pages.add(iter.next());
+            }
+        }
+        return pages;
+    }
+
+    // --- Fixed row population for the explicit schema ---
+
+    private static void populateFixedRow(Group g, int i) {
+        g.append("id", i)
+            .append("big_id", (long) i * 100_000L)
+            .append("score", i * 1.5)
+            .append("weight", (float) (i * 0.1))
+            .append("flag", i % 3 == 0)
+            .append("name", "row_" + i)
+            .append("ts", 1_700_000_000_000L + i * 60_000L);
+        if (i % 5 != 0) g.append("opt_int", i * 7);
+        if (i % 4 != 0) g.append("opt_long", (long) i * 31);
+        if (i % 3 != 0) g.append("opt_double", i * 2.7);
+        if (i % 6 != 0) g.append("opt_str", "val_" + (i % 100));
+    }
+
+    // --- Parquet file writing ---
+
+    private byte[] writeTestFile(
+        ParquetProperties.WriterVersion version,
+        CompressionCodecName codec,
+        MessageType schema,
+        int numRows,
+        BiConsumer<Group, Integer> rowPopulator
+    ) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile(out))
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withWriterVersion(version)
+                .withCompressionCodec(codec)
+                .withRowGroupSize(4096)
+                .withPageSize(512)
+                .build()
+        ) {
+            for (int i = 0; i < numRows; i++) {
+                Group g = factory.newGroup();
+                rowPopulator.accept(g, i);
+                writer.write(g);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    // --- In-memory Parquet infrastructure ---
+
+    private static StorageObject storageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                return new ByteArrayInputStream(data, (int) position, (int) Math.min(length, data.length - position));
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.EPOCH;
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://correctness_test.parquet");
+            }
+        };
+    }
+
+    private static OutputFile outputFile(ByteArrayOutputStream out) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position = 0;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        out.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        out.write(b, off, len);
+                        position += len;
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        out.close();
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+
+            @Override
+            public String getPath() {
+                return "memory://correctness_test.parquet";
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRangesTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/RowRangesTests.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class RowRangesTests extends ESTestCase {
+
+    public void testAllCoversEntireRowGroup() {
+        RowRanges all = RowRanges.all(1000);
+        assertThat(all.selectedRowCount(), equalTo(1000L));
+        assertThat(all.density(), equalTo(1.0));
+        assertThat(all.rangeCount(), equalTo(1));
+        assertTrue(all.isAll());
+        assertFalse(all.isEmpty());
+    }
+
+    public void testEmptyRowGroup() {
+        RowRanges empty = RowRanges.all(0);
+        assertThat(empty.selectedRowCount(), equalTo(0L));
+        assertTrue(empty.isEmpty());
+    }
+
+    public void testSingleRange() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.selectedRowCount(), equalTo(400L));
+        assertThat(range.density(), equalTo(0.4));
+        assertThat(range.rangeCount(), equalTo(1));
+        assertThat(range.rangeStart(0), equalTo(100L));
+        assertThat(range.rangeEnd(0), equalTo(500L));
+        assertFalse(range.isAll());
+        assertFalse(range.isEmpty());
+    }
+
+    public void testEmptyRange() {
+        RowRanges range = RowRanges.of(500, 500, 1000);
+        assertTrue(range.isEmpty());
+        assertThat(range.selectedRowCount(), equalTo(0L));
+    }
+
+    public void testIntersectOverlapping() {
+        RowRanges a = RowRanges.of(0, 500, 1000);
+        RowRanges b = RowRanges.of(300, 800, 1000);
+        RowRanges result = a.intersect(b);
+        assertThat(result.rangeCount(), equalTo(1));
+        assertThat(result.rangeStart(0), equalTo(300L));
+        assertThat(result.rangeEnd(0), equalTo(500L));
+        assertThat(result.selectedRowCount(), equalTo(200L));
+    }
+
+    public void testIntersectNoOverlap() {
+        RowRanges a = RowRanges.of(0, 100, 1000);
+        RowRanges b = RowRanges.of(200, 300, 1000);
+        RowRanges result = a.intersect(b);
+        assertTrue(result.isEmpty());
+    }
+
+    public void testIntersectMultipleRanges() {
+        RowRanges a = RowRanges.ofSorted(new long[] { 0, 200, 500 }, new long[] { 100, 400, 700 }, 1000);
+        RowRanges b = RowRanges.ofSorted(new long[] { 50, 350 }, new long[] { 250, 600 }, 1000);
+        RowRanges result = a.intersect(b);
+        assertThat(result.rangeCount(), equalTo(4));
+        assertThat(result.rangeStart(0), equalTo(50L));
+        assertThat(result.rangeEnd(0), equalTo(100L));
+        assertThat(result.rangeStart(1), equalTo(200L));
+        assertThat(result.rangeEnd(1), equalTo(250L));
+        assertThat(result.rangeStart(2), equalTo(350L));
+        assertThat(result.rangeEnd(2), equalTo(400L));
+        assertThat(result.rangeStart(3), equalTo(500L));
+        assertThat(result.rangeEnd(3), equalTo(600L));
+    }
+
+    public void testIntersectWithEmpty() {
+        RowRanges a = RowRanges.of(0, 500, 1000);
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        assertTrue(a.intersect(empty).isEmpty());
+        assertTrue(empty.intersect(a).isEmpty());
+    }
+
+    public void testUnionNonOverlapping() {
+        RowRanges a = RowRanges.of(0, 100, 1000);
+        RowRanges b = RowRanges.of(200, 300, 1000);
+        RowRanges result = a.union(b);
+        assertThat(result.rangeCount(), equalTo(2));
+        assertThat(result.selectedRowCount(), equalTo(200L));
+    }
+
+    public void testUnionOverlapping() {
+        RowRanges a = RowRanges.of(0, 200, 1000);
+        RowRanges b = RowRanges.of(100, 300, 1000);
+        RowRanges result = a.union(b);
+        assertThat(result.rangeCount(), equalTo(1));
+        assertThat(result.rangeStart(0), equalTo(0L));
+        assertThat(result.rangeEnd(0), equalTo(300L));
+        assertThat(result.selectedRowCount(), equalTo(300L));
+    }
+
+    public void testUnionWithEmpty() {
+        RowRanges a = RowRanges.of(0, 500, 1000);
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        RowRanges result = a.union(empty);
+        assertThat(result.selectedRowCount(), equalTo(500L));
+    }
+
+    public void testComplement() {
+        RowRanges range = RowRanges.of(200, 800, 1000);
+        RowRanges complement = range.complement();
+        assertThat(complement.rangeCount(), equalTo(2));
+        assertThat(complement.rangeStart(0), equalTo(0L));
+        assertThat(complement.rangeEnd(0), equalTo(200L));
+        assertThat(complement.rangeStart(1), equalTo(800L));
+        assertThat(complement.rangeEnd(1), equalTo(1000L));
+        assertThat(complement.selectedRowCount(), equalTo(400L));
+    }
+
+    public void testComplementOfAll() {
+        RowRanges all = RowRanges.all(1000);
+        RowRanges complement = all.complement();
+        assertTrue(complement.isEmpty());
+    }
+
+    public void testComplementOfEmpty() {
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        RowRanges complement = empty.complement();
+        assertTrue(complement.isAll());
+        assertThat(complement.selectedRowCount(), equalTo(1000L));
+    }
+
+    public void testComplementMultipleRanges() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 100, 500 }, new long[] { 200, 600 }, 1000);
+        RowRanges complement = ranges.complement();
+        assertThat(complement.rangeCount(), equalTo(3));
+        assertThat(complement.rangeStart(0), equalTo(0L));
+        assertThat(complement.rangeEnd(0), equalTo(100L));
+        assertThat(complement.rangeStart(1), equalTo(200L));
+        assertThat(complement.rangeEnd(1), equalTo(500L));
+        assertThat(complement.rangeStart(2), equalTo(600L));
+        assertThat(complement.rangeEnd(2), equalTo(1000L));
+    }
+
+    public void testDensity() {
+        RowRanges range = RowRanges.of(0, 800, 1000);
+        assertThat(range.density(), equalTo(0.8));
+    }
+
+    public void testDensityZeroTotal() {
+        RowRanges range = RowRanges.of(0, 0, 0);
+        assertThat(range.density(), equalTo(1.0));
+    }
+
+    public void testAntiFragmentationHighDensity() {
+        RowRanges range = RowRanges.of(0, 900, 1000);
+        assertTrue(range.shouldDiscard(0.8, 32));
+    }
+
+    public void testAntiFragmentationLowDensity() {
+        RowRanges range = RowRanges.of(0, 200, 1000);
+        assertFalse(range.shouldDiscard(0.8, 32));
+    }
+
+    public void testAntiFragmentationTooManyTransitions() {
+        long[] starts = new long[40];
+        long[] ends = new long[40];
+        for (int i = 0; i < 40; i++) {
+            starts[i] = i * 25;
+            ends[i] = i * 25 + 10;
+        }
+        RowRanges fragmented = RowRanges.ofSorted(starts, ends, 1000);
+        assertTrue(fragmented.shouldDiscard(0.8, 32));
+    }
+
+    public void testAntiFragmentationFewTransitions() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 500 }, new long[] { 100, 600 }, 1000);
+        assertFalse(ranges.shouldDiscard(0.8, 32));
+    }
+
+    public void testFromUnsortedMergesOverlapping() {
+        List<long[]> ranges = new ArrayList<>();
+        ranges.add(new long[] { 200, 400 });
+        ranges.add(new long[] { 0, 100 });
+        ranges.add(new long[] { 50, 250 });
+        RowRanges result = RowRanges.fromUnsorted(ranges, 1000);
+        assertThat(result.rangeCount(), equalTo(1));
+        assertThat(result.rangeStart(0), equalTo(0L));
+        assertThat(result.rangeEnd(0), equalTo(400L));
+    }
+
+    public void testFromUnsortedNonOverlapping() {
+        List<long[]> ranges = new ArrayList<>();
+        ranges.add(new long[] { 500, 600 });
+        ranges.add(new long[] { 0, 100 });
+        ranges.add(new long[] { 200, 300 });
+        RowRanges result = RowRanges.fromUnsorted(ranges, 1000);
+        assertThat(result.rangeCount(), equalTo(3));
+        assertThat(result.rangeStart(0), equalTo(0L));
+        assertThat(result.rangeEnd(0), equalTo(100L));
+        assertThat(result.rangeStart(1), equalTo(200L));
+        assertThat(result.rangeEnd(1), equalTo(300L));
+        assertThat(result.rangeStart(2), equalTo(500L));
+        assertThat(result.rangeEnd(2), equalTo(600L));
+    }
+
+    public void testFromUnsortedEmpty() {
+        RowRanges result = RowRanges.fromUnsorted(new ArrayList<>(), 1000);
+        assertTrue(result.isEmpty());
+    }
+
+    public void testIntersectIdentity() {
+        RowRanges a = RowRanges.of(100, 500, 1000);
+        RowRanges result = a.intersect(RowRanges.all(1000));
+        assertThat(result.rangeCount(), equalTo(1));
+        assertThat(result.rangeStart(0), equalTo(100L));
+        assertThat(result.rangeEnd(0), equalTo(500L));
+    }
+
+    public void testToString() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        String str = range.toString();
+        assertTrue(str.contains("[100, 500)"));
+        assertTrue(str.contains("total=1000"));
+    }
+
+    public void testOverlapsEmpty() {
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        assertFalse(empty.overlaps(0, 100));
+    }
+
+    public void testOverlapsSingleRangeFullyInsideSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertTrue(range.overlaps(200, 300));
+    }
+
+    public void testOverlapsSingleRangePartialOverlapAtStart() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertTrue(range.overlaps(50, 150));
+    }
+
+    public void testOverlapsSingleRangePartialOverlapAtEnd() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertTrue(range.overlaps(150, 250));
+    }
+
+    public void testOverlapsSingleRangeNoOverlapBefore() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertFalse(range.overlaps(0, 50));
+    }
+
+    public void testOverlapsSingleRangeNoOverlapAfter() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertFalse(range.overlaps(300, 400));
+    }
+
+    public void testOverlapsMultipleRangesFirst() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 500 }, new long[] { 100, 600 }, 1000);
+        assertTrue(ranges.overlaps(50, 80));
+    }
+
+    public void testOverlapsMultipleRangesMiddle() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 200, 500 }, new long[] { 100, 300, 700 }, 1000);
+        assertTrue(ranges.overlaps(250, 280));
+    }
+
+    public void testOverlapsMultipleRangesGap() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 200 }, new long[] { 100, 300 }, 1000);
+        assertFalse(ranges.overlaps(120, 180));
+    }
+
+    public void testOverlapsBoundaryPageStartEqualsRangeEnd() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertFalse(range.overlaps(200, 300));
+    }
+
+    public void testOverlapsBoundaryPageEndEqualsRangeStart() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertFalse(range.overlaps(0, 100));
+    }
+
+    public void testOverlapsBoundaryPageStartEqualsRangeStart() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertTrue(range.overlaps(100, 150));
+    }
+
+    public void testFirstSelectedInRangeEmpty() {
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        assertThat(empty.firstSelectedInRange(0, 100), equalTo(-1L));
+    }
+
+    public void testFirstSelectedInRangeFullyInsideSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.firstSelectedInRange(200, 400), equalTo(200L));
+    }
+
+    public void testFirstSelectedInRangeStartsBeforeSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.firstSelectedInRange(50, 200), equalTo(100L));
+    }
+
+    public void testFirstSelectedInRangeStartsInMiddleOfSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.firstSelectedInRange(150, 200), equalTo(150L));
+    }
+
+    public void testFirstSelectedInRangeNoSelectionInRange() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.firstSelectedInRange(0, 50), equalTo(-1L));
+    }
+
+    public void testFirstSelectedInRangeMultipleRangesSecondRange() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 200 }, new long[] { 100, 350 }, 1000);
+        assertThat(ranges.firstSelectedInRange(250, 400), equalTo(250L));
+    }
+
+    public void testLastSelectedInRangeEmpty() {
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        assertThat(empty.lastSelectedInRange(0, 100), equalTo(-1L));
+    }
+
+    public void testLastSelectedInRangeFullyInsideSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.lastSelectedInRange(200, 400), equalTo(399L));
+    }
+
+    public void testLastSelectedInRangeEndsAfterSelection() {
+        RowRanges range = RowRanges.of(100, 300, 1000);
+        assertThat(range.lastSelectedInRange(50, 500), equalTo(299L));
+    }
+
+    public void testLastSelectedInRangeEndsInMiddleOfSelection() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.lastSelectedInRange(50, 250), equalTo(249L));
+    }
+
+    public void testLastSelectedInRangeNoSelectionInRange() {
+        RowRanges range = RowRanges.of(100, 500, 1000);
+        assertThat(range.lastSelectedInRange(0, 50), equalTo(-1L));
+    }
+
+    public void testLastSelectedInRangeMultipleRanges() {
+        RowRanges ranges = RowRanges.ofSorted(new long[] { 0, 150 }, new long[] { 100, 300 }, 1000);
+        assertThat(ranges.lastSelectedInRange(50, 250), equalTo(249L));
+    }
+
+    public void testNextRunInPageEmpty() {
+        RowRanges empty = RowRanges.of(0, 0, 1000);
+        assertThat(empty.nextRunInPage(0, 128), equalTo(new RowRanges.Run(128, 0)));
+    }
+
+    public void testNextRunInPageFullySelected() {
+        RowRanges all = RowRanges.all(1000);
+        assertThat(all.nextRunInPage(0, 64), equalTo(new RowRanges.Run(0, 64)));
+    }
+
+    public void testNextRunInPageLeadingGap() {
+        RowRanges range = RowRanges.of(5, 100, 1000);
+        assertThat(range.nextRunInPage(0, 50), equalTo(new RowRanges.Run(5, 45)));
+    }
+
+    public void testNextRunInPageNoSelectionInWindow() {
+        RowRanges range = RowRanges.of(100, 200, 1000);
+        assertThat(range.nextRunInPage(0, 50), equalTo(new RowRanges.Run(50, 0)));
+    }
+
+    public void testNextRunInPageTruncatedToWindow() {
+        RowRanges range = RowRanges.of(0, 100, 1000);
+        assertThat(range.nextRunInPage(90, 20), equalTo(new RowRanges.Run(0, 10)));
+    }
+}


### PR DESCRIPTION
Add `PageColumnReader` that reads Parquet data pages directly via
`PageReader`, bypassing `ColumnReadStoreImpl` for flat columns. Uses
bulk `PlainValueDecoder`, `DictionaryValueDecoder`, and
`DefinitionLevelDecoder` with `ValuesReader` fallback for non-standard
encodings (`DELTA_BINARY_PACKED`, `DELTA_BYTE_ARRAY`, etc.).

When a record filter is active, falls back to the row-at-a-time
`ColumnReader` path to avoid page-index filtering incompatibilities.

**Key components:**
- `PageColumnReader` — core page-level batch reader for all flat column types
- `PlainValueDecoder` / `DictionaryValueDecoder` — bulk PLAIN and RLE dictionary decoding
- `DefinitionLevelDecoder` — bulk def-level → null BitSet/WordMask
- `DecodeBuffers` — per-column reusable buffer pool (each column owns its own instance)
- `RowRanges` — row range tracking for future page skipping
- `WordMask` / `ConstantBlockDetection` — batch null tracking and constant-value optimization
- `ColumnInfo` — extracted record for per-column metadata

**Correctness tests** compare the optimized path against a baseline `ColumnReader` path
across V1/V2 writer versions × compression codecs, plus a randomized test with random
column counts, types, and null patterns.

Builds on top of https://github.com/elastic/elasticsearch/pull/147008

Developed with AI-assisted tooling