### PR TITLE
Fix ServerCliTests in FIPS mode

### DIFF
--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
@@ -385,7 +385,7 @@ public class ServerCliTests extends CommandTestCase {
     }
 
     private KeystoreSecureSettingsLoader setupMockKeystoreLoader() {
-        var loader = new KeystoreSecureSettingsLoader();
+        var loader = new KeystoreSecureSettingsLoader(new KeyStoreLoader());
         this.mockSecureSettingsLoader = loader;
         return loader;
     }
@@ -496,7 +496,8 @@ public class ServerCliTests extends CommandTestCase {
             if (mockSecureSettingsLoader != null) {
                 return mockSecureSettingsLoader;
             }
-            return super.secureSettingsLoader(processInfo);
+            var loader = super.secureSettingsLoader(processInfo);
+            return loader instanceof KeyStoreLoader ksl ? new KeystoreSecureSettingsLoader(ksl) : loader;
         }
 
         @Override
@@ -555,15 +556,20 @@ public class ServerCliTests extends CommandTestCase {
         }
     }
 
-    static class KeystoreSecureSettingsLoader extends KeyStoreLoader {
+    static class KeystoreSecureSettingsLoader implements SecureSettingsLoader {
+        private final KeyStoreLoader delegate;
         boolean loaded = false;
         LoadedSecrets secrets = null;
         String password = null;
         boolean bootstrapped = false;
 
+        KeystoreSecureSettingsLoader(KeyStoreLoader delegate) {
+            this.delegate = delegate;
+        }
+
         @Override
         public LoadedSecrets load(Environment environment, Terminal terminal) throws Exception {
-            var result = super.load(environment, terminal);
+            var result = delegate.load(environment, terminal);
             loaded = true;
             secrets = result;
             password = result.password().get().toString();
@@ -577,7 +583,12 @@ public class ServerCliTests extends CommandTestCase {
             if (inFipsJvm() && (password == null || password.isEmpty())) {
                 return KeyStoreWrapper.create();
             }
-            return super.bootstrap(environment, password);
+            return delegate.bootstrap(environment, password);
+        }
+
+        @Override
+        public boolean supportsSecurityAutoConfiguration() {
+            return delegate.supportsSecurityAutoConfiguration();
         }
     }
 }

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
@@ -385,7 +385,7 @@ public class ServerCliTests extends CommandTestCase {
     }
 
     private KeystoreSecureSettingsLoader setupMockKeystoreLoader() {
-        var loader = new KeystoreSecureSettingsLoader(new KeyStoreLoader());
+        var loader = new KeystoreSecureSettingsLoader();
         this.mockSecureSettingsLoader = loader;
         return loader;
     }
@@ -497,7 +497,7 @@ public class ServerCliTests extends CommandTestCase {
                 return mockSecureSettingsLoader;
             }
             var loader = super.secureSettingsLoader(processInfo);
-            return loader instanceof KeyStoreLoader ksl ? new KeystoreSecureSettingsLoader(ksl) : loader;
+            return loader instanceof KeyStoreLoader ? new KeystoreSecureSettingsLoader() : loader;
         }
 
         @Override
@@ -556,20 +556,15 @@ public class ServerCliTests extends CommandTestCase {
         }
     }
 
-    static class KeystoreSecureSettingsLoader implements SecureSettingsLoader {
-        private final KeyStoreLoader delegate;
+    static class KeystoreSecureSettingsLoader extends KeyStoreLoader {
         boolean loaded = false;
         LoadedSecrets secrets = null;
         String password = null;
         boolean bootstrapped = false;
 
-        KeystoreSecureSettingsLoader(KeyStoreLoader delegate) {
-            this.delegate = delegate;
-        }
-
         @Override
         public LoadedSecrets load(Environment environment, Terminal terminal) throws Exception {
-            var result = delegate.load(environment, terminal);
+            var result = super.load(environment, terminal);
             loaded = true;
             secrets = result;
             password = result.password().get().toString();
@@ -583,12 +578,7 @@ public class ServerCliTests extends CommandTestCase {
             if (inFipsJvm() && (password == null || password.isEmpty())) {
                 return KeyStoreWrapper.create();
             }
-            return delegate.bootstrap(environment, password);
-        }
-
-        @Override
-        public boolean supportsSecurityAutoConfiguration() {
-            return delegate.supportsSecurityAutoConfiguration();
+            return super.bootstrap(environment, password);
         }
     }
 }


### PR DESCRIPTION
The `TestServerCli.secureSettingsLoader()` was changed in #144927 to delegate to `super.secureSettingsLoader(processInfo)` instead of returning the test's `KeystoreSecureSettingsLoader` directly. This inadvertently dropped the FIPS workaround that skips `KeyStoreWrapper.bootstrap()` when the password is empty.

This PR restores the FIPS-safe test loader when `es.secure_settings.source` selects a `KeyStoreLoader`. 
