### PR TITLE
ESQL: More explicit test for unresolved promql

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -56,6 +56,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Fork;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
 import org.elasticsearch.xpack.esql.plan.logical.ViewUnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinConfig;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinType;
@@ -176,12 +177,11 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
     );
 
     // List of classes that are "unresolved" NamedExpression subclasses, therefore not suitable for use with logical/physical plan nodes.
-    private static final List<Class<?>> UNRESOLVED_CLASSES = List.of(
+    private static final List<Class<?>> UNRESOLVED_EXPRESSIONS = List.of(
         UnresolvedAttribute.class,
         UnresolvedException.class,
         UnresolvedFunction.class,
-        UnresolvedNamedExpression.class,
-        UnresolvedPromqlFunction.class
+        UnresolvedNamedExpression.class
     );
 
     private final Class<T> subclass;
@@ -652,9 +652,22 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
     }
 
     public static <T extends Node<?>> T makeNode(Class<? extends T> nodeClass) throws Exception {
+        if (nodeClass.equals(UnresolvedPromqlFunction.class)) {
+            /*
+             * Promql's functions turn into WithinSeriesAggregate or AcrossSeriesAggregate or something.
+             * It's like an unresolved expression. Building it from makeNode will make invalid trees.
+             */
+            throw new IllegalArgumentException("can't make an UnresolvedPromqlFunction");
+        }
         if (Modifier.isAbstract(nodeClass.getModifiers())) {
             var subclasses = innerSubclassesOf(nodeClass);
-            nodeClass = randomValueOtherThanMany(UNRESOLVED_CLASSES::contains, () -> randomFrom(subclasses));
+            /*
+             * Promql's functions turn into WithinSeriesAggregate or AcrossSeriesAggregate or something.
+             * It's like an unresolved expression. Building it from makeNode will make invalid trees.
+             */
+            subclasses.remove(UnresolvedPromqlFunction.class);
+            // It *is* safe to build an UnresoledRelation here because it is a leaf node.
+            nodeClass = randomFrom(subclasses);
         }
         Class<?> testSubclassFor = testClassFor(nodeClass);
         if (testSubclassFor != null) {
@@ -763,7 +776,7 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
         if (Modifier.isAbstract(argClass.getModifiers())) {
             while (true) {
                 var candidate = randomFrom(subclassesOf(asNodeSubclass, CLASSNAME_FILTER));
-                if (UNRESOLVED_CLASSES.stream().allMatch(unresolved -> unresolved.isAssignableFrom(candidate) == false)) {
+                if (UNRESOLVED_EXPRESSIONS.stream().allMatch(unresolved -> unresolved.isAssignableFrom(candidate) == false)) {
                     asNodeSubclass = candidate;
                     break;
                 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -56,7 +56,6 @@ import org.elasticsearch.xpack.esql.plan.logical.Fork;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
-import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
 import org.elasticsearch.xpack.esql.plan.logical.ViewUnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinConfig;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinType;


### PR DESCRIPTION
Promql's unresolved functions turn into one of four different "shapes" of logical plan after the function is resolved. At analyer time. The UnresolvedPromqlFunction is how we ask the analyzer to make that change, but it's upsetting EsqlNodeSubclassTests because it's "unresolved" AND a LogicalPlan. And EsqlNodeSubclassTests only supports unresolved *Expression* subclasses! This adds an explicit filter out for this strange case.

Closes #147164
