### PR TITLE
[ESQL] Fix row over-read and lost-wakeup hang on external source

### DIFF
--- a/docs/changelog/147266.yaml
+++ b/docs/changelog/147266.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147266
+summary: Fix row over-read and lost-wakeup hang on external source
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -398,7 +398,15 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             List<SplitRange> ranges = new ArrayList<>(rowGroups.size());
             for (BlockMetaData block : rowGroups) {
                 Map<String, Object> stats = buildRowGroupStats(block);
-                ranges.add(new SplitRange(block.getStartingPos(), block.getTotalByteSize(), stats));
+                // Use the compressed on-disk size for the SplitRange length: this value is fed to
+                // readRange() which builds a byte range end = startingPos + length for Parquet's
+                // withRange(rangeStart, rangeEnd) filter. That filter includes a row group when its
+                // starting position lies in the range, so the end must land at or before the next
+                // row group's starting position. getTotalByteSize() returns the uncompressed size
+                // (much larger than what is actually on disk), which would make adjacent ranges
+                // overlap in byte space and cause Parquet to select each row group from multiple
+                // splits, producing duplicate rows.
+                ranges.add(new SplitRange(block.getStartingPos(), block.getCompressedSize(), stats));
             }
             List<SplitRange> coalesced = coalesceRowGroupRanges(ranges, DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES);
             return coalesced.size() < 2 ? ranges : coalesced;

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1652,7 +1652,106 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertEquals("Reading all ranges should produce the same total as a full read", totalRowsDirect, totalRowsFromRanges);
     }
 
+    /**
+     * Regression test for a row over-read bug: row groups must map to exactly one split.
+     * Previously {@code SplitRange.length} was built from
+     * {@code BlockMetaData.getTotalByteSize()} (uncompressed size), causing ranges to overlap
+     * in byte space. Parquet's {@code withRange(rangeStart, rangeEnd)} filter then selected
+     * each row group from multiple adjacent splits, producing duplicate rows on read.
+     * <p>
+     * Constructs a multi-row-group Snappy-compressed Parquet file (where uncompressed is
+     * meaningfully larger than compressed), verifies the split set is non-overlapping in
+     * byte space, and verifies that reading every split exactly once sums to the true row
+     * count with no duplication and no drops.
+     */
+    public void testReadRangeCoverageIsExactlyOneRowCountTotal() throws Exception {
+        int numRows = 5_000;
+        byte[] parquetData = createCompressibleMultiRowGroupFile(numRows, CompressionCodecName.SNAPPY);
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        assertTrue("Need at least 3 ranges for this regression test, got " + ranges.size(), ranges.size() >= 3);
+
+        // Byte ranges must be sorted and non-overlapping (end_i <= start_{i+1}).
+        long lastEnd = Long.MIN_VALUE;
+        for (RangeAwareFormatReader.SplitRange r : ranges) {
+            assertTrue("Range length must be positive", r.length() > 0);
+            assertTrue(
+                "Ranges must be sorted and non-overlapping: offset=" + r.offset() + ", previous end=" + lastEnd,
+                r.offset() >= lastEnd
+            );
+            lastEnd = r.offset() + r.length();
+        }
+
+        // Sum rows emitted across all splits and compare to the true row count.
+        int totalRowsFromRanges = 0;
+        for (RangeAwareFormatReader.SplitRange range : ranges) {
+            long rangeStart = range.offset();
+            long rangeEnd = rangeStart + range.length();
+            try (
+                CloseableIterator<Page> iterator = reader.readRange(
+                    storageObject,
+                    null,
+                    1000,
+                    rangeStart,
+                    rangeEnd,
+                    List.of(),
+                    ErrorPolicy.STRICT
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    totalRowsFromRanges += iterator.next().getPositionCount();
+                }
+            }
+        }
+
+        assertEquals("Sum of rows across splits must equal the row count written", numRows, totalRowsFromRanges);
+    }
+
     // --- Test helpers ---
+
+    /**
+     * Creates a multi-row-group Parquet file whose uncompressed row-group sizes are meaningfully
+     * larger than the on-disk compressed sizes. The payload is a highly repetitive string, so
+     * codecs such as Snappy compress it dramatically. Used to exercise the split-range length
+     * contract (compressed bytes) vs uncompressed byte reporting in Parquet metadata.
+     */
+    private byte[] createCompressibleMultiRowGroupFile(int numRows, CompressionCodecName codec) throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("payload")
+            .named("test_schema");
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+        // Highly compressible: 512 bytes of a single character.
+        String payload = "a".repeat(512);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(codec)
+                .withRowGroupSize(8 * 1024L)
+                .withPageSize(512)
+                .build()
+        ) {
+            for (int i = 0; i < numRows; i++) {
+                Group g = groupFactory.newGroup();
+                g.add("id", (long) i);
+                g.add("payload", payload);
+                writer.write(g);
+            }
+        }
+        return outputStream.toByteArray();
+    }
 
     private static byte[] toFloat16Bytes(float value) {
         short float16 = Float.floatToFloat16(value);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -68,12 +68,13 @@ public final class AsyncExternalSourceBuffer {
             return;
         }
         long pageBytes = page.ramBytesUsedByBlocks();
-        long prevBytes = bytesInBuffer.getAndAdd(pageBytes);
+        bytesInBuffer.addAndGet(pageBytes);
         queue.add(page);
         queueSize.incrementAndGet();
-        if (prevBytes == 0) {
-            notifyNotEmpty();
-        }
+        // Always notify: the conditional guard on prevBytes==0 previously caused a lost-wakeup race
+        // when a consumer drained and blocked on notEmptyFuture between our getAndAdd and queue.add.
+        // notifyNotEmpty() is a no-op when no listener is registered, so unconditional fire is cheap.
+        notifyNotEmpty();
         if (noMoreInputs) {
             // O(N) but acceptable because it only occurs with finish(), and the queue size should be very small.
             if (queue.removeIf(p -> p == page)) {
@@ -99,10 +100,11 @@ public final class AsyncExternalSourceBuffer {
         if (page != null) {
             queueSize.decrementAndGet();
             long pageBytes = page.ramBytesUsedByBlocks();
-            long prevBytes = bytesInBuffer.getAndAdd(-pageBytes);
-            if (prevBytes >= maxBufferBytes && (prevBytes - pageBytes) < maxBufferBytes) {
-                notifyNotFull();
-            }
+            bytesInBuffer.addAndGet(-pageBytes);
+            // Always notify: the previous threshold-crossing guard could miss a crossing because the
+            // producer's waitForSpace snapshot of bytesInBuffer can race with concurrent addPage calls,
+            // orphaning notFullFuture. notifyNotFull() is a no-op when no listener is registered.
+            notifyNotFull();
         }
         signalCompletionIfDrained();
         return page;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -492,32 +492,42 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     }
 
     private void startSliceQueueRead(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
-        ActionListener<Void> failureListener = failureListener(buffer, driverContext);
-        executor.execute(ActionRunnable.run(failureListener, () -> processNextSplit(sliceQueue, buffer, driverContext, rowLimit)));
+        ActionListener<Void> completionListener = ActionListener.assertOnce(ActionListener.wrap(v -> {
+            buffer.finish(false);
+            driverContext.removeAsyncAction();
+        }, e -> {
+            buffer.onFailure(e);
+            driverContext.removeAsyncAction();
+        }));
+        try {
+            executor.execute(
+                ActionRunnable.wrap(completionListener, l -> processNextSplit(sliceQueue, buffer, driverContext, rowLimit, l))
+            );
+        } catch (Exception e) {
+            completionListener.onFailure(e);
+        }
     }
 
     private void processNextSplit(
         ExternalSliceQueue queue,
         AsyncExternalSourceBuffer buffer,
         DriverContext driverContext,
-        int rowsRemaining
+        int rowsRemaining,
+        ActionListener<Void> completionListener
     ) {
         if (buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
-            buffer.finish(false);
-            driverContext.removeAsyncAction();
+            completionListener.onResponse(null);
             return;
         }
         ExternalSplit split = queue.nextSplit();
         if (split == null) {
-            buffer.finish(false);
-            driverContext.removeAsyncAction();
+            completionListener.onResponse(null);
             return;
         }
-        ActionListener<Void> failureListener = failureListener(buffer, driverContext);
         List<ExternalSplit> leaves = flattenToLeaves(split);
         processNextLeaf(leaves, 0, queue, buffer, driverContext, rowsRemaining, ActionListener.wrap(remaining -> {
-            executor.execute(ActionRunnable.run(failureListener, () -> processNextSplit(queue, buffer, driverContext, remaining)));
-        }, failureListener::onFailure));
+            executor.execute(ActionRunnable.wrap(completionListener, l -> processNextSplit(queue, buffer, driverContext, remaining, l)));
+        }, completionListener::onFailure));
     }
 
     private void processNextLeaf(
@@ -620,14 +630,23 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         VirtualColumnInjector injector
     ) {
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = fileList != null ? fileList.fileSchemaInfo() : null;
-
-        ActionListener<Void> failureListener = failureListener(buffer, driverContext);
-        executor.execute(
-            ActionRunnable.run(
-                failureListener,
-                () -> processNextFile(0, projectedColumns, buffer, driverContext, injector, schemaInfo, rowLimit)
-            )
-        );
+        ActionListener<Void> completionListener = ActionListener.assertOnce(ActionListener.wrap(v -> {
+            buffer.finish(false);
+            driverContext.removeAsyncAction();
+        }, e -> {
+            buffer.onFailure(e);
+            driverContext.removeAsyncAction();
+        }));
+        try {
+            executor.execute(
+                ActionRunnable.wrap(
+                    completionListener,
+                    l -> processNextFile(0, projectedColumns, buffer, driverContext, injector, schemaInfo, rowLimit, l)
+                )
+            );
+        } catch (Exception e) {
+            completionListener.onFailure(e);
+        }
     }
 
     private void processNextFile(
@@ -637,11 +656,11 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         DriverContext driverContext,
         VirtualColumnInjector injector,
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo,
-        int rowsRemaining
+        int rowsRemaining,
+        ActionListener<Void> completionListener
     ) {
         if (fileIndex >= fileList.fileCount() || buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
-            buffer.finish(false);
-            driverContext.removeAsyncAction();
+            completionListener.onResponse(null);
             return;
         }
 
@@ -670,8 +689,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 pages = formatReader.read(obj, ctx);
             }
         } catch (Exception e) {
-            buffer.onFailure(e);
-            driverContext.removeAsyncAction();
+            completionListener.onFailure(e);
             return;
         }
 
@@ -689,12 +707,10 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             wrappedPages = wrapWithInjector(adaptedPages, injector);
         } catch (Exception e) {
             closeQuietly(pages);
-            buffer.onFailure(e);
-            driverContext.removeAsyncAction();
+            completionListener.onFailure(e);
             return;
         }
 
-        ActionListener<Void> failureListener = failureListener(buffer, driverContext);
         drainPagesWithBudgetAsync(
             wrappedPages,
             buffer,
@@ -703,12 +719,12 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             ActionListener.runAfter(ActionListener.<Integer>wrap(consumed -> {
                 int remaining = rowLimit != FormatReader.NO_LIMIT ? rowsRemaining - consumed : rowsRemaining;
                 executor.execute(
-                    ActionRunnable.run(
-                        failureListener,
-                        () -> processNextFile(fileIndex + 1, projectedColumns, buffer, driverContext, injector, schemaInfo, remaining)
+                    ActionRunnable.wrap(
+                        completionListener,
+                        l -> processNextFile(fileIndex + 1, projectedColumns, buffer, driverContext, injector, schemaInfo, remaining, l)
                     )
                 );
-            }, failureListener::onFailure), () -> closeQuietly(wrappedPages))
+            }, completionListener::onFailure), () -> closeQuietly(wrappedPages))
         );
     }
 
@@ -859,6 +875,12 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         return leaves;
     }
 
+    /**
+     * Failure-only listener used by non-iterative paths ({@link #startSyncWrapperRead},
+     * {@link #consumePagesInBackground}) where {@code removeAsyncAction()} lives in the
+     * drain's {@code runAfter} callback. Do NOT use for the iterative slice-queue or
+     * multi-file paths — those use a single {@code completionListener} instead.
+     */
     private static ActionListener<Void> failureListener(AsyncExternalSourceBuffer buffer, DriverContext driverContext) {
         return ActionListener.wrap(v -> {}, e -> {
             buffer.onFailure(e);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBufferTests.java
@@ -7,13 +7,20 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.IsBlockedResult;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Unit tests for {@link AsyncExternalSourceBuffer} backpressure via {@link AsyncExternalSourceBuffer#waitForSpace()}.
@@ -104,5 +111,109 @@ public class AsyncExternalSourceBufferTests extends ESTestCase {
         assertEquals(0, buffer.size());
         assertEquals(0, buffer.bytesInBuffer());
         buffer.finish(true);
+    }
+
+    /**
+     * Regression test for a lost-wakeup race between {@link AsyncExternalSourceBuffer#addPage(Page)}
+     * and {@link AsyncExternalSourceBuffer#pollPage()}.
+     * <p>
+     * The prior implementation guarded {@code notifyNotEmpty()} on a snapshot of {@code bytesInBuffer}
+     * taken BEFORE the page was inserted into the queue, and guarded {@code notifyNotFull()} on a
+     * threshold-crossing check using that same snapshot. A consumer that drained the queue and
+     * installed a {@code notEmptyFuture} in the tiny window between a producer's {@code getAndAdd}
+     * and {@code queue.add} would be orphaned — the producer would see {@code prevBytes != 0} and
+     * skip the wakeup. On buffers with a low max capacity this deadlocks both sides.
+     * <p>
+     * This test runs tens of thousands of add/poll interleavings against a small buffer. Pre-fix it
+     * reliably hangs; post-fix it completes in well under the safety deadline.
+     */
+    public void testNoLostWakeupUnderConcurrentAddAndPoll() throws Exception {
+        // Tight buffer to force frequent back-pressure flips. Each test page is ~224 B (2 cols x 1 row
+        // IntBlocks), so 3 * 8224 comfortably fits a handful of pages, with producer regularly waiting.
+        final long maxBufferBytes = 3L * 8224;
+        final int iterations = 50;
+        final int pagesPerIteration = 5_000;
+        final long deadlineNanos = TimeUnit.SECONDS.toNanos(30);
+
+        for (int iter = 0; iter < iterations; iter++) {
+            AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+            AtomicInteger pagesAdded = new AtomicInteger();
+            AtomicInteger pagesConsumed = new AtomicInteger();
+            AtomicReference<Throwable> producerError = new AtomicReference<>();
+
+            Thread producer = new Thread(() -> {
+                try {
+                    for (int i = 0; i < pagesPerIteration; i++) {
+                        SubscribableListener<Void> space = buffer.waitForSpace();
+                        if (space.isDone() == false) {
+                            PlainActionFuture<Void> fut = new PlainActionFuture<>();
+                            space.addListener(fut);
+                            fut.actionGet(TimeValue.timeValueSeconds(10));
+                        }
+                        buffer.addPage(createTestPage(2, 1));
+                        pagesAdded.incrementAndGet();
+                    }
+                    buffer.finish(false);
+                } catch (Throwable t) {
+                    producerError.set(t);
+                }
+            }, "async-buffer-producer");
+            producer.setDaemon(true);
+            producer.start();
+
+            long deadline = System.nanoTime() + deadlineNanos;
+            while (buffer.isFinished() == false) {
+                Page p = buffer.pollPage();
+                if (p != null) {
+                    p.releaseBlocks();
+                    pagesConsumed.incrementAndGet();
+                } else {
+                    IsBlockedResult blk = buffer.waitForReading();
+                    if (blk.listener().isDone() == false) {
+                        PlainActionFuture<Void> fut = new PlainActionFuture<>();
+                        blk.listener().addListener(fut);
+                        try {
+                            fut.actionGet(TimeValue.timeValueSeconds(10));
+                        } catch (Exception e) {
+                            throw new AssertionError(
+                                "consumer stuck waiting for data (lost wakeup) iter="
+                                    + iter
+                                    + " addedSoFar="
+                                    + pagesAdded.get()
+                                    + " consumedSoFar="
+                                    + pagesConsumed.get()
+                                    + " queueSize="
+                                    + buffer.size()
+                                    + " bytesInBuffer="
+                                    + buffer.bytesInBuffer(),
+                                e
+                            );
+                        }
+                    }
+                }
+                if (System.nanoTime() > deadline) {
+                    throw new AssertionError(
+                        "test deadline exceeded iter="
+                            + iter
+                            + " added="
+                            + pagesAdded.get()
+                            + " consumed="
+                            + pagesConsumed.get()
+                            + " queueSize="
+                            + buffer.size()
+                            + " bytesInBuffer="
+                            + buffer.bytesInBuffer()
+                    );
+                }
+            }
+
+            producer.join(TimeUnit.SECONDS.toMillis(5));
+            assertFalse("producer thread should have exited", producer.isAlive());
+            assertNull("producer threw", producerError.get());
+            assertEquals("all pages should have been added", pagesPerIteration, pagesAdded.get());
+            assertEquals("all pages should have been consumed", pagesPerIteration, pagesConsumed.get());
+            assertEquals(0, buffer.size());
+            assertEquals(0, buffer.bytesInBuffer());
+        }
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -16,6 +17,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -1909,6 +1911,314 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         operator.close();
     }
 
+    // ===== Multi-driver concurrent tests with real DriverContext and backpressure =====
+
+    /**
+     * Concurrent sanity check for the slice-queue path: multiple producer drivers processing
+     * many splits (including {@link CoalescedSplit} entries with multiple leaves) from a shared
+     * {@link ExternalSliceQueue} with real {@link DriverContext} async-action tracking and a
+     * real thread pool. Verifies that {@code waitForAsyncActions} completes for every driver
+     * and no splits are dropped or double-read.
+     * <p>
+     * Parameters are randomized to vary timing across repeated runs.
+     */
+    public void testSliceQueueMultiDriverRealContextManyBackpressuredSplits() throws Exception {
+        int driverCount = randomIntBetween(2, 6);
+        int pagesPerSplit = randomIntBetween(3, 8);
+        int bufferSize = randomIntBetween(1, 3);
+
+        int plainSplitCount = randomIntBetween(10, 30);
+        int coalescedCount = randomIntBetween(5, 15);
+        int leafCounter = 0;
+        List<ExternalSplit> queueEntries = new ArrayList<>();
+        for (int i = 0; i < plainSplitCount; i++) {
+            queueEntries.add(
+                new FileSplit("test", StoragePath.of("s3://bucket/rg" + leafCounter++ + ".parquet"), 0, 100, "parquet", Map.of(), Map.of())
+            );
+        }
+        for (int i = 0; i < coalescedCount; i++) {
+            int leavesInCoalesced = randomIntBetween(2, 3);
+            List<ExternalSplit> children = new ArrayList<>();
+            for (int c = 0; c < leavesInCoalesced; c++) {
+                children.add(
+                    new FileSplit(
+                        "test",
+                        StoragePath.of("s3://bucket/rg" + leafCounter++ + ".parquet"),
+                        0,
+                        100,
+                        "parquet",
+                        Map.of(),
+                        Map.of()
+                    )
+                );
+            }
+            queueEntries.add(new CoalescedSplit("test", children));
+        }
+        int totalLeaves = leafCounter;
+        ExternalSliceQueue sliceQueue = new ExternalSliceQueue(queueEntries);
+
+        AtomicInteger totalReadCount = new AtomicInteger(0);
+        FormatReader formatReader = new MultiPageFormatReader(totalReadCount, pagesPerSplit);
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+        StoragePath path = StoragePath.of("s3://bucket/rg0.parquet");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        // Producer executor is separate from consumer threads to avoid thread starvation
+        ExecutorService producerExec = Executors.newFixedThreadPool(driverCount, EsExecutors.daemonThreadFactory("test", "sq-producer"));
+        try {
+            SourceOperator[] operators = new SourceOperator[driverCount];
+            DriverContext[] contexts = new DriverContext[driverCount];
+            AtomicInteger pageCount = new AtomicInteger(0);
+            Thread[] consumers = new Thread[driverCount];
+
+            for (int d = 0; d < driverCount; d++) {
+                DriverContext ctx = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
+                contexts[d] = ctx;
+                AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+                    storageProvider,
+                    formatReader,
+                    path,
+                    attributes,
+                    100,
+                    bufferSize,
+                    producerExec,
+                    null,
+                    null,
+                    null,
+                    sliceQueue
+                );
+                operators[d] = factory.get(ctx);
+            }
+
+            for (int d = 0; d < driverCount; d++) {
+                final int driverIdx = d;
+                consumers[d] = new Thread(() -> {
+                    try {
+                        while (operators[driverIdx].isFinished() == false) {
+                            Page page = operators[driverIdx].getOutput();
+                            if (page != null) {
+                                pageCount.incrementAndGet();
+                                page.releaseBlocks();
+                            } else {
+                                Thread.sleep(1);
+                            }
+                        }
+                    } catch (Exception e) {
+                        throw new AssertionError("Consumer " + driverIdx + " failed", e);
+                    }
+                });
+                consumers[d].start();
+            }
+
+            for (int d = 0; d < driverCount; d++) {
+                consumers[d].join(TimeUnit.SECONDS.toMillis(15));
+                assertFalse("Consumer thread " + d + " should have completed", consumers[d].isAlive());
+            }
+
+            for (int d = 0; d < driverCount; d++) {
+                contexts[d].finish();
+                PlainActionFuture<Void> asyncFuture = new PlainActionFuture<>();
+                contexts[d].waitForAsyncActions(asyncFuture);
+                asyncFuture.actionGet(TimeValue.timeValueSeconds(10));
+            }
+
+            assertEquals("All leaves should be read", totalLeaves, totalReadCount.get());
+            assertEquals("Total pages should be totalLeaves * pagesPerSplit", totalLeaves * pagesPerSplit, pageCount.get());
+
+            for (SourceOperator op : operators) {
+                op.close();
+            }
+        } finally {
+            producerExec.shutdown();
+            assertTrue(producerExec.awaitTermination(15, TimeUnit.SECONDS));
+        }
+    }
+
+    /**
+     * Failure-injection test for the slice-queue path with a real {@link DriverContext}: a
+     * format reader that throws after producing a few pages. Verifies that
+     * {@code waitForAsyncActions} still completes (i.e., {@code removeAsyncAction} fires on
+     * the error path), which is the property the single-completion-listener refactor guarantees.
+     */
+    public void testSliceQueueMidStreamFailureCompletesAsyncActions() throws Exception {
+        int goodSplits = randomIntBetween(2, 5);
+        int totalSplits = goodSplits + randomIntBetween(2, 5);
+        int pagesPerSplit = randomIntBetween(3, 6);
+
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int i = 0; i < totalSplits; i++) {
+            splits.add(new FileSplit("test", StoragePath.of("s3://bucket/s" + i + ".parquet"), 0, 100, "parquet", Map.of(), Map.of()));
+        }
+        ExternalSliceQueue sliceQueue = new ExternalSliceQueue(splits);
+
+        AtomicInteger readCount = new AtomicInteger(0);
+        FormatReader formatReader = new FailAfterNReadsFormatReader(readCount, goodSplits, pagesPerSplit);
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+        StoragePath path = StoragePath.of("s3://bucket/s0.parquet");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        ExecutorService realExec = Executors.newFixedThreadPool(2, EsExecutors.daemonThreadFactory("test", "fail-test"));
+        try {
+            DriverContext ctx = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
+            AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+                storageProvider,
+                formatReader,
+                path,
+                attributes,
+                100,
+                2,
+                realExec,
+                null,
+                null,
+                null,
+                sliceQueue
+            );
+            SourceOperator operator = factory.get(ctx);
+
+            List<Page> pages = new ArrayList<>();
+            Exception operatorError = null;
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+            while (operator.isFinished() == false && System.nanoTime() < deadline) {
+                try {
+                    Page page = operator.getOutput();
+                    if (page != null) {
+                        pages.add(page);
+                    } else {
+                        Thread.sleep(1);
+                    }
+                } catch (Exception e) {
+                    operatorError = e;
+                    break;
+                }
+            }
+            assertNotNull("Operator should propagate the injected read failure", operatorError);
+
+            ctx.finish();
+            PlainActionFuture<Void> asyncFuture = new PlainActionFuture<>();
+            ctx.waitForAsyncActions(asyncFuture);
+            asyncFuture.actionGet(TimeValue.timeValueSeconds(10));
+
+            for (Page p : pages) {
+                p.releaseBlocks();
+            }
+            operator.close();
+        } finally {
+            realExec.shutdown();
+            assertTrue(realExec.awaitTermination(15, TimeUnit.SECONDS));
+        }
+    }
+
+    /**
+     * Concurrent sanity check for the multi-file path: multiple producer drivers processing
+     * files from a resolved {@link FileList} with real {@link DriverContext} async-action
+     * tracking. Verifies that {@code waitForAsyncActions} completes for every driver.
+     */
+    public void testMultiFileMultiDriverRealContextBackpressure() throws Exception {
+        int driverCount = randomIntBetween(2, 4);
+        int fileCount = randomIntBetween(4, 10);
+        int pagesPerFile = randomIntBetween(3, 8);
+        int bufferSize = randomIntBetween(1, 3);
+
+        List<StorageEntry> entries = new ArrayList<>();
+        for (int i = 0; i < fileCount; i++) {
+            entries.add(new StorageEntry(StoragePath.of("s3://bucket/f" + i + ".parquet"), 100 * (i + 1), Instant.EPOCH));
+        }
+        FileList fileList = GlobExpander.fileListOf(entries, "s3://bucket/*.parquet");
+
+        AtomicInteger totalReadCount = new AtomicInteger(0);
+        FormatReader formatReader = new MultiPageFormatReader(totalReadCount, pagesPerFile);
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+
+        StoragePath path = StoragePath.of("s3://bucket/f0.parquet");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        ExecutorService producerExec = Executors.newFixedThreadPool(driverCount, EsExecutors.daemonThreadFactory("test", "mf-producer"));
+        try {
+            SourceOperator[] operators = new SourceOperator[driverCount];
+            DriverContext[] contexts = new DriverContext[driverCount];
+            AtomicInteger pageCount = new AtomicInteger(0);
+            Thread[] consumers = new Thread[driverCount];
+
+            for (int d = 0; d < driverCount; d++) {
+                DriverContext ctx = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
+                contexts[d] = ctx;
+                AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+                    storageProvider,
+                    formatReader,
+                    path,
+                    attributes,
+                    100,
+                    bufferSize,
+                    producerExec,
+                    fileList
+                );
+                operators[d] = factory.get(ctx);
+            }
+
+            for (int d = 0; d < driverCount; d++) {
+                final int driverIdx = d;
+                consumers[d] = new Thread(() -> {
+                    try {
+                        while (operators[driverIdx].isFinished() == false) {
+                            Page page = operators[driverIdx].getOutput();
+                            if (page != null) {
+                                pageCount.incrementAndGet();
+                                page.releaseBlocks();
+                            } else {
+                                Thread.sleep(1);
+                            }
+                        }
+                    } catch (Exception e) {
+                        throw new AssertionError("Consumer " + driverIdx + " failed", e);
+                    }
+                });
+                consumers[d].start();
+            }
+
+            for (int d = 0; d < driverCount; d++) {
+                consumers[d].join(TimeUnit.SECONDS.toMillis(15));
+                assertFalse("Consumer thread " + d + " should have completed", consumers[d].isAlive());
+            }
+
+            for (int d = 0; d < driverCount; d++) {
+                contexts[d].finish();
+                PlainActionFuture<Void> asyncFuture = new PlainActionFuture<>();
+                contexts[d].waitForAsyncActions(asyncFuture);
+                asyncFuture.actionGet(TimeValue.timeValueSeconds(10));
+            }
+
+            assertEquals(fileCount * driverCount, totalReadCount.get());
+            assertEquals(fileCount * pagesPerFile * driverCount, pageCount.get());
+
+            for (SourceOperator op : operators) {
+                op.close();
+            }
+        } finally {
+            producerExec.shutdown();
+            assertTrue(producerExec.awaitTermination(15, TimeUnit.SECONDS));
+        }
+    }
+
     // ===== Helpers =====
 
     private static CloseableIterator<Page> emptyIterator() {
@@ -2467,6 +2777,66 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
     /**
      * Test async format reader that returns empty pages via async callback.
      */
+    /**
+     * Format reader that succeeds for the first N reads (returning multiple pages each),
+     * then throws an IOException on the (N+1)th read. Used to test error-path cleanup.
+     */
+    private static class FailAfterNReadsFormatReader implements FormatReader {
+        private final AtomicInteger readCount;
+        private final int failAfter;
+        private final int pagesPerRead;
+
+        FailAfterNReadsFormatReader(AtomicInteger readCount, int failAfter, int pagesPerRead) {
+            this.readCount = readCount;
+            this.failAfter = failAfter;
+            this.pagesPerRead = pagesPerRead;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+            int call = readCount.incrementAndGet();
+            if (call > failAfter) {
+                throw new IOException("Injected read failure on call " + call);
+            }
+            return new CloseableIterator<>() {
+                private int remaining = pagesPerRead;
+
+                @Override
+                public boolean hasNext() {
+                    return remaining > 0;
+                }
+
+                @Override
+                public Page next() {
+                    if (remaining <= 0) throw new NoSuchElementException();
+                    remaining--;
+                    return createTestPage();
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
+
+        @Override
+        public String formatName() {
+            return "test-fail-after-n";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
+    }
+
     private static class TestAsyncFormatReader implements FormatReader {
         @Override
         public SourceMetadata metadata(StorageObject object) {


### PR DESCRIPTION
## Summary

Two correctness bugs in the ESQL external-source (Parquet) reader path that were reproducing on multi-row-group files against `hits.parquet` STATS query.

### 1. Row over-read (Parquet split construction)

Split byte-range lengths were built from `BlockMetaData.getTotalByteSize()`, which returns the **uncompressed** row-group size. Because the split range is consumed as `readRange(startingPos, startingPos + length)` and Parquet's `withRange()` filter selects row groups whose `startingPos` falls in the range, uncompressed lengths produced **overlapping** split ranges in compressed byte space. Row groups at the overlapping boundaries were read by 2-4 different splits.

On `hits.parquet` (Snappy-compressed, 226 row groups, uncompressed/compressed ratio ~3.6x): `COUNT(*)` returned 251,063,342 instead of the true 99,997,497 (2.51x over-read). Distribution of how many splits selected each row group: `{1x: 2, 2x: 120, 3x: 92, 4x: 12}`.

Fix: use `block.getCompressedSize()` for the split length. Regression test writes a Snappy multi-row-group Parquet and asserts (a) split byte ranges are non-overlapping, (b) sum of rows across splits equals the file's row count.

### 2. Lost-wakeup deadlock in the async source buffer

The async buffer fed by a producer chain and drained by the Driver gated its `notifyNotEmpty` / `notifyNotFull` calls on snapshot checks taken *before* the queue was updated:

- `addPage` only notified the consumer if `prevBytes == 0` at the moment of `getAndAdd(pageBytes)`.
- `pollPage` only notified the producer on a threshold-crossing check against the same kind of stale snapshot.

Concurrent interleavings between `addPage` and `pollPage` could leave either listener orphaned:

```
State: queue has p1, bytesInBuffer=pageBytes. No listener registered.
T2 addPage(p2) step 1: captures prev = pageBytes (!= 0)
T1 pollPage p1: queueSize->0, bytesInBuffer->pageBytes
T1 pollPage: queue.poll() -> null (T2 not queue.add'd yet)
T1 waitForReading: queueSize=0, registers notEmptyFuture F
T2 continues: queue.add(p2), queueSize++, checks captured prev==0? NO -> skip notify
```

F never fires. Consumer parked. Queue has p2 waiting. Subsequent `addPage` calls all see `prev != 0`. Eventually the buffer fills, producer blocks on `notFullFuture`, also orphaned (its symmetric race). Classic lost-wakeup deadlock.

This was the original hang the previous timeout was papering over. With the over-read fixed, per-driver page volume dropped ~2.5x and the race fired intermittently (1/19 drivers) instead of consistently (all 19).

Fix: drop both snapshot-based guards and call `notifyNotEmpty()` / `notifyNotFull()` unconditionally. Each call is one uncontended lock + null check when no listener is registered - cheap versus page construction. Regression test runs a producer thread + consumer thread through 50 iterations x 5000 pages against a small buffer; reliably hangs pre-fix, completes in ~100 ms post-fix.

## Results

| | Before | After |
|---|---|---|
| `COUNT(*)` on hits.parquet | 251,063,342 (2.51x) | **99,997,497** |
| Wall time | 33 s | **10.8 s** |