### PR TITLE
Rework ping-request timeouts

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -11,7 +11,10 @@ package org.elasticsearch.cluster.coordination;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionResponse.Empty;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.ChannelActionListener;
@@ -33,9 +36,7 @@ import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.AbstractTransportRequest;
 import org.elasticsearch.transport.ConnectTransportException;
-import org.elasticsearch.transport.ReceiveTimeoutTransportException;
 import org.elasticsearch.transport.TransportConnectionListener;
-import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportRequestOptions.Type;
 import org.elasticsearch.transport.TransportResponseHandler;
@@ -105,6 +106,8 @@ public final class FollowersChecker {
     private final NodeHealthService nodeHealthService;
     private final Executor clusterCoordinationExecutor;
     private volatile FastResponseState fastResponseState;
+
+    private static final TransportRequestOptions PING_REQUEST_OPTIONS = TransportRequestOptions.of(null, Type.PING);
 
     public FollowersChecker(
         Settings settings,
@@ -289,6 +292,57 @@ public final class FollowersChecker {
             handleWakeUp();
         }
 
+        private final ActionListener<ActionResponse.Empty> responseHandler = new ActionListener<>() {
+            @Override
+            public void onResponse(Empty ignored) {
+                if (running() == false) {
+                    logger.trace("{} no longer running", FollowerChecker.this);
+                    return;
+                }
+
+                failureCountSinceLastSuccess = 0;
+                timeoutCountSinceLastSuccess = 0;
+                logger.trace("{} check successful", FollowerChecker.this);
+                scheduleNextWakeUp();
+            }
+
+            @Override
+            public void onFailure(Exception exp) {
+                if (running() == false) {
+                    logger.debug(() -> format("%s no longer running", FollowerChecker.this), exp);
+                    return;
+                }
+
+                if (exp instanceof ElasticsearchTimeoutException) {
+                    timeoutCountSinceLastSuccess++;
+                } else {
+                    failureCountSinceLastSuccess++;
+                }
+
+                final String reason;
+                if (exp instanceof ConnectTransportException || exp.getCause() instanceof ConnectTransportException) {
+                    logger.debug(() -> format("%s disconnected", FollowerChecker.this), exp);
+                    reason = "disconnected";
+                } else if (exp.getCause() instanceof NodeHealthCheckFailureException) {
+                    logger.debug(() -> format("%s health check failed", FollowerChecker.this), exp);
+                    reason = "health check failed";
+                } else if (failureCountSinceLastSuccess + timeoutCountSinceLastSuccess >= followerCheckRetryCount) {
+                    logger.debug(() -> format("%s failed too many times", FollowerChecker.this), exp);
+                    reason = "followers check retry count exceeded [timeouts="
+                        + timeoutCountSinceLastSuccess
+                        + ", failures="
+                        + failureCountSinceLastSuccess
+                        + "]";
+                } else {
+                    logger.debug(() -> format("%s failed, retrying", FollowerChecker.this), exp);
+                    scheduleNextWakeUp();
+                    return;
+                }
+
+                failNode(reason);
+            }
+        };
+
         private void handleWakeUp() {
             if (running() == false) {
                 logger.trace("handleWakeUp: not running");
@@ -302,63 +356,18 @@ public final class FollowersChecker {
                 discoveryNode,
                 FOLLOWER_CHECK_ACTION_NAME,
                 request,
-                TransportRequestOptions.of(followerCheckTimeout, Type.PING),
-                new TransportResponseHandler.Empty() {
-
-                    @Override
-                    public Executor executor() {
-                        return TransportResponseHandler.TRANSPORT_WORKER;
-                    }
-
-                    @Override
-                    public void handleResponse() {
-                        if (running() == false) {
-                            logger.trace("{} no longer running", FollowerChecker.this);
-                            return;
-                        }
-
-                        failureCountSinceLastSuccess = 0;
-                        timeoutCountSinceLastSuccess = 0;
-                        logger.trace("{} check successful", FollowerChecker.this);
-                        scheduleNextWakeUp();
-                    }
-
-                    @Override
-                    public void handleException(TransportException exp) {
-                        if (running() == false) {
-                            logger.debug(() -> format("%s no longer running", FollowerChecker.this), exp);
-                            return;
-                        }
-
-                        if (exp instanceof ReceiveTimeoutTransportException) {
-                            timeoutCountSinceLastSuccess++;
-                        } else {
-                            failureCountSinceLastSuccess++;
-                        }
-
-                        final String reason;
-                        if (exp instanceof ConnectTransportException || exp.getCause() instanceof ConnectTransportException) {
-                            logger.debug(() -> format("%s disconnected", FollowerChecker.this), exp);
-                            reason = "disconnected";
-                        } else if (exp.getCause() instanceof NodeHealthCheckFailureException) {
-                            logger.debug(() -> format("%s health check failed", FollowerChecker.this), exp);
-                            reason = "health check failed";
-                        } else if (failureCountSinceLastSuccess + timeoutCountSinceLastSuccess >= followerCheckRetryCount) {
-                            logger.debug(() -> format("%s failed too many times", FollowerChecker.this), exp);
-                            reason = "followers check retry count exceeded [timeouts="
-                                + timeoutCountSinceLastSuccess
-                                + ", failures="
-                                + failureCountSinceLastSuccess
-                                + "]";
-                        } else {
-                            logger.debug(() -> format("%s failed, retrying", FollowerChecker.this), exp);
-                            scheduleNextWakeUp();
-                            return;
-                        }
-
-                        failNode(reason);
-                    }
-                }
+                PING_REQUEST_OPTIONS,
+                new ActionListenerResponseHandler<>(
+                    ActionListener.addTimeout(
+                        followerCheckTimeout,
+                        transportService.getThreadPool(),
+                        TransportResponseHandler.TRANSPORT_WORKER,
+                        responseHandler,
+                        () -> {/* not cancellable */}
+                    ),
+                    ignored -> ActionResponse.Empty.INSTANCE,
+                    TransportResponseHandler.TRANSPORT_WORKER
+                )
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -12,6 +12,9 @@ package org.elasticsearch.cluster.coordination;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionResponse.Empty;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -33,7 +36,6 @@ import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.NodeDisconnectedException;
 import org.elasticsearch.transport.ReceiveTimeoutTransportException;
 import org.elasticsearch.transport.TransportConnectionListener;
-import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportRequestOptions.Type;
 import org.elasticsearch.transport.TransportResponseHandler;
@@ -41,7 +43,6 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -95,6 +96,8 @@ public class LeaderChecker {
     private final AtomicReference<CheckScheduler> currentChecker = new AtomicReference<>();
 
     private volatile DiscoveryNodes discoveryNodes;
+
+    private static final TransportRequestOptions PING_REQUEST_OPTIONS = TransportRequestOptions.of(null, Type.PING);
 
     LeaderChecker(
         final Settings settings,
@@ -221,6 +224,101 @@ public class LeaderChecker {
             }
         }
 
+        private final ActionListener<Empty> responseHandler = new ActionListener<>() {
+            @Override
+            public void onResponse(Empty ignored) {
+                if (isClosed.get()) {
+                    logger.debug("closed check scheduler received a response, doing nothing");
+                    return;
+                }
+
+                rejectedCountSinceLastSuccess = 0;
+                timeoutCountSinceLastSuccess = 0;
+                scheduleNextWakeUp(); // logs trace message indicating success
+            }
+
+            @Override
+            public void onFailure(Exception exp) {
+                if (isClosed.get()) {
+                    logger.debug("closed check scheduler received a response, doing nothing");
+                    return;
+                }
+
+                if (exp instanceof ConnectTransportException || exp.getCause() instanceof ConnectTransportException) {
+                    logger.debug(() -> "leader [" + leader + "] disconnected during check", exp);
+                    leaderFailed(
+                        () -> format(
+                            "master node [%s] disconnected, restarting discovery [%s]",
+                            leader.descriptionWithoutAttributes(),
+                            ExceptionsHelper.unwrapCause(exp).getMessage()
+                        ),
+                        exp
+                    );
+                    return;
+                } else if (exp.getCause() instanceof NodeHealthCheckFailureException) {
+                    logger.debug(() -> "leader [" + leader + "] health check failed", exp);
+                    leaderFailed(
+                        () -> format(
+                            "master node [%s] reported itself as unhealthy [%s], %s",
+                            leader.descriptionWithoutAttributes(),
+                            exp.getCause().getMessage(),
+                            RESTARTING_DISCOVERY_TEXT
+                        ),
+                        exp
+                    );
+                    return;
+                }
+
+                if (exp instanceof ReceiveTimeoutTransportException) {
+                    timeoutCountSinceLastSuccess += 1;
+                } else {
+                    rejectedCountSinceLastSuccess += 1;
+                }
+
+                long failureCount = rejectedCountSinceLastSuccess + timeoutCountSinceLastSuccess;
+                if (failureCount >= leaderCheckRetryCount) {
+                    logger.debug(
+                        () -> format(
+                            "leader [%s] failed %s consecutive checks (rejected [%s], timed out [%s], limit [%s] is %s)",
+                            leader,
+                            failureCount,
+                            rejectedCountSinceLastSuccess,
+                            timeoutCountSinceLastSuccess,
+                            LEADER_CHECK_RETRY_COUNT_SETTING.getKey(),
+                            leaderCheckRetryCount
+                        ),
+                        exp
+                    );
+                    leaderFailed(
+                        () -> format(
+                            "[%s] consecutive checks of the master node [%s] were unsuccessful ([%s] rejected, [%s] timed out), "
+                                + "%s [last unsuccessful check: %s]",
+                            failureCount,
+                            leader.descriptionWithoutAttributes(),
+                            rejectedCountSinceLastSuccess,
+                            timeoutCountSinceLastSuccess,
+                            RESTARTING_DISCOVERY_TEXT,
+                            ExceptionsHelper.unwrapCause(exp).getMessage()
+                        ),
+                        exp
+                    );
+                    return;
+                }
+
+                logger.debug(
+                    () -> format(
+                        "%s consecutive failures (limit [%s] is %s) with leader [%s]",
+                        failureCount,
+                        LEADER_CHECK_RETRY_COUNT_SETTING.getKey(),
+                        leaderCheckRetryCount,
+                        leader
+                    ),
+                    exp
+                );
+                scheduleNextWakeUp();
+            }
+        };
+
         void handleWakeUp() {
             if (isClosed.get()) {
                 logger.trace("closed check scheduler woken up, doing nothing");
@@ -233,106 +331,18 @@ public class LeaderChecker {
                 leader,
                 LEADER_CHECK_ACTION_NAME,
                 new LeaderCheckRequest(transportService.getLocalNode()),
-                TransportRequestOptions.of(leaderCheckTimeout, Type.PING),
-                new TransportResponseHandler.Empty() {
-                    @Override
-                    public Executor executor() {
-                        return TransportResponseHandler.TRANSPORT_WORKER;
-                    }
-
-                    @Override
-                    public void handleResponse() {
-                        if (isClosed.get()) {
-                            logger.debug("closed check scheduler received a response, doing nothing");
-                            return;
-                        }
-
-                        rejectedCountSinceLastSuccess = 0;
-                        timeoutCountSinceLastSuccess = 0;
-                        scheduleNextWakeUp(); // logs trace message indicating success
-                    }
-
-                    @Override
-                    public void handleException(TransportException exp) {
-                        if (isClosed.get()) {
-                            logger.debug("closed check scheduler received a response, doing nothing");
-                            return;
-                        }
-
-                        if (exp instanceof ConnectTransportException || exp.getCause() instanceof ConnectTransportException) {
-                            logger.debug(() -> "leader [" + leader + "] disconnected during check", exp);
-                            leaderFailed(
-                                () -> format(
-                                    "master node [%s] disconnected, restarting discovery [%s]",
-                                    leader.descriptionWithoutAttributes(),
-                                    ExceptionsHelper.unwrapCause(exp).getMessage()
-                                ),
-                                exp
-                            );
-                            return;
-                        } else if (exp.getCause() instanceof NodeHealthCheckFailureException) {
-                            logger.debug(() -> "leader [" + leader + "] health check failed", exp);
-                            leaderFailed(
-                                () -> format(
-                                    "master node [%s] reported itself as unhealthy [%s], %s",
-                                    leader.descriptionWithoutAttributes(),
-                                    exp.getCause().getMessage(),
-                                    RESTARTING_DISCOVERY_TEXT
-                                ),
-                                exp
-                            );
-                            return;
-                        }
-
-                        if (exp instanceof ReceiveTimeoutTransportException) {
-                            timeoutCountSinceLastSuccess += 1;
-                        } else {
-                            rejectedCountSinceLastSuccess += 1;
-                        }
-
-                        long failureCount = rejectedCountSinceLastSuccess + timeoutCountSinceLastSuccess;
-                        if (failureCount >= leaderCheckRetryCount) {
-                            logger.debug(
-                                () -> format(
-                                    "leader [%s] failed %s consecutive checks (rejected [%s], timed out [%s], limit [%s] is %s)",
-                                    leader,
-                                    failureCount,
-                                    rejectedCountSinceLastSuccess,
-                                    timeoutCountSinceLastSuccess,
-                                    LEADER_CHECK_RETRY_COUNT_SETTING.getKey(),
-                                    leaderCheckRetryCount
-                                ),
-                                exp
-                            );
-                            leaderFailed(
-                                () -> format(
-                                    "[%s] consecutive checks of the master node [%s] were unsuccessful ([%s] rejected, [%s] timed out), "
-                                        + "%s [last unsuccessful check: %s]",
-                                    failureCount,
-                                    leader.descriptionWithoutAttributes(),
-                                    rejectedCountSinceLastSuccess,
-                                    timeoutCountSinceLastSuccess,
-                                    RESTARTING_DISCOVERY_TEXT,
-                                    ExceptionsHelper.unwrapCause(exp).getMessage()
-                                ),
-                                exp
-                            );
-                            return;
-                        }
-
-                        logger.debug(
-                            () -> format(
-                                "%s consecutive failures (limit [%s] is %s) with leader [%s]",
-                                failureCount,
-                                LEADER_CHECK_RETRY_COUNT_SETTING.getKey(),
-                                leaderCheckRetryCount,
-                                leader
-                            ),
-                            exp
-                        );
-                        scheduleNextWakeUp();
-                    }
-                }
+                PING_REQUEST_OPTIONS,
+                new ActionListenerResponseHandler<>(
+                    ActionListener.addTimeout(
+                        leaderCheckTimeout,
+                        transportService.getThreadPool(),
+                        TransportResponseHandler.TRANSPORT_WORKER,
+                        responseHandler,
+                        () -> {/* not cancellable */}
+                    ),
+                    ignored -> ActionResponse.Empty.INSTANCE,
+                    TransportResponseHandler.TRANSPORT_WORKER
+                )
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -11,6 +11,7 @@ package org.elasticsearch.cluster.coordination;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
@@ -34,7 +35,6 @@ import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.AbstractTransportRequest;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.NodeDisconnectedException;
-import org.elasticsearch.transport.ReceiveTimeoutTransportException;
 import org.elasticsearch.transport.TransportConnectionListener;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportRequestOptions.Type;
@@ -269,7 +269,7 @@ public class LeaderChecker {
                     return;
                 }
 
-                if (exp instanceof ReceiveTimeoutTransportException) {
+                if (exp instanceof ElasticsearchTimeoutException) {
                     timeoutCountSinceLastSuccess += 1;
                 } else {
                     rejectedCountSinceLastSuccess += 1;

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionResponse;
@@ -31,7 +32,6 @@ import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
 import org.elasticsearch.transport.ConnectTransportException;
-import org.elasticsearch.transport.ReceiveTimeoutTransportException;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
@@ -167,7 +167,7 @@ public class LeaderCheckerTests extends ESTestCase {
         final AtomicBoolean leaderFailed = new AtomicBoolean();
 
         final LeaderChecker leaderChecker = new LeaderChecker(settings, transportService, (msg, e) -> {
-            assertThat(e, anyOf(instanceOf(RemoteTransportException.class), instanceOf(ReceiveTimeoutTransportException.class)));
+            assertThat(e, anyOf(instanceOf(RemoteTransportException.class), instanceOf(ElasticsearchTimeoutException.class)));
             if (e instanceof RemoteTransportException) {
                 assertThat(e.getCause().getMessage(), equalTo("simulated error"));
             }


### PR DESCRIPTION
As with #132713 there's no need to rely on transport-layer timeouts for
leader-check and follower-check requests: the requests are not
cancellable so the only effect of this timeout is to complete the
sender's listener early, which can be done outside the transport layer.