### PR TITLE
Handle CHERRY_PICK_HEAD when resolving transport version base ref

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/ResolveTransportVersionConflictFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/ResolveTransportVersionConflictFuncTest.groovy
@@ -174,6 +174,7 @@ class ResolveTransportVersionConflictFuncTest extends AbstractTransportVersionFu
 
         then:
         assertResolveAndValidateSuccess(result)
+        assertOutputContains(result.output, "Resolving transport version conflicts by accepting upstream changes...")
         assertReferableDefinition("upstream_new_tv2", "8125000,8012002")
         assertUpperBound("9.2", "upstream_new_tv2,8125000")
         assertUpperBound("9.1", "upstream_new_tv2,8012002")

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
@@ -293,6 +293,8 @@ public abstract class TransportVersionResourcesService implements BuildService<T
                 String refName;
                 if (refExists("MERGE_HEAD")) {
                     refName = gitCommand("rev-parse", "--verify", "MERGE_HEAD").strip();
+                } else if (refExists("CHERRY_PICK_HEAD")) {
+                    refName = gitCommand("rev-parse", "--verify", "CHERRY_PICK_HEAD").strip();
                 } else {
                     String upstreamRef = findUpstreamRef();
                     refName = gitCommand("merge-base", upstreamRef, "HEAD").strip();


### PR DESCRIPTION
During a cherry-pick, MERGE_HEAD does not exist, so getBaseRefName() was falling through to findUpstreamRef() which defaults to computing the merge-base with main.  Instead we need to check CHERRY_PICK_HEAD as the base ref during cherry-picks so that the upstream upper bounds come from the cherry-picked commit itself. This also fixes the existing test, which was passing because it didn't check that we didn't fall through and the resulting state just happened to be ok.