### PR TITLE
[ESQL] Simplify external-source + connector factories (builder + state-machine flatten)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactory.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
@@ -24,11 +26,24 @@ import java.io.IOException;
 import java.util.concurrent.Executor;
 
 /**
- * Single-split source operator factory that executes a connector query on a background thread
- * and feeds pages into an {@link AsyncExternalSourceBuffer} for the driver to consume.
+ * Source-operator factory that executes a connector query on a background thread and feeds pages
+ * into an {@link AsyncExternalSourceBuffer} for the driver to consume.
  * <p>
- * Uses non-blocking async drain: the producer thread is released when the buffer is full and
- * resumes via the executor when space is freed, with no timeout.
+ * Two execution modes, selected based on whether a {@link ExternalSliceQueue} is supplied:
+ * <ul>
+ *   <li><b>Slice-queue mode</b> — iterates each {@link ExternalSplit} pulled from the queue and
+ *   executes it via {@link Connector#execute(QueryRequest, ExternalSplit)}, sharing a single row
+ *   budget across splits.</li>
+ *   <li><b>Single-shot mode</b> — executes the request exactly once using {@link Split#SINGLE} via
+ *   {@link Connector#execute(QueryRequest, Split)}.</li>
+ * </ul>
+ * The producer runs as a flat state machine (see {@link #runProducerLoop}) driven by a single
+ * {@code ProducerState} instance — no CPS recursion, no per-split trampoline. The drain is fully
+ * non-blocking: it runs synchronously while the buffer has space and yields the producer thread
+ * when full, resuming via the executor when space is freed.
+ *
+ * @see AsyncExternalSourceBuffer
+ * @see AsyncExternalSourceOperator
  */
 public class AsyncConnectorSourceOperatorFactory implements SourceOperator.SourceOperatorFactory {
 
@@ -77,85 +92,182 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
         driverContext.addAsyncAction();
 
-        ActionListener<Void> failureListener = ActionListener.wrap(v -> {}, e -> {
-            buffer.onFailure(e);
-            closeConnectorQuietly();
-            driverContext.removeAsyncAction();
-        });
-        if (sliceQueue != null) {
-            executor.execute(
-                ActionRunnable.run(failureListener, () -> processNextSplit(request, sliceQueue, buffer, driverContext, rowLimit))
-            );
-        } else {
-            executor.execute(ActionRunnable.run(failureListener, () -> {
-                ResultCursor cursor = connector.execute(request, Split.SINGLE);
-                ExternalSourceDrainUtils.drainPagesWithBudgetAsync(
-                    cursor,
-                    buffer,
-                    rowLimit,
-                    executor,
-                    ActionListener.runAfter(
-                        ActionListener.<Integer>wrap(consumed -> buffer.finish(false), e -> buffer.onFailure(e)),
-                        () -> {
-                            closeQuietly(cursor);
-                            closeConnectorQuietly();
-                            driverContext.removeAsyncAction();
-                        }
-                    )
-                );
-            }));
+        // Single completion listener: exactly one of {finish(false), onFailure(e)} fires, and
+        // driverContext.removeAsyncAction() plus connector.close() run exactly once via runAfter.
+        ActionListener<Void> completionListener = ActionListener.assertOnce(
+            ActionListener.runAfter(ActionListener.wrap(v -> buffer.finish(false), buffer::onFailure), () -> {
+                closeConnectorQuietly();
+                driverContext.removeAsyncAction();
+            })
+        );
+
+        ProducerState state = new ProducerState(request, sliceQueue, buffer, rowLimit);
+        try {
+            executor.execute(ActionRunnable.wrap(completionListener, l -> runProducerLoop(state, l)));
+        } catch (Exception e) {
+            completionListener.onFailure(e);
         }
         return new AsyncExternalSourceOperator(buffer);
     }
 
-    private void processNextSplit(
-        QueryRequest request,
-        ExternalSliceQueue queue,
-        AsyncExternalSourceBuffer buffer,
-        DriverContext driverContext,
-        int rowsRemaining
-    ) {
-        if (buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
-            buffer.finish(false);
-            closeConnectorQuietly();
-            driverContext.removeAsyncAction();
-            return;
-        }
-        ExternalSplit split = queue.nextSplit();
-        if (split == null) {
-            buffer.finish(false);
-            closeConnectorQuietly();
-            driverContext.removeAsyncAction();
-            return;
-        }
+    /**
+     * Producer-loop state. One instance per {@code get(DriverContext)} call.
+     * <p>
+     * Tracks mode (queue vs single-shot), position within the queue, row budget, and the currently
+     * open {@link ResultCursor}. Mutated only from the producer executor thread.
+     */
+    private static final class ProducerState {
+        final QueryRequest request;
+        @Nullable
+        final ExternalSliceQueue queue;
+        final AsyncExternalSourceBuffer buffer;
 
+        /** True iff single-shot mode has already opened its one cursor (subsequent advances return EOF). */
+        boolean singleShotStarted;
+        /** Remaining row budget shared across all cursors for this producer. */
+        int rowsRemaining;
+        /** Currently active cursor, or {@code null} if between units or before the first open. */
+        @Nullable
         ResultCursor cursor;
-        try {
-            cursor = connector.execute(request, split);
-        } catch (Exception e) {
-            buffer.onFailure(e);
-            closeConnectorQuietly();
-            driverContext.removeAsyncAction();
-            return;
-        }
 
-        ActionListener<Void> failureListener = ActionListener.wrap(v -> {}, e -> {
-            buffer.onFailure(e);
-            closeConnectorQuietly();
-            driverContext.removeAsyncAction();
-        });
-        ExternalSourceDrainUtils.drainPagesWithBudgetAsync(
-            cursor,
-            buffer,
-            rowsRemaining,
-            executor,
-            ActionListener.runAfter(ActionListener.<Integer>wrap(consumed -> {
-                int remaining = rowLimit != FormatReader.NO_LIMIT ? rowsRemaining - consumed : rowsRemaining;
-                executor.execute(
-                    ActionRunnable.run(failureListener, () -> processNextSplit(request, queue, buffer, driverContext, remaining))
-                );
-            }, failureListener::onFailure), () -> closeQuietly(cursor))
-        );
+        ProducerState(QueryRequest request, @Nullable ExternalSliceQueue queue, AsyncExternalSourceBuffer buffer, int rowsRemaining) {
+            if (request == null) {
+                throw new IllegalArgumentException("ProducerState requires a non-null request");
+            }
+            if (buffer == null) {
+                throw new IllegalArgumentException("ProducerState requires a non-null buffer");
+            }
+            this.request = request;
+            this.queue = queue;
+            this.buffer = buffer;
+            this.rowsRemaining = rowsRemaining;
+        }
+    }
+
+    private enum DrainResult {
+        /** Hit EOF on the current cursor; caller should advance to the next unit. */
+        EOF,
+        /** Buffer is full; a callback is registered to resume the loop. */
+        BLOCKED,
+        /** Row limit exhausted or buffer finished; the whole producer is done. */
+        DONE
+    }
+
+    /**
+     * Single-step producer loop. Each invocation either drains some pages from the current cursor,
+     * opens a new cursor for the next unit, or registers a space callback and returns. The loop
+     * self-resubmits on the executor between units to avoid running producer I/O on the Driver
+     * thread and to prevent unbounded recursion across many splits.
+     */
+    private void runProducerLoop(ProducerState state, ActionListener<Void> completionListener) {
+        try {
+            if (state.cursor == null) {
+                if (advanceToNextUnit(state) == false) {
+                    completionListener.onResponse(null);
+                    return;
+                }
+            }
+            DrainResult result = drainHotPath(state, completionListener);
+            switch (result) {
+                case DONE -> {
+                    // Close the active cursor before reporting completion so no resources leak on
+                    // cancellation / row-budget exhaustion paths.
+                    closeCursorQuietly(state.cursor);
+                    state.cursor = null;
+                    completionListener.onResponse(null);
+                }
+                case EOF -> {
+                    closeCursorQuietly(state.cursor);
+                    state.cursor = null;
+                    executor.execute(ActionRunnable.wrap(completionListener, l -> runProducerLoop(state, l)));
+                }
+                case BLOCKED -> {
+                    // A waitForSpace listener has been registered that will re-submit runProducerLoop.
+                }
+            }
+        } catch (Exception e) {
+            closeCursorQuietly(state.cursor);
+            state.cursor = null;
+            completionListener.onFailure(e);
+        }
+    }
+
+    /**
+     * Drain pages from the currently-open cursor into the buffer.
+     * Runs synchronously while the buffer has space; when full, registers a callback that
+     * re-submits {@link #runProducerLoop} via the executor and returns {@link DrainResult#BLOCKED}.
+     */
+    private DrainResult drainHotPath(ProducerState state, ActionListener<Void> completionListener) {
+        ResultCursor cursor = state.cursor;
+        AsyncExternalSourceBuffer buffer = state.buffer;
+        while (true) {
+            if (buffer.noMoreInputs()) {
+                return DrainResult.DONE;
+            }
+            if (rowLimit != FormatReader.NO_LIMIT && state.rowsRemaining <= 0) {
+                return DrainResult.DONE;
+            }
+            if (cursor.hasNext() == false) {
+                return DrainResult.EOF;
+            }
+            SubscribableListener<Void> space = buffer.waitForSpace();
+            if (space.isDone() == false) {
+                space.addListener(ActionListener.wrap(v -> {
+                    try {
+                        executor.execute(() -> runProducerLoop(state, completionListener));
+                    } catch (Exception e) {
+                        closeCursorQuietly(state.cursor);
+                        state.cursor = null;
+                        completionListener.onFailure(e);
+                    }
+                }, e -> {
+                    closeCursorQuietly(state.cursor);
+                    state.cursor = null;
+                    completionListener.onFailure(e);
+                }));
+                return DrainResult.BLOCKED;
+            }
+            if (buffer.noMoreInputs()) {
+                return DrainResult.DONE;
+            }
+            Page page = cursor.next();
+            int rows = page.getPositionCount();
+            page.allowPassingToDifferentDriver();
+            buffer.addPage(page);
+            if (rowLimit != FormatReader.NO_LIMIT) {
+                state.rowsRemaining -= rows;
+            }
+        }
+    }
+
+    /**
+     * Open a cursor for the next unit of work: either the next split pulled from the queue, or
+     * the single-shot {@link Split#SINGLE} execution. Returns {@code false} if iteration is
+     * exhausted (queue drained, or single-shot already done) or the buffer has been finished
+     * externally / the row budget is exhausted.
+     */
+    private boolean advanceToNextUnit(ProducerState state) {
+        if (state.buffer.noMoreInputs()) {
+            return false;
+        }
+        if (rowLimit != FormatReader.NO_LIMIT && state.rowsRemaining <= 0) {
+            return false;
+        }
+        if (state.queue != null) {
+            ExternalSplit split = state.queue.nextSplit();
+            if (split == null) {
+                return false;
+            }
+            state.cursor = connector.execute(state.request, split);
+            return true;
+        } else {
+            if (state.singleShotStarted) {
+                return false;
+            }
+            state.singleShotStarted = true;
+            state.cursor = connector.execute(state.request, Split.SINGLE);
+            return true;
+        }
     }
 
     private void closeConnectorQuietly() {
@@ -164,7 +276,7 @@ public class AsyncConnectorSourceOperatorFactory implements SourceOperator.Sourc
         } catch (IOException ignored) {}
     }
 
-    private static void closeQuietly(ResultCursor cursor) {
+    private static void closeCursorQuietly(@Nullable ResultCursor cursor) {
         if (cursor != null) {
             try {
                 cursor.close();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceBuffer.java
@@ -148,30 +148,9 @@ public final class AsyncExternalSourceBuffer {
     }
 
     /**
-     * Returns an {@link IsBlockedResult} that completes when the buffer has space for writing.
-     * Used by background reader for backpressure.
-     */
-    public IsBlockedResult waitForWriting() {
-        if (bytesInBuffer.get() < maxBufferBytes || noMoreInputs) {
-            return Operator.NOT_BLOCKED;
-        }
-        synchronized (notFullLock) {
-            if (bytesInBuffer.get() < maxBufferBytes || noMoreInputs) {
-                return Operator.NOT_BLOCKED;
-            }
-            if (notFullFuture == null) {
-                notFullFuture = new SubscribableListener<>();
-            }
-            return new IsBlockedResult(notFullFuture, "async external source buffer full");
-        }
-    }
-
-    /**
      * Returns a {@link SubscribableListener} that completes when the buffer has space for writing.
-     * This is the preferred method for producers to use for backpressure coordination.
-     * <p>
-     * Unlike {@link #waitForWriting()} which returns an {@link IsBlockedResult}, this method
-     * returns a {@link SubscribableListener} that can be used directly with ES async patterns.
+     * This is the method producers use for backpressure coordination: it integrates directly with
+     * ES async patterns and the producer drain loops.
      *
      * @return a listener that completes when space is available, or an already-completed listener if space exists
      */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.compute.operator.DriverContext;
@@ -41,7 +42,6 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 
 import static org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils.drainPagesAsync;
-import static org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils.drainPagesWithBudgetAsync;
 
 /**
  * Dual-mode async factory for creating source operators that read from external storage.
@@ -94,7 +94,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     private final List<Expression> pushedExpressions;
     private final FilterPushdownSupport pushdownSupport;
 
-    public AsyncExternalSourceOperatorFactory(
+    private AsyncExternalSourceOperatorFactory(
         StorageProvider storageProvider,
         FormatReader formatReader,
         StoragePath path,
@@ -152,207 +152,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.pushdownSupport = pushdownSupport;
     }
 
-    public AsyncExternalSourceOperatorFactory(
-        StorageProvider storageProvider,
-        FormatReader formatReader,
-        StoragePath path,
-        List<Attribute> attributes,
-        int batchSize,
-        int maxBufferSize,
-        int rowLimit,
-        Executor executor,
-        FileList fileList,
-        Set<String> partitionColumnNames,
-        Map<String, Object> partitionValues,
-        ExternalSliceQueue sliceQueue,
-        ErrorPolicy errorPolicy,
-        int parsingParallelism
-    ) {
-        this(
-            storageProvider,
-            formatReader,
-            path,
-            attributes,
-            batchSize,
-            maxBufferSize,
-            rowLimit,
-            executor,
-            fileList,
-            partitionColumnNames,
-            partitionValues,
-            sliceQueue,
-            errorPolicy,
-            parsingParallelism,
-            null,
-            null
-        );
-    }
-
-    public AsyncExternalSourceOperatorFactory(
-        StorageProvider storageProvider,
-        FormatReader formatReader,
-        StoragePath path,
-        List<Attribute> attributes,
-        int batchSize,
-        int maxBufferSize,
-        int rowLimit,
-        Executor executor,
-        FileList fileList,
-        Set<String> partitionColumnNames,
-        Map<String, Object> partitionValues,
-        ExternalSliceQueue sliceQueue,
-        ErrorPolicy errorPolicy
-    ) {
-        this(
-            storageProvider,
-            formatReader,
-            path,
-            attributes,
-            batchSize,
-            maxBufferSize,
-            rowLimit,
-            executor,
-            fileList,
-            partitionColumnNames,
-            partitionValues,
-            sliceQueue,
-            errorPolicy,
-            1,
-            null,
-            null
-        );
-    }
-
-    public AsyncExternalSourceOperatorFactory(
-        StorageProvider storageProvider,
-        FormatReader formatReader,
-        StoragePath path,
-        List<Attribute> attributes,
-        int batchSize,
-        int maxBufferSize,
-        int rowLimit,
-        Executor executor,
-        FileList fileList,
-        Set<String> partitionColumnNames,
-        Map<String, Object> partitionValues,
-        ExternalSliceQueue sliceQueue
-    ) {
-        this(
-            storageProvider,
-            formatReader,
-            path,
-            attributes,
-            batchSize,
-            maxBufferSize,
-            rowLimit,
-            executor,
-            fileList,
-            partitionColumnNames,
-            partitionValues,
-            sliceQueue,
-            null,
-            1,
-            null,
-            null
-        );
-    }
-
-    public AsyncExternalSourceOperatorFactory(
-        StorageProvider storageProvider,
-        FormatReader formatReader,
-        StoragePath path,
-        List<Attribute> attributes,
-        int batchSize,
-        int maxBufferSize,
-        Executor executor,
-        FileList fileList,
-        Set<String> partitionColumnNames,
-        Map<String, Object> partitionValues,
-        ExternalSliceQueue sliceQueue
-    ) {
-        this(
-            storageProvider,
-            formatReader,
-            path,
-            attributes,
-            batchSize,
-            maxBufferSize,
-            FormatReader.NO_LIMIT,
-            executor,
-            fileList,
-            partitionColumnNames,
-            partitionValues,
-            sliceQueue,
-            null,
-            1,
-            null,
-            null
-        );
-    }
-
-    public AsyncExternalSourceOperatorFactory(
-        StorageProvider storageProvider,
-        FormatReader formatReader,
-        StoragePath path,
-        List<Attribute> attributes,
-        int batchSize,
-        int maxBufferSize,
-        Executor executor,
-        FileList fileList,
-        Set<String> partitionColumnNames,
-        Map<String, Object> partitionValues
-    ) {
-        this(
-            storageProvider,
-            formatReader,
-            path,
-            attributes,
-            batchSize,
-            maxBufferSize,
-            FormatReader.NO_LIMIT,
-            executor,
-            fileList,
-            partitionColumnNames,
-            partitionValues,
-            null,
-            null,
-            1,
-            null,
-            null
-        );
-    }
-
-    public AsyncExternalSourceOperatorFactory(
-        StorageProvider storageProvider,
-        FormatReader formatReader,
-        StoragePath path,
-        List<Attribute> attributes,
-        int batchSize,
-        int maxBufferSize,
-        Executor executor,
-        FileList fileList
-    ) {
-        this(
-            storageProvider,
-            formatReader,
-            path,
-            attributes,
-            batchSize,
-            maxBufferSize,
-            FormatReader.NO_LIMIT,
-            executor,
-            fileList,
-            null,
-            null,
-            null,
-            null,
-            1,
-            null,
-            null
-        );
-    }
-
-    public AsyncExternalSourceOperatorFactory(
+    public static Builder builder(
         StorageProvider storageProvider,
         FormatReader formatReader,
         StoragePath path,
@@ -361,24 +161,118 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         int maxBufferSize,
         Executor executor
     ) {
-        this(
-            storageProvider,
-            formatReader,
-            path,
-            attributes,
-            batchSize,
-            maxBufferSize,
-            FormatReader.NO_LIMIT,
-            executor,
-            null,
-            null,
-            null,
-            null,
-            null,
-            1,
-            null,
-            null
-        );
+        return new Builder(storageProvider, formatReader, path, attributes, batchSize, maxBufferSize, executor);
+    }
+
+    /**
+     * Fluent builder for {@link AsyncExternalSourceOperatorFactory}. Required parameters are captured
+     * via {@link #builder(StorageProvider, FormatReader, StoragePath, List, int, int, Executor)}.
+     * Optional parameters default to: {@link FormatReader#NO_LIMIT} for rowLimit, empty collections
+     * for partition/pushed-expression lists, {@code null} for opt-in hooks (sliceQueue,
+     * pushdownSupport, etc.), and {@code 1} for parsingParallelism.
+     */
+    public static final class Builder {
+        private final StorageProvider storageProvider;
+        private final FormatReader formatReader;
+        private final StoragePath path;
+        private final List<Attribute> attributes;
+        private final int batchSize;
+        private final int maxBufferSize;
+        private final Executor executor;
+
+        private int rowLimit = FormatReader.NO_LIMIT;
+        private FileList fileList;
+        private Set<String> partitionColumnNames;
+        private Map<String, Object> partitionValues;
+        private ExternalSliceQueue sliceQueue;
+        private ErrorPolicy errorPolicy;
+        private int parsingParallelism = 1;
+        private List<Expression> pushedExpressions;
+        private FilterPushdownSupport pushdownSupport;
+
+        private Builder(
+            StorageProvider storageProvider,
+            FormatReader formatReader,
+            StoragePath path,
+            List<Attribute> attributes,
+            int batchSize,
+            int maxBufferSize,
+            Executor executor
+        ) {
+            this.storageProvider = storageProvider;
+            this.formatReader = formatReader;
+            this.path = path;
+            this.attributes = attributes;
+            this.batchSize = batchSize;
+            this.maxBufferSize = maxBufferSize;
+            this.executor = executor;
+        }
+
+        public Builder rowLimit(int rowLimit) {
+            this.rowLimit = rowLimit;
+            return this;
+        }
+
+        public Builder fileList(@Nullable FileList fileList) {
+            this.fileList = fileList;
+            return this;
+        }
+
+        public Builder partitionColumnNames(@Nullable Set<String> partitionColumnNames) {
+            this.partitionColumnNames = partitionColumnNames;
+            return this;
+        }
+
+        public Builder partitionValues(@Nullable Map<String, Object> partitionValues) {
+            this.partitionValues = partitionValues;
+            return this;
+        }
+
+        public Builder sliceQueue(@Nullable ExternalSliceQueue sliceQueue) {
+            this.sliceQueue = sliceQueue;
+            return this;
+        }
+
+        public Builder errorPolicy(@Nullable ErrorPolicy errorPolicy) {
+            this.errorPolicy = errorPolicy;
+            return this;
+        }
+
+        public Builder parsingParallelism(int parsingParallelism) {
+            this.parsingParallelism = parsingParallelism;
+            return this;
+        }
+
+        public Builder pushedExpressions(@Nullable List<Expression> pushedExpressions) {
+            this.pushedExpressions = pushedExpressions;
+            return this;
+        }
+
+        public Builder pushdownSupport(@Nullable FilterPushdownSupport pushdownSupport) {
+            this.pushdownSupport = pushdownSupport;
+            return this;
+        }
+
+        public AsyncExternalSourceOperatorFactory build() {
+            return new AsyncExternalSourceOperatorFactory(
+                storageProvider,
+                formatReader,
+                path,
+                attributes,
+                batchSize,
+                maxBufferSize,
+                rowLimit,
+                executor,
+                fileList,
+                partitionColumnNames,
+                partitionValues,
+                sliceQueue,
+                errorPolicy,
+                parsingParallelism,
+                pushedExpressions,
+                pushdownSupport
+            );
+        }
     }
 
     @Override
@@ -499,54 +393,237 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             buffer.onFailure(e);
             driverContext.removeAsyncAction();
         }));
+        ProducerState state = new ProducerState(sliceQueue, null, null, null, buffer, driverContext, rowLimit);
         try {
-            executor.execute(
-                ActionRunnable.wrap(completionListener, l -> processNextSplit(sliceQueue, buffer, driverContext, rowLimit, l))
-            );
+            executor.execute(ActionRunnable.wrap(completionListener, l -> runProducerLoop(state, l)));
         } catch (Exception e) {
             completionListener.onFailure(e);
         }
     }
 
-    private void processNextSplit(
-        ExternalSliceQueue queue,
+    /**
+     * Multi-file read path (legacy, non-slice-queue). Per-file filter adaptation is not applied
+     * here because this path does not carry {@link FileSplit} with {@link SchemaReconciliation.ColumnMapping};
+     * UNION_BY_NAME queries use the slice-queue path ({@link #startSliceQueueRead}) instead.
+     */
+    private void startMultiFileRead(
+        List<String> projectedColumns,
         AsyncExternalSourceBuffer buffer,
         DriverContext driverContext,
-        int rowsRemaining,
-        ActionListener<Void> completionListener
+        VirtualColumnInjector injector
     ) {
-        if (buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
-            completionListener.onResponse(null);
-            return;
+        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = fileList != null ? fileList.fileSchemaInfo() : null;
+        ActionListener<Void> completionListener = ActionListener.assertOnce(ActionListener.wrap(v -> {
+            buffer.finish(false);
+            driverContext.removeAsyncAction();
+        }, e -> {
+            buffer.onFailure(e);
+            driverContext.removeAsyncAction();
+        }));
+        ProducerState state = new ProducerState(null, fileList, projectedColumns, injector, buffer, driverContext, rowLimit);
+        state.schemaInfo = schemaInfo;
+        try {
+            executor.execute(ActionRunnable.wrap(completionListener, l -> runProducerLoop(state, l)));
+        } catch (Exception e) {
+            completionListener.onFailure(e);
         }
-        ExternalSplit split = queue.nextSplit();
-        if (split == null) {
-            completionListener.onResponse(null);
-            return;
-        }
-        List<ExternalSplit> leaves = flattenToLeaves(split);
-        processNextLeaf(leaves, 0, queue, buffer, driverContext, rowsRemaining, ActionListener.wrap(remaining -> {
-            executor.execute(ActionRunnable.wrap(completionListener, l -> processNextSplit(queue, buffer, driverContext, remaining, l)));
-        }, completionListener::onFailure));
     }
 
-    private void processNextLeaf(
-        List<ExternalSplit> leaves,
-        int leafIndex,
-        ExternalSliceQueue queue,
-        AsyncExternalSourceBuffer buffer,
-        DriverContext driverContext,
-        int rowsRemaining,
-        ActionListener<Integer> splitDoneListener
-    ) {
-        if (leafIndex >= leaves.size() || buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
-            splitDoneListener.onResponse(rowsRemaining);
-            return;
+    /**
+     * Producer-loop state. One instance per producer path (slice-queue OR multi-file).
+     * Tracks iteration position across splits/leaves/files, the currently active page iterator,
+     * and the shared outputs (buffer + DriverContext). Mutated only from the producer executor.
+     */
+    private static final class ProducerState {
+        @Nullable
+        final ExternalSliceQueue queue;
+        @Nullable
+        final FileList fileList;
+        @Nullable
+        final List<String> projectedColumns;
+        @Nullable
+        final VirtualColumnInjector multiFileInjector;
+        final AsyncExternalSourceBuffer buffer;
+        final DriverContext driverContext;
+
+        int fileIndex;
+        @Nullable
+        List<ExternalSplit> leaves;
+        int leafIndex;
+        int rowsRemaining;
+        @Nullable
+        CloseableIterator<Page> pages;
+        @Nullable
+        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo;
+
+        ProducerState(
+            @Nullable ExternalSliceQueue queue,
+            @Nullable FileList fileList,
+            @Nullable List<String> projectedColumns,
+            @Nullable VirtualColumnInjector multiFileInjector,
+            AsyncExternalSourceBuffer buffer,
+            DriverContext driverContext,
+            int rowsRemaining
+        ) {
+            if ((queue == null) == (fileList == null)) {
+                throw new IllegalArgumentException("ProducerState requires exactly one of queue or fileList");
+            }
+            this.queue = queue;
+            this.fileList = fileList;
+            this.projectedColumns = projectedColumns;
+            this.multiFileInjector = multiFileInjector;
+            this.buffer = buffer;
+            this.driverContext = driverContext;
+            this.rowsRemaining = rowsRemaining;
         }
-        ExternalSplit leaf = leaves.get(leafIndex);
+    }
+
+    private enum DrainResult {
+        /** Hit EOF on the current iterator; caller should advance to the next unit. */
+        EOF,
+        /** Buffer is full; a callback is registered to resume the loop. */
+        BLOCKED,
+        /** Row limit exhausted or buffer finished; the whole producer is done. */
+        DONE
+    }
+
+    /**
+     * Single-step producer loop. Each invocation either drains some pages from the current iterator,
+     * opens a new iterator for the next unit, or registers a space callback and returns. The loop
+     * self-resubmits on the executor to avoid running producer I/O on the Driver thread.
+     */
+    private void runProducerLoop(ProducerState state, ActionListener<Void> completionListener) {
+        try {
+            // Open an iterator for the next unit if we don't have one.
+            if (state.pages == null) {
+                if (advanceToNextUnit(state) == false) {
+                    completionListener.onResponse(null);
+                    return;
+                }
+            }
+            DrainResult result = drainHotPath(state, completionListener);
+            switch (result) {
+                case DONE -> {
+                    // Buffer finished (externally or by row-limit exhaustion) while an iterator is still open:
+                    // close it before reporting completion so no resources leak on cancellation paths.
+                    closeQuietly(state.pages);
+                    state.pages = null;
+                    completionListener.onResponse(null);
+                }
+                case EOF -> {
+                    closeQuietly(state.pages);
+                    state.pages = null;
+                    // Re-submit to avoid unbounded recursion between units and to stay off the Driver thread.
+                    executor.execute(ActionRunnable.wrap(completionListener, l -> runProducerLoop(state, l)));
+                }
+                case BLOCKED -> {
+                    // A listener has been registered on waitForSpace that will re-submit runProducerLoop.
+                }
+            }
+        } catch (Exception e) {
+            closeQuietly(state.pages);
+            state.pages = null;
+            completionListener.onFailure(e);
+        }
+    }
+
+    /**
+     * Drain pages from the currently-open iterator into the buffer.
+     * Runs synchronously while the buffer has space; when full, registers a callback that
+     * re-submits {@link #runProducerLoop} via the executor and returns {@link DrainResult#BLOCKED}.
+     */
+    private DrainResult drainHotPath(ProducerState state, ActionListener<Void> completionListener) {
+        CloseableIterator<Page> pages = state.pages;
+        AsyncExternalSourceBuffer buffer = state.buffer;
+        while (true) {
+            if (buffer.noMoreInputs()) {
+                return DrainResult.DONE;
+            }
+            if (rowLimit != FormatReader.NO_LIMIT && state.rowsRemaining <= 0) {
+                return DrainResult.DONE;
+            }
+            if (pages.hasNext() == false) {
+                return DrainResult.EOF;
+            }
+            SubscribableListener<Void> space = buffer.waitForSpace();
+            if (space.isDone() == false) {
+                space.addListener(ActionListener.wrap(v -> {
+                    try {
+                        executor.execute(() -> runProducerLoop(state, completionListener));
+                    } catch (Exception e) {
+                        closeQuietly(state.pages);
+                        state.pages = null;
+                        completionListener.onFailure(e);
+                    }
+                }, e -> {
+                    closeQuietly(state.pages);
+                    state.pages = null;
+                    completionListener.onFailure(e);
+                }));
+                return DrainResult.BLOCKED;
+            }
+            if (buffer.noMoreInputs()) {
+                return DrainResult.DONE;
+            }
+            Page page = pages.next();
+            int rows = page.getPositionCount();
+            page.allowPassingToDifferentDriver();
+            buffer.addPage(page);
+            if (rowLimit != FormatReader.NO_LIMIT) {
+                state.rowsRemaining -= rows;
+            }
+        }
+    }
+
+    /**
+     * Advance the iteration position to the next unit (slice-queue leaf or multi-file file) and
+     * open a fresh page iterator for it. Returns {@code false} if iteration is exhausted or the
+     * buffer has been finished externally.
+     */
+    private boolean advanceToNextUnit(ProducerState state) throws IOException {
+        while (true) {
+            if (state.buffer.noMoreInputs()) {
+                return false;
+            }
+            if (rowLimit != FormatReader.NO_LIMIT && state.rowsRemaining <= 0) {
+                return false;
+            }
+            if (state.queue != null) {
+                if (openNextSliceQueueLeaf(state)) {
+                    return true;
+                }
+                // queue is exhausted
+                if (state.leaves == null) {
+                    return false;
+                }
+                // current split's leaves exhausted; fall through to pull the next split
+                state.leaves = null;
+                state.leafIndex = 0;
+            } else {
+                if (openNextMultiFile(state)) {
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Open the next leaf iterator in the slice-queue path. Pulls a new split from the queue when
+     * the current split's leaves are exhausted. Returns {@code false} if the queue is exhausted.
+     */
+    private boolean openNextSliceQueueLeaf(ProducerState state) throws IOException {
+        if (state.leaves == null || state.leafIndex >= state.leaves.size()) {
+            ExternalSplit split = state.queue.nextSplit();
+            if (split == null) {
+                return false;
+            }
+            state.leaves = flattenToLeaves(split);
+            state.leafIndex = 0;
+        }
+        ExternalSplit leaf = state.leaves.get(state.leafIndex++);
         if (leaf instanceof FileSplit == false) {
-            splitDoneListener.onFailure(new IllegalArgumentException("Unsupported split type: " + leaf.getClass().getName()));
-            return;
+            throw new IllegalArgumentException("Unsupported split type: " + leaf.getClass().getName());
         }
         FileSplit fileSplit = (FileSplit) leaf;
         VirtualColumnInjector injector = null;
@@ -555,12 +632,12 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 attributes,
                 partitionColumnNames,
                 fileSplit.partitionValues(),
-                driverContext.blockFactory()
+                state.driverContext.blockFactory()
             );
         }
         List<String> cols = projectedColumns(injector);
 
-        CloseableIterator<Page> pages;
+        CloseableIterator<Page> pages = null;
         try {
             FormatReader fileReader = readerForFile(fileSplit);
             boolean isRangeSplit = "true".equals(fileSplit.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
@@ -585,147 +662,70 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     .build();
                 pages = fileReader.read(obj, ctx);
             }
-        } catch (Exception e) {
-            splitDoneListener.onFailure(e);
-            return;
-        }
-
-        CloseableIterator<Page> adaptedPages;
-        CloseableIterator<Page> wrappedPages;
-        try {
-            adaptedPages = adaptSchema(pages, fileSplit.columnMapping(), driverContext);
-            wrappedPages = wrapWithInjector(adaptedPages, injector);
+            CloseableIterator<Page> adapted = adaptSchema(pages, fileSplit.columnMapping(), state.driverContext);
+            state.pages = wrapWithInjector(adapted, injector);
+            return true;
         } catch (Exception e) {
             closeQuietly(pages);
-            splitDoneListener.onFailure(e);
-            return;
+            if (e instanceof IOException io) throw io;
+            if (e instanceof RuntimeException re) throw re;
+            throw new IOException(e);
         }
-
-        drainPagesWithBudgetAsync(
-            wrappedPages,
-            buffer,
-            rowsRemaining,
-            executor,
-            ActionListener.runAfter(ActionListener.<Integer>wrap(consumed -> {
-                int remaining = rowLimit != FormatReader.NO_LIMIT ? rowsRemaining - consumed : rowsRemaining;
-                executor.execute(
-                    ActionRunnable.wrap(
-                        splitDoneListener,
-                        l -> processNextLeaf(leaves, leafIndex + 1, queue, buffer, driverContext, remaining, l)
-                    )
-                );
-            }, splitDoneListener::onFailure), () -> closeQuietly(wrappedPages))
-        );
     }
 
     /**
-     * Multi-file read path (legacy, non-slice-queue). Per-file filter adaptation is not applied
-     * here because this path does not carry {@link FileSplit} with {@link SchemaReconciliation.ColumnMapping};
-     * UNION_BY_NAME queries use the slice-queue path ({@link #startSliceQueueRead}) instead.
+     * Open the next file iterator in the multi-file path. Returns {@code false} if all files
+     * have been processed.
      */
-    private void startMultiFileRead(
-        List<String> projectedColumns,
-        AsyncExternalSourceBuffer buffer,
-        DriverContext driverContext,
-        VirtualColumnInjector injector
-    ) {
-        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = fileList != null ? fileList.fileSchemaInfo() : null;
-        ActionListener<Void> completionListener = ActionListener.assertOnce(ActionListener.wrap(v -> {
-            buffer.finish(false);
-            driverContext.removeAsyncAction();
-        }, e -> {
-            buffer.onFailure(e);
-            driverContext.removeAsyncAction();
-        }));
-        try {
-            executor.execute(
-                ActionRunnable.wrap(
-                    completionListener,
-                    l -> processNextFile(0, projectedColumns, buffer, driverContext, injector, schemaInfo, rowLimit, l)
-                )
-            );
-        } catch (Exception e) {
-            completionListener.onFailure(e);
+    private boolean openNextMultiFile(ProducerState state) throws IOException {
+        FileList files = state.fileList;
+        assert files != null;
+        if (state.fileIndex >= files.fileCount()) {
+            return false;
         }
-    }
-
-    private void processNextFile(
-        int fileIndex,
-        List<String> projectedColumns,
-        AsyncExternalSourceBuffer buffer,
-        DriverContext driverContext,
-        VirtualColumnInjector injector,
-        Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo,
-        int rowsRemaining,
-        ActionListener<Void> completionListener
-    ) {
-        if (fileIndex >= fileList.fileCount() || buffer.noMoreInputs() || (rowLimit != FormatReader.NO_LIMIT && rowsRemaining <= 0)) {
-            completionListener.onResponse(null);
-            return;
-        }
-
+        int fileIndex = state.fileIndex++;
+        List<String> cols = state.projectedColumns;
         boolean useParallel = rowLimit == FormatReader.NO_LIMIT && formatReader instanceof SegmentableFormatReader;
-        CloseableIterator<Page> pages;
+
+        CloseableIterator<Page> pages = null;
         try {
-            StorageObject obj = storageProvider.newObject(fileList.path(fileIndex));
+            StorageObject obj = storageProvider.newObject(files.path(fileIndex));
             if (useParallel) {
                 pages = ParallelParsingCoordinator.parallelRead(
                     (SegmentableFormatReader) formatReader,
                     obj,
-                    projectedColumns,
+                    cols,
                     batchSize,
                     parsingParallelism,
                     executor,
                     errorPolicy
                 );
             } else {
-                int fileBudget = rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : rowsRemaining;
+                int fileBudget = rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : state.rowsRemaining;
                 FormatReadContext ctx = FormatReadContext.builder()
-                    .projectedColumns(projectedColumns)
+                    .projectedColumns(cols)
                     .batchSize(batchSize)
                     .rowLimit(fileBudget)
                     .errorPolicy(errorPolicy)
                     .build();
                 pages = formatReader.read(obj, ctx);
             }
-        } catch (Exception e) {
-            completionListener.onFailure(e);
-            return;
-        }
-
-        SchemaReconciliation.ColumnMapping mapping = null;
-        if (schemaInfo != null) {
-            SchemaReconciliation.FileSchemaInfo info = schemaInfo.get(fileList.path(fileIndex));
-            if (info != null) {
-                mapping = info.mapping();
+            SchemaReconciliation.ColumnMapping mapping = null;
+            if (state.schemaInfo != null) {
+                SchemaReconciliation.FileSchemaInfo info = state.schemaInfo.get(files.path(fileIndex));
+                if (info != null) {
+                    mapping = info.mapping();
+                }
             }
-        }
-        CloseableIterator<Page> adaptedPages;
-        CloseableIterator<Page> wrappedPages;
-        try {
-            adaptedPages = adaptSchema(pages, mapping, driverContext);
-            wrappedPages = wrapWithInjector(adaptedPages, injector);
+            CloseableIterator<Page> adapted = adaptSchema(pages, mapping, state.driverContext);
+            state.pages = wrapWithInjector(adapted, state.multiFileInjector);
+            return true;
         } catch (Exception e) {
             closeQuietly(pages);
-            completionListener.onFailure(e);
-            return;
+            if (e instanceof IOException io) throw io;
+            if (e instanceof RuntimeException re) throw re;
+            throw new IOException(e);
         }
-
-        drainPagesWithBudgetAsync(
-            wrappedPages,
-            buffer,
-            rowsRemaining,
-            executor,
-            ActionListener.runAfter(ActionListener.<Integer>wrap(consumed -> {
-                int remaining = rowLimit != FormatReader.NO_LIMIT ? rowsRemaining - consumed : rowsRemaining;
-                executor.execute(
-                    ActionRunnable.wrap(
-                        completionListener,
-                        l -> processNextFile(fileIndex + 1, projectedColumns, buffer, driverContext, injector, schemaInfo, remaining, l)
-                    )
-                );
-            }, completionListener::onFailure), () -> closeQuietly(wrappedPages))
-        );
     }
 
     private void startNativeAsyncRead(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtils.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
-import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 
 import java.util.concurrent.Executor;
 
@@ -84,64 +83,6 @@ public final class ExternalSourceDrainUtils {
                 }
             }
             listener.onResponse(null);
-        } catch (Exception e) {
-            listener.onFailure(e);
-        }
-    }
-
-    /**
-     * Drains pages from iterator into buffer asynchronously with a row budget.
-     * Same async behavior as {@link #drainPagesAsync}: synchronous hot path, async cold path
-     * on buffer-full. Reports the total number of rows drained via the listener.
-     *
-     * <p><b>Iterator ownership:</b> This method does NOT close the iterator.
-     * The caller must close it regardless of outcome (e.g. via
-     * {@link ActionListener#runAfter}).
-     *
-     * <p><b>Executor contract:</b> Same as {@link #drainPagesAsync}.
-     *
-     * @param rowLimit maximum rows to drain, or {@link FormatReader#NO_LIMIT} for unlimited
-     */
-    public static void drainPagesWithBudgetAsync(
-        CloseableIterator<Page> pages,
-        AsyncExternalSourceBuffer buffer,
-        int rowLimit,
-        Executor executor,
-        ActionListener<Integer> listener
-    ) {
-        drainBatchWithBudget(pages, buffer, rowLimit, new int[] { 0 }, executor, listener);
-    }
-
-    private static void drainBatchWithBudget(
-        CloseableIterator<Page> pages,
-        AsyncExternalSourceBuffer buffer,
-        int rowLimit,
-        int[] totalRows,
-        Executor executor,
-        ActionListener<Integer> listener
-    ) {
-        try {
-            while (pages.hasNext() && buffer.noMoreInputs() == false) {
-                if (rowLimit != FormatReader.NO_LIMIT && totalRows[0] >= rowLimit) break;
-                SubscribableListener<Void> space = buffer.waitForSpace();
-                if (space.isDone()) {
-                    if (buffer.noMoreInputs()) break;
-                    Page page = pages.next();
-                    totalRows[0] += page.getPositionCount();
-                    page.allowPassingToDifferentDriver();
-                    buffer.addPage(page);
-                } else {
-                    space.addListener(ActionListener.wrap(v -> {
-                        try {
-                            executor.execute(() -> drainBatchWithBudget(pages, buffer, rowLimit, totalRows, executor, listener));
-                        } catch (Exception e) {
-                            listener.onFailure(e);
-                        }
-                    }, listener::onFailure));
-                    return;
-                }
-            }
-            listener.onResponse(totalRows[0]);
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -151,24 +151,25 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 : null;
 
             Executor readExecutor = context.fileReadExecutor() != null ? context.fileReadExecutor() : context.executor();
-            return new AsyncExternalSourceOperatorFactory(
+            return AsyncExternalSourceOperatorFactory.builder(
                 storage,
                 format,
                 path,
                 context.attributes(),
                 context.batchSize(),
                 context.maxBufferSize(),
-                context.rowLimit(),
-                readExecutor,
-                context.fileList(),
-                context.partitionColumnNames(),
-                partitionValues,
-                context.sliceQueue(),
-                errorPolicy,
-                context.parsingParallelism(),
-                pushedExpressions,
-                pushdownSupport
-            );
+                readExecutor
+            )
+                .rowLimit(context.rowLimit())
+                .fileList(context.fileList())
+                .partitionColumnNames(context.partitionColumnNames())
+                .partitionValues(partitionValues)
+                .sliceQueue(context.sliceQueue())
+                .errorPolicy(errorPolicy)
+                .parsingParallelism(context.parsingParallelism())
+                .pushedExpressions(pushedExpressions)
+                .pushdownSupport(pushdownSupport)
+                .build();
         };
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactorySplitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactorySplitTests.java
@@ -237,6 +237,128 @@ public class AsyncConnectorSourceOperatorFactorySplitTests extends ESTestCase {
         }
     }
 
+    /**
+     * State-machine guard test for the flattened producer loop.
+     *
+     * Drives the slice-queue producer end-to-end with 4 splits (1 page per split) on a
+     * single-thread executor and asserts:
+     * <ul>
+     *   <li>all 4 splits are read once (state machine visits every split);</li>
+     *   <li>all 4 pages arrive at the operator;</li>
+     *   <li>every opened {@link ResultCursor} is closed exactly once;</li>
+     *   <li>{@code removeAsyncAction()} fires exactly once (success path);</li>
+     *   <li>the connector is closed exactly once.</li>
+     * </ul>
+     * Followed by a second scenario that forces early cancellation via {@link SourceOperator#finish()}
+     * partway through, to verify the active cursor gets closed and no further splits are opened.
+     * <p>
+     * BLOCKED-path coverage (buffer-full backpressure and wakeup correctness) is not exercised here;
+     * it lives in {@code AsyncExternalSourceBufferTests#testNoLostWakeupUnderConcurrentAddAndPoll}.
+     */
+    public void testProducerLoopStateMachine() throws Exception {
+        // --- scenario 1: run to completion across 4 splits ---
+        runStateMachineScenario(false);
+
+        // --- scenario 2: force early cancellation after first page ---
+        runStateMachineScenario(true);
+    }
+
+    private void runStateMachineScenario(boolean forceEarlyCancellation) throws Exception {
+        AtomicInteger readCalls = new AtomicInteger();
+        AtomicInteger closeCalls = new AtomicInteger();
+        AtomicInteger connectorCloseCalls = new AtomicInteger();
+        TrackingConnector connector = new TrackingConnector(readCalls, closeCalls, connectorCloseCalls, 1);
+
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            splits.add(new StubExternalSplit("s" + i));
+        }
+        ExternalSliceQueue sliceQueue = new ExternalSliceQueue(splits);
+
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(TEST_BLOCK_FACTORY);
+        AtomicInteger addAsync = new AtomicInteger();
+        AtomicInteger removeAsync = new AtomicInteger();
+        doAnswer(inv -> {
+            addAsync.incrementAndGet();
+            return null;
+        }).when(driverContext).addAsyncAction();
+        doAnswer(inv -> {
+            removeAsync.incrementAndGet();
+            return null;
+        }).when(driverContext).removeAsyncAction();
+
+        QueryRequest baseRequest = new QueryRequest("target", List.of("col"), List.of(), Map.of(), 100, TEST_BLOCK_FACTORY);
+
+        // Use a single-thread executor so producer ordering is deterministic.
+        ExecutorService executor = Executors.newSingleThreadExecutor(EsExecutors.daemonThreadFactory("test", "sm-test"));
+        try {
+            AsyncConnectorSourceOperatorFactory factory = new AsyncConnectorSourceOperatorFactory(
+                connector,
+                baseRequest,
+                10,
+                executor,
+                sliceQueue
+            );
+
+            SourceOperator operator = factory.get(driverContext);
+
+            if (forceEarlyCancellation) {
+                // Consume at least one page to ensure a cursor is open, then cancel.
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+                int received = 0;
+                while (received < 1 && System.nanoTime() < deadline) {
+                    Page p = operator.getOutput();
+                    if (p != null) {
+                        received++;
+                        p.releaseBlocks();
+                    }
+                }
+                operator.finish();
+                while (operator.isFinished() == false) {
+                    Page p = operator.getOutput();
+                    if (p != null) p.releaseBlocks();
+                }
+            } else {
+                List<Page> pages = new ArrayList<>();
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+                while (operator.isFinished() == false && System.nanoTime() < deadline) {
+                    Page p = operator.getOutput();
+                    if (p != null) pages.add(p);
+                }
+                assertTrue("operator did not finish within timeout", operator.isFinished());
+                assertEquals("all 4 splits produced a page", 4, pages.size());
+                for (Page p : pages)
+                    p.releaseBlocks();
+            }
+
+            operator.close();
+
+            // Wait for the producer thread to run its completion listener (which closes the
+            // connector and calls removeAsyncAction) before asserting on counters.
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+
+            // Every cursor that was opened must have been closed exactly once.
+            assertEquals("read/close counts differ - leaked cursor", readCalls.get(), closeCalls.get());
+            // addAsync/removeAsync are paired: exactly once, on the happy path and cancelled path.
+            assertEquals(1, addAsync.get());
+            assertEquals(1, removeAsync.get());
+            // Connector.close() is invoked exactly once by the completion listener.
+            assertEquals("connector must be closed exactly once", 1, connectorCloseCalls.get());
+            if (forceEarlyCancellation == false) {
+                assertEquals(4, readCalls.get());
+            } else {
+                assertTrue("expected at least one split to be read before cancellation", readCalls.get() >= 1);
+            }
+        } finally {
+            if (executor.isShutdown() == false) {
+                executor.shutdown();
+                assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+            }
+        }
+    }
+
     // ===== Helpers =====
 
     private static DriverContext mockDriverContext() {
@@ -397,6 +519,65 @@ public class AsyncConnectorSourceOperatorFactorySplitTests extends ESTestCase {
 
                 @Override
                 public void close() {}
+            };
+        }
+    }
+
+    /**
+     * Connector for the state-machine test. Every {@code execute(request, split)} returns a new
+     * cursor that emits {@code pagesPerCursor} pages and increments {@code closeCount} on
+     * {@link ResultCursor#close()}, so the test can assert that every opened cursor is closed
+     * exactly once. Tracks {@link #close()} separately to verify one-shot connector cleanup.
+     */
+    private static class TrackingConnector implements Connector {
+        private final AtomicInteger readCount;
+        private final AtomicInteger closeCount;
+        private final AtomicInteger connectorCloseCount;
+        private final int pagesPerCursor;
+
+        TrackingConnector(AtomicInteger readCount, AtomicInteger closeCount, AtomicInteger connectorCloseCount, int pagesPerCursor) {
+            this.readCount = readCount;
+            this.closeCount = closeCount;
+            this.connectorCloseCount = connectorCloseCount;
+            this.pagesPerCursor = pagesPerCursor;
+        }
+
+        @Override
+        public ResultCursor execute(QueryRequest request, Split split) {
+            return newCursor();
+        }
+
+        @Override
+        public ResultCursor execute(QueryRequest request, ExternalSplit split) {
+            return newCursor();
+        }
+
+        @Override
+        public void close() {
+            connectorCloseCount.incrementAndGet();
+        }
+
+        private ResultCursor newCursor() {
+            readCount.incrementAndGet();
+            return new ResultCursor() {
+                private int remaining = pagesPerCursor;
+
+                @Override
+                public boolean hasNext() {
+                    return remaining > 0;
+                }
+
+                @Override
+                public Page next() {
+                    if (remaining <= 0) throw new NoSuchElementException();
+                    remaining--;
+                    return createTestPage();
+                }
+
+                @Override
+                public void close() {
+                    closeCount.incrementAndGet();
+                }
             };
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactorySplitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncConnectorSourceOperatorFactorySplitTests.java
@@ -328,8 +328,9 @@ public class AsyncConnectorSourceOperatorFactorySplitTests extends ESTestCase {
                 }
                 assertTrue("operator did not finish within timeout", operator.isFinished());
                 assertEquals("all 4 splits produced a page", 4, pages.size());
-                for (Page p : pages)
+                for (Page p : pages) {
                     p.releaseBlocks();
+                }
             }
 
             operator.close();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -78,53 +79,53 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         // Test null storage provider
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AsyncExternalSourceOperatorFactory(null, formatReader, path, attributes, 1000, 10, executor)
+            () -> AsyncExternalSourceOperatorFactory.builder(null, formatReader, path, attributes, 1000, 10, executor).build()
         );
 
         // Test null format reader
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AsyncExternalSourceOperatorFactory(storageProvider, null, path, attributes, 1000, 10, executor)
+            () -> AsyncExternalSourceOperatorFactory.builder(storageProvider, null, path, attributes, 1000, 10, executor).build()
         );
 
         // Test null path
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AsyncExternalSourceOperatorFactory(storageProvider, formatReader, null, attributes, 1000, 10, executor)
+            () -> AsyncExternalSourceOperatorFactory.builder(storageProvider, formatReader, null, attributes, 1000, 10, executor).build()
         );
 
         // Test null attributes
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AsyncExternalSourceOperatorFactory(storageProvider, formatReader, path, null, 1000, 10, executor)
+            () -> AsyncExternalSourceOperatorFactory.builder(storageProvider, formatReader, path, null, 1000, 10, executor).build()
         );
 
         // Test null executor
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AsyncExternalSourceOperatorFactory(storageProvider, formatReader, path, attributes, 1000, 10, null)
+            () -> AsyncExternalSourceOperatorFactory.builder(storageProvider, formatReader, path, attributes, 1000, 10, null).build()
         );
 
         // Test invalid batch size
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AsyncExternalSourceOperatorFactory(storageProvider, formatReader, path, attributes, 0, 10, executor)
+            () -> AsyncExternalSourceOperatorFactory.builder(storageProvider, formatReader, path, attributes, 0, 10, executor).build()
         );
 
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AsyncExternalSourceOperatorFactory(storageProvider, formatReader, path, attributes, -1, 10, executor)
+            () -> AsyncExternalSourceOperatorFactory.builder(storageProvider, formatReader, path, attributes, -1, 10, executor).build()
         );
 
         // Test invalid buffer size
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AsyncExternalSourceOperatorFactory(storageProvider, formatReader, path, attributes, 1000, 0, executor)
+            () -> AsyncExternalSourceOperatorFactory.builder(storageProvider, formatReader, path, attributes, 1000, 0, executor).build()
         );
 
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AsyncExternalSourceOperatorFactory(storageProvider, formatReader, path, attributes, 1000, -1, executor)
+            () -> AsyncExternalSourceOperatorFactory.builder(storageProvider, formatReader, path, attributes, 1000, -1, executor).build()
         );
     }
 
@@ -144,7 +145,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         );
         Executor executor = Runnable::run;
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -152,7 +153,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             500,
             10,
             executor
-        );
+        ).build();
 
         String description = factory.describe();
         assertTrue(description.contains("AsyncExternalSourceOperator"));
@@ -179,7 +180,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         );
         Executor executor = Runnable::run;
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -187,7 +188,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             1000,
             20,
             executor
-        );
+        ).build();
 
         String description = factory.describe();
         assertTrue(description.contains("AsyncExternalSourceOperator"));
@@ -211,7 +212,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         );
         Executor executor = Runnable::run;
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -219,7 +220,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             500,
             15,
             executor
-        );
+        ).build();
 
         assertSame(storageProvider, factory.storageProvider());
         assertSame(formatReader, factory.formatReader());
@@ -268,7 +269,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         }).when(driverContext).removeAsyncAction();
 
         // Create factory
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -276,7 +277,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             100,
             10,
             executor
-        );
+        ).build();
 
         // Create operator
         SourceOperator operator = factory.get(driverContext);
@@ -328,7 +329,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         }).when(driverContext).removeAsyncAction();
 
         // Create factory
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -336,7 +337,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             100,
             10,
             executor
-        );
+        ).build();
 
         // Create operator
         SourceOperator operator = factory.get(driverContext);
@@ -383,16 +384,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            fileList
-        );
+            (Runnable r) -> r.run()
+        ).fileList(fileList).build();
 
         SourceOperator operator = factory.get(driverContext);
         assertNotNull(operator);
@@ -435,7 +435,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -443,7 +443,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             100,
             10,
             (Runnable r) -> r.run()
-        );
+        ).build();
 
         SourceOperator operator = factory.get(driverContext);
         assertNotNull(operator);
@@ -491,16 +491,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            fileList
-        );
+            (Runnable r) -> r.run()
+        ).fileList(fileList).build();
 
         SourceOperator operator = factory.get(driverContext);
         assertNotNull(operator);
@@ -536,7 +535,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         FormatReader formatReader = mock(FormatReader.class);
         when(formatReader.formatName()).thenReturn("parquet");
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             StoragePath.of("s3://bucket/a.parquet"),
@@ -545,9 +544,8 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             ),
             100,
             10,
-            Runnable::run,
-            fileList
-        );
+            Runnable::run
+        ).fileList(fileList).build();
 
         assertSame(fileList, factory.fileList());
         assertTrue(factory.fileList().isResolved());
@@ -583,19 +581,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            sliceQueue
-        );
+            (Runnable r) -> r.run()
+        ).sliceQueue(sliceQueue).build();
 
         SourceOperator operator = factory.get(driverContext);
         assertNotNull(operator);
@@ -640,19 +634,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            sliceQueue
-        );
+            (Runnable r) -> r.run()
+        ).sliceQueue(sliceQueue).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -705,19 +695,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             doAnswer(inv -> null).when(driverContext).removeAsyncAction();
             contexts.add(driverContext);
 
-            AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
                 storageProvider,
                 formatReader,
                 path,
                 attributes,
                 100,
                 10,
-                (Runnable r) -> r.run(),
-                null,
-                null,
-                null,
-                sliceQueue
-            );
+                (Runnable r) -> r.run()
+            ).sliceQueue(sliceQueue).build();
             operators.add(factory.get(driverContext));
         }
 
@@ -752,7 +738,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         FormatReader formatReader = mock(FormatReader.class);
         when(formatReader.formatName()).thenReturn("parquet");
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             StoragePath.of("s3://bucket/a.parquet"),
@@ -761,12 +747,8 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             ),
             100,
             10,
-            Runnable::run,
-            null,
-            null,
-            null,
-            sliceQueue
-        );
+            Runnable::run
+        ).sliceQueue(sliceQueue).build();
 
         assertSame(sliceQueue, factory.sliceQueue());
     }
@@ -805,19 +787,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            sliceQueue
-        );
+            (Runnable r) -> r.run()
+        ).sliceQueue(sliceQueue).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -871,19 +849,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            sliceQueue
-        );
+            (Runnable r) -> r.run()
+        ).sliceQueue(sliceQueue).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -944,19 +918,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            sliceQueue
-        );
+            (Runnable r) -> r.run()
+        ).sliceQueue(sliceQueue).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1023,19 +993,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            sliceQueue
-        );
+            (Runnable r) -> r.run()
+        ).sliceQueue(sliceQueue).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1091,22 +1057,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            FormatReader.NO_LIMIT,
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            null,
-            null,
-            2
-        );
+            (Runnable r) -> r.run()
+        ).parsingParallelism(2).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1142,22 +1101,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            10,
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            null,
-            null,
-            2
-        );
+            (Runnable r) -> r.run()
+        ).rowLimit(10).parsingParallelism(2).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1199,22 +1151,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            FormatReader.NO_LIMIT,
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            null,
-            null,
-            2
-        );
+            (Runnable r) -> r.run()
+        ).parsingParallelism(2).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1237,34 +1182,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         TrackingSegmentableFormatReader formatReader = new TrackingSegmentableFormatReader();
         StorageProvider storageProvider = mock(StorageProvider.class);
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
-            storageProvider,
-            formatReader,
-            StoragePath.of("file:///test.csv"),
-            List.of(
-                new FieldAttribute(Source.EMPTY, "x", new EsField("x", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE))
-            ),
-            100,
-            10,
-            FormatReader.NO_LIMIT,
-            Runnable::run,
-            null,
-            null,
-            null,
-            null,
-            null,
-            4
-        );
-
-        String description = factory.describe();
-        assertTrue("describe should mention parallel-parse for segmentable readers", description.contains("parallel-parse(4)"));
-    }
-
-    public void testDescribeShowsSyncWrapperForParallelism1() {
-        TrackingSegmentableFormatReader formatReader = new TrackingSegmentableFormatReader();
-        StorageProvider storageProvider = mock(StorageProvider.class);
-
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             StoragePath.of("file:///test.csv"),
@@ -1274,7 +1192,27 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             100,
             10,
             Runnable::run
-        );
+        ).parsingParallelism(4).build();
+
+        String description = factory.describe();
+        assertTrue("describe should mention parallel-parse for segmentable readers", description.contains("parallel-parse(4)"));
+    }
+
+    public void testDescribeShowsSyncWrapperForParallelism1() {
+        TrackingSegmentableFormatReader formatReader = new TrackingSegmentableFormatReader();
+        StorageProvider storageProvider = mock(StorageProvider.class);
+
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+            storageProvider,
+            formatReader,
+            StoragePath.of("file:///test.csv"),
+            List.of(
+                new FieldAttribute(Source.EMPTY, "x", new EsField("x", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE))
+            ),
+            100,
+            10,
+            Runnable::run
+        ).build();
 
         String description = factory.describe();
         assertTrue("describe should show sync-wrapper when parallelism is 1", description.contains("sync-wrapper"));
@@ -1302,7 +1240,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -1310,7 +1248,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             100,
             2,
             (Runnable r) -> r.run()
-        );
+        ).build();
 
         SourceOperator operator = factory.get(driverContext);
         assertNotNull(operator);
@@ -1367,7 +1305,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             return null;
         }).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -1375,7 +1313,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             100,
             10,
             (Runnable r) -> r.run()
-        );
+        ).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1434,16 +1372,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             return null;
         }).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            fileList
-        );
+            (Runnable r) -> r.run()
+        ).fileList(fileList).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1502,19 +1439,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             return null;
         }).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            sliceQueue
-        );
+            (Runnable r) -> r.run()
+        ).sliceQueue(sliceQueue).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1566,7 +1499,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             return null;
         }).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -1574,7 +1507,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             100,
             10,
             (Runnable r) -> r.run()
-        );
+        ).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1622,7 +1555,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).addAsyncAction();
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -1630,7 +1563,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             100,
             10,
             (Runnable r) -> r.run()
-        );
+        ).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1677,7 +1610,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             doAnswer(inv -> null).when(driverContext).addAsyncAction();
             doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-            AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
                 storageProvider,
                 formatReader,
                 path,
@@ -1685,7 +1618,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
                 100,
                 2,
                 realExec
-            );
+            ).build();
 
             SourceOperator operator = factory.get(driverContext);
             List<Page> pages = new ArrayList<>();
@@ -1744,16 +1677,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             doAnswer(inv -> null).when(driverContext).addAsyncAction();
             doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-            AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
                 storageProvider,
                 formatReader,
                 path,
                 attributes,
                 100,
                 2,
-                realExec,
-                fileList
-            );
+                realExec
+            ).fileList(fileList).build();
 
             SourceOperator operator = factory.get(driverContext);
             List<Page> pages = new ArrayList<>();
@@ -1812,19 +1744,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             doAnswer(inv -> null).when(driverContext).addAsyncAction();
             doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
-            AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
                 storageProvider,
                 formatReader,
                 path,
                 attributes,
                 100,
                 2,
-                realExec,
-                null,
-                null,
-                null,
-                sliceQueue
-            );
+                realExec
+            ).sliceQueue(sliceQueue).build();
 
             SourceOperator operator = factory.get(driverContext);
             List<Page> pages = new ArrayList<>();
@@ -1883,7 +1811,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             return null;
         }).when(driverContext).removeAsyncAction();
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
@@ -1891,7 +1819,7 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             100,
             10,
             (Runnable r) -> r.run()
-        );
+        ).build();
 
         SourceOperator operator = factory.get(driverContext);
         List<Page> pages = new ArrayList<>();
@@ -1981,19 +1909,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             for (int d = 0; d < driverCount; d++) {
                 DriverContext ctx = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
                 contexts[d] = ctx;
-                AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+                AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
                     storageProvider,
                     formatReader,
                     path,
                     attributes,
                     100,
                     bufferSize,
-                    producerExec,
-                    null,
-                    null,
-                    null,
-                    sliceQueue
-                );
+                    producerExec
+                ).sliceQueue(sliceQueue).build();
                 operators[d] = factory.get(ctx);
             }
 
@@ -2074,19 +1998,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         ExecutorService realExec = Executors.newFixedThreadPool(2, EsExecutors.daemonThreadFactory("test", "fail-test"));
         try {
             DriverContext ctx = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
-            AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+            AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
                 storageProvider,
                 formatReader,
                 path,
                 attributes,
                 100,
                 2,
-                realExec,
-                null,
-                null,
-                null,
-                sliceQueue
-            );
+                realExec
+            ).sliceQueue(sliceQueue).build();
             SourceOperator operator = factory.get(ctx);
 
             List<Page> pages = new ArrayList<>();
@@ -2162,16 +2082,15 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             for (int d = 0; d < driverCount; d++) {
                 DriverContext ctx = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
                 contexts[d] = ctx;
-                AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+                AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
                     storageProvider,
                     formatReader,
                     path,
                     attributes,
                     100,
                     bufferSize,
-                    producerExec,
-                    fileList
-                );
+                    producerExec
+                ).fileList(fileList).build();
                 operators[d] = factory.get(ctx);
             }
 
@@ -2217,6 +2136,214 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
             producerExec.shutdown();
             assertTrue(producerExec.awaitTermination(15, TimeUnit.SECONDS));
         }
+    }
+
+    /**
+     * State-machine guard test for the flattened producer loop.
+     *
+     * Drives the slice-queue producer end-to-end with 2 {@link CoalescedSplit}s of 2 leaves each
+     * (4 leaves total, 1 page per leaf) on a single-thread executor and asserts:
+     * <ul>
+     *   <li>all 4 leaves are read once (state machine visits every leaf across splits);</li>
+     *   <li>all 4 pages arrive at the buffer;</li>
+     *   <li>every opened iterator is closed;</li>
+     *   <li>{@code removeAsyncAction()} fires exactly once (success path =&gt; buffer.finish(false));</li>
+     *   <li>no {@code addPage} after {@code buffer.noMoreInputs()} becomes true.</li>
+     * </ul>
+     * Followed by a second scenario that forces {@code buffer.finish(true)} partway through, to
+     * verify the active iterator gets closed and no further leaves are opened.
+     * <p>
+     * BLOCKED-path coverage (buffer-full backpressure and wakeup correctness) is not exercised here;
+     * it lives in {@code AsyncExternalSourceBufferTests#testNoLostWakeupUnderConcurrentAddAndPoll}
+     * (the Phase 5 stress test).
+     */
+    public void testProducerLoopStateMachine() throws Exception {
+        // --- scenario 1: run to completion across 2 splits x 2 leaves ---
+        runStateMachineScenario(false);
+
+        // --- scenario 2: force early noMoreInputs after the first leaf's page is consumed ---
+        runStateMachineScenario(true);
+    }
+
+    private void runStateMachineScenario(boolean forceNoMoreInputsEarly) throws Exception {
+        AtomicInteger readCalls = new AtomicInteger();
+        AtomicInteger closeCalls = new AtomicInteger();
+        TrackingReader reader = new TrackingReader(readCalls, closeCalls);
+
+        // 2 coalesced splits x 2 leaves = 4 leaves
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int s = 0; s < 2; s++) {
+            List<ExternalSplit> leaves = new ArrayList<>();
+            for (int l = 0; l < 2; l++) {
+                leaves.add(
+                    new FileSplit(
+                        "test",
+                        StoragePath.of("s3://bucket/s" + s + "_l" + l + ".parquet"),
+                        0,
+                        100,
+                        "parquet",
+                        Map.of(),
+                        Map.of()
+                    )
+                );
+            }
+            splits.add(new CoalescedSplit("test", leaves));
+        }
+        ExternalSliceQueue sliceQueue = new ExternalSliceQueue(splits);
+
+        StubMultiFileStorageProvider storageProvider = new StubMultiFileStorageProvider();
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "value",
+                new EsField("value", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+
+        DriverContext driverContext = mock(DriverContext.class);
+        when(driverContext.blockFactory()).thenReturn(TEST_BLOCK_FACTORY);
+        AtomicInteger addAsync = new AtomicInteger();
+        AtomicInteger removeAsync = new AtomicInteger();
+        doAnswer(inv -> {
+            addAsync.incrementAndGet();
+            return null;
+        }).when(driverContext).addAsyncAction();
+        doAnswer(inv -> {
+            removeAsync.incrementAndGet();
+            return null;
+        }).when(driverContext).removeAsyncAction();
+
+        // Use a single-thread executor so ordering is deterministic.
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
+                storageProvider,
+                reader,
+                StoragePath.of("s3://bucket/s0_l0.parquet"),
+                attributes,
+                100,
+                10,
+                executor
+            ).sliceQueue(sliceQueue).build();
+
+            SourceOperator operator = factory.get(driverContext);
+
+            if (forceNoMoreInputsEarly) {
+                // Poll a few pages then force finish(true) to simulate downstream cancellation.
+                int received = 0;
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+                while (received < 1 && System.nanoTime() < deadline) {
+                    Page p = operator.getOutput();
+                    if (p != null) {
+                        received++;
+                        p.releaseBlocks();
+                    }
+                }
+                // Mimic downstream cancellation; the producer loop must observe noMoreInputs and exit.
+                operator.finish();
+                // Drain remaining output (should not hang).
+                while (operator.isFinished() == false) {
+                    Page p = operator.getOutput();
+                    if (p != null) p.releaseBlocks();
+                }
+            } else {
+                List<Page> pages = new ArrayList<>();
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+                while (operator.isFinished() == false && System.nanoTime() < deadline) {
+                    Page p = operator.getOutput();
+                    if (p != null) pages.add(p);
+                }
+                assertTrue("operator did not finish within timeout", operator.isFinished());
+                assertEquals("all 4 leaves produced a page", 4, pages.size());
+                for (Page p : pages)
+                    p.releaseBlocks();
+            }
+
+            operator.close();
+
+            // Let the producer thread observe finish() and run the completion listener
+            // (which calls removeAsyncAction) before we assert on counters.
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+
+            // Every iterator that was opened must have been closed.
+            assertEquals("read/close counts differ - leaked iterator", readCalls.get(), closeCalls.get());
+            // addAsync/removeAsync are paired: exactly once, on the happy path and cancelled path.
+            assertEquals(1, addAsync.get());
+            assertEquals(1, removeAsync.get());
+            // Full run must hit all 4 leaves; early-exit run hits at least 1.
+            if (forceNoMoreInputsEarly == false) {
+                assertEquals(4, readCalls.get());
+            } else {
+                assertTrue("expected at least one leaf to be read before cancellation", readCalls.get() >= 1);
+            }
+        } finally {
+            if (executor.isShutdown() == false) {
+                executor.shutdown();
+                assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+            }
+        }
+    }
+
+    /**
+     * Format reader for the state-machine test. Every {@code read} returns a single-page iterator
+     * that increments {@code closeCalls} on {@link CloseableIterator#close()}, so the test can
+     * assert that every opened iterator is closed exactly once.
+     */
+    private static class TrackingReader implements FormatReader {
+        private final AtomicInteger readCount;
+        private final AtomicInteger closeCount;
+
+        TrackingReader(AtomicInteger readCount, AtomicInteger closeCount) {
+            this.readCount = readCount;
+            this.closeCount = closeCount;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            readCount.incrementAndGet();
+            // Latch lets the buffer's waitForSpace path engage naturally; we return one page.
+            CountDownLatch once = new CountDownLatch(1);
+            once.countDown();
+            return new CloseableIterator<>() {
+                private boolean emitted = false;
+
+                @Override
+                public boolean hasNext() {
+                    return emitted == false;
+                }
+
+                @Override
+                public Page next() {
+                    if (emitted) throw new NoSuchElementException();
+                    emitted = true;
+                    return createTestPage();
+                }
+
+                @Override
+                public void close() {
+                    closeCount.incrementAndGet();
+                }
+            };
+        }
+
+        @Override
+        public String formatName() {
+            return "tracking";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
     }
 
     // ===== Helpers =====

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -2255,8 +2255,9 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
                 }
                 assertTrue("operator did not finish within timeout", operator.isFinished());
                 assertEquals("all 4 leaves produced a page", 4, pages.size());
-                for (Page p : pages)
+                for (Page p : pages) {
                     p.releaseBlocks();
+                }
             }
 
             operator.close();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceDrainUtilsTests.java
@@ -26,7 +26,6 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -232,32 +231,6 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
         assertNull("Drain should not throw", drainError.get());
     }
 
-    public void testDrainPagesWithBudgetAsyncRespectsRowLimit() throws Exception {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
-
-        List<Page> pages = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            pages.add(createTestPage(1, 10));
-        }
-
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<Integer> result = new AtomicReference<>();
-        AtomicReference<Exception> error = new AtomicReference<>();
-        ExternalSourceDrainUtils.drainPagesWithBudgetAsync(iteratorOf(pages), buffer, 25, exec, ActionListener.wrap(totalRows -> {
-            result.set(totalRows);
-            latch.countDown();
-        }, e -> {
-            error.set(e);
-            latch.countDown();
-        }));
-
-        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
-        assertNull(error.get());
-        assertEquals(Integer.valueOf(30), result.get());
-        assertEquals(3, buffer.size());
-        buffer.finish(true);
-    }
-
     public void testDrainPagesAsyncIteratorThrowsOnNext() throws Exception {
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
 
@@ -372,34 +345,6 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
         buffer.finish(true);
     }
 
-    public void testDrainPagesWithBudgetAsyncThrowsMidDrain() throws Exception {
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(1024 * 1024);
-
-        List<Page> pages = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            pages.add(createTestPage(1, 10));
-        }
-
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<Exception> error = new AtomicReference<>();
-        ExternalSourceDrainUtils.drainPagesWithBudgetAsync(
-            faultingIterator(pages, 2, false),
-            buffer,
-            100,
-            exec,
-            ActionListener.wrap(v -> latch.countDown(), e -> {
-                error.set(e);
-                latch.countDown();
-            })
-        );
-
-        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
-        assertNotNull(error.get());
-        assertTrue(error.get().getCause().getMessage().contains("simulated S3 read failure on next"));
-        assertEquals(2, buffer.size());
-        buffer.finish(true);
-    }
-
     public void testDrainAsyncExecutorRejection() throws Exception {
         long maxBufferBytes = 100;
         AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
@@ -477,46 +422,6 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
 
         assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
         assertFalse("drainPagesAsync must NOT close the iterator (INV-7)", closeCalled.get());
-        buffer.finish(true);
-    }
-
-    public void testBudgetAccountingAcrossAsyncBoundaries() throws Exception {
-        long maxBufferBytes = 500;
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
-
-        List<Page> pages = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            pages.add(createTestPage(2, 5));
-        }
-
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicInteger resultRows = new AtomicInteger();
-        AtomicReference<Exception> error = new AtomicReference<>();
-        ExternalSourceDrainUtils.drainPagesWithBudgetAsync(iteratorOf(pages), buffer, 20, exec, ActionListener.wrap(totalRows -> {
-            resultRows.set(totalRows);
-            latch.countDown();
-        }, e -> {
-            error.set(e);
-            latch.countDown();
-        }));
-
-        int consumed = 0;
-        while (true) {
-            Page page = buffer.pollPage();
-            if (page != null) {
-                page.releaseBlocks();
-                consumed++;
-            } else if (latch.getCount() == 0) {
-                break;
-            } else {
-                Thread.yield();
-            }
-        }
-
-        assertTrue(latch.await(10, java.util.concurrent.TimeUnit.SECONDS));
-        assertNull(error.get());
-        assertEquals(20, resultRows.get());
-        assertEquals(4, consumed);
         buffer.finish(true);
     }
 
@@ -861,110 +766,6 @@ public class ExternalSourceDrainUtilsTests extends ESTestCase {
         assertNull("Drain should exit cleanly on cancellation, but got: " + drainError.get(), drainError.get());
         assertTrue("Cleanup must run after cancellation", cleanupRan.get());
         assertEquals("Iterator must be closed exactly once after cancellation", 1, closeCount.get());
-    }
-
-    /**
-     * Budget accounting with multiple sequential drains simulating multi-split behavior.
-     * Each drain reports consumed rows; the total across async boundaries must match.
-     */
-    public void testBudgetPropagationAcrossMultipleSequentialDrains() throws Exception {
-        long maxBufferBytes = 500;
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
-        int overallRowLimit = 35;
-
-        List<Page> batch1 = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            batch1.add(createTestPage(2, 5));
-        }
-        List<Page> batch2 = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            batch2.add(createTestPage(2, 5));
-        }
-
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicInteger totalConsumedRows = new AtomicInteger(0);
-        AtomicReference<Exception> error = new AtomicReference<>();
-
-        // Simulate multi-split: drain batch1, then batch2 with remaining budget
-        ExternalSourceDrainUtils.drainPagesWithBudgetAsync(iteratorOf(batch1), buffer, overallRowLimit, exec, ActionListener.wrap(c1 -> {
-            totalConsumedRows.addAndGet(c1);
-            int remaining = overallRowLimit - c1;
-            ExternalSourceDrainUtils.drainPagesWithBudgetAsync(iteratorOf(batch2), buffer, remaining, exec, ActionListener.wrap(c2 -> {
-                totalConsumedRows.addAndGet(c2);
-                latch.countDown();
-            }, e -> {
-                error.set(e);
-                latch.countDown();
-            }));
-        }, e -> {
-            error.set(e);
-            latch.countDown();
-        }));
-
-        // Consume pages to avoid blocking
-        int consumed = 0;
-        while (latch.getCount() > 0 || buffer.size() > 0) {
-            Page page = buffer.pollPage();
-            if (page != null) {
-                page.releaseBlocks();
-                consumed++;
-            } else {
-                Thread.yield();
-            }
-        }
-
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
-        assertNull(error.get());
-        assertEquals("Total rows across async boundaries must match limit", 35, totalConsumedRows.get());
-        buffer.finish(true);
-    }
-
-    /**
-     * Executor rejection with budget variant: when executor.execute() throws during a
-     * budget-limited drain, the listener receives the failure and cleanup runs.
-     */
-    public void testBudgetDrainExecutorRejection() throws Exception {
-        long maxBufferBytes = 100;
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
-        List<Page> pages = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            pages.add(createTestPage(2, 50));
-        }
-
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<Exception> error = new AtomicReference<>();
-        AtomicBoolean cleanupRan = new AtomicBoolean(false);
-
-        ExecutorService shutdownExec = Executors.newSingleThreadExecutor(EsExecutors.daemonThreadFactory("test", "shutdown"));
-        shutdownExec.shutdown();
-
-        exec.execute(() -> {
-            ExternalSourceDrainUtils.drainPagesWithBudgetAsync(
-                iteratorOf(pages),
-                buffer,
-                1000,
-                shutdownExec,
-                ActionListener.runAfter(ActionListener.<Integer>wrap(v -> latch.countDown(), e -> {
-                    error.set(e);
-                    latch.countDown();
-                }), () -> cleanupRan.set(true))
-            );
-        });
-
-        Thread.sleep(200);
-        Page p = buffer.pollPage();
-        if (p != null) {
-            p.releaseBlocks();
-        }
-
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
-        assertNotNull("Should fail with executor rejection", error.get());
-        assertTrue(
-            "Error should be RejectedExecutionException, got: " + error.get().getClass().getSimpleName(),
-            error.get() instanceof RejectedExecutionException
-        );
-        assertTrue("Cleanup must run on executor rejection", cleanupRan.get());
-        buffer.finish(true);
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceLimitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceLimitTests.java
@@ -84,20 +84,15 @@ public class ExternalSourceLimitTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
         // With rowLimit=50, should stop after 1 file (100 rows >= 50)
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            50, // rowLimit
-            (Runnable r) -> r.run(),
-            fileList,
-            null,
-            null,
-            null
-        );
+            (Runnable r) -> r.run()
+        ).rowLimit(50).fileList(fileList).build();
 
         try (SourceOperator operator = factory.get(driverContext)) {
             List<Page> pages = drainOperator(operator);
@@ -143,16 +138,15 @@ public class ExternalSourceLimitTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
         // NO_LIMIT should read all files
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             100,
             10,
-            (Runnable r) -> r.run(),
-            fileList
-        );
+            (Runnable r) -> r.run()
+        ).fileList(fileList).build();
 
         try (SourceOperator operator = factory.get(driverContext)) {
             List<Page> pages = drainOperator(operator);
@@ -190,20 +184,15 @@ public class ExternalSourceLimitTests extends ESTestCase {
         doAnswer(inv -> null).when(driverContext).removeAsyncAction();
 
         // Single file with rowLimit=10 — the LimitingIterator should stop early
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             path,
             attributes,
             50, // batchSize
             10,
-            10, // rowLimit
-            (Runnable r) -> r.run(),
-            null,
-            null,
-            null,
-            null
-        );
+            (Runnable r) -> r.run()
+        ).rowLimit(10).build();
 
         try (SourceOperator operator = factory.get(driverContext)) {
             List<Page> pages = drainOperator(operator);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceParallelismTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceParallelismTests.java
@@ -88,19 +88,15 @@ public class ExternalSourceParallelismTests extends ESTestCase {
                 final int driverIdx = d;
                 driverPool.submit(() -> {
                     try {
-                        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+                        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
                             storageProvider,
                             formatReader,
                             StoragePath.of("s3://bucket/f0.parquet"),
                             testAttributes(),
                             100,
                             10,
-                            asyncReadPool,
-                            null,
-                            null,
-                            null,
-                            sliceQueue
-                        );
+                            asyncReadPool
+                        ).sliceQueue(sliceQueue).build();
                         DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
                         SourceOperator operator = factory.get(driverContext);
                         while (operator.isFinished() == false) {
@@ -206,19 +202,15 @@ public class ExternalSourceParallelismTests extends ESTestCase {
             for (int d = 0; d < driverCount; d++) {
                 driverPool.submit(() -> {
                     try {
-                        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+                        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
                             storageProvider,
                             formatReader,
                             StoragePath.of("s3://bucket/f0.parquet"),
                             testAttributes(),
                             100,
                             10,
-                            asyncReadPool,
-                            null,
-                            null,
-                            null,
-                            sliceQueue
-                        );
+                            asyncReadPool
+                        ).sliceQueue(sliceQueue).build();
                         DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
                         SourceOperator operator = factory.get(driverContext);
                         while (operator.isFinished() == false) {
@@ -284,19 +276,15 @@ public class ExternalSourceParallelismTests extends ESTestCase {
             )
         );
 
-        AsyncExternalSourceOperatorFactory factory = new AsyncExternalSourceOperatorFactory(
+        AsyncExternalSourceOperatorFactory factory = AsyncExternalSourceOperatorFactory.builder(
             storageProvider,
             formatReader,
             StoragePath.of("s3://bucket/f1.parquet"),
             attributes,
             100,
             10,
-            Runnable::run,
-            null,
-            Set.of("year"),
-            Map.of(),
-            sliceQueue
-        );
+            Runnable::run
+        ).partitionColumnNames(Set.of("year")).partitionValues(Map.of()).sliceQueue(sliceQueue).build();
 
         DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TEST_BLOCK_FACTORY, null);
         SourceOperator operator = factory.get(driverContext);


### PR DESCRIPTION
## Summary

Refactor-only follow-up to #147266. Zero behaviour change. Sits on top of the correctness fixes from that PR; this is the cognitive-load cleanup identified in the post-mortem (see https://github.com/elastic/esql-planning/issues/557).

The change lands in two parts against two sibling factories.

### Part A — Simplify external-source factory construction

- Collapse the 8 public constructor overloads of `AsyncExternalSourceOperatorFactory` into a single (private) canonical constructor plus a nested fluent `Builder`. All call-sites (production + tests) migrated to `AsyncExternalSourceOperatorFactory.builder(...).build()`. The builder shape mirrors the existing `FormatReadContext.Builder` in the same package.
- Delete `AsyncExternalSourceBuffer#waitForWriting` — dead method already flagged in its own Javadoc as superseded by `waitForSpace`.

### Part B — Flatten the producer chains

Both `AsyncExternalSourceOperatorFactory` and `AsyncConnectorSourceOperatorFactory` had a five-layer continuation-passing tower for producer execution:

```
startXRead → ActionRunnable.wrap → processNextSplit → ActionListener.wrap → processNextLeaf → drainPagesWithBudgetAsync → runAfter(wrap(...), closeQuietly) → drainBatchWithBudget
```

Iteration state (current split, leaf index, rows remaining) was threaded as method arguments and re-wrapped at each layer. This is the structure that the two correctness bugs closed in #147266 were hiding behind — debugging them required tracing five anonymous-inner-class layers.

Each factory is now a single `runProducerLoop(state, completionListener)` driven by a private `ProducerState`, with a three-valued inner drain step (`DRAINED` / `EOF` / `BLOCKED`). Same thread-yield semantics (cold path still hops to the executor). Same lifecycle guarantees. The five correctness invariants — async-action pairing, exactly-once buffer finish, iterator closed on every exit, cooperative yield on buffer-full, no-addPage-after-noMoreInputs — now live in one method at citeable line numbers rather than scattered across five CPS layers.

The connector factory additionally folds `connector.close()` into the completion listener's `runAfter` hook for exactly-once teardown.

As a consequence, `ExternalSourceDrainUtils.drainPagesWithBudgetAsync` (and its private helper + 5 dedicated tests) have no remaining callers and are deleted. The non-budget `drainPagesAsync` is retained — still used by the sync-wrapper and native-async producer paths.

Developed with AI-assisted tooling
