### PR TITLE
[9.4] Add mapper feature for ignored fields stored in binary doc values (#147054)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
@@ -700,8 +700,8 @@ _doc_count:
 ---
 fields with ignore_malformed:
   - requires:
-      cluster_features: ["gte_v8.8.0"]
-      reason: support for boolean ignore_malformed was added in 8.8.0
+      cluster_features: ["gte_v8.8.0", "mapper.doc_values.ignored_values_in_binary_dv"]
+      reason: support for boolean ignore_malformed was added in 8.8.0, sort order affected by binary doc values
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
@@ -236,6 +236,10 @@ keyword with non-lowercase normalizer:
 
 ---
 keyword with normalizer and skip store original value:
+  - requires:
+      cluster_features: [ "mapper.doc_values.ignored_values_in_binary_dv" ]
+      reason: "Sort order of ignored values is affected by binary docvalues"
+
   - do:
       indices.create:
         index: test-keyword-with-normalizer
@@ -328,6 +332,10 @@ keyword with normalizer and skip store original value:
 ---
 
 keyword with built-in normalizer:
+  - requires:
+      cluster_features: [ "mapper.doc_values.ignored_values_in_binary_dv" ]
+      reason: "Sort order of ignored values is affected by binary docvalues"
+
   - do:
       indices.create:
         index: test-keyword-with-normalizer

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -85,6 +85,7 @@ public class MapperFeatures implements FeatureSpecification {
         "mapper.dense_vector.dynamic_template_nested_object_fix"
     );
     public static final NodeFeature ES940_DISK_BBQ = new NodeFeature("mapper.es940_disk_bbq");
+    public static final NodeFeature IGNORED_VALUES_STORED_IN_BINARY_DV = new NodeFeature("mapper.doc_values.ignored_values_in_binary_dv");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -145,7 +146,8 @@ public class MapperFeatures implements FeatureSpecification {
             DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX,
             FLATTENED_MAPPED_SUBFIELDS_FEATURE,
             ES940_DISK_BBQ,
-            FLATTENED_PASSTHROUGH_FEATURE
+            FLATTENED_PASSTHROUGH_FEATURE,
+            IGNORED_VALUES_STORED_IN_BINARY_DV
         );
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Add mapper feature for ignored fields stored in binary doc values (#147054)](https://github.com/elastic/elasticsearch/pull/147054)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)