### PR TITLE
Fixed NPE in binary doc values query

### DIFF
--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.blockloader.docvalues.CustomBinaryDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.MultiValueSeparateCountBinaryDocValuesReader;
 
 import java.io.IOException;
@@ -82,6 +83,16 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
         Predicate<BytesRef> predicate,
         float cost
     ) {
+        // When the count field is missing, the format is IntegratedCounts
+        return counts == null ? integratedCountIterator(values, predicate, cost) : separateCountIterator(values, counts, predicate, cost);
+    }
+
+    private static DocIdSetIterator separateCountIterator(
+        BinaryDocValues values,
+        NumericDocValues counts,
+        Predicate<BytesRef> predicate,
+        float cost
+    ) {
         return TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(counts) {
             final MultiValueSeparateCountBinaryDocValuesReader reader = new MultiValueSeparateCountBinaryDocValuesReader();
 
@@ -89,6 +100,22 @@ abstract class AbstractBinaryDocValuesQuery extends Query {
             public boolean matches() throws IOException {
                 values.advance(counts.docID());
                 return reader.match(values.binaryValue(), counts.longValue(), predicate);
+            }
+
+            @Override
+            public float matchCost() {
+                return cost;
+            }
+        });
+    }
+
+    private static DocIdSetIterator integratedCountIterator(BinaryDocValues values, Predicate<BytesRef> predicate, float cost) {
+        return TwoPhaseIterator.asDocIdSetIterator(new TwoPhaseIterator(values) {
+            final CustomBinaryDocValuesReader reader = new CustomBinaryDocValuesReader();
+
+            @Override
+            public boolean matches() throws IOException {
+                return reader.match(values.binaryValue(), predicate);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/BinaryDocValuesLengthQuery.java
@@ -58,9 +58,12 @@ final class BinaryDocValuesLengthQuery extends Query {
                 String countsFieldName = fieldName + COUNT_FIELD_SUFFIX;
                 final NumericDocValues counts = context.reader().getNumericDocValues(countsFieldName);
                 DocValuesSkipper countsSkipper = context.reader().getDocValuesSkipper(countsFieldName);
-                assert countsSkipper != null : "no skipper for counts field [" + countsFieldName + "]";
+
                 final DocIdSetIterator iterator;
-                if (countsSkipper.maxValue() == 1 && values instanceof BlockLoader.OptionalLengthReader direct) {
+                if (counts != null
+                    && countsSkipper != null
+                    && countsSkipper.maxValue() == 1
+                    && values instanceof BlockLoader.OptionalLengthReader direct) {
                     iterator = direct.tryLengthIterator(length);
                 } else {
                     Predicate<BytesRef> lengthPredicate = bytes -> bytes.length == length;

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermQueryTests.java
@@ -69,6 +69,44 @@ public class SlowCustomBinaryDocValuesTermQueryTests extends ESTestCase {
         }
     }
 
+    public void testIntegratedCountFormat() throws Exception {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            Map<String, Long> expectedCounts = new HashMap<>();
+            expectedCounts.put("a", 2L);
+            expectedCounts.put("b", 5L);
+            expectedCounts.put("c", 1L);
+            expectedCounts.put("d", 3L);
+            expectedCounts.put("e", 10L);
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                for (var entry : expectedCounts.entrySet()) {
+                    for (int i = 0; i < entry.getValue(); i++) {
+                        Document document = new Document();
+
+                        var field = new MultiValuedBinaryDocValuesField.IntegratedCount(
+                            "field",
+                            MultiValuedBinaryDocValuesField.ValueOrdering.SORTED_UNIQUE
+                        );
+                        field.add(new BytesRef(entry.getKey().getBytes(StandardCharsets.UTF_8)));
+                        if (randomBoolean()) {
+                            field.add(new BytesRef("z".getBytes(StandardCharsets.UTF_8)));
+                        }
+                        document.add(field);
+                        writer.addDocument(document);
+                    }
+                }
+
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    for (var entry : expectedCounts.entrySet()) {
+                        long count = searcher.count(new SlowCustomBinaryDocValuesTermQuery(fieldName, new BytesRef(entry.getKey())));
+                        assertEquals(entry.getValue().longValue(), count);
+                    }
+                }
+            }
+        }
+    }
+
     public void testNoField() throws IOException {
         String fieldName = "field";
 


### PR DESCRIPTION
Fixes an NPE in `AbstractBinaryDocValuesQuery.multiValuedIterator` that surfaces intermittently in mixed-cluster BWC tests (when a 9.5 node reads IntegratedCount-format binary doc values produced by a 9.4 peer).

Nodes on 9.4 will use the `IntegratedCount` format for binary doc values, which nodes on 9.5 do not understand ever since commit https://github.com/elastic/elasticsearch/commit/7ababc02bfa58ab18f25d94864484084a7b9bf9f#diff-a451545d548a42bd9de35f916a36e09f7588cc819476c3823a3aab9237ca568f removed the dual read path.

This fix reintroduced that path back.