### PR TITLE
ESQL: fix false-positive duplicate time-bucket in TS aggregate (#143697)

### DIFF
--- a/docs/changelog/147293.yaml
+++ b/docs/changelog/147293.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+  - 143697
+pr: 147293
+summary: Fix false-positive duplicate time-bucket in TS aggregate
+type: bug

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -47,6 +47,12 @@ tests:
 - class: org.elasticsearch.packaging.test.DebMetadataTests
   method: test05CheckLintian
   issue: https://github.com/elastic/elasticsearch/issues/142819
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
+  method: test {feature:METRICS}
+  issue: https://github.com/elastic/elasticsearch/issues/153507
+- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
+  method: test {feature:METRICS}
+  issue: https://github.com/elastic/elasticsearch/issues/153507
 - class: org.elasticsearch.upgrades.FullClusterRestartIT
   method: testClusterState {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/143800

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -47,12 +47,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DebMetadataTests
   method: test05CheckLintian
   issue: https://github.com/elastic/elasticsearch/issues/142819
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test {feature:METRICS}
-  issue: https://github.com/elastic/elasticsearch/issues/143697
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test {feature:METRICS}
-  issue: https://github.com/elastic/elasticsearch/issues/143697
 - class: org.elasticsearch.upgrades.FullClusterRestartIT
   method: testClusterState {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/143800

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/EsqlQueryGenerator.java
@@ -515,7 +515,16 @@ public class EsqlQueryGenerator {
                 if (sampleField == null) sampleField = anyName;
                 yield "sample(" + sampleField + ", " + randomIntBetween(1, 10) + ")";
             }
-            default -> "first(" + anyName + ", " + randomDateField(previousOutput) + ")";
+            default -> {
+                String dateField = randomDateField(previousOutput);
+                if (dateField == null) yield "count(*)";
+                // In a TS pipeline, first(field, datetime) is implicitly converted to FirstOverTime which requires
+                // numeric. Null previousCommands means we're in TimeSeriesStatsGenerator (always TS).
+                boolean isTimeSeries = previousCommands == null || previousCommands.stream().anyMatch(c -> "ts".equals(c.commandName()));
+                String firstField = isTimeSeries ? randomNumericField(previousOutput) : anyName;
+                if (firstField == null) firstField = anyName;
+                yield "first(" + firstField + ", " + dateField + ")";
+            }
         };
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -49,8 +50,10 @@ import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -260,8 +263,20 @@ public final class TranslateTimeSeriesAggregate extends AnalyzerRules.Parameteri
                 }
             }
         };
-        // extract time-bucket from nested expressions like evals
-        aggregate.child().forEachExpressionUp(NamedExpression.class, extractTimeBucket);
+        // extract time-bucket from nested expressions like evals, but only for expressions
+        // actually referenced as grouping keys - avoids false positives when an EVAL defines
+        // a date_trunc(@timestamp) that is later overridden by a non-grouping STATS aggregate
+        Set<NameId> groupingIds = new HashSet<>();
+        for (Expression g : aggregate.groupings()) {
+            if (g instanceof NamedExpression ne) {
+                groupingIds.add(ne.id());
+            }
+        }
+        aggregate.child().forEachExpressionUp(NamedExpression.class, e -> {
+            if (groupingIds.contains(e.id())) {
+                extractTimeBucket.accept(e);
+            }
+        });
         // extract time-bucket directly from groupings
         aggregate.groupings()
             .stream()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -7763,6 +7763,23 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         assertThat(lastOverTime.filter(), instanceOf(Equals.class));
     }
 
+    public void testTranslateNoFalsePositiveTimeBucketWhenEvalAliasOverridden() {
+        // Regression: when EVAL defines date_trunc(@timestamp) in a variable that is later overridden
+        // as a non-grouping STATS output, TranslateTimeSeriesAggregate incorrectly counted it as a
+        // second time bucket and threw "expected at most one time bucket" (#143697).
+        var plan = planMetrics("""
+            TS k8s
+            | EVAL tbucket = date_trunc(1h, @timestamp)
+            | STATS tbucket = max(rate(network.total_bytes_in)) BY bucket(@timestamp, 1h)
+            | LIMIT 10
+            """);
+        Holder<TimeSeriesAggregate> tsHolder = new Holder<>();
+        plan.forEachDown(TimeSeriesAggregate.class, tsHolder::set);
+        assertNotNull("expected a TimeSeriesAggregate in the plan", tsHolder.get());
+        assertNotNull(tsHolder.get().timeBucket());
+        assertThat(tsHolder.get().timeBucket().buckets().fold(FoldContext.small()), equalTo(Duration.ofHours(1)));
+    }
+
     public void testTranslateWithInlineFilterWithImplicitLastOverTime() {
         var query = """
             TS k8s | STATS avg(network.bytes_in) WHERE cluster == "prod" BY bucket(@timestamp, 1 minute)


### PR DESCRIPTION
## What

Closes #143697. `TranslateTimeSeriesAggregate` searches all named expressions for a time-bucket anchor, not just those referenced in the `STATS BY` clause. When an `EVAL` defined `date_trunc(@timestamp)` in a variable that was subsequently overridden as a non-grouping aggregate output, the optimizer see two time buckets and threw `expected at most one time bucket`. 

## Fix

Restrict the traversal to expressions whose IDs appear in the groupings.

Tested on `main` - fails on the new regression test with `expected at most one time bucket`; passes with the fix restored. +`GenerativeIT.test {feature:METRICS}` (single-node) passes against a live cluster with the fix applied.

## Scope / out-of-scope

While stress-testing the multi-node variant, found a distinct, unrelated, deterministically reproducible bug: a `STATS` output alias colliding with a grouping key name (e.g.`STATS pod = first(events_received, @timestamp) BY pod`) fails with `optimized incorrectly due to missing references`. This is the same failure family as#149619 / #145445 / #153030. Filed #153507.