### PR TITLE
[9.4] Add missing test feature for keyword skip store parameter (#147075)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
@@ -233,8 +233,8 @@ synthetic_source text with ignored multi-field and multiple values in the same d
 ---
 synthetic_source text with normalized keyword with store original value:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
-      reason: "Source mode configured through index setting"
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.keyword.normalizer_skip_store_setting"]
+      reason: "Source mode configured through index setting, normalizer_skip_store setting must be present"
 
   - do:
       indices.create:
@@ -275,8 +275,8 @@ synthetic_source text with normalized keyword with store original value:
 ---
 synthetic_source text with normalized keyword with skip store original value:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
-      reason: "Source mode configured through index setting"
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.keyword.normalizer_skip_store_setting"]
+      reason: "Source mode configured through index setting, normalizer_skip_store setting must be present"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
@@ -140,6 +140,10 @@ keyword with normalizer:
 
 ---
 keyword with non-lowercase normalizer:
+  - requires:
+      cluster_features: [ "mapper.keyword.normalizer_skip_store_setting" ]
+      reason: "setting under test must be present"
+
   - do:
       indices.create:
         index: test-keyword-with-normalizer
@@ -237,8 +241,8 @@ keyword with non-lowercase normalizer:
 ---
 keyword with normalizer and skip store original value:
   - requires:
-      cluster_features: [ "mapper.doc_values.ignored_values_in_binary_dv" ]
-      reason: "Sort order of ignored values is affected by binary docvalues"
+      cluster_features: [ "mapper.keyword.normalizer_skip_store_setting", "mapper.doc_values.ignored_values_in_binary_dv" ]
+      reason: "Setting under test must be present, sort order of ignored values is affected by binary docvalues"
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -86,6 +86,7 @@ public class MapperFeatures implements FeatureSpecification {
     );
     public static final NodeFeature ES940_DISK_BBQ = new NodeFeature("mapper.es940_disk_bbq");
     public static final NodeFeature IGNORED_VALUES_STORED_IN_BINARY_DV = new NodeFeature("mapper.doc_values.ignored_values_in_binary_dv");
+    static final NodeFeature KEYWORD_NORMALIZER_SKIP_STORE_SETTING = new NodeFeature("mapper.keyword.normalizer_skip_store_setting");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -147,7 +148,8 @@ public class MapperFeatures implements FeatureSpecification {
             FLATTENED_MAPPED_SUBFIELDS_FEATURE,
             ES940_DISK_BBQ,
             FLATTENED_PASSTHROUGH_FEATURE,
-            IGNORED_VALUES_STORED_IN_BINARY_DV
+            IGNORED_VALUES_STORED_IN_BINARY_DV,
+            KEYWORD_NORMALIZER_SKIP_STORE_SETTING
         );
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Add missing test feature for keyword skip store parameter (#147075)](https://github.com/elastic/elasticsearch/pull/147075)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)