### PR TITLE
[ESQL] Handle null lastModified in external source resolution

### DIFF
--- a/docs/changelog/147389.yaml
+++ b/docs/changelog/147389.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 147211
+pr: 147389
+summary: Handle null `lastModified` in external source resolution
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -178,7 +179,8 @@ public class ExternalSourceResolver {
         if (isCacheable(provider)) {
             // Stat the file first (cheap HEAD/stat) to get mtime for the cache key.
             object = provider.newObject(storagePath);
-            long mtime = object.lastModified().toEpochMilli();
+            Instant lastMod = object.lastModified();
+            long mtime = lastMod != null ? lastMod.toEpochMilli() : Instant.EPOCH.toEpochMilli();
             String formatType = detectFormatType(storagePath);
             SchemaCacheKey schemaKey = SchemaCacheKey.build(storagePath.toString(), mtime, formatType, config);
             SchemaCacheEntry schemaEntry = cacheService.getOrComputeSchema(schemaKey, k -> {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageEntry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageEntry.java
@@ -14,4 +14,10 @@ import java.time.Instant;
 /**
  * Metadata about an object returned from directory listing.
  */
-public record StorageEntry(StoragePath path, long length, Instant lastModified) {}
+public record StorageEntry(StoragePath path, long length, Instant lastModified) {
+    public StorageEntry {
+        if (lastModified == null) {
+            lastModified = Instant.EPOCH;
+        }
+    }
+}


### PR DESCRIPTION
StorageObject.lastModified() may return null per its SPI contract,
but the schema caching path added in #147297 called .toEpochMilli()
on the result without a null check. This caused NPEs for providers
that do not expose modification time (e.g. the gRPC/Flight datasource).

Guard the direct call site in ExternalSourceResolver and normalize
null to Instant.EPOCH in StorageEntry so all downstream consumers
(FileListCompactor, GenericFileList) are also protected.

Closes #147211

Developed with AI-assisted tooling