### PR TITLE
ES|QL|DS: heterogeneous FROM indices + datasets (Phase 2)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.cluster.metadata.DataSourceMetadata;
+import org.elasticsearch.cluster.metadata.DataSourceSetting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.ExtensiblePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.dataset.DeleteDatasetAction;
+import org.elasticsearch.xpack.esql.datasources.dataset.PutDatasetAction;
+import org.elasticsearch.xpack.esql.datasources.datasource.DeleteDataSourceAction;
+import org.elasticsearch.xpack.esql.datasources.datasource.PutDataSourceAction;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.DataSourceValidator;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * End-to-end integration for {@code FROM <dataset>}: creates a data source and a dataset via the
+ * CRUD API, both pointing at a local CSV fixture, and runs a {@code FROM <name>} query against
+ * them. Proves that the parser → dataset rewriter → external-source resolver → analyzer →
+ * execution pipeline wires up the way the PR description claims.
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false, minNumDataNodes = 1)
+public class FromDatasetIT extends AbstractEsqlIntegTestCase {
+
+    private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(30);
+    private Path csvFixture;
+
+    public static final class EsqlEnterpriseWithDatasourceExtensions extends EsqlPluginWithEnterpriseOrTrialLicense {
+        @Override
+        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
+            super.loadExtensions(loader);
+        }
+    }
+
+    /** Minimal pass-through validator registered for type {@code test}; accepts any resource scheme. */
+    public static final class TestDataSourcePlugin extends Plugin implements DataSourcePlugin {
+        @Override
+        public Map<String, DataSourceValidator> datasourceValidators(Settings settings) {
+            return Map.of("test", new TestValidator());
+        }
+    }
+
+    private static final class TestValidator implements DataSourceValidator {
+        @Override
+        public String type() {
+            return "test";
+        }
+
+        @Override
+        public Map<String, DataSourceSetting> validateDatasource(Map<String, Object> datasourceSettings) {
+            Map<String, DataSourceSetting> out = new HashMap<>();
+            for (Map.Entry<String, Object> e : datasourceSettings.entrySet()) {
+                out.put(e.getKey(), new DataSourceSetting(e.getValue(), e.getKey().startsWith("secret_")));
+            }
+            return out;
+        }
+
+        @Override
+        public Map<String, Object> validateDataset(
+            Map<String, DataSourceSetting> datasourceSettings,
+            String resource,
+            Map<String, Object> datasetSettings
+        ) {
+            return datasetSettings == null ? Map.of() : new HashMap<>(datasetSettings);
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.remove(EsqlPluginWithEnterpriseOrTrialLicense.class);
+        plugins.add(EsqlEnterpriseWithDatasourceExtensions.class);
+        plugins.add(HttpDataSourcePlugin.class);
+        plugins.add(CsvDataSourcePlugin.class);
+        plugins.add(TestDataSourcePlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
+
+    @Before
+    public void writeFixture() throws IOException {
+        csvFixture = createTempFile("dataset-fixture-", ".csv");
+        Files.writeString(csvFixture, String.join("\n", "emp_no:integer,first_name:keyword", "1,Alice", "2,Bob", "3,Carol") + "\n");
+    }
+
+    @After
+    public void cleanupRegistry() throws Exception {
+        try {
+            client().execute(DeleteDatasetAction.INSTANCE, deleteDatasetRequest("employees"))
+                .get(30, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception ignored) {}
+        try {
+            client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest("local_ds"))
+                .get(30, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception ignored) {}
+    }
+
+    public void testFromDatasetReadsCsvFixture() throws Exception {
+        assumeTrue("requires external data sources feature flag", DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                putDatasetRequest("employees", "local_ds", csvFixture.toUri().toString(), Map.of("format", "csv"))
+            )
+        );
+
+        try (var response = run(syncEsqlQueryRequest("FROM employees | SORT emp_no | LIMIT 10"), TIMEOUT)) {
+            List<? extends ColumnInfo> columns = response.columns();
+            assertThat(columns, hasSize(2));
+            assertThat(columns.get(0).name(), equalTo("emp_no"));
+            assertThat(columns.get(1).name(), equalTo("first_name"));
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(3));
+            assertThat(rows.get(0).get(0), equalTo(1));
+            assertThat(rows.get(0).get(1).toString(), equalTo("Alice"));
+            assertThat(rows.get(1).get(0), equalTo(2));
+            assertThat(rows.get(1).get(1).toString(), equalTo("Bob"));
+            assertThat(rows.get(2).get(0), equalTo(3));
+            assertThat(rows.get(2).get(1).toString(), equalTo("Carol"));
+        }
+    }
+
+    public void testFromMixedIndexAndDatasetRejected() throws Exception {
+        assumeTrue("requires external data sources feature flag", DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+
+        assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
+        assertAcked(
+            client().execute(
+                PutDatasetAction.INSTANCE,
+                putDatasetRequest("employees", "local_ds", csvFixture.toUri().toString(), Map.of("format", "csv"))
+            )
+        );
+
+        Exception ex = expectThrows(Exception.class, () -> run(syncEsqlQueryRequest("FROM some_real_index, employees | LIMIT 1"), TIMEOUT));
+        Throwable cause = ex;
+        while (cause != null && cause.getMessage() != null && cause.getMessage().contains("mixing indices and datasets") == false) {
+            cause = cause.getCause();
+        }
+        assertThat("error chain should contain Phase-1 mix-rejection", cause, org.hamcrest.Matchers.notNullValue());
+    }
+
+    private static PutDataSourceAction.Request putDataSourceRequest(String name, Map<String, Object> settings) {
+        return new PutDataSourceAction.Request(TIMEOUT, TIMEOUT, name, "test", null, new HashMap<>(settings));
+    }
+
+    private static PutDatasetAction.Request putDatasetRequest(
+        String name,
+        String dataSource,
+        String resource,
+        Map<String, Object> settings
+    ) {
+        return new PutDatasetAction.Request(TIMEOUT, TIMEOUT, name, dataSource, resource, null, new HashMap<>(settings));
+    }
+
+    private static DeleteDataSourceAction.Request deleteDataSourceRequest(String name) {
+        return new DeleteDataSourceAction.Request(TIMEOUT, TIMEOUT, new String[] { name });
+    }
+
+    private static DeleteDatasetAction.Request deleteDatasetRequest(String name) {
+        return new DeleteDatasetAction.Request(TIMEOUT, TIMEOUT, new String[] { name });
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/FromDatasetIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.datasource.csv.CsvDataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
@@ -22,7 +23,6 @@ import org.elasticsearch.xpack.esql.datasources.datasource.DeleteDataSourceActio
 import org.elasticsearch.xpack.esql.datasources.datasource.PutDataSourceAction;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourceValidator;
-import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.junit.After;
 import org.junit.Before;
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
 import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
@@ -48,7 +49,13 @@ import static org.hamcrest.Matchers.hasSize;
  * them. Proves that the parser → dataset rewriter → external-source resolver → analyzer →
  * execution pipeline wires up the way the PR description claims.
  */
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false, minNumDataNodes = 1)
+@ESIntegTestCase.ClusterScope(
+    scope = ESIntegTestCase.Scope.SUITE,
+    numDataNodes = 1,
+    numClientNodes = 0,
+    supportsDedicatedMasters = false,
+    minNumDataNodes = 1
+)
 public class FromDatasetIT extends AbstractEsqlIntegTestCase {
 
     private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(30);
@@ -126,6 +133,9 @@ public class FromDatasetIT extends AbstractEsqlIntegTestCase {
             client().execute(DeleteDataSourceAction.INSTANCE, deleteDataSourceRequest("local_ds"))
                 .get(30, java.util.concurrent.TimeUnit.SECONDS);
         } catch (Exception ignored) {}
+        try {
+            client().admin().indices().prepareDelete("local_emps").get();
+        } catch (Exception ignored) {}
     }
 
     public void testFromDatasetReadsCsvFixture() throws Exception {
@@ -156,8 +166,12 @@ public class FromDatasetIT extends AbstractEsqlIntegTestCase {
         }
     }
 
-    public void testFromMixedIndexAndDatasetRejected() throws Exception {
+    public void testFromMixedIndexAndDataset() throws Exception {
         assumeTrue("requires external data sources feature flag", DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled());
+
+        // Seed a real ES index with a single compatible row.
+        client().admin().indices().prepareCreate("local_emps").setMapping("emp_no", "type=integer", "first_name", "type=keyword").get();
+        client().prepareIndex("local_emps").setSource("emp_no", 99, "first_name", "Diana").setRefreshPolicy(IMMEDIATE).get();
 
         assertAcked(client().execute(PutDataSourceAction.INSTANCE, putDataSourceRequest("local_ds", Map.of())));
         assertAcked(
@@ -167,12 +181,21 @@ public class FromDatasetIT extends AbstractEsqlIntegTestCase {
             )
         );
 
-        Exception ex = expectThrows(Exception.class, () -> run(syncEsqlQueryRequest("FROM some_real_index, employees | LIMIT 1"), TIMEOUT));
-        Throwable cause = ex;
-        while (cause != null && cause.getMessage() != null && cause.getMessage().contains("mixing indices and datasets") == false) {
-            cause = cause.getCause();
+        try (var response = run(syncEsqlQueryRequest("FROM local_emps,employees | SORT emp_no"), TIMEOUT)) {
+            List<? extends ColumnInfo> columns = response.columns();
+            assertThat(columns, hasSize(2));
+            assertThat(columns.get(0).name(), equalTo("emp_no"));
+            assertThat(columns.get(1).name(), equalTo("first_name"));
+
+            List<List<Object>> rows = getValuesList(response);
+            assertThat(rows, hasSize(4));
+            // rows from the CSV dataset (1..3) + the one row from the ES index (99)
+            assertThat(rows.get(0).get(0), equalTo(1));
+            assertThat(rows.get(1).get(0), equalTo(2));
+            assertThat(rows.get(2).get(0), equalTo(3));
+            assertThat(rows.get(3).get(0), equalTo(99));
+            assertThat(rows.get(3).get(1).toString(), equalTo("Diana"));
         }
-        assertThat("error chain should contain Phase-1 mix-rejection", cause, org.hamcrest.Matchers.notNullValue());
     }
 
     private static PutDataSourceAction.Request putDataSourceRequest(String name, Map<String, Object> settings) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.IndexPattern;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
@@ -32,7 +33,9 @@ import java.util.Map;
 /**
  * Rewrites {@code FROM <dataset>} to the same {@link UnresolvedExternalRelation} the {@code EXTERNAL}
  * command produces, so both paths converge at the existing resolver + analyzer. Runs once on the
- * parsed plan before pre-analysis. Phase 1 rejects mixed indices-and-datasets patterns.
+ * parsed plan before pre-analysis. Mixed index + dataset FROM produces a {@link UnionAll} whose
+ * children the analyzer + mapper route independently — same shape the parser builds for mixed
+ * index + subquery FROM.
  */
 public final class DatasetRewriter {
 
@@ -64,12 +67,10 @@ public final class DatasetRewriter {
         if (datasetNames.isEmpty()) {
             return relation;
         }
+        List<LogicalPlan> children = new ArrayList<>(datasetNames.size() + (indexNames.isEmpty() ? 0 : 1));
         if (indexNames.isEmpty() == false) {
-            throw new VerificationException(
-                "FROM mixing indices and datasets is not supported yet; requested mix: indices=" + indexNames + ", datasets=" + datasetNames
-            );
+            children.add(withIndexPattern(relation, String.join(",", indexNames)));
         }
-        List<LogicalPlan> children = new ArrayList<>(datasetNames.size());
         for (String name : datasetNames) {
             Dataset dataset = datasets.get(name);
             DataSource parent = dataSources.get(dataset.dataSource().getName());
@@ -87,6 +88,19 @@ public final class DatasetRewriter {
 
     private static List<String> splitPattern(String pattern) {
         return Arrays.stream(pattern.split(",")).map(String::trim).filter(s -> s.isEmpty() == false).toList();
+    }
+
+    /** Rebuild an {@link UnresolvedRelation} with a narrower index pattern, preserving the rest. */
+    private static UnresolvedRelation withIndexPattern(UnresolvedRelation original, String newPattern) {
+        return new UnresolvedRelation(
+            original.source(),
+            new IndexPattern(original.source(), newPattern),
+            original.frozen(),
+            original.metadataFields(),
+            original.indexMode(),
+            null,
+            original.telemetryLabel()
+        );
     }
 
     /** Parent data source settings (secrets unwrapped to plaintext) overlaid by the dataset's settings. */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.cluster.metadata.DataSource;
+import org.elasticsearch.cluster.metadata.DataSourceMetadata;
+import org.elasticsearch.cluster.metadata.DataSourceSetting;
+import org.elasticsearch.cluster.metadata.Dataset;
+import org.elasticsearch.cluster.metadata.DatasetMetadata;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.xpack.esql.VerificationException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Rewrites {@code FROM <dataset>} to the same {@link UnresolvedExternalRelation} the {@code EXTERNAL}
+ * command produces, so both paths converge at the existing resolver + analyzer. Runs once on the
+ * parsed plan before pre-analysis. Phase 1 rejects mixed indices-and-datasets patterns.
+ */
+public final class DatasetRewriter {
+
+    private DatasetRewriter() {}
+
+    public static LogicalPlan rewrite(LogicalPlan parsed, ProjectMetadata projectMetadata) {
+        if (DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled() == false) {
+            return parsed;
+        }
+        DatasetMetadata datasetMetadata = DatasetMetadata.get(projectMetadata);
+        if (datasetMetadata.datasets().isEmpty()) {
+            return parsed;
+        }
+        DataSourceMetadata dataSourceMetadata = DataSourceMetadata.get(projectMetadata);
+        return parsed.transformUp(UnresolvedRelation.class, r -> rewriteOne(r, datasetMetadata, dataSourceMetadata));
+    }
+
+    private static LogicalPlan rewriteOne(UnresolvedRelation relation, DatasetMetadata datasets, DataSourceMetadata dataSources) {
+        List<String> names = splitPattern(relation.indexPattern().indexPattern());
+        List<String> datasetNames = new ArrayList<>();
+        List<String> indexNames = new ArrayList<>();
+        for (String name : names) {
+            if (datasets.get(name) != null) {
+                datasetNames.add(name);
+            } else {
+                indexNames.add(name);
+            }
+        }
+        if (datasetNames.isEmpty()) {
+            return relation;
+        }
+        if (indexNames.isEmpty() == false) {
+            throw new VerificationException(
+                "FROM mixing indices and datasets is not supported yet; requested mix: indices=" + indexNames + ", datasets=" + datasetNames
+            );
+        }
+        List<LogicalPlan> children = new ArrayList<>(datasetNames.size());
+        for (String name : datasetNames) {
+            Dataset dataset = datasets.get(name);
+            DataSource parent = dataSources.get(dataset.dataSource().getName());
+            if (parent == null) {
+                throw new VerificationException(
+                    "dataset [" + name + "] references unknown data source [" + dataset.dataSource().getName() + "]"
+                );
+            }
+            Map<String, Object> merged = mergeSettings(parent, dataset);
+            Literal path = Literal.keyword(relation.source(), dataset.resource());
+            children.add(new UnresolvedExternalRelation(relation.source(), path, toParams(relation.source(), merged)));
+        }
+        return children.size() == 1 ? children.get(0) : new UnionAll(relation.source(), children, List.of());
+    }
+
+    private static List<String> splitPattern(String pattern) {
+        return Arrays.stream(pattern.split(",")).map(String::trim).filter(s -> s.isEmpty() == false).toList();
+    }
+
+    /** Parent data source settings (secrets unwrapped to plaintext) overlaid by the dataset's settings. */
+    private static Map<String, Object> mergeSettings(DataSource parent, Dataset dataset) {
+        Map<String, Object> merged = new HashMap<>();
+        for (Map.Entry<String, DataSourceSetting> e : parent.settings().entrySet()) {
+            merged.put(e.getKey(), e.getValue().secret() ? e.getValue().secretValue().toString() : e.getValue().nonSecretValue());
+        }
+        merged.putAll(dataset.settings());
+        return merged;
+    }
+
+    private static Map<String, Expression> toParams(Source source, Map<String, Object> merged) {
+        Map<String, Expression> params = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> e : merged.entrySet()) {
+            params.put(e.getKey(), Literal.keyword(source, String.valueOf(e.getValue())));
+        }
+        return params;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -64,6 +64,7 @@ import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtract
 import org.elasticsearch.xpack.esql.core.querydsl.QueryDslTimestampBoundsExtractor.TimestampBounds;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.datasources.DatasetRewriter;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolution;
 import org.elasticsearch.xpack.esql.datasources.ExternalSourceResolver;
 import org.elasticsearch.xpack.esql.datasources.PartitionFilterHintExtractor;
@@ -874,6 +875,9 @@ public class EsqlSession {
 
         TimeSpanMarker preAnalysisProfile = executionInfo.queryProfile().preAnalysis();
         preAnalysisProfile.start();
+        // Rewrite FROM targets that resolve to datasets into UnresolvedExternalRelation so the rest of
+        // pre-analysis + analysis treats them identically to the inline EXTERNAL command.
+        parsed = DatasetRewriter.rewrite(parsed, projectMetadata);
         PreAnalyzer.PreAnalysis preAnalysis = preAnalyzer.preAnalyze(parsed);
         preAnalysisProfile.stop();
         // Initialize the PreAnalysisResult with the local cluster's minimum transport version, so our planning will be correct also in

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.metadata.DataSource;
+import org.elasticsearch.cluster.metadata.DataSourceMetadata;
+import org.elasticsearch.cluster.metadata.DataSourceReference;
+import org.elasticsearch.cluster.metadata.DataSourceSetting;
+import org.elasticsearch.cluster.metadata.Dataset;
+import org.elasticsearch.cluster.metadata.DatasetMetadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.VerificationException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.plan.IndexPattern;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedExternalRelation;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class DatasetRewriterTests extends ESTestCase {
+
+    public void testNoDatasetsLeavesPlanUnchanged() {
+        UnresolvedRelation relation = relationOf("my_index");
+        ProjectMetadata project = projectWith(Map.of(), Map.of());
+        assertSame(relation, DatasetRewriter.rewrite(relation, project));
+    }
+
+    public void testSingleDatasetRewritesToUnresolvedExternalRelation() {
+        DataSource parent = dataSource("s3_parent", Map.of("region", new DataSourceSetting("us-east-1", false)));
+        Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/*.parquet", null, Map.of("format", "parquet"));
+        ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
+
+        LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("logs"), project);
+
+        assertThat(rewritten, instanceOf(UnresolvedExternalRelation.class));
+        UnresolvedExternalRelation out = (UnresolvedExternalRelation) rewritten;
+        assertThat(tablePathString(out), equalTo("s3://logs/*.parquet"));
+        assertThat(paramValue(out, "region"), equalTo("us-east-1"));
+        assertThat(paramValue(out, "format"), equalTo("parquet"));
+    }
+
+    public void testDatasetSettingsOverrideParentOnKeyCollision() {
+        DataSource parent = dataSource("s3_parent", Map.of("region", new DataSourceSetting("us-east-1", false)));
+        Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/", null, Map.of("region", "eu-west-2"));
+        ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
+
+        LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("logs"), project);
+        assertThat(paramValue((UnresolvedExternalRelation) rewritten, "region"), equalTo("eu-west-2"));
+    }
+
+    public void testMultipleDatasetsProduceUnionAll() {
+        DataSource parent = dataSource("s3_parent", Map.of());
+        Dataset ds1 = new Dataset("ds1", new DataSourceReference("s3_parent"), "s3://a/", null, Map.of());
+        Dataset ds2 = new Dataset("ds2", new DataSourceReference("s3_parent"), "s3://b/", null, Map.of());
+        ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("ds1", ds1, "ds2", ds2));
+
+        LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("ds1,ds2"), project);
+
+        assertThat(rewritten, instanceOf(UnionAll.class));
+        UnionAll union = (UnionAll) rewritten;
+        assertThat(union.children(), hasSize(2));
+        assertThat(union.children().get(0), instanceOf(UnresolvedExternalRelation.class));
+        assertThat(union.children().get(1), instanceOf(UnresolvedExternalRelation.class));
+    }
+
+    public void testMixedIndicesAndDatasetsRejected() {
+        DataSource parent = dataSource("s3_parent", Map.of());
+        Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/", null, Map.of());
+        ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
+
+        VerificationException ex = expectThrows(
+            VerificationException.class,
+            () -> DatasetRewriter.rewrite(relationOf("some_idx,logs"), project)
+        );
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("mixing indices and datasets"));
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("indices=[some_idx]"));
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("datasets=[logs]"));
+    }
+
+    public void testUnknownParentDataSourceRejected() {
+        Dataset orphan = new Dataset("orphan", new DataSourceReference("ghost_parent"), "s3://x/", null, Map.of());
+        ProjectMetadata project = projectWith(Map.of(), Map.of("orphan", orphan));
+
+        VerificationException ex = expectThrows(
+            VerificationException.class,
+            () -> DatasetRewriter.rewrite(relationOf("orphan"), project)
+        );
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("dataset [orphan]"));
+        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("unknown data source [ghost_parent]"));
+    }
+
+    public void testSecretSettingUnwrappedToPlaintext() {
+        DataSource parent = dataSource(
+            "s3_parent",
+            Map.of("access_key", new DataSourceSetting("AKIAEXAMPLE", true), "region", new DataSourceSetting("us-east-1", false))
+        );
+        Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/", null, Map.of());
+        ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
+
+        LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("logs"), project);
+        assertThat(paramValue((UnresolvedExternalRelation) rewritten, "access_key"), equalTo("AKIAEXAMPLE"));
+    }
+
+    // --
+
+    private static UnresolvedRelation relationOf(String pattern) {
+        return new UnresolvedRelation(Source.EMPTY, new IndexPattern(Source.EMPTY, pattern), false, List.of(), IndexMode.STANDARD, null);
+    }
+
+    private static DataSource dataSource(String name, Map<String, DataSourceSetting> settings) {
+        return new DataSource(name, "test", null, settings);
+    }
+
+    private static ProjectMetadata projectWith(Map<String, DataSource> dataSources, Map<String, Dataset> datasets) {
+        return ProjectMetadata.builder(ProjectId.DEFAULT)
+            .putCustom(DataSourceMetadata.TYPE, new DataSourceMetadata(dataSources))
+            .datasets(datasets)
+            .build();
+    }
+
+    private static String tablePathString(UnresolvedExternalRelation relation) {
+        Object value = ((Literal) relation.tablePath()).value();
+        return value instanceof BytesRef br ? BytesRefs.toString(br) : value.toString();
+    }
+
+    private static String paramValue(UnresolvedExternalRelation relation, String key) {
+        Expression expression = relation.params().get(key);
+        Object value = ((Literal) expression).value();
+        return value instanceof BytesRef br ? BytesRefs.toString(br) : value.toString();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.metadata.DataSourceMetadata;
 import org.elasticsearch.cluster.metadata.DataSourceReference;
 import org.elasticsearch.cluster.metadata.DataSourceSetting;
 import org.elasticsearch.cluster.metadata.Dataset;
-import org.elasticsearch.cluster.metadata.DatasetMetadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.common.lucene.BytesRefs;
@@ -46,7 +45,13 @@ public class DatasetRewriterTests extends ESTestCase {
 
     public void testSingleDatasetRewritesToUnresolvedExternalRelation() {
         DataSource parent = dataSource("s3_parent", Map.of("region", new DataSourceSetting("us-east-1", false)));
-        Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/*.parquet", null, Map.of("format", "parquet"));
+        Dataset dataset = new Dataset(
+            "logs",
+            new DataSourceReference("s3_parent"),
+            "s3://logs/*.parquet",
+            null,
+            Map.of("format", "parquet")
+        );
         ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
 
         LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("logs"), project);
@@ -100,10 +105,7 @@ public class DatasetRewriterTests extends ESTestCase {
         Dataset orphan = new Dataset("orphan", new DataSourceReference("ghost_parent"), "s3://x/", null, Map.of());
         ProjectMetadata project = projectWith(Map.of(), Map.of("orphan", orphan));
 
-        VerificationException ex = expectThrows(
-            VerificationException.class,
-            () -> DatasetRewriter.rewrite(relationOf("orphan"), project)
-        );
+        VerificationException ex = expectThrows(VerificationException.class, () -> DatasetRewriter.rewrite(relationOf("orphan"), project));
         assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("dataset [orphan]"));
         assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("unknown data source [ghost_parent]"));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/DatasetRewriterTests.java
@@ -87,18 +87,20 @@ public class DatasetRewriterTests extends ESTestCase {
         assertThat(union.children().get(1), instanceOf(UnresolvedExternalRelation.class));
     }
 
-    public void testMixedIndicesAndDatasetsRejected() {
+    public void testMixedIndicesAndDatasetsProduceUnionAll() {
         DataSource parent = dataSource("s3_parent", Map.of());
         Dataset dataset = new Dataset("logs", new DataSourceReference("s3_parent"), "s3://logs/", null, Map.of());
         ProjectMetadata project = projectWith(Map.of("s3_parent", parent), Map.of("logs", dataset));
 
-        VerificationException ex = expectThrows(
-            VerificationException.class,
-            () -> DatasetRewriter.rewrite(relationOf("some_idx,logs"), project)
-        );
-        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("mixing indices and datasets"));
-        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("indices=[some_idx]"));
-        assertThat(ex.getMessage(), org.hamcrest.Matchers.containsString("datasets=[logs]"));
+        LogicalPlan rewritten = DatasetRewriter.rewrite(relationOf("idx_a,logs,idx_b"), project);
+
+        assertThat(rewritten, instanceOf(UnionAll.class));
+        UnionAll union = (UnionAll) rewritten;
+        assertThat(union.children(), hasSize(2));
+        assertThat(union.children().get(0), instanceOf(UnresolvedRelation.class));
+        UnresolvedRelation indexChild = (UnresolvedRelation) union.children().get(0);
+        assertThat(indexChild.indexPattern().indexPattern(), equalTo("idx_a,idx_b"));
+        assertThat(union.children().get(1), instanceOf(UnresolvedExternalRelation.class));
     }
 
     public void testUnknownParentDataSourceRejected() {


### PR DESCRIPTION
Phase 2 of #459 ([elastic/esql-planning#572](https://github.com/elastic/esql-planning/issues/572)): lifts the Phase-1 restriction so `FROM <index>, <dataset>` works end-to-end.

**Stacks on top of [#147355](https://github.com/elastic/elasticsearch/pull/147355) (Phase 1).** Rebase once that lands.

## What changes

`DatasetRewriter.rewriteOne` no longer throws when a FROM mixes index names and dataset names. Instead it emits a `UnionAll` with:

- One `UnresolvedRelation` carrying the index-only subset of the original pattern (preserving `frozen` / `metadataFields` / `indexMode` / telemetry label).
- One `UnresolvedExternalRelation` per dataset, resource + merged-parent-settings, exactly like Phase 1 produces for dataset-only FROMs.

The shape matches what `LogicalPlanBuilder.visitRelation:388-400` already produces for mixed index + subquery FROM — a precedent the parser set for this exact case.

## Why no analyzer / mapper changes

Walking the pipeline:

- **Analyzer** dispatches rules by node type. `ResolveTable` handles the `UnresolvedRelation` child (indices → `EsRelation`). `ResolveExternalRelations` handles each `UnresolvedExternalRelation` child (dataset → `ExternalRelation`). Both already run in the "Initialize" batch, independently, per child.
- **Mapper** — `Mapper.mapLeaf:89-98` wraps **both** `EsRelation` and `ExternalRelation` in `FragmentExec`. So every branch of a mixed `UnionAll` is a `FragmentExec` by the time it reaches `Mapper.mapFork`. The existing condition at `Mapper.java:271` (`if (child instanceof FragmentExec) child = new ExchangeExec(...)`) wraps them all uniformly. No Mapper widen needed — the deep dive's "one-line fix" was unnecessary once you follow the concrete flow.
- **Execution** — `breakPlanIntoSubPlansAndMainPlan` wraps each child in its own `ExchangeSinkExec`; each subplan executes independently via the existing per-subplan path.

So the primitive we reuse is the parser's `UnionAll` shape + the mapper's `FragmentExec`-agnostic fork handling. Zero new logical-plan surface.

## Scope

| Case | Result |
|---|---|
| `FROM idx1, idx2` | unchanged — `UnresolvedRelation("idx1,idx2")` |
| `FROM ds1` | Phase 1 — `UnresolvedExternalRelation` |
| `FROM ds1, ds2` | Phase 1 — `UnionAll(UER, UER)` |
| `FROM idx1, ds1` | **new** — `UnionAll(UnresolvedRelation("idx1"), UER)` |
| `FROM idx1, idx2, ds1, ds2` | **new** — `UnionAll(UnresolvedRelation("idx1,idx2"), UER, UER)` |

Gated by `DataSourceMetadata.ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG`, same as Phase 1.

## Tests

### Unit — `DatasetRewriterTests`

Replaces Phase 1's `testMixedIndicesAndDatasetsRejected` with `testMixedIndicesAndDatasetsProduceUnionAll`:

- Input: `FROM idx_a, logs, idx_b` where `logs` is a dataset.
- Asserts: `UnionAll.children()` is `[UnresolvedRelation("idx_a,idx_b"), UnresolvedExternalRelation]`.

### Integration — `FromDatasetIT.testFromMixedIndexAndDataset`

Replaces Phase 1's `testFromMixedIndexAndDatasetRejected`. Seeds a real ES index `local_emps` with `(emp_no=99, first_name="Diana")`, PUTs a DataSource + Dataset over the CSV fixture (3 rows: Alice, Bob, Carol), then runs:

```
FROM local_emps,employees | SORT emp_no
```

Asserts 4 rows come back in the expected order — proof the parser → rewriter → analyzer → mapper → execution pipeline unions the two sources on the fly.

## Out of scope (follow-ups tracked on #572)

- Wildcard expansion — `FROM log_*` where the pattern straddles both types. Still pending; design calls for it to use `IndexNameExpressionResolver` with `resolveDatasets(true)`.
- Schema-conflict edge cases (same column name, different types on the two branches). Handled by the existing `Fork.outputUnion` machinery (produces UNSUPPORTED); no explicit test here, but the plumbing is covered.
- `_index` metadata semantics for dataset rows.
