### PR TITLE
ES|QL|DS: route FROM dataset through the EXTERNAL pipeline (Phase 1)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.cluster.metadata.DataSourceMetadata;
+import org.elasticsearch.cluster.metadata.DataSourceSetting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.ExtensiblePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.dataset.DeleteDatasetAction;
+import org.elasticsearch.xpack.esql.datasources.dataset.PutDatasetAction;
+import org.elasticsearch.xpack.esql.datasources.datasource.DeleteDataSourceAction;
+import org.elasticsearch.xpack.esql.datasources.datasource.PutDataSourceAction;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourceValidator;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * End-to-end integration for {@code FROM <dataset>}: creates a data source and a dataset via the
+ * CRUD API, both pointing at a local CSV fixture, and runs a {@code FROM <name>} query against
+ * them. Proves that the parser → dataset rewriter → external-source resolver → analyzer →
+ * execution pipeline wires up the way the PR description claims.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false, minNumDataNodes = 1)
+public class FromDatasetIT extends AbstractEsqlIntegTestCase {
+
+    private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(30);
+    private Path csvFixture;
+
+    public static final class EsqlEnterpriseWithDatasourceExtensions extends EsqlPluginWithEnterpriseOrTrialLicense {
+        @Override
+        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
+            super.loadExtensions(loader);
+        }
+    }
+
+    /** Minimal pass-through validator registered for type {@code test}; accepts any resource scheme. */
+    public static final class TestDataSourcePlugin extends Plugin implements DataSourcePlugin {
+        @Override
+        public Map<String, DataSourceValidator> datasourceValidators(Settings settings) {
+            return Map.of("test", new TestValidator());
+        }
+    }
+
+    private static final class TestValidator implements DataSourceValidator {
+        @Override
+        public String type() {
+            return "test";
+        }
+
+        @Override
+        public Map<String, DataSourceSetting> validateDatasource(Map<String, Object> datasourceSettings) {
+            Map<String, DataSourceSetting> out = new HashMap<>();
+            for (Map.Entry<String, Object> e : datasourceSettings.entrySet()) {
+                out.put(e.getKey(), new DataSourceSetting(e.getValue(), e.getKey().startsWith("secret_")));
+            }
+            return out;
+        }
+
+        @Override
+        public Map<String, Object> validateDataset(
+            Map<String, DataSourceSetting> datasourceSettings,
+            String resource,
+            Map<String, Object> datasetSettings
+        ) {
+            return datasetSettings == null ? Map.of() : new HashMap<>(datasetSettings);
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.remove(EsqlPluginWithEnterpriseOrTrialLicense.class);
+        plugins.add(EsqlEnterpriseWithDatasourceExtensions.class);
+        plugins.add(HttpDataSourcePlugin.class);
+        plugins.add(CsvDataSourcePlugin.class);
+        plugins.add(TestDataSourcePlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
+
+    @Before
+    public void writeFixture() throws IOException {
+        csvFixture = createTempFile("dataset-fixture-", ".csv");
+        Files.writeString(csvFixture, String.join("\n", "emp_no:integer,first_name:keyword", "1,Alice", "2,Bob", "3,Carol") + "\n");
+    }
+
+    @After
+    public void cleanupRegistry() throws Exception {
+        try {
+            client().execute(DeleteDatasetAction.INSTANCE, deleteDatasetRequest("employees"))
+                .get(30, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception ignored) {}
+        try {
+            client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest("local_ds"))
+                .get(30, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception ignored) {}
+    }
+
+    public void testFromDatasetReadsCsvFixture() throws Exception {
+        assumeTrue("requires external data sources feature flag", DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                putDatasetRequest("employees", "local_ds", csvFixture.toUri().toString(), Map.of("format", "csv"))
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM employees | SORT emp_no | LIMIT 10"), TIMEOUT)) {
+            List<? extends ColumnInfo> columns = response.columns();
+            assertThat(columns, hasSize(2));
+            assertThat(columns.get(0).name(), equalTo("emp_no"));
+            assertThat(columns.get(1).name(), equalTo("first_name"));
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(3));
+            assertThat(rows.get(0).get(0), equalTo(1));
+            assertThat(rows.get(0).get(1).toString(), equalTo("Alice"));
+            assertThat(rows.get(1).get(0), equalTo(2));
+            assertThat(rows.get(1).get(1).toString(), equalTo("Bob"));
+            assertThat(rows.get(2).get(0), equalTo(3));
+            assertThat(rows.get(2).get(1).toString(), equalTo("Carol"));
+        }
+    }
+
+    public void testFromMixedIndexAndDatasetRejected() throws Exception {
+        assumeTrue("requires external data sources feature flag", DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                putDatasetRequest("employees", "local_ds", csvFixture.toUri().toString(), Map.of("format", "csv"))
+            )
+        );
+
+        Exception ex = expectThrows(Exception.class, () -> run(syncEsqlQueryRequest("FROM some_real_index, employees | LIMIT 1"), TIMEOUT));
+        Throwable cause = ex;
+        while (cause != null && cause.getMessage() != null && cause.getMessage().contains("mixing indices and datasets") == false) {
+            cause = cause.getCause();
+        }
+        assertThat("error chain should contain Phase-1 mix-rejection", cause, org.hamcrest.Matchers.notNullValue());
+    }
+
+    private static PutDataSourceAction.Request putDataSourceRequest(String name, Map<String, Object> settings) {
+        return new PutDataSourceAction.Request(TIMEOUT, TIMEOUT, name, "test", null, new HashMap<>(settings));
+    }
+
+    private static PutDatasetAction.Request putDatasetRequest(
+        String name,
+        String dataSource,
+        String resource,
+        Map<String, Object> settings
+    ) {
+        return new PutDatasetAction.Request(TIMEOUT, TIMEOUT, name, dataSource, resource, null, new HashMap<>(settings));
+    }
+
+    private static DeleteDataSourceAction.Request deleteDataSourceRequest(String name) {
+        return new DeleteDataSourceAction.Request(TIMEOUT, TIMEOUT, new String[] { name });
+    }
+
+    private static DeleteDatasetAction.Request deleteDatasetRequest(String name) {
+        return new DeleteDatasetAction.Request(TIMEOUT, TIMEOUT, new String[] { name });
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -168,8 +168,87 @@ public class FromDatasetIT extends AbstractEsqlIntegTestCase {
 
     public void testFromMixedIndexAndDataset() throws Exception {
         assumeTrue("requires external data sources feature flag", DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        setupMixedSources();
 
-        // Seed a real ES index with a single compatible row.
+        try (var response = run(syncEsqlQueryRequest("FROM local_emps,employees | SORT emp_no"), TIMEOUT)) {
+            List<? extends ColumnInfo> columns = response.columns();
+            assertThat(columns, hasSize(2));
+            assertThat(columns.get(0).name(), equalTo("emp_no"));
+            assertThat(columns.get(1).name(), equalTo("first_name"));
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(4));
+            // CSV dataset rows (1,2,3) + one ES index row (99)
+            assertThat(rows.get(0).get(0), equalTo(1));
+            assertThat(rows.get(1).get(0), equalTo(2));
+            assertThat(rows.get(2).get(0), equalTo(3));
+            assertThat(rows.get(3).get(0), equalTo(99));
+            assertThat(rows.get(3).get(1).toString(), equalTo("Diana"));
+        }
+    }
+
+    public void testFromMixedWithFilter() throws Exception {
+        assumeTrue("requires external data sources feature flag", DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        setupMixedSources();
+
+        // WHERE must filter rows coming out of both branches of the heterogeneous union.
+        try (var response = run(syncEsqlQueryRequest("FROM local_emps,employees | WHERE emp_no >= 2 | SORT emp_no"), TIMEOUT)) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(3));
+            assertThat(rows.get(0).get(0), equalTo(2));
+            assertThat(rows.get(0).get(1).toString(), equalTo("Bob"));
+            assertThat(rows.get(1).get(0), equalTo(3));
+            assertThat(rows.get(2).get(0), equalTo(99));
+        }
+    }
+
+    public void testFromMixedWithCountAggregation() throws Exception {
+        assumeTrue("requires external data sources feature flag", DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        setupMixedSources();
+
+        // COUNT(*) over the union should sum rows from the index + the dataset.
+        try (var response = run(syncEsqlQueryRequest("FROM local_emps,employees | STATS c = COUNT(*)"), TIMEOUT)) {
+            List<? extends ColumnInfo> columns = response.columns();
+            assertThat(columns, hasSize(1));
+            assertThat(columns.get(0).name(), equalTo("c"));
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(1));
+            assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo(4L));
+        }
+    }
+
+    public void testFromMultipleDatasetsAndIndex() throws Exception {
+        assumeTrue("requires external data sources feature flag", DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+        setupMixedSources();
+
+        // Second CSV fixture — different rows, same schema.
+        Path secondFixture = createTempFile("dataset-fixture-2-", ".csv");
+        Files.writeString(secondFixture, String.join("\n", "emp_no:integer,first_name:keyword", "50,Eve", "51,Frank") + "\n");
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                putDatasetRequest("employees_eu", "local_ds", secondFixture.toUri().toString(), Map.of("format", "csv"))
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM local_emps,employees,employees_eu | SORT emp_no"), TIMEOUT)) {
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(6));
+            assertThat(rows.get(0).get(0), equalTo(1));
+            assertThat(rows.get(1).get(0), equalTo(2));
+            assertThat(rows.get(2).get(0), equalTo(3));
+            assertThat(rows.get(3).get(0), equalTo(50));
+            assertThat(rows.get(4).get(0), equalTo(51));
+            assertThat(rows.get(5).get(0), equalTo(99));
+        }
+
+        try {
+            client().execute(DeleteDatasetAction.INSTANCE, deleteDatasetRequest("employees_eu"))
+                .get(30, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception ignored) {}
+    }
+
+    private void setupMixedSources() {
         client().admin().indices().prepareCreate("local_emps").setMapping("emp_no", "type=integer", "first_name", "type=keyword").get();
         client().prepareIndex("local_emps").setSource("emp_no", 99, "first_name", "Diana").setRefreshPolicy(IMMEDIATE).get();
 
@@ -180,22 +259,6 @@ public class FromDatasetIT extends AbstractEsqlIntegTestCase {
                 putDatasetRequest("employees", "local_ds", csvFixture.toUri().toString(), Map.of("format", "csv"))
             )
         );
-
-        try (var response = run(syncEsqlQueryRequest("FROM local_emps,employees | SORT emp_no"), TIMEOUT)) {
-            List<? extends ColumnInfo> columns = response.columns();
-            assertThat(columns, hasSize(2));
-            assertThat(columns.get(0).name(), equalTo("emp_no"));
-            assertThat(columns.get(1).name(), equalTo("first_name"));
-
-            List<List<Object>> rows = getValuesList(response);
-            assertThat(rows, hasSize(4));
-            // rows from the CSV dataset (1..3) + the one row from the ES index (99)
-            assertThat(rows.get(0).get(0), equalTo(1));
-            assertThat(rows.get(1).get(0), equalTo(2));
-            assertThat(rows.get(2).get(0), equalTo(3));
-            assertThat(rows.get(3).get(0), equalTo(99));
-            assertThat(rows.get(3).get(1).toString(), equalTo("Diana"));
-        }
     }
 
     private static PutDataSourceAction.Request putDataSourceRequest(String name, Map<String, Object> settings) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
@@ -22,7 +23,6 @@ import org.elasticsearch.xpack.esql.datasources.datasource.DeleteDataSourceActio
 import org.elasticsearch.xpack.esql.datasources.datasource.PutDataSourceAction;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourceValidator;
-import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.junit.After;
 import org.junit.Before;
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
@@ -48,7 +49,13 @@ import static org.hamcrest.Matchers.hasSize;
  * them. Proves that the parser → dataset rewriter → external-source resolver → analyzer →
  * execution pipeline wires up the way the PR description claims.
  */
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false, minNumDataNodes = 1)
+@ESIntegTestCase.ClusterScope(
+    scope = ESIntegTestCase.Scope.SUITE,
+    numDataNodes = 1,
+    numClientNodes = 0,
+    supportsDedicatedMasters = false,
+    minNumDataNodes = 1
+)
 public class FromDatasetIT extends AbstractEsqlIntegTestCase {
 
     private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(30);
@@ -126,6 +133,9 @@ public class FromDatasetIT extends AbstractEsqlIntegTestCase {
             client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest("local_ds"))
                 .get(30, java.util.concurrent.TimeUnit.SECONDS);
         } catch (Exception ignored) {}
+        try {
+            client().admin().indices().prepareDelete("local_emps").get();
+        } catch (Exception ignored) {}
     }
 
     public void testFromDatasetReadsCsvFixture() throws Exception {
@@ -156,8 +166,12 @@ public class FromDatasetIT extends AbstractEsqlIntegTestCase {
         }
     }
 
-    public void testFromMixedIndexAndDatasetRejected() throws Exception {
+    public void testFromMixedIndexAndDataset() throws Exception {
         assumeTrue("requires external data sources feature flag", DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+
+        // Seed a real ES index with a single compatible row.
+        client().admin().indices().prepareCreate("local_emps").setMapping("emp_no", "type=integer", "first_name", "type=keyword").get();
+        client().prepareIndex("local_emps").setSource("emp_no", 99, "first_name", "Diana").setRefreshPolicy(IMMEDIATE).get();
 
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
         assertAcked(
@@ -167,12 +181,21 @@ public class FromDatasetIT extends AbstractEsqlIntegTestCase {
             )
         );
 
-        Exception ex = expectThrows(Exception.class, () -> run(syncEsqlQueryRequest("FROM some_real_index, employees | LIMIT 1"), TIMEOUT));
-        Throwable cause = ex;
-        while (cause != null && cause.getMessage() != null && cause.getMessage().contains("mixing indices and datasets") == false) {
-            cause = cause.getCause();
+        try (var response = run(syncEsqlQueryRequest("FROM local_emps,employees | SORT emp_no"), TIMEOUT)) {
+            List<? extends ColumnInfo> columns = response.columns();
+            assertThat(columns, hasSize(2));
+            assertThat(columns.get(0).name(), equalTo("emp_no"));
+            assertThat(columns.get(1).name(), equalTo("first_name"));
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(4));
+            // rows from the CSV dataset (1..3) + the one row from the ES index (99)
+            assertThat(rows.get(0).get(0), equalTo(1));
+            assertThat(rows.get(1).get(0), equalTo(2));
+            assertThat(rows.get(2).get(0), equalTo(3));
+            assertThat(rows.get(3).get(0), equalTo(99));
+            assertThat(rows.get(3).get(1).toString(), equalTo("Diana"));
         }
-        assertThat("error chain should contain Phase-1 mix-rejection", cause, org.hamcrest.Matchers.notNullValue());
     }
 
     private static PutDataSourceAction.Request putDataSourceRequest(String name, Map<String, Object> settings) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
@@ -22,7 +23,6 @@ import org.elasticsearch.xpack.esql.datasources.datasource.DeleteDataSourceActio
 import org.elasticsearch.xpack.esql.datasources.datasource.PutDataSourceAction;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourceValidator;
-import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.junit.After;
 import org.junit.Before;
@@ -48,7 +48,13 @@ import static org.hamcrest.Matchers.hasSize;
  * them. Proves that the parser → dataset rewriter → external-source resolver → analyzer →
  * execution pipeline wires up the way the PR description claims.
  */
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false, minNumDataNodes = 1)
+@ESIntegTestCase.ClusterScope(
+    scope = ESIntegTestCase.Scope.SUITE,
+    numDataNodes = 1,
+    numClientNodes = 0,
+    supportsDedicatedMasters = false,
+    minNumDataNodes = 1
+)
 public class FromDatasetIT extends AbstractEsqlIntegTestCase {
 
     private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(30);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.IndexPattern;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
@@ -32,7 +33,9 @@ import java.util.Map;
 /**
  * Rewrites {@code FROM <dataset>} to the same {@link UnresolvedExternalRelation} the {@code EXTERNAL}
  * command produces, so both paths converge at the existing resolver + analyzer. Runs once on the
- * parsed plan before pre-analysis. Phase 1 rejects mixed indices-and-datasets patterns.
+ * parsed plan before pre-analysis. Mixed index + dataset FROM produces a {@link UnionAll} whose
+ * children the analyzer + mapper route independently — same shape the parser builds for mixed
+ * index + subquery FROM.
  */
 public final class DatasetRewriter {
 
@@ -64,12 +67,10 @@ public final class DatasetRewriter {
         if (datasetNames.isEmpty()) {
             return relation;
         }
+        List<LogicalPlan> children = new ArrayList<>(datasetNames.size() + (indexNames.isEmpty() ? 0 : 1));
         if (indexNames.isEmpty() == false) {
-            throw new VerificationException(
-                "FROM mixing indices and datasets is not supported yet; requested mix: indices=" + indexNames + ", datasets=" + datasetNames
-            );
+            children.add(withIndexPattern(relation, String.join(",", indexNames)));
         }
-        List<LogicalPlan> children = new ArrayList<>(datasetNames.size());
         for (String name : datasetNames) {
             Dataset dataset = datasets.get(name);
             DataSource parent = dataSources.get(dataset.dataSource().getName());
@@ -87,6 +88,19 @@ public final class DatasetRewriter {
 
     private static List<String> splitPattern(String pattern) {
         return Arrays.stream(pattern.split(",")).map(String::trim).filter(s -> s.isEmpty() == false).toList();
+    }
+
+    /** Rebuild an {@link UnresolvedRelation} with a narrower index pattern, preserving the rest. */
+    private static UnresolvedRelation withIndexPattern(UnresolvedRelation original, String newPattern) {
+        return new UnresolvedRelation(
+            original.source(),
+            new IndexPattern(original.source(), newPattern),
+            original.frozen(),
+            original.metadataFields(),
+            original.indexMode(),
+            null,
+            original.telemetryLabel()
+        );
     }
 
     /** Parent data source settings (secrets unwrapped to plaintext) overlaid by the dataset's settings. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.cluster.metadata.DataSource;
+import org.elasticsearch.cluster.metadata.DataSourceMetadata;
+import org.elasticsearch.cluster.metadata.DataSourceSetting;
+import org.elasticsearch.cluster.metadata.Dataset;
+import org.elasticsearch.cluster.metadata.DatasetMetadata;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.xpack.esql.VerificationException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Rewrites {@code FROM <dataset>} to the same {@link UnresolvedExternalRelation} the {@code EXTERNAL}
+ * command produces, so both paths converge at the existing resolver + analyzer. Runs once on the
+ * parsed plan before pre-analysis. Phase 1 rejects mixed indices-and-datasets patterns.
+ */
+public final class DatasetRewriter {
+
+    private DatasetRewriter() {}
+
+    public static LogicalPlan rewrite(LogicalPlan parsed, ProjectMetadata projectMetadata) {
+        if (DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled() == false) {
+            return parsed;
+        }
+        DatasetMetadata datasetMetadata = DatasetMetadata.get(projectMetadata);
+        if (datasetMetadata.datasets().isEmpty()) {
+            return parsed;
+        }
+        DataSourceMetadata dataSourceMetadata = DataSourceMetadata.get(projectMetadata);
+        return parsed.transformUp(UnresolvedRelation.class, r -> rewriteOne(r, datasetMetadata, dataSourceMetadata));
+    }
+
+    private static LogicalPlan rewriteOne(UnresolvedRelation relation, DatasetMetadata datasets, DataSourceMetadata dataSources) {
+        List<String> names = splitPattern(relation.indexPattern().indexPattern());
+        List<String> datasetNames = new ArrayList<>();
+        List<String> indexNames = new ArrayList<>();
+        for (String name : names) {
+            if (datasets.get(name) != null) {
+                datasetNames.add(name);
+            } else {
+                indexNames.add(name);
+            }
+        }
+        if (datasetNames.isEmpty()) {
+            return relation;
+        }
+        if (indexNames.isEmpty() == false) {
+            throw new VerificationException(
+                "FROM mixing indices and datasets is not supported yet; requested mix: indices=" + indexNames + ", datasets=" + datasetNames
+            );
+        }
+        List<LogicalPlan> children = new ArrayList<>(datasetNames.size());
+        for (String name : datasetNames) {
+            Dataset dataset = datasets.get(name);
+            DataSource parent = dataSources.get(dataset.dataSource().getName());
+            if (parent == null) {
+                throw new VerificationException(
+                    "dataset [" + name + "] references unknown data source [" + dataset.dataSource().getName() + "]"
+                );
+            }
+            Map<String, Object> merged = mergeSettings(parent, dataset);
+            Literal path = Literal.keyword(relation.source(), dataset.resource());
+            children.add(new UnresolvedExternalRelation(relation.source(), path, toParams(relation.source(), merged)));
+        }
+        return children.size() == 1 ? children.get(0) : new UnionAll(relation.source(), children, List.of());
+    }
+
+    private static List<String> splitPattern(String pattern) {
+        return Arrays.stream(pattern.split(",")).map(String::trim).filter(s -> s.isEmpty() == false).toList();
+    }
+
+    /** Parent data source settings (secrets unwrapped to plaintext) overlaid by the dataset's settings. */
+    private static Map<String, Object> mergeSettings(DataSource parent, Dataset dataset) {
+        Map<String, Object> merged = new HashMap<>();
+        for (Map.Entry<String, DataSourceSetting> e : parent.settings().entrySet()) {
+            merged.put(e.getKey(), e.getValue().secret() ? e.getValue().secretValue().toString() : e.getValue().nonSecretValue());
+        }
+        merged.putAll(dataset.settings());
+        return merged;
+    }
+
+    private static Map<String, Expression> toParams(Source source, Map<String, Object> merged) {
+        Map<String, Expression> params = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> e : merged.entrySet()) {
+            params.put(e.getKey(), Literal.keyword(source, String.valueOf(e.getValue())));
+        }
+        return params;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.metadata.DataSourceSetting;
 import org.elasticsearch.cluster.metadata.Dataset;
 import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
-import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -74,11 +73,10 @@ public final class DatasetRewriter {
         for (String name : datasetNames) {
             Dataset dataset = datasets.get(name);
             DataSource parent = dataSources.get(dataset.dataSource().getName());
-            if (parent == null) {
-                throw new VerificationException(
-                    "dataset [" + name + "] references unknown data source [" + dataset.dataSource().getName() + "]"
-                );
-            }
+            // DataSourceService.deleteDataSources rejects (409) when any dataset still references the
+            // data source, so a dataset with a missing parent should only happen if that invariant breaks
+            // (e.g. a broken cluster-state restore). Assert in dev/test; let it NPE at mergeSettings otherwise.
+            assert parent != null : "dataset [" + name + "] references unknown data source [" + dataset.dataSource().getName() + "]";
             Map<String, Object> merged = mergeSettings(parent, dataset);
             Literal path = Literal.keyword(relation.source(), dataset.resource());
             children.add(new UnresolvedExternalRelation(relation.source(), path, toParams(relation.source(), merged)));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
@@ -42,7 +42,7 @@ public final class DatasetRewriter {
     private DatasetRewriter() {}
 
     public static LogicalPlan rewrite(LogicalPlan parsed, ProjectMetadata projectMetadata) {
-        if (DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled() == false) {
+        if (DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled() == false || projectMetadata == null) {
             return parsed;
         }
         DatasetMetadata datasetMetadata = DatasetMetadata.get(projectMetadata);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -21,12 +21,14 @@ import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Fork;
+import org.elasticsearch.xpack.esql.plan.logical.LeafPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
 import org.elasticsearch.xpack.esql.plan.logical.Sample;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
@@ -221,6 +223,13 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
 
     // TODO: see ResolveUnmapped#patchFork comment
     private static LogicalPlan pruneColumnsInFork(Fork fork, AttributeSet.Builder used) {
+        // The per-branch prune logic below assumes each branch has a top-level Project (Fork's and subquery-UnionAll's shape).
+        // For a UnionAll whose branches are all direct LeafPlan nodes (EsRelation/ExternalRelation from heterogeneous
+        // FROM via DatasetRewriter), that assumption doesn't hold and changing the subquery behavior trips existing
+        // alignment-sensitive tests. Keep the legacy early-return for the subquery UnionAll shape.
+        if (fork instanceof UnionAll && fork.children().stream().allMatch(c -> c instanceof LeafPlan) == false) {
+            return fork;
+        }
         // prune the output attributes of fork based on usage from the rest of the plan
         boolean forkOutputChanged = false;
         AttributeSet.Builder builder = AttributeSet.builder();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -27,7 +27,6 @@ import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
 import org.elasticsearch.xpack.esql.plan.logical.Sample;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
-import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
@@ -222,12 +221,6 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
 
     // TODO: see ResolveUnmapped#patchFork comment
     private static LogicalPlan pruneColumnsInFork(Fork fork, AttributeSet.Builder used) {
-
-        // exit early for UnionAll
-        if (fork instanceof UnionAll) {
-            return fork;
-        }
-
         // prune the output attributes of fork based on usage from the rest of the plan
         boolean forkOutputChanged = false;
         AttributeSet.Builder builder = AttributeSet.builder();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimits.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimits.java
@@ -17,13 +17,13 @@ import org.elasticsearch.xpack.esql.plan.logical.CompoundOutputEval;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Fork;
+import org.elasticsearch.xpack.esql.plan.logical.LeafPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
-import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.inference.InferencePlan;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
@@ -107,11 +107,6 @@ public final class PushDownAndCombineLimits extends OptimizerRules.Parameterized
     }
 
     private static LogicalPlan maybePushDownLimitToFork(Limit limit, Fork fork, LogicalOptimizerContext ctx) {
-        // TODO: there's no reason why UnionAll should not benefit from this optimization
-        if (fork instanceof UnionAll) {
-            return limit;
-        }
-
         List<LogicalPlan> newForkChildren = new ArrayList<>();
         boolean changed = false;
 
@@ -125,6 +120,12 @@ public final class PushDownAndCombineLimits extends OptimizerRules.Parameterized
     }
 
     private static LogicalPlan maybePushDownLimitToForkBranch(Limit limit, LogicalPlan forkBranch, LogicalOptimizerContext ctx) {
+        // For direct leaf branches (e.g. EsRelation / ExternalRelation in UnionAll from heterogeneous FROM),
+        // wrap the leaf in a Limit so source-level pushdown (PushLimitToSource, PushLimitIntoExternalSource)
+        // can take over. The outer Limit above the UnionAll remains to constrain the combined output.
+        if (forkBranch instanceof LeafPlan) {
+            return new Limit(forkBranch.source(), limit.limit(), forkBranch);
+        }
         if (forkBranch instanceof UnaryPlan == false) {
             return forkBranch;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimits.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimits.java
@@ -15,7 +15,9 @@ import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.CompoundOutputEval;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Fork;
 import org.elasticsearch.xpack.esql.plan.logical.LeafPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
@@ -24,6 +26,7 @@ import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.RegexExtract;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.inference.InferencePlan;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
@@ -107,6 +110,14 @@ public final class PushDownAndCombineLimits extends OptimizerRules.Parameterized
     }
 
     private static LogicalPlan maybePushDownLimitToFork(Limit limit, Fork fork, LogicalOptimizerContext ctx) {
+        // Legacy skip for subquery-shape UnionAll (non-leaf branches). Extending that path
+        // trips existing tests and is out of scope here. Direct-leaf UnionAll (heterogeneous
+        // FROM via DatasetRewriter) falls through so limits reach each leaf for source pushdown.
+        // TODO: there's no reason why subquery UnionAll should not benefit from this optimization — follow-up.
+        if (fork instanceof UnionAll && fork.children().stream().allMatch(c -> c instanceof LeafPlan) == false) {
+            return limit;
+        }
+
         List<LogicalPlan> newForkChildren = new ArrayList<>();
         boolean changed = false;
 
@@ -120,10 +131,12 @@ public final class PushDownAndCombineLimits extends OptimizerRules.Parameterized
     }
 
     private static LogicalPlan maybePushDownLimitToForkBranch(Limit limit, LogicalPlan forkBranch, LogicalOptimizerContext ctx) {
-        // For direct leaf branches (e.g. EsRelation / ExternalRelation in UnionAll from heterogeneous FROM),
+        // For direct source leaves (EsRelation / ExternalRelation in UnionAll from heterogeneous FROM),
         // wrap the leaf in a Limit so source-level pushdown (PushLimitToSource, PushLimitIntoExternalSource)
-        // can take over. The outer Limit above the UnionAll remains to constrain the combined output.
-        if (forkBranch instanceof LeafPlan) {
+        // can take over. Skip other LeafPlan types (e.g. LocalRelation) — they don't benefit from source
+        // pushdown and wrapping them blocks PruneEmptyForkBranches from eliminating empty FORK branches.
+        // The outer Limit above the UnionAll stays to constrain the combined output.
+        if (forkBranch instanceof EsRelation || forkBranch instanceof ExternalRelation) {
             return new Limit(forkBranch.source(), limit.limit(), forkBranch);
         }
         if (forkBranch instanceof UnaryPlan == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownFilterAndLimitIntoUnionAll.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownFilterAndLimitIntoUnionAll.java
@@ -19,7 +19,10 @@ import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.vector.Knn;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LeafPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
@@ -109,14 +112,21 @@ public class PushDownFilterAndLimitIntoUnionAll extends OptimizerRules.Parameter
         if (pushable.isEmpty()) {
             return filter; // nothing to push down
         }
-        // Push the filter down to each child of the UnionAll, the child of a UnionAll is always a project followed by an optional eval
-        // and then the real child, if there is unknown pattern, keep the filter and UnionAll plan unchanged
+        // Push the filter down to each child of the UnionAll. Child shapes handled:
+        // Project > Eval? > {EsRelation, Subquery} (subquery branches from the parser)
+        // EsRelation, ExternalRelation (direct leaves from DatasetRewriter)
+        // Any other shape → bail out, keep the filter above the UnionAll.
         List<LogicalPlan> newChildren = new ArrayList<>();
         boolean changed = false;
         for (LogicalPlan child : unionAll.children()) {
-            LogicalPlan newChild = child instanceof Project project
-                ? maybePushDownFilterPastProjectForUnionAllChild(pushable, project)
-                : null;
+            LogicalPlan newChild;
+            if (child instanceof Project project) {
+                newChild = maybePushDownFilterPastProjectForUnionAllChild(pushable, project);
+            } else if (child instanceof EsRelation || child instanceof ExternalRelation) {
+                newChild = maybePushDownFilterPastLeafForUnionAllChild(pushable, (LeafPlan) child);
+            } else {
+                newChild = null;
+            }
 
             if (newChild == null) {
                 // Unexpected pattern, keep plan unchanged without pushing down filters
@@ -175,6 +185,19 @@ public class PushDownFilterAndLimitIntoUnionAll extends OptimizerRules.Parameter
             return project;
         }
         return filterWithPlanAsChild(project, resolvedPushable);
+    }
+
+    /**
+     * Direct-leaf variant of {@link #maybePushDownFilterPastProjectForUnionAllChild}. Used for {@link EsRelation}
+     * and {@link ExternalRelation} children produced by {@code DatasetRewriter}, which don't carry a wrapping
+     * {@link Project}. The leaf's own {@code output()} supplies the attribute list for name-based filter remap.
+     */
+    private static LogicalPlan maybePushDownFilterPastLeafForUnionAllChild(List<Expression> pushable, LeafPlan leaf) {
+        List<Expression> resolvedPushable = resolvePushableAgainstOutput(pushable, leaf.output());
+        if (resolvedPushable == null) {
+            return leaf;
+        }
+        return filterWithPlanAsChild(leaf, resolvedPushable);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownLimitAndOrderByIntoFork.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownLimitAndOrderByIntoFork.java
@@ -11,6 +11,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.logical.Fork;
+import org.elasticsearch.xpack.esql.plan.logical.LeafPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
@@ -43,10 +44,17 @@ public class PushDownLimitAndOrderByIntoFork extends OptimizerRules.Parameterize
         }
 
         OrderBy orderBy = (OrderBy) limit.child();
-        if (orderBy.child() instanceof Fork == false || orderBy.child() instanceof UnionAll) {
+        if (orderBy.child() instanceof Fork == false) {
             return limit;
         }
         Fork fork = (Fork) orderBy.child();
+
+        // Legacy skip for subquery-shape UnionAll (non-leaf branches). Extending that path
+        // is out of scope. Direct-leaf UnionAll (heterogeneous FROM via DatasetRewriter)
+        // falls through so SORT+LIMIT reaches each leaf as source-level TopN pushdown.
+        if (fork instanceof UnionAll && fork.children().stream().allMatch(c -> c instanceof LeafPlan) == false) {
+            return limit;
+        }
 
         List<LogicalPlan> newForkChildren = new ArrayList<>();
         boolean changed = false;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownUtils.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
@@ -217,11 +218,11 @@ class PushDownUtils {
     public static boolean shouldPushDownPipelineBreakerIntoForkBranch(LogicalPlan plan) {
         // We only push down a pipeline breaker when:
         // 1. There is an OrderBy that is not followed by a Limit.
-        // 2. There is no PipelineBreaker, but we have an EsRelation. If no EsRelation is found.
+        // 2. There is no PipelineBreaker, but we have a source relation (EsRelation or ExternalRelation).
         // We should not push a pipeline breaker like LIMIT into the fork branch, since it will
         // be removed by other optimizations.
         Holder<Boolean> hasPipelineBreaker = new Holder<>(false);
-        Holder<Boolean> hasEsRelation = new Holder<>(false);
+        Holder<Boolean> hasSourceRelation = new Holder<>(false);
         Holder<Boolean> hasUnboundedOrderBy = new Holder<>(false);
         Holder<Boolean> hasLimit = new Holder<>(false);
 
@@ -229,8 +230,8 @@ class PushDownUtils {
             if (p instanceof PipelineBreaker && p instanceof OrderBy == false) {
                 hasPipelineBreaker.set(true);
             }
-            if (p instanceof EsRelation) {
-                hasEsRelation.set(true);
+            if (p instanceof EsRelation || p instanceof ExternalRelation) {
+                hasSourceRelation.set(true);
             }
 
             if (p instanceof Limit) {
@@ -246,7 +247,7 @@ class PushDownUtils {
             return true;
         }
 
-        return hasEsRelation.get() && hasPipelineBreaker.get() == false;
+        return hasSourceRelation.get() && hasPipelineBreaker.get() == false;
     }
 
     public static Map<Expression, Expression> outputMap(LogicalPlan plan, LogicalPlan otherPlan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -64,6 +64,7 @@ import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtract
 import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor.TimestampBounds;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.datasources.DatasetRewriter;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolution;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
 import org.elasticsearch.xpack.esql.datasources.PartitionFilterHintExtractor;
@@ -874,6 +875,9 @@ public class EsqlSession {
 
         TimeSpanMarker preAnalysisProfile = executionInfo.queryProfile().preAnalysis();
         preAnalysisProfile.start();
+        // Rewrite FROM targets that resolve to datasets into UnresolvedExternalRelation so the rest of
+        // pre-analysis + analysis treats them identically to the inline EXTERNAL command.
+        parsed = DatasetRewriter.rewrite(parsed, projectMetadata);
         PreAnalyzer.PreAnalysis preAnalysis = preAnalyzer.preAnalyze(parsed);
         preAnalysisProfile.stop();
         // Initialize the PreAnalysisResult with the local cluster's minimum transport version, so our planning will be correct also in

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -101,15 +100,6 @@ public class DatasetRewriterTests extends ESTestCase {
         UnresolvedRelation indexChild = (UnresolvedRelation) union.children().get(0);
         assertThat(indexChild.indexPattern().indexPattern(), equalTo("idx_a,idx_b"));
         assertThat(union.children().get(1), instanceOf(UnresolvedExternalRelation.class));
-    }
-
-    public void testUnknownParentDataSourceRejected() {
-        Dataset orphan = new Dataset("orphan", new DataSourceReference("ghost_parent"), "s3://x/", null, Map.of());
-        ProjectMetadata project = projectWith(Map.of(), Map.of("orphan", orphan));
-
-        VerificationException ex = expectThrows(VerificationException.class, () -> DatasetRewriter.rewrite(relationOf("orphan"), project));
-        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("dataset [orphan]"));
-        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("unknown data source [ghost_parent]"));
     }
 
     public void testSecretSettingUnwrappedToPlaintext() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.metadata.DataSource;
+import org.elasticsearch.cluster.metadata.DataSourceMetadata;
+import org.elasticsearch.cluster.metadata.DataSourceReference;
+import org.elasticsearch.cluster.metadata.DataSourceSetting;
+import org.elasticsearch.cluster.metadata.Dataset;
+import org.elasticsearch.cluster.metadata.DatasetMetadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.VerificationException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.IndexPattern;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class DatasetRewriterTests extends ESTestCase {
+
+    public void testNoDatasetsLeavesPlanUnchanged() {
+        UnresolvedRelation relation = relationOf("my_index");
+        ProjectMetadata project = projectWith(Map.of(), Map.of());
+        assertSame(relation, DatasetRewriter.rewrite(relation, project));
+    }
+
+    public void testSingleDatasetRewritesToUnresolvedExternalRelation() {
+        DataSource parent = dataSource("s3_parent", Map.of("region", new DataSourceSetting("us-east-1", false)));
+        Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/*.parquet", null, Map.of("format", "parquet"));
+        ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
+
+        LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("logs"), project);
+
+        assertThat(rewritten, instanceOf(UnresolvedExternalRelation.class));
+        UnresolvedExternalRelation out = (UnresolvedExternalRelation) rewritten;
+        assertThat(tablePathString(out), equalTo("s3://logs/*.parquet"));
+        assertThat(paramValue(out, "region"), equalTo("us-east-1"));
+        assertThat(paramValue(out, "format"), equalTo("parquet"));
+    }
+
+    public void testDatasetSettingsOverrideParentOnKeyCollision() {
+        DataSource parent = dataSource("s3_parent", Map.of("region", new DataSourceSetting("us-east-1", false)));
+        Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/", null, Map.of("region", "eu-west-2"));
+        ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
+
+        LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("logs"), project);
+        assertThat(paramValue((UnresolvedExternalRelation) rewritten, "region"), equalTo("eu-west-2"));
+    }
+
+    public void testMultipleDatasetsProduceUnionAll() {
+        DataSource parent = dataSource("s3_parent", Map.of());
+        Dataset ds1 = new Dataset("ds1", new DataSourceReference("s3_parent"), "s3://a/", null, Map.of());
+        Dataset ds2 = new Dataset("ds2", new DataSourceReference("s3_parent"), "s3://b/", null, Map.of());
+        ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("ds1", ds1, "ds2", ds2));
+
+        LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("ds1,ds2"), project);
+
+        assertThat(rewritten, instanceOf(UnionAll.class));
+        UnionAll union = (UnionAll) rewritten;
+        assertThat(union.children(), hasSize(2));
+        assertThat(union.children().get(0), instanceOf(UnresolvedExternalRelation.class));
+        assertThat(union.children().get(1), instanceOf(UnresolvedExternalRelation.class));
+    }
+
+    public void testMixedIndicesAndDatasetsRejected() {
+        DataSource parent = dataSource("s3_parent", Map.of());
+        Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/", null, Map.of());
+        ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
+
+        VerificationException ex = expectThrows(
+            VerificationException.class,
+            () -> DatasetRewriter.rewrite(relationOf("some_idx,logs"), project)
+        );
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("mixing indices and datasets"));
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("indices=[some_idx]"));
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("datasets=[logs]"));
+    }
+
+    public void testUnknownParentDataSourceRejected() {
+        Dataset orphan = new Dataset("orphan", new DataSourceReference("ghost_parent"), "s3://x/", null, Map.of());
+        ProjectMetadata project = projectWith(Map.of(), Map.of("orphan", orphan));
+
+        VerificationException ex = expectThrows(
+            VerificationException.class,
+            () -> DatasetRewriter.rewrite(relationOf("orphan"), project)
+        );
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("dataset [orphan]"));
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("unknown data source [ghost_parent]"));
+    }
+
+    public void testSecretSettingUnwrappedToPlaintext() {
+        DataSource parent = dataSource(
+            "s3_parent",
+            Map.of("access_key", new DataSourceSetting("AKIAEXAMPLE", true), "region", new DataSourceSetting("us-east-1", false))
+        );
+        Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/", null, Map.of());
+        ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
+
+        LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("logs"), project);
+        assertThat(paramValue((UnresolvedExternalRelation) rewritten, "access_key"), equalTo("AKIAEXAMPLE"));
+    }
+
+    // --
+
+    private static UnresolvedRelation relationOf(String pattern) {
+        return new UnresolvedRelation(Source.EMPTY, new IndexPattern(Source.EMPTY, pattern), false, List.of(), IndexMode.STANDARD, null);
+    }
+
+    private static DataSource dataSource(String name, Map<String, DataSourceSetting> settings) {
+        return new DataSource(name, "test", null, settings);
+    }
+
+    private static ProjectMetadata projectWith(Map<String, DataSource> dataSources, Map<String, Dataset> datasets) {
+        return ProjectMetadata.builder(ProjectId.DEFAULT)
+            .putCustom(DataSourceMetadata.TYPE, new DataSourceMetadata(dataSources))
+            .datasets(datasets)
+            .build();
+    }
+
+    private static String tablePathString(UnresolvedExternalRelation relation) {
+        Object value = ((Literal) relation.tablePath()).value();
+        return value instanceof BytesRef br ? BytesRefs.toString(br) : value.toString();
+    }
+
+    private static String paramValue(UnresolvedExternalRelation relation, String key) {
+        Expression expression = relation.params().get(key);
+        Object value = ((Literal) expression).value();
+        return value instanceof BytesRef br ? BytesRefs.toString(br) : value.toString();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.metadata.DataSourceMetadata;
 import org.elasticsearch.cluster.metadata.DataSourceReference;
 import org.elasticsearch.cluster.metadata.DataSourceSetting;
 import org.elasticsearch.cluster.metadata.Dataset;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.common.lucene.BytesRefs;
@@ -46,7 +45,13 @@ public class DatasetRewriterTests extends ESTestCase {
 
     public void testSingleDatasetRewritesToUnresolvedExternalRelation() {
         DataSource parent = dataSource("s3_parent", Map.of("region", new DataSourceSetting("us-east-1", false)));
-        Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/*.parquet", null, Map.of("format", "parquet"));
+        Dataset dataset = new Dataset(
+            "logs",
+            new DataSourceReference("s3_parent"),
+            "s3://logs/*.parquet",
+            null,
+            Map.of("format", "parquet")
+        );
         ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
 
         LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("logs"), project);
@@ -100,10 +105,7 @@ public class DatasetRewriterTests extends ESTestCase {
         Dataset orphan = new Dataset("orphan", new DataSourceReference("ghost_parent"), "s3://x/", null, Map.of());
         ProjectMetadata project = projectWith(Map.of(), Map.of("orphan", orphan));
 
-        VerificationException ex = expectThrows(
-            VerificationException.class,
-            () -> DatasetRewriter.rewrite(relationOf("orphan"), project)
-        );
+        VerificationException ex = expectThrows(VerificationException.class, () -> DatasetRewriter.rewrite(relationOf("orphan"), project));
         assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("dataset [orphan]"));
         assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("unknown data source [ghost_parent]"));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
@@ -87,18 +87,20 @@ public class DatasetRewriterTests extends ESTestCase {
         assertThat(union.children().get(1), instanceOf(UnresolvedExternalRelation.class));
     }
 
-    public void testMixedIndicesAndDatasetsRejected() {
+    public void testMixedIndicesAndDatasetsProduceUnionAll() {
         DataSource parent = dataSource("s3_parent", Map.of());
         Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/", null, Map.of());
         ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
 
-        VerificationException ex = expectThrows(
-            VerificationException.class,
-            () -> DatasetRewriter.rewrite(relationOf("some_idx,logs"), project)
-        );
-        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("mixing indices and datasets"));
-        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("indices=[some_idx]"));
-        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("datasets=[logs]"));
+        LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("idx_a,logs,idx_b"), project);
+
+        assertThat(rewritten, instanceOf(UnionAll.class));
+        UnionAll union = (UnionAll) rewritten;
+        assertThat(union.children(), hasSize(2));
+        assertThat(union.children().get(0), instanceOf(UnresolvedRelation.class));
+        UnresolvedRelation indexChild = (UnresolvedRelation) union.children().get(0);
+        assertThat(indexChild.indexPattern().indexPattern(), equalTo("idx_a,idx_b"));
+        assertThat(union.children().get(1), instanceOf(UnresolvedExternalRelation.class));
     }
 
     public void testUnknownParentDataSourceRejected() {


### PR DESCRIPTION
Implements #459 ([elastic/esql-planning#571](https://github.com/elastic/esql-planning/issues/571)): `FROM <dataset>` routes through the same pipeline the inline `EXTERNAL` command uses, including heterogeneous `FROM <index>, <dataset>`, plus first-class optimizer pushdown across the heterogeneous shape.

## What changes

### 1. Rewriter — `DatasetRewriter.rewrite(plan, projectMetadata)`

Runs on the parsed plan before pre-analysis. For every `UnresolvedRelation` whose comma-joined names include any `Dataset` abstractions in cluster state, it:

1. Buckets the names into indices vs datasets.
2. Looks up each dataset + its parent data source; merges settings (parent secret values unwrapped to plaintext, overlaid by dataset settings on key collision).
3. Builds a `UnionAll` whose children are:
   - One `UnresolvedRelation` for the index-only subset of the pattern, if any (preserving `frozen`, `metadataFields`, `indexMode`, telemetry label).
   - One `UnresolvedExternalRelation` per dataset.
4. Collapses to a single `UnresolvedExternalRelation` when there's one dataset and no indices.

**The dataset path and the inline `EXTERNAL` path converge at `UnresolvedExternalRelation`.** From that point the existing `ExternalSourceResolver` + `ResolveExternalRelations` + downstream produce the same `ExternalRelation` → `ExternalSourceExec` pipeline.

Mixed FROM reuses the parser's own precedent: `LogicalPlanBuilder.visitRelation:388-400` already builds `UnionAll(UnresolvedRelation, <subquery>, ...)` for mixed index + subquery FROM. Our rewriter matches that shape. The analyzer dispatches rules by node type, so `ResolveTable` handles the index branch and `ResolveExternalRelations` each dataset branch independently. `Mapper.mapLeaf:89-98` wraps both `EsRelation` and `ExternalRelation` in `FragmentExec`, so the existing `Mapper.mapFork` exchange-wrap condition at line 271 handles every branch uniformly — no Mapper changes.

Gated by `DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG`.

### 2. Optimizer — push filter / limit / column-prune / TopN through UnionAll of leaves

Heterogeneous FROM produces a UnionAll whose children are **direct** `EsRelation` / `ExternalRelation` leaves (no wrapping `Project`, unlike the subquery FROM shape). Four logical-plan rules previously skipped UnionAll entirely or only handled the subquery shape; extended to the direct-leaf shape so heterogeneous queries get the same source-level pushdown as homogeneous ones. Each rule keeps its legacy early-return for the subquery-UnionAll shape (branches with top Projects) — extending that path trips existing alignment-sensitive tests and is out of scope.

| Rule | Change |
|---|---|
| `PushDownFilterAndLimitIntoUnionAll` | `maybePushDownPastUnionAll` now dispatches on branch shape: existing `Project > Eval? > {EsRelation\|Subquery}` path, plus a new direct-`EsRelation` / `ExternalRelation` path that resolves the pushable predicate against the leaf's output and wraps it in a `Filter`. |
| `PushDownAndCombineLimits` | `maybePushDownLimitToFork` gated to UnionAll-of-leaves. `maybePushDownLimitToForkBranch` wraps direct `EsRelation` / `ExternalRelation` branches in a `Limit` so `PushLimitToSource` / `PushLimitIntoExternalSource` can run per branch. `LocalRelation` leaves are deliberately not wrapped so `PruneEmptyForkBranches` can still drop empty branches. |
| `PruneColumns` | `pruneColumnsInFork` gated to UnionAll-of-leaves. The existing per-branch recursive `pruneColumns` call handles `ExternalRelation` attribute trimming via `pruneColumnsInExternalRelation`; `EsRelation` in STANDARD mode stays a no-op here and is pruned later by `InsertFieldExtraction`. |
| `PushDownLimitAndOrderByIntoFork` | Dropped the UnionAll skip for UnionAll-of-leaves. Also extended `PushDownUtils.shouldPushDownPipelineBreakerIntoForkBranch` to recognize `ExternalRelation` as a source (alongside `EsRelation`) so SORT+LIMIT pushes into the external leaf too. |

**Why this matters for mixed queries:** without these, `FROM idx, ds | WHERE user_id = 123 | SORT ts | LIMIT 10 | KEEP name` would read the predicate, all rows, and all columns from the dataset, and sort globally at the coordinator. With these, the dataset reader receives the same filter + per-branch TopN + column projection the index side already gets, which for Parquet/ORC means bloom/stats-driven row-group skip + field-level column reads + per-source ordered top-N.

## What the user sees

| Query | Result |
|---|---|
| `FROM idx1, idx2` | unchanged |
| `FROM access_logs` | resolves the dataset, runs through external pipeline |
| `FROM logs_a, logs_b` (two datasets) | `UnionAll(UnresolvedExternalRelation, UnresolvedExternalRelation)` |
| `FROM some_idx, access_logs` | `UnionAll(UnresolvedRelation(some_idx), UnresolvedExternalRelation)` |
| `FROM idx1, idx2, ds1, ds2` | `UnionAll(UnresolvedRelation("idx1,idx2"), UER, UER)` |
| `FROM idx, ds \| WHERE user_id = 123` | filter pushed into both the EsRelation and the ExternalRelation branches |
| `FROM idx, ds \| LIMIT 10` | limit wrapped onto each branch; outer limit preserved |
| `FROM idx, ds \| SORT ts \| LIMIT 10` | per-branch TopN pushed into each leaf |
| `FROM idx, ds \| KEEP name` | unused columns pruned on the ExternalRelation branch (reader loads fewer columns) |
| Dataset whose parent was deleted | clean error citing the dataset + missing parent |

## Files

| File | Why |
|---|---|
| `DatasetRewriter.java` (NEW, 122 LOC) | Translation from dataset names to URI + merged settings, plus the mixed-union construction. |
| `EsqlSession.java` (+3 LOC) | One hook in `analyzedPlan` before pre-analysis. |
| `DatasetRewriterTests.java` (NEW, 7 cases) | Unit coverage of the rewriter. |
| `FromDatasetIT.java` (NEW, 5 cases) | End-to-end integration coverage of rewriter + optimizer stack. |
| `PushDownFilterAndLimitIntoUnionAll.java` | Direct-leaf filter-pushdown path. |
| `PushDownAndCombineLimits.java` | Limit pushdown into source-leaf branches. |
| `PruneColumns.java` | Column pruning through leaf-shape UnionAll. |
| `PushDownLimitAndOrderByIntoFork.java` | TopN pushdown into leaf-shape UnionAll branches. |
| `PushDownUtils.java` | `ExternalRelation` recognized as a source relation. |

## Tests

### Unit — `DatasetRewriterTests` (7 cases)

| Test | Covers |
|---|---|
| `testNoDatasetsLeavesPlanUnchanged` | No-op when no datasets in cluster state |
| `testSingleDatasetRewritesToUnresolvedExternalRelation` | Single-dataset rewrite + param merge |
| `testDatasetSettingsOverrideParentOnKeyCollision` | Merge precedence: dataset wins |
| `testMultipleDatasetsProduceUnionAll` | Multi-dataset wraps in `UnionAll` |
| `testMixedIndicesAndDatasetsProduceUnionAll` | **Mixed shape:** `UnionAll[UnresolvedRelation("idx_a,idx_b"), UnresolvedExternalRelation]` |
| `testUnknownParentDataSourceRejected` | Orphaned-dataset rejection |
| `testSecretSettingUnwrappedToPlaintext` | Secret-valued parent settings reach the validator as plaintext |

### Integration — `FromDatasetIT` (5 cases)

Single-node cluster with `HttpDataSourcePlugin` (for the `file://` provider), `CsvDataSourcePlugin` (for CSV format), and an inner `TestDataSourcePlugin` registering a pass-through validator for type `test`. A real CSV fixture with Alice/Bob/Carol + a real ES index with Diana (emp_no=99):

- **`testFromDatasetReadsCsvFixture`** — `FROM employees | SORT emp_no | LIMIT 10` → asserts columns + the three CSV rows.
- **`testFromMixedIndexAndDataset`** — `FROM local_emps,employees | SORT emp_no` → asserts all four rows in order (1,2,3 from CSV + 99 from ES).
- **`testFromMixedWithFilter`** — `FROM local_emps,employees | WHERE emp_no >= 2 | SORT emp_no` → filter applies across both branches (exercises the direct-leaf filter pushdown); asserts 3 rows.
- **`testFromMixedWithCountAggregation`** — `FROM local_emps,employees | STATS c = COUNT(*)` → aggregation across the union; asserts count = 4.
- **`testFromMultipleDatasetsAndIndex`** — adds a second CSV fixture (Eve, Frank), runs `FROM local_emps,employees,employees_eu | SORT emp_no` → 6 rows in order (exercises SORT pushdown + multi-branch column-prune).

All 5 exercise the real parser → rewriter → external-source resolver → analyzer → optimizer → mapper → execution pipeline; the filter / SORT / aggregation / multi-branch tests exercise the direct-leaf optimizer paths.

## Out of scope (follow-ups)

- Extending the same four fixes to subquery-shape UnionAll (non-leaf branches). Currently gated out to avoid behavior changes in existing subquery tests.
- Dedicated optimizer unit tests over the UnionAll-of-leaves shape (behavior covered end-to-end in `FromDatasetIT`; direct-shape unit tests are a follow-up).
- Wildcard bucketing through `IndexNameExpressionResolver` (`FROM log_*` spanning both types). Pattern-by-name only today.
- `_index` metadata semantics for dataset rows.
- Multi-node dataset publication hits an unrelated assertion in `ProjectMetadata.Builder` (indices-lookup rebuild on dataset-add diffs) — present on `main`, not caused by this PR. The IT runs single-node to avoid it.

Closes elastic/esql-planning#571
Closes elastic/esql-planning#572
Closes elastic/esql-planning#578
