### PR TITLE
Remove unused `SamlAuthenticateResponse` constructor

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateResponse.java
@@ -28,11 +28,6 @@ public final class SamlAuthenticateResponse extends ActionResponse {
     private final Authentication authentication;
     private final String inResponseTo;
 
-    // Constructor used in Serverless
-    public SamlAuthenticateResponse(Authentication authentication, String tokenString, String refreshToken, TimeValue expiresIn) {
-        this(authentication, tokenString, refreshToken, expiresIn, null);
-    }
-
     public SamlAuthenticateResponse(
         Authentication authentication,
         String tokenString,


### PR DESCRIPTION
All code paths now use the constructor with `inResponseTo` parameter. Removing it as `in_response_to` should always be considered and returned when available.