### PR TITLE
Return aggregate_metric_double fields from _field_caps when populated

### DIFF
--- a/docs/changelog/147325.yaml
+++ b/docs/changelog/147325.yaml
@@ -1,0 +1,6 @@
+pr: 147325
+summary: Return `aggregate_metric_double` fields from `_field_caps` when populated
+area: Mapping
+type: bug
+issues:
+ - 142139

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.aggregatemetric.mapper;
 
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
@@ -318,6 +319,18 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
         public Query existsQuery(SearchExecutionContext context) {
             assert metricFields.isEmpty() == false : "aggregate metric double should have at least one metric defined";
             return metricFields.values().iterator().next().existsQuery(context);
+        }
+
+        @Override
+        public boolean fieldHasValue(FieldInfos fieldInfos) {
+            // aggregate_metric_double has no lucene field under its own name; each configured metric is stored in a
+            // dedicated "<name>.<metric>" subfield. Report the field as non-empty if any configured metric subfield is present.
+            for (NumberFieldMapper.NumberFieldType subField : metricFields.values()) {
+                if (fieldInfos.fieldInfo(subField.name()) != null) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldTypeTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldTypeTests.java
@@ -10,6 +10,8 @@ import org.apache.lucene.document.DoubleField;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -65,6 +67,48 @@ public class AggregateMetricDoubleFieldTypeTests extends FieldTypeTestCase {
             metricFields.put(m, subfield);
         }
         return new AggregateMetricDoubleFieldType(name, null, metricFields, meta);
+    }
+
+    @Override
+    public MappedFieldType getMappedFieldType() {
+        return createDefaultFieldType("agg_metric", Collections.emptyMap());
+    }
+
+    @Override
+    public void testFieldHasValue() {
+        AggregateMetricDoubleFieldType fieldType = createDefaultFieldType("agg_metric", Collections.emptyMap());
+        // Any configured metric subfield being present in FieldInfos means the aggregate field has a value.
+        FieldInfos fieldInfos = new FieldInfos(
+            new FieldInfo[] { getFieldInfoWithName(subfieldName("agg_metric", randomFrom(Metric.values()))) }
+        );
+        assertTrue(fieldType.fieldHasValue(fieldInfos));
+    }
+
+    public void testFieldHasValueWhenOnlyUnrelatedFieldsArePresent() {
+        AggregateMetricDoubleFieldType fieldType = createDefaultFieldType("agg_metric", Collections.emptyMap());
+        // The parent name on its own and unrelated fields should not count as the aggregate field having a value.
+        FieldInfos fieldInfos = new FieldInfos(
+            new FieldInfo[] { getFieldInfoWithName("agg_metric"), getFieldInfoWithName("another_field") }
+        );
+        assertFalse(fieldType.fieldHasValue(fieldInfos));
+    }
+
+    public void testFieldHasValueWithSingleMetricConfigured() {
+        Metric singleMetric = randomFrom(Metric.values());
+        AggregateMetricDoubleFieldType fieldType = createFieldType("agg_metric", Collections.emptyMap(), singleMetric);
+        // The single configured metric's subfield is present.
+        assertTrue(
+            fieldType.fieldHasValue(
+                new FieldInfos(new FieldInfo[] { getFieldInfoWithName(subfieldName("agg_metric", singleMetric)) })
+            )
+        );
+        // A different metric's subfield (not configured on this field type) does not count.
+        Metric otherMetric = randomValueOtherThan(singleMetric, () -> randomFrom(Metric.values()));
+        assertFalse(
+            fieldType.fieldHasValue(
+                new FieldInfos(new FieldInfo[] { getFieldInfoWithName(subfieldName("agg_metric", otherMetric)) })
+            )
+        );
     }
 
     public void testTermQuery() {


### PR DESCRIPTION
## Problem

`GET /<index>/_field_caps?include_empty_fields=false` drops `aggregate_metric_double` fields even when they are populated in the index, as reported in #142139. Reproducer from the issue:

```
PUT stats-index
{ "mappings": { "properties": { "agg_metric": { "type": "aggregate_metric_double",
    "metrics": ["min","max","sum","value_count"], "default_metric": "max" } } } }

PUT stats-index/_doc/1
{ "agg_metric": { "min": -302.50, "max": 702.30, "sum": 200.0, "value_count": 25 } }

GET stats-index/_field_caps?fields=agg_metric&include_empty_fields=false
→ { "indices": ["stats-index"], "fields": {} }
```

## Root Cause

`FieldCapabilitiesFetcher.retrieveFieldCaps` gates each field on `MappedFieldType#fieldHasValue(FieldInfos)` when `include_empty_fields=false`. The default implementation in `MappedFieldType` is:

```java
public boolean fieldHasValue(FieldInfos fieldInfos) {
    return fieldInfos.fieldInfo(name()) != null;
}
```

`aggregate_metric_double` never writes a Lucene field under its parent name — each configured metric is stored in a dedicated subfield named `<parent>.<metric>` (e.g. `agg_metric.max`). The default lookup of `fieldInfos.fieldInfo("agg_metric")` therefore always returns `null`, and the field is filtered out.

## Fix

Override `fieldHasValue(FieldInfos)` in `AggregateMetricDoubleFieldType` to return `true` if any of the configured metric subfields is present in `FieldInfos`:

```java
@Override
public boolean fieldHasValue(FieldInfos fieldInfos) {
    for (NumberFieldMapper.NumberFieldType subField : metricFields.values()) {
        if (fieldInfos.fieldInfo(subField.name()) != null) {
            return true;
        }
    }
    return false;
}
```

Only configured metric subfields count — an unrelated field with the same prefix or the parent name on its own does not.

## Tests Added

| Change point | Test |
|---|---|
| Override returns `true` when a configured metric subfield is in `FieldInfos` | `testFieldHasValue` (overrides base class) — builds `FieldInfos` containing one random metric subfield and asserts `true` |
| Override returns `false` when only the parent name or unrelated fields are present | `testFieldHasValueWhenOnlyUnrelatedFieldsArePresent` |
| Override respects the set of configured metrics | `testFieldHasValueWithSingleMetricConfigured` — asserts the configured metric counts, a non-configured metric does not |
| Empty `FieldInfos` still returns `false` | Inherited `testFieldHasValueWithEmptyFieldInfos` from `FieldTypeTestCase`, now wired to the aggregate field type via overridden `getMappedFieldType()` |

## Impact

Only `AggregateMetricDoubleFieldType.fieldHasValue` changes. The implementations of `mayExistInIndex`, `existsQuery`, `termQuery`, `termsQuery`, `rangeQuery`, and field-data handling are untouched. The wire and response formats of `_field_caps` do not change; the only observable effect is that a populated `aggregate_metric_double` field now appears in the response when `include_empty_fields=false`, matching the documented behaviour for other field types.

Closes #142139