### PR TITLE
[ESQL] Fix misleading error for missing external files

### DIFF
--- a/docs/changelog/147158.yaml
+++ b/docs/changelog/147158.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 146715
+pr: 147158
+summary: Fix misleading error for missing external files
+type: bug

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageObject.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageObject.java
@@ -134,6 +134,9 @@ public final class HttpStorageObject implements StorageObject {
         if (cachedLength == null) {
             fetchMetadata();
         }
+        if (cachedExists != null && cachedExists == false) {
+            throw new IOException("Object not found: " + path);
+        }
         return cachedLength;
     }
 
@@ -141,6 +144,9 @@ public final class HttpStorageObject implements StorageObject {
     public Instant lastModified() throws IOException {
         if (cachedLastModified == null) {
             fetchMetadata();
+        }
+        if (cachedExists != null && cachedExists == false) {
+            throw new IOException("Object not found: " + path);
         }
         return cachedLastModified;
     }

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageObject.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageObject.java
@@ -16,6 +16,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -58,14 +59,10 @@ public final class LocalStorageObject implements StorageObject {
 
     @Override
     public InputStream newStream() throws IOException {
-        if (Files.exists(filePath) == false) {
-            throw new IOException("File does not exist: " + filePath);
-        }
-
+        checkFileExists();
         if (Files.isRegularFile(filePath) == false) {
             throw new IOException("Path is not a regular file: " + filePath);
         }
-
         return Files.newInputStream(filePath);
     }
 
@@ -77,16 +74,10 @@ public final class LocalStorageObject implements StorageObject {
         if (length < 0) {
             throw new IllegalArgumentException("length must be non-negative, got: " + length);
         }
-
-        if (Files.exists(filePath) == false) {
-            throw new IOException("File does not exist: " + filePath);
-        }
-
+        checkFileExists();
         if (Files.isRegularFile(filePath) == false) {
             throw new IOException("Path is not a regular file: " + filePath);
         }
-
-        // Use RandomAccessFile for efficient range reads
         return new RangeInputStream(filePath, position, length);
     }
 
@@ -100,6 +91,7 @@ public final class LocalStorageObject implements StorageObject {
         if (target.hasRemaining() == false) {
             return 0;
         }
+        checkFileExists();
         try (FileChannel ch = FileChannel.open(filePath, StandardOpenOption.READ)) {
             int startPos = target.position();
             org.elasticsearch.common.io.Channels.readFromFileChannel(ch, position, target);
@@ -113,6 +105,9 @@ public final class LocalStorageObject implements StorageObject {
         if (cachedLength == null) {
             fetchMetadata();
         }
+        if (cachedExists == Boolean.FALSE) {
+            throw new NoSuchFileException(filePath.toString());
+        }
         return cachedLength;
     }
 
@@ -120,6 +115,9 @@ public final class LocalStorageObject implements StorageObject {
     public Instant lastModified() throws IOException {
         if (cachedLastModified == null) {
             fetchMetadata();
+        }
+        if (cachedExists == Boolean.FALSE) {
+            throw new NoSuchFileException(filePath.toString());
         }
         return cachedLastModified;
     }
@@ -135,6 +133,12 @@ public final class LocalStorageObject implements StorageObject {
     @Override
     public StoragePath path() {
         return storagePath;
+    }
+
+    private void checkFileExists() throws NoSuchFileException {
+        if (Files.exists(filePath) == false) {
+            throw new NoSuchFileException(filePath.toString());
+        }
     }
 
     private void fetchMetadata() throws IOException {

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageObject.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageObject.java
@@ -143,12 +143,12 @@ public final class LocalStorageObject implements StorageObject {
 
     private void fetchMetadata() throws IOException {
         if (Files.exists(filePath)) {
-            cachedExists = true;
+            cachedExists = Boolean.TRUE;
             BasicFileAttributes attrs = Files.readAttributes(filePath, BasicFileAttributes.class);
             cachedLength = attrs.size();
             cachedLastModified = attrs.lastModifiedTime().toInstant();
         } else {
-            cachedExists = false;
+            cachedExists = Boolean.FALSE;
             cachedLength = 0L;
             cachedLastModified = null;
         }

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageObjectTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageObjectTests.java
@@ -7,12 +7,20 @@
 
 package org.elasticsearch.xpack.esql.datasource.http;
 
+import org.apache.http.HttpStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
+import java.io.IOException;
 import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for HttpStorageObject with Range header support.
@@ -85,5 +93,35 @@ public class HttpStorageObjectTests extends ESTestCase {
         // Test that we can create the object successfully
         assertNotNull(object);
         assertEquals(path, object.path());
+    }
+
+    public void testLengthOnNotFoundThrows() throws Exception {
+        HttpStorageObject object = objectWithNotFoundResponse();
+        IOException e = expectThrows(IOException.class, object::length);
+        assertThat(e.getMessage(), containsString("Object not found"));
+    }
+
+    public void testLastModifiedOnNotFoundThrows() throws Exception {
+        HttpStorageObject object = objectWithNotFoundResponse();
+        IOException e = expectThrows(IOException.class, object::lastModified);
+        assertThat(e.getMessage(), containsString("Object not found"));
+    }
+
+    public void testExistsOnNotFoundReturnsFalse() throws Exception {
+        HttpStorageObject object = objectWithNotFoundResponse();
+        assertFalse(object.exists());
+    }
+
+    @SuppressWarnings("unchecked")
+    private HttpStorageObject objectWithNotFoundResponse() throws Exception {
+        HttpResponse<Void> mockResponse = mock(HttpResponse.class);
+        when(mockResponse.statusCode()).thenReturn(HttpStatus.SC_NOT_FOUND);
+        when(mockResponse.headers()).thenReturn(HttpHeaders.of(java.util.Map.of(), (a, b) -> true));
+
+        HttpClient mockClient = mock(HttpClient.class);
+        doReturn(mockResponse).when(mockClient).send(any(), any());
+
+        StoragePath path = StoragePath.of("https://example.com/missing.parquet");
+        return new HttpStorageObject(mockClient, path, HttpConfiguration.defaults());
     }
 }

--- a/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProviderTests.java
+++ b/x-pack/plugin/esql-datasource-http/src/test/java/org/elasticsearch/xpack/esql/datasource/http/local/LocalStorageProviderTests.java
@@ -20,9 +20,12 @@ import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
 
 /**
  * Tests for LocalStorageProvider and LocalStorageObject.
@@ -119,7 +122,6 @@ public class LocalStorageProviderTests extends ESTestCase {
     }
 
     public void testFileNotFound() throws IOException {
-        // Use a temp directory path that doesn't exist (within allowed paths)
         Path tempDir = createTempDir();
         Path nonExistentFile = tempDir.resolve("nonexistent_file.txt");
 
@@ -128,7 +130,53 @@ public class LocalStorageProviderTests extends ESTestCase {
         StorageObject object = provider.newObject(path);
 
         assertFalse(object.exists());
-        expectThrows(IOException.class, () -> object.newStream());
+        expectThrows(NoSuchFileException.class, () -> object.newStream());
+    }
+
+    public void testLengthOnNonExistentFileThrows() throws IOException {
+        Path tempDir = createTempDir();
+        Path nonExistentFile = tempDir.resolve("nonexistent_file.txt");
+
+        LocalStorageProvider provider = new LocalStorageProvider();
+        StoragePath path = StoragePath.of(StoragePath.fileUri(nonExistentFile));
+        StorageObject object = provider.newObject(path);
+
+        NoSuchFileException e = expectThrows(NoSuchFileException.class, () -> object.length());
+        assertThat(e.getMessage(), containsString("nonexistent_file.txt"));
+    }
+
+    public void testLastModifiedOnNonExistentFileThrows() throws IOException {
+        Path tempDir = createTempDir();
+        Path nonExistentFile = tempDir.resolve("nonexistent_file.txt");
+
+        LocalStorageProvider provider = new LocalStorageProvider();
+        StoragePath path = StoragePath.of(StoragePath.fileUri(nonExistentFile));
+        StorageObject object = provider.newObject(path);
+
+        expectThrows(NoSuchFileException.class, () -> object.lastModified());
+    }
+
+    public void testReadBytesOnNonExistentFileThrows() throws IOException {
+        Path tempDir = createTempDir();
+        Path nonExistentFile = tempDir.resolve("nonexistent_file.txt");
+
+        LocalStorageProvider provider = new LocalStorageProvider();
+        StoragePath path = StoragePath.of(StoragePath.fileUri(nonExistentFile));
+        StorageObject object = provider.newObject(path);
+
+        ByteBuffer buf = ByteBuffer.allocate(10);
+        expectThrows(NoSuchFileException.class, () -> object.readBytes(0, buf));
+    }
+
+    public void testNewStreamRangeOnNonExistentFileThrows() throws IOException {
+        Path tempDir = createTempDir();
+        Path nonExistentFile = tempDir.resolve("nonexistent_file.txt");
+
+        LocalStorageProvider provider = new LocalStorageProvider();
+        StoragePath path = StoragePath.of(StoragePath.fileUri(nonExistentFile));
+        StorageObject object = provider.newObject(path);
+
+        expectThrows(NoSuchFileException.class, () -> object.newStream(0, 10));
     }
 
     public void testSupportedSchemes() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -107,6 +107,9 @@ final class FileSourceFactory implements ExternalSourceFactory {
             }
 
             StorageObject storageObject = provider.newObject(storagePath);
+            if (storageObject.exists() == false) {
+                throw new IOException("File does not exist: " + location);
+            }
             FormatReader reader = resolveFormatReader(storagePath.objectName(), config).withConfig(config);
             return reader.metadata(storageObject);
         } catch (IOException e) {


### PR DESCRIPTION
StorageObject.length() silently returned 0 for non-existent files/objects,
causing the Parquet reader to report "not a Parquet file (length is too low: 0)"
instead of a clear missing-file error.

Fix `LocalStorageObject` and `HttpStorageObject` to throw from `length()` and
`lastModified()` when the underlying file/object does not exist, matching the
pattern already used by S3, Azure, and GCS providers. Add an `exists()` pre-check
in `FileSourceFactory.resolveMetadata()` for a clear user-facing diagnostic before
format-specific code runs.

The `exists()` pre-check does not add extra network calls — all providers use lazy
`fetchMetadata()` that caches all fields in a single call; subsequent `length()`
from the Parquet adapter hits the cache.

Closes #146715

Developed with AI-assisted tooling