### PR TITLE
Escape bash indirect expansion in repeat-changed-tests pipeline

### DIFF
--- a/.buildkite/scripts/repeat-changed-tests.test.ts
+++ b/.buildkite/scripts/repeat-changed-tests.test.ts
@@ -466,6 +466,11 @@ describe("generatePipeline", () => {
     expect(step.env!["BATCH_COMMAND_0"]).toContain("repeat-rest-test.sh");
     expect(step.env!["BATCH_COMMAND_1"]).toContain("repeat-rest-test.sh");
     expect(step.command).toContain("BUILDKITE_PARALLEL_JOB");
+    // The `$$` escape prevents Buildkite pipeline interpolation from trying to
+    // parse `${!VARNAME}` (bash indirect expansion) as a Buildkite variable,
+    // which fails with "Expected identifier to start with a letter, got !".
+    expect(step.command).toContain('$${!VARNAME}');
+    expect(step.command).not.toMatch(/[^$]\$\{!VARNAME\}/);
   });
 
   test("all test kinds appear in single group with unique keys", () => {

--- a/.buildkite/scripts/repeat-changed-tests.ts
+++ b/.buildkite/scripts/repeat-changed-tests.ts
@@ -250,7 +250,7 @@ export function generatePipeline(tests: ClassifiedTest[]): Pipeline {
       for (let i = 0; i < batchCommands.length; i++) {
         env[`BATCH_COMMAND_${i}`] = batchCommands[i];
       }
-      step.command = 'VARNAME="BATCH_COMMAND_${BUILDKITE_PARALLEL_JOB}"; eval "${!VARNAME}"';
+      step.command = 'VARNAME="BATCH_COMMAND_${BUILDKITE_PARALLEL_JOB}"; eval "$${!VARNAME}"';
       step.parallelism = totalBatches;
       step.env = env;
     }


### PR DESCRIPTION
## Summary

The `repeat-changed-tests` pipeline fails to upload when multiple parallel batches are generated. Buildkite rejects the pipeline with:

```
buildkite-agent: fatal: pipeline interpolation of "(stdin)" failed:
interpolating command: Expected identifier to start with a letter, got !
```

Failing build: https://buildkite.com/elastic/elasticsearch-pull-request/builds/139687#019db9ef-87c7-43d1-b834-96df80e6f73d

## Root cause

In `.buildkite/scripts/repeat-changed-tests.ts`, when `totalBatches > 1`, the step command is:

```bash
VARNAME="BATCH_COMMAND_${BUILDKITE_PARALLEL_JOB}"; eval "${!VARNAME}"
```

`${!VARNAME}` is bash indirect expansion, but Buildkite runs pipeline interpolation on the uploaded YAML before the command reaches bash. Its parser tries to treat `!VARNAME` as a Buildkite variable identifier, which must start with a letter, and fails. This was introduced in #145375.

## Fix

Escape the dollar sign as `$$` so Buildkite leaves `${!VARNAME}` literal and bash performs the indirect expansion at run time:

```bash
VARNAME="BATCH_COMMAND_${BUILDKITE_PARALLEL_JOB}"; eval "\$${!VARNAME}"
```

The neighbouring `${BUILDKITE_PARALLEL_JOB}` doesn't need escaping — Buildkite already handles that variable correctly during interpolation.

## Test plan

- [x] Strengthened the existing `generatePipeline > multiple batches use parallelism with env dispatch` unit test so it asserts the `$$` escape is present and fails if anyone reintroduces the raw `${!VARNAME}` form.
- [x] `bun test .buildkite/scripts/repeat-changed-tests.test.ts` — 37 passed.
- [x] Verified the new assertions fail against the pre-fix code (the `multiple batches` test reports `fail` when the escape is removed).

Made with [Cursor](https://cursor.com)