### PR TITLE
Fix EIRF encode/decode fidelity edge cases

### DIFF
--- a/server/src/main/java/org/elasticsearch/eirf/EirfEncoder.java
+++ b/server/src/main/java/org/elasticsearch/eirf/EirfEncoder.java
@@ -85,7 +85,7 @@ public class EirfEncoder implements Releasable {
             // The schema will prevent duplicate columns. No need to double with JSON's internal duplicate prevention.
             parser.allowDuplicateKeys(true);
             parser.nextToken(); // START_OBJECT
-            flattenObject(parser, 0, schema, scratch);
+            flattenObject(parser, 0, schema, scratch, parser.nextToken());
         }
 
         if (docCount >= rowOffsets.length) {
@@ -176,10 +176,15 @@ public class EirfEncoder implements Releasable {
         }
     }
 
-    private static void flattenObject(XContentParser parser, int parentNonLeafIdx, EirfSchema schema, ScratchBuffers scratch)
-        throws IOException {
-        XContentParser.Token token;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+    private static void flattenObject(
+        XContentParser parser,
+        int parentNonLeafIdx,
+        EirfSchema schema,
+        ScratchBuffers scratch,
+        XContentParser.Token firstToken
+    ) throws IOException {
+        XContentParser.Token token = firstToken;
+        while (token != XContentParser.Token.END_OBJECT) {
             if (token != XContentParser.Token.FIELD_NAME) {
                 throw new IllegalStateException("Expected FIELD_NAME but got " + token);
             }
@@ -187,8 +192,26 @@ public class EirfEncoder implements Releasable {
             token = parser.nextToken();
 
             if (token == XContentParser.Token.START_OBJECT) {
+                // Peek inside the object. An empty object is encoded as a zero-byte KEY_VALUE leaf so rehydration
+                // can emit `{}` — keeping it as a non-leaf with no children would be indistinguishable from a
+                // non-leaf whose children are all absent in this row. Non-empty objects take the normal
+                // non-leaf + recursive flatten path.
+                XContentParser.Token inner = parser.nextToken();
+                if (inner == XContentParser.Token.END_OBJECT) {
+                    int emptyColIdx = schema.appendLeaf(fieldName, parentNonLeafIdx);
+                    scratch.ensureCapacity(emptyColIdx + 1);
+                    if (scratch.columnsSet.getAndSet(emptyColIdx)) {
+                        throw new IllegalArgumentException("Duplicate field [" + fieldName + "]");
+                    }
+                    scratch.typeBytes[emptyColIdx] = EirfType.KEY_VALUE;
+                    scratch.varData[emptyColIdx] = BytesArray.EMPTY;
+                    scratch.varColumnCount++;
+                    token = parser.nextToken();
+                    continue;
+                }
                 int nonLeafIdx = schema.appendNonLeaf(fieldName, parentNonLeafIdx);
-                flattenObject(parser, nonLeafIdx, schema, scratch);
+                flattenObject(parser, nonLeafIdx, schema, scratch, inner);
+                token = parser.nextToken();
                 continue;
             }
 
@@ -254,6 +277,7 @@ public class EirfEncoder implements Releasable {
                 case VALUE_NULL -> scratch.typeBytes[colIdx] = EirfType.NULL;
                 default -> throw new IllegalStateException("Unexpected token: " + token);
             }
+            token = parser.nextToken();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/eirf/EirfEncoder.java
+++ b/server/src/main/java/org/elasticsearch/eirf/EirfEncoder.java
@@ -383,6 +383,12 @@ public class EirfEncoder implements Releasable {
                         break;
                     }
                 }
+                // FIXED_ARRAY is byte-length-terminated with no element count, so a zero-data-size shared
+                // type (NULL/TRUE/FALSE) would be indistinguishable from an empty array. Force UNION in
+                // that case so each element contributes its type byte and the reader can iterate.
+                if (useFixed && EirfType.elemDataSize(sharedType) == 0) {
+                    useFixed = false;
+                }
             }
 
             byte[] packed;

--- a/server/src/main/java/org/elasticsearch/eirf/EirfEncoder.java
+++ b/server/src/main/java/org/elasticsearch/eirf/EirfEncoder.java
@@ -192,10 +192,8 @@ public class EirfEncoder implements Releasable {
             token = parser.nextToken();
 
             if (token == XContentParser.Token.START_OBJECT) {
-                // Peek inside the object. An empty object is encoded as a zero-byte KEY_VALUE leaf so rehydration
-                // can emit `{}` — keeping it as a non-leaf with no children would be indistinguishable from a
-                // non-leaf whose children are all absent in this row. Non-empty objects take the normal
-                // non-leaf + recursive flatten path.
+                // Peek inside the object. An empty object is encoded as a zero-byte KEY_VALUE leaf
+                // Non-empty objects take the normal non-leaf + recursive flatten path.
                 XContentParser.Token inner = parser.nextToken();
                 if (inner == XContentParser.Token.END_OBJECT) {
                     int emptyColIdx = schema.appendLeaf(fieldName, parentNonLeafIdx);
@@ -206,11 +204,10 @@ public class EirfEncoder implements Releasable {
                     scratch.typeBytes[emptyColIdx] = EirfType.KEY_VALUE;
                     scratch.varData[emptyColIdx] = BytesArray.EMPTY;
                     scratch.varColumnCount++;
-                    token = parser.nextToken();
-                    continue;
+                } else {
+                    int nonLeafIdx = schema.appendNonLeaf(fieldName, parentNonLeafIdx);
+                    flattenObject(parser, nonLeafIdx, schema, scratch, inner);
                 }
-                int nonLeafIdx = schema.appendNonLeaf(fieldName, parentNonLeafIdx);
-                flattenObject(parser, nonLeafIdx, schema, scratch, inner);
                 token = parser.nextToken();
                 continue;
             }
@@ -386,6 +383,7 @@ public class EirfEncoder implements Releasable {
                 // FIXED_ARRAY is byte-length-terminated with no element count, so a zero-data-size shared
                 // type (NULL/TRUE/FALSE) would be indistinguishable from an empty array. Force UNION in
                 // that case so each element contributes its type byte and the reader can iterate.
+                // TODO: We will likely switch this to an element count of fixed_arrays for space. Tracked in meta issues
                 if (useFixed && EirfType.elemDataSize(sharedType) == 0) {
                     useFixed = false;
                 }

--- a/server/src/main/java/org/elasticsearch/eirf/EirfRowReader.java
+++ b/server/src/main/java/org/elasticsearch/eirf/EirfRowReader.java
@@ -77,9 +77,13 @@ public final class EirfRowReader {
 
     public byte getTypeByte(int col) {
         if (col >= rowColumnCount) {
-            return EirfType.NULL;
+            return EirfType.ABSENT;
         }
         return rowData.get(typeBytesOffset + col);
+    }
+
+    public boolean isAbsent(int col) {
+        return getTypeByte(col) == EirfType.ABSENT;
     }
 
     public boolean isNull(int col) {

--- a/server/src/main/java/org/elasticsearch/eirf/EirfRowToXContent.java
+++ b/server/src/main/java/org/elasticsearch/eirf/EirfRowToXContent.java
@@ -70,7 +70,10 @@ public final class EirfRowToXContent {
         throws IOException {
         switch (type) {
             case EirfType.INT -> builder.field(leafName, row.getIntValue(leafIdx));
-            case EirfType.FLOAT -> builder.field(leafName, row.getFloatValue(leafIdx));
+            // Emit as double so the textual form preserves enough precision for downstream double re-parsers
+            // (e.g. scaled_float); the value still round-trips bit-for-bit because (double)(float)val == val
+            // holds for any value stored as FLOAT.
+            case EirfType.FLOAT -> builder.field(leafName, (double) row.getFloatValue(leafIdx));
             case EirfType.LONG -> builder.field(leafName, row.getLongValue(leafIdx));
             case EirfType.DOUBLE -> builder.field(leafName, row.getDoubleValue(leafIdx));
             case EirfType.STRING -> {
@@ -106,7 +109,7 @@ public final class EirfRowToXContent {
     private static void writeElementValue(EirfArrayReader array, XContentBuilder builder) throws IOException {
         switch (array.type()) {
             case EirfType.INT -> builder.value(array.intValue());
-            case EirfType.FLOAT -> builder.value(array.floatValue());
+            case EirfType.FLOAT -> builder.value((double) array.floatValue());
             case EirfType.LONG -> builder.value(array.longValue());
             case EirfType.DOUBLE -> builder.value(array.doubleValue());
             case EirfType.STRING -> builder.value(array.stringValue());
@@ -131,7 +134,7 @@ public final class EirfRowToXContent {
     private static void writeKvValue(EirfKeyValueReader kv, XContentBuilder builder) throws IOException {
         switch (kv.type()) {
             case EirfType.INT -> builder.value(kv.intValue());
-            case EirfType.FLOAT -> builder.value(kv.floatValue());
+            case EirfType.FLOAT -> builder.value((double) kv.floatValue());
             case EirfType.LONG -> builder.value(kv.longValue());
             case EirfType.DOUBLE -> builder.value(kv.doubleValue());
             case EirfType.STRING -> builder.value(kv.stringValue());

--- a/server/src/main/java/org/elasticsearch/eirf/EirfRowToXContent.java
+++ b/server/src/main/java/org/elasticsearch/eirf/EirfRowToXContent.java
@@ -39,7 +39,7 @@ public final class EirfRowToXContent {
         for (EirfRowXContentParser.SchemaNode child : node.children()) {
             if (child.isLeaf()) {
                 int leafIdx = child.leafColumnIndex();
-                if (leafIdx >= row.columnCount() || row.isNull(leafIdx)) {
+                if (leafIdx >= row.columnCount() || row.isAbsent(leafIdx)) {
                     continue;
                 }
                 writeLeafValue(row, leafIdx, row.getTypeByte(leafIdx), child.name(), builder);
@@ -56,7 +56,7 @@ public final class EirfRowToXContent {
         for (EirfRowXContentParser.SchemaNode child : node.children()) {
             if (child.isLeaf()) {
                 int leafIdx = child.leafColumnIndex();
-                if (leafIdx < row.columnCount() && row.isNull(leafIdx) == false) {
+                if (leafIdx < row.columnCount() && row.isAbsent(leafIdx) == false) {
                     return true;
                 }
             } else if (isNotEmpty(child, row)) {
@@ -80,6 +80,7 @@ public final class EirfRowToXContent {
                 builder.field(leafName);
                 row.getStringValue(leafIdx).toXContent(builder, null);
             }
+            case EirfType.NULL -> builder.nullField(leafName);
             case EirfType.TRUE -> builder.field(leafName, true);
             case EirfType.FALSE -> builder.field(leafName, false);
             case EirfType.UNION_ARRAY, EirfType.FIXED_ARRAY -> {

--- a/server/src/main/java/org/elasticsearch/eirf/EirfRowXContentParser.java
+++ b/server/src/main/java/org/elasticsearch/eirf/EirfRowXContentParser.java
@@ -221,10 +221,11 @@ public final class EirfRowXContentParser extends AbstractXContentParser {
                 SchemaNode child = node.children[childIdx];
                 childIdxStack[stackDepth - 1]++;
 
-                // Skip null leaves
+                // Skip leaves whose column is absent in this row. Explicit JSON nulls (EirfType.NULL) must fall
+                // through so emitLeafValue surfaces them as VALUE_NULL tokens for the document parser.
                 if (child.isLeaf()) {
                     int colIdx = child.leafColumnIndex;
-                    if (colIdx >= row.columnCount() || row.isNull(colIdx)) {
+                    if (colIdx >= row.columnCount() || row.isAbsent(colIdx)) {
                         continue;
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/eirf/EirfRowXContentParser.java
+++ b/server/src/main/java/org/elasticsearch/eirf/EirfRowXContentParser.java
@@ -221,8 +221,6 @@ public final class EirfRowXContentParser extends AbstractXContentParser {
                 SchemaNode child = node.children[childIdx];
                 childIdxStack[stackDepth - 1]++;
 
-                // Skip leaves whose column is absent in this row. Explicit JSON nulls (EirfType.NULL) must fall
-                // through so emitLeafValue surfaces them as VALUE_NULL tokens for the document parser.
                 if (child.isLeaf()) {
                     int colIdx = child.leafColumnIndex;
                     if (colIdx >= row.columnCount() || row.isAbsent(colIdx)) {

--- a/server/src/main/java/org/elasticsearch/eirf/EirfType.java
+++ b/server/src/main/java/org/elasticsearch/eirf/EirfType.java
@@ -17,7 +17,7 @@ public final class EirfType {
     // 0-byte fixed types.
     // ABSENT = 0x00 so a zero-initialized type-byte slot means "column not set in this document",
     // which must be distinguished from an explicit JSON null (NULL) so that field mappers can apply
-    // null_value substitutions when the source is rehydrated from an EIRF row.
+    // null_value substitutions when the source is mapped from an EIRF row.
     public static final byte ABSENT = 0x00;
     public static final byte NULL = 0x01;
     public static final byte TRUE = 0x02;

--- a/server/src/main/java/org/elasticsearch/eirf/EirfType.java
+++ b/server/src/main/java/org/elasticsearch/eirf/EirfType.java
@@ -14,25 +14,29 @@ package org.elasticsearch.eirf;
  */
 public final class EirfType {
 
-    // 0-byte fixed types
-    public static final byte NULL = 0x00;
-    public static final byte TRUE = 0x01;
-    public static final byte FALSE = 0x02;
+    // 0-byte fixed types.
+    // ABSENT = 0x00 so a zero-initialized type-byte slot means "column not set in this document",
+    // which must be distinguished from an explicit JSON null (NULL) so that field mappers can apply
+    // null_value substitutions when the source is rehydrated from an EIRF row.
+    public static final byte ABSENT = 0x00;
+    public static final byte NULL = 0x01;
+    public static final byte TRUE = 0x02;
+    public static final byte FALSE = 0x03;
 
     // 4-byte scalar types
-    public static final byte INT = 0x03;
-    public static final byte FLOAT = 0x04;
+    public static final byte INT = 0x04;
+    public static final byte FLOAT = 0x05;
 
     // Variable-length types
-    public static final byte STRING = 0x05;
-    public static final byte BINARY = 0x06;
-    public static final byte UNION_ARRAY = 0x07;
-    public static final byte FIXED_ARRAY = 0x08;
-    public static final byte KEY_VALUE = 0x09;
+    public static final byte STRING = 0x06;
+    public static final byte BINARY = 0x07;
+    public static final byte UNION_ARRAY = 0x08;
+    public static final byte FIXED_ARRAY = 0x09;
+    public static final byte KEY_VALUE = 0x0A;
 
     // 8-byte scalar types
-    public static final byte LONG = 0x0A;
-    public static final byte DOUBLE = 0x0B;
+    public static final byte LONG = 0x0B;
+    public static final byte DOUBLE = 0x0C;
 
     /** Small row threshold: var section must be ≤ 65,535 bytes. */
     public static final int SMALL_ROW_MAX_VAR_SIZE = 65535;
@@ -42,7 +46,7 @@ public final class EirfType {
     /**
      * Fixed-section slot size in bytes for the given type byte and row size.
      *
-     * <p>Uses two comparisons: first checks for zero-byte types ({@code < 0x03}),
+     * <p>Uses two comparisons: first checks for zero-byte types ({@code < INT}),
      * then uses a threshold that depends on the row size to split 4-byte from 8-byte.
      */
     public static int fixedSize(byte typeByte, boolean smallRow) {
@@ -67,7 +71,7 @@ public final class EirfType {
      */
     public static int elemDataSize(byte typeByte) {
         return switch (typeByte) {
-            case NULL, TRUE, FALSE -> 0;
+            case ABSENT, NULL, TRUE, FALSE -> 0;
             case INT, FLOAT -> 4;
             case LONG, DOUBLE -> 8;
             default -> -1; // STRING, KEY_VALUE, UNION_ARRAY, FIXED_ARRAY, BINARY: length-prefixed
@@ -83,6 +87,7 @@ public final class EirfType {
 
     public static String name(byte typeByte) {
         return switch (typeByte) {
+            case ABSENT -> "ABSENT";
             case NULL -> "NULL";
             case TRUE -> "TRUE";
             case FALSE -> "FALSE";

--- a/server/src/test/java/org/elasticsearch/eirf/EirfConversionTests.java
+++ b/server/src/test/java/org/elasticsearch/eirf/EirfConversionTests.java
@@ -237,6 +237,56 @@ public class EirfConversionTests extends ESTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    public void testRowToXContentFixedArrayOfNulls() throws IOException {
+        // FIXED_ARRAY of NULL has zero-byte elements; without forcing UNION the array would read back empty.
+        EirfBatch batch = EirfEncoder.encode(List.of(new BytesArray("{\"xs\":[null,null,null]}")), XContentType.JSON);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), builder);
+        builder.close();
+
+        Map<String, Object> result = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+        List<Object> xs = (List<Object>) result.get("xs");
+        assertEquals(3, xs.size());
+        for (Object x : xs) {
+            assertNull(x);
+        }
+
+        batch.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testRowToXContentFixedArrayOfBooleans() throws IOException {
+        EirfBatch batch = EirfEncoder.encode(List.of(new BytesArray("{\"xs\":[true,true,true],\"ys\":[false,false]}")), XContentType.JSON);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), builder);
+        builder.close();
+
+        Map<String, Object> result = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+        assertEquals(List.of(true, true, true), result.get("xs"));
+        assertEquals(List.of(false, false), result.get("ys"));
+
+        batch.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testRowToXContentMixedBooleans() throws IOException {
+        // Mixed shared types fall to UNION naturally; guards that the existing UNION path still works
+        // post-fix when element types differ.
+        EirfBatch batch = EirfEncoder.encode(List.of(new BytesArray("{\"xs\":[true,false,true]}")), XContentType.JSON);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), builder);
+        builder.close();
+
+        Map<String, Object> result = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+        assertEquals(List.of(true, false, true), result.get("xs"));
+
+        batch.close();
+    }
+
+    @SuppressWarnings("unchecked")
     public void testJsonRoundTrip() throws IOException {
         String json = "{\"user\":{\"name\":\"alice\",\"age\":30},\"status\":\"active\",\"score\":3.14}";
         EirfBatch batch = EirfEncoder.encode(List.of(new BytesArray(json)), XContentType.JSON);

--- a/server/src/test/java/org/elasticsearch/eirf/EirfConversionTests.java
+++ b/server/src/test/java/org/elasticsearch/eirf/EirfConversionTests.java
@@ -87,7 +87,7 @@ public class EirfConversionTests extends ESTestCase {
         batch.close();
     }
 
-    public void testRowToXContentSkipsNullFields() throws IOException {
+    public void testRowToXContentSkipsAbsentFields() throws IOException {
         EirfBatch batch = EirfEncoder.encode(
             List.of(new BytesArray("{\"name\":\"alice\",\"age\":30}"), new BytesArray("{\"age\":25}")),
             XContentType.JSON
@@ -100,6 +100,67 @@ public class EirfConversionTests extends ESTestCase {
         Map<String, Object> result = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
         assertFalse(result.containsKey("name"));
         assertEquals(25, result.get("age"));
+
+        batch.close();
+    }
+
+    public void testRowToXContentEmitsExplicitNull() throws IOException {
+        EirfBatch batch = EirfEncoder.encode(List.of(new BytesArray("{\"name\":\"alice\",\"age\":null}")), XContentType.JSON);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), builder);
+        builder.close();
+
+        Map<String, Object> result = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+        assertEquals("alice", result.get("name"));
+        assertTrue("age column should round-trip as explicit null", result.containsKey("age"));
+        assertNull(result.get("age"));
+
+        batch.close();
+    }
+
+    public void testRowToXContentAbsentVsExplicitNullAcrossDocsInBatch() throws IOException {
+        EirfBatch batch = EirfEncoder.encode(
+            List.of(new BytesArray("{\"name\":\"alice\",\"age\":null}"), new BytesArray("{\"name\":\"bob\"}")),
+            XContentType.JSON
+        );
+
+        // Explicit null round-trips back as null so mappers (e.g. null_value substitution) can act on it.
+        XContentBuilder explicit = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), explicit);
+        explicit.close();
+        Map<String, Object> explicitResult = XContentHelper.convertToMap(BytesReference.bytes(explicit), false, XContentType.JSON).v2();
+        assertEquals("alice", explicitResult.get("name"));
+        assertTrue(explicitResult.containsKey("age"));
+        assertNull(explicitResult.get("age"));
+
+        // The second doc never mentioned "age" — it stays absent rather than materializing as null.
+        XContentBuilder absent = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(1), batch.schema(), absent);
+        absent.close();
+        Map<String, Object> absentResult = XContentHelper.convertToMap(BytesReference.bytes(absent), false, XContentType.JSON).v2();
+        assertEquals("bob", absentResult.get("name"));
+        assertFalse(absentResult.containsKey("age"));
+
+        batch.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testRowToXContentPreservesExplicitNullInNestedObject() throws IOException {
+        EirfBatch batch = EirfEncoder.encode(
+            List.of(new BytesArray("{\"agent\":{\"id\":\"a\",\"optional_version\":null}}")),
+            XContentType.JSON
+        );
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), builder);
+        builder.close();
+
+        Map<String, Object> result = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+        Map<String, Object> agent = (Map<String, Object>) result.get("agent");
+        assertEquals("a", agent.get("id"));
+        assertTrue(agent.containsKey("optional_version"));
+        assertNull(agent.get("optional_version"));
 
         batch.close();
     }

--- a/server/src/test/java/org/elasticsearch/eirf/EirfConversionTests.java
+++ b/server/src/test/java/org/elasticsearch/eirf/EirfConversionTests.java
@@ -136,6 +136,43 @@ public class EirfConversionTests extends ESTestCase {
         batch.close();
     }
 
+    public void testRowToXContentFloatEmitsWithDoublePrecision() throws IOException {
+        // 0.10000000149011612 is the exact double representation of 0.1f. The encoder stores it as FLOAT
+        // (because (double)(float)val == val), and we want the rehydrated JSON to keep enough precision for
+        // downstream double parsers rather than collapsing to "0.1".
+        EirfBatch batch = EirfEncoder.encode(List.of(new BytesArray("{\"x\":0.10000000149011612}")), XContentType.JSON);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), builder);
+        builder.close();
+
+        String json = BytesReference.bytes(builder).utf8ToString();
+        assertTrue("expected double-precision textual form of 0.1f, got: " + json, json.contains("0.10000000149011612"));
+
+        batch.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testRowToXContentFloatArrayElementsDeserializeAsDouble() throws IOException {
+        // 0.5 and 0.25 are FLOAT-exact, so they pack as a FIXED_ARRAY of FLOAT. After the cast-to-double
+        // fix, array elements round-trip through the double branch of XContentParser.
+        EirfBatch batch = EirfEncoder.encode(List.of(new BytesArray("{\"xs\":[0.5,0.25]}")), XContentType.JSON);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), builder);
+        builder.close();
+
+        Map<String, Object> result = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+        List<Object> xs = (List<Object>) result.get("xs");
+        assertEquals(2, xs.size());
+        assertTrue("expected double elements, got: " + xs.get(0).getClass(), xs.get(0) instanceof Double);
+        assertTrue("expected double elements, got: " + xs.get(1).getClass(), xs.get(1) instanceof Double);
+        assertEquals(0.5, (Double) xs.get(0), 0.0);
+        assertEquals(0.25, (Double) xs.get(1), 0.0);
+
+        batch.close();
+    }
+
     @SuppressWarnings("unchecked")
     public void testRowToXContentMultipleNestedSiblings() throws IOException {
         String json = "{\"user\":{\"name\":\"alice\"},\"meta\":{\"version\":1}}";

--- a/server/src/test/java/org/elasticsearch/eirf/EirfConversionTests.java
+++ b/server/src/test/java/org/elasticsearch/eirf/EirfConversionTests.java
@@ -165,6 +165,63 @@ public class EirfConversionTests extends ESTestCase {
         batch.close();
     }
 
+    @SuppressWarnings("unchecked")
+    public void testRowToXContentPreservesEmptyObject() throws IOException {
+        EirfBatch batch = EirfEncoder.encode(List.of(new BytesArray("{\"labels\":{},\"application_data\":{}}")), XContentType.JSON);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), builder);
+        builder.close();
+
+        Map<String, Object> result = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+        assertTrue("labels should round-trip as an empty object", result.containsKey("labels"));
+        assertEquals(Map.of(), result.get("labels"));
+        assertTrue("application_data should round-trip as an empty object", result.containsKey("application_data"));
+        assertEquals(Map.of(), result.get("application_data"));
+
+        batch.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testRowToXContentPreservesNestedEmptyObject() throws IOException {
+        EirfBatch batch = EirfEncoder.encode(List.of(new BytesArray("{\"a\":{\"b\":{}}}")), XContentType.JSON);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), builder);
+        builder.close();
+
+        Map<String, Object> result = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+        Map<String, Object> a = (Map<String, Object>) result.get("a");
+        assertTrue(a.containsKey("b"));
+        assertEquals(Map.of(), a.get("b"));
+
+        batch.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testRowToXContentEmptyVsPopulatedObjectAcrossDocsInBatch() throws IOException {
+        // Doc A has labels:{} (empty), doc B has labels:{"x":1} (populated). They must round-trip independently —
+        // a populated labels in one doc must not bleed into a sibling doc that only had an empty object.
+        EirfBatch batch = EirfEncoder.encode(
+            List.of(new BytesArray("{\"labels\":{}}"), new BytesArray("{\"labels\":{\"x\":1}}")),
+            XContentType.JSON
+        );
+
+        XContentBuilder builderA = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(0), batch.schema(), builderA);
+        builderA.close();
+        Map<String, Object> resultA = XContentHelper.convertToMap(BytesReference.bytes(builderA), false, XContentType.JSON).v2();
+        assertEquals(Map.of(), resultA.get("labels"));
+
+        XContentBuilder builderB = XContentFactory.jsonBuilder();
+        EirfRowToXContent.writeRow(batch.getRowReader(1), batch.schema(), builderB);
+        builderB.close();
+        Map<String, Object> resultB = XContentHelper.convertToMap(BytesReference.bytes(builderB), false, XContentType.JSON).v2();
+        assertEquals(Map.of("x", 1), resultB.get("labels"));
+
+        batch.close();
+    }
+
     public void testRowToXContentWithBooleans() throws IOException {
         EirfBatch batch = EirfEncoder.encode(List.of(new BytesArray("{\"active\":true,\"deleted\":false}")), XContentType.JSON);
 

--- a/server/src/test/java/org/elasticsearch/eirf/EirfEncoderTests.java
+++ b/server/src/test/java/org/elasticsearch/eirf/EirfEncoderTests.java
@@ -278,19 +278,19 @@ public class EirfEncoderTests extends ESTestCase {
         assertEquals(3, batch.columnCount());
 
         EirfRowReader row0 = batch.getRowReader(0);
-        assertFalse(row0.isNull(0));
-        assertFalse(row0.isNull(1));
-        assertTrue(row0.isNull(2));
+        assertFalse(row0.isAbsent(0));
+        assertFalse(row0.isAbsent(1));
+        assertTrue(row0.isAbsent(2));
 
         EirfRowReader row1 = batch.getRowReader(1);
-        assertFalse(row1.isNull(0));
-        assertTrue(row1.isNull(1));
-        assertTrue(row1.isNull(2));
+        assertFalse(row1.isAbsent(0));
+        assertTrue(row1.isAbsent(1));
+        assertTrue(row1.isAbsent(2));
 
         EirfRowReader row2 = batch.getRowReader(2);
-        assertTrue(row2.isNull(0));
-        assertFalse(row2.isNull(1));
-        assertFalse(row2.isNull(2));
+        assertTrue(row2.isAbsent(0));
+        assertFalse(row2.isAbsent(1));
+        assertFalse(row2.isAbsent(2));
         assertEquals("c@d.com", row2.getStringValue(2).string());
 
         batch.close();
@@ -333,7 +333,7 @@ public class EirfEncoderTests extends ESTestCase {
 
         EirfRowReader row0 = batch.getRowReader(0);
         assertEquals(2, row0.columnCount());
-        assertTrue(row0.isNull(2));
+        assertTrue(row0.isAbsent(2));
 
         batch.close();
     }

--- a/server/src/test/java/org/elasticsearch/eirf/EirfRowBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/eirf/EirfRowBuilderTests.java
@@ -177,10 +177,10 @@ public class EirfRowBuilderTests extends ESTestCase {
             assertEquals(3, batch.columnCount());
 
             EirfRowReader row0 = batch.getRowReader(0);
-            assertTrue(row0.isNull(2));
+            assertTrue(row0.isAbsent(2));
 
             EirfRowReader row1 = batch.getRowReader(1);
-            assertTrue(row1.isNull(1));
+            assertTrue(row1.isAbsent(1));
             assertEquals("bob@test.com", row1.getStringValue(2).string());
 
             batch.close();

--- a/server/src/test/java/org/elasticsearch/eirf/EirfRowXContentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/eirf/EirfRowXContentParserTests.java
@@ -83,7 +83,7 @@ public class EirfRowXContentParserTests extends ESTestCase {
         }
     }
 
-    public void testNullColumnsSkipped() throws IOException {
+    public void testAbsentColumnsSkipped() throws IOException {
         try (EirfRowBuilder builder = new EirfRowBuilder()) {
             // First doc sets schema with 3 columns
             builder.startDocument();
@@ -92,7 +92,7 @@ public class EirfRowXContentParserTests extends ESTestCase {
             builder.setString("c", "end");
             builder.endDocument();
 
-            // Second doc only sets a and c (b is null)
+            // Second doc only sets a and c (b is absent — never touched on this doc)
             builder.startDocument();
             builder.setString("a", "hello");
             builder.setString("c", "world");
@@ -106,7 +106,35 @@ public class EirfRowXContentParserTests extends ESTestCase {
                     assertFieldName(parser, "a");
                     assertToken(parser, Token.VALUE_STRING);
                     assertEquals("hello", parser.text());
-                    // b is null, should be skipped
+                    // b is absent in this doc, should be skipped
+                    assertFieldName(parser, "c");
+                    assertToken(parser, Token.VALUE_STRING);
+                    assertEquals("world", parser.text());
+                    assertToken(parser, Token.END_OBJECT);
+                    assertNull(parser.nextToken());
+                }
+            }
+        }
+    }
+
+    public void testExplicitNullEmitsValueNullToken() throws IOException {
+        try (EirfRowBuilder builder = new EirfRowBuilder()) {
+            builder.startDocument();
+            builder.setString("a", "hello");
+            builder.setNull("b");
+            builder.setString("c", "world");
+            builder.endDocument();
+
+            try (EirfBatch batch = builder.build()) {
+                EirfRowReader row = batch.getRowReader(0);
+                EirfRowXContentParser.SchemaNode tree = EirfRowXContentParser.buildSchemaTree(batch.schema());
+                try (EirfRowXContentParser parser = new EirfRowXContentParser(tree, row)) {
+                    assertToken(parser, Token.START_OBJECT);
+                    assertFieldName(parser, "a");
+                    assertToken(parser, Token.VALUE_STRING);
+                    assertEquals("hello", parser.text());
+                    assertFieldName(parser, "b");
+                    assertToken(parser, Token.VALUE_NULL);
                     assertFieldName(parser, "c");
                     assertToken(parser, Token.VALUE_STRING);
                     assertEquals("world", parser.text());

--- a/server/src/test/java/org/elasticsearch/eirf/EirfTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/eirf/EirfTypeTests.java
@@ -14,16 +14,18 @@ import org.elasticsearch.test.ESTestCase;
 public class EirfTypeTests extends ESTestCase {
 
     public void testFixedSizeZeroByte() {
+        assertEquals(0, EirfType.fixedSize(EirfType.ABSENT, true));
         assertEquals(0, EirfType.fixedSize(EirfType.NULL, true));
         assertEquals(0, EirfType.fixedSize(EirfType.TRUE, true));
         assertEquals(0, EirfType.fixedSize(EirfType.FALSE, true));
+        assertEquals(0, EirfType.fixedSize(EirfType.ABSENT, false));
         assertEquals(0, EirfType.fixedSize(EirfType.NULL, false));
         assertEquals(0, EirfType.fixedSize(EirfType.TRUE, false));
         assertEquals(0, EirfType.fixedSize(EirfType.FALSE, false));
     }
 
     public void testFixedSizeSmallRow() {
-        // Small row: types 0x03-0x09 → 4 bytes, 0x0A-0x0B → 8 bytes
+        // Small row: types 0x04-0x0A → 4 bytes, 0x0B-0x0C → 8 bytes
         assertEquals(4, EirfType.fixedSize(EirfType.INT, true));
         assertEquals(4, EirfType.fixedSize(EirfType.FLOAT, true));
         assertEquals(4, EirfType.fixedSize(EirfType.STRING, true));
@@ -36,7 +38,7 @@ public class EirfTypeTests extends ESTestCase {
     }
 
     public void testFixedSizeLargeRow() {
-        // Large row: types 0x03-0x04 → 4 bytes, 0x05-0x0B → 8 bytes
+        // Large row: types 0x04-0x05 → 4 bytes, 0x06-0x0C → 8 bytes
         assertEquals(4, EirfType.fixedSize(EirfType.INT, false));
         assertEquals(4, EirfType.fixedSize(EirfType.FLOAT, false));
         assertEquals(8, EirfType.fixedSize(EirfType.STRING, false));
@@ -58,6 +60,7 @@ public class EirfTypeTests extends ESTestCase {
         assertFalse(EirfType.isVariable(EirfType.FLOAT));
         assertFalse(EirfType.isVariable(EirfType.LONG));
         assertFalse(EirfType.isVariable(EirfType.DOUBLE));
+        assertFalse(EirfType.isVariable(EirfType.ABSENT));
         assertFalse(EirfType.isVariable(EirfType.NULL));
         assertFalse(EirfType.isVariable(EirfType.TRUE));
         assertFalse(EirfType.isVariable(EirfType.FALSE));
@@ -72,6 +75,7 @@ public class EirfTypeTests extends ESTestCase {
     }
 
     public void testNameForAllTypes() {
+        assertEquals("ABSENT", EirfType.name(EirfType.ABSENT));
         assertEquals("NULL", EirfType.name(EirfType.NULL));
         assertEquals("TRUE", EirfType.name(EirfType.TRUE));
         assertEquals("FALSE", EirfType.name(EirfType.FALSE));
@@ -92,6 +96,7 @@ public class EirfTypeTests extends ESTestCase {
     }
 
     public void testElemDataSize() {
+        assertEquals(0, EirfType.elemDataSize(EirfType.ABSENT));
         assertEquals(0, EirfType.elemDataSize(EirfType.NULL));
         assertEquals(0, EirfType.elemDataSize(EirfType.TRUE));
         assertEquals(0, EirfType.elemDataSize(EirfType.FALSE));


### PR DESCRIPTION
FIXED_ARRAY with a zero-payload shared type (NULL/TRUE/FALSE)
read back empty: the format is byte-length-terminated with no
element count, so arrays of payload-free elements collapsed to
a 1-byte header regardless of length. Force UNION_ARRAY when
the shared type has no per-element bytes.

Empty nested objects vanished from the rehydrated source:
flattenObject treated `{}` as a non-leaf with no children,
indistinguishable from a field absent in the current row.
Encode empty objects as a zero-byte KEY_VALUE leaf so
rehydration emits `{}` again.

ABSENT aliased to explicit NULL: zero-initialized type-byte
slots meant "column not set in this row" but decoded as
VALUE_NULL, so mappers that distinguish the two (null_value,
flattened) saw spurious nulls. Add EirfType.ABSENT = 0x00
(shifting other type bytes up by 1) and skip ABSENT leaves on
mapping while still emitting NULL leaves.

FLOAT text round-trip lost double precision: storing as 4-byte
FLOAT is numerically lossless when (double)(float)v == v, but
XContentBuilder.field(String, float) formats with float
precision, so -2147483648.0 re-emitted as "-2.1474836E9"
parses back to -2147483600.0 and drifts scaled_float /
half_float consumers. Cast FLOAT to double at emit time on
all three paths (leaf, array element, key-value); serialized
bytes are unchanged.