### PR TITLE
[9.4] Add csv-spec tests for views false circular reference bug (#146664)

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/build.gradle
+++ b/x-pack/plugin/esql/qa/server/single-node/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+
 apply plugin: 'java'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
@@ -42,7 +44,30 @@ tasks.named('javaRestTest') {
   jvmArgs('--add-opens=java.base/java.nio=ALL-UNNAMED')
 }
 
+// Second rest-test variant: runs EsqlSpecIT against a cluster with xpack security enabled and
+// the REST client authenticated as a superuser. The cluster reads the tests.cluster.security.enabled
+// system property (see Clusters.java); ESRestTestCase.restClientSettings() reads the two auth
+// system properties. No test classes are modified.
+tasks.register('javaRestTestSecure', StandaloneRestIntegTestTask) {
+  usesDefaultDistribution("to be triaged")
+  maxParallelForks = 1
+  jvmArgs('--add-opens=java.base/java.nio=ALL-UNNAMED')
+  testClassesDirs = sourceSets.javaRestTest.output.classesDirs
+  classpath = sourceSets.javaRestTest.runtimeClasspath
+  filter {
+    // We can expand this task to support more test classes by removing this filter
+    includeTestsMatching 'org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT'
+  }
+  systemProperty 'tests.cluster.security.enabled', 'true'
+  systemProperty 'tests.rest.cluster.username', 'test-admin'
+  systemProperty 'tests.rest.cluster.password', 'x-pack-test-password'
+}
+
 tasks.named('yamlRestTest') {
   usesDefaultDistribution("to be triaged")
   maxParallelForks = 1
 }
+
+// Uncomment this to start automatically running this as part of CI
+// Otherwise run explicitly with: ./gradlew ":x-pack:plugin:esql:qa:server:single-node:javaRestTestSecure"
+// tasks.named('check').configure { dependsOn 'javaRestTestSecure' }

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/Clusters.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.qa.single_node;
 
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
@@ -18,6 +19,18 @@ import java.nio.file.Path;
 
 public class Clusters {
 
+    /**
+     * System property that, when set to {@code "true"}, enables xpack security on the test
+     * cluster and provisions a single superuser. The corresponding credentials must also be
+     * passed via {@code tests.rest.cluster.username} / {@code tests.rest.cluster.password} so
+     * that {@link org.elasticsearch.test.rest.ESRestTestCase#restClientSettings()} picks them
+     * up and authenticates the REST client. Defaults to {@code "false"} (security disabled).
+     */
+    public static final String SECURITY_ENABLED_PROPERTY = "tests.cluster.security.enabled";
+
+    public static final String ADMIN_USER = System.getProperty("tests.rest.cluster.username", "test-admin");
+    public static final String ADMIN_PASSWORD = System.getProperty("tests.rest.cluster.password", "x-pack-test-password");
+
     public static ElasticsearchCluster testCluster() {
         return testCluster(config -> {});
     }
@@ -27,15 +40,19 @@ public class Clusters {
     }
 
     public static ElasticsearchCluster testCluster(Path csvDataPath, LocalClusterConfigProvider configProvider) {
-        return ElasticsearchCluster.local()
+        boolean securityEnabled = Booleans.parseBoolean(System.getProperty(SECURITY_ENABLED_PROPERTY, "false"));
+        var builder = ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
-            .setting("xpack.security.enabled", "false")
+            .setting("xpack.security.enabled", Boolean.toString(securityEnabled))
             .setting("xpack.license.self_generated.type", "trial")
             .setting("path.repo", csvDataPath::toString)
             .shared(true)
             .configFile("user-agent/custom-regexes.yml", Resource.fromClasspath("custom-regexes.yml"))
             .apply(() -> configProvider)
-            .feature(FeatureFlag.EXTENDED_DOC_VALUES_PARAMS)
-            .build();
+            .feature(FeatureFlag.EXTENDED_DOC_VALUES_PARAMS);
+        if (securityEnabled) {
+            builder.user(ADMIN_USER, ADMIN_PASSWORD, "superuser", true);
+        }
+        return builder.build();
     }
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/views.csv-spec
@@ -611,3 +611,41 @@ FROM employees_extra, employees_extra
 count:long
 200
 ;
+
+wildcardExcludeEmployeeViewsNoFalseCircularReference
+required_capability: views_with_branching
+required_capability: views_crud_as_index_actions
+required_capability: views_false_circular_reference_fix
+
+// Reproduces https://github.com/elastic/elasticsearch/issues/146208
+// FROM *,-employees* should not trigger a false circular view reference error.
+FROM *,-employees*
+| STATS total = COUNT(*)
+| EVAL at_least_one = total > 0
+| KEEP at_least_one
+;
+
+at_least_one:boolean
+true
+;
+
+wildcardExcludeNestedEmployeeViewsNoFalseCircularReference
+required_capability: views_with_branching
+required_capability: views_crud_as_index_actions
+required_capability: views_false_circular_reference_fix
+
+// Reproduces https://github.com/elastic/elasticsearch/issues/146208
+// FROM *,-employees_extra,-employees_all should not trigger a false circular view reference error.
+FROM *,-employees_extra,-employees_all
+| STATS total = COUNT(*)
+| EVAL at_least_one = total > 0
+| KEEP at_least_one
+;
+warningRegex: \(in view \[employees_not_rehired\]\): evaluation of \[is_rehired == false\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex: \(in view \[employees_rehired\]\): evaluation of \[is_rehired == true\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex: \(in view \[employees_not_rehired\]\): java.lang.IllegalArgumentException: single-value function encountered multi-value
+warningRegex: \(in view \[employees_rehired\]\): java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+at_least_one:boolean
+true
+;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -380,6 +380,8 @@ public class CsvIT extends ESTestCase {
                     switch (currentGroupName) {
                         // Temporarily allow a few so they have time to migrate away
                         case "enrich", "inlinestats", "limit", "lookup-join" -> logger.warn("stop using FROM *");
+                        // Views tests need FROM * with exclusions to test wildcard view resolution (e.g. FROM *,-employees*)
+                        case "views" -> logger.info("FROM * used in views test");
                         default -> throw new IllegalStateException(
                             "FROM * is not allowed in csv-spec tests because it makes them brittle. We add new data sets frequently."
                         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1263,7 +1263,13 @@ public class EsqlCapabilities {
         /**
          * Fixed a bug where views are incorrectly de-duplicated.
          */
+
         VIEWS_DEDUPLICATION_BUGFIX,
+        /**
+         * Fixed false circular view reference errors when multiple sibling views are resolved together.
+         * See https://github.com/elastic/elasticsearch/issues/146208
+         */
+        VIEWS_FALSE_CIRCULAR_REFERENCE_FIX,
 
         /**
          * Support for the {@code leading_zeros} named parameter.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -181,6 +181,7 @@ public class ViewResolver {
                 case Fork fork -> {
                     replaceViewsFork(fork, parser, seenInner, viewQueries, depth, planListener.delegateFailureAndWrap((l, result) -> {
                         plan.forEachDown(resolvedPlans::add);
+                        result.forEachDown(resolvedPlans::add);
                         l.onResponse(result);
                     }));
                     return;
@@ -195,6 +196,9 @@ public class ViewResolver {
                         depth,
                         planListener.delegateFailureAndWrap((l, result) -> {
                             plan.forEachDown(resolvedPlans::add);
+                            // Also mark the resolved result subtree so transformDown does not
+                            // re-process view-body nodes the UR was replaced with.
+                            result.forEachDown(resolvedPlans::add);
                             l.onResponse(result);
                         })
                     );
@@ -266,6 +270,14 @@ public class ViewResolver {
         var patterns = Arrays.stream(unresolvedRelation.indexPattern().indexPattern().split(","))
             .filter(pattern -> Regex.isSimpleMatchPattern(pattern) == false || seenWildcards.contains(pattern) == false)
             .toArray(String[]::new);
+        if (patterns.length == 0) {
+            // All patterns are wildcards already resolved in this scope. Returning without a
+            // request is a no-op AND avoids the security layer's empty-indices → "_all"
+            // normalization, which would otherwise re-expand to the full cluster lookup and
+            // leak "_all" as a literal pattern into downstream merge/concat code.
+            listener.onResponse(unresolvedRelation);
+            return;
+        }
         for (String pattern : patterns) {
             if (Regex.isSimpleMatchPattern(pattern)) {
                 seenWildcards.add(pattern);
@@ -325,8 +337,14 @@ public class ViewResolver {
         String[] originalPatterns
     ) {
         List<ViewPlan> result = new ArrayList<>();
-        List<String> unresolvedPatterns = new ArrayList<>();
         HashSet<String> addedViews = new HashSet<>();
+        // Positive patterns that must remain in the unresolved UR because they contribute non-view
+        // resources or were not visible / unauthorized. We collect them here during the first pass
+        // but emit them into unresolvedPatterns in original-query order during the second pass,
+        // so exclusion patterns stay at their original positions — reordering them changes the
+        // semantics of {@link IndexAbstractionResolver}, which applies exclusions against state
+        // accumulated so far.
+        HashSet<String> patternsNeedingUnresolved = new HashSet<>();
         int unresolvedInsertPos = -1;
 
         for (var expr : response.getResolvedIndexExpressions().expressions()) {
@@ -338,7 +356,7 @@ public class ViewResolver {
                 if (unresolvedInsertPos < 0) {
                     unresolvedInsertPos = result.size();
                 }
-                unresolvedPatterns.add(expr.original());
+                patternsNeedingUnresolved.add(expr.original());
                 continue;
             }
 
@@ -372,18 +390,28 @@ public class ViewResolver {
                 if (unresolvedInsertPos < 0) {
                     unresolvedInsertPos = result.size();
                 }
-                unresolvedPatterns.add(expr.original());
+                patternsNeedingUnresolved.add(expr.original());
             }
         }
 
-        // Preserve exclusion patterns targeting non-view resources
-        if (unresolvedPatterns.isEmpty() == false) {
-            var viewNames = getMetadata().views();
-            for (String pattern : originalPatterns) {
-                if (patternIsExclusion(pattern) && isConcreteViewExclusion(pattern, viewNames::containsKey) == false) {
+        // Second pass: build unresolvedPatterns from originalPatterns in original order, keeping
+        // positive patterns flagged above and exclusions that don't target concrete views.
+        List<String> unresolvedPatterns = new ArrayList<>();
+        var viewNames = getMetadata().views();
+        for (String pattern : originalPatterns) {
+            if (patternIsExclusion(pattern)) {
+                if (isConcreteViewExclusion(pattern, viewNames::containsKey) == false) {
                     unresolvedPatterns.add(pattern);
                 }
+            } else if (patternsNeedingUnresolved.contains(pattern)) {
+                unresolvedPatterns.add(pattern);
             }
+        }
+
+        // Only emit the UR plan if it would contribute at least one positive pattern.
+        // A UR with only exclusions has no positive basis to match against and would be a
+        // semantically empty input — preserve prior behavior of omitting it in that case.
+        if (patternsNeedingUnresolved.isEmpty() == false) {
             result.add(unresolvedInsertPos, createUnresolvedRelationPlan(unresolvedRelation, unresolvedPatterns));
         }
 
@@ -786,12 +814,24 @@ public class ViewResolver {
         // Parse the view query with the view name, which causes all Source objects
         // to be tagged with the view name during parsing
         LogicalPlan subquery = parser.apply(view.query(), view.name());
-        if (subquery instanceof UnresolvedRelation ur) {
-            // Simple UnresolvedRelation subqueries are not kept as views, so we can compact them together and avoid branched plans
+        if (subquery instanceof UnresolvedRelation ur && containsExclusion(ur) == false) {
+            // Simple UnresolvedRelation subqueries are not kept as views, so we can compact them together and avoid branched plans.
+            // But exclusion patterns must stay scoped to the view body — a bare UR with an exclusion that gets merged with sibling
+            // or outer URs would have its exclusion's scope widened across the merged pattern list (see #146XXX), so those are
+            // wrapped in a NamedSubquery via the else branch to prevent merging.
             return ur;
         } else {
-            // More complex subqueries are maintained with the view name for branch identification
+            // More complex subqueries (or simple URs containing exclusions) are maintained with the view name for branch identification
             return new NamedSubquery(subquery.source(), subquery, view.name());
         }
+    }
+
+    private static boolean containsExclusion(UnresolvedRelation ur) {
+        for (String pattern : ur.indexPattern().indexPattern().split(",")) {
+            if (patternIsExclusion(pattern)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -163,7 +163,9 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         addIndex("logs-public");
         addIndex("logs-secret");
         LogicalPlan plan = query("FROM safe-logs,logs-secret");
-        assertThat(replaceViews(plan), matchesPlan(query("FROM logs*,-logs-secret,logs-secret")));
+        // The view body's -logs-secret exclusion stays scoped to the view — it must not widen
+        // onto the sibling outer pattern "logs-secret", which explicitly asks to include it.
+        assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM logs*,-logs-secret),(FROM logs-secret)")));
     }
 
     public void testExclusionWithNoRemainingIndexMatch() {
@@ -178,6 +180,50 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         addIndex("logs3");
         LogicalPlan plan = query("FROM logs*,-logs3");
         assertThat(replaceViews(plan), matchesPlan(query("FROM logs2,logs*,-logs3")));
+    }
+
+    /**
+     * Exclusion patterns must be preserved at their original position in the unresolved-pattern
+     * list, not appended after positive patterns. Pattern order matters because
+     * {@code IndexAbstractionResolver} processes exclusions against prior accumulated state —
+     * reordering {@code -*-view-*} from before {@code data-view-*} to after it changes the
+     * semantics (the exclusion would now strip {@code data-view-*} matches from the result).
+     * <p>
+     * {@code match-nothing-*} is dropped here because its expansion is empty+SUCCESS in the
+     * null-fallback path. In the security-enabled path it would be NOT_VISIBLE and preserved,
+     * but the exclusion-order bug exists on either path.
+     */
+    public void testExclusionPreservesOriginalOrder() {
+        addIndex("data-index-origin");
+        addIndex("data-view-extra");
+        addView("data-view-origin", "FROM data-index-origin");
+        LogicalPlan plan = query("FROM match-nothing-*,-*-view-*,data-view-*");
+        assertThat(replaceViews(plan), matchesPlan(query("FROM data-index-origin,-*-view-*,data-view-*")));
+    }
+
+    /**
+     * A view body's exclusion must stay scoped to its own body. When the body is a simple
+     * {@link UnresolvedRelation} containing an exclusion, it must not be merged with sibling or
+     * outer URs, because the merge concatenates patterns into one UR and widens the scope of
+     * the exclusion to everything in the combined pattern list.
+     * <p>
+     * Real-world failure (ServerlessCrossProjectEsqlIT):
+     * <pre>
+     *   indices: index-a1, index-a2, index-b1, index-b2
+     *   view data-view = FROM index-b*,-*2        (scopes to index-b*, excludes index-b2)
+     *   query: FROM index-a*,data-view            (expects index-a1, index-a2, index-b1)
+     * </pre>
+     * Before the fix the resolver merged into {@code UR(index-a*,index-b*,-*2)} so the view
+     * body's {@code -*2} excluded {@code index-a2} as well, producing only {@code a1, b1}.
+     */
+    public void testViewBodyExclusionNotLeakedToOuter() {
+        addIndex("index-a1");
+        addIndex("index-a2");
+        addIndex("index-b1");
+        addIndex("index-b2");
+        addView("data-view", "FROM index-b*,-*2");
+        LogicalPlan plan = query("FROM index-a*,data-view");
+        assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM index-a*),(FROM index-b*,-*2)")));
     }
 
     public void testExclusionMultipleViews() {
@@ -755,6 +801,84 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
             () -> replaceViews(query("FROM view_a | FORK (WHERE emp.age > 30) (WHERE emp.age < 50)"))
         );
         assertThat(e.getMessage(), containsString("circular view reference 'view_a'"));
+    }
+
+    /**
+     * Reproduces https://github.com/elastic/elasticsearch/issues/146665
+     * FORK queries that reference no views should succeed even when circular views exist on the cluster.
+     */
+    public void testForkWithCircularViewsOnClusterButNotReferenced() {
+        assumeTrue("Requires FORK support", EsqlCapabilities.Cap.FORK_V9.isEnabled());
+        addView("view_x", "FROM view_y");
+        addView("view_y", "FROM view_x");
+        addIndex("logs-001");
+        // FORK query with wildcard that matches only the index, not the circular views
+        LogicalPlan plan = query("FROM logs-* | FORK (STATS c = COUNT(*)) (LIMIT 5)");
+        LogicalPlan result = replaceViews(plan);
+        assertNotNull("FORK query should resolve without circular view errors", result);
+        assertThat("Plan did not change, no views matched", result, matchesPlan(plan));
+    }
+
+    /**
+     * Reproduces https://github.com/elastic/elasticsearch/issues/146665
+     * FORK query with FROM * but excluding the circular views should succeed.
+     */
+    public void testForkWithStarWildcardExcludingCircularViews() {
+        assumeTrue("Requires FORK support", EsqlCapabilities.Cap.FORK_V9.isEnabled());
+        addView("view_x", "FROM view_y");
+        addView("view_y", "FROM view_x");
+        addIndex("logs");
+        // FROM *,-view_* excludes the circular views — should succeed
+        LogicalPlan plan = query("FROM *,-view_* | FORK (STATS c = COUNT(*)) (LIMIT 5)");
+        LogicalPlan result = replaceViews(plan);
+        assertNotNull("FORK query excluding circular views should resolve without errors", result);
+        assertThat("Plan did not change, no views matched", result, matchesPlan(plan));
+    }
+
+    /**
+     * Reproduces <a href="https://github.com/elastic/elasticsearch/issues/146208">#146208</a>.
+     * FROM *,-employees* against a cluster populated with the csv-spec views (several simple
+     * views whose bodies share underlying wildcard patterns, plus employee views that are
+     * excluded by the outer pattern) should not trigger a false circular view reference.
+     * <p>
+     * This mirrors the manual-server reproduction: the bug only fires when a recursive
+     * re-visit of an already-resolved UnresolvedRelation issues a view-resolve request with
+     * empty indices, which the security layer expands to "_all". The fix short-circuits that
+     * re-entry in {@link ViewResolver#replaceViewsUnresolvedRelation} when all patterns have
+     * already been consumed by seenWildcards.
+     */
+    public void testFromStarExcludingEmployeesWithCsvSpecViews_Issue146208() {
+        assumeTrue("Requires views with branching support", EsqlCapabilities.Cap.VIEWS_WITH_BRANCHING.isEnabled());
+        // Indices referenced by the csv-spec view bodies (plus "logs" from default setup)
+        addIndex("addresses");
+        addIndex("airports");
+        addIndex("airports_mp");
+        addIndex("languages_lookup_non_unique_key");
+        addIndex("employees");
+
+        // Non-employee views from views.csv-spec — none reference each other, but their bodies
+        // share underlying index patterns (airports, addresses) that the outer FROM * expands to.
+        addView("country_addresses", "FROM addresses | STATS count=COUNT() BY country");
+        addView("country_languages", "FROM languages_lookup_non_unique_key | STATS count=COUNT() BY country");
+        addView("airports_mp_filtered", "FROM airports | LOOKUP JOIN airports_mp ON abbrev == abbrev");
+        addView("country_airports", "FROM airports | STATS count=COUNT() BY country");
+
+        // Employee views — all excluded by the outer -employees* pattern
+        addView("employees_all", "FROM employees");
+        addView("employees_extra", "FROM employees, employees_all");
+        addView("employees_rehired", "FROM employees | WHERE is_rehired == true");
+        addView("employees_not_rehired", "FROM employees | WHERE is_rehired == false");
+
+        // Must not throw a circular view reference error.
+        LogicalPlan result = replaceViews(query("FROM *,-employees* | LIMIT 1"));
+        assertNotNull("FROM *,-employees* should resolve without false circular reference errors", result);
+        assertThat("Should match four views and one index pattern", result, matchesPlan(query("""
+            FROM *,-employees*,
+            (FROM addresses | STATS count=COUNT() BY country),
+            (FROM languages_lookup_non_unique_key | STATS count=COUNT() BY country),
+            (FROM airports | LOOKUP JOIN airports_mp ON abbrev == abbrev),
+            (FROM airports | STATS count=COUNT() BY country)
+            | LIMIT 1""")));
     }
 
     public void testCircularViewExcludedByWildcard() {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Add csv-spec tests for views false circular reference bug (#146664)