### PR TITLE
Use shared minCompetitiveDocScore for score filtering within BulkNeighborQueue

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/BulkNeighborQueue.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/BulkNeighborQueue.java
@@ -114,18 +114,27 @@ public class BulkNeighborQueue {
 
     /**
      * Adds a batch of node-and-score elements using insert-with-overflow semantics.
+     * <p>
+     * {@code minCompetitiveDocScore} is an inclusive lower bound (encoded with
+     * {@link NeighborQueue#encodeRaw}) shared across segments: candidates whose encoded value is
+     * below this bound are rejected without being inserted, even when they may technically be greater than the current internally
+     * observed minimum threshold. Pass {@code Long.MIN_VALUE} to apply no additional filtering beyond the queue's own threshold.
+     * <p>
+     * Note: {@code minCompetitiveDocScore} is not applied when a tiny heap is used.
+     *
      * @param docs node ids
      * @param scores node scores
      * @param count number of entries to read from docs/scores
      * @param bestScore best score in the batch, used for fast rejection
+     * @param minCompetitiveDocScore encoded inclusive lower bound, or {@code Long.MIN_VALUE} to disable
      * @return the number of elements that were accepted (added or replaced).
      */
-    public int insertWithOverflowBulk(int[] docs, float[] scores, int count, float bestScore) {
+    public int insertWithOverflowBulk(int[] docs, float[] scores, int count, float bestScore, long minCompetitiveDocScore) {
         if (tinyHeap != null) {
             return insertWithOverflowTiny(docs, scores, count, bestScore);
         }
         assert collector != null;
-        return collector.insertWithOverflowBulk(docs, scores, count, bestScore);
+        return collector.insertWithOverflowBulk(docs, scores, count, bestScore, minCompetitiveDocScore);
     }
 
     /**
@@ -210,7 +219,7 @@ public class BulkNeighborQueue {
             return threshold;
         }
 
-        private int insertWithOverflowBulk(int[] docs, float[] scores, int count, float bestScore) {
+        private int insertWithOverflowBulk(int[] docs, float[] scores, int count, float bestScore, long minCompetitiveDocScore) {
             if (count <= 0) {
                 return 0;
             }
@@ -232,17 +241,23 @@ public class BulkNeighborQueue {
             if (bestScore < thresholdScore) {
                 return accepted;
             }
-            return accepted + insertBranchless(docs, scores, i, count);
+            return accepted + insertBranchless(docs, scores, i, count, minCompetitiveDocScore);
         }
 
-        private int insertBranchless(int[] docs, float[] scores, int start, int count) {
+        private int insertBranchless(int[] docs, float[] scores, int start, int count, long minCompetitiveDocScore) {
             int accepted = 0;
+            // this.threshold is always applied (exclusive). minCompetitiveDocScore is an optional external
+            // constraint (inclusive); shift by one to align with the exclusive comparison, bypassing it
+            // entirely when Long.MIN_VALUE is passed to avoid underflow.
+            long effectiveThreshold = minCompetitiveDocScore == Long.MIN_VALUE
+                ? this.threshold
+                : Math.max(this.threshold, minCompetitiveDocScore - 1);
             for (int i = start; i < count; i++) {
                 float score = scores[i];
                 int doc = docs[i];
                 long encoded = encodeRaw(doc, score);
                 values[size] = encoded;
-                int acceptedDelta = encoded > threshold ? 1 : 0;
+                int acceptedDelta = encoded > effectiveThreshold ? 1 : 0;
                 size += acceptedDelta;
                 accepted += acceptedDelta;
                 if (size == capacity) {

--- a/server/src/main/java/org/elasticsearch/search/vectors/AbstractIVFKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/AbstractIVFKnnVectorQuery.java
@@ -139,7 +139,7 @@ abstract class AbstractIVFKnnVectorQuery extends Query implements QueryProfilerP
         }
         TopDocs[] perLeafResults = taskExecutor.invokeAll(tasks).toArray(TopDocs[]::new);
 
-        TopDocs topK = mergeLeafResults(k, perLeafResults);
+        TopDocs topK = mergeLeafResults(k, perLeafResults, knnCollectorManager.getMinCompetitiveDocScore());
         vectorOpsCount = (int) topK.totalHits.value();
         if (topK.scoreDocs.length == 0) {
             return Queries.NO_DOCS_INSTANCE;
@@ -147,7 +147,7 @@ abstract class AbstractIVFKnnVectorQuery extends Query implements QueryProfilerP
         return new KnnScoreDocQuery(topK.scoreDocs, reader);
     }
 
-    private TopDocs mergeLeafResults(int mergeK, TopDocs[] perLeafResults) {
+    private TopDocs mergeLeafResults(int mergeK, TopDocs[] perLeafResults, long minCompetitiveDocScore) {
         // During merge across segments, always favor bulk pivot collection.
         // Segment-level unsorted gathering avoids per-segment sorting work.
         BulkNeighborQueue mergeQueue = BulkNeighborQueue.forMerging(mergeK);
@@ -173,7 +173,7 @@ abstract class AbstractIVFKnnVectorQuery extends Query implements QueryProfilerP
                     bestScore = scoreDoc.score;
                 }
             }
-            mergeQueue.insertWithOverflowBulk(docs, scores, count, bestScore);
+            mergeQueue.insertWithOverflowBulk(docs, scores, count, bestScore, minCompetitiveDocScore);
         }
         ScoreDoc[] mergedScoreDocs = new ScoreDoc[mergeQueue.size()];
         int[] index = new int[] { mergedScoreDocs.length - 1 };
@@ -264,6 +264,10 @@ abstract class AbstractIVFKnnVectorQuery extends Query implements QueryProfilerP
         public AbstractMaxScoreKnnCollector newCollector(int visitedLimit, KnnSearchStrategy searchStrategy, LeafReaderContext context)
             throws IOException {
             return new MaxScoreTopKnnCollector(k, visitedLimit, searchStrategy);
+        }
+
+        public long getMinCompetitiveDocScore() {
+            return longAccumulator == null ? LEAST_COMPETITIVE : longAccumulator.get();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/vectors/MaxScoreTopKnnCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/MaxScoreTopKnnCollector.java
@@ -76,7 +76,7 @@ class MaxScoreTopKnnCollector extends AbstractMaxScoreKnnCollector implements Bu
 
     @Override
     public int bulkCollect(int[] docs, float[] scores, int count, float bestScore) {
-        return queue.insertWithOverflowBulk(docs, scores, count, bestScore);
+        return queue.insertWithOverflowBulk(docs, scores, count, bestScore, minCompetitiveDocScore);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/BulkNeighborQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/BulkNeighborQueueTests.java
@@ -71,8 +71,9 @@ public class BulkNeighborQueueTests extends ESTestCase {
 
     public void testEqualBestScoreStillUsesDocTieBreak() {
         BulkNeighborQueue queue = new BulkNeighborQueue(1);
-        assertEquals(1, queue.insertWithOverflowBulk(new int[] { 5 }, new float[] { 1.0f }, 1, 1.0f));
-        assertEquals(1, queue.insertWithOverflowBulk(new int[] { 4 }, new float[] { 1.0f }, 1, 1.0f));
+        long noFilter = NeighborQueue.encodeRaw(Integer.MAX_VALUE, Float.NEGATIVE_INFINITY);
+        assertEquals(1, queue.insertWithOverflowBulk(new int[] { 5 }, new float[] { 1.0f }, 1, 1.0f, noFilter));
+        assertEquals(1, queue.insertWithOverflowBulk(new int[] { 4 }, new float[] { 1.0f }, 1, 1.0f, noFilter));
 
         List<Long> drained = drainEncoded(queue);
         assertEquals(1, drained.size());
@@ -81,8 +82,69 @@ public class BulkNeighborQueueTests extends ESTestCase {
         assertEquals(1.0f, queue.decodeScore(encoded), 0.0f);
     }
 
+    public void testMinCompetitiveDocScoreAtLongMinValueHandledCorrectly() {
+        BulkNeighborQueue queue = BulkNeighborQueue.forMerging(1);
+        queue.insertWithOverflowBulk(new int[]{5}, new float[]{0.0f}, 1, 0.0f, Long.MIN_VALUE);
+        queue.insertWithOverflowBulk(new int[]{6}, new float[]{1.0f}, 1, 1.0f, Long.MIN_VALUE);
+
+        List<Long> drained = drainEncoded(queue);
+        assertEquals(1, drained.size());
+        assertEquals(6, queue.decodeNodeId(drained.getFirst()));
+        assertEquals(1.0f, queue.decodeScore(drained.getFirst()), 0.0f);
+    }
+
+    public void testMinCompetitiveDocScoreFiltersInReservoirPath() {
+        // k > TINY_K_BINARY_THRESHOLD (10) forces the reservoir path where minCompetitiveDocScore is applied
+        int k = 11;
+        BulkNeighborQueue queue = new BulkNeighborQueue(k);
+
+        // Fill the queue with scores 1.0 to 2.0 so the internal threshold is encodeRaw(0, 1.0f)
+        int[] initialDocs = new int[k];
+        float[] initialScores = new float[k];
+        for (int i = 0; i < k; i++) {
+            initialDocs[i] = i;
+            initialScores[i] = 1.0f + i * 0.1f;
+        }
+        long noFilter = NeighborQueue.encodeRaw(Integer.MAX_VALUE, Float.NEGATIVE_INFINITY);
+        queue.insertWithOverflowBulk(initialDocs, initialScores, k, 2.0f, noFilter);
+
+        // minCompetitiveDocScore = encodeRaw(MAX, 1.5f) raises the effective threshold above the
+        // queue's own threshold of 1.0f: only candidates with score > 1.5f should be accepted
+        long minCompScore = NeighborQueue.encodeRaw(Integer.MAX_VALUE, 1.5f);
+        int[] newDocs = new int[] { 100, 101, 102, 103 };
+        float[] newScores = new float[] { 1.2f, 1.4f, 1.6f, 1.8f };
+        int accepted = queue.insertWithOverflowBulk(newDocs, newScores, 4, 1.8f, minCompScore);
+
+        // Docs with scores 1.2 and 1.4 are below the competitive threshold and must be rejected;
+        // docs with scores 1.6 and 1.8 exceed it and must be accepted
+        assertEquals(2, accepted);
+    }
+
+    public void testMergeDoesNotFilterKthDocWhenItEqualsMinCompetitiveDocScore() {
+        // The kth doc from segment B has encoded value == minCompetitiveDocScore.
+        // It must still appear in the global top-mergeK after merge.
+        int mergeK = 4;
+        BulkNeighborQueue mergeQueue = BulkNeighborQueue.forMerging(mergeK);
+
+        // Segment A: fill the queue with low-scoring docs (no filtering)
+        long noFilter = NeighborQueue.encodeRaw(Integer.MAX_VALUE, Float.NEGATIVE_INFINITY);
+        mergeQueue.insertWithOverflowBulk(new int[] { 0, 1, 2, 3 }, new float[] { 0f, 1f, 2f, 3f }, 4, 3f, noFilter);
+
+        // Segment B: minCompetitiveDocScore is the exact encoded value of the kth doc (100, 7f)
+        long minCompScore = NeighborQueue.encodeRaw(100, 7f);
+        mergeQueue.insertWithOverflowBulk(new int[] { 97, 98, 99, 100 }, new float[] { 10f, 9f, 8f, 7f }, 4, 10f, minCompScore);
+
+        // Drain is worst-to-best; global top-4 must be [7, 8, 9, 10], not [3, 8, 9, 10]
+        List<Long> drained = drainEncoded(mergeQueue);
+        assertEquals(4, drained.size());
+        assertEquals(7f, BulkNeighborQueue.decodeScoreRaw(drained.get(0)), 0f);
+        assertEquals(8f, BulkNeighborQueue.decodeScoreRaw(drained.get(1)), 0f);
+        assertEquals(9f, BulkNeighborQueue.decodeScoreRaw(drained.get(2)), 0f);
+        assertEquals(10f, BulkNeighborQueue.decodeScoreRaw(drained.get(3)), 0f);
+    }
+
     private static void assertTopKMatches(BulkNeighborQueue queue, int[] docs, float[] scores, int count, int k, float bestScore) {
-        queue.insertWithOverflowBulk(docs, scores, count, bestScore);
+        queue.insertWithOverflowBulk(docs, scores, count, bestScore, NeighborQueue.encodeRaw(Integer.MAX_VALUE, Float.NEGATIVE_INFINITY));
         assertEquals(k, queue.size());
 
         long[] expected = topKEncoded(queue, docs, scores, count, k);

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/BulkNeighborQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/BulkNeighborQueueTests.java
@@ -84,8 +84,8 @@ public class BulkNeighborQueueTests extends ESTestCase {
 
     public void testMinCompetitiveDocScoreAtLongMinValueHandledCorrectly() {
         BulkNeighborQueue queue = BulkNeighborQueue.forMerging(1);
-        queue.insertWithOverflowBulk(new int[]{5}, new float[]{0.0f}, 1, 0.0f, Long.MIN_VALUE);
-        queue.insertWithOverflowBulk(new int[]{6}, new float[]{1.0f}, 1, 1.0f, Long.MIN_VALUE);
+        queue.insertWithOverflowBulk(new int[] { 5 }, new float[] { 0.0f }, 1, 0.0f, Long.MIN_VALUE);
+        queue.insertWithOverflowBulk(new int[] { 6 }, new float[] { 1.0f }, 1, 1.0f, Long.MIN_VALUE);
 
         List<Long> drained = drainEncoded(queue);
         assertEquals(1, drained.size());


### PR DESCRIPTION
## Context

This PR builds on the changes made in https://github.com/elastic/elasticsearch/pull/146588 and commented on in https://github.com/elastic/elasticsearch/pull/146588#pullrequestreview-4151167004.

## Proposed Solution

The solution works by taking the observed `minCompetitiveDocScore` and using it as an inclusive lower bound when performing the `bulkCollect` operation. We pass the value in to the collector to maintain the current single iteration over the docs/scores within the `bulkCollect` method.

## Alternative Solution

It seems plausible that we could modify the `BulkNeighborQueue` threshold during the `MaxScoreTopKnnCollector#updateMinCompetitiveDocScore` method call, but that seems to add to the complexity of the `BulkNeighborQueue`, which doesn't currently know about that value.

## Metrics

I am working on getting performance metrics for this PR. I'll leave it in draft status until I get them.