### PR TITLE
[8.19] Fix Reindexing Slicing Bug

### DIFF
--- a/docs/changelog/147254.yaml
+++ b/docs/changelog/147254.yaml
@@ -1,6 +1,7 @@
 area: Reindex
-issues:
- - 146741
+issues: []
 pr: 147254
-summary: Fixes a bug in AbstractAsyncBulkByScrollAction which removed the scroll parameter from the search request when the request was sliced, and max docs <= scroll size 
+summary: "Fixes a bug in AbstractAsyncBulkByScrollAction which removed the scroll\
+  \ parameter from the search request when the request was sliced, and max docs <=\
+  \ scroll size"
 type: bug

--- a/docs/changelog/147254.yaml
+++ b/docs/changelog/147254.yaml
@@ -1,7 +1,0 @@
-area: Reindex
-issues: []
-pr: 147254
-summary: "Fixes a bug in AbstractAsyncBulkByScrollAction which removed the scroll\
-  \ parameter from the search request when the request was sliced, and max docs <=\
-  \ scroll size"
-type: bug

--- a/docs/changelog/147254.yaml
+++ b/docs/changelog/147254.yaml
@@ -1,5 +1,6 @@
 area: Reindex
-issues: []
+issues:
+ - 146741
 pr: 147254
-summary: "[8.19] Fix Reindexing Slicing Bug"
+summary: Fixes a bug in AbstractAsyncBulkByScrollAction which removed the scroll parameter from the search request when the request was sliced, and max docs <= scroll size 
 type: bug

--- a/docs/changelog/147254.yaml
+++ b/docs/changelog/147254.yaml
@@ -1,0 +1,5 @@
+area: Reindex
+issues: []
+pr: 147254
+summary: "[8.19] Fix Reindexing Slicing Bug"
+type: bug

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -207,9 +207,11 @@ public abstract class AbstractAsyncBulkByScrollAction<
         sourceBuilder.seqNoAndPrimaryTerm(needsSourceDocumentSeqNoAndPrimaryTerm);
 
         /*
-         * Do not open scroll if max docs <= scroll size and not resuming on version conflicts
+         * Do not open scroll if max docs <= scroll size and not resuming on version conflicts.
+         * Sliced searches must keep their scroll. Slicing without a scroll fails SearchRequest validation.
          */
-        if (mainRequest.getMaxDocs() != MAX_DOCS_ALL_MATCHES
+        if (sourceBuilder.slice() == null
+            && mainRequest.getMaxDocs() != MAX_DOCS_ALL_MATCHES
             && mainRequest.getMaxDocs() <= preparedSearchRequest.source().size()
             && mainRequest.isAbortOnVersionConflict()) {
             preparedSearchRequest.scroll((Scroll) null);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -56,6 +56,7 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
@@ -68,6 +69,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.slice.SliceBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
@@ -910,6 +912,20 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false);
 
         assertThat(preparedSearchRequest.scroll(), nullValue());
+    }
+
+    /**
+     * Sliced bulk-by-scroll must retain scroll when {@code max_docs} is at most the batch size. Otherwise, the search has
+     * {@code slice} without scroll set, which fails request validation.
+     */
+    public void testKeepScrollWhenMaxDocsAtMostScrollSizeButSliced() {
+        testRequest.setMaxDocs(between(1, 100));
+        testRequest.getSearchRequest().source().size(100);
+        testRequest.getSearchRequest().source().slice(new SliceBuilder(IdFieldMapper.NAME, 0, 5));
+
+        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false);
+
+        assertThat(preparedSearchRequest.scroll(), notNullValue());
     }
 
     public void testEnableScrollWhenProceedOnVersionConflict() {


### PR DESCRIPTION
Fixes a bug in AbstractAsyncBulkByScrollAction which removed scroll search on sliced requests.

Backport of https://github.com/elastic/elasticsearch/pull/146915

Relates: https://github.com/elastic/elasticsearch/issues/146741