### PR TITLE
[9.4] ESQL: Assert partial output agg on PushCount...ToSource rule (#146942)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushCountQueryAndTagsToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushCountQueryAndTagsToSource.java
@@ -86,6 +86,9 @@ public class PushCountQueryAndTagsToSource extends PhysicalOptimizerRules.Optimi
             if (withFilter.isEmpty() || withFilter.stream().allMatch(PushCountQueryAndTagsToSource::shouldPush) == false) {
                 return aggregateExec;
             }
+            // Next lines expect the agg to have a partial-output layout.
+            // This rule is currently used in the LocalPhysicalPlanOptimizer, so it's a safe assumption now.
+            assert aggregateExec.getMode().isOutputPartial() : "expected partial-output agg, got " + aggregateExec.getMode();
             List<Attribute> statsOutput;
             if (count instanceof CountApproximate ca) {
                 statsOutput = AbstractPhysicalOperationProviders.intermediateAttributes(


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ESQL: Assert partial output agg on PushCount...ToSource rule (#146942)