### PR TITLE
Disable benchmark trigger

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -176,6 +176,7 @@ spec:
           branch: main
           cronline: "0 6 * * * UTC"
           message: "Check for new java pre release build 1x per day"
+          enabled: false
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
JDK27 ea currently fails during benchmark runs. A new ASM is needed; but not yet available. Disabling until asm can be bumped to be compatible with jdk27ea 