### PR TITLE
ESQL: gate external-basic BWC on KEYWORD-only cap

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -139,12 +139,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.transforms.ClientTransformIndexerTests
   method: testDisablePitWhenCrossProjectSearchIsEnabled
   issue: https://github.com/elastic/elasticsearch/issues/144822
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:external-basic.scoreFunction}
-  issue: https://github.com/elastic/elasticsearch/issues/145352
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:external-basic.topSnippetsFunction}
-  issue: https://github.com/elastic/elasticsearch/issues/145353
 - class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
   method: testKnnVectors
   issue: https://github.com/elastic/elasticsearch/issues/145377

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/external-basic.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/external-basic.csv-spec
@@ -779,6 +779,7 @@ War and Peace: A Novel (6 Volumes) | WAR AND PEACE: A NOVEL (6 VOLUMES)
 externalRerankBooks
 required_capability: external_command
 required_capability: rerank
+required_capability: datasource_file_readers_no_text_type
 
 EXTERNAL "{{books}}"
 | WHERE book_no IN ("5327", "9032", "4536", "2776")
@@ -830,6 +831,7 @@ emp_no:integer |d:double
 topSnippetsFunction
 required_capability: external_command
 required_capability: top_snippets_function
+required_capability: datasource_file_readers_no_text_type
 
 EXTERNAL "{{books}}"
 | EVAL snippets = TOP_SNIPPETS(description, "Tolkien")
@@ -845,6 +847,7 @@ scoreFunction
 required_capability: external_command
 required_capability: top_snippets_function
 required_capability: score_function
+required_capability: datasource_file_readers_no_text_type
 
 EXTERNAL "{{books}}"
 | EVAL score = SCORE(TOP_SNIPPETS(description, "Tolkien"))

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2318,6 +2318,16 @@ public class EsqlCapabilities {
         EXTERNAL_CSV_IP_SUPPORT(DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled()),
 
         /**
+         * Datasource file plugins (CSV, ORC, Parquet) no longer return {@code TEXT} types, only {@code KEYWORD}.
+         * See <a href="https://github.com/elastic/elasticsearch/pull/145334">#145334</a>. Used to gate the affected
+         * {@code external-basic.csv-spec} tests so they are skipped on mixed clusters where a pre-change coordinator
+         * still maps string typed-schema/Parquet-String/ORC-String to {@code TEXT} - see
+         * <a href="https://github.com/elastic/elasticsearch/issues/145352">#145352</a> and
+         * <a href="https://github.com/elastic/elasticsearch/issues/145353">#145353</a>.
+         */
+        DATASOURCE_FILE_READERS_NO_TEXT_TYPE,
+
+        /**
          * https://github.com/elastic/elasticsearch/issues/142219
          */
         INLINE_STATS_WITH_CONSTANTS(INLINE_STATS.enabled),


### PR DESCRIPTION
## Issue

`MixedClusterEsqlSpecIT` was failing on
`test {csv-spec:external-basic.scoreFunction}` (#145352) and `test {csv-spec:external-basic.topSnippetsFunction}` (#145353) with:

```
Different column type for column [title] (KEYWORD != TEXT)
expected:<KEYWORD> but was:<TEXT>
```

`externalRerankBooks` shares the same root cause though had not yet been reported muted.

## Verification

#145334 intentionally changed the CSV, ORC and Parquet datasource file readers to map string typed-schema / `String`/`VARCHAR`/`CHAR` columns to `KEYWORD` instead of `TEXT`, and updated `external-basic.csv-spec` expectations accordingly. Pre-change coordinators still return `TEXT`, so on a mixed cluster those tests fail whenever an old node coordinates the query.

To confirm this was the sole cause (and not anything else in the `d4f31dec6b2..HEAD` range), in a throwaway worktree at HEAD I reverted *only* `CsvFormatReader.parseDataType` so `TEXT`/`TXT` maps back to `DataType.TEXT`, kept every other file identical, and ran the single-node `EsqlSpecIT.test {csv-spec:external-basic.scoreFunction}`. It reproduced the exact same assertion, byte-for-byte. A single-node cluster has one node = one coordinator, so this precisely models the mixed-cluster case where the old-version node coordinates.

## Fix

Adds `DATASOURCE_FILE_READERS_NO_TEXT_TYPE` to `EsqlCapabilities`, and gates the three affected tests in `external-basic.csv-spec` with it.

Also unmutes both entries from `muted-tests.yml`.

Closes #145352
Closes #145353

Made-with: Cursor