### PR TITLE
Fix more views exclusions bugs

### DIFF
--- a/docs/changelog/147323.yaml
+++ b/docs/changelog/147323.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147323
+summary: Fix more views exclusions bugs
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -694,9 +694,17 @@ public class ViewResolver {
             LogicalPlan inner = (value instanceof NamedSubquery ns) ? ns.child() : value;
             hasInnerFork = true;
             if (inner instanceof ViewUnionAll innerVua) {
-                // Named branches from inner ViewUnionAll: lift with their own names
+                // Named branches from inner ViewUnionAll: lift with their own names. A bare UR with
+                // an exclusion must be wrapped in a NamedSubquery before lifting — otherwise the
+                // subsequent merge step would concatenate its pattern list with a sibling outer UR,
+                // widening the exclusion's scope beyond the inner view body it came from.
                 for (Map.Entry<String, LogicalPlan> innerEntry : innerVua.namedSubqueries().entrySet()) {
-                    flat.put(makeUniqueKey(flat, innerEntry.getKey()), innerEntry.getValue());
+                    String innerKey = innerEntry.getKey();
+                    LogicalPlan innerValue = innerEntry.getValue();
+                    if (innerValue instanceof UnresolvedRelation innerUr && containsExclusion(innerUr)) {
+                        innerValue = new NamedSubquery(innerUr.source(), innerUr, innerKey);
+                    }
+                    flat.put(makeUniqueKey(flat, innerKey), innerValue);
                 }
             } else {
                 // Plain Fork/UnionAll from user-written subqueries: lift children with suffixed parent name

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -707,12 +707,17 @@ public class ViewResolver {
                     flat.put(makeUniqueKey(flat, innerKey), innerValue);
                 }
             } else {
-                // Plain Fork/UnionAll from user-written subqueries: lift children with suffixed parent name
+                // Plain Fork/UnionAll from user-written subqueries: lift children with suffixed parent name.
+                // As in the ViewUnionAll branch above, a bare UR child with an exclusion must be wrapped in
+                // a NamedSubquery before lifting so the subsequent merge step does not widen its scope.
                 Fork fork = (Fork) inner;
                 int childIndex = 1;
                 for (LogicalPlan child : fork.children()) {
                     LogicalPlan unwrapped = (child instanceof Subquery sq) ? sq.child() : child;
                     String childKey = parentKey + "#" + childIndex++;
+                    if (unwrapped instanceof UnresolvedRelation childUr && containsExclusion(childUr)) {
+                        unwrapped = new NamedSubquery(childUr.source(), childUr, childKey);
+                    }
                     flat.put(makeUniqueKey(flat, childKey), unwrapped);
                 }
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -268,6 +268,27 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM view-1-*),(FROM index-2-*,-*a),(FROM view-2-*,index-1-*,-*b)")));
     }
 
+    /**
+     * A user-written subquery inside a view body carries its own scope. When its parent view is
+     * composed with sibling outer patterns, the subquery's exclusion must not widen to the outer
+     * patterns.
+     * <p>
+     * Without the fix in {@code tryFlattenViewUnionAll}'s fork-child branch, the inner subquery's
+     * {@code -*b} would merge with the outer {@code inner-b} pattern and wrongly exclude it.
+     */
+    public void testUserSubqueryExclusionInViewBodyDoesNotLeakToOuter() {
+        assumeTrue("Requires views with branching support", EsqlCapabilities.Cap.VIEWS_WITH_BRANCHING.isEnabled());
+        addIndex("outer-a");
+        addIndex("outer-b");
+        addIndex("inner-a");
+        addIndex("inner-b");
+        addView("my_view", "FROM outer-*, (FROM inner-*,-*b)");
+        LogicalPlan plan = query("FROM my_view, inner-b");
+        // The -*b in the inner subquery must only exclude -*b from matches of inner-*, not from the
+        // outer inner-b pattern. Each scope-carrying UR stays in its own branch.
+        assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM inner-b,outer-*),(FROM inner-*,-*b)")));
+    }
+
     public void testExclusionMultipleViews() {
         addView("view1", "FROM emp1");
         addView("view2", "FROM emp2");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -226,6 +226,48 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM index-a*),(FROM index-b*,-*2)")));
     }
 
+    /**
+     * Reproduces the bug where an inner view's exclusion leaks to an outer view's sibling indices
+     * across multiple levels of nesting.
+     * <p>
+     * Setup:
+     * <pre>
+     *   indices:    index-1-a, index-1-b, index-2-a, index-2-b,
+     *               view-1-r-a, view-1-r-b, view-2-r-a, view-2-r-b
+     *   view-2-l:   FROM index-2-*,-*a          (resolves to index-2-b)
+     *   view-1-l:   FROM view-2-*,index-1-*,-*b (matches view-2-l + view-2-r-*, index-1-*; excludes *b)
+     *   view-0-l:   FROM view-1-*               (matches view-1-l + view-1-r-*)
+     * </pre>
+     * Query: {@code FROM view-0-l}
+     * <p>
+     * The {@code -*b} exclusion in {@code view-1-l}'s body must stay scoped to {@code view-1-l} —
+     * it must not leak to the outer {@code view-0-l} and cause {@code view-1-r-b} to be excluded.
+     * <p>
+     * The single-level case is covered by {@link #testViewBodyExclusionNotLeakedToOuter}. In the
+     * nested case the view-flattening path in {@code ViewResolver.tryFlattenViewUnionAll} would
+     * lift the inner ViewUnionAll's entries (ViewUnionAll extends UnionAll extends Fork, which
+     * triggers the fork-flattening branch) and then merge their bare URs with sibling outer URs,
+     * re-widening the exclusion's scope. The fix wraps exclusion-bearing URs in a NamedSubquery
+     * before lifting so the subsequent merge step leaves them alone.
+     */
+    public void testViewBodyExclusionNotLeakedThroughNestedViews() {
+        addIndex("index-1-a");
+        addIndex("index-1-b");
+        addIndex("index-2-a");
+        addIndex("index-2-b");
+        addIndex("view-1-r-a");
+        addIndex("view-1-r-b");
+        addIndex("view-2-r-a");
+        addIndex("view-2-r-b");
+        addView("view-2-l", "FROM index-2-*,-*a");
+        addView("view-1-l", "FROM view-2-*,index-1-*,-*b");
+        addView("view-0-l", "FROM view-1-*");
+        LogicalPlan plan = query("FROM view-0-l");
+        // The inner -*b exclusion must stay scoped to view-1-l's body, not widen to view-0-l's
+        // sibling view-1-r-* indices. Each scope-carrying UR stays in its own branch.
+        assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM view-1-*),(FROM index-2-*,-*a),(FROM view-2-*,index-1-*,-*b)")));
+    }
+
     public void testExclusionMultipleViews() {
         addView("view1", "FROM emp1");
         addView("view2", "FROM emp2");


### PR DESCRIPTION
A recent fix for exclusions leaking into other index patterns was done in https://github.com/elastic/elasticsearch/pull/146664. However, it turns out this did not cover all cases.

So this PR expands the range of the fix to three cases, in all cases it acts by blocking compaction:
1- original fix blocked compaction when a view resolves with a plain index (already merged in #146664)
2- fix blocking compaction with nested view resolution (this PR)
3- another fix blocking compaction with nested subquery (and even FORK) resolution (also this PR)

At this point it appears we have blocked all places where exclusions could be compacted.
It is likely that many of the cases we have now blocked would actually fail with the nested-subqueries are not allowed error, which is completely fine in my mind. Certainly better than the query succeeding, but resulting in incorrect results.