### PR TITLE
[9.4] [TEST] Drain cluster state after ML feature reset before waitForPendingTasks in x-pack REST tests #147237 (#147237)

### DIFF
--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
@@ -146,6 +146,10 @@ public abstract class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
     private void clearMlState() throws Exception {
         if (isMachineLearningTest()) {
             new MlRestTestStateCleaner(logger, adminClient()).resetFeatures();
+            // _features/_reset can enqueue async cluster-state updates (e.g. inference
+            // endpoint cache invalidation via ClearInferenceEndpointCacheAction). Drain
+            // them here so the subsequent waitForPendingTasks does not race with them.
+            waitForClusterUpdates();
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [TEST] Drain cluster state after ML feature reset before waitForPendingTasks in x-pack REST tests #147237 (#147237)