### PR TITLE
Move the Indexing pressure settings doc in the ToC

### DIFF
--- a/docs/redirects.yml
+++ b/docs/redirects.yml
@@ -8,6 +8,9 @@ redirects:
   # Path settings moved from index settings to configuration reference (node path.data / path.logs)
   'reference/elasticsearch/index-settings/path.md': 'reference/elasticsearch/configuration-reference/path.md'
 
+  # Indexing pressure documents node setting indexing_pressure.memory.limit, not index-level settings
+  'reference/elasticsearch/index-settings/pressure.md': 'reference/elasticsearch/configuration-reference/indexing-pressure-settings.md'
+
   # Related to https://github.com/elastic/elasticsearch/pull/130716/
   'reference/query-languages/eql/eql-ex-threat-detection.md': 'docs-content://explore-analyze/query-filter/languages/example-detect-threats-with-eql.md'
 

--- a/docs/reference/elasticsearch/configuration-reference/index.md
+++ b/docs/reference/elasticsearch/configuration-reference/index.md
@@ -35,6 +35,7 @@ The settings are grouped by feature or purpose, for example:
 - [Index management](/reference/elasticsearch/configuration-reference/index-management-settings.md)
 - [Index recovery](/reference/elasticsearch/configuration-reference/index-recovery-settings.md)
 - [Index buffer](/reference/elasticsearch/configuration-reference/indexing-buffer-settings.md)
+- [Indexing pressure](/reference/elasticsearch/configuration-reference/indexing-pressure-settings.md)
 - [Inference](/reference/elasticsearch/configuration-reference/inference-settings.md)
 - [License](/reference/elasticsearch/configuration-reference/license-settings.md)
 - [Local gateway](/reference/elasticsearch/configuration-reference/local-gateway.md)

--- a/docs/reference/elasticsearch/configuration-reference/indexing-pressure-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/indexing-pressure-settings.md
@@ -12,7 +12,7 @@ Indexing documents into {{es}} introduces system load in the form of memory and 
 
 Indexing pressure can build up through external operations, such as indexing requests, or internal mechanisms, such as recoveries and {{ccr}}. If too much indexing work is introduced into the system, the cluster can become saturated. This can adversely impact other operations, such as search, cluster coordination, and background processing.
 
-To prevent these issues, {{es}} internally monitors indexing load. When the load exceeds certain limits, new indexing work is rejected
+To prevent these issues, {{es}} internally monitors indexing load. When the load exceeds certain limits, new indexing work is rejected.
 
 
 ## Indexing stages [indexing-stages]

--- a/docs/reference/elasticsearch/index-settings/index.md
+++ b/docs/reference/elasticsearch/index-settings/index.md
@@ -47,7 +47,5 @@ Settings are available for the following modules:
   Configure the backing indices in a time series data stream (TSDS).
 * [Translog](translog.md)
   Control the transaction log and background flush operations.
-* [Indexing pressure](pressure.md)
-  Configure indexing back pressure limits.
 
 There are also index settings associated with [text analysis](docs-content://manage-data/data-store/text-analysis.md), which define analyzers, tokenizers, token filters, and character filters.

--- a/docs/reference/elasticsearch/toc.yml
+++ b/docs/reference/elasticsearch/toc.yml
@@ -16,6 +16,7 @@ toc:
       - file: configuration-reference/index-management-settings.md
       - file: configuration-reference/index-recovery-settings.md
       - file: configuration-reference/indexing-buffer-settings.md
+      - file: configuration-reference/indexing-pressure-settings.md
       - file: configuration-reference/license-settings.md
       - file: configuration-reference/local-gateway.md
       - file: configuration-reference/machine-learning-settings.md
@@ -67,7 +68,6 @@ toc:
         - file: index-settings/time-series.md
         - file: index-settings/source.md
         - file: index-settings/translog.md
-        - file: index-settings/pressure.md
   - file: index-lifecycle-actions/index.md
     children:
         - file: index-lifecycle-actions/ilm-allocate.md


### PR DESCRIPTION
Fixes [#1798](https://github.com/elastic/docs-content/issues/1798) And moves the [Indexing pressure](https://www.elastic.co/docs/reference/elasticsearch/index-settings/pressure) page from the Index settings section, as it does not describe any index-level settings.

It's been moved to the configuration reference section instead.