### PR TITLE
[9.3] Fix Reindexing Slicing Bug

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -221,9 +221,11 @@ public abstract class AbstractAsyncBulkByScrollAction<
         }
 
         /*
-         * Do not open scroll if max docs <= scroll size and not resuming on version conflicts
+         * Do not open scroll if max docs <= scroll size and not resuming on version conflicts.
+         * Sliced searches must keep their scroll. Slicing without a scroll fails SearchRequest validation.
          */
-        if (mainRequest.getMaxDocs() != MAX_DOCS_ALL_MATCHES
+        if (sourceBuilder.slice() == null
+            && mainRequest.getMaxDocs() != MAX_DOCS_ALL_MATCHES
             && mainRequest.getMaxDocs() <= preparedSearchRequest.source().size()
             && mainRequest.isAbortOnVersionConflict()) {
             preparedSearchRequest.scroll(null);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -56,6 +56,7 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
@@ -69,6 +70,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchResponseUtils;
+import org.elasticsearch.search.slice.SliceBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
@@ -896,6 +898,20 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false);
 
         assertThat(preparedSearchRequest.scroll(), nullValue());
+    }
+
+    /**
+     * Sliced bulk-by-scroll must retain scroll when {@code max_docs} is at most the batch size. Otherwise, the search has
+     * {@code slice} without scroll set, which fails request validation.
+     */
+    public void testKeepScrollWhenMaxDocsAtMostScrollSizeButSliced() {
+        testRequest.setMaxDocs(between(1, 100));
+        testRequest.getSearchRequest().source().size(100);
+        testRequest.getSearchRequest().source().slice(new SliceBuilder(IdFieldMapper.NAME, 0, 5));
+
+        var preparedSearchRequest = AbstractAsyncBulkByScrollAction.prepareSearchRequest(testRequest, false, false, false);
+
+        assertThat(preparedSearchRequest.scroll(), notNullValue());
     }
 
     public void testEnableScrollWhenProceedOnVersionConflict() {


### PR DESCRIPTION
Fixes a bug in `AbstractAsyncBulkByScrollAction` which removed scroll search on sliced requests

Backport of https://github.com/elastic/elasticsearch/pull/146915

Relates: https://github.com/elastic/elasticsearch/issues/146741