### PR TITLE
Verifying that S3BlobContainer.children() behaves correctly in RepositoryAnalyzeAction

### DIFF
--- a/docs/changelog/147061.yaml
+++ b/docs/changelog/147061.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 147061
+summary: Verifying that S3BlobContainer.children() behaves correctly in `RepositoryAnalyzeAction`
+type: enhancement

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/ChildBlobContainer.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/ChildBlobContainer.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.repositories.blobstore.testkit.analyze;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.DeleteResult;
+import org.elasticsearch.common.blobstore.OperationPurpose;
+import org.elasticsearch.common.blobstore.OptionalBytesReference;
+import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
+import org.elasticsearch.common.blobstore.support.BlobMetadata;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.core.CheckedConsumer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This is a stub for child containers returned by the BlobRepository#children methods in the integration tests in this package.
+ * It only implements AbstractBlobContainer#listBlobs, which is needed by RepositoryAnalyzeAction to verify child listings. All other
+ * methods are stubbed out and throw UnsupportedOperationException.
+ */
+public class ChildBlobContainer extends AbstractBlobContainer {
+    private final Map<String, byte[]> blobs;
+    private final String prefix;
+
+    ChildBlobContainer(BlobPath parentPath, String dirName, Map<String, byte[]> blobs) {
+        super(parentPath.add(dirName));
+        this.prefix = dirName + "/";
+        this.blobs = blobs;
+    }
+
+    @Override
+    public Map<String, BlobMetadata> listBlobs(OperationPurpose purpose) throws IOException {
+        return blobs.entrySet()
+            .stream()
+            .filter(e -> e.getKey().startsWith(prefix))
+            .collect(
+                Collectors.toMap(
+                    e -> e.getKey().substring(prefix.length()),
+                    e -> new BlobMetadata(e.getKey().substring(prefix.length()), e.getValue().length)
+                )
+            );
+    }
+
+    @Override
+    public boolean blobExists(OperationPurpose purpose, String blobName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream readBlob(OperationPurpose purpose, String blobName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream readBlob(OperationPurpose purpose, String blobName, long position, long length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeBlob(OperationPurpose purpose, String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeMetadataBlob(
+        OperationPurpose purpose,
+        String blobName,
+        boolean failIfAlreadyExists,
+        boolean atomic,
+        CheckedConsumer<OutputStream, IOException> writer
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeBlobAtomic(
+        OperationPurpose purpose,
+        String blobName,
+        InputStream inputStream,
+        long blobSize,
+        boolean failIfAlreadyExists
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DeleteResult delete(OperationPurpose purpose) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteBlobsIgnoringIfNotExists(OperationPurpose purpose, Iterator<String> blobNames) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, BlobContainer> children(OperationPurpose purpose) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, BlobMetadata> listBlobsByPrefix(OperationPurpose purpose, String blobNamePrefix) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void compareAndExchangeRegister(
+        OperationPurpose purpose,
+        String key,
+        BytesReference expected,
+        BytesReference updated,
+        ActionListener<OptionalBytesReference> listener
+    ) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void getRegister(OperationPurpose purpose, String key, ActionListener<OptionalBytesReference> listener) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisFailureIT.java
@@ -675,6 +675,135 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         assertAnalysisFailureMessage(analyseRepositoryExpectFailure(request).getMessage());
     }
 
+    public void testFailsIfChildrenNotEmpty() {
+        final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
+        request.blobCount(1);
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
+        blobStore.setDisruption(new Disruption() {
+            @Override
+            public Map<String, BlobContainer> onChildren(BlobContainer self, Map<String, BlobContainer> actual) {
+                if (actual.isEmpty()) {
+                    // Inject a spurious child directory when the flat container should have none
+                    return Map.of("spurious-dir", self);
+                }
+                return actual;
+            }
+        });
+        assertAnalysisFailureMessage(analyseRepositoryExpectFailure(request).getMessage());
+    }
+
+    public void testFailsIfChildrenMissingAfterWrite() {
+        final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
+        request.blobCount(1);
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
+        blobStore.setDisruption(new Disruption() {
+            @Override
+            public Map<String, BlobContainer> onChildren(BlobContainer self, Map<String, BlobContainer> actual) {
+                if (actual.containsKey("test-child-dir-1")) {
+                    // Hide the child directory that was just written
+                    return Map.of();
+                }
+                return actual;
+            }
+        });
+        assertAnalysisFailureMessage(analyseRepositoryExpectFailure(request).getMessage());
+    }
+
+    public void testFailsOnChildrenException() {
+        final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
+        request.blobCount(1);
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
+        final CountDown countDown = new CountDown(1);
+        blobStore.setDisruption(new Disruption() {
+            @Override
+            public Map<String, BlobContainer> onChildren(BlobContainer self, Map<String, BlobContainer> actual) throws IOException {
+                if (countDown.countDown()) {
+                    throw new IOException("simulated children listing failure");
+                }
+                return actual;
+            }
+        });
+        final Exception exception = analyseRepositoryExpectFailure(request);
+        assertAnalysisFailureMessage(exception.getMessage());
+        final IOException ioException = (IOException) ExceptionsHelper.unwrap(exception, IOException.class);
+        assert ioException != null : exception;
+        assertThat(ioException.getMessage(), equalTo("simulated children listing failure"));
+    }
+
+    public void testFailsIfPartialChildrenListing() {
+        final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
+        request.blobCount(1);
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
+        blobStore.setDisruption(new Disruption() {
+            @Override
+            public Map<String, BlobContainer> onChildren(BlobContainer self, Map<String, BlobContainer> actual) {
+                if (actual.containsKey("test-child-dir-1") && actual.containsKey("test-child-dir-2")) {
+                    // Return only one of the two expected directories
+                    return Map.of("test-child-dir-2", actual.get("test-child-dir-2"));
+                }
+                return actual;
+            }
+        });
+        assertAnalysisFailureMessage(analyseRepositoryExpectFailure(request).getMessage());
+    }
+
+    public void testFailsIfChildListBlobsReportsBlobMissing() {
+        final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
+        request.blobCount(1);
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
+        blobStore.setDisruption(new Disruption() {
+            @Override
+            public Map<String, BlobMetadata> onChildListBlobs(String dirName, Map<String, BlobMetadata> actual) {
+                if (dirName.equals("test-child-dir-1") && actual.isEmpty() == false) {
+                    final HashMap<String, BlobMetadata> disrupted = new HashMap<>(actual);
+                    disrupted.remove(disrupted.keySet().iterator().next());
+                    return disrupted;
+                }
+                return actual;
+            }
+        });
+        assertAnalysisFailureMessage(analyseRepositoryExpectFailure(request).getMessage());
+    }
+
+    public void testFailsIfChildListBlobsReportsExtraBlob() {
+        final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
+        request.blobCount(1);
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
+        blobStore.setDisruption(new Disruption() {
+            @Override
+            public Map<String, BlobMetadata> onChildListBlobs(String dirName, Map<String, BlobMetadata> actual) {
+                if (dirName.equals("test-child-dir-1") && actual.isEmpty() == false) {
+                    final HashMap<String, BlobMetadata> disrupted = new HashMap<>(actual);
+                    disrupted.put("spurious-blob", new BlobMetadata("spurious-blob", 0));
+                    return disrupted;
+                }
+                return actual;
+            }
+        });
+        assertAnalysisFailureMessage(analyseRepositoryExpectFailure(request).getMessage());
+    }
+
+    public void testFailsOnChildListBlobsException() {
+        final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
+        request.blobCount(1);
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
+        final CountDown countDown = new CountDown(1);
+        blobStore.setDisruption(new Disruption() {
+            @Override
+            public Map<String, BlobMetadata> onChildListBlobs(String dirName, Map<String, BlobMetadata> actual) throws IOException {
+                if (countDown.countDown()) {
+                    throw new IOException("simulated child listBlobs failure");
+                }
+                return actual;
+            }
+        });
+        final Exception exception = analyseRepositoryExpectFailure(request);
+        assertAnalysisFailureMessage(exception.getMessage());
+        final IOException ioException = (IOException) ExceptionsHelper.unwrap(exception, IOException.class);
+        assert ioException != null : exception;
+        assertThat(ioException.getMessage(), equalTo("simulated child listBlobs failure"));
+    }
+
     private RepositoryVerificationException analyseRepositoryExpectFailure(RepositoryAnalyzeAction.Request request) {
         return safeAwaitAndUnwrapFailure(
             RepositoryVerificationException.class,
@@ -829,6 +958,14 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
         default Map<String, BlobMetadata> onPrefixList(String prefix, Map<String, BlobMetadata> filteredListing) throws IOException {
             return filteredListing;
+        }
+
+        default Map<String, BlobContainer> onChildren(BlobContainer self, Map<String, BlobContainer> actual) throws IOException {
+            return actual;
+        }
+
+        default Map<String, BlobMetadata> onChildListBlobs(String dirName, Map<String, BlobMetadata> actual) throws IOException {
+            return actual;
         }
     }
 
@@ -1036,9 +1173,17 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         }
 
         @Override
-        public Map<String, BlobContainer> children(OperationPurpose purpose) {
+        public Map<String, BlobContainer> children(OperationPurpose purpose) throws IOException {
             assertPurpose(purpose);
-            return Map.of();
+            final Map<String, BlobContainer> actual = new HashMap<>();
+            for (final String blobName : blobs.keySet()) {
+                final int slashIdx = blobName.indexOf('/');
+                if (slashIdx > 0) {
+                    final String dirName = blobName.substring(0, slashIdx);
+                    actual.putIfAbsent(dirName, new DisruptibleChildBlobContainer(path(), dirName, blobs, disruption));
+                }
+            }
+            return disruption.onChildren(this, actual);
         }
 
         @Override
@@ -1085,6 +1230,22 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
                 }
             } else {
                 listener.onResponse(OptionalBytesReference.MISSING);
+            }
+        }
+
+        private static class DisruptibleChildBlobContainer extends ChildBlobContainer {
+            private final String dirName;
+            private final Disruption disruption;
+
+            DisruptibleChildBlobContainer(BlobPath parentPath, String dirName, Map<String, byte[]> blobs, Disruption disruption) {
+                super(parentPath, dirName, blobs);
+                this.dirName = dirName;
+                this.disruption = disruption;
+            }
+
+            @Override
+            public Map<String, BlobMetadata> listBlobs(OperationPurpose purpose) throws IOException {
+                return disruption.onChildListBlobs(dirName, super.listBlobs(purpose));
             }
         }
     }

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisSuccessIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisSuccessIT.java
@@ -52,6 +52,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -349,6 +350,7 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
         private final Map<String, BytesRegister> registers = ConcurrentCollections.newConcurrentMap();
         private final AtomicBoolean firstRegisterRead = new AtomicBoolean(true);
         private final AtomicLong prefixListCallCount = new AtomicLong();
+        private final AtomicLong childrenCallCount = new AtomicLong();
 
         private final Object registerMutex = new Object();
         private long contendedRegisterValue = 0L;
@@ -491,9 +493,15 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
                 } else {
                     blobs.put(blobName, contents);
                 }
-                assertThat(blobs.keySet().toString(), blobs.size(), lessThanOrEqualTo(maxBlobCount + 1 /* overwrite-check blob */));
+                final int childBlobCount = 4;
+                // +1 for overwrite-check blob, +childBlobCount for temporary child-listing blobs written by verifyChildrenListing
+                assertThat(blobs.keySet().toString(), blobs.size(), lessThanOrEqualTo(maxBlobCount + 1 + childBlobCount));
                 final long currentTotal = totalBytesWritten.addAndGet(blobSize - existingSize);
-                assertThat(currentTotal, lessThanOrEqualTo(maxTotalBlobSize + maxBlobSize /* max size of overwrite-check blob */));
+                final long childBlobSize = childBlobCount; // 1 byte each
+                assertThat(
+                    currentTotal,
+                    lessThanOrEqualTo(maxTotalBlobSize + maxBlobSize /* max size of overwrite-check blob */ + childBlobSize)
+                );
             } finally {
                 writeSemaphore.release();
             }
@@ -525,6 +533,11 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
                 prefixListCallCount.get(),
                 greaterThanOrEqualTo(1L)
             );
+            assertThat(
+                "children was never called by RepositoryAnalyzeAction, so verifyChildrenListing was never called",
+                childrenCallCount.get(),
+                greaterThanOrEqualTo(1L)
+            );
             synchronized (registerMutex) {
                 assertThat(contendedRegisterValue, equalTo(expectedRegisterOperationCount));
                 assertThat(uncontendedRegisterValue, greaterThanOrEqualTo(expectedRegisterOperationCount));
@@ -552,7 +565,16 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
         @Override
         public Map<String, BlobContainer> children(OperationPurpose purpose) {
             assertPurpose(purpose);
-            return Map.of();
+            childrenCallCount.incrementAndGet();
+            final Map<String, BlobContainer> children = new HashMap<>();
+            for (final String blobName : blobs.keySet()) {
+                final int slashIdx = blobName.indexOf('/');
+                if (slashIdx > 0) {
+                    final String dirName = blobName.substring(0, slashIdx);
+                    children.putIfAbsent(dirName, new ChildBlobContainer(path(), dirName, blobs));
+                }
+            }
+            return children;
         }
 
         @Override

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalyzeAction.java
@@ -943,6 +943,7 @@ public class RepositoryAnalyzeAction extends HandledTransportAction<RepositoryAn
                     if (missingBlobs.isEmpty()) {
                         logger.trace("all expected blobs found, cleaning up [{}:{}]", request.getRepositoryName(), blobPath);
                         verifyPrefixListing(blobContainer, blobsMap);
+                        verifyChildrenListing(blobContainer);
                     } else {
                         final RepositoryVerificationException repositoryVerificationException = new RepositoryVerificationException(
                             request.repositoryName,
@@ -1043,6 +1044,89 @@ public class RepositoryAnalyzeAction extends HandledTransportAction<RepositoryAn
                         )
                     );
                     return;
+                }
+            }
+        }
+
+        /**
+         * Verify that {@link BlobContainer#children} correctly reports child containers using delimiter-based hierarchical listing.
+         * <ol>
+         *     <li>Verify the flat test container has no children (all test blobs are written without subdirectories).</li>
+         *     <li>Write blobs into subdirectories and verify {@code children()} returns the subdirectories.</li>
+         *     <li>Cleans up the subdirectories blobs.</li>
+         * </ol>
+         */
+        private void verifyChildrenListing(BlobContainer blobContainer) throws IOException {
+            // Step 1: flat container should have no children
+            final Map<String, BlobContainer> childContainers = blobContainer.children(OperationPurpose.REPOSITORY_ANALYSIS);
+            if (childContainers.isEmpty() == false) {
+                fail(
+                    new RepositoryVerificationException(
+                        request.repositoryName,
+                        "children() should return no child containers for a flat blob container but returned " + childContainers.keySet()
+                    )
+                );
+                return;
+            }
+
+            // Step 2: write a blob into a subdirectory and verify children() discovers it
+            final Map<String, List<String>> parentChildMap = Map.of(
+                "test-child-dir-1",
+                List.of("test-child-blob-1a", "test-child-blob-1b"),
+                "test-child-dir-2",
+                List.of("test-child-blob-2a", "test-child-blob-2b")
+            );
+            for (Map.Entry<String, List<String>> entry : parentChildMap.entrySet()) {
+                final String parentBlobName = entry.getKey();
+                for (final String childBlobName : entry.getValue()) {
+                    blobContainer.writeBlob(
+                        OperationPurpose.REPOSITORY_ANALYSIS,
+                        parentBlobName + "/" + childBlobName,
+                        new BytesArray(new byte[] { 0 }),
+                        true
+                    );
+                }
+            }
+            try {
+                final Map<String, BlobContainer> childContainersAfterWrite = blobContainer.children(OperationPurpose.REPOSITORY_ANALYSIS);
+                if (childContainersAfterWrite.keySet().equals(parentChildMap.keySet()) == false) {
+                    fail(
+                        new RepositoryVerificationException(
+                            request.repositoryName,
+                            "children() should return [" + parentChildMap.keySet() + "] but returned " + childContainersAfterWrite.keySet()
+                        )
+                    );
+                    return;
+                }
+                for (Map.Entry<String, List<String>> entry : parentChildMap.entrySet()) {
+                    final String dirName = entry.getKey();
+                    final Set<String> childBlobs = childContainersAfterWrite.get(dirName)
+                        .listBlobs(OperationPurpose.REPOSITORY_ANALYSIS)
+                        .keySet();
+                    final Set<String> expectedChildBlobs = new HashSet<>(entry.getValue());
+                    if (childBlobs.equals(expectedChildBlobs) == false) {
+                        fail(
+                            new RepositoryVerificationException(
+                                request.repositoryName,
+                                "children() should return ["
+                                    + expectedChildBlobs
+                                    + "] for directory ["
+                                    + dirName
+                                    + "] but returned "
+                                    + childBlobs
+                            )
+                        );
+                        logger.trace("children listing verified for [{}:{}]", request.getRepositoryName(), blobPath);
+                    }
+                }
+            } finally {
+                // Step 3: clean up the subdirectory blob
+                for (Map.Entry<String, List<String>> entry : parentChildMap.entrySet()) {
+                    final List<String> childBlobNames = entry.getValue()
+                        .stream()
+                        .map(childBlobName -> entry.getKey() + "/" + childBlobName)
+                        .toList();
+                    blobContainer.deleteBlobsIgnoringIfNotExists(OperationPurpose.REPOSITORY_ANALYSIS, childBlobNames.iterator());
                 }
             }
         }


### PR DESCRIPTION
This adds a check to RepositoryAnalyzeAction (used by the _analyze repo API) that S3BlobContainer.children() behaves the way we expect it to with the configured object store.
Note: The `children` method calls the same S3 API methods that the `listBlobsByPrefix` does, so this is largely already tested and possibly not needed. The only real difference is that `children` depends on having a `/` delimiter in the path to an object.