### PR TITLE
Replace TSDB VersionConfig with static final constants

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesConsumer.java
@@ -133,11 +133,23 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
         try {
             final String dataName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, dataExtension);
             data = state.directory.createOutput(dataName, state.context);
-            CodecUtil.writeIndexHeader(data, dataCodec, formatConfig.versionCurrent(), state.segmentInfo.getId(), state.segmentSuffix);
+            CodecUtil.writeIndexHeader(
+                data,
+                dataCodec,
+                TSDBDocValuesFormatConfig.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
 
             final String metaName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, metaExtension);
             meta = state.directory.createOutput(metaName, state.context);
-            CodecUtil.writeIndexHeader(meta, metaCodec, formatConfig.versionCurrent(), state.segmentInfo.getId(), state.segmentSuffix);
+            CodecUtil.writeIndexHeader(
+                meta,
+                metaCodec,
+                TSDBDocValuesFormatConfig.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
             meta.writeByte((byte) formatConfig.numericBlockShift());
 
             maxDoc = state.segmentInfo.maxDoc();
@@ -474,7 +486,7 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
                 data,
                 blockAddressesStart,
                 metaCodecName,
-                formatConfig.versionCurrent(),
+                TSDBDocValuesFormatConfig.VERSION_CURRENT,
                 formatConfig.directMonotonicBlockShift()
             );
         }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -117,12 +117,12 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
                 version = CodecUtil.checkIndexHeader(
                     in,
                     metaCodec,
-                    formatConfig.versionStart(),
-                    formatConfig.versionCurrent(),
+                    TSDBDocValuesFormatConfig.VERSION_START,
+                    TSDBDocValuesFormatConfig.VERSION_CURRENT,
                     state.segmentInfo.getId(),
                     state.segmentSuffix
                 );
-                if (version >= formatConfig.versionLargeBlocks()) {
+                if (version >= TSDBDocValuesFormatConfig.VERSION_NUMERIC_LARGE_BLOCKS) {
                     blockShift = in.readByte();
                 }
                 readFields(in, state.fieldInfos, version, blockShift);
@@ -144,8 +144,8 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
             final int version2 = CodecUtil.checkIndexHeader(
                 data,
                 dataCodec,
-                formatConfig.versionStart(),
-                formatConfig.versionCurrent(),
+                TSDBDocValuesFormatConfig.VERSION_START,
+                TSDBDocValuesFormatConfig.VERSION_CURRENT,
                 state.segmentInfo.getId(),
                 state.segmentSuffix
             );
@@ -1983,7 +1983,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
 
     private BinaryEntry readBinary(IndexInput meta, int version) throws IOException {
         final BinaryDVCompressionMode compression;
-        if (version >= formatConfig.versionBinaryCompression()) {
+        if (version >= TSDBDocValuesFormatConfig.VERSION_BINARY_DV_COMPRESSION) {
             compression = BinaryDVCompressionMode.fromMode(meta.readByte());
         } else {
             compression = BinaryDVCompressionMode.NO_COMPRESS;
@@ -2051,7 +2051,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         SortedEntry entry = new SortedEntry();
         entry.ordsEntry = new NumericEntry();
         entry.termsDictEntry = new TermsDictEntry();
-        if (version >= formatConfig.versionPrefixPartitions()) {
+        if (version >= TSDBDocValuesFormatConfig.VERSION_PREFIX_PARTITIONS) {
             readTermDict(meta, entry.termsDictEntry, termsDictBlockLz4Shift);
             readNumeric(meta, entry.ordsEntry, numericBlockShift);
             if (primarySorted && meta.readByte() == 1) {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBDocValuesFormatConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBDocValuesFormatConfig.java
@@ -22,7 +22,7 @@ package org.elasticsearch.index.codec.tsdb;
  * @param writePrefixPartitions      whether to write prefix-based partition metadata for the primary sort field
  */
 public record TSDBDocValuesFormatConfig(
-    VersionConfig version,
+    int version,
     TermsDictConfig termsDict,
     SkipIndexConfig skipIndex,
     NumericConfig numeric,
@@ -30,32 +30,6 @@ public record TSDBDocValuesFormatConfig(
     int directMonotonicBlockShift,
     boolean writePrefixPartitions
 ) {
-
-    /** @return minimum format version for header validation */
-    public int versionStart() {
-        return version.start();
-    }
-
-    /** @return format version to write in file headers */
-    public int versionCurrent() {
-        return version.current();
-    }
-
-    /** @return version at which large numeric blocks were introduced */
-    public int versionLargeBlocks() {
-        return version.largeBlocks();
-    }
-
-    /** @return version at which binary DV compression was introduced */
-    public int versionBinaryCompression() {
-        return version.binaryCompression();
-    }
-
-    /** @return version at which prefix partitions were introduced */
-    public int versionPrefixPartitions() {
-        return version.prefixPartitions();
-    }
-
     /** @return terms dict block mask */
     public int termsBlockLz4Mask() {
         return termsDict.blockLz4Mask();
@@ -127,15 +101,6 @@ public record TSDBDocValuesFormatConfig(
     }
 
     /**
-     * @param start              minimum format version for header validation
-     * @param current            format version to write in file headers
-     * @param largeBlocks        version at which large numeric blocks were introduced
-     * @param binaryCompression  version at which binary DV compression was introduced
-     * @param prefixPartitions   version at which prefix partitions were introduced
-     */
-    public record VersionConfig(int start, int current, int largeBlocks, int binaryCompression, int prefixPartitions) {}
-
-    /**
      * @param blockLz4Mask      terms dict block mask
      * @param blockLz4Shift     terms dict block shift
      * @param reverseIndexShift terms dict reverse index shift
@@ -169,4 +134,10 @@ public record TSDBDocValuesFormatConfig(
         boolean enablePerBlockCompression,
         BinaryDVCompressionMode compressionMode
     ) {}
+
+    public static final int VERSION_START = 0;
+    public static final int VERSION_BINARY_DV_COMPRESSION = 1;
+    public static final int VERSION_NUMERIC_LARGE_BLOCKS = 2;
+    public static final int VERSION_PREFIX_PARTITIONS = 4;
+    public static final int VERSION_CURRENT = VERSION_PREFIX_PARTITIONS;
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormat.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.codec.tsdb.SortedFieldObserver;
 import org.elasticsearch.index.codec.tsdb.SortedFieldObserverFactory;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig.TermsDictConfig;
-import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig.VersionConfig;
 
 import java.io.IOException;
 
@@ -53,11 +52,6 @@ public class ES819TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValues
     static final String DATA_EXTENSION = "dvd";
     static final String META_CODEC = "ES819TSDBDocValuesMetadata";
     static final String META_EXTENSION = "dvm";
-    static final int VERSION_START = 0;
-    static final int VERSION_BINARY_DV_COMPRESSION = 1;
-    static final int VERSION_NUMERIC_LARGE_BLOCKS = 2;
-    static final int VERSION_PREFIX_PARTITIONS = 4;
-    static final int VERSION_CURRENT = VERSION_PREFIX_PARTITIONS;
 
     static final int TERMS_DICT_BLOCK_LZ4_SHIFT = 6;
     static final int TERMS_DICT_BLOCK_LZ4_SIZE = 1 << TERMS_DICT_BLOCK_LZ4_SHIFT;
@@ -118,14 +112,6 @@ public class ES819TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValues
      * The block shift used in DirectMonotonicWriter when encoding the start docs of each ordinal with ordinal range encoding.
      */
     static final int ORDINAL_RANGE_ENCODING_BLOCK_SHIFT = 12;
-
-    static final VersionConfig VERSION_CONFIG = new VersionConfig(
-        VERSION_START,
-        VERSION_CURRENT,
-        VERSION_NUMERIC_LARGE_BLOCKS,
-        VERSION_BINARY_DV_COMPRESSION,
-        VERSION_PREFIX_PARTITIONS
-    );
 
     static final TermsDictConfig TERMS_DICT_CONFIG = new TermsDictConfig(
         TERMS_DICT_BLOCK_LZ4_MASK,
@@ -289,7 +275,7 @@ public class ES819TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValues
         this.enableOptimizedMerge = enableOptimizedMerge;
         this.docOffsetsCodec = docOffsetsCodec;
         this.formatConfig = new TSDBDocValuesFormatConfig(
-            VERSION_CONFIG,
+            TSDBDocValuesFormatConfig.VERSION_CURRENT,
             TERMS_DICT_CONFIG,
             new TSDBDocValuesFormatConfig.SkipIndexConfig(SKIP_INDEX_LEVEL_SHIFT, SKIP_INDEX_MAX_LEVEL, skipIndexIntervalSize),
             new TSDBDocValuesFormatConfig.NumericConfig(

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesConsumerVersion0.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesConsumerVersion0.java
@@ -47,6 +47,7 @@ import org.elasticsearch.index.codec.tsdb.DISIAccumulator;
 import org.elasticsearch.index.codec.tsdb.DocValuesConsumerUtil.MergeStats;
 import org.elasticsearch.index.codec.tsdb.OffsetsAccumulator;
 import org.elasticsearch.index.codec.tsdb.TSDBDocValuesEncoder;
+import org.elasticsearch.index.codec.tsdb.TSDBDocValuesFormatConfig;
 import org.elasticsearch.index.codec.tsdb.TsdbDocValuesProducer;
 import org.elasticsearch.index.codec.tsdb.XDocValuesConsumer;
 
@@ -101,7 +102,7 @@ final class ES819TSDBDocValuesConsumerVersion0 extends XDocValuesConsumer {
             CodecUtil.writeIndexHeader(
                 data,
                 dataCodec,
-                ES819TSDBDocValuesFormat.VERSION_START, // Test with version 0 rather than current
+                TSDBDocValuesFormatConfig.VERSION_START, // Test with version 0 rather than current
                 state.segmentInfo.getId(),
                 state.segmentSuffix
             );
@@ -110,7 +111,7 @@ final class ES819TSDBDocValuesConsumerVersion0 extends XDocValuesConsumer {
             CodecUtil.writeIndexHeader(
                 meta,
                 metaCodec,
-                ES819TSDBDocValuesFormat.VERSION_START, // Test with version 0 rather than current
+                TSDBDocValuesFormatConfig.VERSION_START, // Test with version 0 rather than current
                 state.segmentInfo.getId(),
                 state.segmentSuffix
             );


### PR DESCRIPTION
VersionConfig only ever had a single instance, and all its methods returned constant values. Adding more versions would mean telescoping the constructor each time.  We replace this with some simple static final constants which can be added in the usual manner.