### PR TITLE
ESQL: Fix NodeSubclassTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -445,21 +445,12 @@ tests:
 - class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
   method: testBulkOperations {useLegacyFormat=false useSyntheticSource=true}
   issue: https://github.com/elastic/elasticsearch/issues/147177
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.logical.promql.operator.VectorBinaryComparison}
-  issue: https://github.com/elastic/elasticsearch/issues/147195
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.logical.promql.UnresolvedPromqlFunction}
-  issue: https://github.com/elastic/elasticsearch/issues/147199
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=aggregations/terms_text_docvalues/Indexing disabled}
   issue: https://github.com/elastic/elasticsearch/issues/147200
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=index/100_field_name_length_limit/Test field name length limit array}
   issue: https://github.com/elastic/elasticsearch/issues/147205
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testInfoParameters {class org.elasticsearch.xpack.esql.plan.logical.promql.UnresolvedPromqlFunction}
-  issue: https://github.com/elastic/elasticsearch/issues/147223
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:tstep.docs_tstep_by_one_hour_duration_as_string}
   issue: https://github.com/elastic/elasticsearch/issues/147228
@@ -481,36 +472,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.CsvIT
   method: test {csv-spec:tstep.tstep_with_request_timestamp_bounds_only}
   issue: https://github.com/elastic/elasticsearch/issues/147228
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.logical.TopNBy}
-  issue: https://github.com/elastic/elasticsearch/issues/147232
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.logical.TopN}
-  issue: https://github.com/elastic/elasticsearch/issues/147233
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/KNN Vector similarity search only}
   issue: https://github.com/elastic/elasticsearch/issues/147251
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.logical.promql.UnresolvedPromqlFunction}
-  issue: https://github.com/elastic/elasticsearch/issues/147258
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.physical.SubqueryExec}
-  issue: https://github.com/elastic/elasticsearch/issues/147270
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.physical.OutputExec}
-  issue: https://github.com/elastic/elasticsearch/issues/147271
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.physical.HashJoinExec}
-  issue: https://github.com/elastic/elasticsearch/issues/147272
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testTransform {class org.elasticsearch.xpack.esql.plan.physical.LookupJoinExec}
-  issue: https://github.com/elastic/elasticsearch/issues/147273
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate}
-  issue: https://github.com/elastic/elasticsearch/issues/147280
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.logical.OrderBy}
-  issue: https://github.com/elastic/elasticsearch/issues/147281
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -653,7 +653,8 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
 
     public static <T extends Node<?>> T makeNode(Class<? extends T> nodeClass) throws Exception {
         if (Modifier.isAbstract(nodeClass.getModifiers())) {
-            nodeClass = randomFrom(innerSubclassesOf(nodeClass));
+            var subclasses = innerSubclassesOf(nodeClass);
+            nodeClass = randomValueOtherThanMany(UNRESOLVED_CLASSES::contains, () -> randomFrom(subclasses));
         }
         Class<?> testSubclassFor = testClassFor(nodeClass);
         if (testSubclassFor != null) {


### PR DESCRIPTION
Handle UNRESOLVED nodes in a node position in the query tree that were added by #146691

Closes #147195
Closes #147199
Closes #147223
Closes #147232
Closes #147233
Closes #147258
Closes #147270
Closes #147271
Closes #147272
Closes #147273
Closes #147280
Closes #147281
