### PR TITLE
[9.4] ESQL: LIMIT BY fixed telemetry and tests (#146992)

### DIFF
--- a/docs/changelog/146992.yaml
+++ b/docs/changelog/146992.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 146992
+summary: LIMIT BY fixed telemetry and tests
+type: feature

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TelemetryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TelemetryIT.java
@@ -180,6 +180,15 @@ public class TelemetryIT extends AbstractEsqlIntegTestCase {
                     Map.ofEntries(),
                     true
                 ) },
+            new Object[] { new Test("""
+                FROM idx
+                | LIMIT 3 BY host
+                """, Map.ofEntries(Map.entry("FROM", 1), Map.entry("LIMIT BY", 1)), Map.ofEntries(), true) },
+            new Object[] { new Test("""
+                FROM idx
+                | SORT id
+                | LIMIT 3 BY host
+                """, Map.ofEntries(Map.entry("FROM", 1), Map.entry("SORT", 1), Map.entry("LIMIT BY", 1)), Map.ofEntries(), true) },
             new Object[] {
                 new Test(
                     "TS time_series_idx | STATS max(cpu) BY host | LIMIT 10",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/LimitBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/LimitBy.java
@@ -82,6 +82,11 @@ public class LimitBy extends UnaryPlan implements TelemetryAware, PipelineBreake
         return new LimitBy(source(), limitPerGroup, newChild, groupings, duplicated);
     }
 
+    @Override
+    public String telemetryLabel() {
+        return "LIMIT BY";
+    }
+
     public Expression limitPerGroup() {
         return limitPerGroup;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/VerifierMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/VerifierMetricsTests.java
@@ -13,13 +13,9 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.watcher.common.stats.Counters;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.analysis.Verifier;
-import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
-import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_FUNCTION_REGISTRY;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PARSER;
@@ -29,11 +25,13 @@ import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.DISSECT;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.DROP;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.ENRICH;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.EVAL;
+import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.FORK;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.FROM;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.GROK;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.INLINE_STATS;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.KEEP;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.LIMIT;
+import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.LIMIT_BY;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.LOOKUP_JOIN;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.LOOKUP_JOIN_ON_EXPRESSION;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.MV_EXPAND;
@@ -43,215 +41,56 @@ import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.ROW;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.SHOW;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.SORT;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.STATS;
+import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.SUBQUERY;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.TS;
 import static org.elasticsearch.xpack.esql.telemetry.FeatureMetric.WHERE;
 import static org.elasticsearch.xpack.esql.telemetry.Metrics.FEATURES_PREFIX;
-import static org.elasticsearch.xpack.esql.telemetry.Metrics.FUNC_PREFIX;
 
 public class VerifierMetricsTests extends ESTestCase {
 
     public void testDissectQuery() {
         Counters c = esql("from employees | dissect concat(first_name, \" \", last_name) \"%{a} %{b}\"");
-        assertEquals(1L, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("concat", c));
+        assertMetrics(c, Map.of(DISSECT, 1L, FROM, 1L), Map.of("concat", 1L));
     }
 
     public void testEvalQuery() {
         Counters c = esql("from employees | eval name_len = length(first_name)");
-        assertEquals(0, dissect(c));
-        assertEquals(1L, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("length", c));
+        assertMetrics(c, Map.of(EVAL, 1L, FROM, 1L), Map.of("length", 1L));
     }
 
     public void testGrokQuery() {
         Counters c = esql("from employees | grok concat(first_name, \" \", last_name) \"%{WORD:a} %{WORD:b}\"");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(1L, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("concat", c));
+        assertMetrics(c, Map.of(GROK, 1L, FROM, 1L), Map.of("concat", 1L));
     }
 
     public void testLimitQuery() {
         Counters c = esql("from employees | limit 2");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(1L, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, subqueryInFromCommand(c));
+        assertMetrics(c, Map.of(LIMIT, 1L, FROM, 1L));
+    }
+
+    public void testLimitByQuery() {
+        Counters c = esql("from employees | sort first_name | limit 3 by gender");
+        assertMetrics(c, Map.of(LIMIT_BY, 1L, SORT, 1L, FROM, 1L));
     }
 
     public void testSortQuery() {
         Counters c = esql("from employees | sort first_name desc nulls first");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(1L, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, subqueryInFromCommand(c));
+        assertMetrics(c, Map.of(SORT, 1L, FROM, 1L));
     }
 
     public void testStatsQuery() {
         Counters c = esql("from employees | stats l = max(languages)");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(1L, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("max", c));
+        assertMetrics(c, Map.of(STATS, 1L, FROM, 1L), Map.of("max", 1L));
     }
 
     public void testWhereQuery() {
         Counters c = esql("from employees | where languages > 2");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(1L, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, subqueryInFromCommand(c));
+        assertMetrics(c, Map.of(WHERE, 1L, FROM, 1L));
     }
 
     public void testTwoWhereQuery() {
         Counters c = esql("from employees | where languages > 2 | limit 5 | sort first_name | where first_name == \"George\"");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(1L, limit(c));
-        assertEquals(1L, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(1L, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, subqueryInFromCommand(c));
+        assertMetrics(c, Map.of(LIMIT, 1L, SORT, 1L, WHERE, 1L, FROM, 1L));
     }
 
     public void testTwoQueriesExecuted() {
@@ -276,35 +115,11 @@ public class VerifierMetricsTests extends ESTestCase {
               | stats y = min(x) by x
             """, verifier);
         Counters c = metrics.stats();
-        assertEquals(1L, dissect(c));
-        assertEquals(1L, eval(c));
-        assertEquals(1L, grok(c));
-        assertEquals(1L, limit(c));
-        assertEquals(2L, sort(c));
-        assertEquals(1L, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(2L, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(2L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, subqueryInFromCommand(c));
-
-        assertEquals(1, function("length", c));
-        assertEquals(1, function("concat", c));
-        assertEquals(1, function("max", c));
-        assertEquals(1, function("min", c));
-
-        assertEquals(0, function("sin", c));
-        assertEquals(0, function("cos", c));
+        assertMetrics(
+            c,
+            Map.of(DISSECT, 1L, EVAL, 1L, GROK, 1L, LIMIT, 1L, SORT, 2L, STATS, 1L, WHERE, 2L, FROM, 2L),
+            Map.of("length", 1L, "concat", 1L, "max", 1L, "min", 1L)
+        );
     }
 
     public void testMultipleFunctions() {
@@ -320,8 +135,7 @@ public class VerifierMetricsTests extends ESTestCase {
             """, verifier);
 
         Counters c = metrics.stats();
-        assertEquals(1, function("length", c));
-        assertEquals(0, function("concat", c));
+        assertMetrics(c, Map.of(EVAL, 1L, LIMIT, 1L, SORT, 1L, WHERE, 1L, FROM, 1L), Map.of("length", 1L));
 
         esqlWithVerifier("""
               from employees
@@ -336,25 +150,11 @@ public class VerifierMetricsTests extends ESTestCase {
             """, verifier);
         c = metrics.stats();
 
-        assertEquals(2, function("length", c));
-        assertEquals(1, function("concat", c));
-        assertEquals(1, function("max", c));
-        assertEquals(1, function("min", c));
-
-        EsqlFunctionRegistry fr = TEST_FUNCTION_REGISTRY.snapshotRegistry();
-        Map<Class<?>, String> functions = new HashMap<>();
-        for (FunctionDefinition func : fr.listFunctions()) {
-            if (functions.containsKey(func.clazz()) == false) {
-                functions.put(func.clazz(), func.name());
-            }
-        }
-        for (String value : functions.values()) {
-            if (Set.of("length", "concat", "max", "min").contains(value) == false) {
-                assertEquals(0, function(value, c));
-            }
-        }
-        Map<?, ?> map = (Map<?, ?>) c.toNestedMap().get("functions");
-        assertEquals(functions.size(), map.size());
+        assertMetrics(
+            c,
+            Map.of(DISSECT, 1L, EVAL, 2L, GROK, 1L, LIMIT, 1L, SORT, 2L, STATS, 1L, WHERE, 2L, FROM, 2L),
+            Map.of("length", 2L, "concat", 1L, "max", 1L, "min", 1L)
+        );
     }
 
     public void testEnrich() {
@@ -365,28 +165,7 @@ public class VerifierMetricsTests extends ESTestCase {
             | eval x = to_string(languages)
             | enrich languages on x
             | keep emp_no, language_name""");
-        assertEquals(0, dissect(c));
-        assertEquals(1L, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(1L, limit(c));
-        assertEquals(1L, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(1L, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(1L, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("to_string", c));
+        assertMetrics(c, Map.of(EVAL, 1L, LIMIT, 1L, SORT, 1L, ENRICH, 1L, FROM, 1L, KEEP, 1L), Map.of("to_string", 1L));
     }
 
     public void testMvExpand() {
@@ -400,104 +179,22 @@ public class VerifierMetricsTests extends ESTestCase {
             | limit 2
             | where job LIKE \"*a*\"
             | limit 3""");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(1L, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(1L, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(1L, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(1L, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
+        assertMetrics(c, Map.of(LIMIT, 1L, WHERE, 1L, MV_EXPAND, 1L, FROM, 1L, KEEP, 1L));
     }
 
     public void testShowInfo() {
         Counters c = esql("show info |  stats  a = count(*), b = count(*), c = count(*) |  mv_expand c");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(1L, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(1L, mvExpand(c));
-        assertEquals(1L, show(c));
-        assertEquals(0, row(c));
-        assertEquals(0, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("count", c));
+        assertMetrics(c, Map.of(STATS, 1L, MV_EXPAND, 1L, SHOW, 1L), Map.of("count", 1L));
     }
 
     public void testRow() {
         Counters c = esql("row a = [\"1\", \"2\"] | enrich languages on a with a_lang = language_name");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(1L, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(1L, row(c));
-        assertEquals(0, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
+        assertMetrics(c, Map.of(ENRICH, 1L, ROW, 1L));
     }
 
     public void testDropAndRename() {
         Counters c = esql("from employees | rename gender AS foo | stats bar = count(*) by foo | drop foo | sort bar | drop bar");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(1L, sort(c));
-        assertEquals(1L, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(1L, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(1L, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("count", c));
+        assertMetrics(c, Map.of(SORT, 1L, STATS, 1L, FROM, 1L, DROP, 1L, RENAME, 1L), Map.of("count", 1L));
     }
 
     public void testKeep() {
@@ -507,27 +204,7 @@ public class VerifierMetricsTests extends ESTestCase {
             | where languages is null or emp_no <= 10030
             | where languages in (2, 3, emp_no)
             | keep languages""");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(1L, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(1L, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
+        assertMetrics(c, Map.of(WHERE, 1L, FROM, 1L, KEEP, 1L));
     }
 
     public void testCategorize() {
@@ -536,29 +213,7 @@ public class VerifierMetricsTests extends ESTestCase {
             | keep emp_no, languages, gender
             | where languages is null or emp_no <= 10030
             | STATS COUNT() BY CATEGORIZE(gender)""");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(1L, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(1L, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(1L, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("count", c));
-        assertEquals(1, function("categorize", c));
+        assertMetrics(c, Map.of(STATS, 1L, WHERE, 1L, FROM, 1L, KEEP, 1L), Map.of("count", 1L, "categorize", 1L));
     }
 
     public void testInlineStatsStandalone() {
@@ -567,28 +222,7 @@ public class VerifierMetricsTests extends ESTestCase {
             from employees
             | inline stats max(salary) by gender
             | where languages is not null""");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(1L, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(1L, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("max", c));
+        assertMetrics(c, Map.of(WHERE, 1L, FROM, 1L, INLINE_STATS, 1L), Map.of("max", 1L));
     }
 
     public void testInlineStatsWithOtherStats() {
@@ -598,28 +232,7 @@ public class VerifierMetricsTests extends ESTestCase {
             | inline stats m = max(salary) by gender
             | where languages is not null
             | stats max(m) by languages""");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(1L, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(1L, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(1L, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("max", c));
+        assertMetrics(c, Map.of(STATS, 1L, WHERE, 1L, FROM, 1L, INLINE_STATS, 1L), Map.of("max", 1L));
     }
 
     public void testBinaryPlanAfterStats() {
@@ -628,28 +241,7 @@ public class VerifierMetricsTests extends ESTestCase {
             | eval language_code = languages
             | stats m = max(salary) by language_code
             | lookup join languages_lookup on language_code""");
-        assertEquals(0, dissect(c));
-        assertEquals(1L, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(1L, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(1L, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("max", c));
+        assertMetrics(c, Map.of(EVAL, 1L, STATS, 1L, FROM, 1L, LOOKUP_JOIN, 1L), Map.of("max", 1L));
     }
 
     public void testBinaryPlanAfterStatsExpressionJoin() {
@@ -663,28 +255,7 @@ public class VerifierMetricsTests extends ESTestCase {
             | stats m = max(salary) by language_code
             | rename language_code as language_code_left
             | lookup join languages_lookup on language_code_left >= language_code""");
-        assertEquals(0, dissect(c));
-        assertEquals(1L, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(1L, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(1L, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(1L, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("max", c));
+        assertMetrics(c, Map.of(EVAL, 1L, STATS, 1L, FROM, 1L, RENAME, 1L, LOOKUP_JOIN_ON_EXPRESSION, 1L), Map.of("max", 1L));
     }
 
     public void testBinaryPlanAfterInlineStats() {
@@ -694,28 +265,7 @@ public class VerifierMetricsTests extends ESTestCase {
             | eval language_code = languages
             | inline stats m = max(salary) by language_code
             | lookup join languages_lookup on language_code""");
-        assertEquals(0, dissect(c));
-        assertEquals(1L, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(1L, inlineStats(c));
-        assertEquals(1L, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("max", c));
+        assertMetrics(c, Map.of(EVAL, 1L, FROM, 1L, INLINE_STATS, 1L, LOOKUP_JOIN, 1L), Map.of("max", 1L));
     }
 
     public void testTimeSeriesAggregate() {
@@ -723,29 +273,7 @@ public class VerifierMetricsTests extends ESTestCase {
         Counters c = esql("""
             TS k8s
             | STATS sum(avg_over_time(network.cost))""");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(1L, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(0, from(c));
-        assertEquals(1L, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
-        assertEquals(1, function("sum", c));
-        assertEquals(1, function("avg_over_time", c));
+        assertMetrics(c, Map.of(STATS, 1L, TS, 1L), Map.of("sum", 1L, "avg_over_time", 1L));
     }
 
     public void testTimeSeriesNoAggregate() {
@@ -753,27 +281,7 @@ public class VerifierMetricsTests extends ESTestCase {
         Counters c = esql("""
             TS metrics
             | KEEP salary""");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(0, from(c));
-        assertEquals(1L, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(1L, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
+        assertMetrics(c, Map.of(TS, 1L, KEEP, 1L));
     }
 
     public void testBinaryPlanAfterSubqueryInFromCommand() {
@@ -785,151 +293,36 @@ public class VerifierMetricsTests extends ESTestCase {
                       , (from employees | stats min = min(salary) by languages)
             | where min > 0 and max < 100000
             """);
-        assertEquals(0, dissect(c));
-        assertEquals(1L, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(1L, stats(c));
-        assertEquals(0, promql(c));
-        assertEquals(1L, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(1L, from(c));
-        assertEquals(0, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(1L, subqueryInFromCommand(c));
-        assertEquals(1L, function("max", c));
-        assertEquals(1L, function("min", c));
+        assertMetrics(c, Map.of(EVAL, 1L, STATS, 1L, WHERE, 1L, FROM, 1L, SUBQUERY, 1L, FORK, 1L), Map.of("max", 1L, "min", 1L));
     }
 
     public void testPromql() {
         Counters c = esql("""
             PROMQL index=k8s step=5m sum(network.cost)""");
-        assertEquals(0, dissect(c));
-        assertEquals(0, eval(c));
-        assertEquals(0, grok(c));
-        assertEquals(0, limit(c));
-        assertEquals(0, sort(c));
-        assertEquals(0, stats(c));
-        assertEquals(1, promql(c));
-        assertEquals(0, where(c));
-        assertEquals(0, enrich(c));
-        assertEquals(0, mvExpand(c));
-        assertEquals(0, show(c));
-        assertEquals(0, row(c));
-        assertEquals(0, from(c));
-        assertEquals(1L, ts(c));
-        assertEquals(0, drop(c));
-        assertEquals(0, keep(c));
-        assertEquals(0, rename(c));
-        assertEquals(0, inlineStats(c));
-        assertEquals(0, lookupJoinOnFields(c));
-        assertEquals(0, lookupJoinOnExpression(c));
-        assertEquals(0, subqueryInFromCommand(c));
+        assertMetrics(c, Map.of(PROMQL, 1L, TS, 1L));
     }
 
-    private long dissect(Counters c) {
-        return c.get(FEATURES_PREFIX + DISSECT);
+    private void assertMetrics(Counters c, Map<FeatureMetric, Long> expectedFeatures) {
+        assertMetrics(c, expectedFeatures, Map.of());
     }
 
-    private long eval(Counters c) {
-        return c.get(FEATURES_PREFIX + EVAL);
-    }
-
-    private long grok(Counters c) {
-        return c.get(FEATURES_PREFIX + GROK);
-    }
-
-    private long limit(Counters c) {
-        return c.get(FEATURES_PREFIX + LIMIT);
-    }
-
-    private long sort(Counters c) {
-        return c.get(FEATURES_PREFIX + SORT);
-    }
-
-    private long stats(Counters c) {
-        return c.get(FEATURES_PREFIX + STATS);
-    }
-
-    private long where(Counters c) {
-        return c.get(FEATURES_PREFIX + WHERE);
-    }
-
-    private long enrich(Counters c) {
-        return c.get(FEATURES_PREFIX + ENRICH);
-    }
-
-    private long mvExpand(Counters c) {
-        return c.get(FEATURES_PREFIX + MV_EXPAND);
-    }
-
-    private long show(Counters c) {
-        return c.get(FEATURES_PREFIX + SHOW);
-    }
-
-    private long row(Counters c) {
-        return c.get(FEATURES_PREFIX + ROW);
-    }
-
-    private long from(Counters c) {
-        return c.get(FEATURES_PREFIX + FROM);
-    }
-
-    private long ts(Counters c) {
-        return c.get(FEATURES_PREFIX + TS);
-    }
-
-    private long promql(Counters c) {
-        return c.get(FEATURES_PREFIX + PROMQL);
-    }
-
-    private long drop(Counters c) {
-        return c.get(FEATURES_PREFIX + DROP);
-    }
-
-    private long keep(Counters c) {
-        return c.get(FEATURES_PREFIX + KEEP);
-    }
-
-    private long rename(Counters c) {
-        return c.get(FEATURES_PREFIX + RENAME);
-    }
-
-    private long inlineStats(Counters c) {
-        return c.get(FEATURES_PREFIX + INLINE_STATS);
-    }
-
-    private long lookupJoinOnFields(Counters c) {
-        return c.get(FEATURES_PREFIX + LOOKUP_JOIN);
-    }
-
-    private long lookupJoinOnExpression(Counters c) {
-        return c.get(FEATURES_PREFIX + LOOKUP_JOIN_ON_EXPRESSION);
-    }
-
-    private long subqueryInFromCommand(Counters c) {
-        return c.get(FEATURES_PREFIX + FeatureMetric.SUBQUERY);
-    }
-
-    private long function(String function, Counters c) {
-        return c.get(FUNC_PREFIX + function);
-    }
-
-    private void assertNullFunction(String function, Counters c) {
-        try {
-            c.get(FUNC_PREFIX + function);
-            fail();
-        } catch (NullPointerException npe) {
-
+    /**
+     * Asserts that every counter in {@code c} equals the value declared in {@code expectedFeatures} or
+     * {@code expectedFunctions}, defaulting to {@code 0} for anything absent from the maps.
+     */
+    private void assertMetrics(Counters c, Map<FeatureMetric, Long> expectedFeatures, Map<String, Long> expectedFunctions) {
+        for (FeatureMetric metric : FeatureMetric.values()) {
+            long expectedValue = expectedFeatures.getOrDefault(metric, 0L);
+            assertEquals("Counter [" + metric + "]", expectedValue, c.get(FEATURES_PREFIX + metric));
+        }
+        Map<?, ?> functionCounters = (Map<?, ?>) c.toNestedMap().get("functions");
+        for (var entry : functionCounters.entrySet()) {
+            String name = (String) entry.getKey();
+            long expectedValue = expectedFunctions.getOrDefault(name, 0L);
+            assertEquals("Function [" + name + "]", expectedValue, ((Number) entry.getValue()).longValue());
+        }
+        for (String name : expectedFunctions.keySet()) {
+            assertNotNull("Expected function [" + name + "] is not a registered function", functionCounters.get(name));
         }
     }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -63,6 +63,7 @@ setup:
             - registered_domain_command
             - user_agent_command
             - fn_json_extract
+            - esql_limit_by
       reason: "Test that should only be executed on snapshot versions"
 
   - do: { xpack.usage: { } }
@@ -78,6 +79,7 @@ setup:
   - set: { esql.features.grok: grok_counter }
   - set: { esql.features.keep: keep_counter }
   - set: { esql.features.limit: limit_counter }
+  - set: { esql.features.limit_by: limit_by_counter }
   - set: { esql.features.mv_expand: mv_expand_counter }
   - set: { esql.features.rename: rename_counter }
   - set: { esql.features.row: row_counter }
@@ -138,6 +140,7 @@ setup:
   - match: { esql.features.registered_domain: $registered_domain_counter }
   - match: { esql.features.user_agent: $user_agent_counter }
   - gt: { esql.features.limit: $limit_counter }
+  - match: { esql.features.limit_by: $limit_by_counter }
   - gt: { esql.features.sort: $sort_counter }
   - gt: { esql.features.stats: $stats_counter }
   - gt: { esql.features.where: $where_counter }
@@ -194,6 +197,7 @@ setup:
   - match: { esql.features.registered_domain: $registered_domain_counter }
   - match: { esql.features.user_agent: $user_agent_counter }
   - match: { esql.features.limit: $limit_counter }
+  - match: { esql.features.limit_by: $limit_by_counter }
   - match: { esql.features.sort: $sort_counter }
   - gt: { esql.features.stats: $stats_counter }
   - match: { esql.features.where: $where_counter }
@@ -225,6 +229,19 @@ setup:
   - exists: esql.functions.mv_sum
   - exists: esql.functions.to_dateperiod
 
+  - set: { esql.features.limit_by: limit_by_counter }
+
+  - do:
+      esql.query:
+        body:
+          query: 'from test
+            | sort count desc
+            | limit 3 by message
+            | limit 100'
+
+  - do: { xpack.usage: { } }
+  - gt: { esql.features.limit_by: $limit_by_counter }
+
 ---
 "Basic ESQL usage output (telemetry) non-snapshot version":
   - requires:
@@ -233,7 +250,7 @@ setup:
         - method: POST
           path: /_query
           parameters: [ ]
-          capabilities: [ non_snapshot_test_for_telemetry_v2, fn_contains, promql_command_v0 ]
+          capabilities: [ non_snapshot_test_for_telemetry_v2, fn_contains, promql_command_v0, esql_limit_by ]
       reason: "Test that should only be executed on release versions"
 
   - do: { xpack.usage: { } }
@@ -248,6 +265,7 @@ setup:
   - set: { esql.features.grok: grok_counter }
   - set: { esql.features.keep: keep_counter }
   - set: { esql.features.limit: limit_counter }
+  - set: { esql.features.limit_by: limit_by_counter }
   - set: { esql.features.mv_expand: mv_expand_counter }
   - set: { esql.features.rename: rename_counter }
   - set: { esql.features.row: row_counter }
@@ -306,6 +324,7 @@ setup:
   - match: { esql.features.registered_domain: $registered_domain_counter }
   - match: { esql.features.user_agent: $user_agent_counter }
   - gt: { esql.features.limit: $limit_counter }
+  - match: { esql.features.limit_by: $limit_by_counter }
   - gt: { esql.features.sort: $sort_counter }
   - gt: { esql.features.stats: $stats_counter }
   - match: { esql.features.promql: $promql_counter }
@@ -361,6 +380,7 @@ setup:
   - match: { esql.features.uri_parts: $uri_parts_counter }
   - match: { esql.features.registered_domain: $registered_domain_counter }
   - match: { esql.features.limit: $limit_counter }
+  - match: { esql.features.limit_by: $limit_by_counter }
   - match: { esql.features.sort: $sort_counter }
   - gt: { esql.features.stats: $stats_counter }
   - match: { esql.features.where: $where_counter }
@@ -392,6 +412,19 @@ setup:
   - exists: esql.functions.idelta
   - exists: esql.functions.mv_sum
   - exists: esql.functions.to_dateperiod
+
+  - set: { esql.features.limit_by: limit_by_counter }
+
+  - do:
+      esql.query:
+        body:
+          query: 'from test
+            | sort count desc
+            | limit 3 by message
+            | limit 100'
+
+  - do: { xpack.usage: { } }
+  - gt: { esql.features.limit_by: $limit_by_counter }
 
 ---
 took:


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ESQL: LIMIT BY fixed telemetry and tests (#146992)