### PR TITLE
[ES|QL] Pass request_time_filter to CsvIT and unmute TSTEP tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -445,27 +445,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=index/100_field_name_length_limit/Test field name length limit array}
   issue: https://github.com/elastic/elasticsearch/issues/147205
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:tstep.docs_tstep_by_one_hour_duration_as_string}
-  issue: https://github.com/elastic/elasticsearch/issues/147228
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:tstep.tstep_by_ten_minutes_duration}
-  issue: https://github.com/elastic/elasticsearch/issues/147228
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:k8s-timeseries-sum-over-time.sum_over_time_with_tstep_window}
-  issue: https://github.com/elastic/elasticsearch/issues/147228
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:tstep.tstep_with_timezone_and_duration}
-  issue: https://github.com/elastic/elasticsearch/issues/147228
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:tstep.docs_tstep_by_one_hour_duration}
-  issue: https://github.com/elastic/elasticsearch/issues/147228
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:tstep.tstep_by_ten_minutes_duration_as_string}
-  issue: https://github.com/elastic/elasticsearch/issues/147228
-- class: org.elasticsearch.xpack.esql.CsvIT
-  method: test {csv-spec:tstep.tstep_with_request_timestamp_bounds_only}
-  issue: https://github.com/elastic/elasticsearch/issues/147228
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/KNN Vector similarity search only}
   issue: https://github.com/elastic/elasticsearch/issues/147251

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -411,9 +411,9 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         query = maybeRandomizeQuery(query);
 
         RequestObjectBuilder builder = new RequestObjectBuilder(randomFrom(XContentType.values()));
-        if (Strings.isNullOrEmpty(testCase.timestampBoundsGte) == false) {
-            String gte = testCase.timestampBoundsGte;
-            String lte = testCase.timestampBoundsLte;
+        if (Strings.isNullOrEmpty(testCase.requestTimeRangeGte) == false) {
+            String gte = testCase.requestTimeRangeGte;
+            String lte = testCase.requestTimeRangeLte;
             builder.filter(b -> {
                 b.startObject("range");
                 b.startObject("@timestamp");

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvSpecReader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvSpecReader.java
@@ -44,8 +44,8 @@ public final class CsvSpecReader {
         private final List<String> requiredCapabilities = new ArrayList<>();
         private final List<SpecReader.Parser> optionParsers = new ArrayList<>();
         WhenLoadsRequestedToStored requestStored = WhenLoadsRequestedToStored.IGNORE_VALUE_ORDER;
-        String timestampBoundsGte;
-        String timestampBoundsLte;
+        String requestTimeRangeGte;
+        String requestTimeRangeLte;
         CsvTestCase testCase;
 
         private ParserContext() {}
@@ -74,12 +74,12 @@ public final class CsvSpecReader {
                 testCase.query = query.toString();
                 testCase.requiredCapabilities = List.copyOf(requiredCapabilities);
                 testCase.requestStored = requestStored;
-                testCase.timestampBoundsGte = timestampBoundsGte;
-                testCase.timestampBoundsLte = timestampBoundsLte;
+                testCase.requestTimeRangeGte = requestTimeRangeGte;
+                testCase.requestTimeRangeLte = requestTimeRangeLte;
                 requiredCapabilities.clear();
                 requestStored = WhenLoadsRequestedToStored.IGNORE_VALUE_ORDER;
-                timestampBoundsGte = null;
-                timestampBoundsLte = null;
+                requestTimeRangeGte = null;
+                requestTimeRangeLte = null;
                 query.setLength(0);
             } else {
                 query.append(line).append("\r\n");
@@ -147,9 +147,9 @@ public final class CsvSpecReader {
                         "request_time_filter must be two ISO-8601 instants separated by a comma: [" + value + "]"
                     );
                 }
-                state.timestampBoundsGte = value.substring(0, comma).trim();
-                state.timestampBoundsLte = value.substring(comma + 1).trim();
-                if (state.timestampBoundsGte.isEmpty() || state.timestampBoundsLte.isEmpty()) {
+                state.requestTimeRangeGte = value.substring(0, comma).trim();
+                state.requestTimeRangeLte = value.substring(comma + 1).trim();
+                if (state.requestTimeRangeGte.isEmpty() || state.requestTimeRangeLte.isEmpty()) {
                     throw new IllegalArgumentException("request_time_filter values must not be empty: [" + value + "]");
                 }
                 return Boolean.TRUE;
@@ -226,8 +226,8 @@ public final class CsvSpecReader {
          * When set from a {@code timestamp_bounds:} line in the expected-results section, the REST request includes
          * a Query DSL range on {@code @timestamp} with these bounds (inclusive).
          */
-        public String timestampBoundsGte;
-        public String timestampBoundsLte;
+        public String requestTimeRangeGte;
+        public String requestTimeRangeLte;
 
         /**
          * Returns the warning headers expected to be added by the test. To declare such a header, use the `warning:definition` format

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/CsvIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
 import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
+import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.ingest.common.IngestCommonPlugin;
 import org.elasticsearch.license.License;
@@ -240,6 +241,9 @@ public class CsvIT extends ESTestCase {
         views.ensureNoFailures();
 
         var request = syncEsqlQueryRequest(testCase.query);
+        if (testCase.requestTimeRangeGte != null && testCase.requestTimeRangeGte.isEmpty() == false) {
+            request.filter(new RangeQueryBuilder("@timestamp").gte(testCase.requestTimeRangeGte).lte(testCase.requestTimeRangeLte));
+        }
         var listener = new ResponseListener(cluster.getInstance(TransportService.class).getThreadPool());
         cluster.client().execute(EsqlQueryAction.INSTANCE, request, listener);
         // Using a longer timeout here as test infrastructure might populate data lazily while request is in progress.


### PR DESCRIPTION
`CsvIT` is not passing `request_time_filter` directive as a DSL query filter on the `EsqlQueryRequest`. All tests that rely on request-time `@timestamp` range therefore fail consistently. 