### PR TITLE
[9.3] Add missing test feature for keyword skip store parameter (#147075)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
@@ -233,8 +233,8 @@ synthetic_source text with ignored multi-field and multiple values in the same d
 ---
 synthetic_source text with normalized keyword with store original value:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
-      reason: "Source mode configured through index setting"
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.keyword.normalizer_skip_store_setting"]
+      reason: "Source mode configured through index setting, normalizer_skip_store setting must be present"
 
   - do:
       indices.create:
@@ -275,8 +275,8 @@ synthetic_source text with normalized keyword with store original value:
 ---
 synthetic_source text with normalized keyword with skip store original value:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
-      reason: "Source mode configured through index setting"
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.keyword.normalizer_skip_store_setting"]
+      reason: "Source mode configured through index setting, normalizer_skip_store setting must be present"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
@@ -140,6 +140,10 @@ keyword with normalizer:
 
 ---
 keyword with non-lowercase normalizer:
+  - requires:
+      cluster_features: [ "mapper.keyword.normalizer_skip_store_setting" ]
+      reason: "setting under test must be present"
+
   - do:
       indices.create:
         index: test-keyword-with-normalizer
@@ -236,6 +240,9 @@ keyword with non-lowercase normalizer:
 
 ---
 keyword with normalizer and skip store original value:
+  - requires:
+      cluster_features: [ "mapper.keyword.normalizer_skip_store_setting"]
+      reason: "Setting under test must be present"
   - do:
       indices.create:
         index: test-keyword-with-normalizer

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -75,6 +75,7 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX = new NodeFeature(
         "mapper.dense_vector.dynamic_template_nested_object_fix"
     );
+    static final NodeFeature KEYWORD_NORMALIZER_SKIP_STORE_SETTING = new NodeFeature("mapper.keyword.normalizer_skip_store_setting");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -127,7 +128,8 @@ public class MapperFeatures implements FeatureSpecification {
             STORE_HIGH_CARDINALITY_KEYWORDS_IN_BINARY_DOC_VALUES,
             TDIGEST_TYPE,
             DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX,
-            DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX
+            DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX,
+            KEYWORD_NORMALIZER_SKIP_STORE_SETTING
         );
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Add missing test feature for keyword skip store parameter (#147075)](https://github.com/elastic/elasticsearch/pull/147075)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)