### PR TITLE
[9.3] Add missing guard for PROMQL capability (#147149)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -351,9 +351,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.RcsCcsSearchYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_half_byte_quantized/Test create, merge, and search cosine}
   issue: https://github.com/elastic/elasticsearch/issues/146781
-- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
-  method: testPromqlQueryWithConflictingTsTypesMarksFieldUnsupported
-  issue: https://github.com/elastic/elasticsearch/issues/147088
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -3422,6 +3422,8 @@ public class AnalyzerTests extends ESTestCase {
      * just like TS + STATS.
      */
     public void testPromqlQueryWithConflictingTsTypesMarksFieldUnsupported() {
+        assumeTrue("Requires PROMQL", EsqlCapabilities.Cap.PROMQL_COMMAND_V0.isEnabled());
+
         FieldCapabilitiesResponse caps = buildCapsWithConflictingTsTypes();
         IndexResolution resolution = IndexResolver.mergedMappings("test", fieldsInfoOnCurrentVersion(caps, true), (p, r) -> Map.of());
         assertThat(resolution.get().mapping().get("status"), instanceOf(InvalidMappedField.class));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -3417,23 +3417,6 @@ public class AnalyzerTests extends ESTestCase {
         assertThat(plan.output().getFirst().dataType(), equalTo(KEYWORD));
     }
 
-    /**
-     * PROMQL queries operate on time series data and should enforce time series field type merging,
-     * just like TS + STATS.
-     */
-    public void testPromqlQueryWithConflictingTsTypesMarksFieldUnsupported() {
-        assumeTrue("Requires PROMQL", EsqlCapabilities.Cap.PROMQL_COMMAND_V0.isEnabled());
-
-        FieldCapabilitiesResponse caps = buildCapsWithConflictingTsTypes();
-        IndexResolution resolution = IndexResolver.mergedMappings("test", fieldsInfoOnCurrentVersion(caps, true), (p, r) -> Map.of());
-        assertThat(resolution.get().mapping().get("status"), instanceOf(InvalidMappedField.class));
-        var plan = analyze("""
-            PROMQL index=test
-                step=5m start="2024-05-10T00:20:00.000Z" end="2024-05-10T00:25:00.000Z"
-                avg(rate(bytes_in[5m]))""", analyzer(resolution, TEST_VERIFIER));
-        assertThat(resolution.get().mapping().get("status").getDataType(), equalTo(UNSUPPORTED));
-    }
-
     private static FieldCapabilitiesResponse buildCapsWithConflictingTsTypes() {
         IndexFieldCapabilities timestamp = new IndexFieldCapabilitiesBuilder("@timestamp", "date").build();
         IndexFieldCapabilities dimensionField = new IndexFieldCapabilitiesBuilder("status", "keyword").isDimension(true).build();


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Add missing guard for PROMQL capability (#147149)