### PR TITLE
Fix misplaced bracket in ECS v1 CISCOFW733100 grok pattern

### DIFF
--- a/docs/changelog/147313.yaml
+++ b/docs/changelog/147313.yaml
@@ -1,0 +1,6 @@
+pr: 147313
+summary: Fix misplaced bracket in ECS v1 CISCOFW733100 grok pattern
+area: Ingest Node
+type: bug
+issues:
+ - 143332

--- a/libs/grok/src/main/resources/patterns/ecs-v1/firewalls
+++ b/libs/grok/src/main/resources/patterns/ecs-v1/firewalls
@@ -89,7 +89,7 @@ CISCOFW710001_710002_710003_710005_710006 %{WORD:cisco.asa.network.transport} (?
 # ASA-6-713172
 CISCOFW713172 Group = %{DATA:cisco.asa.source.group}, IP = %{IP:source.ip}, Automatic NAT Detection Status:\s+Remote end\s*%{DATA:@metadata.cisco.asa.remote_nat}\s*behind a NAT device\s+This\s+end\s*%{DATA:@metadata.cisco.asa.local_nat}\s*behind a NAT device
 # ASA-4-733100
-CISCOFW733100 \\s*%{DATA:[cisco.asa.burst.object}\s*\] drop %{DATA:cisco.asa.burst.id} exceeded. Current burst rate is %{INT:cisco.asa.burst.current_rate:int} per second, max configured rate is %{INT:cisco.asa.burst.configured_rate:int}; Current average rate is %{INT:cisco.asa.burst.avg_rate:int} per second, max configured rate is %{INT:cisco.asa.burst.configured_avg_rate:int}; Cumulative total count is %{INT:cisco.asa.burst.cumulative_count:int}
+CISCOFW733100 \[\s*%{DATA:cisco.asa.burst.object}\s*\] drop %{DATA:cisco.asa.burst.id} exceeded. Current burst rate is %{INT:cisco.asa.burst.current_rate:int} per second, max configured rate is %{INT:cisco.asa.burst.configured_rate:int}; Current average rate is %{INT:cisco.asa.burst.avg_rate:int} per second, max configured rate is %{INT:cisco.asa.burst.configured_avg_rate:int}; Cumulative total count is %{INT:cisco.asa.burst.cumulative_count:int}
 #== End Cisco ASA ==
 
 

--- a/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
+++ b/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
@@ -905,6 +905,60 @@ public class GrokTests extends ESTestCase {
         assertThat(combined, equalTo("(?<_ingest._grok_match_index.0>foo)|(?<_ingest._grok_match_index.1>bar)"));
     }
 
+    public void testCiscoAsaBurstRateLimitEcsV1Pattern() {
+        Grok grok = new Grok(GrokBuiltinPatterns.get(true), "%{CISCOFW733100}", logger::warn);
+        Map<String, Object> captures = grok.captures(
+            "[ Scanning] drop rate-1 exceeded. Current burst rate is 19 per second, max configured rate is 10;"
+                + " Current average rate is 9 per second, max configured rate is 5; Cumulative total count is 5538"
+        );
+        assertThat(captures, equalTo(Map.ofEntries(
+            Map.entry("cisco.asa.burst.object", "Scanning"),
+            Map.entry("cisco.asa.burst.id", "rate-1"),
+            Map.entry("cisco.asa.burst.current_rate", 19),
+            Map.entry("cisco.asa.burst.configured_rate", 10),
+            Map.entry("cisco.asa.burst.avg_rate", 9),
+            Map.entry("cisco.asa.burst.configured_avg_rate", 5),
+            Map.entry("cisco.asa.burst.cumulative_count", 5538)
+        )));
+    }
+
+    public void testCiscoAsaBurstRateLimitEcsV1PatternNoLeadingSpace() {
+        Grok grok = new Grok(GrokBuiltinPatterns.get(true), "%{CISCOFW733100}", logger::warn);
+        Map<String, Object> captures = grok.captures(
+            "[Scanning] drop rate-1 exceeded. Current burst rate is 19 per second, max configured rate is 10;"
+                + " Current average rate is 9 per second, max configured rate is 5; Cumulative total count is 5538"
+        );
+        assertThat(captures.get("cisco.asa.burst.object"), equalTo("Scanning"));
+    }
+
+    public void testCiscoAsaBurstRateLimitEcsV1PatternDoesNotMatchWithoutBrackets() {
+        Grok grok = new Grok(GrokBuiltinPatterns.get(true), "%{CISCOFW733100}", logger::warn);
+        assertThat(
+            grok.captures(
+                "Scanning drop rate-1 exceeded. Current burst rate is 19 per second, max configured rate is 10;"
+                    + " Current average rate is 9 per second, max configured rate is 5; Cumulative total count is 5538"
+            ),
+            nullValue()
+        );
+    }
+
+    public void testCiscoAsaBurstRateLimitLegacyPattern() {
+        Grok grok = new Grok(GrokBuiltinPatterns.get(false), "%{CISCOFW733100}", logger::warn);
+        Map<String, Object> captures = grok.captures(
+            "[ Scanning] drop rate-1 exceeded. Current burst rate is 19 per second, max configured rate is 10;"
+                + " Current average rate is 9 per second, max configured rate is 5; Cumulative total count is 5538"
+        );
+        assertThat(captures, equalTo(Map.ofEntries(
+            Map.entry("drop_type", "Scanning"),
+            Map.entry("drop_rate_id", "rate-1"),
+            Map.entry("drop_rate_current_burst", "19"),
+            Map.entry("drop_rate_max_burst", "10"),
+            Map.entry("drop_rate_current_avg", "9"),
+            Map.entry("drop_rate_max_avg", "5"),
+            Map.entry("drop_total_count", "5538")
+        )));
+    }
+
     private void assertGrokedField(String fieldName) {
         String line = "foo";
         // test both with and without ECS compatibility


### PR DESCRIPTION
## Problem

The ECS v1 grok pattern `CISCOFW733100` never matches valid Cisco ASA message 733100 lines. Any `%ASA-*-733100: [ ... ] drop rate-* exceeded. ...` message tags as `_grokparsefailure` instead of extracting the `cisco.asa.burst.*` fields, as reported in #143332.

## Root Cause

In `libs/grok/src/main/resources/patterns/ecs-v1/firewalls` line 92 the pattern is written as:

```
CISCOFW733100 \\s*%{DATA:[cisco.asa.burst.object}\s*\] drop ...
```

Two issues:
- `\\s*` is a literal backslash followed by `s*`, not `\[\s*` — the opening bracket expected by the sample input was replaced with an escaped backslash.
- `%{DATA:[cisco.asa.burst.object}` injects the `[` into the capture-field name, producing a malformed grok reference.

The legacy variant of the same pattern (line 83 of `libs/grok/src/main/resources/patterns/legacy/firewalls`) already has the correct form: `\[\s*%{DATA:drop_type}\s*\]`.

## Fix

- `libs/grok/src/main/resources/patterns/ecs-v1/firewalls`: rewrite the prefix to `\[\s*%{DATA:cisco.asa.burst.object}\s*\] drop ...`, mirroring the legacy pattern's structure while keeping the ECS v1 field name `cisco.asa.burst.object`.

## Tests Added

| Change Point | Test |
|---|---|
| Fix prefix so ECS v1 CISCOFW733100 parses rate-limit drop messages | `testCiscoAsaBurstRateLimitEcsV1Pattern` — full-match assertion on the sample log line from #143332 with all seven `cisco.asa.burst.*` captures (Integers where `:int` coercion is declared) |
| Boundary: optional whitespace inside brackets | `testCiscoAsaBurstRateLimitEcsV1PatternNoLeadingSpace` — `[Scanning]` (no space) still matches because `\s*` allows zero |
| Negative: missing brackets must not match | `testCiscoAsaBurstRateLimitEcsV1PatternDoesNotMatchWithoutBrackets` — bare `Scanning drop ...` returns null |
| Regression: legacy pattern unchanged | `testCiscoAsaBurstRateLimitLegacyPattern` — identical sample input matches legacy's `drop_type`/`drop_rate_*`/`drop_total_count` fields (strings; legacy has no `:int` coercion) |

## Impact

Only the ECS v1 `CISCOFW733100` pattern is modified. No other patterns in the ecs-v1 or legacy firewall banks change. Users relying on `CISCOFW733100` with ECS v1 will now get the documented `cisco.asa.burst.*` fields; users on the legacy pattern are unaffected.

Closes #143332