### PR TITLE
[9.4] License check for Query Approximation (#147097)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -67,7 +67,6 @@ import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.analytics.mapper.EncodedTDigest;
-import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerSettings;
@@ -134,7 +133,6 @@ import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.Configuration;
-import org.elasticsearch.xpack.esql.session.EsqlSession;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 import org.elasticsearch.xpack.esql.telemetry.Metrics;
 import org.elasticsearch.xpack.versionfield.Version;
@@ -710,7 +708,7 @@ public final class EsqlTestUtils {
             AnalyzerSettings.QUERY_TIMESERIES_RESULT_TRUNCATION_MAX_SIZE.getDefault(Settings.EMPTY),
             AnalyzerSettings.QUERY_TIMESERIES_RESULT_TRUNCATION_DEFAULT_SIZE.getDefault(Settings.EMPTY),
             null,
-            EsqlSession.approximationSettings(new EsqlQueryRequest(), statement),
+            statement.setting(QuerySettings.APPROXIMATION),
             Map.of()
         );
     }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionBreakerIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionBreakerIT.java
@@ -86,7 +86,7 @@ public class EsqlActionBreakerIT extends EsqlActionIT {
             .build();
     }
 
-    public static class EsqlTestPluginWithMockBlockFactory extends EsqlPlugin {
+    public static class EsqlTestPluginWithMockBlockFactory extends EsqlPluginWithEnterpriseOrTrialLicense {
         @Override
         protected BlockFactoryProvider blockFactoryProvider(BlockFactoryBuilder builder) {
             return new BlockFactoryProvider(new MockBlockFactory(builder));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlLicenseChecker.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlLicenseChecker.java
@@ -15,9 +15,15 @@ import org.elasticsearch.rest.RestStatus;
 
 public class EsqlLicenseChecker {
 
-    public static final LicensedFeature.Momentary CCS_FEATURE = LicensedFeature.momentary(
+    private static final LicensedFeature.Momentary CCS_FEATURE = LicensedFeature.momentary(
         null,
         "esql-ccs",
+        License.OperationMode.ENTERPRISE
+    );
+
+    private static final LicensedFeature.Momentary QUERY_APPROXIMATION_FEATURE = LicensedFeature.momentary(
+        null,
+        "esql-approximation",
         License.OperationMode.ENTERPRISE
     );
 
@@ -40,12 +46,23 @@ public class EsqlLicenseChecker {
      * to run ES|QL cross-cluster searches and what license (if any) was found.
      */
     public static ElasticsearchStatusException invalidLicenseForCcsException(XPackLicenseState licenseState) {
-        String message = "A valid Enterprise license is required to run ES|QL cross-cluster searches. License found: ";
-        if (licenseState == null) {
-            message += "none";
-        } else {
-            message += licenseState.statusDescription();
+        return getException("A valid Enterprise license is required to run ES|QL cross-cluster searches.", licenseState);
+    }
+
+    /**
+     * @param licenseState existing license state. Need to extract info on the current installed license.
+     * @throws ElasticsearchStatusException if query approximation is not supported.
+     */
+    public static void checkQueryApproximation(XPackLicenseState licenseState) throws ElasticsearchStatusException {
+        if (licenseState == null || QUERY_APPROXIMATION_FEATURE.check(licenseState) == false) {
+            throw getException("A valid Enterprise license is required to use ES|QL query approximation.", licenseState);
         }
-        return new ElasticsearchStatusException(message, RestStatus.BAD_REQUEST);
+    }
+
+    private static ElasticsearchStatusException getException(String message, XPackLicenseState licenseState) {
+        return new ElasticsearchStatusException(
+            message + " License found: " + (licenseState == null ? "none" : licenseState.statusDescription()),
+            RestStatus.BAD_REQUEST
+        );
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -395,11 +395,15 @@ public class EsqlSession {
         return projectRouting;
     }
 
-    public static ApproximationSettings approximationSettings(EsqlQueryRequest request, EsqlStatement statement) {
+    private ApproximationSettings approximationSettings(EsqlQueryRequest request, EsqlStatement statement) {
         // The precedence for settings is: SET in the statement > request parameter > default (=disabled).
-        return new ApproximationSettings.Builder(false).merge(request.approximation())
+        ApproximationSettings settings = new ApproximationSettings.Builder(false).merge(request.approximation())
             .merge(statement.setting(QuerySettings.APPROXIMATION))
             .build();
+        if (settings != null) {
+            EsqlLicenseChecker.checkQueryApproximation(verifier.licenseState());
+        }
+        return settings;
     }
 
     /**

--- a/x-pack/qa/multi-cluster-search-security/src/yamlRestTest/resources/rest-api-spec/test/basic_license/querying_cluster/80_esql.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/yamlRestTest/resources/rest-api-spec/test/basic_license/querying_cluster/80_esql.yml
@@ -174,3 +174,35 @@ teardown:
   - do:
       enrich.delete_policy:
         name: suggestions
+
+
+---
+"ES|QL query approximation fails with basic license":
+  - requires:
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [approximation_v7]
+      reason: "needs query approximation"
+
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          query: 'SET approximation=true; FROM * | STATS count=COUNT()'
+
+  - match: { error.type: "status_exception" }
+  - match: { error.reason: "A valid Enterprise license is required to use ES|QL query approximation. License found: active basic license" }
+
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          query: 'FROM * | STATS count=COUNT()'
+          approximation:
+            rows: 1234567
+
+  - match: { error.type: "status_exception" }
+  - match: { error.reason: "A valid Enterprise license is required to use ES|QL query approximation. License found: active basic license" }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - License check for Query Approximation (#147097)