### PR TITLE
[8.19] Fix ErrorReportingTestListener null.out failure (#147248)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/ErrorReportingTestListener.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/ErrorReportingTestListener.java
@@ -27,6 +27,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.Deque;
@@ -213,7 +215,14 @@ public class ErrorReportingTestListener implements TestOutputListener, TestListe
         private final Writer writer;
 
         EventWriter(Descriptor descriptor) {
-            this.outputFile = new File(outputDirectory, descriptor.className() + ".out");
+            // className is null for root/composite suites (e.g. the top-level "Gradle Test Run"),
+            // so fall back to the suite name to avoid collapsing different suites onto a single "null.out" file.
+            String baseName = descriptor.className();
+            if (baseName == null) {
+                String name = descriptor.name();
+                baseName = (name == null ? "unknown" : name).replaceAll("[^a-zA-Z0-9._-]", "_");
+            }
+            this.outputFile = new File(outputDirectory, baseName + ".out");
 
             FileOutputStream fos;
             try {
@@ -249,11 +258,20 @@ public class ErrorReportingTestListener implements TestOutputListener, TestListe
         }
 
         public BufferedReader reader() {
+            // The output file may have been concurrently closed/deleted by another afterSuite callback
+            // that mapped to the same Descriptor. Treat a missing file as empty output rather than failing the build.
+            if (outputFile.isFile() == false) {
+                return new BufferedReader(emptyReader());
+            }
             try {
                 return new BufferedReader(new FileReader(outputFile));
             } catch (IOException e) {
                 throw new UncheckedIOException("Unable to read test suite output file", e);
             }
+        }
+
+        private static Reader emptyReader() {
+            return new StringReader("");
         }
 
         @Override

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/test/ErrorReportingTestListenerSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/test/ErrorReportingTestListenerSpec.groovy
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.test
+
+import org.elasticsearch.gradle.OS
+import org.gradle.api.logging.Logger
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.TestDescriptor
+import org.gradle.api.tasks.testing.TestOutputEvent
+import org.gradle.api.tasks.testing.TestResult
+import org.gradle.api.tasks.testing.logging.TestLoggingContainer
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class ErrorReportingTestListenerSpec extends Specification {
+
+    @TempDir
+    File tempDir
+
+    File outputDir
+    ErrorReportingTestListener listener
+
+    def setup() {
+        outputDir = new File(tempDir, "output")
+        assert outputDir.mkdirs()
+        def testTask = Stub(Test) {
+            getTestLogging() >> Stub(TestLoggingContainer)
+            getLogger() >> Stub(Logger)
+        }
+        listener = new ErrorReportingTestListener(testTask, outputDir)
+    }
+
+    def "suite output is captured in a file named after the class"() {
+        given:
+        def suite = suiteDescriptor("com.example.FooTests", "com.example.FooTests")
+
+        when:
+        listener.onOutput(suite, outputEvent("hi"))
+
+        then:
+        new File(outputDir, "com.example.FooTests.out").isFile()
+    }
+
+    def "suites without a class name never produce null.out"() {
+        given:
+        def suite = suiteDescriptor(null, "Gradle Test Run :x-pack:plugin:esql:internalClusterTest")
+
+        when:
+        listener.onOutput(suite, outputEvent("root output"))
+
+        then:
+        new File(outputDir, "null.out").exists() == false
+        outputDir.listFiles().length == 1
+        outputDir.listFiles()[0].name != "null.out"
+    }
+
+    def "distinct suites without class names map to distinct files"() {
+        given:
+        def suiteA = suiteDescriptor(null, "Gradle Test Run :a")
+        def suiteB = suiteDescriptor(null, "Gradle Test Run :b")
+
+        when:
+        listener.onOutput(suiteA, outputEvent("a"))
+        listener.onOutput(suiteB, outputEvent("b"))
+
+        then:
+        outputDir.listFiles().length == 2
+    }
+
+    @IgnoreIf({ OS.current() == OS.WINDOWS })
+    def "afterSuite tolerates an output file that was concurrently removed"() {
+        // Simulates the race where a concurrent afterSuite for an equivalent Descriptor
+        // has already closed and deleted the shared output file before this afterSuite reads it.
+        given:
+        def suite = suiteDescriptor("com.example.FooTests", "com.example.FooTests")
+        listener.onOutput(suite, outputEvent("captured output"))
+        def outputFile = new File(outputDir, "com.example.FooTests.out")
+        assert outputFile.isFile()
+        assert outputFile.delete()
+
+        when:
+        listener.afterSuite(suite, failedResult())
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "afterSuite without captured output is a no-op"() {
+        given:
+        def suite = suiteDescriptor("com.example.FooTests", "com.example.FooTests")
+
+        when:
+        listener.afterSuite(suite, failedResult())
+
+        then:
+        noExceptionThrown()
+        outputDir.listFiles().length == 0
+    }
+
+    def "afterTest records only failing tests"() {
+        given:
+        def parent = suiteDescriptor("com.example.FooTests", "com.example.FooTests")
+        def failing = testDescriptor("testBoom", "com.example.FooTests", parent)
+        def passing = testDescriptor("testOk", "com.example.FooTests", parent)
+
+        when:
+        listener.afterTest(failing, failedResult())
+        listener.afterTest(passing, succeededResult())
+
+        then:
+        listener.failedTests*.fullName == ["com.example.FooTests.testBoom"]
+    }
+
+    private TestDescriptor suiteDescriptor(String className, String name) {
+        return Stub(TestDescriptor) {
+            getClassName() >> className
+            getName() >> name
+            isComposite() >> true
+            getParent() >> null
+        }
+    }
+
+    private TestDescriptor testDescriptor(String name, String className, TestDescriptor parent) {
+        return Stub(TestDescriptor) {
+            getClassName() >> className
+            getName() >> name
+            isComposite() >> false
+            getParent() >> parent
+        }
+    }
+
+    private TestOutputEvent outputEvent(String message) {
+        return Stub(TestOutputEvent) {
+            getMessage() >> message
+            getDestination() >> TestOutputEvent.Destination.StdOut
+        }
+    }
+
+    private TestResult failedResult() {
+        return Stub(TestResult) {
+            getResultType() >> TestResult.ResultType.FAILURE
+            getExceptions() >> []
+        }
+    }
+
+    private TestResult succeededResult() {
+        return Stub(TestResult) {
+            getResultType() >> TestResult.ResultType.SUCCESS
+            getExceptions() >> []
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix ErrorReportingTestListener null.out failure (#147248)