### PR TITLE
Clean up IndexRecoveryIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -271,7 +271,10 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
      */
     private void unthrottleRecovery() {
         updateClusterSettings(
-            ensureNoThrottlingOnNodeSettings().put(RecoverySettings.INDICES_RECOVERY_CHUNK_SIZE.getKey(), RecoverySettings.DEFAULT_CHUNK_SIZE)
+            ensureNoThrottlingOnNodeSettings().put(
+                RecoverySettings.INDICES_RECOVERY_CHUNK_SIZE.getKey(),
+                RecoverySettings.DEFAULT_CHUNK_SIZE
+            )
         );
     }
 
@@ -2083,11 +2086,10 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     }
 
     private CreateSnapshotResponse createSnapshot(String indexName) {
-        final var createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(
-            TEST_REQUEST_TIMEOUT,
-            REPO_NAME,
-            SNAP_NAME
-        ).setWaitForCompletion(true).setIndices(indexName).get();
+        final var createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, REPO_NAME, SNAP_NAME)
+            .setWaitForCompletion(true)
+            .setIndices(indexName)
+            .get();
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
         assertThat(
             createSnapshotResponse.getSnapshotInfo().successfulShards(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -871,7 +871,8 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             REPO_NAME,
             SNAP_NAME
         ).setWaitForCompletion(true).get();
-        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
+        int totalShards = restoreSnapshotResponse.getRestoreInfo().totalShards();
+        assertThat(totalShards, greaterThan(0));
 
         ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -122,7 +122,6 @@ import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.engine.MockEngineSupport;
 import org.elasticsearch.test.index.IndexVersionUtils;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.TestTransportChannel;
 import org.elasticsearch.transport.TransportService;
@@ -130,12 +129,10 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -147,7 +144,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singletonMap;
-import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.action.DocWriteResponse.Result.CREATED;
 import static org.elasticsearch.action.DocWriteResponse.Result.UPDATED;
 import static org.elasticsearch.action.support.ActionTestUtils.assertNoFailureListener;
@@ -165,7 +161,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
@@ -267,7 +262,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
      * @param dataSize size in bytes to recover in 10 seconds
      */
     private void throttleRecovery10Seconds(ByteSizeValue dataSize) {
-        long chunkSize = Math.max(1, dataSize.getBytes() / 10);
+        final long chunkSize = Math.max(1, dataSize.getBytes() / 10);
         updateClusterSettings(createRecoverySettingsChunkPerSecond(chunkSize));
     }
 
@@ -276,10 +271,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
      */
     private void unthrottleRecovery() {
         updateClusterSettings(
-            Settings.builder()
-                // 200mb is an arbitrary number intended to be large enough to avoid more throttling.
-                .put(RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "200mb")
-                .put(RecoverySettings.INDICES_RECOVERY_CHUNK_SIZE.getKey(), RecoverySettings.DEFAULT_CHUNK_SIZE)
+            ensureNoThrottlingSettings().put(RecoverySettings.INDICES_RECOVERY_CHUNK_SIZE.getKey(), RecoverySettings.DEFAULT_CHUNK_SIZE)
         );
     }
 
@@ -307,7 +299,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         });
 
         logger.info("--> checking cluster recovery stats reflect the ongoing recovery on each node");
-        NodesStatsResponse statsResponse = clusterAdmin().prepareNodesStats()
+        final NodesStatsResponse statsResponse = clusterAdmin().prepareNodesStats()
             .clear()
             .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Recovery))
             .get();
@@ -332,12 +324,12 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
      * @param isRecoveryThrottlingNode whether to expect throttling to have occurred on the node
      */
     public void assertNodeHasThrottleTimeAndNoRecoveries(String nodeName, Boolean isRecoveryThrottlingNode) {
-        NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats(nodeName)
+        final NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats(nodeName)
             .clear()
             .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Recovery))
             .get();
         assertThat(nodesStatsResponse.getNodes(), hasSize(1));
-        NodeStats nodeStats = nodesStatsResponse.getNodes().get(0);
+        final NodeStats nodeStats = nodesStatsResponse.getNodes().getFirst();
         final RecoveryStats recoveryStats = nodeStats.getIndices().getRecoveryStats();
         assertThat(recoveryStats.currentAsSource(), equalTo(0));
         assertThat(recoveryStats.currentAsTarget(), equalTo(0));
@@ -358,7 +350,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
 
     public void testGatewayRecovery() throws Exception {
         logger.info("--> start nodes");
-        String node = internalCluster().startNode();
+        final String node = internalCluster().startNode();
 
         createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0);
 
@@ -367,14 +359,14 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen();
 
         logger.info("--> request recoveries");
-        RecoveryResponse response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
+        final RecoveryResponse response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
         assertThat(response.shardRecoveryStates().size(), equalTo(SHARD_COUNT_1));
-        assertThat(response.shardRecoveryStates().get(INDEX_NAME).size(), equalTo(1));
+        assertThat(response.shardRecoveryStates().get(INDEX_NAME), hasSize(1));
 
-        List<RecoveryState> recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
-        assertThat(recoveryStates.size(), equalTo(1));
+        final List<RecoveryState> recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
+        assertThat(recoveryStates, hasSize(1));
 
-        RecoveryState recoveryState = recoveryStates.get(0);
+        final RecoveryState recoveryState = recoveryStates.getFirst();
 
         assertRecoveryState(recoveryState, 0, RecoverySource.ExistingStoreRecoverySource.INSTANCE, true, Stage.DONE, null, node);
 
@@ -392,10 +384,10 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen();
 
         logger.info("--> request recoveries");
-        RecoveryResponse response = indicesAdmin().prepareRecoveries(INDEX_NAME).setActiveOnly(true).get();
+        final RecoveryResponse response = indicesAdmin().prepareRecoveries(INDEX_NAME).setActiveOnly(true).get();
 
-        List<RecoveryState> recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
-        assertThat(recoveryStates.size(), equalTo(0));  // Should not expect any responses back
+        final List<RecoveryState> recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
+        assertThat(recoveryStates, empty());  // Should not expect any responses back
     }
 
     public void testReplicaRecovery() throws Exception {
@@ -422,19 +414,17 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         setReplicaCount(1, INDEX_NAME);
         ensureGreen(INDEX_NAME);
 
-        final RecoveryResponse response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
-
         // we should now have two total shards, one primary and one replica
-        List<RecoveryState> recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
-        assertThat(recoveryStates.size(), equalTo(2));
+        final List<RecoveryState> recoveryStates = getRecoveryStates(INDEX_NAME);
+        assertThat(recoveryStates, hasSize(2));
 
-        List<RecoveryState> nodeAResponses = findRecoveriesForTargetNode(nodeA, recoveryStates);
-        assertThat(nodeAResponses.size(), equalTo(1));
-        List<RecoveryState> nodeBResponses = findRecoveriesForTargetNode(nodeB, recoveryStates);
-        assertThat(nodeBResponses.size(), equalTo(1));
+        final List<RecoveryState> nodeAResponses = findRecoveriesForTargetNode(nodeA, recoveryStates);
+        assertThat(nodeAResponses, hasSize(1));
+        final List<RecoveryState> nodeBResponses = findRecoveriesForTargetNode(nodeB, recoveryStates);
+        assertThat(nodeBResponses, hasSize(1));
 
         // validate node A recovery
-        final RecoveryState nodeARecoveryState = nodeAResponses.get(0);
+        final RecoveryState nodeARecoveryState = nodeAResponses.getFirst();
         final RecoverySource expectedRecoverySource;
         if (closedIndex == false) {
             expectedRecoverySource = RecoverySource.EmptyStoreRecoverySource.INSTANCE;
@@ -445,7 +435,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         validateIndexRecoveryState(nodeARecoveryState.getIndex());
 
         // validate node B recovery
-        final RecoveryState nodeBRecoveryState = nodeBResponses.get(0);
+        final RecoveryState nodeBRecoveryState = nodeBResponses.getFirst();
         assertRecoveryState(nodeBRecoveryState, 0, PeerRecoverySource.INSTANCE, false, Stage.DONE, nodeA, nodeB);
         validateIndexRecoveryState(nodeBRecoveryState.getIndex());
 
@@ -472,7 +462,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                 .build()
         );
 
-        int numDocs = randomIntBetween(10, 200);
+        final int numDocs = randomIntBetween(10, 200);
         final IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
             docs[i] = prepareIndex(INDEX_NAME).setSource(
@@ -505,8 +495,8 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ReplicaShardAllocatorIT.ensureActivePeerRecoveryRetentionLeasesAdvanced(INDEX_NAME);
 
         // hold peer recovery on phase 2 after nodeB down
-        CountDownLatch phase1ReadyBlocked = new CountDownLatch(1);
-        CountDownLatch allowToCompletePhase1Latch = new CountDownLatch(1);
+        final CountDownLatch phase1ReadyBlocked = new CountDownLatch(1);
+        final CountDownLatch allowToCompletePhase1Latch = new CountDownLatch(1);
         final var transportService = MockTransportService.getInstance(nodeA);
         transportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (PeerRecoveryTargetService.Actions.CLEAN_FILES.equals(action)) {
@@ -522,14 +512,12 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             public Settings onNodeStopped(String nodeName) throws Exception {
                 safeAwait(phase1ReadyBlocked);
                 // nodeB stopped, peer recovery from nodeA to nodeC, it will be cancelled after nodeB get started.
-                RecoveryResponse response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
+                final List<RecoveryState> recoveryStates = getRecoveryStates(INDEX_NAME);
+                final List<RecoveryState> nodeCRecoveryStates = findRecoveriesForTargetNode(nodeC, recoveryStates);
+                assertThat(nodeCRecoveryStates, hasSize(1));
 
-                List<RecoveryState> recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
-                List<RecoveryState> nodeCRecoveryStates = findRecoveriesForTargetNode(nodeC, recoveryStates);
-                assertThat(nodeCRecoveryStates.size(), equalTo(1));
-
-                assertOnGoingRecoveryState(nodeCRecoveryStates.get(0), 0, PeerRecoverySource.INSTANCE, false, nodeA, nodeC);
-                validateIndexRecoveryState(nodeCRecoveryStates.get(0).getIndex());
+                assertOnGoingRecoveryState(nodeCRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, false, nodeA, nodeC);
+                validateIndexRecoveryState(nodeCRecoveryStates.getFirst().getIndex());
 
                 return super.onNodeStopped(nodeName);
             }
@@ -541,9 +529,9 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         transportService.clearAllRules();
 
         // make sure nodeA has primary and nodeB has replica
-        ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
-        List<ShardRouting> startedShards = RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.STARTED);
-        assertThat(startedShards.size(), equalTo(2));
+        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+        final List<ShardRouting> startedShards = RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.STARTED);
+        assertThat(startedShards, hasSize(2));
         for (ShardRouting shardRouting : startedShards) {
             if (shardRouting.primary()) {
                 assertThat(state.nodes().get(shardRouting.currentNodeId()).getName(), equalTo(nodeA));
@@ -558,15 +546,13 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         final String nodeA = internalCluster().startNode();
 
         logger.info("--> create index on node: {}", nodeA);
-        ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0].getStats()
+        final ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0]
+            .getStats()
             .getStore()
             .size();
 
         logger.info("--> start node B");
-        final String nodeB = internalCluster().startNode(
-            // Ensure that the target node has a high enough recovery max bytes per second to avoid any throttling
-            Settings.builder().put(RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "200mb")
-        );
+        final String nodeB = internalCluster().startNode(ensureNoThrottlingSettings());
 
         ensureGreen();
 
@@ -586,22 +572,20 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         });
 
         logger.info("--> request recoveries");
-        RecoveryResponse response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
-
-        List<RecoveryState> recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
+        List<RecoveryState> recoveryStates = getRecoveryStates(INDEX_NAME);
         List<RecoveryState> nodeARecoveryStates = findRecoveriesForTargetNode(nodeA, recoveryStates);
-        assertThat(nodeARecoveryStates.size(), equalTo(1));
+        assertThat(nodeARecoveryStates, hasSize(1));
         List<RecoveryState> nodeBRecoveryStates = findRecoveriesForTargetNode(nodeB, recoveryStates);
-        assertThat(nodeBRecoveryStates.size(), equalTo(1));
+        assertThat(nodeBRecoveryStates, hasSize(1));
 
-        assertRecoveryState(nodeARecoveryStates.get(0), 0, RecoverySource.EmptyStoreRecoverySource.INSTANCE, true, Stage.DONE, null, nodeA);
-        validateIndexRecoveryState(nodeARecoveryStates.get(0).getIndex());
+        assertRecoveryState(nodeARecoveryStates.getFirst(), 0, RecoverySource.EmptyStoreRecoverySource.INSTANCE, true, Stage.DONE, null, nodeA);
+        validateIndexRecoveryState(nodeARecoveryStates.getFirst().getIndex());
 
-        assertOnGoingRecoveryState(nodeBRecoveryStates.get(0), 0, PeerRecoverySource.INSTANCE, true, nodeA, nodeB);
-        validateIndexRecoveryState(nodeBRecoveryStates.get(0).getIndex());
+        assertOnGoingRecoveryState(nodeBRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, nodeA, nodeB);
+        validateIndexRecoveryState(nodeBRecoveryStates.getFirst().getIndex());
 
         logger.info("--> request node recovery stats");
-        NodesStatsResponse statsResponse = clusterAdmin().prepareNodesStats()
+        final NodesStatsResponse statsResponse = clusterAdmin().prepareNodesStats()
             .clear()
             .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Recovery))
             .get();
@@ -623,21 +607,19 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         // wait for it to be finished
         ensureGreen();
 
-        response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
+        recoveryStates = getRecoveryStates(INDEX_NAME);
+        assertThat(recoveryStates, hasSize(1));
 
-        recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
-        assertThat(recoveryStates.size(), equalTo(1));
+        assertRecoveryState(recoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
+        validateIndexRecoveryState(recoveryStates.getFirst().getIndex());
 
-        assertRecoveryState(recoveryStates.get(0), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
-        validateIndexRecoveryState(recoveryStates.get(0).getIndex());
-
-        Consumer<String> assertNodeHasThrottleTimeAndNoRecoveries = nodeName -> {
+        final Consumer<String> assertNodeHasThrottleTimeAndNoRecoveries = nodeName -> {
             NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats(nodeName)
                 .clear()
                 .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Recovery))
                 .get();
             assertThat(nodesStatsResponse.getNodes(), hasSize(1));
-            NodeStats nodeStats = nodesStatsResponse.getNodes().get(0);
+            NodeStats nodeStats = nodesStatsResponse.getNodes().getFirst();
             final RecoveryStats recoveryStats = nodeStats.getIndices().getRecoveryStats();
             assertThat(recoveryStats.currentAsSource(), equalTo(0));
             assertThat(recoveryStats.currentAsTarget(), equalTo(0));
@@ -652,7 +634,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen();
 
         logger.info("--> start node C");
-        String nodeC = internalCluster().startNode();
+        final String nodeC = internalCluster().startNode();
         assertFalse(clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setWaitForNodes("3").get().isTimedOut());
 
         logger.info("--> slowing down recoveries");
@@ -661,68 +643,73 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         logger.info("--> move replica shard from: {} to: {}", nodeA, nodeC);
         ClusterRerouteUtils.reroute(client(), new MoveAllocationCommand(INDEX_NAME, 0, nodeA, nodeC));
 
-        response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
-        recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
+        recoveryStates = getRecoveryStates(INDEX_NAME);
 
         nodeARecoveryStates = findRecoveriesForTargetNode(nodeA, recoveryStates);
-        assertThat(nodeARecoveryStates.size(), equalTo(1));
+        assertThat(nodeARecoveryStates, hasSize(1));
         nodeBRecoveryStates = findRecoveriesForTargetNode(nodeB, recoveryStates);
-        assertThat(nodeBRecoveryStates.size(), equalTo(1));
+        assertThat(nodeBRecoveryStates, hasSize(1));
         List<RecoveryState> nodeCRecoveryStates = findRecoveriesForTargetNode(nodeC, recoveryStates);
-        assertThat(nodeCRecoveryStates.size(), equalTo(1));
+        assertThat(nodeCRecoveryStates, hasSize(1));
 
-        assertRecoveryState(nodeARecoveryStates.get(0), 0, PeerRecoverySource.INSTANCE, false, Stage.DONE, nodeB, nodeA);
-        validateIndexRecoveryState(nodeARecoveryStates.get(0).getIndex());
+        assertRecoveryState(nodeARecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, false, Stage.DONE, nodeB, nodeA);
+        validateIndexRecoveryState(nodeARecoveryStates.getFirst().getIndex());
 
-        assertRecoveryState(nodeBRecoveryStates.get(0), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
-        validateIndexRecoveryState(nodeBRecoveryStates.get(0).getIndex());
+        assertRecoveryState(nodeBRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
+        validateIndexRecoveryState(nodeBRecoveryStates.getFirst().getIndex());
 
         // relocations of replicas are marked as REPLICA and the source node is the node holding the primary (B)
-        assertOnGoingRecoveryState(nodeCRecoveryStates.get(0), 0, PeerRecoverySource.INSTANCE, false, nodeB, nodeC);
-        validateIndexRecoveryState(nodeCRecoveryStates.get(0).getIndex());
+        assertOnGoingRecoveryState(nodeCRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, false, nodeB, nodeC);
+        validateIndexRecoveryState(nodeCRecoveryStates.getFirst().getIndex());
 
         if (randomBoolean()) {
             // shutdown node with relocation source of replica shard and check if recovery continues
             internalCluster().stopNode(nodeA);
             ensureStableCluster(2);
 
-            response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
-            recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
+            recoveryStates = getRecoveryStates(INDEX_NAME);
 
             nodeARecoveryStates = findRecoveriesForTargetNode(nodeA, recoveryStates);
-            assertThat(nodeARecoveryStates.size(), equalTo(0));
+            assertThat(nodeARecoveryStates, empty());
             nodeBRecoveryStates = findRecoveriesForTargetNode(nodeB, recoveryStates);
-            assertThat(nodeBRecoveryStates.size(), equalTo(1));
+            assertThat(nodeBRecoveryStates, hasSize(1));
             nodeCRecoveryStates = findRecoveriesForTargetNode(nodeC, recoveryStates);
-            assertThat(nodeCRecoveryStates.size(), equalTo(1));
+            assertThat(nodeCRecoveryStates, hasSize(1));
 
-            assertRecoveryState(nodeBRecoveryStates.get(0), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
-            validateIndexRecoveryState(nodeBRecoveryStates.get(0).getIndex());
+            assertRecoveryState(nodeBRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
+            validateIndexRecoveryState(nodeBRecoveryStates.getFirst().getIndex());
 
-            assertOnGoingRecoveryState(nodeCRecoveryStates.get(0), 0, PeerRecoverySource.INSTANCE, false, nodeB, nodeC);
-            validateIndexRecoveryState(nodeCRecoveryStates.get(0).getIndex());
+            assertOnGoingRecoveryState(nodeCRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, false, nodeB, nodeC);
+            validateIndexRecoveryState(nodeCRecoveryStates.getFirst().getIndex());
         }
 
         logger.info("--> speeding up recoveries");
         unthrottleRecovery();
         ensureGreen();
 
-        response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
-        recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
+        recoveryStates = getRecoveryStates(INDEX_NAME);
 
         nodeARecoveryStates = findRecoveriesForTargetNode(nodeA, recoveryStates);
-        assertThat(nodeARecoveryStates.size(), equalTo(0));
+        assertThat(nodeARecoveryStates, empty());
         nodeBRecoveryStates = findRecoveriesForTargetNode(nodeB, recoveryStates);
-        assertThat(nodeBRecoveryStates.size(), equalTo(1));
+        assertThat(nodeBRecoveryStates, hasSize(1));
         nodeCRecoveryStates = findRecoveriesForTargetNode(nodeC, recoveryStates);
-        assertThat(nodeCRecoveryStates.size(), equalTo(1));
+        assertThat(nodeCRecoveryStates, hasSize(1));
 
-        assertRecoveryState(nodeBRecoveryStates.get(0), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
-        validateIndexRecoveryState(nodeBRecoveryStates.get(0).getIndex());
+        assertRecoveryState(nodeBRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, Stage.DONE, nodeA, nodeB);
+        validateIndexRecoveryState(nodeBRecoveryStates.getFirst().getIndex());
 
         // relocations of replicas are marked as REPLICA and the source node is the node holding the primary (B)
-        assertRecoveryState(nodeCRecoveryStates.get(0), 0, PeerRecoverySource.INSTANCE, false, Stage.DONE, nodeB, nodeC);
-        validateIndexRecoveryState(nodeCRecoveryStates.get(0).getIndex());
+        assertRecoveryState(nodeCRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, false, Stage.DONE, nodeB, nodeC);
+        validateIndexRecoveryState(nodeCRecoveryStates.getFirst().getIndex());
+    }
+
+    private static List<RecoveryState> getRecoveryStates(String indexName) {
+        return indicesAdmin()
+            .prepareRecoveries(indexName)
+            .get()
+            .shardRecoveryStates()
+            .get(indexName);
     }
 
     /**
@@ -736,17 +723,15 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         final String nodeA = internalCluster().startNode();
 
         logger.info("--> creating index on node A");
-        ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0].getStats()
+        final ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0]
+            .getStats()
             .getStore()
             .size();
 
         logger.info("--> starting node B");
-        final String nodeB = internalCluster().startNode(
-            // Ensure that the target node has a high enough recovery max bytes per second to avoid any throttling
-            Settings.builder().put(RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "200mb")
-        );
+        final String nodeB = internalCluster().startNode(ensureNoThrottlingSettings());
 
-        long chunkSize = Math.max(1, shardSize.getBytes() / 10);
+        final long chunkSize = Math.max(1, shardSize.getBytes() / 10);
         logger.info(
             "--> restarting node A with recovery throttling settings. Index shard size is `{}`. Throttling down to a "
                 + "chunk of size `{}` per second. This will slow recovery of the shard to 10 seconds.",
@@ -770,7 +755,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
 
         logger.info("--> checking throttling increases on Node A (source node), while Node B (target node) reports no throttling");
         assertBusy(() -> {
-            NodesStatsResponse nodeStatsResponse = clusterAdmin().prepareNodesStats()
+            final NodesStatsResponse nodeStatsResponse = clusterAdmin().prepareNodesStats()
                 .clear()
                 .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Recovery))
                 .get();
@@ -778,7 +763,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             for (NodeStats nodeStats : nodeStatsResponse.getNodes()) {
                 final RecoveryStats recoveryStats = nodeStats.getIndices().getRecoveryStats();
                 if (nodeStats.getNode().getName().equals(nodeA)) {
-                    assertThat("node A throttling should  increase", recoveryStats.throttleTime().millis(), greaterThan(0L));
+                    assertThat("node A throttling should increase", recoveryStats.throttleTime().millis(), greaterThan(0L));
                 }
                 if (nodeStats.getNode().getName().equals(nodeB)) {
                     assertThat("node B throttling should _not_ increase", recoveryStats.throttleTime().millis(), equalTo(0L));
@@ -807,18 +792,15 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
      */
     public void testTargetThrottling() throws Exception {
         logger.info("--> starting node A with default settings");
-        final String nodeA = internalCluster().startNode(
-            Settings.builder()
-                // Use a high value so that when unthrottling recoveries we do not cause accidental throttling on the source node.
-                .put(RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "200mb")
-        );
+        final String nodeA = internalCluster().startNode(ensureNoThrottlingSettings());
 
         logger.info("--> creating index on node A");
-        ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0].getStats()
+        final ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0]
+            .getStats()
             .getStore()
             .size();
 
-        long chunkSize = Math.max(1, shardSize.getBytes() / 10);
+        final long chunkSize = Math.max(1, shardSize.getBytes() / 10);
         logger.info(
             "--> starting node B with recovery throttling settings. Index shard size is `{}`. Throttling down to a "
                 + "chunk of size `{}` per second. This will slow recovery of the existing shard to 10 seconds.",
@@ -836,7 +818,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
 
         logger.info("--> checking throttling increases on Node B (target node), while Node A (source node) reports no throttling");
         assertBusy(() -> {
-            NodesStatsResponse statsResponse1 = clusterAdmin().prepareNodesStats()
+            final NodesStatsResponse statsResponse1 = clusterAdmin().prepareNodesStats()
                 .clear()
                 .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Recovery))
                 .get();
@@ -869,7 +851,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
 
     public void testSnapshotRecovery() throws Exception {
         logger.info("--> start node A");
-        String nodeA = internalCluster().startNode();
+        final String nodeA = internalCluster().startNode();
 
         logger.info("--> create repository");
         createRepository(randomBoolean());
@@ -880,31 +862,30 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0);
 
         logger.info("--> snapshot");
-        CreateSnapshotResponse createSnapshotResponse = createSnapshot(INDEX_NAME);
+        final CreateSnapshotResponse createSnapshotResponse = createSnapshot(INDEX_NAME);
 
         indicesAdmin().prepareClose(INDEX_NAME).get();
 
         logger.info("--> restore");
-        RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(TEST_REQUEST_TIMEOUT, REPO_NAME, SNAP_NAME)
+        final RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin()
+            .prepareRestoreSnapshot(TEST_REQUEST_TIMEOUT, REPO_NAME, SNAP_NAME)
             .setWaitForCompletion(true)
             .get();
-        int totalShards = restoreSnapshotResponse.getRestoreInfo().totalShards();
-        assertThat(totalShards, greaterThan(0));
+        assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         ensureGreen();
 
         logger.info("--> request recoveries");
-        RecoveryResponse response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
+        final RecoveryResponse response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
 
-        Repository repository = internalCluster().getAnyMasterNodeInstance(RepositoriesService.class).repository(REPO_NAME);
+        final Repository repository = internalCluster().getAnyMasterNodeInstance(RepositoriesService.class).repository(REPO_NAME);
         final RepositoryData repositoryData = AbstractSnapshotIntegTestCase.getRepositoryData(repository);
         for (Map.Entry<String, List<RecoveryState>> indexRecoveryStates : response.shardRecoveryStates().entrySet()) {
-
             assertThat(indexRecoveryStates.getKey(), equalTo(INDEX_NAME));
-            List<RecoveryState> recoveryStates = indexRecoveryStates.getValue();
-            assertThat(recoveryStates.size(), equalTo(totalShards));
+            final List<RecoveryState> recoveryStates = indexRecoveryStates.getValue();
+            assertThat(recoveryStates, hasSize(restoreSnapshotResponse.getRestoreInfo().totalShards()));
 
-            for (RecoveryState recoveryState : recoveryStates) {
+            for (final RecoveryState recoveryState : recoveryStates) {
                 SnapshotRecoverySource recoverySource = new SnapshotRecoverySource(
                     ((SnapshotRecoverySource) recoveryState.getRecoverySource()).restoreUUID(),
                     new Snapshot(REPO_NAME, createSnapshotResponse.getSnapshotInfo().snapshotId()),
@@ -918,18 +899,13 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     }
 
     private List<RecoveryState> findRecoveriesForTargetNode(String nodeName, List<RecoveryState> recoveryStates) {
-        List<RecoveryState> nodeResponses = new ArrayList<>();
-        for (RecoveryState recoveryState : recoveryStates) {
-            if (recoveryState.getTargetNode().getName().equals(nodeName)) {
-                nodeResponses.add(recoveryState);
-            }
-        }
-        return nodeResponses;
+        return recoveryStates
+            .stream()
+            .filter(recoveryState -> nodeName.equals(recoveryState.getTargetNode().getName()))
+            .toList();
     }
 
-    private IndicesStatsResponse createAndPopulateIndex(String name, int nodeCount, int shardCount, int replicaCount)
-        throws ExecutionException, InterruptedException {
-
+    private IndicesStatsResponse createAndPopulateIndex(String name, int nodeCount, int shardCount, int replicaCount) {
         logger.info("--> creating test index: {}", name);
         assertAcked(
             prepareCreate(
@@ -997,8 +973,8 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     }
 
     /**
-     * Tests scenario where recovery target successfully sends recovery request to source but then the channel gets closed while
-     * the source is working on the recovery process.
+     * Tests a scenario where the recovery target successfully sends a recovery request to the source, but then the channel gets closed
+     * while the source is working on the recovery process.
      */
     public void testDisconnectsDuringRecovery() throws Exception {
         checkDisconnectsDuringRecovery(false);
@@ -1024,11 +1000,11 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             flush(indexName);
         }
 
-        String firstNodeToStop = randomFrom(internalCluster().getNodeNames());
-        Settings firstNodeToStopDataPathSettings = internalCluster().dataPathSettings(firstNodeToStop);
+        final String firstNodeToStop = randomFrom(internalCluster().getNodeNames());
+        final Settings firstNodeToStopDataPathSettings = internalCluster().dataPathSettings(firstNodeToStop);
         internalCluster().stopNode(firstNodeToStop);
-        String secondNodeToStop = randomFrom(internalCluster().getNodeNames());
-        Settings secondNodeToStopDataPathSettings = internalCluster().dataPathSettings(secondNodeToStop);
+        final String secondNodeToStop = randomFrom(internalCluster().getNodeNames());
+        final Settings secondNodeToStopDataPathSettings = internalCluster().dataPathSettings(secondNodeToStop);
         internalCluster().stopNode(secondNodeToStop);
 
         final long desyncNanoTime = System.nanoTime();
@@ -1054,8 +1030,8 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         recoveryStates.removeIf(r -> r.getTimer().getStartNanoTime() <= desyncNanoTime);
 
         assertThat(recoveryStates, hasSize(1));
-        final RecoveryState recoveryState = recoveryStates.get(0);
-        assertThat(Strings.toString(recoveryState), recoveryState.getIndex().totalFileCount(), is(0));
+        final RecoveryState recoveryState = recoveryStates.getFirst();
+        assertThat(Strings.toString(recoveryState), recoveryState.getIndex().totalFileCount(), equalTo(0));
         assertThat(recoveryState.getTranslog().recoveredOperations(), greaterThan(0));
     }
 
@@ -1069,16 +1045,16 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                 .build()
         );
         indicesAdmin().preparePutMapping("test").setSource("test_field", "type=text,analyzer=test_analyzer").get();
-        int numDocs = between(1, 10);
+        final int numDocs = between(1, 10);
         for (int i = 0; i < numDocs; i++) {
             prepareIndex("test").setId("u" + i).setSource(singletonMap("test_field", Integer.toString(i)), XContentType.JSON).get();
         }
-        Semaphore recoveryBlocked = new Semaphore(1);
+        final Semaphore recoveryBlocked = new Semaphore(1);
         for (DiscoveryNode node : clusterService().state().nodes()) {
             MockTransportService.getInstance(node.getName()).addSendBehavior((connection, requestId, action, request, options) -> {
                 if (action.equals(PeerRecoverySourceService.Actions.START_RECOVERY)) {
                     if (recoveryBlocked.tryAcquire()) {
-                        PluginsService pluginService = internalCluster().getInstance(PluginsService.class, node.getName());
+                        final PluginsService pluginService = internalCluster().getInstance(PluginsService.class, node.getName());
                         pluginService.filterPlugins(TestAnalysisPlugin.class).forEach(p -> p.throwParsingError.set(true));
                     }
                 }
@@ -1087,7 +1063,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         }
         setReplicaCount(1, "test");
 
-        var allocator = internalCluster().getInstance(ShardsAllocator.class);
+        final var allocator = internalCluster().getInstance(ShardsAllocator.class);
         if (allocator instanceof BalancedShardsAllocator) {
             // BalancedShardsAllocator will try other node once retries are exhausted
             ensureGreen("test");
@@ -1104,16 +1080,16 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
 
     /** Makes sure the new master does not repeatedly fetch index metadata from recovering replicas */
     public void testOngoingRecoveryAndMasterFailOver() throws Exception {
-        String indexName = "test";
+        final String indexName = "test";
         internalCluster().startNodes(2);
-        String nodeWithPrimary = internalCluster().startDataOnlyNode();
+        final String nodeWithPrimary = internalCluster().startDataOnlyNode();
         assertAcked(
             indicesAdmin().prepareCreate(indexName)
                 .setSettings(indexSettings(1, 0).put("index.routing.allocation.include._name", nodeWithPrimary))
         );
-        CountDownLatch phase1ReadyBlocked = new CountDownLatch(1);
-        CountDownLatch allowToCompletePhase1Latch = new CountDownLatch(1);
-        Semaphore blockRecovery = new Semaphore(1);
+        final CountDownLatch phase1ReadyBlocked = new CountDownLatch(1);
+        final CountDownLatch allowToCompletePhase1Latch = new CountDownLatch(1);
+        final Semaphore blockRecovery = new Semaphore(1);
         MockTransportService.getInstance(nodeWithPrimary).addSendBehavior((connection, requestId, action, request, options) -> {
             if (PeerRecoveryTargetService.Actions.CLEAN_FILES.equals(action) && blockRecovery.tryAcquire()) {
                 phase1ReadyBlocked.countDown();
@@ -1122,7 +1098,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             connection.sendRequest(requestId, action, request, options);
         });
         try {
-            String nodeWithReplica = internalCluster().startDataOnlyNode();
+            final String nodeWithReplica = internalCluster().startDataOnlyNode();
             updateIndexSettings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
@@ -1146,17 +1122,13 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen(indexName);
     }
 
-    @TestLogging(
-        reason = "https://github.com/elastic/elasticsearch/issues/89235",
-        value = "org.elasticsearch.indices.recovery:TRACE, org.elasticsearch.index.shard:TRACE, org.elasticsearch.index.engine:TRACE"
-    )
     public void testRecoverLocallyUpToGlobalCheckpoint() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(2);
-        List<String> nodes = randomSubsetOf(
+        final List<String> nodes = randomSubsetOf(
             2,
             clusterService().state().nodes().getDataNodes().values().stream().map(DiscoveryNode::getName).collect(Collectors.toSet())
         );
-        String indexName = "test-index";
+        final String indexName = "test-index";
         createIndex(
             indexName,
             indexSettings(1, 1)
@@ -1166,20 +1138,20 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                 .build()
         );
         ensureGreen(indexName);
-        int numDocs = randomIntBetween(0, 100);
+        final int numDocs = randomIntBetween(0, 100);
         indexRandom(
             randomBoolean(),
             false,
             randomBoolean(),
-            IntStream.range(0, numDocs).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).collect(toList())
+            IntStream.range(0, numDocs).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).toList()
         );
         indicesAdmin().prepareRefresh(indexName).get(); // avoid refresh when we are failing a shard
-        String failingNode = randomFrom(nodes);
-        PlainActionFuture<StartRecoveryRequest> startRecoveryRequestFuture = new PlainActionFuture<>();
+        final String failingNode = randomFrom(nodes);
+        final PlainActionFuture<StartRecoveryRequest> startRecoveryRequestFuture = new PlainActionFuture<>();
         // Peer recovery fails if the primary does not see the recovering replica in the replication group (when the cluster state
         // update on the primary is delayed). To verify the local recovery stats, we have to manually remember this value in the
         // first try because the local recovery happens once and its stats is reset when the recovery fails.
-        SetOnce<Integer> localRecoveredOps = new SetOnce<>();
+        final SetOnce<Integer> localRecoveredOps = new SetOnce<>();
         for (String node : nodes) {
             MockTransportService.getInstance(node).addSendBehavior((connection, requestId, action, request, options) -> {
                 if (action.equals(PeerRecoverySourceService.Actions.START_RECOVERY)) {
@@ -1197,7 +1169,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                     }
                 }
                 if (action.equals(PeerRecoveryTargetService.Actions.FILE_CHUNK)) {
-                    RetentionLeases retentionLeases = internalCluster().getInstance(IndicesService.class, node)
+                    final RetentionLeases retentionLeases = internalCluster().getInstance(IndicesService.class, node)
                         .indexServiceSafe(resolveIndex(indexName))
                         .getShard(0)
                         .getRetentionLeases();
@@ -1210,7 +1182,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         }
         assertGlobalCheckpointIsStableAndSyncedInAllNodes(indexName, nodes, 0);
 
-        IndexShard shard = internalCluster().getInstance(IndicesService.class, failingNode)
+        final IndexShard shard = internalCluster().getInstance(IndicesService.class, failingNode)
             .getShardOrNull(new ShardId(resolveIndex(indexName), 0));
         final long lastSyncedGlobalCheckpoint = shard.getLastSyncedGlobalCheckpoint();
         final long localCheckpointOfSafeCommit;
@@ -1219,13 +1191,13 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         }
         final long maxSeqNo = shard.seqNoStats().getMaxSeqNo();
         shard.failShard("test", new IOException("simulated"));
-        StartRecoveryRequest startRecoveryRequest = startRecoveryRequestFuture.actionGet();
+        final StartRecoveryRequest startRecoveryRequest = startRecoveryRequestFuture.actionGet();
         logger.info(
             "--> start recovery request: starting seq_no {}, commit {}",
             startRecoveryRequest.startingSeqNo(),
             startRecoveryRequest.metadataSnapshot().commitUserData()
         );
-        SequenceNumbers.CommitInfo commitInfoAfterLocalRecovery = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(
+        final SequenceNumbers.CommitInfo commitInfoAfterLocalRecovery = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(
             startRecoveryRequest.metadataSnapshot().commitUserData().entrySet()
         );
         assertThat(commitInfoAfterLocalRecovery.localCheckpoint(), equalTo(lastSyncedGlobalCheckpoint));
@@ -1233,7 +1205,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         assertThat(startRecoveryRequest.startingSeqNo(), equalTo(lastSyncedGlobalCheckpoint + 1));
         ensureGreen(indexName);
         assertThat((long) localRecoveredOps.get(), equalTo(lastSyncedGlobalCheckpoint - localCheckpointOfSafeCommit));
-        for (RecoveryState recoveryState : indicesAdmin().prepareRecoveries().get().shardRecoveryStates().get(indexName)) {
+        for (final RecoveryState recoveryState : indicesAdmin().prepareRecoveries().get().shardRecoveryStates().get(indexName)) {
             if (startRecoveryRequest.targetNode().equals(recoveryState.getTargetNode())) {
                 assertThat("expect an operation-based recovery", recoveryState.getIndex().fileDetails(), empty());
                 assertThat(
@@ -1251,7 +1223,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     public void testUsesFileBasedRecoveryIfRetentionLeaseMissing() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(2);
 
-        String indexName = "test-index";
+        final String indexName = "test-index";
         createIndex(
             indexName,
             indexSettings(1, 1).put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
@@ -1262,7 +1234,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             randomBoolean(),
             randomBoolean(),
             randomBoolean(),
-            IntStream.range(0, between(0, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).collect(toList())
+            IntStream.range(0, between(0, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).toList()
         );
         ensureGreen(indexName);
 
@@ -1275,7 +1247,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             discoveryNodes.get(indexShardRoutingTable.primaryShard().currentNodeId()).getName()
         ).getShardOrNull(shardId);
 
-        final ShardRouting replicaShardRouting = indexShardRoutingTable.replicaShards().get(0);
+        final ShardRouting replicaShardRouting = indexShardRoutingTable.replicaShards().getFirst();
         internalCluster().restartNode(
             discoveryNodes.get(replicaShardRouting.currentNodeId()).getName(),
             new InternalTestCluster.RestartCallback() {
@@ -1301,10 +1273,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen(indexName);
 
         // noinspection OptionalGetWithoutIsPresent because it fails the test if absent
-        final RecoveryState recoveryState = indicesAdmin().prepareRecoveries(indexName)
-            .get()
-            .shardRecoveryStates()
-            .get(indexName)
+        final RecoveryState recoveryState = getRecoveryStates(indexName)
             .stream()
             .filter(rs -> rs.getPrimary() == false)
             .findFirst()
@@ -1315,7 +1284,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     public void testUsesFileBasedRecoveryIfRetentionLeaseAheadOfGlobalCheckpoint() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(2);
 
-        String indexName = "test-index";
+        final String indexName = "test-index";
         createIndex(
             indexName,
             indexSettings(1, 1).put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
@@ -1326,7 +1295,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             randomBoolean(),
             randomBoolean(),
             randomBoolean(),
-            IntStream.range(0, between(0, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).collect(toList())
+            IntStream.range(0, between(0, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).toList()
         );
         ensureGreen(indexName);
 
@@ -1339,7 +1308,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             discoveryNodes.get(indexShardRoutingTable.primaryShard().currentNodeId()).getName()
         ).getShardOrNull(shardId);
 
-        final ShardRouting replicaShardRouting = indexShardRoutingTable.replicaShards().get(0);
+        final ShardRouting replicaShardRouting = indexShardRoutingTable.replicaShards().getFirst();
         internalCluster().restartNode(
             discoveryNodes.get(replicaShardRouting.currentNodeId()).getName(),
             new InternalTestCluster.RestartCallback() {
@@ -1357,7 +1326,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                         randomBoolean(),
                         randomBoolean(),
                         randomBoolean(),
-                        IntStream.range(0, between(1, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).collect(toList())
+                        IntStream.range(0, between(1, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).toList()
                     );
 
                     // We do not guarantee that the replica can recover locally all the way to its own global checkpoint before starting
@@ -1377,10 +1346,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen(indexName);
 
         // noinspection OptionalGetWithoutIsPresent because it fails the test if absent
-        final RecoveryState recoveryState = indicesAdmin().prepareRecoveries(indexName)
-            .get()
-            .shardRecoveryStates()
-            .get(indexName)
+        final RecoveryState recoveryState = getRecoveryStates(indexName)
             .stream()
             .filter(rs -> rs.getPrimary() == false)
             .findFirst()
@@ -1391,7 +1357,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     public void testUsesFileBasedRecoveryIfOperationsBasedRecoveryWouldBeUnreasonable() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(2);
 
-        String indexName = "test-index";
+        final String indexName = "test-index";
         final Settings.Builder settings = indexSettings(1, 1).put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
             .put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "12h")
             .put(IndexService.RETENTION_LEASE_SYNC_INTERVAL_SETTING.getKey(), "100ms");
@@ -1410,7 +1376,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             randomBoolean(),
             false,
             randomBoolean(),
-            IntStream.range(0, between(0, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).collect(toList())
+            IntStream.range(0, between(0, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).toList()
         );
         ensureGreen(indexName);
 
@@ -1440,7 +1406,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         final DiscoveryNodes discoveryNodes = clusterService().state().nodes();
         final IndexShardRoutingTable indexShardRoutingTable = clusterService().state().routingTable().shardRoutingTable(shardId);
 
-        final ShardRouting replicaShardRouting = indexShardRoutingTable.replicaShards().get(0);
+        final ShardRouting replicaShardRouting = indexShardRoutingTable.replicaShards().getFirst();
         assertTrue(
             "should have lease for " + replicaShardRouting,
             indicesAdmin().prepareStats(indexName).get().getShards()[0].getRetentionLeaseStats()
@@ -1491,7 +1457,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                         randomBoolean(),
                         randomBoolean(),
                         randomBoolean(),
-                        IntStream.range(0, newDocCount).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).collect(toList())
+                        IntStream.range(0, newDocCount).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).toList()
                     );
 
                     flush(indexName);
@@ -1513,10 +1479,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen(indexName);
 
         // noinspection OptionalGetWithoutIsPresent because it fails the test if absent
-        final RecoveryState recoveryState = indicesAdmin().prepareRecoveries(indexName)
-            .get()
-            .shardRecoveryStates()
-            .get(indexName)
+        final RecoveryState recoveryState = getRecoveryStates(indexName)
             .stream()
             .filter(rs -> rs.getPrimary() == false)
             .findFirst()
@@ -1527,13 +1490,13 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     public void testDoesNotCopyOperationsInSafeCommit() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(2);
 
-        String indexName = "test-index";
+        final String indexName = "test-index";
         createIndex(indexName, indexSettings(1, 0).put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true).build());
         indexRandom(
             randomBoolean(),
             randomBoolean(),
             randomBoolean(),
-            IntStream.range(0, between(0, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).collect(toList())
+            IntStream.range(0, between(0, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).toList()
         );
 
         final ShardId shardId = new ShardId(resolveIndex(indexName), 0);
@@ -1546,13 +1509,13 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ).getShardOrNull(shardId);
         final long maxSeqNoBeforeRecovery = primary.seqNoStats().getMaxSeqNo();
         assertBusy(() -> assertThat(primary.getLastSyncedGlobalCheckpoint(), equalTo(maxSeqNoBeforeRecovery)));
-        assertThat(indicesAdmin().prepareFlush(indexName).get().getFailedShards(), is(0)); // makes a safe commit
+        assertThat(indicesAdmin().prepareFlush(indexName).get().getFailedShards(), equalTo(0)); // makes a safe commit
 
         indexRandom(
             randomBoolean(),
             randomBoolean(),
             randomBoolean(),
-            IntStream.range(0, between(0, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).collect(toList())
+            IntStream.range(0, between(0, 100)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).toList()
         );
 
         setReplicaCount(1, indexName);
@@ -1560,10 +1523,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         final long maxSeqNoAfterRecovery = primary.seqNoStats().getMaxSeqNo();
 
         // noinspection OptionalGetWithoutIsPresent because it fails the test if absent
-        final RecoveryState recoveryState = indicesAdmin().prepareRecoveries(indexName)
-            .get()
-            .shardRecoveryStates()
-            .get(indexName)
+        final RecoveryState recoveryState = getRecoveryStates(indexName)
             .stream()
             .filter(rs -> rs.getPrimary() == false)
             .findFirst()
@@ -1606,7 +1566,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             randomBoolean(),
             false,
             randomBoolean(),
-            IntStream.range(0, randomIntBetween(0, 10)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).collect(toList())
+            IntStream.range(0, randomIntBetween(0, 10)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).toList()
         );
 
         assertThat(indicesAdmin().prepareFlush(indexName).get().getFailedShards(), equalTo(0));
@@ -1634,7 +1594,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             randomBoolean(),
             false,
             randomBoolean(),
-            IntStream.range(0, randomIntBetween(0, 10)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).collect(toList())
+            IntStream.range(0, randomIntBetween(0, 10)).mapToObj(n -> prepareIndex(indexName).setSource("num", n)).toList()
         );
 
         logger.info("--> add replicas again");
@@ -1671,16 +1631,16 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
 
     public void testPeerRecoveryTrimsLocalTranslog() throws Exception {
         internalCluster().startNode();
-        List<String> dataNodes = internalCluster().startDataOnlyNodes(2);
-        String indexName = "test-index";
+        final List<String> dataNodes = internalCluster().startDataOnlyNodes(2);
+        final String indexName = "test-index";
         createIndex(indexName, indexSettings(1, 1).put("index.routing.allocation.include._name", String.join(",", dataNodes)).build());
         ensureGreen(indexName);
-        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
-        DiscoveryNode nodeWithOldPrimary = clusterState.nodes()
+        final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+        final DiscoveryNode nodeWithOldPrimary = clusterState.nodes()
             .get(clusterState.routingTable().index(indexName).shard(0).primaryShard().currentNodeId());
         final var transportService = MockTransportService.getInstance(nodeWithOldPrimary.getName());
-        CountDownLatch readyToRestartNode = new CountDownLatch(1);
-        AtomicBoolean stopped = new AtomicBoolean();
+        final CountDownLatch readyToRestartNode = new CountDownLatch(1);
+        final AtomicBoolean stopped = new AtomicBoolean();
         transportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (action.equals("indices:data/write/bulk[s][r]") && randomInt(100) < 5) {
                 throw new NodeClosedException(nodeWithOldPrimary);
@@ -1693,16 +1653,16 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             }
             connection.sendRequest(requestId, action, request, options);
         });
-        Thread[] indexers = new Thread[randomIntBetween(1, 8)];
+        final Thread[] indexers = new Thread[randomIntBetween(1, 8)];
         for (int i = 0; i < indexers.length; i++) {
             indexers[i] = new Thread(() -> {
                 while (stopped.get() == false) {
                     try {
-                        DocWriteResponse response = prepareIndex(indexName).setSource(
+                        final DocWriteResponse response = prepareIndex(indexName).setSource(
                             Map.of("f" + randomIntBetween(1, 10), randomNonNegativeLong()),
                             XContentType.JSON
                         ).get();
-                        assertThat(response.getResult(), is(oneOf(CREATED, UPDATED)));
+                        assertThat(response.getResult(), oneOf(CREATED, UPDATED));
                     } catch (ElasticsearchException ignored) {}
                 }
             });
@@ -1739,8 +1699,8 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
 
     public void testReservesBytesDuringPeerRecoveryPhaseOne() throws Exception {
         internalCluster().startNode();
-        List<String> dataNodes = internalCluster().startDataOnlyNodes(2);
-        String indexName = "test-index";
+        final List<String> dataNodes = internalCluster().startDataOnlyNodes(2);
+        final String indexName = "test-index";
         createIndex(indexName, indexSettings(1, 0).put("index.routing.allocation.include._name", String.join(",", dataNodes)).build());
         ensureGreen(indexName);
         final List<IndexRequestBuilder> indexRequests = IntStream.range(0, between(10, 500))
@@ -1749,8 +1709,8 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         indexRandom(randomBoolean(), true, true, indexRequests);
         assertThat(indicesAdmin().prepareFlush(indexName).get().getFailedShards(), equalTo(0));
 
-        ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
-        DiscoveryNode nodeWithPrimary = clusterState.nodes()
+        final ClusterState clusterState = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+        final DiscoveryNode nodeWithPrimary = clusterState.nodes()
             .get(clusterState.routingTable().index(indexName).shard(0).primaryShard().currentNodeId());
 
         final AtomicBoolean fileInfoIntercepted = new AtomicBoolean();
@@ -1763,13 +1723,13 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                         .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Store))
                         .get()
                         .getNodes()
-                        .get(0)
+                        .getFirst()
                         .getIndices();
                     assertThat(nodeIndicesStats.getStore().reservedSizeInBytes(), equalTo(0L));
                     assertThat(
                         nodeIndicesStats.getShardStats(clusterState.metadata().getProject().index(indexName).getIndex())
                             .stream()
-                            .flatMap(s -> Arrays.stream(s.getShards()))
+                            .flatMap(s -> Stream.of(s.getShards()))
                             .map(s -> s.getStats().getStore().reservedSizeInBytes())
                             .toList(),
                         everyItem(equalTo(StoreStats.UNKNOWN_RESERVED_BYTES))
@@ -1783,7 +1743,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                             .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Store))
                             .get()
                             .getNodes()
-                            .get(0)
+                            .getFirst()
                             .getIndices()
                             .getStore()
                             .reservedSizeInBytes(),
@@ -1813,7 +1773,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     public void testWaitForClusterStateToBeAppliedOnSourceNode() throws Exception {
         internalCluster().startMasterOnlyNode();
         final var primaryNode = internalCluster().startDataOnlyNode();
-        String indexName = "test-index";
+        final String indexName = "test-index";
         createIndex(indexName, indexSettings(1, 0).build());
         ensureGreen(indexName);
         final List<IndexRequestBuilder> indexRequests = IntStream.range(0, between(10, 500))
@@ -1883,7 +1843,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     public void testDeleteIndexDuringFinalization() throws Exception {
         internalCluster().startMasterOnlyNode();
         final var primaryNode = internalCluster().startDataOnlyNode();
-        String indexName = "test-index";
+        final String indexName = "test-index";
         createIndex(indexName, indexSettings(1, 0).build());
         ensureGreen(indexName);
         final List<IndexRequestBuilder> indexRequests = IntStream.range(0, between(10, 500))
@@ -2115,18 +2075,18 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     }
 
     private void assertGlobalCheckpointIsStableAndSyncedInAllNodes(String indexName, List<String> nodes, int shard) throws Exception {
-        assertThat(nodes, is(not(empty())));
+        assertThat(nodes, not(empty()));
 
-        ShardId shardId = new ShardId(resolveIndex(indexName), shard);
-        IndexShard indexShard = internalCluster().getInstance(IndicesService.class, nodes.get(0)).getShardOrNull(shardId);
-        assertThat(indexShard, is(notNullValue()));
-        long maxSeqNo = indexShard.seqNoStats().getMaxSeqNo();
+        final ShardId shardId = new ShardId(resolveIndex(indexName), shard);
+        final IndexShard indexShard = internalCluster().getInstance(IndicesService.class, nodes.getFirst()).getShardOrNull(shardId);
+        assertThat(indexShard, notNullValue());
+        final long maxSeqNo = indexShard.seqNoStats().getMaxSeqNo();
 
-        for (String node : nodes) {
+        for (final String node : nodes) {
             IndexShard nodeIndexShard = internalCluster().getInstance(IndicesService.class, node).getShardOrNull(shardId);
-            assertThat(nodeIndexShard, is(notNullValue()));
+            assertThat(nodeIndexShard, notNullValue());
 
-            assertThat(nodeIndexShard.seqNoStats().getMaxSeqNo(), is(equalTo(maxSeqNo)));
+            assertThat(nodeIndexShard.seqNoStats().getMaxSeqNo(), equalTo(maxSeqNo));
             assertBusy(() -> assertThat(nodeIndexShard.getLastSyncedGlobalCheckpoint(), equalTo(maxSeqNo)));
         }
     }
@@ -2145,7 +2105,8 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     }
 
     private CreateSnapshotResponse createSnapshot(String indexName) {
-        CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, REPO_NAME, SNAP_NAME)
+        final CreateSnapshotResponse createSnapshotResponse = clusterAdmin()
+            .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, REPO_NAME, SNAP_NAME)
             .setWaitForCompletion(true)
             .setIndices(indexName)
             .get();
@@ -2156,7 +2117,12 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         );
 
         assertThat(
-            clusterAdmin().prepareGetSnapshots(TEST_REQUEST_TIMEOUT, REPO_NAME).setSnapshots(SNAP_NAME).get().getSnapshots().get(0).state(),
+            clusterAdmin().prepareGetSnapshots(TEST_REQUEST_TIMEOUT, REPO_NAME)
+                .setSnapshots(SNAP_NAME)
+                .get()
+                .getSnapshots()
+                .getFirst()
+                .state(),
             equalTo(SnapshotState.SUCCESS)
         );
         return createSnapshotResponse;
@@ -2196,13 +2162,18 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                         throw new IllegalStateException();
                     }
                     final long docSeqNo = seqNoDocValue.longValue();
-                    assertThat(docSeqNo, is(greaterThan(commitLocalCheckpoint)));
+                    assertThat(docSeqNo, greaterThan(commitLocalCheckpoint));
                     localCheckpointTracker.markSeqNoAsProcessed(docSeqNo);
                     localCheckpointTracker.markSeqNoAsPersisted(docSeqNo);
                 }
             }
-            assertThat(localCheckpointTracker.getPersistedCheckpoint(), is(greaterThanOrEqualTo(commitLocalCheckpoint)));
+            assertThat(localCheckpointTracker.getPersistedCheckpoint(), greaterThanOrEqualTo(commitLocalCheckpoint));
             return localCheckpointTracker.getPersistedCheckpoint();
         }
+    }
+
+    // Ensure that the target node has high enough recovery max-bytes-per-second to avoid any throttling (setting large enough BPS)
+    private static Settings.Builder ensureNoThrottlingSettings() {
+        return Settings.builder().put(RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "200mb");
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -546,8 +546,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         final String nodeA = internalCluster().startNode();
 
         logger.info("--> create index on node: {}", nodeA);
-        final ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0]
-            .getStats()
+        final ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0].getStats()
             .getStore()
             .size();
 
@@ -578,7 +577,15 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         List<RecoveryState> nodeBRecoveryStates = findRecoveriesForTargetNode(nodeB, recoveryStates);
         assertThat(nodeBRecoveryStates, hasSize(1));
 
-        assertRecoveryState(nodeARecoveryStates.getFirst(), 0, RecoverySource.EmptyStoreRecoverySource.INSTANCE, true, Stage.DONE, null, nodeA);
+        assertRecoveryState(
+            nodeARecoveryStates.getFirst(),
+            0,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            true,
+            Stage.DONE,
+            null,
+            nodeA
+        );
         validateIndexRecoveryState(nodeARecoveryStates.getFirst().getIndex());
 
         assertOnGoingRecoveryState(nodeBRecoveryStates.getFirst(), 0, PeerRecoverySource.INSTANCE, true, nodeA, nodeB);
@@ -705,11 +712,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     }
 
     private static List<RecoveryState> getRecoveryStates(String indexName) {
-        return indicesAdmin()
-            .prepareRecoveries(indexName)
-            .get()
-            .shardRecoveryStates()
-            .get(indexName);
+        return indicesAdmin().prepareRecoveries(indexName).get().shardRecoveryStates().get(indexName);
     }
 
     /**
@@ -723,8 +726,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         final String nodeA = internalCluster().startNode();
 
         logger.info("--> creating index on node A");
-        final ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0]
-            .getStats()
+        final ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0].getStats()
             .getStore()
             .size();
 
@@ -795,8 +797,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         final String nodeA = internalCluster().startNode(ensureNoThrottlingSettings());
 
         logger.info("--> creating index on node A");
-        final ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0]
-            .getStats()
+        final ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0].getStats()
             .getStore()
             .size();
 
@@ -867,10 +868,11 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         indicesAdmin().prepareClose(INDEX_NAME).get();
 
         logger.info("--> restore");
-        final RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin()
-            .prepareRestoreSnapshot(TEST_REQUEST_TIMEOUT, REPO_NAME, SNAP_NAME)
-            .setWaitForCompletion(true)
-            .get();
+        final RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(
+            TEST_REQUEST_TIMEOUT,
+            REPO_NAME,
+            SNAP_NAME
+        ).setWaitForCompletion(true).get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         ensureGreen();
@@ -899,10 +901,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     }
 
     private List<RecoveryState> findRecoveriesForTargetNode(String nodeName, List<RecoveryState> recoveryStates) {
-        return recoveryStates
-            .stream()
-            .filter(recoveryState -> nodeName.equals(recoveryState.getTargetNode().getName()))
-            .toList();
+        return recoveryStates.stream().filter(recoveryState -> nodeName.equals(recoveryState.getTargetNode().getName())).toList();
     }
 
     private IndicesStatsResponse createAndPopulateIndex(String name, int nodeCount, int shardCount, int replicaCount) {
@@ -1273,11 +1272,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen(indexName);
 
         // noinspection OptionalGetWithoutIsPresent because it fails the test if absent
-        final RecoveryState recoveryState = getRecoveryStates(indexName)
-            .stream()
-            .filter(rs -> rs.getPrimary() == false)
-            .findFirst()
-            .get();
+        final RecoveryState recoveryState = getRecoveryStates(indexName).stream().filter(rs -> rs.getPrimary() == false).findFirst().get();
         assertThat(recoveryState.getIndex().totalFileCount(), greaterThan(0));
     }
 
@@ -1346,11 +1341,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen(indexName);
 
         // noinspection OptionalGetWithoutIsPresent because it fails the test if absent
-        final RecoveryState recoveryState = getRecoveryStates(indexName)
-            .stream()
-            .filter(rs -> rs.getPrimary() == false)
-            .findFirst()
-            .get();
+        final RecoveryState recoveryState = getRecoveryStates(indexName).stream().filter(rs -> rs.getPrimary() == false).findFirst().get();
         assertThat(recoveryState.getIndex().totalFileCount(), greaterThan(0));
     }
 
@@ -1479,11 +1470,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ensureGreen(indexName);
 
         // noinspection OptionalGetWithoutIsPresent because it fails the test if absent
-        final RecoveryState recoveryState = getRecoveryStates(indexName)
-            .stream()
-            .filter(rs -> rs.getPrimary() == false)
-            .findFirst()
-            .get();
+        final RecoveryState recoveryState = getRecoveryStates(indexName).stream().filter(rs -> rs.getPrimary() == false).findFirst().get();
         assertThat(recoveryState.getIndex().totalFileCount(), greaterThan(0));
     }
 
@@ -1523,11 +1510,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         final long maxSeqNoAfterRecovery = primary.seqNoStats().getMaxSeqNo();
 
         // noinspection OptionalGetWithoutIsPresent because it fails the test if absent
-        final RecoveryState recoveryState = getRecoveryStates(indexName)
-            .stream()
-            .filter(rs -> rs.getPrimary() == false)
-            .findFirst()
-            .get();
+        final RecoveryState recoveryState = getRecoveryStates(indexName).stream().filter(rs -> rs.getPrimary() == false).findFirst().get();
         assertThat(
             (long) recoveryState.getTranslog().recoveredOperations(),
             lessThanOrEqualTo(maxSeqNoAfterRecovery - maxSeqNoBeforeRecovery)
@@ -2105,11 +2088,11 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     }
 
     private CreateSnapshotResponse createSnapshot(String indexName) {
-        final CreateSnapshotResponse createSnapshotResponse = clusterAdmin()
-            .prepareCreateSnapshot(TEST_REQUEST_TIMEOUT, REPO_NAME, SNAP_NAME)
-            .setWaitForCompletion(true)
-            .setIndices(indexName)
-            .get();
+        final CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(
+            TEST_REQUEST_TIMEOUT,
+            REPO_NAME,
+            SNAP_NAME
+        ).setWaitForCompletion(true).setIndices(indexName).get();
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
         assertThat(
             createSnapshotResponse.getSnapshotInfo().successfulShards(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -271,7 +271,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
      */
     private void unthrottleRecovery() {
         updateClusterSettings(
-            ensureNoThrottlingSettings().put(RecoverySettings.INDICES_RECOVERY_CHUNK_SIZE.getKey(), RecoverySettings.DEFAULT_CHUNK_SIZE)
+            ensureNoThrottlingOnNodeSettings().put(RecoverySettings.INDICES_RECOVERY_CHUNK_SIZE.getKey(), RecoverySettings.DEFAULT_CHUNK_SIZE)
         );
     }
 
@@ -361,7 +361,6 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         logger.info("--> request recoveries");
         final RecoveryResponse response = indicesAdmin().prepareRecoveries(INDEX_NAME).get();
         assertThat(response.shardRecoveryStates().size(), equalTo(SHARD_COUNT_1));
-        assertThat(response.shardRecoveryStates().get(INDEX_NAME), hasSize(1));
 
         final List<RecoveryState> recoveryStates = response.shardRecoveryStates().get(INDEX_NAME);
         assertThat(recoveryStates, hasSize(1));
@@ -551,7 +550,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             .size();
 
         logger.info("--> start node B");
-        final String nodeB = internalCluster().startNode(ensureNoThrottlingSettings());
+        final String nodeB = internalCluster().startNode(ensureNoThrottlingOnNodeSettings());
 
         ensureGreen();
 
@@ -596,7 +595,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             .clear()
             .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Recovery))
             .get();
-        for (NodeStats nodeStats : statsResponse.getNodes()) {
+        for (final NodeStats nodeStats : statsResponse.getNodes()) {
             final RecoveryStats recoveryStats = nodeStats.getIndices().getRecoveryStats();
             if (nodeStats.getNode().getName().equals(nodeA)) {
                 assertThat("node A should have ongoing recovery as source", recoveryStats.currentAsSource(), equalTo(1));
@@ -621,12 +620,12 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         validateIndexRecoveryState(recoveryStates.getFirst().getIndex());
 
         final Consumer<String> assertNodeHasThrottleTimeAndNoRecoveries = nodeName -> {
-            NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats(nodeName)
+            final NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats(nodeName)
                 .clear()
                 .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Recovery))
                 .get();
             assertThat(nodesStatsResponse.getNodes(), hasSize(1));
-            NodeStats nodeStats = nodesStatsResponse.getNodes().getFirst();
+            final NodeStats nodeStats = nodesStatsResponse.getNodes().getFirst();
             final RecoveryStats recoveryStats = nodeStats.getIndices().getRecoveryStats();
             assertThat(recoveryStats.currentAsSource(), equalTo(0));
             assertThat(recoveryStats.currentAsTarget(), equalTo(0));
@@ -711,10 +710,6 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         validateIndexRecoveryState(nodeCRecoveryStates.getFirst().getIndex());
     }
 
-    private static List<RecoveryState> getRecoveryStates(String indexName) {
-        return indicesAdmin().prepareRecoveries(indexName).get().shardRecoveryStates().get(indexName);
-    }
-
     /**
      * Tests shard recovery throttling on the source node. Node statistics should show throttling time on the source node, while no
      * throttling should be shown on the target node because the source will send data more slowly than the target's throttling threshold.
@@ -731,7 +726,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             .size();
 
         logger.info("--> starting node B");
-        final String nodeB = internalCluster().startNode(ensureNoThrottlingSettings());
+        final String nodeB = internalCluster().startNode(ensureNoThrottlingOnNodeSettings());
 
         final long chunkSize = Math.max(1, shardSize.getBytes() / 10);
         logger.info(
@@ -794,7 +789,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
      */
     public void testTargetThrottling() throws Exception {
         logger.info("--> starting node A with default settings");
-        final String nodeA = internalCluster().startNode(ensureNoThrottlingSettings());
+        final String nodeA = internalCluster().startNode(ensureNoThrottlingOnNodeSettings());
 
         logger.info("--> creating index on node A");
         final ByteSizeValue shardSize = createAndPopulateIndex(INDEX_NAME, 1, SHARD_COUNT_1, REPLICA_COUNT_0).getShards()[0].getStats()
@@ -2088,7 +2083,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
     }
 
     private CreateSnapshotResponse createSnapshot(String indexName) {
-        final CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(
+        final var createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(
             TEST_REQUEST_TIMEOUT,
             REPO_NAME,
             SNAP_NAME
@@ -2155,8 +2150,12 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         }
     }
 
-    // Ensure that the target node has high enough recovery max-bytes-per-second to avoid any throttling (setting large enough BPS)
-    private static Settings.Builder ensureNoThrottlingSettings() {
+    private static List<RecoveryState> getRecoveryStates(String indexName) {
+        return indicesAdmin().prepareRecoveries(indexName).get().shardRecoveryStates().get(indexName);
+    }
+
+    // Ensure that the node has high enough recovery max-bytes-per-second to avoid any throttling (setting large enough BPS)
+    private static Settings.Builder ensureNoThrottlingOnNodeSettings() {
         return Settings.builder().put(RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "200mb");
     }
 }


### PR DESCRIPTION
- Use final keyword when appropriate
- Use toList() instead of collect(toList), get(0) -> getFirst() etc.
- Extract a few methods to make a test a bit easier to read
- Remove TestLogging for a closed issue

Relates: https://github.com/elastic/elasticsearch/pull/147141#discussion_r3124993450