### PR TITLE
Fix incorrect variable used in assertion error message

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1398,7 +1398,7 @@ public final class InternalTestCluster extends TestCluster {
                 final long replicaWriteBytes = indexingPressure.stats().getCurrentReplicaBytes();
                 if (replicaWriteBytes > 0) {
                     throw new AssertionError(
-                        "pending replica write bytes [" + combinedBytes + "] bytes on node [" + nodeAndClient.name + "]."
+                        "pending replica write bytes [" + replicaWriteBytes + "] bytes on node [" + nodeAndClient.name + "]."
                     );
                 }
             }


### PR DESCRIPTION
A recent test failure had this message in it, which I assume has the wrong variable in it from a copy paste error eons ago.