### PR TITLE
[9.3] [TEST] Fix MLModelDeploymentFullClusterRestartIT UPGRADED failures (#147274)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -8,9 +8,6 @@ tests:
 - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
   method: testTracingCrossCluster
   issue: https://github.com/elastic/elasticsearch/issues/112731
-- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/115528
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
   issue: https://github.com/elastic/elasticsearch/issues/115808
@@ -69,9 +66,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
   issue: https://github.com/elastic/elasticsearch/issues/122755
-- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-  method: testDeploymentSurvivesRestart {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/124160
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
   issue: https://github.com/elastic/elasticsearch/issues/120720

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -89,14 +89,18 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractXpackFullClus
     }
 
     public void testDeploymentSurvivesRestart() throws Exception {
+        // The guard must cover both parameterized runs (OLD and UPGRADED). If it is placed only inside the OLD branch,
+        // @Before maybeUpgrade() still upgrades the cluster for the UPGRADED run. UPGRADED then enters the `else` branch
+        // against an empty cluster (no model was ever created) and fails with 404 on _stats. See #147226 for the
+        // full-bwc failure this caused on 9.4.
+        assumeTrue(
+            "PyTorch model deployment inference is not reliably supported before 8.3.0",
+            getOldClusterTestVersion().onOrAfter("8.3.0")
+        );
 
         String modelId = "trained-model-full-cluster-restart";
 
         if (isRunningAgainstOldCluster()) {
-            assumeTrue(
-                "PyTorch model deployment inference is not reliably supported before 8.3.0",
-                getOldClusterTestVersion().onOrAfter("8.3.0")
-            );
             createTrainedModel(modelId);
             putModelDefinition(modelId);
             putVocabulary(List.of("these", "are", "my", "words"), modelId);


### PR DESCRIPTION
Backports the following commits to 9.3:

* [TEST] Fix MLModelDeploymentFullClusterRestartIT UPGRADED failures (#147274)

Additionally removes the two muted-tests.yml entries that were hiding both variants of `testDeploymentSurvivesRestart` on this branch (issues #115528 and #124160). With the version guard now hoisted above the `if/else`, both variants are skipped via `assumeTrue` for pre-8.3.0 BWC runs — the underlying flake those mutes were covering is no longer reachable.

