### PR TITLE
Fix DateRangeDocValuesReader to appendNull for empty positions

### DIFF
--- a/docs/changelog/147153.yaml
+++ b/docs/changelog/147153.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 146380
+pr: 147153
+summary: Fix `DateRangeDocValuesReader` to `appendNull` for empty positions
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DateRangeDocValuesLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DateRangeDocValuesLoader.java
@@ -75,15 +75,19 @@ public class DateRangeDocValuesLoader extends BlockDocValuesReader.DocValuesBloc
                     } else {
                         BytesRef ref = docValues.docValues().binaryValue();
                         var ranges = BinaryRangeUtil.decodeLongRanges(ref);
-                        for (var range : ranges) {
-                            lastDoc = doc;
-                            this.docId = doc;
-                            // While the index stores ranges with fully-inclusive bounds [from, to], in ESQL we always
-                            // represent and use date ranges as half-open [from, to), so we add 1 to the upper bound here.
-                            long from = (long) range.getFrom();
-                            long toIndex = (long) range.getTo();
-                            builder.from().appendLong(from);
-                            builder.to().appendLong(toIndex + 1);
+                        if (ranges.isEmpty()) {
+                            builder.appendNull();
+                        } else {
+                            for (var range : ranges) {
+                                lastDoc = doc;
+                                this.docId = doc;
+                                // While the index stores ranges with fully-inclusive bounds [from, to], in ESQL we always
+                                // represent and use date ranges as half-open [from, to), so we add 1 to the upper bound here.
+                                long from = (long) range.getFrom();
+                                long toIndex = (long) range.getTo();
+                                builder.from().appendLong(from);
+                                builder.to().appendLong(toIndex + 1);
+                            }
                         }
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DateRangeDocValuesLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/DateRangeDocValuesLoader.java
@@ -70,6 +70,8 @@ public class DateRangeDocValuesLoader extends BlockDocValuesReader.DocValuesBloc
                     if (doc < lastDoc) {
                         throw new IllegalStateException("docs within same block must be in order");
                     }
+                    lastDoc = doc;
+                    this.docId = doc;
                     if (false == docValues.docValues().advanceExact(doc)) {
                         builder.appendNull();
                     } else {
@@ -77,17 +79,21 @@ public class DateRangeDocValuesLoader extends BlockDocValuesReader.DocValuesBloc
                         var ranges = BinaryRangeUtil.decodeLongRanges(ref);
                         if (ranges.isEmpty()) {
                             builder.appendNull();
+                        } else if (ranges.size() == 1) {
+                            var range = ranges.get(0);
+                            // While the index stores ranges with fully-inclusive bounds [from, to], in ESQL we always
+                            // represent and use date ranges as half-open [from, to), so we add 1 to the upper bound here.
+                            builder.from().appendLong((long) range.getFrom());
+                            builder.to().appendLong((long) range.getTo() + 1);
                         } else {
+                            builder.from().beginPositionEntry();
+                            builder.to().beginPositionEntry();
                             for (var range : ranges) {
-                                lastDoc = doc;
-                                this.docId = doc;
-                                // While the index stores ranges with fully-inclusive bounds [from, to], in ESQL we always
-                                // represent and use date ranges as half-open [from, to), so we add 1 to the upper bound here.
-                                long from = (long) range.getFrom();
-                                long toIndex = (long) range.getTo();
-                                builder.from().appendLong(from);
-                                builder.to().appendLong(toIndex + 1);
+                                builder.from().appendLong((long) range.getFrom());
+                                builder.to().appendLong((long) range.getTo() + 1);
                             }
+                            builder.from().endPositionEntry();
+                            builder.to().endPositionEntry();
                         }
                     }
                 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateRangeDocValuesLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateRangeDocValuesLoaderTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.mapper.blockloader.docvalues.DateRangeDocValuesLoader;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class DateRangeDocValuesLoaderTests extends ESTestCase {
+
+    private static final String FIELD_NAME = "test_date_range";
+
+    /**
+     * Verifies that a document whose binary doc value encodes zero ranges produces a null entry in the
+     * loaded block rather than silently skipping the position, which would cause the block to have
+     * fewer positions than expected and trigger a sanity-check failure in ValuesSourceReaderOperator.
+     */
+    public void testEmptyRangesAppendsNull() throws IOException {
+        // Encode a single valid inclusive range [1000, 2000].
+        var oneRange = BinaryRangeUtil.encodeLongRanges(Set.of(new RangeFieldMapper.Range(RangeType.DATE, 1000L, 2000L, true, true)));
+        // Encode zero ranges — this is the edge case that triggered the bug.
+        var emptyRanges = BinaryRangeUtil.encodeLongRanges(Set.of());
+
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            // Doc 0: one valid range.
+            iw.addDocument(List.of(new BinaryDocValuesField(FIELD_NAME, oneRange)));
+            // Doc 1: binary doc value present but encodes zero ranges — the bug case.
+            iw.addDocument(List.of(new BinaryDocValuesField(FIELD_NAME, emptyRanges)));
+            // Doc 2: no binary doc value at all — the normal null case.
+            iw.addDocument(List.of());
+            iw.forceMerge(1);
+
+            try (DirectoryReader dr = iw.getReader()) {
+                LeafReaderContext ctx = getOnlyLeafReader(dr).getContext();
+                var loader = new DateRangeDocValuesLoader(FIELD_NAME);
+                try (var reader = loader.columnAtATimeReader(ctx).apply(newLimitedBreaker(ByteSizeValue.ofMb(1)))) {
+                    var block = (TestBlock) reader.read(TestBlock.factory(), TestBlock.docs(0, 1, 2), 0, false);
+
+                    assertThat(block.size(), equalTo(3));
+                    // Doc 0: non-null range present — to is stored as upper+1 (half-open [from, to)).
+                    assertThat(block.get(0), notNullValue());
+                    // Doc 1: zero ranges encoded — must produce null, not skip the position.
+                    assertThat(block.get(1), nullValue());
+                    // Doc 2: no doc value — null.
+                    assertThat(block.get(2), nullValue());
+                }
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateRangeDocValuesLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateRangeDocValuesLoaderTests.java
@@ -30,6 +30,38 @@ public class DateRangeDocValuesLoaderTests extends ESTestCase {
     private static final String FIELD_NAME = "test_date_range";
 
     /**
+     * Verifies that a document with multiple stored ranges produces a multi-value entry in the loaded
+     * block, with each range represented as a half-open [from, to) interval.
+     */
+    public void testMultipleRangesProducesMultiValueEntry() throws IOException {
+        // encodeLongRanges sorts by from then to, so [1000,2000] comes before [3000,4000].
+        var twoRanges = BinaryRangeUtil.encodeLongRanges(
+            Set.of(
+                new RangeFieldMapper.Range(RangeType.DATE, 1000L, 2000L, true, true),
+                new RangeFieldMapper.Range(RangeType.DATE, 3000L, 4000L, true, true)
+            )
+        );
+
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            iw.addDocument(List.of(new BinaryDocValuesField(FIELD_NAME, twoRanges)));
+            iw.forceMerge(1);
+
+            try (DirectoryReader dr = iw.getReader()) {
+                LeafReaderContext ctx = getOnlyLeafReader(dr).getContext();
+                var loader = new DateRangeDocValuesLoader(FIELD_NAME);
+                try (var reader = loader.columnAtATimeReader(ctx).apply(newLimitedBreaker(ByteSizeValue.ofMb(1)))) {
+                    var block = (TestBlock) reader.read(TestBlock.factory(), TestBlock.docs(0), 0, false);
+
+                    assertThat(block.size(), equalTo(1));
+                    // Both ranges stored as inclusive [from, to] are converted to half-open [from, to+1).
+                    // The from-values and to-values are each collected into a list for the multi-value position.
+                    assertThat(block.get(0), equalTo(List.of(List.of(1000L, 3000L), List.of(2001L, 4001L))));
+                }
+            }
+        }
+    }
+
+    /**
      * Verifies that a document whose binary doc value encodes zero ranges produces a null entry in the
      * loaded block rather than silently skipping the position, which would cause the block to have
      * fewer positions than expected and trigger a sanity-check failure in ValuesSourceReaderOperator.

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateRangeDocValuesLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateRangeDocValuesLoaderTests.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class DateRangeDocValuesLoaderTests extends ESTestCase {
@@ -57,8 +56,8 @@ public class DateRangeDocValuesLoaderTests extends ESTestCase {
                     var block = (TestBlock) reader.read(TestBlock.factory(), TestBlock.docs(0, 1, 2), 0, false);
 
                     assertThat(block.size(), equalTo(3));
-                    // Doc 0: non-null range present — to is stored as upper+1 (half-open [from, to)).
-                    assertThat(block.get(0), notNullValue());
+                    // Doc 0: [1000, 2000] inclusive stored as half-open [1000, 2001) in the block.
+                    assertThat(block.get(0), equalTo(List.of(1000L, 2001L)));
                     // Doc 1: zero ranges encoded — must produce null, not skip the position.
                     assertThat(block.get(1), nullValue());
                     // Doc 2: no doc value — null.

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
@@ -995,14 +995,21 @@ public class TestBlock implements BlockLoader.Block {
             assert fromBlock.size() == toBlock.size();
             var values = new ArrayList<>(fromBlock.size());
             for (int i = 0; i < fromBlock.size(); i++) {
-                values.add(List.of(fromBlock.values.get(i), toBlock.values.get(i)));
+                Object f = fromBlock.values.get(i);
+                if (f == null) {
+                    values.add(null);
+                } else {
+                    values.add(List.of(f, toBlock.values.get(i)));
+                }
             }
             return new TestBlock(values);
         }
 
         @Override
         public BlockLoader.Builder appendNull() {
-            throw new UnsupportedOperationException();
+            from.appendNull();
+            to.appendNull();
+            return this;
         }
 
         @Override

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRandomMappingRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRandomMappingRestTest.java
@@ -24,9 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Generative test that creates random Elasticsearch indices with varied mappings
@@ -59,18 +57,6 @@ public abstract class GenerativeRandomMappingRestTest extends GenerativeRestTest
     }).build();
 
     private static volatile List<GeneratedIndex> generatedIndices;
-
-    private static final Set<String> ADDITIONAL_ALLOWED_ERRORS = Set.of(
-        // DateRangeDocValuesReader produces blocks with incorrect position counts when reading date_range
-        // fields with multi-value documents. The mismatch causes an IllegalStateException at the compute layer,
-        // surfaced as partial results. https://github.com/elastic/elasticsearch/issues/146380
-        "RangeArrayBlock.*has \\[\\d+\\] positions instead of"
-    );
-
-    private static final Set<Pattern> ADDITIONAL_ALLOWED_PATTERNS = ADDITIONAL_ALLOWED_ERRORS.stream()
-        .map(x -> ".*" + x + ".*")
-        .map(x -> Pattern.compile(x, Pattern.DOTALL))
-        .collect(Collectors.toSet());
 
     private static final Pattern CANNOT_LOAD_BLOCKS_WITHOUT_DOC_VALUES = Pattern.compile(
         ".*Cannot load blocks without doc values.*",
@@ -235,11 +221,6 @@ public abstract class GenerativeRandomMappingRestTest extends GenerativeRestTest
 
     private static boolean isAdditionalAllowedError(String errorMessage, String query) {
         if (errorMessage == null) return false;
-        for (Pattern p : ADDITIONAL_ALLOWED_PATTERNS) {
-            if (isAllowedError(errorMessage, p)) {
-                return true;
-            }
-        }
         // RangeFieldMapper throws "Cannot load blocks without doc values" for *_range fields
         // with doc_values:false. https://github.com/elastic/elasticsearch/issues/146527
         if (isAllowedError(errorMessage, CANNOT_LOAD_BLOCKS_WITHOUT_DOC_VALUES) && hasRangeFieldType()) {


### PR DESCRIPTION
When advanceExact returns true but decodeLongRanges yields an empty list, no position was appended to the block builder, producing a block with fewer positions than expected and silently triggering the IllegalStateException guard in ValuesSourceReaderOperator.sanityCheckBlock.

Fix by calling builder.appendNull() when the decoded ranges list is empty. Also fix TestBlock.LongRangeBuilder.appendNull(), which threw UnsupportedOperationException and would have prevented the existing no-doc-values null path from being tested via TestBlock.factory().

Closes #146380