### PR TITLE
ESQL: fix false-positive duplicate time-bucket in TS aggregate

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -45,8 +46,10 @@ import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -258,8 +261,20 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Parameter
                 }
             }
         };
-        // extract time-bucket from nested expressions like evals
-        aggregate.child().forEachExpressionUp(NamedExpression.class, extractTimeBucket);
+        // extract time-bucket from nested expressions like evals, but only for expressions
+        // actually referenced as grouping keys - avoids false positives when an EVAL defines
+        // a date_trunc(@timestamp) that is later overridden by a non-grouping STATS aggregate
+        Set<NameId> groupingIds = new HashSet<>();
+        for (Expression g : aggregate.groupings()) {
+            if (g instanceof NamedExpression ne) {
+                groupingIds.add(ne.id());
+            }
+        }
+        aggregate.child().forEachExpressionUp(NamedExpression.class, e -> {
+            if (groupingIds.contains(e.id())) {
+                extractTimeBucket.accept(e);
+            }
+        });
         // extract time-bucket directly from groupings
         aggregate.groupings()
             .stream()


### PR DESCRIPTION
## Summary

`TranslateTimeSeriesAggregate` scanned **all** named expressions in child EVAL plans when looking for a time-bucket anchor, not just those actually referenced in the `STATS BY` clause. This caused a spurious `expected at most one time bucket` error when:

1. An `EVAL` defined `date_trunc(@timestamp)` in a variable, and
2. That same variable was later **overridden** as a non-grouping aggregate output in `STATS`, while the `BY` clause used a different time-bucket expression.

Fix: build a set of IDs from the `STATS` groupings, and only call `extractTimeBucket` on child-plan expressions whose ID is in that set.

Closes #143697

## Test plan
- [ ] Existing TS CSV-spec tests pass (`./gradlew :x-pack:plugin:esql:internalClusterTest --tests "org.elasticsearch.xpack.esql.CsvIT.*timeseries*"`)
- [ ] ESQL optimizer unit tests pass
- [ ] `GenerativeMetricsIT` unmuted and passing (covered by companion PR)