### PR TITLE
[9.3] Async Search: Ensure cleanup is also done against aliases (#146356)

### DIFF
--- a/docs/changelog/146356.yaml
+++ b/docs/changelog/146356.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 146184
+pr: 146356
+summary: "Async Search: Ensure cleanup is also done against aliases"
+type: bug

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIndexAliasIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIndexAliasIT.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.search;
+
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xpack.async.AsyncResultsIndexPlugin;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.async.AsyncTaskIndexService;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
+import static org.elasticsearch.xpack.core.XPackPlugin.ASYNC_RESULTS_INDEX;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Makes .async-search index an alias pointing to another index and ensures it's cleaned up
+ */
+public class AsyncSearchIndexAliasIT extends AsyncSearchIntegTestCase {
+
+    private static final String BACKING_INDEX = ASYNC_RESULTS_INDEX + "-000001";
+
+    public static class AsyncResultsWithAliasPlugin extends AsyncResultsIndexPlugin {
+
+        public AsyncResultsWithAliasPlugin(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings unused) {
+            SystemIndexDescriptor original = AsyncTaskIndexService.getSystemIndexDescriptor();
+            return List.of(
+                SystemIndexDescriptor.builder()
+                    .setIndexPattern(original.getIndexPattern())
+                    .setDescription(original.getDescription())
+                    .setPrimaryIndex(BACKING_INDEX)
+                    .setAliasName(ASYNC_RESULTS_INDEX)
+                    .setMappings(original.getMappings())
+                    .setSettings(original.getSettings())
+                    .setOrigin(ASYNC_SEARCH_ORIGIN)
+                    .build()
+            );
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(
+            LocalStateCompositeXPackPlugin.class,
+            AsyncSearch.class,
+            AsyncResultsWithAliasPlugin.class,
+            ReindexPlugin.class
+        );
+    }
+
+    public void testSearchAsyncIndexIsAlias() throws Exception {
+        String dataIndex = randomIndexName();
+        createIndex(dataIndex, Settings.builder().put("index.number_of_shards", 1).build());
+
+        int numDocs = randomIntBetween(1, 10);
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk(dataIndex).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        for (int i = 0; i < numDocs; i++) {
+            bulkRequestBuilder.add(prepareIndex(dataIndex).setSource("field", "value" + i));
+        }
+        bulkRequestBuilder.get();
+
+        final SubmitAsyncSearchRequest submitRequest = new SubmitAsyncSearchRequest(
+            new SearchSourceBuilder().query(new MatchAllQueryBuilder()),
+            dataIndex
+        ).setKeepOnCompletion(true).setKeepAlive(TimeValue.timeValueSeconds(2));
+
+        int asyncSearches = randomIntBetween(1, 10);
+        for (int i = 0; i < asyncSearches; i++) {
+            AsyncSearchResponse submitResponse = submitAsyncSearch(submitRequest);
+            String searchId = submitResponse.getId();
+            try {
+                assertNotNull(searchId);
+            } finally {
+                submitResponse.decRef();
+            }
+            ensureTaskNotRunning(searchId);
+        }
+
+        refresh(ASYNC_RESULTS_INDEX);
+        assertAsyncSearchIndexIsAlias();
+        assertAsyncSearchIndexHasNoDocuments();
+    }
+
+    private void assertAsyncSearchIndexIsAlias() {
+        var aliasResponse = indicesAdmin().prepareGetAliases(TEST_REQUEST_TIMEOUT, ASYNC_RESULTS_INDEX).get();
+        var aliases = aliasResponse.getAliases();
+        assertThat(aliases, hasKey(BACKING_INDEX));
+        List<AliasMetadata> aliasList = aliases.get(BACKING_INDEX);
+        assertThat(aliasList, hasSize(1));
+        assertThat(aliasList.get(0).alias(), equalTo(ASYNC_RESULTS_INDEX));
+        assertTrue(aliasList.get(0).writeIndex());
+    }
+
+    private void assertAsyncSearchIndexHasNoDocuments() throws Exception {
+        assertBusy(() -> {
+            SearchResponse resp = client().prepareSearch(ASYNC_RESULTS_INDEX).setSize(0).get();
+            try {
+                assertThat(resp.getHits().getTotalHits().value(), equalTo(0L));
+            } finally {
+                resp.decRef();
+            }
+        });
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskMaintenanceService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskMaintenanceService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -144,7 +145,13 @@ public class AsyncTaskMaintenanceService extends AbstractLifecycleComponent impl
         }
 
         final List<ProjectId> projectsOnLocalNode = state.metadata().projects().keySet().stream().filter(project -> {
-            final IndexRoutingTable indexRouting = state.routingTable(project).index(index);
+            IndexAbstraction index = state.projectState(project).metadata().getIndicesLookup().get(this.index);
+
+            if (index == null || index.getWriteIndex() == null) {
+                return false;
+            }
+
+            final IndexRoutingTable indexRouting = state.routingTable(project).index(index.getWriteIndex());
             if (indexRouting == null) {
                 return false;
             }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskMaintenanceServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncTaskMaintenanceServiceTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
@@ -70,20 +71,23 @@ public class AsyncTaskMaintenanceServiceTests extends ESTestCase {
         final Metadata.Builder metadataBuilder = Metadata.builder();
         final GlobalRoutingTable.Builder grtBuilder = GlobalRoutingTable.builder();
 
+        final IndexMetadata p1IndexMetadata = getIndexMetadata();
         final ProjectId p1 = ProjectId.fromId("p1");
-        metadataBuilder.put(ProjectMetadata.builder(p1).put(getIndexMetadata(), false));
-        grtBuilder.put(p1, buildRoutingTableWithIndex(localNodeId));
+        metadataBuilder.put(ProjectMetadata.builder(p1).put(p1IndexMetadata, false));
+        grtBuilder.put(p1, buildRoutingTableWithIndex(p1IndexMetadata.getIndex(), localNodeId));
 
+        final IndexMetadata p2IndexMetadata = getIndexMetadata();
         final ProjectId p2 = ProjectId.fromId("p2");
-        metadataBuilder.put(ProjectMetadata.builder(p2).put(getIndexMetadata(), false));
-        grtBuilder.put(p2, buildRoutingTableWithIndex(alternateNodeId));
+        metadataBuilder.put(ProjectMetadata.builder(p2).put(p2IndexMetadata, false));
+        grtBuilder.put(p2, buildRoutingTableWithIndex(p2IndexMetadata.getIndex(), alternateNodeId));
 
         final ProjectId p3 = ProjectId.fromId("p3");
         grtBuilder.put(p3, RoutingTable.builder());
 
+        final IndexMetadata p4IndexMetadata = getIndexMetadata();
         final ProjectId p4 = ProjectId.fromId("p4");
-        metadataBuilder.put(ProjectMetadata.builder(p4).put(getIndexMetadata(), false));
-        grtBuilder.put(p4, buildRoutingTableWithIndex(localNodeId));
+        metadataBuilder.put(ProjectMetadata.builder(p4).put(p4IndexMetadata, false));
+        grtBuilder.put(p4, buildRoutingTableWithIndex(p4IndexMetadata.getIndex(), localNodeId));
 
         metadataBuilder.put(ProjectMetadata.builder(p3));
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
@@ -182,11 +186,14 @@ public class AsyncTaskMaintenanceServiceTests extends ESTestCase {
         Mockito.verifyNoMoreInteractions(threadPoolSpy);
 
         // Update the cluster state to add project 4 again
+        final IndexMetadata p4ReaddedIndexMetadata = getIndexMetadata();
         previousState = clusterState;
         clusterState = ClusterState.builder(previousState)
-            .metadata(Metadata.builder(previousState.metadata()).put(ProjectMetadata.builder(p4).put(getIndexMetadata(), false)))
+            .metadata(Metadata.builder(previousState.metadata()).put(ProjectMetadata.builder(p4).put(p4ReaddedIndexMetadata, false)))
             .routingTable(
-                GlobalRoutingTable.builder(previousState.globalRoutingTable()).put(p4, buildRoutingTableWithIndex(localNodeId)).build()
+                GlobalRoutingTable.builder(previousState.globalRoutingTable())
+                    .put(p4, buildRoutingTableWithIndex(p4ReaddedIndexMetadata.getIndex(), localNodeId))
+                    .build()
             )
             .build();
 
@@ -208,12 +215,70 @@ public class AsyncTaskMaintenanceServiceTests extends ESTestCase {
         Mockito.verifyNoMoreInteractions(threadPoolSpy);
     }
 
+    @SuppressWarnings("unchecked")
+    public void testWorksWithAliases() {
+        final String localNodeId = randomIdentifier();
+        final String concreteIndexName = ASYNC_RESULTS_INDEX + "-000001";
+
+        final IndexMetadata indexMetadata = IndexMetadata.builder(concreteIndexName)
+            .settings(indexSettings(IndexVersion.current(), 1, 0))
+            .putAlias(AliasMetadata.builder(ASYNC_RESULTS_INDEX).writeIndex(true))
+            .build();
+
+        final ProjectId project = ProjectId.fromId("p1");
+        final Index concreteIndex = indexMetadata.getIndex();
+
+        final Metadata.Builder metadataBuilder = Metadata.builder().put(ProjectMetadata.builder(project).put(indexMetadata, false));
+
+        final RoutingTable.Builder routingTableBuilder = RoutingTable.builder()
+            .add(
+                IndexRoutingTable.builder(concreteIndex)
+                    .addShard(TestShardRouting.newShardRouting(new ShardId(concreteIndex, 0), localNodeId, true, ShardRoutingState.STARTED))
+                    .build()
+            );
+
+        final GlobalRoutingTable.Builder grtBuilder = GlobalRoutingTable.builder().put(project, routingTableBuilder);
+
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(metadataBuilder)
+            .routingTable(grtBuilder.build())
+            .build();
+
+        final ClusterService clusterService = Mockito.mock(ClusterService.class);
+        final ThreadPool threadPoolSpy = Mockito.spy(threadPool);
+
+        final Client client = Mockito.mock(Client.class);
+        Mockito.doAnswer(invocationOnMock -> {
+            ActionListener<?> listener = invocationOnMock.getArgument(2, ActionListener.class);
+            listener.onResponse(null);
+            return null;
+        }).when(client).execute(same(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), any(ActionListener.class));
+
+        final ProjectResolver projectResolver = Mockito.spy(TestProjectResolvers.mustExecuteFirst());
+
+        final AsyncTaskMaintenanceService service = new AsyncTaskMaintenanceService(
+            clusterService,
+            projectResolver,
+            localNodeId,
+            Settings.EMPTY,
+            threadPoolSpy,
+            client
+        );
+
+        service.start();
+
+        service.clusterChanged(new ClusterChangedEvent(getTestName(), clusterState, ClusterState.EMPTY_STATE));
+
+        verify(projectResolver, times(1)).executeOnProject(eq(project), any(CheckedRunnable.class));
+        verify(client, times(1)).execute(same(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), any(ActionListener.class));
+        verify(threadPoolSpy, times(1)).schedule(any(Runnable.class), eq(timeValueHours(1)), any(ExecutorService.class));
+    }
+
     private static IndexMetadata getIndexMetadata() {
         return IndexMetadata.builder(ASYNC_RESULTS_INDEX).settings(indexSettings(IndexVersion.current(), 1, 0)).build();
     }
 
-    private static RoutingTable.Builder buildRoutingTableWithIndex(String nodeId) {
-        final Index index = new Index(ASYNC_RESULTS_INDEX, randomUUID());
+    private static RoutingTable.Builder buildRoutingTableWithIndex(Index index, String nodeId) {
         return RoutingTable.builder()
             .add(
                 IndexRoutingTable.builder(index)


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Async Search: Ensure cleanup is also done against aliases (#146356)