### PR TITLE
[9.2] Add node feature for data stream mappings api (#147189)

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamFeatures.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamFeatures.java
@@ -34,6 +34,8 @@ public class DataStreamFeatures implements FeatureSpecification {
 
     public static final NodeFeature FAILURE_STORE_IN_LOG_DATA_STREAMS = new NodeFeature("logs_data_streams.failure_store.enabled");
 
+    public static final NodeFeature DATA_STREAMS_MAPPINGS_API = new NodeFeature("data_stream.mappings_api");
+
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of(DataStream.DATA_STREAM_FAILURE_STORE_FEATURE);
@@ -46,7 +48,8 @@ public class DataStreamFeatures implements FeatureSpecification {
             DOWNSAMPLE_AGGREGATE_DEFAULT_METRIC_FIX,
             LOGS_STREAM_FEATURE,
             FAILURE_STORE_IN_LOG_DATA_STREAMS,
-            DOWNSAMPLE_MULTI_VALUE_DIMENSIONS
+            DOWNSAMPLE_MULTI_VALUE_DIMENSIONS,
+            DATA_STREAMS_MAPPINGS_API
         );
     }
 }

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/250_data_stream_mappings.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/250_data_stream_mappings.yml
@@ -2,6 +2,10 @@ setup:
   - skip:
       features: allowed_warnings
 
+  - requires:
+      cluster_features: ["data_stream.mappings_api"]
+      reason: feature under test must be present
+
 ---
 "Test single data stream":
   - do:

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/280_data_stream_mappings-timeseries.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/280_data_stream_mappings-timeseries.yml
@@ -1,3 +1,8 @@
+setup:
+  - requires:
+      cluster_features: [ "data_stream.mappings_api" ]
+      reason: feature under test must be present
+
 ---
 "Test time_series data stream":
   - do:

--- a/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
@@ -2091,6 +2091,10 @@ setup:
   - skip:
       features: headers
 
+  - requires:
+      cluster_features: [ "data_stream.mappings_api" ]
+      reason: test uses data_stream mappings api
+
   - do:
       indices.put_index_template:
         name: test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
@@ -254,7 +254,7 @@
 ---
 "Simulate index template with data stream with mapping and setting overrides":
   - requires:
-      cluster_features: [ "logs_stream" ]
+      cluster_features: [ "logs_stream", "data_stream.mappings_api" ]
       reason: requires setting 'logs_stream' to get or set data stream mappings
 
   - do:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Add node feature for data stream mappings api (#147189)](https://github.com/elastic/elasticsearch/pull/147189)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)