### PR TITLE
[9.4] Derive CAGRA nn-descent iterations from ef_construction (#147180)

### DIFF
--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsFormat.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsFormat.java
@@ -115,6 +115,14 @@ public class ES92GpuHnswVectorsFormat extends KnnVectorsFormat {
         return m + m * efConstruction / 256;
     }
 
+    /**
+     * Translates HNSW {@code efConstruction} to the CAGRA NN-Descent max iterations,
+     * TODO: use the cuvs API for converting HNSW CPU Params to Cagra params when available.
+     */
+    public static int cagraNNDescentNumIterations(int efConstruction) {
+        return 5 + efConstruction / 16;
+    }
+
     @Override
     public String toString() {
         return NAME

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
@@ -330,13 +330,14 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
             if (algorithm == CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT) {
                 logger.debug(
                     "Building CAGRA graph: numVectors=[{}], dims=[{}], algorithm=[{}], similarity=[{}], "
-                        + "graphDegree=[{}], intermediateGraphDegree=[{}], nnDescentIterations=[5], dataType=[{}]",
+                        + "graphDegree=[{}], intermediateGraphDegree=[{}], nnDescentIterations=[{}], dataType=[{}]",
                     dataset.size(),
                     dataset.columns(),
                     algorithm,
                     fieldInfo.getVectorSimilarityFunction(),
                     M,
                     beamWidth,
+                    cagraIndexParams.getNNDescentNumIterations(),
                     dataType
                 );
             } else {
@@ -370,7 +371,17 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
     }
 
     private CagraIndexParams createCagraIndexParams(VectorSimilarityFunction similarityFunction, int numVectors, int dims) {
-        return createCagraIndexParams(similarityFunction, numVectors, dims, M, beamWidth, dataType, totalDeviceMemory);
+        int nnDescentNumIterations = ES92GpuHnswVectorsFormat.cagraNNDescentNumIterations(beamWidth);
+        return createCagraIndexParams(
+            similarityFunction,
+            numVectors,
+            dims,
+            M,
+            beamWidth,
+            nnDescentNumIterations,
+            dataType,
+            totalDeviceMemory
+        );
     }
 
     static CagraIndexParams createCagraIndexParams(
@@ -379,6 +390,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         int dims,
         int graphDegree,
         int intermediateGraphDegree,
+        int nnDescentNumIterations,
         CuVSMatrix.DataType dataType,
         long totalDeviceMemory
     ) {
@@ -428,7 +440,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 .withCuVSIvfPqParams(ivfPqParams)
                 .withGraphDegree(graphDegree)
                 .withIntermediateGraphDegree(intermediateGraphDegree)
-                .withNNDescentNumIterations(5)
+                .withNNDescentNumIterations(nnDescentNumIterations)
                 .withMetric(distanceType)
                 .build();
         } else {
@@ -436,7 +448,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 .withCagraGraphBuildAlgo(CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT)
                 .withGraphDegree(graphDegree)
                 .withIntermediateGraphDegree(intermediateGraphDegree)
-                .withNNDescentNumIterations(5)
+                .withNNDescentNumIterations(nnDescentNumIterations)
                 .withMetric(distanceType)
                 .build();
         }

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/CagraParameterTranslationTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/CagraParameterTranslationTests.java
@@ -44,7 +44,8 @@ public class CagraParameterTranslationTests extends ESTestCase {
         assertEquals(12, params.getGraphDegree());
         assertEquals(22, params.getIntermediateGraphDegree());
         assertEquals(CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT, params.getCagraGraphBuildAlgo());
-        assertEquals(5, params.getNNDescentNumIterations());
+        // 5 + ef_construction / 16 = 5 + 100 / 16 = 11
+        assertEquals(11, params.getNNDescentNumIterations());
     }
 
     public void testUserParameters_m24_ef200() {
@@ -219,12 +220,14 @@ public class CagraParameterTranslationTests extends ESTestCase {
     ) {
         int graphDegree = ES92GpuHnswVectorsFormat.cagraGraphDegree(m);
         int intermediateGraphDegree = ES92GpuHnswVectorsFormat.cagraIntermediateGraphDegree(m, efConstruction);
+        int nnDescentNumIterations = ES92GpuHnswVectorsFormat.cagraNNDescentNumIterations(efConstruction);
         return ES92GpuHnswVectorsWriter.createCagraIndexParams(
             similarity,
             numVectors,
             dims,
             graphDegree,
             intermediateGraphDegree,
+            nnDescentNumIterations,
             dataType,
             gpuMemory
         );


### PR DESCRIPTION
Backport for #147180

Match the cuvs cagra.cpp heuristic
nn_descent_params.max_iterations = 5 + ef_construction / 16
on both NN_DESCENT and IVF_PQ graph build algos, replacing
the previously hardcoded value of 5.

