### PR TITLE
Add missing test feature check to logsdb sort tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -437,15 +437,6 @@ tests:
   method: test {p0=mapping/20_synthetic_source/synthetic_source text with normalized keyword with store original value}
   issue: https://github.com/elastic/elasticsearch/issues/147064
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=logsdb/10_settings/override sort mode settings}
-  issue: https://github.com/elastic/elasticsearch/issues/147064
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=logsdb/10_settings/override sort order settings}
-  issue: https://github.com/elastic/elasticsearch/issues/147064
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=logsdb/10_settings/override sort missing settings}
-  issue: https://github.com/elastic/elasticsearch/issues/147064
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=indices.simulate_index_template/10_basic/Simulate index template with data stream with mapping and setting overrides}
   issue: https://github.com/elastic/elasticsearch/issues/147064
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml
@@ -245,8 +245,8 @@ non-default sort settings with presence of nested:
 ---
 override sort order settings:
   - requires:
-      cluster_features: [ "index.logsdb_no_host_name_field" ]
-      reason: "Change in default sort config for logsdb"
+      cluster_features: [ "index.logsdb_no_host_name_field", "mapper.provide_index_sort_setting_defaults"]
+      reason: "Change in default sort config for logsdb, changed error message output"
   - do:
       catch: bad_request
       indices.create:
@@ -281,8 +281,8 @@ override sort order settings:
 ---
 override sort missing settings:
   - requires:
-      cluster_features: [ "index.logsdb_no_host_name_field" ]
-      reason: "Change in default sort config for logsdb"
+      cluster_features: [ "index.logsdb_no_host_name_field", "mapper.provide_index_sort_setting_defaults"]
+      reason: "Change in default sort config for logsdb, changed error message output"
   - do:
       catch: bad_request
       indices.create:
@@ -317,8 +317,8 @@ override sort missing settings:
 ---
 override sort mode settings:
   - requires:
-      cluster_features: [ "index.logsdb_no_host_name_field" ]
-      reason: "Change in default sort config for logsdb"
+      cluster_features: [ "index.logsdb_no_host_name_field", "mapper.provide_index_sort_setting_defaults"]
+      reason: "Change in default sort config for logsdb, changed error message output"
   - do:
       catch: bad_request
       indices.create:


### PR DESCRIPTION
In #135886 we changed the error message when an invalid sort configuration is defined, and updated the logsdb sort tests to match. 

This PR adds a check to those updated tests to verify the `mapper.provide_index_sort_setting_defaults` test feature is present, indicating that the error message is updated.

This is required to fix bwc mixed-cluster tests.

Relates to #147064.