### PR TITLE
Fix flaky IndexRecoveryIT.testSourceThrottling test: ensure the nodeB will not be throttled

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -88,9 +88,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:ints.convertStringToBaseIndexGroup7}
   issue: https://github.com/elastic/elasticsearch/issues/141375
-- class: org.elasticsearch.indices.recovery.IndexRecoveryIT
-  method: testSourceThrottling
-  issue: https://github.com/elastic/elasticsearch/issues/141548
 - class: org.elasticsearch.search.aggregations.metrics.TopHitsIT
   method: testMixedSortFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/142077

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -740,8 +740,11 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             .getStore()
             .size();
 
-        logger.info("--> starting node B with default settings");
-        final String nodeB = internalCluster().startNode();
+        logger.info("--> starting node B");
+        final String nodeB = internalCluster().startNode(
+            // Ensure that the target node has a high enough recovery max bytes per second to avoid any throttling
+            Settings.builder().put(RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "200mb")
+        );
 
         long chunkSize = Math.max(1, shardSize.getBytes() / 10);
         logger.info(


### PR DESCRIPTION
I think this was the intention of fixing this problem here: https://github.com/elastic/elasticsearch/commit/b8b7101d15bed0521c31e9d0a2e8dffa26fc53ca

Based on my understanding, and a look at other tests in the same class, we should make the other node (not under test) robust, so that it doesn't throttle. We do the same in a `testTargetThrottling` with nodeA, when we test nodeB throttling.

Closes: #141548 
