### PR TITLE
[9.4] Restore TEXT field size estimate for Enrich and LookupJoin (#147357)

### DIFF
--- a/docs/changelog/147357.yaml
+++ b/docs/changelog/147357.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147357
+summary: Restore TEXT field size estimate for Enrich and `LookupJoin`
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExec.java
@@ -169,7 +169,7 @@ public class EnrichExec extends UnaryExec implements EstimatesRowSize, ExecutesO
 
     @Override
     public PhysicalPlan estimateRowSize(State state) {
-        state.add(false, enrichFields);
+        state.add(false, enrichFields, true);
         return this;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
@@ -73,6 +73,23 @@ public interface EstimatesRowSize {
         }
 
         /**
+         * Similar to {@link #add(boolean, List)} but count text fields as keyword field.
+         * This allows pipeline with Enrich, LookupJoin to avoiding generate many smaller pages,
+         * which have significant overhead per page.
+         */
+        public void add(boolean needsSortedDocIds, List<? extends Expression> expressions, boolean countTextFieldAsKeyword) {
+            for (var expr : expressions) {
+                DataType dataType = expr.dataType();
+                if (countTextFieldAsKeyword && dataType == DataType.TEXT) {
+                    dataType = DataType.KEYWORD;
+                }
+                estimatedRowSize += estimateSize(dataType);
+            }
+            maxEstimatedRowSize = Math.max(estimatedRowSize, maxEstimatedRowSize);
+            this.needsSortedDocIds |= needsSortedDocIds;
+        }
+
+        /**
          * Model an operator that consumes all fields.
          * @return the number of bytes added to pages emitted by the operator
          *         being modeled

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LookupJoinExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LookupJoinExec.java
@@ -118,7 +118,7 @@ public class LookupJoinExec extends BinaryExec implements EstimatesRowSize {
 
     @Override
     public PhysicalPlan estimateRowSize(State state) {
-        state.add(false, addedFields);
+        state.add(false, addedFields, true);
         return this;
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -440,9 +440,14 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             new ResolvedEnrichPolicy(
                 "employee_id",
                 EnrichPolicy.MATCH_TYPE,
-                List.of("department"),
+                List.of("department", "description"),
                 Map.of("", ".enrich-departments-1", "cluster_1", ".enrich-departments-2"),
-                Map.of("department", new EsField("department", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE))
+                Map.of(
+                    "department",
+                    new EsField("department", DataType.KEYWORD, Map.of(), true, EsField.TimeSeriesFieldType.NONE),
+                    "description",
+                    new EsField("description", DataType.TEXT, Map.of(), true, EsField.TimeSeriesFieldType.NONE)
+                )
             )
         );
         builder.addEnrichPolicy(
@@ -2982,6 +2987,17 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         var source = source(extract.child());
         // an int for doc id, and int for the "a" enriched field, and a long for the "b" enriched field
         assertThat(source.estimatedRowSize(), equalTo(allFieldRowSize + Integer.BYTES * 2 + Long.BYTES));
+    }
+
+    public void testEnrichEstimateRowSize() {
+        var plan = physicalPlan("""
+                FROM test
+                | ENRICH departments ON emp_no
+                | KEEP emp_no, department, description
+            """);
+        var optimized = optimizedPlan(plan);
+        var source = (EsQueryExec) optimized.collectFirstChildren(e -> e instanceof EsQueryExec).getFirst();
+        assertThat(source.estimatedRowSize(), equalTo(108));
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Restore TEXT field size estimate for Enrich and LookupJoin (#147357)