### PR TITLE
[9.4] Stabilize FetchPhaseDocsIterator leaf-ordering test (#146940)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -270,9 +270,6 @@ tests:
 - class: org.elasticsearch.reindex.management.ReindexListRelocationIT
   method: testListReindexShowsOriginalIdentityAfterRelocation
   issue: https://github.com/elastic/elasticsearch/issues/145963
-- class: org.elasticsearch.search.fetch.FetchPhaseDocsIteratorTests
-  method: testIterateAsyncVisitsLeavesInDocIdOrder
-  issue: https://github.com/elastic/elasticsearch/issues/146078
 - class: org.elasticsearch.xpack.entsearch.EnterpriseSearchRestIT
   method: test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type}
   issue: https://github.com/elastic/elasticsearch/issues/146106

--- a/server/src/test/java/org/elasticsearch/search/fetch/FetchPhaseDocsIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/FetchPhaseDocsIteratorTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.action.ActionListener;
@@ -594,7 +595,11 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
     public void testIterateAsyncVisitsLeavesInDocIdOrder() throws Exception {
         int docCount = 200;
         Directory directory = newDirectory();
-        RandomIndexWriter writer = new RandomIndexWriter(random(), directory);
+        RandomIndexWriter writer = new RandomIndexWriter(
+            random(),
+            directory,
+            newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE)
+        );
         for (int i = 0; i < docCount; i++) {
             Document doc = new Document();
             doc.add(new StringField("field", "value" + i, Field.Store.NO));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Stabilize FetchPhaseDocsIterator leaf-ordering test (#146940)](https://github.com/elastic/elasticsearch/pull/146940)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)