### PR TITLE
[ESQL] Cache schema for single-file external paths

### DIFF
--- a/docs/changelog/147297.yaml
+++ b/docs/changelog/147297.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147297
+summary: Cache schema for single-file external paths
+type: enhancement

--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageProvider.java
@@ -92,6 +92,11 @@ public final class HttpStorageProvider implements StorageProvider {
     }
 
     @Override
+    public boolean supportsStableMetadata() {
+        return false;
+    }
+
+    @Override
     public void close() {
         // HttpClient implements AutoCloseable in Java 21+
         // Closing it shuts down the internal selector thread and connection pool

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProvider.java
@@ -75,6 +75,11 @@ class ConcurrencyLimitedStorageProvider implements StorageProvider {
     }
 
     @Override
+    public boolean supportsStableMetadata() {
+        return delegate.supportsStableMetadata();
+    }
+
+    @Override
     public void close() throws IOException {
         delegate.close();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -165,8 +165,6 @@ public class ExternalSourceResolver {
             return resolveMultiFileSource(path, config, hints, hivePartitioning);
         }
 
-        SourceMetadata metadata = resolveSingleSource(path, config);
-        ExternalSourceMetadata extMetadata = wrapAsExternalSourceMetadata(metadata, config);
         /*
          * A concrete one-entry FileList is required so {@link org.elasticsearch.xpack.esql.datasources.FileSplitProvider}
          * can discover block-aligned splits for compressed files (e.g. .json.bz2). UNRESOLVED lists skip split discovery,
@@ -174,7 +172,30 @@ public class ExternalSourceResolver {
          */
         StoragePath storagePath = StoragePath.of(path);
         StorageProvider provider = resolveProvider(storagePath, config);
-        StorageObject object = provider.newObject(storagePath);
+
+        ExternalSourceMetadata extMetadata;
+        StorageObject object;
+        if (isCacheable(provider)) {
+            // Stat the file first (cheap HEAD/stat) to get mtime for the cache key.
+            object = provider.newObject(storagePath);
+            long mtime = object.lastModified().toEpochMilli();
+            String formatType = detectFormatType(storagePath);
+            SchemaCacheKey schemaKey = SchemaCacheKey.build(storagePath.toString(), mtime, formatType, config);
+            SchemaCacheEntry schemaEntry = cacheService.getOrComputeSchema(schemaKey, k -> {
+                SourceMetadata meta = resolveSingleSource(path, config);
+                Map<String, Object> enrichedMeta = meta.statistics()
+                    .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
+                    .orElse(meta.sourceMetadata());
+                return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta);
+            });
+            List<Attribute> schema = schemaEntry.toAttributes();
+            extMetadata = buildMetadataFromCache(schemaEntry, schema, config);
+        } else {
+            SourceMetadata metadata = resolveSingleSource(path, config);
+            extMetadata = wrapAsExternalSourceMetadata(metadata, config);
+            object = provider.newObject(storagePath);
+        }
+
         FileList singletonList = GlobExpander.fileListOf(
             List.of(new StorageEntry(storagePath, object.length(), object.lastModified())),
             path
@@ -189,11 +210,11 @@ public class ExternalSourceResolver {
         boolean hivePartitioning
     ) throws Exception {
         StoragePath storagePath = StoragePath.of(path);
+        StorageProvider provider = resolveProvider(storagePath, config);
 
         FormatReader.SchemaResolution schemaResolution = parseSchemaResolution(config);
 
         if (schemaResolution != FormatReader.SchemaResolution.FIRST_FILE_WINS) {
-            StorageProvider provider = resolveProvider(storagePath, config);
             int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
             int maxGlobExpansion = ExternalSourceSettings.MAX_GLOB_EXPANSION.get(settings);
             FileList raw = path.indexOf(',') >= 0
@@ -205,20 +226,17 @@ public class ExternalSourceResolver {
             return resolveMultiFileWithReconciliation(raw, config, schemaResolution);
         }
 
-        boolean cacheable = cacheService != null
-            && cacheService.isEnabled()
-            && "http".equals(storagePath.scheme()) == false
-            && "https".equals(storagePath.scheme()) == false;
+        boolean cacheable = isCacheable(provider);
 
         FileList listing;
         if (cacheable) {
             ListingCacheKey listingKey = ListingCacheKey.build(storagePath.scheme(), storagePath.host(), storagePath.path(), config);
             listing = cacheService.getOrComputeListing(
                 listingKey,
-                k -> expandAndCompact(path, config, hints, hivePartitioning, storagePath)
+                k -> expandAndCompact(path, provider, hints, hivePartitioning, storagePath)
             );
         } else {
-            listing = expandAndCompact(path, config, hints, hivePartitioning, storagePath);
+            listing = expandAndCompact(path, provider, hints, hivePartitioning, storagePath);
         }
 
         if (listing.fileCount() == 0) {
@@ -263,15 +281,23 @@ public class ExternalSourceResolver {
 
     private FileList expandAndCompact(
         String path,
-        Map<String, Object> config,
+        StorageProvider provider,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
         boolean hivePartitioning,
         StoragePath storagePath
     ) throws Exception {
-        StorageProvider provider = resolveProvider(storagePath, config);
         int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
         int maxGlobExpansion = ExternalSourceSettings.MAX_GLOB_EXPANSION.get(settings);
         return GlobExpander.expandAndCompact(path, provider, hints, hivePartitioning, storagePath, maxDiscoveredFiles, maxGlobExpansion);
+    }
+
+    /**
+     * Returns {@code true} when the schema cache can be consulted for the given provider.
+     * Providers that do not support stable metadata (e.g. HTTP) are excluded because
+     * mtime-based cache invalidation is not reliable for them.
+     */
+    private boolean isCacheable(StorageProvider provider) {
+        return cacheService != null && cacheService.isEnabled() && provider.supportsStableMetadata();
     }
 
     private StorageProvider resolveProvider(StoragePath storagePath, Map<String, Object> config) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageProvider.java
@@ -66,6 +66,11 @@ class RetryableStorageProvider implements StorageProvider {
     }
 
     @Override
+    public boolean supportsStableMetadata() {
+        return delegate.supportsStableMetadata();
+    }
+
+    @Override
     public void close() throws IOException {
         delegate.close();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StorageProvider.java
@@ -44,4 +44,14 @@ public interface StorageProvider extends Closeable {
 
     /** Returns the URI schemes this provider handles (e.g., ["http", "https"]). */
     List<String> supportedSchemes();
+
+    /**
+     * Whether this provider's objects have reliable last-modified timestamps suitable
+     * for mtime-based cache invalidation. Returns {@code true} by default.
+     * Providers serving dynamic content (e.g. HTTP URLs) should return {@code false}
+     * so the schema cache is bypassed and metadata is resolved fresh on every query.
+     */
+    default boolean supportsStableMetadata() {
+        return true;
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -526,6 +526,78 @@ public class ExternalSourceResolverTests extends ESTestCase {
         }
     }
 
+    public void testSingleFileSchemaCacheHitAfterMiss() throws Exception {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/data/single.parquet", schema);
+
+        CountingStorageProvider countingProvider = new CountingStorageProvider(Map.of(), schemasByPath);
+
+        Settings settings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(settings)) {
+            ExternalSourceResolver resolver = createResolverWithCache(countingProvider, schemasByPath, cacheService);
+
+            PlainActionFuture<ExternalSourceResolution> f1 = new PlainActionFuture<>();
+            resolver.resolve(List.of("s3://bucket/data/single.parquet"), Map.of(), f1);
+            ExternalSourceResolution res1 = f1.actionGet();
+            assertNotNull(res1.resolvedSource("s3://bucket/data/single.parquet"));
+            assertEquals(1, res1.resolvedSource("s3://bucket/data/single.parquet").fileList().fileCount());
+
+            Map<String, Object> stats1 = cacheService.usageStats();
+            assertEquals(1L, stats1.get("schema_cache.misses"));
+            assertEquals(0L, stats1.get("schema_cache.hits"));
+            assertEquals(1, stats1.get("schema_cache.count"));
+
+            PlainActionFuture<ExternalSourceResolution> f2 = new PlainActionFuture<>();
+            resolver.resolve(List.of("s3://bucket/data/single.parquet"), Map.of(), f2);
+            ExternalSourceResolution res2 = f2.actionGet();
+            assertNotNull(res2.resolvedSource("s3://bucket/data/single.parquet"));
+            assertEquals(1, res2.resolvedSource("s3://bucket/data/single.parquet").fileList().fileCount());
+
+            Map<String, Object> stats2 = cacheService.usageStats();
+            assertEquals(1L, stats2.get("schema_cache.misses"));
+            assertEquals(1L, stats2.get("schema_cache.hits"));
+            assertEquals(1, stats2.get("schema_cache.count"));
+        }
+    }
+
+    public void testSingleFileCacheDisabledBypassesCache() throws Exception {
+        List<Attribute> schema = List.of(attr("val", DataType.LONG));
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/d/file.parquet", schema);
+
+        CountingStorageProvider countingProvider = new CountingStorageProvider(Map.of(), schemasByPath);
+
+        Settings settings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", false)
+            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(settings)) {
+            ExternalSourceResolver resolver = createResolverWithCache(countingProvider, schemasByPath, cacheService);
+
+            for (int i = 0; i < 3; i++) {
+                PlainActionFuture<ExternalSourceResolution> f = new PlainActionFuture<>();
+                resolver.resolve(List.of("s3://bucket/d/file.parquet"), Map.of(), f);
+                ExternalSourceResolution res = f.actionGet();
+                assertNotNull(res.resolvedSource("s3://bucket/d/file.parquet"));
+            }
+
+            Map<String, Object> stats = cacheService.usageStats();
+            assertEquals("schema cache should have no entries when disabled", 0, stats.get("schema_cache.count"));
+            assertEquals("schema cache should have no hits when disabled", 0L, stats.get("schema_cache.hits"));
+            assertEquals("schema cache should have no misses when disabled", 0L, stats.get("schema_cache.misses"));
+        }
+    }
+
     public void testCacheDisabledCallsLoaderEveryTime() throws Exception {
         List<Attribute> schema = List.of(attr("val", DataType.LONG));
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();


### PR DESCRIPTION
Single-file EXTERNAL paths bypassed ExternalSourceCacheService,
causing expensive Parquet footer re-reads on every query. Route
single-file resolution through the schema cache using the same
SchemaCacheKey infrastructure already used by glob patterns.

Add StorageProvider#supportsStableMetadata() SPI method so each
provider can declare whether mtime-based cache invalidation is
reliable, replacing hardcoded HTTP scheme checks.

Developed with AI-assisted tooling