### PR TITLE
ESQL: fix GenerativeMetricsIT first() in TS context and unmute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -112,9 +112,6 @@ tests:
 - class: org.elasticsearch.xpack.security.support.MetadataFlattenedMigrationIntegTests
   method: testMigrationWithConcurrentUpdates
   issue: https://github.com/elastic/elasticsearch/issues/143674
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/143697
 - class: org.elasticsearch.upgrades.FullClusterRestartIT
   method: testClusterState {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/143800

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/EsqlQueryGenerator.java
@@ -510,7 +510,16 @@ public class EsqlQueryGenerator {
                 if (sampleField == null) sampleField = anyName;
                 yield "sample(" + sampleField + ", " + randomIntBetween(1, 10) + ")";
             }
-            default -> "first(" + anyName + ", " + randomDateField(previousOutput) + ")";
+            default -> {
+                String dateField = randomDateField(previousOutput);
+                if (dateField == null) yield "count(*)";
+                // In a TS pipeline, first(field, datetime) is implicitly converted to FirstOverTime which requires
+                // numeric. Null previousCommands means we're in TimeSeriesStatsGenerator (always TS).
+                boolean isTimeSeries = previousCommands == null || previousCommands.stream().anyMatch(c -> "ts".equals(c.commandName()));
+                String firstField = isTimeSeries ? randomNumericField(previousOutput) : anyName;
+                if (firstField == null) firstField = anyName;
+                yield "first(" + firstField + ", " + dateField + ")";
+            }
         };
     }
 


### PR DESCRIPTION
## Summary

In a TS pipeline, `first(field, datetime)` is implicitly converted to `FirstOverTime(field)` by `InsertDefaultInnerTimeSeriesAggregate`. `FirstOverTime` requires a numeric first argument, but `EsqlQueryGenerator.agg()` was passing any field type (including `text`), producing a validation failure:

```
argument of [event_log] must be [numeric except unsigned_long], found value [event_log] type [text]
```

Fix: detect TS context in `agg()` (via `previousCommands` containing a `"ts"` source command, or `null` when called from `TimeSeriesStatsGenerator` which is always TS) and restrict the `first()` field argument to numeric types in that case.

Unmutes `GenerativeMetricsIT` (#143697). Depends on companion fix #147291 which resolves the original "expected at most one time bucket" failure for the same issue.

Closes #143697

## Test plan
- [ ] `GenerativeMetricsIT` passes with original reproducing seed (`-Dtests.seed=72347B67D428C4BB`)
- [ ] Existing TS CSV-spec and optimizer tests pass