### PR TITLE
[ESQL] Suppress ColumnIndexFilter INFO log spam

### DIFF
--- a/docs/changelog/147253.yaml
+++ b/docs/changelog/147253.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147253
+summary: Suppress `ColumnIndexFilter` INFO log spam
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/config/log4j2.properties
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/config/log4j2.properties
@@ -1,0 +1,2 @@
+logger.parquet_column_index_filter.name = org.apache.parquet.internal.filter2.columnindex.ColumnIndexFilter
+logger.parquet_column_index_filter.level = warn


### PR DESCRIPTION
Parquet-mr's ColumnIndexFilter logs at INFO for every (row group × filtered column) pair that lacks column/offset indexes. Files without column indexes are common (the feature is optional, added in parquet-format 2.5), so on a ~200 row-group file with a single WHERE predicate this produces ~200 INFO lines per query, drowning the server log during investigation.

Adds a log4j2 config fragment to the parquet datasource plugin that sets this logger to WARN, following the established pattern used by other plugins (inference, ingest-attachment, x-pack core) to quiet noisy third-party libraries.

Developed with AI-assisted tooling