### PR TITLE
ES|QL: Fix EsqlNodeSubclassTests to avoid instantiating blacklisted plans

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -427,9 +427,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.ApproximationGoldenTests
   method: testApproximationDisabled
   issue: https://github.com/elastic/elasticsearch/issues/147144
-- class: org.elasticsearch.xpack.esql.plan.logical.CommandLicenseTests
-  method: testLicenseCheck
-  issue: https://github.com/elastic/elasticsearch/issues/147147
 - class: org.elasticsearch.ingest.common.IngestCommonClientYamlTestSuiteIT
   method: test {yaml=ingest/70_bulk/Update with pipeline}
   issue: https://github.com/elastic/elasticsearch/issues/147163

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -514,6 +514,15 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
              */
             @SuppressWarnings("unchecked") // safe because this is the lowest possible bounds for Node
             Class<? extends Node<?>> asNodeSubclass = (Class<? extends Node<?>>) argType;
+            if (Modifier.isAbstract(asNodeSubclass.getModifiers())) {
+                while (true) {
+                    var candidate = randomFrom(subclassesOf(asNodeSubclass, CLASSNAME_FILTER));
+                    if (UNRESOLVED_CLASSES.stream().allMatch(unresolved -> unresolved.isAssignableFrom(candidate) == false)) {
+                        asNodeSubclass = candidate;
+                        break;
+                    }
+                }
+            }
             return makeNode(asNodeSubclass);
         }
 


### PR DESCRIPTION
Same as for https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java#L765, we have to exclude blacklisted classes (unresolved plans in particular)  during arg generation.

Fixes: https://github.com/elastic/elasticsearch/issues/147147