### PR TITLE
Enable `soft_fail` for repeat-changed-tests steps

### DIFF
--- a/.buildkite/pipelines/pull-request/repeat-changed-tests.yml
+++ b/.buildkite/pipelines/pull-request/repeat-changed-tests.yml
@@ -6,3 +6,4 @@ steps:
           npm install -g bun@1.0.4
           bun .buildkite/scripts/repeat-changed-tests.ts
         timeout_in_minutes: 10
+        soft_fail: true

--- a/.buildkite/scripts/repeat-changed-tests.ts
+++ b/.buildkite/scripts/repeat-changed-tests.ts
@@ -56,6 +56,7 @@ interface PipelineStep {
   command: string;
   timeout_in_minutes: number;
   agents: typeof AGENTS;
+  soft_fail: boolean;
   parallelism?: number;
   env?: Record<string, string>;
 }
@@ -243,6 +244,7 @@ export function generatePipeline(tests: ClassifiedTest[]): Pipeline {
       command: batchCommands[0],
       timeout_in_minutes: 60,
       agents: { ...AGENTS },
+      soft_fail: true,
     };
 
     if (totalBatches > 1) {


### PR DESCRIPTION
Don't fail CI for PRs on "repeat-changed-tests" jobs failure. We don't want the steps to fail currently. We need to gather the data and improve the pipelines so they do not fail on unrelated issues like timeouts and full disk.