### PR TITLE
[9.4] Fix `OsProbe` failure when `cpu.max` file is empty (#146822)

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -12,7 +12,9 @@ package org.elasticsearch.monitor.os;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.unit.Processors;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.monitor.Probes;
@@ -327,11 +329,20 @@ public class OsProbe {
      * @param path path to the file to read
      * @return the single line
      * @throws IOException if an I/O exception occurs reading the file
+     * @throws IllegalStateException if the file contains zero lines
      */
-    private static String readSingleLine(final Path path) throws IOException {
+    static String readSingleLine(final Path path) throws IOException {
         final List<String> lines = Files.readAllLines(path);
+        if (lines.isEmpty()) {
+            throw new IllegalStateException(Strings.format("File %s is empty, exactly one line was expected", path));
+        }
         assert lines.size() == 1 : String.join("\n", lines);
-        return lines.get(0);
+        return lines.getFirst();
+    }
+
+    @Nullable
+    private static String maybeSingleLine(final List<String> lines) {
+        return lines.size() == 1 ? lines.getFirst() : null;
     }
 
     // this property is to support a hack to workaround an issue with Docker containers mounting the cgroups hierarchy inconsistently with
@@ -421,21 +432,26 @@ public class OsProbe {
         return readSingleLine(PathUtils.get("/sys/fs/cgroup/cpuacct", controlGroup, "cpuacct.usage"));
     }
 
+    @Nullable
     private long[] getCgroupV2CpuLimit(String controlGroup) throws IOException {
-        String entry = readCgroupV2CpuLimit(controlGroup);
+        final var entry = maybeSingleLine(readCgroupV2CpuLimit(controlGroup));
+        if (entry == null) {
+            return null;
+        }
         String[] parts = entry.split("\\s+");
-        assert parts.length == 2 : "Expected 2 fields in [cpu.max]";
+        if (parts.length != 2) {
+            return null;
+        }
 
         long[] values = new long[2];
-
         values[0] = "max".equals(parts[0]) ? -1L : Long.parseLong(parts[0]);
         values[1] = Long.parseLong(parts[1]);
         return values;
     }
 
     @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu.max")
-    String readCgroupV2CpuLimit(String controlGroup) throws IOException {
-        return readSingleLine(PathUtils.get("/sys/fs/cgroup/", controlGroup, "cpu.max"));
+    List<String> readCgroupV2CpuLimit(String controlGroup) throws IOException {
+        return Files.readAllLines(PathUtils.get("/sys/fs/cgroup/", controlGroup, "cpu.max"));
     }
 
     /**
@@ -769,6 +785,10 @@ public class OsProbe {
                 cgroupCpuAcctUsageNanos = cpuStatsMap.get("usage_usec").multiply(THOUSAND); // convert from micros to nanos
 
                 long[] cpuLimits = getCgroupV2CpuLimit(cpuControlGroup);
+                if (cpuLimits == null) {
+                    logger.debug("no cpu_quota and cpu_period data found in cpu.max");
+                    return null;
+                }
                 cgroupCpuAcctCpuCfsQuotaMicros = cpuLimits[0];
                 cgroupCpuAcctCpuCfsPeriodMicros = cpuLimits[1];
 

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -13,13 +13,16 @@ import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.unit.Processors;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.both;
@@ -183,7 +186,8 @@ public class OsProbeTests extends ESTestCase {
         final int availableCgroupsVersion = randomFrom(0, 1, 2);
         final String hierarchy = randomAlphaOfLength(16);
 
-        final OsProbe probe = buildStubOsProbe(availableCgroupsVersion, hierarchy);
+        final OsProbe probe = new OsProbeMock(hierarchy).setAvailableCgroupsVersion(availableCgroupsVersion)
+            .setProcSelfCgroupLines(getProcSelfGroupLines(availableCgroupsVersion, hierarchy));
 
         final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
 
@@ -218,6 +222,32 @@ public class OsProbeTests extends ESTestCase {
         }
     }
 
+    public void testCgroupProbeWithMissingCpuMax() {
+        final int cgroupsVersion = 2;
+        final var hierarchy = randomAlphaOfLength(16);
+
+        final var probe = new OsProbeMock(hierarchy).setAvailableCgroupsVersion(cgroupsVersion)
+            .setProcSelfCgroupLines(getProcSelfGroupLines(cgroupsVersion, hierarchy))
+            .setCgroupCpuMax(List.of());
+
+        final var cgroup = probe.osStats().getCgroup();
+
+        assertNull(cgroup);
+    }
+
+    public void testCgroupProbeWithInvalidCpuMax() {
+        final int cgroupsVersion = 2;
+        final var hierarchy = randomAlphaOfLength(16);
+
+        final var probe = new OsProbeMock(hierarchy).setAvailableCgroupsVersion(cgroupsVersion)
+            .setProcSelfCgroupLines(getProcSelfGroupLines(cgroupsVersion, hierarchy))
+            .setCgroupCpuMax(List.of("42"));
+
+        final var cgroup = probe.osStats().getCgroup();
+
+        assertNull(cgroup);
+    }
+
     public void testCgroupProbeWithMissingCpuAcct() {
         final String hierarchy = randomAlphaOfLength(16);
 
@@ -226,7 +256,7 @@ public class OsProbeTests extends ESTestCase {
             .map(line -> line.replaceFirst(",cpuacct", ""))
             .toList();
 
-        final OsProbe probe = buildStubOsProbe(1, hierarchy, procSelfCgroupLines);
+        final OsProbe probe = new OsProbeMock(hierarchy).setAvailableCgroupsVersion(1).setProcSelfCgroupLines(procSelfCgroupLines);
 
         final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
 
@@ -241,7 +271,7 @@ public class OsProbeTests extends ESTestCase {
             .map(line -> line.replaceFirst(":cpu,", ":"))
             .toList();
 
-        final OsProbe probe = buildStubOsProbe(1, hierarchy, procSelfCgroupLines);
+        final OsProbe probe = new OsProbeMock(hierarchy).setAvailableCgroupsVersion(1).setProcSelfCgroupLines(procSelfCgroupLines);
 
         final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
 
@@ -256,7 +286,7 @@ public class OsProbeTests extends ESTestCase {
             .filter(line -> line.contains(":memory:") == false)
             .toList();
 
-        final OsProbe probe = buildStubOsProbe(1, hierarchy, procSelfCgroupLines);
+        final OsProbe probe = new OsProbeMock(hierarchy).setAvailableCgroupsVersion(1).setProcSelfCgroupLines(procSelfCgroupLines);
 
         final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
 
@@ -360,6 +390,32 @@ public class OsProbeTests extends ESTestCase {
         assertThat(osProbe.getTotalPhysicalMemorySize(), greaterThan(0L));
     }
 
+    public void testReadSingleLine() throws Exception {
+        var file = createTempFile();
+        Files.writeString(file, "test");
+
+        var line = OsProbe.readSingleLine(file);
+
+        assertEquals("test", line);
+    }
+
+    public void testReadSingleLineEmptyFile() throws Exception {
+        var file = createTempFile();
+
+        assertThrows(IllegalStateException.class, () -> OsProbe.readSingleLine(file));
+    }
+
+    public void testReadSingleLineFileWithMultipleLines() throws Exception {
+        var file = createTempFile();
+        Files.writeString(file, """
+            first
+            second
+            third
+            """);
+
+        assertThrows(AssertionError.class, () -> OsProbe.readSingleLine(file));
+    }
+
     private static List<String> getProcSelfGroupLines(int cgroupsVersion, String hierarchy) {
         // It doesn't really matter if cgroupsVersion == 0 here
 
@@ -382,123 +438,171 @@ public class OsProbeTests extends ESTestCase {
         );
     }
 
-    private static OsProbe buildStubOsProbe(final int availableCgroupsVersion, final String hierarchy) {
-        List<String> procSelfCgroupLines = getProcSelfGroupLines(availableCgroupsVersion, hierarchy);
-
-        return buildStubOsProbe(availableCgroupsVersion, hierarchy, procSelfCgroupLines);
-    }
-
-    /**
-     * Builds a test instance of OsProbe. Methods that ordinarily read from the filesystem are overridden to return values based upon
-     * the arguments to this method.
-     *
-     * @param availableCgroupsVersion what version of cgroups are available, 1 or 2, or 0 for no cgroups. Normally OsProbe establishes this
-     *                                for itself.
-     * @param hierarchy a mock value used to generate a cgroup hierarchy.
-     * @param procSelfCgroupLines the lines that will be used as the content of <code>/proc/self/cgroup</code>
-     * @param procMeminfoLines lines that will be used as the content of <code>/proc/meminfo</code>
-     * @return a test instance
-     */
     private static OsProbe buildStubOsProbe(
         final int availableCgroupsVersion,
         final String hierarchy,
         List<String> procSelfCgroupLines,
         List<String> procMeminfoLines
     ) {
-        return new OsProbe() {
-            @Override
-            OsStats.Cgroup getCgroup(boolean isLinux) {
-                // Pretend we're always on Linux so that we can run the cgroup tests
-                return super.getCgroup(true);
-            }
-
-            @Override
-            List<String> readProcSelfCgroup() {
-                return procSelfCgroupLines;
-            }
-
-            @Override
-            String readSysFsCgroupCpuAcctCpuAcctUsage(String controlGroup) {
-                assertThat(controlGroup, equalTo("/" + hierarchy));
-                return "364869866063112";
-            }
-
-            @Override
-            String readSysFsCgroupCpuAcctCpuCfsPeriod(String controlGroup) {
-                assertThat(controlGroup, equalTo("/" + hierarchy));
-                return "100000";
-            }
-
-            @Override
-            String readSysFsCgroupCpuAcctCpuAcctCfsQuota(String controlGroup) {
-                assertThat(controlGroup, equalTo("/" + hierarchy));
-                return "50000";
-            }
-
-            @Override
-            List<String> readSysFsCgroupCpuAcctCpuStat(String controlGroup) {
-                return Arrays.asList("nr_periods 17992", "nr_throttled 1311", "throttled_time 139298645489");
-            }
-
-            @Override
-            String readSysFsCgroupMemoryLimitInBytes(String controlGroup) {
-                assertThat(controlGroup, equalTo("/" + hierarchy));
-                // This is the highest value that can be stored in an unsigned 64 bit number, hence too big for long
-                return "18446744073709551615";
-            }
-
-            @Override
-            String readSysFsCgroupMemoryUsageInBytes(String controlGroup) {
-                assertThat(controlGroup, equalTo("/" + hierarchy));
-                return "4796416";
-            }
-
-            @Override
-            boolean areCgroupStatsAvailable() {
-                return availableCgroupsVersion > 0;
-            }
-
-            @Override
-            List<String> readProcMeminfo() {
-                return procMeminfoLines;
-            }
-
-            @Override
-            String readSysFsCgroupV2MemoryLimitInBytes(String controlGroup) {
-                assertThat(controlGroup, equalTo("/" + hierarchy));
-                // This is the highest value that can be stored in an unsigned 64 bit number, hence too big for long
-                return "18446744073709551615";
-            }
-
-            @Override
-            String readSysFsCgroupV2MemoryUsageInBytes(String controlGroup) {
-                assertThat(controlGroup, equalTo("/" + hierarchy));
-                return "4796416";
-            }
-
-            @Override
-            List<String> readCgroupV2CpuStats(String controlGroup) {
-                assertThat(controlGroup, equalTo("/" + hierarchy));
-                return List.of(
-                    "usage_usec 364869866063",
-                    "user_usec 34636",
-                    "system_usec 9896",
-                    "nr_periods 17992",
-                    "nr_throttled 1311",
-                    "throttled_usec 139298645"
-                );
-            }
-
-            @Override
-            String readCgroupV2CpuLimit(String controlGroup) {
-                assertThat(controlGroup, equalTo("/" + hierarchy));
-                return "50000 100000";
-            }
-        };
+        return new OsProbeMock(hierarchy).setAvailableCgroupsVersion(availableCgroupsVersion)
+            .setProcSelfCgroupLines(procSelfCgroupLines)
+            .setProcMeminfoLines(procMeminfoLines);
     }
 
-    private static OsProbe buildStubOsProbe(final int availableCgroupsVersion, final String hierarchy, List<String> procSelfCgroupLines) {
-        return buildStubOsProbe(availableCgroupsVersion, hierarchy, procSelfCgroupLines, List.of());
-    }
+    /**
+     * A mock implementation of {@link OsProbe} that overrides all methods that would normally read from the filesystem. The {@code set*()}
+     * methods in this class can be called to specify the exact values to be returned by this mock.
+     */
+    private static final class OsProbeMock extends OsProbe {
 
+        private final String hierarchy;
+        private int availableCgroupsVersion = 0;
+        private List<String> procSelfCgroupLines = List.of();
+        private List<String> procMeminfoLines = List.of();
+        private List<String> cgroupCpuMax = List.of("50000 100000");
+
+        /**
+         * Creates a new instance of a mock {@link OsProbe}.
+         *
+         * @param hierarchy a mock value used to generate a cgroup hierarchy.
+         */
+        OsProbeMock(String hierarchy) {
+            this.hierarchy = hierarchy;
+        }
+
+        /**
+         * Set the cgroups version.
+         *
+         * @param availableCgroupsVersion what version of cgroups are available, 1 or 2, or 0 for no cgroups. Normally OsProbe establishes
+         *                               this for itself.
+         * @return {@code this}.
+         */
+        OsProbeMock setAvailableCgroupsVersion(int availableCgroupsVersion) {
+            this.availableCgroupsVersion = availableCgroupsVersion;
+            return this;
+        }
+
+        /**
+         * Sets the contents of {@code /proc/self/cgroup}.
+         *
+         * @param procSelfCgroupLines the lines that will be used as the content of {@code /proc/self/cgroup}.
+         * @return {@code this}.
+         */
+        OsProbeMock setProcSelfCgroupLines(List<String> procSelfCgroupLines) {
+            this.procSelfCgroupLines = procSelfCgroupLines;
+            return this;
+        }
+
+        /**
+         * Sets the contents of {@code /proc/meminfo}.
+         *
+         * @param procMeminfoLines lines that will be used as the content of {@code /proc/meminfo}.
+         * @return {@code this}.
+         */
+        OsProbeMock setProcMeminfoLines(List<String> procMeminfoLines) {
+            this.procMeminfoLines = procMeminfoLines;
+            return this;
+        }
+
+        /**
+         * Sets the contents of {@code /sys/fs/cgroup/${hierarchy}/cpu.max}.
+         *
+         * @param cgroupCpuMax a single line content of {@code /sys/fs/cgroup/${hierarchy}/}, where {@code ${hierarchy}} is the value passed
+         *                    to the {@link #OsProbeMock(String)} constructor.
+         * @return {@code this}.
+         */
+        OsProbeMock setCgroupCpuMax(List<String> cgroupCpuMax) {
+            this.cgroupCpuMax = cgroupCpuMax;
+            return this;
+        }
+
+        @Override
+        OsStats.Cgroup getCgroup(boolean isLinux) {
+            // Pretend we're always on Linux so that we can run the cgroup tests
+            return super.getCgroup(true);
+        }
+
+        @Override
+        List<String> readProcSelfCgroup() {
+            return procSelfCgroupLines;
+        }
+
+        @Override
+        String readSysFsCgroupCpuAcctCpuAcctUsage(String controlGroup) {
+            MatcherAssert.assertThat(controlGroup, equalTo("/" + hierarchy));
+            return "364869866063112";
+        }
+
+        @Override
+        String readSysFsCgroupCpuAcctCpuCfsPeriod(String controlGroup) {
+            MatcherAssert.assertThat(controlGroup, equalTo("/" + hierarchy));
+            return "100000";
+        }
+
+        @Override
+        String readSysFsCgroupCpuAcctCpuAcctCfsQuota(String controlGroup) {
+            MatcherAssert.assertThat(controlGroup, equalTo("/" + hierarchy));
+            return "50000";
+        }
+
+        @Override
+        List<String> readSysFsCgroupCpuAcctCpuStat(String controlGroup) {
+            return Arrays.asList("nr_periods 17992", "nr_throttled 1311", "throttled_time 139298645489");
+        }
+
+        @Override
+        String readSysFsCgroupMemoryLimitInBytes(String controlGroup) {
+            MatcherAssert.assertThat(controlGroup, equalTo("/" + hierarchy));
+            // This is the highest value that can be stored in an unsigned 64 bit number, hence too big for long
+            return "18446744073709551615";
+        }
+
+        @Override
+        String readSysFsCgroupMemoryUsageInBytes(String controlGroup) {
+            MatcherAssert.assertThat(controlGroup, equalTo("/" + hierarchy));
+            return "4796416";
+        }
+
+        @Override
+        boolean areCgroupStatsAvailable() {
+            return availableCgroupsVersion > 0;
+        }
+
+        @Override
+        List<String> readProcMeminfo() {
+            return procMeminfoLines;
+        }
+
+        @Override
+        String readSysFsCgroupV2MemoryLimitInBytes(String controlGroup) {
+            MatcherAssert.assertThat(controlGroup, equalTo("/" + hierarchy));
+            // This is the highest value that can be stored in an unsigned 64 bit number, hence too big for long
+            return "18446744073709551615";
+        }
+
+        @Override
+        String readSysFsCgroupV2MemoryUsageInBytes(String controlGroup) {
+            MatcherAssert.assertThat(controlGroup, equalTo("/" + hierarchy));
+            return "4796416";
+        }
+
+        @Override
+        List<String> readCgroupV2CpuStats(String controlGroup) {
+            MatcherAssert.assertThat(controlGroup, equalTo("/" + hierarchy));
+            return List.of(
+                "usage_usec 364869866063",
+                "user_usec 34636",
+                "system_usec 9896",
+                "nr_periods 17992",
+                "nr_throttled 1311",
+                "throttled_usec 139298645"
+            );
+        }
+
+        @Override
+        List<String> readCgroupV2CpuLimit(String controlGroup) {
+            MatcherAssert.assertThat(controlGroup, equalTo("/" + hierarchy));
+            return cgroupCpuMax;
+        }
+    }
 }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix `OsProbe` failure when `cpu.max` file is empty (#146822)