### PR TITLE
[9.4] [ML] Preserve zero-allocation trained-model deployments in cluster state during ML-node shutdown rebalances (#146910)

### DIFF
--- a/docs/changelog/146910.yaml
+++ b/docs/changelog/146910.yaml
@@ -1,0 +1,7 @@
+area: Machine Learning
+issues:
+ - 146806
+pr: 146910
+summary: Preserve zero-allocation trained-model deployments in cluster state during
+  ML-node shutdown rebalances
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -226,6 +227,10 @@ public class TrainedModelAssignmentMetadata implements Metadata.ProjectCustom {
 
         public boolean hasModelDeployment(String deploymentId) {
             return deploymentRoutingEntries.containsKey(deploymentId);
+        }
+
+        public Set<String> deploymentIds() {
+            return Set.copyOf(deploymentRoutingEntries.keySet());
         }
 
         public Builder addNewAssignment(String deploymentId, TrainedModelAssignment.Builder assignment) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
@@ -19,6 +19,8 @@ import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -38,6 +40,8 @@ public class TransportInferTrainedModelDeploymentAction extends TransportTasksAc
     InferTrainedModelDeploymentAction.Request,
     InferTrainedModelDeploymentAction.Response,
     InferTrainedModelDeploymentAction.Response> {
+
+    private static final Logger logger = LogManager.getLogger(TransportInferTrainedModelDeploymentAction.class);
 
     private final ThreadPool threadPool;
 
@@ -72,6 +76,16 @@ public class TransportInferTrainedModelDeploymentAction extends TransportTasksAc
         } else if (failedNodeExceptions.isEmpty() == false) {
             throw failedNodeExceptions.get(0);
         } else if (tasks.isEmpty()) {
+            // Only warn about deployments with deployment IDs starting with '.' which are
+            // reserved for system-registered deployments (e.g., ElasticsearchInternalService's default
+            // ELSER/E5/rerank endpoints.
+            if (request.getId().startsWith(".")) {
+                logger.warn(
+                    "No deployment task found for system-registered deployment [{}] on any node when handling "
+                        + "inference request; assignment may be missing from cluster state",
+                    request.getId()
+                );
+            }
             throw new ElasticsearchStatusException(
                 "Unable to find model deployment task [{}] please stop and start the deployment or try again momentarily",
                 RestStatus.NOT_FOUND,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -186,7 +186,19 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                     newMetadata -> logger.debug(
                         () -> format("rebalanced model assignments [%s]", Strings.toString(newMetadata, false, true))
                     ),
-                    e -> logger.warn("failed to rebalance models", e)
+                    e -> {
+                        List<String> deploymentIdsBeforeRebalance = TrainedModelAssignmentMetadata.fromState(event.state())
+                            .allAssignments()
+                            .keySet()
+                            .stream()
+                            .toList();
+                        logger.warn(
+                            "failed to rebalance models, cluster state assignments may be stale. "
+                                + "error type: [{}], deployments at start of rebalance: {}",
+                            e.getClass().getSimpleName(),
+                            deploymentIdsBeforeRebalance
+                        );
+                    }
                 )
             );
         }
@@ -664,50 +676,98 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         }
 
         for (TrainedModelAssignment existingAssignment : currentMetadata.allAssignments().values()) {
-            boolean foundShuttingDownNodeForAssignment = false;
-
             String existingDeploymentId = existingAssignment.getDeploymentId();
-            TrainedModelAssignment.Builder assignmentBuilder = builder.hasModelDeployment(existingAssignment.getDeploymentId())
-                ? builder.getAssignment(existingDeploymentId)
-                : TrainedModelAssignment.Builder.fromAssignment(existingAssignment)
-                    /*
-                     * If this code path happens that means that the assignment originally existed prior to the rebalance and then
-                     * disappeared. This would be an anomaly so we'll set the assignment to stopping and attempt to gracefully shut down
-                     * the native process.
-                     */
-                    .stopAssignment(NODES_CHANGED_REASON)
-                    // If there are other routes that are now outdated after the rebalance we don't want to include them, so let's start
-                    // with a fresh table
-                    .clearNodeRoutingTable();
 
-            for (String nodeId : shuttingDownNodeIds) {
-                if (existingAssignment.isRoutedToNode(nodeId)
-                    && existingAssignment.getNodeRoutingTable()
-                        .get(nodeId)
-                        .getState()
-                        .isAnyOf(RoutingState.STARTED, RoutingState.STARTING)) {
-                    logger.debug(
-                        () -> format(
-                            "Found assignment deployment id: [%s] with route to shutting down node id: [%s], adding stopping route",
-                            existingDeploymentId,
-                            nodeId
-                        )
+            boolean wasDroppedByRebalancer = builder.hasModelDeployment(existingDeploymentId) == false;
+            // Fast path for zero-allocation deployments: nothing to drain, nothing to stop.
+            // If the rebalancer already has the deployment, leave its version untouched.
+            // Otherwise carry the existing assignment forward unchanged so it is never silently lost.
+            if (existingAssignment.getNodeRoutingTable().isEmpty()) {
+                if (wasDroppedByRebalancer) {
+                    errorAssignmentDroppedByRebalancer(existingDeploymentId, existingAssignment, shuttingDownNodeIds, builder);
+                    builder.addOrOverwriteAssignment(
+                        existingDeploymentId,
+                        TrainedModelAssignment.Builder.fromAssignment(existingAssignment)
                     );
-
-                    foundShuttingDownNodeForAssignment = true;
-                    RoutingInfo stoppingRouteInfo = createShuttingDownRoute(existingAssignment.getNodeRoutingTable().get(nodeId));
-
-                    assignmentBuilder.addOrOverwriteRoutingEntry(nodeId, stoppingRouteInfo);
                 }
+                continue;
             }
 
-            // if we didn't find a shutting down routing info then we don't want to add an empty assignment here
-            if (foundShuttingDownNodeForAssignment) {
+            TrainedModelAssignment.Builder assignmentBuilder;
+            if (wasDroppedByRebalancer) {
+                errorAssignmentDroppedByRebalancer(existingDeploymentId, existingAssignment, shuttingDownNodeIds, builder);
+                assignmentBuilder = TrainedModelAssignment.Builder.fromAssignment(existingAssignment)
+                    /*
+                     * The assignment existed before the rebalance but was not emitted by the rebalancer.
+                     * Transition it to STOPPING while preserving routes so the node service can drain them
+                     * on the next reconciliation instead of leaving native processes orphaned.
+                     */
+                    .stopAssignment(NODES_CHANGED_REASON);
+            } else {
+                assignmentBuilder = builder.getAssignment(existingDeploymentId);
+            }
+
+            applyShuttingDownRoutes(existingAssignment, shuttingDownNodeIds, assignmentBuilder);
+
+            // Always write back for assignments dropped by the rebalancer to prevent silent data loss.
+            if (wasDroppedByRebalancer) {
                 builder.addOrOverwriteAssignment(existingDeploymentId, assignmentBuilder);
             }
         }
 
+        assert currentMetadata.allAssignments().keySet().stream().allMatch(builder::hasModelDeployment)
+            : "setShuttingDownNodeRoutesToStopping must not drop any assignment present in currentMetadata";
+
         return builder;
+    }
+
+    private static void errorAssignmentDroppedByRebalancer(
+        String deploymentId,
+        TrainedModelAssignment preRebalanceAssignment,
+        Set<String> shuttingDownNodeIds,
+        TrainedModelAssignmentMetadata.Builder rebalancerOutput
+    ) {
+        logger.error(
+            "Assignment [{}] was present in cluster state before rebalance but is missing from "
+                + "rebalancer output; preserving it to avoid silent loss (this should not happen). "
+                + "Please report this warning. "
+                + "targetAllocations={}, preRebalanceRouting={}, preRebalanceState={}, "
+                + "shuttingDownNodes={}, rebalancerOutputDeployments={}",
+            deploymentId,
+            preRebalanceAssignment.getTaskParams().getNumberOfAllocations(),
+            preRebalanceAssignment.getNodeRoutingTable(),
+            preRebalanceAssignment.getAssignmentState(),
+            shuttingDownNodeIds,
+            rebalancerOutput.deploymentIds()
+        );
+    }
+
+    /**
+     * For each node in {@code shuttingDownNodeIds} that has an active ({@link RoutingState#STARTING} or
+     * {@link RoutingState#STARTED}) route in {@code existingAssignment}, converts that route to a
+     * {@link RoutingState#STOPPING} route and writes it into {@code assignmentBuilder}.
+     */
+    private static void applyShuttingDownRoutes(
+        TrainedModelAssignment existingAssignment,
+        Set<String> shuttingDownNodeIds,
+        TrainedModelAssignment.Builder assignmentBuilder
+    ) {
+        for (String nodeId : shuttingDownNodeIds) {
+            if (existingAssignment.isRoutedToNode(nodeId)
+                && existingAssignment.getNodeRoutingTable().get(nodeId).getState().isAnyOf(RoutingState.STARTED, RoutingState.STARTING)) {
+                logger.debug(
+                    () -> format(
+                        "Found assignment deployment id: [%s] with route to shutting down node id: [%s], adding stopping route",
+                        existingAssignment.getDeploymentId(),
+                        nodeId
+                    )
+                );
+                assignmentBuilder.addOrOverwriteRoutingEntry(
+                    nodeId,
+                    createShuttingDownRoute(existingAssignment.getNodeRoutingTable().get(nodeId))
+                );
+            }
+        }
     }
 
     private void checkModelIsFullyAllocatedIfScalingIsNotPossible(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
@@ -90,6 +90,7 @@ import static org.elasticsearch.core.Strings.format;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -1963,6 +1964,110 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         assertThat(assignment.getNodeRoutingTable().get(shuttingDownNodeId).getState(), is(RoutingState.STOPPING));
         assertThat(assignment.getReason().isPresent(), is(true));
         assertThat(assignment.getReason().get(), is("nodes changed"));
+    }
+
+    public void testSetShuttingDownNodeRoutesToStopping_GivenZeroAllocationAssignmentMissingFromBuilder_ItIsPreserved() {
+        var shuttingDownNodeId = "shutting-down-1";
+        var zeroAllocDeploymentId = "zero-alloc-deployment";
+        // Use 0 allocations so calculateAssignmentState() returns STARTED (matching the production state
+        // of a deployment that adaptive allocations has scaled down to zero)
+        StartTrainedModelDeploymentAction.TaskParams taskParams = newParams(zeroAllocDeploymentId, 100, 0, 1);
+
+        // Existing cluster state: a zero-allocation deployment (no routing entries, STARTED state)
+        TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                zeroAllocDeploymentId,
+                TrainedModelAssignment.Builder.empty(taskParams, null).calculateAndSetAssignmentState()
+            )
+            .build();
+
+        // Rebalancer output: empty (simulates the anomaly — rebalancer dropped the deployment)
+        TrainedModelAssignmentMetadata.Builder rebalanced = TrainedModelAssignmentMetadata.Builder.empty();
+
+        TrainedModelAssignmentMetadata result = TrainedModelAssignmentClusterService.setShuttingDownNodeRoutesToStopping(
+            currentMetadata,
+            Set.of(shuttingDownNodeId),
+            rebalanced
+        ).build();
+
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(zeroAllocDeploymentId);
+        assertThat("zero-allocation deployment must not be silently dropped", assignment, is(notNullValue()));
+        assertThat(assignment.getNodeRoutingTable().entrySet(), is(empty()));
+        // The assignment state should be preserved as STARTED (not STOPPING) for zero-alloc deployments
+        assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTED));
+    }
+
+    public void testSetShuttingDownNodeRoutesToStopping_GivenZeroAllocationAssignmentPresentInBuilder_ItIsNotOverwritten() {
+        var shuttingDownNodeId = "shutting-down-1";
+        var zeroAllocDeploymentId = "zero-alloc-deployment";
+        var currentSentinelReason = "reason-from-current-metadata";
+        var rebalancedSentinelReason = "reason-from-rebalancer";
+        StartTrainedModelDeploymentAction.TaskParams taskParams = newParams(zeroAllocDeploymentId, 100, 0, 1);
+
+        // Sentinel on the current-metadata version so we can detect if the fast path
+        // accidentally overwrites the rebalancer's version with this one.
+        TrainedModelAssignment.Builder currentBuilder = TrainedModelAssignment.Builder.empty(taskParams, null)
+            .setReason(currentSentinelReason)
+            .calculateAndSetAssignmentState();
+        TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(zeroAllocDeploymentId, currentBuilder)
+            .build();
+
+        // Rebalancer output already contains the zero-allocation deployment — tagged with a distinct
+        // sentinel reason so the assertion can prove the rebalancer's version survived untouched.
+        TrainedModelAssignmentMetadata.Builder rebalanced = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                zeroAllocDeploymentId,
+                TrainedModelAssignment.Builder.empty(taskParams, null).setReason(rebalancedSentinelReason).calculateAndSetAssignmentState()
+            );
+
+        TrainedModelAssignmentMetadata result = TrainedModelAssignmentClusterService.setShuttingDownNodeRoutesToStopping(
+            currentMetadata,
+            Set.of(shuttingDownNodeId),
+            rebalanced
+        ).build();
+
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(zeroAllocDeploymentId);
+        assertThat(assignment, is(notNullValue()));
+        assertThat(assignment.getNodeRoutingTable().entrySet(), is(empty()));
+        assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTED));
+        // The rebalancer's version must win — the fast path must not overwrite it with currentMetadata's version.
+        assertThat(assignment.getReason(), equalTo(Optional.of(rebalancedSentinelReason)));
+    }
+
+    public void testSetShuttingDownNodeRoutesToStopping_GivenAnomalyAssignmentWithNoShuttingDownRoutes_ItIsStillPreserved() {
+        var shuttingDownNodeId = "shutting-down-1";
+        var healthyNodeId = "node-1";
+        var deploymentId = "deployment-routed-to-healthy-node";
+        StartTrainedModelDeploymentAction.TaskParams taskParams = newParams(deploymentId, 100);
+
+        // Assignment has a route to a healthy node only (not the shutting-down node)
+        TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                deploymentId,
+                TrainedModelAssignment.Builder.empty(taskParams, null)
+                    .addRoutingEntry(healthyNodeId, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            )
+            .build();
+
+        // Rebalancer output: empty (anomaly — rebalancer dropped the deployment)
+        TrainedModelAssignmentMetadata.Builder rebalanced = TrainedModelAssignmentMetadata.Builder.empty();
+
+        TrainedModelAssignmentMetadata result = TrainedModelAssignmentClusterService.setShuttingDownNodeRoutesToStopping(
+            currentMetadata,
+            Set.of(shuttingDownNodeId),
+            rebalanced
+        ).build();
+
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(deploymentId);
+        assertThat("deployment routed only to healthy nodes must not be dropped by the anomaly branch", assignment, is(notNullValue()));
+        assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STOPPING));
+        assertThat(
+            "healthy-node route must be preserved so the node service can drain it on the next reconciliation",
+            assignment.getNodeRoutingTable(),
+            hasKey(healthyNodeId)
+        );
+        assertThat(assignment.getNodeRoutingTable().get(healthyNodeId).getState(), equalTo(RoutingState.STARTED));
     }
 
     private static ClusterState createClusterState(List<String> nodeIds, Metadata metadata) {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [ML] Preserve zero-allocation trained-model deployments in cluster state during ML-node shutdown rebalances (#146910)