### PR TITLE
Support more types in last and first over time

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/types/first_over_time.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/types/first_over_time.md
@@ -7,9 +7,14 @@
 | counter_double | time_duration {applies_to}`stack: preview 9.3.0` | double |
 | counter_integer | time_duration {applies_to}`stack: preview 9.3.0` | integer |
 | counter_long | time_duration {applies_to}`stack: preview 9.3.0` | long |
+| date | time_duration {applies_to}`stack: preview 9.3.0` | date |
+| date_nanos | time_duration {applies_to}`stack: preview 9.3.0` | date_nanos |
 | double | time_duration {applies_to}`stack: preview 9.3.0` | double |
 | exponential_histogram {applies_to}`stack: preview 9.3.0, ga 9.4.0` | time_duration {applies_to}`stack: preview 9.3.0` | exponential_histogram |
 | integer | time_duration {applies_to}`stack: preview 9.3.0` | integer |
+| ip | time_duration {applies_to}`stack: preview 9.3.0` | ip |
+| keyword | time_duration {applies_to}`stack: preview 9.3.0` | keyword |
 | long | time_duration {applies_to}`stack: preview 9.3.0` | long |
 | tdigest {applies_to}`stack: ga 9.4.0` | time_duration {applies_to}`stack: preview 9.3.0` | tdigest |
+| text | time_duration {applies_to}`stack: preview 9.3.0` | keyword |
 

--- a/docs/reference/query-languages/esql/_snippets/functions/types/last_over_time.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/types/last_over_time.md
@@ -7,9 +7,14 @@
 | counter_double | time_duration {applies_to}`stack: preview 9.3.0` | double |
 | counter_integer | time_duration {applies_to}`stack: preview 9.3.0` | integer |
 | counter_long | time_duration {applies_to}`stack: preview 9.3.0` | long |
+| date | time_duration {applies_to}`stack: preview 9.3.0` | date |
+| date_nanos | time_duration {applies_to}`stack: preview 9.3.0` | date_nanos |
 | double | time_duration {applies_to}`stack: preview 9.3.0` | double |
 | exponential_histogram {applies_to}`stack: preview 9.3.0, ga 9.4.0` | time_duration {applies_to}`stack: preview 9.3.0` | exponential_histogram |
 | integer | time_duration {applies_to}`stack: preview 9.3.0` | integer |
+| ip | time_duration {applies_to}`stack: preview 9.3.0` | ip |
+| keyword | time_duration {applies_to}`stack: preview 9.3.0` | keyword |
 | long | time_duration {applies_to}`stack: preview 9.3.0` | long |
 | tdigest {applies_to}`stack: ga 9.4.0` | time_duration {applies_to}`stack: preview 9.3.0` | tdigest |
+| text | time_duration {applies_to}`stack: preview 9.3.0` | keyword |
 

--- a/docs/reference/query-languages/esql/kibana/definition/functions/first_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/first_over_time.json
@@ -62,6 +62,42 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "date",
+          "optional" : false,
+          "description" : "the metric field to calculate the value for"
+        },
+        {
+          "name" : "window",
+          "type" : "time_duration",
+          "optional" : true,
+          "description" : "the time window over which to compute the first over time value"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "the metric field to calculate the value for"
+        },
+        {
+          "name" : "window",
+          "type" : "time_duration",
+          "optional" : true,
+          "description" : "the time window over which to compute the first over time value"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date_nanos"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "double",
           "optional" : false,
           "description" : "the metric field to calculate the value for"
@@ -116,6 +152,42 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "ip",
+          "optional" : false,
+          "description" : "the metric field to calculate the value for"
+        },
+        {
+          "name" : "window",
+          "type" : "time_duration",
+          "optional" : true,
+          "description" : "the time window over which to compute the first over time value"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "ip"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "the metric field to calculate the value for"
+        },
+        {
+          "name" : "window",
+          "type" : "time_duration",
+          "optional" : true,
+          "description" : "the time window over which to compute the first over time value"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "long",
           "optional" : false,
           "description" : "the metric field to calculate the value for"
@@ -147,6 +219,24 @@
       ],
       "variadic" : false,
       "returnType" : "tdigest"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "the metric field to calculate the value for"
+        },
+        {
+          "name" : "window",
+          "type" : "time_duration",
+          "optional" : true,
+          "description" : "the time window over which to compute the first over time value"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
     }
   ],
   "examples" : [

--- a/docs/reference/query-languages/esql/kibana/definition/functions/last_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/last_over_time.json
@@ -62,6 +62,42 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "date",
+          "optional" : false,
+          "description" : "the metric field to calculate the latest value for"
+        },
+        {
+          "name" : "window",
+          "type" : "time_duration",
+          "optional" : true,
+          "description" : "the time window over which to find the latest value"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "date_nanos",
+          "optional" : false,
+          "description" : "the metric field to calculate the latest value for"
+        },
+        {
+          "name" : "window",
+          "type" : "time_duration",
+          "optional" : true,
+          "description" : "the time window over which to find the latest value"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "date_nanos"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "double",
           "optional" : false,
           "description" : "the metric field to calculate the latest value for"
@@ -116,6 +152,42 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "ip",
+          "optional" : false,
+          "description" : "the metric field to calculate the latest value for"
+        },
+        {
+          "name" : "window",
+          "type" : "time_duration",
+          "optional" : true,
+          "description" : "the time window over which to find the latest value"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "ip"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "the metric field to calculate the latest value for"
+        },
+        {
+          "name" : "window",
+          "type" : "time_duration",
+          "optional" : true,
+          "description" : "the time window over which to find the latest value"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "long",
           "optional" : false,
           "description" : "the metric field to calculate the latest value for"
@@ -147,6 +219,24 @@
       ],
       "variadic" : false,
       "returnType" : "tdigest"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "the metric field to calculate the latest value for"
+        },
+        {
+          "name" : "window",
+          "type" : "time_duration",
+          "optional" : true,
+          "description" : "the time window over which to find the latest value"
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
     }
   ],
   "examples" : [

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/tsdb-mapping.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/index/mappings/tsdb-mapping.json
@@ -14,6 +14,9 @@
       "type": "keyword",
       "time_series_dimension": true
     },
+    "bool_field": {
+      "type": "boolean"
+    },
     "network": {
       "properties": {
         "connections": {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstOverTime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstOverTime.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.aggregate;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.FirstBytesRefByTimestampAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.FirstDoubleByTimestampAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.FirstExponentialHistogramByTimestampAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.FirstFloatByTimestampAggregatorFunctionSupplier;
@@ -64,7 +65,7 @@ public class FirstOverTime extends TimeSeriesAggregateFunction implements Option
     // TODO: support all types
     @FunctionInfo(
         type = FunctionType.TIME_SERIES_AGGREGATE,
-        returnType = { "long", "integer", "double", "exponential_histogram", "tdigest" },
+        returnType = { "long", "integer", "double", "exponential_histogram", "tdigest", "date", "date_nanos", "ip", "keyword" },
         description = "Calculates the earliest value of a field, where recency determined by the `@timestamp` field.",
         appliesTo = {
             @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.PREVIEW, version = "9.2.0"),
@@ -75,7 +76,20 @@ public class FirstOverTime extends TimeSeriesAggregateFunction implements Option
         Source source,
         @Param(
             name = "field",
-            type = { "counter_long", "counter_integer", "counter_double", "long", "integer", "double", "exponential_histogram", "tdigest" },
+            type = {
+                "counter_long",
+                "counter_integer",
+                "counter_double",
+                "long",
+                "integer",
+                "double",
+                "exponential_histogram",
+                "tdigest",
+                "date",
+                "date_nanos",
+                "ip",
+                "keyword",
+                "text" },
             description = "the metric field to calculate the value for"
         ) Expression field,
         @Param(
@@ -126,7 +140,7 @@ public class FirstOverTime extends TimeSeriesAggregateFunction implements Option
 
     @Override
     public DataType dataType() {
-        return field().dataType().noCounter();
+        return field().dataType().noCounter().noText();
     }
 
     @Override
@@ -136,7 +150,12 @@ public class FirstOverTime extends TimeSeriesAggregateFunction implements Option
             dt -> (dt.noCounter().isNumeric() && dt != DataType.UNSIGNED_LONG)
                 || dt == DataType.AGGREGATE_METRIC_DOUBLE
                 || dt == DataType.EXPONENTIAL_HISTOGRAM
-                || dt == DataType.TDIGEST,
+                || dt == DataType.TDIGEST
+                || dt == DataType.DATETIME
+                || dt == DataType.DATE_NANOS
+                || dt == DataType.IP
+                || dt == DataType.KEYWORD
+                || dt == DataType.TEXT,
             sourceText(),
             DEFAULT,
             "numeric except unsigned_long"
@@ -151,12 +170,13 @@ public class FirstOverTime extends TimeSeriesAggregateFunction implements Option
         // we can read the first encountered value for each group of `_tsid` and time bucket.
         final DataType type = field().dataType();
         return switch (type) {
-            case LONG, COUNTER_LONG -> new FirstLongByTimestampAggregatorFunctionSupplier();
+            case LONG, COUNTER_LONG, DATETIME, DATE_NANOS -> new FirstLongByTimestampAggregatorFunctionSupplier();
             case INTEGER, COUNTER_INTEGER -> new FirstIntByTimestampAggregatorFunctionSupplier();
             case DOUBLE, COUNTER_DOUBLE -> new FirstDoubleByTimestampAggregatorFunctionSupplier();
             case FLOAT -> new FirstFloatByTimestampAggregatorFunctionSupplier();
             case EXPONENTIAL_HISTOGRAM -> new FirstExponentialHistogramByTimestampAggregatorFunctionSupplier();
             case TDIGEST -> new FirstTDigestByTimestampAggregatorFunctionSupplier();
+            case KEYWORD, TEXT, IP -> new FirstBytesRefByTimestampAggregatorFunctionSupplier();
             default -> throw EsqlIllegalArgumentException.illegalDataType(type);
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastOverTime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastOverTime.java
@@ -65,7 +65,7 @@ public class LastOverTime extends TimeSeriesAggregateFunction implements Optiona
     // TODO: support all types
     @FunctionInfo(
         type = FunctionType.TIME_SERIES_AGGREGATE,
-        returnType = { "long", "integer", "double", "_tsid", "exponential_histogram", "tdigest" },
+        returnType = { "long", "integer", "double", "_tsid", "exponential_histogram", "tdigest", "date", "date_nanos", "ip", "keyword" },
         description = "Calculates the latest value of a field, where recency determined by the `@timestamp` field.",
         appliesTo = {
             @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.PREVIEW, version = "9.2.0"),
@@ -85,7 +85,12 @@ public class LastOverTime extends TimeSeriesAggregateFunction implements Optiona
                 "double",
                 "_tsid",
                 "exponential_histogram",
-                "tdigest" },
+                "tdigest",
+                "date",
+                "date_nanos",
+                "ip",
+                "keyword",
+                "text", },
             description = "the metric field to calculate the latest value for"
         ) Expression field,
         @Param(
@@ -136,7 +141,7 @@ public class LastOverTime extends TimeSeriesAggregateFunction implements Optiona
 
     @Override
     public DataType dataType() {
-        return field().dataType().noCounter();
+        return field().dataType().noCounter().noText();
     }
 
     @Override
@@ -146,7 +151,12 @@ public class LastOverTime extends TimeSeriesAggregateFunction implements Optiona
             dt -> (dt.noCounter().isNumeric() && dt != DataType.UNSIGNED_LONG)
                 || dt == DataType.TSID_DATA_TYPE
                 || dt == DataType.EXPONENTIAL_HISTOGRAM
-                || dt == DataType.TDIGEST,
+                || dt == DataType.TDIGEST
+                || dt == DataType.DATETIME
+                || dt == DataType.DATE_NANOS
+                || dt == DataType.KEYWORD
+                || dt == DataType.TEXT
+                || dt == DataType.IP,
             sourceText(),
             DEFAULT,
             "numeric except unsigned_long"
@@ -161,11 +171,11 @@ public class LastOverTime extends TimeSeriesAggregateFunction implements Optiona
         // we can read the first encountered value for each group of `_tsid` and time bucket.
         final DataType type = field().dataType();
         return switch (type) {
-            case LONG, COUNTER_LONG -> new LastLongByTimestampAggregatorFunctionSupplier();
+            case LONG, COUNTER_LONG, DATETIME, DATE_NANOS -> new LastLongByTimestampAggregatorFunctionSupplier();
             case INTEGER, COUNTER_INTEGER -> new LastIntByTimestampAggregatorFunctionSupplier();
             case DOUBLE, COUNTER_DOUBLE -> new LastDoubleByTimestampAggregatorFunctionSupplier();
             case FLOAT -> new LastFloatByTimestampAggregatorFunctionSupplier();
-            case TSID_DATA_TYPE -> new LastBytesRefByTimestampAggregatorFunctionSupplier();
+            case TSID_DATA_TYPE, IP, KEYWORD, TEXT -> new LastBytesRefByTimestampAggregatorFunctionSupplier();
             case EXPONENTIAL_HISTOGRAM -> new LastExponentialHistogramByTimestampAggregatorFunctionSupplier();
             case TDIGEST -> new LastTDigestByTimestampAggregatorFunctionSupplier();
             default -> throw EsqlIllegalArgumentException.illegalDataType(type);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -3336,18 +3336,10 @@ public class VerifierTests extends ESTestCase {
 
     public void testNoDimensionsInAggsOnlyInByClause() {
         tsdb().error(
-            "TS test | STATS count(host) BY bucket(@timestamp, 1 minute)",
+            "TS test | STATS count(bool_field) BY bucket(@timestamp, 1 minute)",
             equalTo(
-                "1:23: argument of [implicit time-series aggregation function (LastOverTime) for host] must be "
-                    + "[numeric except unsigned_long], found value [host] type [keyword]; "
-                    + "to aggregate non-numeric fields, use the FROM command instead of the TS command"
-            )
-        );
-        tsdb().error(
-            "TS test | STATS max(name) BY bucket(@timestamp, 1 minute)",
-            equalTo(
-                "1:21: argument of [implicit time-series aggregation function (LastOverTime) for name] must be "
-                    + "[numeric except unsigned_long], found value [name] type [keyword]; "
+                "1:23: argument of [implicit time-series aggregation function (LastOverTime) for bool_field] must be "
+                    + "[numeric except unsigned_long], found value [bool_field] type [boolean]; "
                     + "to aggregate non-numeric fields, use the FROM command instead of the TS command"
             )
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -3334,6 +3334,25 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
+    public void testNoDimensionsInAggsOnlyInByClause() {
+        tsdb().error(
+            "TS test | STATS count(host) BY bucket(@timestamp, 1 minute)",
+            equalTo(
+                "1:23: argument of [implicit time-series aggregation function (LastOverTime) for host] must be "
+                    + "[numeric except unsigned_long], found value [host] type [keyword]; "
+                    + "to aggregate non-numeric fields, use the FROM command instead of the TS command"
+            )
+        );
+        tsdb().error(
+            "TS test | STATS max(name) BY bucket(@timestamp, 1 minute)",
+            equalTo(
+                "1:21: argument of [implicit time-series aggregation function (LastOverTime) for name] must be "
+                    + "[numeric except unsigned_long], found value [name] type [keyword]; "
+                    + "to aggregate non-numeric fields, use the FROM command instead of the TS command"
+            )
+        );
+    }
+
     public void testSortInTimeSeries() {
         tsdb().error(
             "TS test | SORT host | STATS avg(last_over_time(network.connections))",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -3334,25 +3334,6 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
-    public void testNoDimensionsInAggsOnlyInByClause() {
-        tsdb().error(
-            "TS test | STATS count(host) BY bucket(@timestamp, 1 minute)",
-            equalTo(
-                "1:23: argument of [implicit time-series aggregation function (LastOverTime) for host] must be "
-                    + "[numeric except unsigned_long], found value [host] type [keyword]; "
-                    + "to aggregate non-numeric fields, use the FROM command instead of the TS command"
-            )
-        );
-        tsdb().error(
-            "TS test | STATS max(name) BY bucket(@timestamp, 1 minute)",
-            equalTo(
-                "1:21: argument of [implicit time-series aggregation function (LastOverTime) for name] must be "
-                    + "[numeric except unsigned_long], found value [name] type [keyword]; "
-                    + "to aggregate non-numeric fields, use the FROM command instead of the TS command"
-            )
-        );
-    }
-
     public void testSortInTimeSeries() {
         tsdb().error(
             "TS test | SORT host | STATS avg(last_over_time(network.connections))",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstOverTimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstOverTimeTests.java
@@ -49,7 +49,12 @@ public class FirstOverTimeTests extends AbstractAggregationTestCase {
                 .stream()
                 .map(s -> s.withAppliesTo(expHistogramPreviewAppliesTo).withAppliesTo(histogramGaAppliesTo))
                 .toList(),
-            MultiRowTestCaseSupplier.tdigestCases(1, 100).stream().map(s -> s.withAppliesTo(histogramGaAppliesTo)).toList()
+            MultiRowTestCaseSupplier.tdigestCases(1, 100).stream().map(s -> s.withAppliesTo(histogramGaAppliesTo)).toList(),
+            MultiRowTestCaseSupplier.dateCases(1, 1000),
+            MultiRowTestCaseSupplier.dateNanosCases(1, 1000),
+            MultiRowTestCaseSupplier.ipCases(1, 1000),
+            MultiRowTestCaseSupplier.stringCases(1, 1000, DataType.KEYWORD),
+            MultiRowTestCaseSupplier.stringCases(1, 1000, DataType.TEXT)
         );
         for (List<TestCaseSupplier.TypedDataSupplier> valuesSupplier : valuesSuppliers) {
             for (TestCaseSupplier.TypedDataSupplier fieldSupplier : valuesSupplier) {
@@ -104,7 +109,7 @@ public class FirstOverTimeTests extends AbstractAggregationTestCase {
             }
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData, timestampsField),
-                standardAggregatorName("First", type) + "ByTimestamp",
+                standardAggregatorNameAllBytesTheSame("First", type) + "ByTimestamp",
                 fieldSupplier.type(),
                 equalTo(expected)
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastOverTimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastOverTimeTests.java
@@ -49,7 +49,12 @@ public class LastOverTimeTests extends AbstractAggregationTestCase {
                 .stream()
                 .map(s -> s.withAppliesTo(expHistogramPreviewAppliesTo).withAppliesTo(histogramGaAppliesTo))
                 .toList(),
-            MultiRowTestCaseSupplier.tdigestCases(1, 100).stream().map(s -> s.withAppliesTo(histogramGaAppliesTo)).toList()
+            MultiRowTestCaseSupplier.tdigestCases(1, 100).stream().map(s -> s.withAppliesTo(histogramGaAppliesTo)).toList(),
+            MultiRowTestCaseSupplier.dateCases(1, 1000),
+            MultiRowTestCaseSupplier.dateNanosCases(1, 1000),
+            MultiRowTestCaseSupplier.ipCases(1, 1000),
+            MultiRowTestCaseSupplier.stringCases(1, 1000, DataType.KEYWORD),
+            MultiRowTestCaseSupplier.stringCases(1, 1000, DataType.TEXT)
         );
         for (List<TestCaseSupplier.TypedDataSupplier> valuesSupplier : valuesSuppliers) {
             for (TestCaseSupplier.TypedDataSupplier fieldSupplier : valuesSupplier) {
@@ -104,7 +109,7 @@ public class LastOverTimeTests extends AbstractAggregationTestCase {
             }
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData, timestampsField),
-                standardAggregatorName("Last", type) + "ByTimestamp",
+                standardAggregatorNameAllBytesTheSame("Last", type) + "ByTimestamp",
                 fieldSupplier.type(),
                 equalTo(expected)
             );


### PR DESCRIPTION
This change adds support for additional types, including ip, date, date_nanos, keyword, and text to last_over_time and first_over_time. While supporting these types is not essential, it allows users to execute a wider variety of queries.