### PR TITLE
[9.4] Add link to "advanced workflows" from query approximation setting (#146365)

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/settings/approximation.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/settings/approximation.md
@@ -5,7 +5,7 @@
 serverless: preview
 stack: preview 9.4.0
 ```
-Enables query approximation if possible for the query. A boolean value `false` (default) disables query approximation and `true` enables it with default settings. Map values enable query approximation with custom settings.
+Enables [query approximation](/reference/query-languages/esql/esql-query-approximation.md) if possible for the query. A boolean value `false` (default) disables query approximation and `true` enables it with default settings. Map values enable query approximation with custom settings.
 
 **Type**: `boolean` `map_param`
 

--- a/docs/reference/query-languages/esql/kibana/definition/settings/approximation.json
+++ b/docs/reference/query-languages/esql/kibana/definition/settings/approximation.json
@@ -9,5 +9,5 @@
   "serverlessOnly" : false,
   "preview" : true,
   "snapshotOnly" : false,
-  "description" : "Enables query approximation if possible for the query. A boolean value `false` (default) disables query approximation and `true` enables it with default settings. Map values enable query approximation with custom settings."
+  "description" : "Enables [query approximation](https://www.elastic.co/docs/reference/query-languages/esql/esql-query-approximation) if possible for the query. A boolean value `false` (default) disables query approximation and `true` enables it with default settings. Map values enable query approximation with custom settings."
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
@@ -108,9 +108,8 @@ public class QuerySettings {
         name = "approximation",
         type = { "boolean", "map_param" },
         since = "9.4.0",
-        // TODO: make "query approximation" a link to an "Advanced workflows" page when that's ready.
-        description = "Enables query approximation if possible for the query. "
-            + "A boolean value `false` (default) disables query approximation and `true` enables it with "
+        description = "Enables [query approximation](/reference/query-languages/esql/esql-query-approximation.md) if possible for the "
+            + "query. A boolean value `false` (default) disables query approximation and `true` enables it with "
             + "default settings. Map values enable query approximation with custom settings."
     )
     @MapParam(


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Add link to "advanced workflows" from query approximation setting (#146365)