### PR TITLE
[TEST] Drain cluster state after ML feature reset before waitForPendingTasks in x-pack REST tests

### DIFF
--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
@@ -146,6 +146,10 @@ public abstract class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
     private void clearMlState() throws Exception {
         if (isMachineLearningTest()) {
             new MlRestTestStateCleaner(logger, adminClient()).resetFeatures();
+            // _features/_reset can enqueue async cluster-state updates (e.g. inference
+            // endpoint cache invalidation via ClearInferenceEndpointCacheAction). Drain
+            // them here so the subsequent waitForPendingTasks does not race with them.
+            waitForClusterUpdates();
         }
     }
 


### PR DESCRIPTION
This addresses intermittent failures (e.g. `clear_inference_endpoint_cache` still visible in `/_cat/tasks`) by calling `ESRestTestCase.waitForClusterUpdates()` immediately after `MlRestTestStateCleaner.resetFeatures()` in `AbstractXPackRestTest`, only when `isMachineLearningTest()` is true, so `POST /_features/_reset` can finish enqueued master work before the suite asserts there are no pending tasks. In `ServerlessXpackRestIT`, the `waitForPendingTasksFilter` no longer exempts `clear_inference_endpoint_cache` (the race is fixed by ordering), while the existing `push_shard_sizes` filter for serverless autoscaling is retained. 