### PR TITLE
Revert "Add JDK 21 test task to simdvec module"

### DIFF
--- a/libs/simdvec/build.gradle
+++ b/libs/simdvec/build.gradle
@@ -44,26 +44,11 @@ tasks.withType(CheckForbiddenApisTask).configureEach {
 }
 
 tasks.named('test').configure {
-  dependsOn 'testJava21'
+  if (buildParams.getRuntimeJavaVersion().map{ it.majorVersion.toInteger() }.get() >= 21) {
+    jvmArgs '--add-modules=jdk.incubator.vector'
+  }
 }
 
 tasks.withType(CheckForbiddenApisTask).configureEach {
   replaceSignatureFiles 'jdk-signatures'
-}
-
-def java21Launcher = javaToolchains.launcherFor {
-  languageVersion = JavaLanguageVersion.of(21)
-}
-
-tasks.register('testJava21', Test) {
-  description = 'Runs simdvec tests with JDK 21 to verify runtime version guards'
-  group = 'verification'
-  testClassesDirs = sourceSets.test.output.classesDirs
-  classpath = sourceSets.test.runtimeClasspath
-  javaLauncher = java21Launcher
-  executable = java21Launcher.get().executablePath.asFile.absolutePath
-  jvmArgs '--add-modules=jdk.incubator.vector'
-  onlyIf('runtime JDK is not already 21') {
-    buildParams.getRuntimeJavaVersion().get().majorVersion.toInteger() > 21
-  }
 }


### PR DESCRIPTION
Reverts elastic/elasticsearch#145007

The PR had some minor problems, but these had a big impact when combined with the latest CI changes where tests to run are detected, filtered and run multiple times (https://github.com/elastic/elasticsearch/pull/145375)