### PR TITLE
ES|QL: Support mixed standard and block arguments in GroupingAggregator

### DIFF
--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -472,10 +472,7 @@ public class GroupingAggregatorImplementer {
             } else {
                 TypeName typeName = a.type();
                 boolean isVector = valuesAreVector && a.supportsVectorReadAccess();
-                builder.addParameter(
-                    isVector ? vectorType(typeName) : blockType(typeName),
-                    isVector ? a.vectorName() : a.blockName()
-                );
+                builder.addParameter(isVector ? vectorType(typeName) : blockType(typeName), isVector ? a.vectorName() : a.blockName());
             }
         }
         for (Argument a : aggParams) {

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -515,23 +515,26 @@ public class GroupingAggregatorImplementer {
                 builder.endControlFlow();
             }
 
+            // Read all vector arguments first, they don't need to be read in nested loops
             for (Argument a : aggParams) {
-                if (a instanceof StandardArgument) {
-                    if (valuesAreVector && a.supportsVectorReadAccess()) {
-                        a.read(builder, a.vectorName(), "valuesPosition");
-                    } else {
-                        builder.addStatement("int $L = $L.getFirstValueIndex(valuesPosition)", a.startName(), a.blockName());
-                        builder.addStatement("int $L = $L + $L.getValueCount(valuesPosition)", a.endName(), a.startName(), a.blockName());
-                        builder.beginControlFlow(
-                            "for (int $L = $L; $L < $L; $L++)",
-                            a.offsetName(),
-                            a.startName(),
-                            a.offsetName(),
-                            a.endName(),
-                            a.offsetName()
-                        );
-                        a.read(builder, a.blockName(), a.offsetName());
-                    }
+                if (valuesAreVector && a instanceof StandardArgument && a.supportsVectorReadAccess()) {
+                    a.read(builder, a.vectorName(), "valuesPosition");
+                }
+            }
+            // Then read all remaining arguments with nested loops
+            for (Argument a : aggParams) {
+                if (a instanceof StandardArgument && (valuesAreVector == false || a.supportsVectorReadAccess() == false)) {
+                    builder.addStatement("int $L = $L.getFirstValueIndex(valuesPosition)", a.startName(), a.blockName());
+                    builder.addStatement("int $L = $L + $L.getValueCount(valuesPosition)", a.endName(), a.startName(), a.blockName());
+                    builder.beginControlFlow(
+                        "for (int $L = $L; $L < $L; $L++)",
+                        a.offsetName(),
+                        a.startName(),
+                        a.offsetName(),
+                        a.endName(),
+                        a.offsetName()
+                    );
+                    a.read(builder, a.blockName(), a.offsetName());
                 }
             }
             combineRawInput(builder);

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -93,9 +93,13 @@ public class GroupingAggregatorImplementer {
     private final List<AggregatorImplementer.IntermediateStateDesc> intermediateState;
 
     private final AggregationState aggState;
+    /**
+     * The input arguments to the combine method, excluding the {@link PositionArgument} which is filtered out.
+     * Its original index in the combine signature is stored in {@link #positionParamIndex}.
+     */
     private final List<Argument> aggParams;
-    private final boolean hasOnlyBlockArguments;
-    private final boolean allArgumentsSupportVectors;
+    private final int positionParamIndex;
+    private final boolean anyArgumentSupportsVectors;
     private final boolean processNulls;
 
     public GroupingAggregatorImplementer(
@@ -136,16 +140,24 @@ public class GroupingAggregatorImplementer {
             requireArgs(requireType(aggState.declaredType()), requireType(INT_VECTOR), requireType(GROUPING_AGGREGATOR_EVALUATOR_CONTEXT))
         );
 
-        this.aggParams = combine.getParameters().stream().skip(aggState.declaredType().isPrimitive() ? 1 : 2).map(v -> {
+        List<Argument> allCombineArgs = combine.getParameters().stream().skip(aggState.declaredType().isPrimitive() ? 1 : 2).map(v -> {
             Argument a = Argument.fromParameter(types, v);
             if ((a instanceof StandardArgument || a instanceof BlockArgument || a instanceof PositionArgument) == false) {
                 throw new IllegalArgumentException("unsupported argument [" + declarationType + "][" + a + "]");
             }
             return a;
-        }).filter(a -> a instanceof PositionArgument == false).toList();
+        }).toList();
+        int posIdx = -1;
+        for (int i = 0; i < allCombineArgs.size(); i++) {
+            if (allCombineArgs.get(i) instanceof PositionArgument) {
+                posIdx = i;
+                break;
+            }
+        }
+        this.positionParamIndex = posIdx;
+        this.aggParams = allCombineArgs.stream().filter(a -> a instanceof PositionArgument == false).toList();
 
-        this.hasOnlyBlockArguments = this.aggParams.stream().allMatch(a -> a instanceof BlockArgument);
-        this.allArgumentsSupportVectors = aggParams.stream().noneMatch(a -> a.supportsVectorReadAccess() == false);
+        this.anyArgumentSupportsVectors = aggParams.stream().anyMatch(a -> a instanceof StandardArgument && a.supportsVectorReadAccess());
         this.processNulls = processNulls;
 
         this.createParameters = init.getParameters()
@@ -222,7 +234,7 @@ public class GroupingAggregatorImplementer {
         builder.addMethod(prepareProcessRawInputPage());
         for (ClassName groupIdClass : GROUP_IDS_CLASSES) {
             builder.addMethod(addRawInputLoop(groupIdClass, false));
-            if (hasOnlyBlockArguments == false && allArgumentsSupportVectors) {
+            if (anyArgumentSupportsVectors) {
                 builder.addMethod(addRawInputLoop(groupIdClass, true));
             }
             builder.addMethod(addIntermediateInput(groupIdClass));
@@ -340,24 +352,21 @@ public class GroupingAggregatorImplementer {
         }
 
         String groupIdTrackingStatement = "maybeEnableGroupIdTracking(seenGroupIds, "
-            + aggParams.stream().map(arg -> arg.blockName()).collect(joining(", "))
+            + aggParams.stream().map(Argument::blockName).collect(joining(", "))
             + ")";
 
-        if (allArgumentsSupportVectors && hasOnlyBlockArguments == false) {
+        if (anyArgumentSupportsVectors) {
 
             for (Argument a : aggParams) {
-                builder.addStatement(
-                    "$T $L = $L.asVector()",
-                    vectorType(a.elementType()),
-                    (a instanceof BlockArgument) ? (a.name() + "Vector") : a.vectorName(),
-                    a.blockName()
-                );
-                builder.beginControlFlow("if ($L == null)", (a instanceof BlockArgument) ? (a.name() + "Vector") : a.vectorName());
-                {
-                    builder.addStatement(groupIdTrackingStatement);
-                    returnAddInput(builder, false);
+                if (a instanceof StandardArgument && a.supportsVectorReadAccess()) {
+                    builder.addStatement("$T $L = $L.asVector()", vectorType(a.elementType()), a.vectorName(), a.blockName());
+                    builder.beginControlFlow("if ($L == null)", a.vectorName());
+                    {
+                        builder.addStatement(groupIdTrackingStatement);
+                        returnAddInput(builder, false);
+                    }
+                    builder.endControlFlow();
                 }
-                builder.endControlFlow();
             }
             returnAddInput(builder, true);
         } else {
@@ -376,7 +385,11 @@ public class GroupingAggregatorImplementer {
             params.add(declarationType);
             for (Argument a : aggParams) {
                 pattern.append(", $L");
-                params.add(valuesAreVector ? a.vectorName() : a.blockName());
+                if (a instanceof BlockArgument) {
+                    params.add(a.blockName());
+                } else {
+                    params.add(valuesAreVector && a.supportsVectorReadAccess() ? a.vectorName() : a.blockName());
+                }
             }
             pattern.append(")");
             builder.addStatement(pattern.toString(), params.toArray());
@@ -420,17 +433,15 @@ public class GroupingAggregatorImplementer {
             MethodSpec.Builder builder = MethodSpec.methodBuilder("add").addAnnotation(Override.class).addModifiers(Modifier.PUBLIC);
             builder.addParameter(TypeName.INT, "positionOffset").addParameter(groupIdsType, "groupIds");
 
-            if (hasOnlyBlockArguments && valuesAreVector) {
-                builder.addComment("This type does not support vectors because all values are multi-valued");
-                typeBuilder.addMethod(builder.build());
-                continue;
-            }
-
             StringBuilder pattern = new StringBuilder("addRawInput(positionOffset, groupIds");
             List<Object> params = new ArrayList<>();
             for (Argument a : aggParams) {
                 pattern.append(", $L");
-                params.add(valuesAreVector ? a.vectorName() : a.blockName());
+                if (a instanceof BlockArgument) {
+                    params.add(a.blockName());
+                } else {
+                    params.add(valuesAreVector && a.supportsVectorReadAccess() ? a.vectorName() : a.blockName());
+                }
             }
             pattern.append(")");
             builder.addStatement(pattern.toString(), params.toArray());
@@ -456,23 +467,22 @@ public class GroupingAggregatorImplementer {
         builder.addParameter(TypeName.INT, "positionOffset").addParameter(groupsType, "groups");
 
         for (Argument a : aggParams) {
-            boolean isBlockArgument = a instanceof BlockArgument;
-            TypeName typeName = isBlockArgument ? Types.elementType(a.type()) : a.type();
-            builder.addParameter(
-                valuesAreVector ? vectorType(typeName) : blockType(typeName),
-                valuesAreVector ? a.vectorName() : a.blockName()
-            );
+            if (a instanceof BlockArgument) {
+                builder.addParameter(a.dataType(true), a.blockName());
+            } else {
+                TypeName typeName = a.type();
+                boolean isVector = valuesAreVector && a.supportsVectorReadAccess();
+                builder.addParameter(
+                    isVector ? vectorType(typeName) : blockType(typeName),
+                    isVector ? a.vectorName() : a.blockName()
+                );
+            }
         }
         for (Argument a : aggParams) {
             if (a.scratchType() != null) {
                 // Add scratch var that will be used for some blocks/vectors, e.g. for bytes_ref
                 builder.addStatement("$T $L = new $T()", a.scratchType(), a.scratchName(), a.scratchType());
             }
-        }
-
-        if (hasOnlyBlockArguments && valuesAreVector) {
-            builder.addComment("This type does not support vectors because all values are multi-valued");
-            return builder.build();
         }
 
         builder.beginControlFlow("for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++)");
@@ -483,14 +493,16 @@ public class GroupingAggregatorImplementer {
                 builder.endControlFlow();
             }
             builder.addStatement("int valuesPosition = groupPosition + positionOffset");
-
-            if (valuesAreVector == false && hasOnlyBlockArguments == false) {
+            if (valuesAreVector == false) {
                 for (Argument a : aggParams) {
-                    builder.beginControlFlow("if ($L.isNull(valuesPosition))", a.blockName());
-                    builder.addStatement("continue");
-                    builder.endControlFlow();
+                    if (a instanceof StandardArgument) {
+                        builder.beginControlFlow("if ($L.isNull(valuesPosition))", a.blockName());
+                        builder.addStatement("continue");
+                        builder.endControlFlow();
+                    }
                 }
             }
+
             if (groupsIsBlock) {
                 builder.addStatement("int groupStart = groups.getFirstValueIndex(groupPosition)");
                 builder.addStatement("int groupEnd = groupStart + groups.getValueCount(groupPosition)");
@@ -506,20 +518,11 @@ public class GroupingAggregatorImplementer {
                 builder.endControlFlow();
             }
 
-            if (valuesAreVector) {
-                for (Argument a : aggParams) {
-                    a.read(builder, a.vectorName(), "valuesPosition");
-                }
-                combineRawInput(builder);
-            } else {
-                if (hasOnlyBlockArguments) {
-                    String params = aggParams.stream().map(Argument::blockName).collect(joining(", "));
-                    warningsBlock(
-                        builder,
-                        () -> builder.addStatement("$T.combine(state, groupId, valuesPosition, $L)", declarationType, params)
-                    );
-                } else {
-                    for (Argument a : aggParams) {
+            for (Argument a : aggParams) {
+                if (a instanceof StandardArgument) {
+                    if (valuesAreVector && a.supportsVectorReadAccess()) {
+                        a.read(builder, a.vectorName(), "valuesPosition");
+                    } else {
                         builder.addStatement("int $L = $L.getFirstValueIndex(valuesPosition)", a.startName(), a.blockName());
                         builder.addStatement("int $L = $L + $L.getValueCount(valuesPosition)", a.endName(), a.startName(), a.blockName());
                         builder.beginControlFlow(
@@ -532,10 +535,12 @@ public class GroupingAggregatorImplementer {
                         );
                         a.read(builder, a.blockName(), a.offsetName());
                     }
-                    combineRawInput(builder);
-                    for (Argument a : aggParams) {
-                        builder.endControlFlow();
-                    }
+                }
+            }
+            combineRawInput(builder);
+            for (Argument a : aggParams) {
+                if (a instanceof StandardArgument && (valuesAreVector == false || a.supportsVectorReadAccess() == false)) {
+                    builder.endControlFlow();
                 }
             }
 
@@ -563,12 +568,20 @@ public class GroupingAggregatorImplementer {
             pattern.append("$T.combine(state, groupId");
             params.add(declarationType);
         }
-        if (hasOnlyBlockArguments) {
-            pattern.append(", p");
-        }
-        for (Argument a : aggParams) {
+        for (int i = 0; i < aggParams.size(); i++) {
+            if (positionParamIndex == i) {
+                pattern.append(", valuesPosition");
+            }
+            Argument a = aggParams.get(i);
             pattern.append(", $L");
-            params.add(a.valueName());
+            if (a instanceof BlockArgument) {
+                params.add(a.blockName());
+            } else {
+                params.add(a.valueName());
+            }
+        }
+        if (positionParamIndex >= aggParams.size()) {
+            pattern.append(", valuesPosition");
         }
         if (returnType.isPrimitive()) {
             pattern.append(")");
@@ -586,9 +599,11 @@ public class GroupingAggregatorImplementer {
                 Stream.concat(
                     Stream.of(requireType(GROUPING_AGGREGATOR_FUNCTION_ADD_INPUT), requireType(aggState.declaredType())),
                     aggParams.stream().map(a -> {
-                        boolean isBlockArgument = a instanceof BlockArgument;
-                        TypeName typeName = isBlockArgument ? Types.elementType(a.type()) : a.type();
-                        return requireType(valuesAreVector ? vectorType(typeName) : blockType(typeName));
+                        if (a instanceof BlockArgument) {
+                            return requireType(a.type());
+                        }
+                        TypeName typeName = a.type();
+                        return requireType(valuesAreVector && a.supportsVectorReadAccess() ? vectorType(typeName) : blockType(typeName));
                     })
                 ).toArray(Methods.TypeMatcher[]::new)
             )

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/FirstExponentialHistogramByTimestampGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/FirstExponentialHistogramByTimestampGroupingAggregatorFunction.java
@@ -170,11 +170,11 @@ public final class FirstExponentialHistogramByTimestampGroupingAggregatorFunctio
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        long timestampValue = timestampVector.getLong(valuesPosition);
         int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
         int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
         for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
           ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
-          long timestampValue = timestampVector.getLong(valuesPosition);
           FirstExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
         }
       }
@@ -288,11 +288,11 @@ public final class FirstExponentialHistogramByTimestampGroupingAggregatorFunctio
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        long timestampValue = timestampVector.getLong(valuesPosition);
         int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
         int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
         for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
           ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
-          long timestampValue = timestampVector.getLong(valuesPosition);
           FirstExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
         }
       }
@@ -393,11 +393,11 @@ public final class FirstExponentialHistogramByTimestampGroupingAggregatorFunctio
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
+      long timestampValue = timestampVector.getLong(valuesPosition);
       int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
       int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
       for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
         ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
-        long timestampValue = timestampVector.getLong(valuesPosition);
         FirstExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
       }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/FirstExponentialHistogramByTimestampGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/FirstExponentialHistogramByTimestampGroupingAggregatorFunction.java
@@ -79,21 +79,44 @@ public final class FirstExponentialHistogramByTimestampGroupingAggregatorFunctio
       state.enableGroupIdTracking(seenGroupIds);
       return null;
     }
-    maybeEnableGroupIdTracking(seenGroupIds, valueBlock, timestampBlock);
+    LongVector timestampVector = timestampBlock.asVector();
+    if (timestampVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, valueBlock, timestampBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
       public void add(int positionOffset, IntArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, valueBlock, timestampVector);
       }
 
       @Override
       public void add(int positionOffset, IntBigArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, valueBlock, timestampVector);
       }
 
       @Override
       public void add(int positionOffset, IntVector groupIds) {
-        addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, valueBlock, timestampVector);
       }
 
       @Override
@@ -130,6 +153,29 @@ public final class FirstExponentialHistogramByTimestampGroupingAggregatorFunctio
             long timestampValue = timestampBlock.getLong(timestampOffset);
             FirstExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
           }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups,
+      ExponentialHistogramBlock valueBlock, LongVector timestampVector) {
+    ExponentialHistogramScratch valueScratch = new ExponentialHistogramScratch();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
+        int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
+        for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+          ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
+          long timestampValue = timestampVector.getLong(valuesPosition);
+          FirstExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
         }
       }
     }
@@ -230,6 +276,29 @@ public final class FirstExponentialHistogramByTimestampGroupingAggregatorFunctio
     }
   }
 
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups,
+      ExponentialHistogramBlock valueBlock, LongVector timestampVector) {
+    ExponentialHistogramScratch valueScratch = new ExponentialHistogramScratch();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
+        int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
+        for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+          ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
+          long timestampValue = timestampVector.getLong(valuesPosition);
+          FirstExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
+        }
+      }
+    }
+  }
+
   @Override
   public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
@@ -314,6 +383,22 @@ public final class FirstExponentialHistogramByTimestampGroupingAggregatorFunctio
           long timestampValue = timestampBlock.getLong(timestampOffset);
           FirstExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
         }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups,
+      ExponentialHistogramBlock valueBlock, LongVector timestampVector) {
+    ExponentialHistogramScratch valueScratch = new ExponentialHistogramScratch();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
+      int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
+      for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+        ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
+        long timestampValue = timestampVector.getLong(valuesPosition);
+        FirstExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/FirstTDigestByTimestampGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/FirstTDigestByTimestampGroupingAggregatorFunction.java
@@ -78,21 +78,44 @@ public final class FirstTDigestByTimestampGroupingAggregatorFunction implements 
       state.enableGroupIdTracking(seenGroupIds);
       return null;
     }
-    maybeEnableGroupIdTracking(seenGroupIds, tdigestBlock, timestampBlock);
+    LongVector timestampVector = timestampBlock.asVector();
+    if (timestampVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, tdigestBlock, timestampBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
       public void add(int positionOffset, IntArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, tdigestBlock, timestampVector);
       }
 
       @Override
       public void add(int positionOffset, IntBigArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, tdigestBlock, timestampVector);
       }
 
       @Override
       public void add(int positionOffset, IntVector groupIds) {
-        addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, tdigestBlock, timestampVector);
       }
 
       @Override
@@ -129,6 +152,29 @@ public final class FirstTDigestByTimestampGroupingAggregatorFunction implements 
             long timestampValue = timestampBlock.getLong(timestampOffset);
             FirstTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
           }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, TDigestBlock tdigestBlock,
+      LongVector timestampVector) {
+    TDigestHolder tdigestScratch = new TDigestHolder();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
+        int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
+        for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
+          TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
+          long timestampValue = timestampVector.getLong(valuesPosition);
+          FirstTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
         }
       }
     }
@@ -229,6 +275,29 @@ public final class FirstTDigestByTimestampGroupingAggregatorFunction implements 
     }
   }
 
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, TDigestBlock tdigestBlock,
+      LongVector timestampVector) {
+    TDigestHolder tdigestScratch = new TDigestHolder();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
+        int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
+        for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
+          TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
+          long timestampValue = timestampVector.getLong(valuesPosition);
+          FirstTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
+        }
+      }
+    }
+  }
+
   @Override
   public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
@@ -313,6 +382,22 @@ public final class FirstTDigestByTimestampGroupingAggregatorFunction implements 
           long timestampValue = timestampBlock.getLong(timestampOffset);
           FirstTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
         }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, TDigestBlock tdigestBlock,
+      LongVector timestampVector) {
+    TDigestHolder tdigestScratch = new TDigestHolder();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
+      int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
+      for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
+        TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
+        long timestampValue = timestampVector.getLong(valuesPosition);
+        FirstTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/FirstTDigestByTimestampGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/FirstTDigestByTimestampGroupingAggregatorFunction.java
@@ -169,11 +169,11 @@ public final class FirstTDigestByTimestampGroupingAggregatorFunction implements 
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        long timestampValue = timestampVector.getLong(valuesPosition);
         int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
         int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
         for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
           TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
-          long timestampValue = timestampVector.getLong(valuesPosition);
           FirstTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
         }
       }
@@ -287,11 +287,11 @@ public final class FirstTDigestByTimestampGroupingAggregatorFunction implements 
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        long timestampValue = timestampVector.getLong(valuesPosition);
         int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
         int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
         for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
           TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
-          long timestampValue = timestampVector.getLong(valuesPosition);
           FirstTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
         }
       }
@@ -392,11 +392,11 @@ public final class FirstTDigestByTimestampGroupingAggregatorFunction implements 
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
+      long timestampValue = timestampVector.getLong(valuesPosition);
       int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
       int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
       for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
         TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
-        long timestampValue = timestampVector.getLong(valuesPosition);
         FirstTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
       }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/LastExponentialHistogramByTimestampGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/LastExponentialHistogramByTimestampGroupingAggregatorFunction.java
@@ -79,21 +79,44 @@ public final class LastExponentialHistogramByTimestampGroupingAggregatorFunction
       state.enableGroupIdTracking(seenGroupIds);
       return null;
     }
-    maybeEnableGroupIdTracking(seenGroupIds, valueBlock, timestampBlock);
+    LongVector timestampVector = timestampBlock.asVector();
+    if (timestampVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, valueBlock, timestampBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
       public void add(int positionOffset, IntArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, valueBlock, timestampVector);
       }
 
       @Override
       public void add(int positionOffset, IntBigArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, valueBlock, timestampVector);
       }
 
       @Override
       public void add(int positionOffset, IntVector groupIds) {
-        addRawInput(positionOffset, groupIds, valueBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, valueBlock, timestampVector);
       }
 
       @Override
@@ -130,6 +153,29 @@ public final class LastExponentialHistogramByTimestampGroupingAggregatorFunction
             long timestampValue = timestampBlock.getLong(timestampOffset);
             LastExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
           }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups,
+      ExponentialHistogramBlock valueBlock, LongVector timestampVector) {
+    ExponentialHistogramScratch valueScratch = new ExponentialHistogramScratch();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
+        int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
+        for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+          ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
+          long timestampValue = timestampVector.getLong(valuesPosition);
+          LastExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
         }
       }
     }
@@ -230,6 +276,29 @@ public final class LastExponentialHistogramByTimestampGroupingAggregatorFunction
     }
   }
 
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups,
+      ExponentialHistogramBlock valueBlock, LongVector timestampVector) {
+    ExponentialHistogramScratch valueScratch = new ExponentialHistogramScratch();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
+        int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
+        for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+          ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
+          long timestampValue = timestampVector.getLong(valuesPosition);
+          LastExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
+        }
+      }
+    }
+  }
+
   @Override
   public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
@@ -314,6 +383,22 @@ public final class LastExponentialHistogramByTimestampGroupingAggregatorFunction
           long timestampValue = timestampBlock.getLong(timestampOffset);
           LastExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
         }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups,
+      ExponentialHistogramBlock valueBlock, LongVector timestampVector) {
+    ExponentialHistogramScratch valueScratch = new ExponentialHistogramScratch();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
+      int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
+      for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
+        ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
+        long timestampValue = timestampVector.getLong(valuesPosition);
+        LastExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/LastExponentialHistogramByTimestampGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/LastExponentialHistogramByTimestampGroupingAggregatorFunction.java
@@ -170,11 +170,11 @@ public final class LastExponentialHistogramByTimestampGroupingAggregatorFunction
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        long timestampValue = timestampVector.getLong(valuesPosition);
         int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
         int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
         for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
           ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
-          long timestampValue = timestampVector.getLong(valuesPosition);
           LastExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
         }
       }
@@ -288,11 +288,11 @@ public final class LastExponentialHistogramByTimestampGroupingAggregatorFunction
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        long timestampValue = timestampVector.getLong(valuesPosition);
         int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
         int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
         for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
           ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
-          long timestampValue = timestampVector.getLong(valuesPosition);
           LastExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
         }
       }
@@ -393,11 +393,11 @@ public final class LastExponentialHistogramByTimestampGroupingAggregatorFunction
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
+      long timestampValue = timestampVector.getLong(valuesPosition);
       int valueStart = valueBlock.getFirstValueIndex(valuesPosition);
       int valueEnd = valueStart + valueBlock.getValueCount(valuesPosition);
       for (int valueOffset = valueStart; valueOffset < valueEnd; valueOffset++) {
         ExponentialHistogram valueValue = valueBlock.getExponentialHistogram(valueOffset, valueScratch);
-        long timestampValue = timestampVector.getLong(valuesPosition);
         LastExponentialHistogramByTimestampAggregator.combine(state, groupId, valueValue, timestampValue);
       }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/LastTDigestByTimestampGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/LastTDigestByTimestampGroupingAggregatorFunction.java
@@ -78,21 +78,44 @@ public final class LastTDigestByTimestampGroupingAggregatorFunction implements G
       state.enableGroupIdTracking(seenGroupIds);
       return null;
     }
-    maybeEnableGroupIdTracking(seenGroupIds, tdigestBlock, timestampBlock);
+    LongVector timestampVector = timestampBlock.asVector();
+    if (timestampVector == null) {
+      maybeEnableGroupIdTracking(seenGroupIds, tdigestBlock, timestampBlock);
+      return new GroupingAggregatorFunction.AddInput() {
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+          addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+          addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        }
+
+        @Override
+        public void close() {
+        }
+      };
+    }
     return new GroupingAggregatorFunction.AddInput() {
       @Override
       public void add(int positionOffset, IntArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, tdigestBlock, timestampVector);
       }
 
       @Override
       public void add(int positionOffset, IntBigArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, tdigestBlock, timestampVector);
       }
 
       @Override
       public void add(int positionOffset, IntVector groupIds) {
-        addRawInput(positionOffset, groupIds, tdigestBlock, timestampBlock);
+        addRawInput(positionOffset, groupIds, tdigestBlock, timestampVector);
       }
 
       @Override
@@ -129,6 +152,29 @@ public final class LastTDigestByTimestampGroupingAggregatorFunction implements G
             long timestampValue = timestampBlock.getLong(timestampOffset);
             LastTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
           }
+        }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntArrayBlock groups, TDigestBlock tdigestBlock,
+      LongVector timestampVector) {
+    TDigestHolder tdigestScratch = new TDigestHolder();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
+        int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
+        for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
+          TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
+          long timestampValue = timestampVector.getLong(valuesPosition);
+          LastTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
         }
       }
     }
@@ -229,6 +275,29 @@ public final class LastTDigestByTimestampGroupingAggregatorFunction implements G
     }
   }
 
+  private void addRawInput(int positionOffset, IntBigArrayBlock groups, TDigestBlock tdigestBlock,
+      LongVector timestampVector) {
+    TDigestHolder tdigestScratch = new TDigestHolder();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      if (groups.isNull(groupPosition)) {
+        continue;
+      }
+      int valuesPosition = groupPosition + positionOffset;
+      int groupStart = groups.getFirstValueIndex(groupPosition);
+      int groupEnd = groupStart + groups.getValueCount(groupPosition);
+      for (int g = groupStart; g < groupEnd; g++) {
+        int groupId = groups.getInt(g);
+        int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
+        int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
+        for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
+          TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
+          long timestampValue = timestampVector.getLong(valuesPosition);
+          LastTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
+        }
+      }
+    }
+  }
+
   @Override
   public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
@@ -313,6 +382,22 @@ public final class LastTDigestByTimestampGroupingAggregatorFunction implements G
           long timestampValue = timestampBlock.getLong(timestampOffset);
           LastTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
         }
+      }
+    }
+  }
+
+  private void addRawInput(int positionOffset, IntVector groups, TDigestBlock tdigestBlock,
+      LongVector timestampVector) {
+    TDigestHolder tdigestScratch = new TDigestHolder();
+    for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
+      int valuesPosition = groupPosition + positionOffset;
+      int groupId = groups.getInt(groupPosition);
+      int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
+      int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
+      for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
+        TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
+        long timestampValue = timestampVector.getLong(valuesPosition);
+        LastTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
       }
     }
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/LastTDigestByTimestampGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/LastTDigestByTimestampGroupingAggregatorFunction.java
@@ -169,11 +169,11 @@ public final class LastTDigestByTimestampGroupingAggregatorFunction implements G
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        long timestampValue = timestampVector.getLong(valuesPosition);
         int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
         int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
         for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
           TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
-          long timestampValue = timestampVector.getLong(valuesPosition);
           LastTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
         }
       }
@@ -287,11 +287,11 @@ public final class LastTDigestByTimestampGroupingAggregatorFunction implements G
       int groupEnd = groupStart + groups.getValueCount(groupPosition);
       for (int g = groupStart; g < groupEnd; g++) {
         int groupId = groups.getInt(g);
+        long timestampValue = timestampVector.getLong(valuesPosition);
         int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
         int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
         for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
           TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
-          long timestampValue = timestampVector.getLong(valuesPosition);
           LastTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
         }
       }
@@ -392,11 +392,11 @@ public final class LastTDigestByTimestampGroupingAggregatorFunction implements G
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int valuesPosition = groupPosition + positionOffset;
       int groupId = groups.getInt(groupPosition);
+      long timestampValue = timestampVector.getLong(valuesPosition);
       int tdigestStart = tdigestBlock.getFirstValueIndex(valuesPosition);
       int tdigestEnd = tdigestStart + tdigestBlock.getValueCount(valuesPosition);
       for (int tdigestOffset = tdigestStart; tdigestOffset < tdigestEnd; tdigestOffset++) {
         TDigestHolder tdigestValue = tdigestBlock.getTDigestHolder(tdigestOffset, tdigestScratch);
-        long timestampValue = timestampVector.getLong(valuesPosition);
         LastTDigestByTimestampAggregator.combine(state, groupId, tdigestValue, timestampValue);
       }
     }


### PR DESCRIPTION
Part of #147150. This is intended to optimize #147150.

Extend the annotation processor to allow combine methods with both standard (scalar) and block-typed arguments for grouping aggregators. Standard arguments get the vector-optimized code path while block arguments are passed through as blocks in both paths.

This allows us to have a vectorized code path, even if some arguments to the aggregator are nullable:

For example `irate` has the following three inputs:
 * `timestamp` - only non-null values matter
 * `value` - the counter value, only non-null values matter
 * `temporality` - both null and non-null values matter!
 
 In order to deal with nulls in an aggregator, you have to use block-typed arguments in combine.
 Before this PR, it was only support that either all or no arguments are block-typed. That means the `irate` combiner has to look like this:
 
 ```
 public static void combine(
        DoubleIrateGroupingState current,
        int groupId,
        @Position int position,
        DoubleBlock values,
        LongBlock timestamps,
        BytesRefBlock temporality
    )
 ```

This has the problem that it disables the optimized, vectorized code path in the `AggregatorFunction`, that usually would be created for `timestamp` and `value`.

In this PR I lift this restriction: It is now possible to mix and match `StandardArgument`s and block-typed arguments:

```
public static void combine(
        DoubleIrateGroupingState current,
        int groupId,
        double value,
        long timestamp,
        @Position int position,
        BytesRefBlock temporality
    )
```

This allows us to generate a vectorized code-path for cases where `value` and `timestamp` are vectors, temporality will always be passed in as block.

In addition, this expresses the semantics that we only care about rows where both `value` and `timestamp` are null.
So we can optimize accordingly: If either the values or the timestamps are all null, we can skip processing the page entirely.

For now, this optimization is only implemented for grouping aggregators. I also gave non-grouping aggregators a shot,
but it causes a larger diff and we don't really need that yet.
