### PR TITLE
Write skipindex to a separate file in TSDB Codec

### DIFF
--- a/docs/changelog/147238.yaml
+++ b/docs/changelog/147238.yaml
@@ -1,0 +1,5 @@
+area: Codec
+issues: []
+pr: 147238
+summary: Write skipindex to a separate file in TSDB Codec
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesConsumer.java
@@ -104,7 +104,7 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
 
     final Directory dir;
     final IOContext context;
-    IndexOutput data, meta;
+    IndexOutput data, meta, skip;
     final int maxDoc;
     byte[] termsDictBuffer;
     final boolean enableOptimizedMerge;
@@ -144,6 +144,8 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
         final String dataExtension,
         final String metaCodec,
         final String metaExtension,
+        final String skipCodec,
+        final String skipExtension,
         final TSDBDocValuesFormatConfig formatConfig,
         final DocOffsetsCodec.Encoder docOffsetsEncoder,
         final SortedFieldObserverFactory sortedFieldObserverFactory,
@@ -186,6 +188,10 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
                 state.segmentSuffix
             );
             meta.writeByte((byte) formatConfig.numericBlockShift());
+
+            final String skipName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, skipExtension);
+            skip = state.directory.createOutput(skipName, state.context);
+            CodecUtil.writeIndexHeader(skip, skipCodec, formatConfig.version(), state.segmentInfo.getId(), state.segmentSuffix);
 
             maxDoc = state.segmentInfo.maxDoc();
             this.enableOptimizedMerge = enableOptimizedMerge;
@@ -1024,14 +1030,17 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
             if (data != null) {
                 CodecUtil.writeFooter(data); // write checksum
             }
+            if (skip != null) {
+                CodecUtil.writeFooter(skip);
+            }
             success = true;
         } finally {
             if (success) {
-                IOUtils.close(data, meta);
+                IOUtils.close(data, meta, skip);
             } else {
-                IOUtils.closeWhileHandlingException(data, meta);
+                IOUtils.closeWhileHandlingException(data, meta, skip);
             }
-            meta = data = null;
+            meta = data = skip = null;
         }
     }
 
@@ -1085,7 +1094,7 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
 
     private void writeSkipIndex(final FieldInfo field, final DocValuesProducer valuesProducer) throws IOException {
         assert field.docValuesSkipIndexType() != DocValuesSkipIndexType.NONE;
-        final long start = data.getFilePointer();
+        final long start = skip.getFilePointer();
         final SortedNumericDocValues values = valuesProducer.getSortedNumeric(field);
         long globalMaxValue = Long.MIN_VALUE;
         long globalMinValue = Long.MAX_VALUE;
@@ -1126,7 +1135,7 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
             writeLevels(accumulators);
         }
         meta.writeLong(start); // record the start in meta
-        meta.writeLong(data.getFilePointer() - start); // record the length
+        meta.writeLong(skip.getFilePointer() - start); // record the length
         assert globalDocCount == 0 || globalMaxValue >= globalMinValue;
         meta.writeLong(globalMaxValue);
         meta.writeLong(globalMinValue);
@@ -1144,14 +1153,14 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
         int totalAccumulators = accumulators.size();
         for (int index = 0; index < totalAccumulators; index++) {
             final int levels = getLevels(index, totalAccumulators);
-            data.writeByte((byte) levels);
+            skip.writeByte((byte) levels);
             for (int level = levels - 1; level >= 0; level--) {
                 final SkipAccumulator acc = accumulatorsLevels.get(level).get(index >> (formatConfig.skipIndexLevelShift() * level));
-                data.writeInt(acc.maxDocID);
-                data.writeInt(acc.minDocID);
-                data.writeLong(acc.maxValue);
-                data.writeLong(acc.minValue);
-                data.writeInt(acc.docCount);
+                skip.writeInt(acc.maxDocID);
+                skip.writeInt(acc.minDocID);
+                skip.writeLong(acc.maxValue);
+                skip.writeLong(acc.minValue);
+                skip.writeInt(acc.docCount);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesConsumer.java
@@ -191,7 +191,13 @@ public abstract class AbstractTSDBDocValuesConsumer extends XDocValuesConsumer {
 
             final String skipName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, skipExtension);
             skip = state.directory.createOutput(skipName, state.context);
-            CodecUtil.writeIndexHeader(skip, skipCodec, formatConfig.version(), state.segmentInfo.getId(), state.segmentSuffix);
+            CodecUtil.writeIndexHeader(
+                skip,
+                skipCodec,
+                TSDBDocValuesFormatConfig.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
 
             maxDoc = state.segmentInfo.maxDoc();
             this.enableOptimizedMerge = enableOptimizedMerge;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -37,6 +37,7 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.FileTypeHint;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
 import org.apache.lucene.util.BytesRef;
@@ -71,7 +72,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     final IntObjectHashMap<SortedSetEntry> sortedSets;
     final IntObjectHashMap<SortedNumericEntry> sortedNumerics;
     private final IntObjectHashMap<DocValuesSkipperEntry> skippers;
-    private final IndexInput data;
+    private final IndexInput data, skip;
     private final int maxDoc;
     final int version;
     private final int primarySortFieldNumber;
@@ -94,6 +95,8 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         final String dataExtension,
         final String metaCodec,
         final String metaExtension,
+        final String skipCodec,
+        final String skipExtension,
         final TSDBDocValuesFormatConfig formatConfig,
         final DocOffsetsCodec.Decoder docOffsetsDecoder,
         final NumericBlockCodec numericCodec,
@@ -178,6 +181,32 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
                 IOUtils.closeWhileHandlingException(this.data);
             }
         }
+
+        if (version >= TSDBDocValuesFormatConfig.VERSION_SEPARATE_SKIPLIST) {
+            IndexInput tempIn = null;
+            try {
+                String skipIndexName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, skipExtension);
+                tempIn = state.directory.openInput(skipIndexName, state.context.withHints(FileTypeHint.INDEX));
+                final int skipVersion = CodecUtil.checkIndexHeader(
+                    tempIn,
+                    skipCodec,
+                    TSDBDocValuesFormatConfig.VERSION_START,
+                    TSDBDocValuesFormatConfig.VERSION_SEPARATE_SKIPLIST,
+                    state.segmentInfo.getId(),
+                    state.segmentSuffix
+                );
+                if (version != skipVersion) {
+                    throw new CorruptIndexException("Format versions mismatch: meta=" + version + ", skipIndex=" + skipVersion, tempIn);
+                }
+                CodecUtil.retrieveChecksum(tempIn);
+            } catch (Throwable t) {
+                IOUtils.closeWhileHandlingException(data, tempIn);
+                throw t;
+            }
+            this.skip = tempIn;
+        } else {
+            this.skip = null;
+        }
     }
 
     protected AbstractTSDBDocValuesProducer(final AbstractTSDBDocValuesProducer original) {
@@ -192,6 +221,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         this.sortedNumerics = original.sortedNumerics;
         this.skippers = original.skippers;
         this.data = original.data.clone();
+        this.skip = original.skip == null ? null : original.skip.clone();
         this.maxDoc = original.maxDoc;
         this.version = original.version;
         this.primarySortFieldNumber = original.primarySortFieldNumber;
@@ -1818,7 +1848,11 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
                     }
                 } else {
                     if (input == null) {
-                        input = data.slice("doc value skipper", entry.offset, entry.length);
+                        if (skip == null) {
+                            input = data.slice("doc value skipper", entry.offset, entry.length);
+                        } else {
+                            input = skip.slice("doc value skipper", entry.offset, entry.length);
+                        }
                     }
                     assert target > maxDocID[0] : "target must be bigger than current interval";
                     while (true) {
@@ -1896,11 +1930,14 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     @Override
     public void checkIntegrity() throws IOException {
         CodecUtil.checksumEntireFile(data);
+        if (skip != null) {
+            CodecUtil.checksumEntireFile(skip);
+        }
     }
 
     @Override
     public void close() throws IOException {
-        data.close();
+        IOUtils.close(data, skip);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBDocValuesFormatConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBDocValuesFormatConfig.java
@@ -139,5 +139,6 @@ public record TSDBDocValuesFormatConfig(
     public static final int VERSION_BINARY_DV_COMPRESSION = 1;
     public static final int VERSION_NUMERIC_LARGE_BLOCKS = 2;
     public static final int VERSION_PREFIX_PARTITIONS = 4;
-    public static final int VERSION_CURRENT = VERSION_PREFIX_PARTITIONS;
+    public static final int VERSION_SEPARATE_SKIPLIST = 5;
+    public static final int VERSION_CURRENT = VERSION_SEPARATE_SKIPLIST;
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesConsumer.java
@@ -31,6 +31,8 @@ final class ES819TSDBDocValuesConsumer extends AbstractTSDBDocValuesConsumer {
         final String dataExtension,
         final String metaCodec,
         final String metaExtension,
+        final String skipCodec,
+        final String skipExtension,
         final TSDBDocValuesFormatConfig formatConfig,
         final DocOffsetsCodec.Encoder docOffsetsEncoder,
         final SortedFieldObserverFactory sortedFieldObserverFactory
@@ -42,6 +44,8 @@ final class ES819TSDBDocValuesConsumer extends AbstractTSDBDocValuesConsumer {
             dataExtension,
             metaCodec,
             metaExtension,
+            skipCodec,
+            skipExtension,
             formatConfig,
             docOffsetsEncoder,
             sortedFieldObserverFactory,

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormat.java
@@ -52,6 +52,8 @@ public class ES819TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValues
     static final String DATA_EXTENSION = "dvd";
     static final String META_CODEC = "ES819TSDBDocValuesMetadata";
     static final String META_EXTENSION = "dvm";
+    static final String SKIP_CODEC = "ES819TSDBDocValuesSkip";
+    static final String SKIP_EXTENSION = "dvs";
 
     static final int TERMS_DICT_BLOCK_LZ4_SHIFT = 6;
     static final int TERMS_DICT_BLOCK_LZ4_SIZE = 1 << TERMS_DICT_BLOCK_LZ4_SHIFT;
@@ -303,6 +305,8 @@ public class ES819TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValues
             DATA_EXTENSION,
             META_CODEC,
             META_EXTENSION,
+            SKIP_CODEC,
+            SKIP_EXTENSION,
             formatConfig,
             docOffsetsCodec.getEncoder(),
             formatConfig.writePrefixPartitions()
@@ -321,6 +325,8 @@ public class ES819TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValues
             DATA_EXTENSION,
             META_CODEC,
             META_EXTENSION,
+            SKIP_CODEC,
+            SKIP_EXTENSION,
             formatConfig,
             docOffsetsCodec.getDecoder()
         );

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -29,6 +29,8 @@ final class ES819TSDBDocValuesProducer extends AbstractTSDBDocValuesProducer {
         final String dataExtension,
         final String metaCodec,
         final String metaExtension,
+        final String skipCodec,
+        final String skipExtension,
         final TSDBDocValuesFormatConfig formatConfig,
         final DocOffsetsCodec.Decoder docOffsetsDecoder
     ) throws IOException {
@@ -38,6 +40,8 @@ final class ES819TSDBDocValuesProducer extends AbstractTSDBDocValuesProducer {
             dataExtension,
             metaCodec,
             metaExtension,
+            skipCodec,
+            skipExtension,
             formatConfig,
             docOffsetsDecoder,
             new TSDBNumericBlockCodec(),

--- a/server/src/main/java/org/elasticsearch/index/store/LuceneFilesExtensions.java
+++ b/server/src/main/java/org/elasticsearch/index/store/LuceneFilesExtensions.java
@@ -40,6 +40,7 @@ public enum LuceneFilesExtensions {
     // cache, so we use mmap, which provides better performance.
     DVD("dvd", "DocValues", false, true),
     DVM("dvm", "DocValues Metadata", true, false),
+    DVS("dvs", "DocValues Skip data", false, true),
     FDM("fdm", "Field Metadata", true, false),
     FDT("fdt", "Field Data", false, false),
     FDX("fdx", "Field Index", false, false),

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerTests.java
@@ -797,7 +797,7 @@ public class IndexDiskUsageAnalyzerTests extends ESTestCase {
                 }
                 final long bytes = directory.fileLength(file);
                 switch (ext) {
-                    case DVD, DVM -> stats.addDocValues(fieldLookup.getDocValuesField(file), bytes);
+                    case DVD, DVM, DVS -> stats.addDocValues(fieldLookup.getDocValuesField(file), bytes);
                     case TIM, TIP, TMD, DOC, POS, PAY -> stats.addInvertedIndex(fieldLookup.getPostingsField(file), bytes);
                     case KDI, KDD, KDM, DIM -> stats.addPoints("_all_points_fields", bytes);
                     case FDT, FDX, FDM ->


### PR DESCRIPTION
Ports https://github.com/apache/lucene/pull/15976 to the TSDB 
Codec.  This should improve page cache locality and mmap performance 
in stateful, and allows us to eagerly download the skip index in serverless.
