### PR TITLE
[9.4] Fix NPE when having double nested field with knn query (#146933)

### DIFF
--- a/docs/changelog/146933.yaml
+++ b/docs/changelog/146933.yaml
@@ -1,0 +1,6 @@
+area: Vector Search
+issues:
+ - 141830
+pr: 146933
+summary: Fix NPE when having double nested field with knn query
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/nested/VectorNestedIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/nested/VectorNestedIT.java
@@ -9,11 +9,15 @@
 
 package org.elasticsearch.search.nested;
 
+import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.InnerHitBuilder;
+import org.elasticsearch.index.query.NestedQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.vectors.KnnSearchBuilder;
+import org.elasticsearch.search.vectors.KnnVectorQueryBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.List;
@@ -164,5 +168,77 @@ public class VectorNestedIT extends ESIntegTestCase {
             assertEquals("3", response.getHits().getHits()[1].getId());
             assertEquals("rat", response.getHits().getHits()[1].field("name").getValue());
         });
+    }
+
+    public void testDoubleNestedFloat() throws Exception {
+        testDoubleNested("float");
+    }
+
+    public void testDoubleNestedByte() throws Exception {
+        testDoubleNested("byte");
+    }
+
+    private void testDoubleNested(String elementType) throws Exception {
+        assertAcked(
+            prepareCreate("test").setMapping(
+                jsonBuilder().startObject()
+                    .startObject("properties")
+                    .startObject("nested")
+                    .field("type", "nested")
+                    .startObject("properties")
+                    .startObject("nested")
+                    .field("type", "nested")
+                    .startObject("properties")
+                    .startObject("vector")
+                    .field("type", "dense_vector")
+                    .field("element_type", elementType)
+                    .field("index", true)
+                    .field("dims", 3)
+                    .field("similarity", "cosine")
+                    .startObject("index_options")
+                    .field("type", "hnsw")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            ).setSettings(Settings.builder().put(indexSettings()).put("index.number_of_shards", 1))
+        );
+        ensureGreen();
+
+        // empty document
+        prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().endObject()).get();
+        refresh();
+
+        QueryBuilder knn = new KnnVectorQueryBuilder("nested.nested.vector", new float[] { 1, 1, 1 }, 1, 1, 10f, null, null);
+        QueryBuilder nested1 = new NestedQueryBuilder("nested.nested", knn, ScoreMode.Total);
+        QueryBuilder nested2 = new NestedQueryBuilder("nested", nested1, ScoreMode.Total);
+
+        assertResponse(prepareSearch("test").setQuery(nested2), response -> assertThat(response.getHits().getHits().length, equalTo(0)));
+
+        prepareIndex("test").setId("1")
+            .setSource(
+                jsonBuilder().startObject()
+                    .startArray("nested")
+                    .startObject()
+                    .startArray("nested")
+                    .startObject()
+                    .field("vector", new float[] { 1, 1, 1 })
+                    .endObject()
+                    .endArray()
+                    .endObject()
+                    .endArray()
+                    .endObject()
+            )
+            .get();
+        refresh();
+
+        assertResponse(
+            prepareSearch("test").setQuery(nested2),
+            response -> assertThat(response.getHits().getHits().length, greaterThan(0))
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/vectors/PatienceCollectorManager.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/PatienceCollectorManager.java
@@ -39,17 +39,23 @@ class PatienceCollectorManager implements KnnCollectorManager {
 
     @Override
     public KnnCollector newCollector(int visitLimit, KnnSearchStrategy searchStrategy, LeafReaderContext ctx) throws IOException {
-        return new AdaptiveHnswQueueSaturationCollector(knnCollectorManager.newCollector(visitLimit, searchStrategy, ctx));
+        KnnCollector collector = knnCollectorManager.newCollector(visitLimit, searchStrategy, ctx);
+        if (collector == null) {
+            return null;
+        }
+        return new AdaptiveHnswQueueSaturationCollector(collector);
     }
 
     @Override
     public KnnCollector newOptimisticCollector(int visitLimit, KnnSearchStrategy searchStrategy, LeafReaderContext ctx, int k)
         throws IOException {
         if (knnCollectorManager.isOptimistic()) {
-            return new AdaptiveHnswQueueSaturationCollector(knnCollectorManager.newOptimisticCollector(visitLimit, searchStrategy, ctx, k));
-        } else {
-            return null;
+            KnnCollector collector = knnCollectorManager.newOptimisticCollector(visitLimit, searchStrategy, ctx, k);
+            if (collector != null) {
+                return new AdaptiveHnswQueueSaturationCollector(collector);
+            }
         }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix NPE when having double nested field with knn query (#146933)](https://github.com/elastic/elasticsearch/pull/146933)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)