### PR TITLE
[9.4] Fixing lookup test failures (#147326)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/260_knn_lookup_query_builder.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/260_knn_lookup_query_builder.yml
@@ -1,6 +1,6 @@
 setup:
   - requires:
-      cluster_features: "mapper.base64_dense_vectors"
+      cluster_features: ["mapper.base64_dense_vectors", "search.vectors.lookup_query_vector_builder"]
       reason: 'search.vectors.lookup_query_vector_builder'
 
 # one index with excluded vectors, with bytes, floats, bits and bfloats16


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fixing lookup test failures (#147326)](https://github.com/elastic/elasticsearch/pull/147326)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)