### PR TITLE
FSDirectoryFactory: fix read advice for slices inside CFS

### DIFF
--- a/docs/changelog/147222.yaml
+++ b/docs/changelog/147222.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 147222
+summary: "FSDirectoryFactory: fix read advice for slices inside CFS"
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
@@ -157,9 +157,6 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
             if (context.hints().contains(StandardIOBehaviorHint.INSTANCE)) {
                 return Optional.of(ReadAdvice.NORMAL);
             }
-            if (name.endsWith(".cfs")) {
-                return Optional.of(ReadAdvice.NORMAL);
-            }
             // Bloom filter files are accessed randomly during point lookups,
             // so sequential pre-fetching would not be beneficial
             if (name.endsWith(".sfbf")) {


### PR DESCRIPTION
Stop deriving read advice from file name and rely on `IOContext` instead. Previously, `.cfs` files were always treated as `ReadAdvice.NORMAL`, causing slices inside CFS to inherit incorrect advice. This change removes the `.cfs` special case so slices correctly use the intended access pattern. Results in ~2x reduction in disk reads on vector benchmarks due to proper random read advice.