### PR TITLE
[ESQL] Re-land single-file schema caching with null-safe lastModified

### DIFF
--- a/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-http/src/main/java/org/elasticsearch/xpack/esql/datasource/http/HttpStorageProvider.java
@@ -92,6 +92,11 @@ public final class HttpStorageProvider implements StorageProvider {
     }
 
     @Override
+    public boolean supportsStableMetadata() {
+        return false;
+    }
+
+    @Override
     public void close() {
         // HttpClient implements AutoCloseable in Java 21+
         // Closing it shuts down the internal selector thread and connection pool

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageProvider.java
@@ -75,6 +75,11 @@ class ConcurrencyLimitedStorageProvider implements StorageProvider {
     }
 
     @Override
+    public boolean supportsStableMetadata() {
+        return delegate.supportsStableMetadata();
+    }
+
+    @Override
     public void close() throws IOException {
         delegate.close();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -165,8 +166,6 @@ public class ExternalSourceResolver {
             return resolveMultiFileSource(path, config, hints, hivePartitioning);
         }
 
-        SourceMetadata metadata = resolveSingleSource(path, config);
-        ExternalSourceMetadata extMetadata = wrapAsExternalSourceMetadata(metadata, config);
         /*
          * A concrete one-entry FileList is required so {@link org.elasticsearch.xpack.esql.datasources.FileSplitProvider}
          * can discover block-aligned splits for compressed files (e.g. .json.bz2). UNRESOLVED lists skip split discovery,
@@ -174,7 +173,34 @@ public class ExternalSourceResolver {
          */
         StoragePath storagePath = StoragePath.of(path);
         StorageProvider provider = resolveProvider(storagePath, config);
-        StorageObject object = provider.newObject(storagePath);
+
+        ExternalSourceMetadata extMetadata;
+        StorageObject object;
+        if (isCacheable(provider)) {
+            // Stat the file first (cheap HEAD/stat) to get mtime for the cache key.
+            // Null mtime (e.g. gRPC/Flight, GCS/Azure fixtures) falls back to EPOCH so the
+            // cache key is stable; providers that never report trustworthy mtime should
+            // eventually return supportsStableMetadata() == false to bypass caching entirely.
+            object = provider.newObject(storagePath);
+            Instant lastMod = object.lastModified();
+            long mtime = lastMod != null ? lastMod.toEpochMilli() : Instant.EPOCH.toEpochMilli();
+            String formatType = detectFormatType(storagePath);
+            SchemaCacheKey schemaKey = SchemaCacheKey.build(storagePath.toString(), mtime, formatType, config);
+            SchemaCacheEntry schemaEntry = cacheService.getOrComputeSchema(schemaKey, k -> {
+                SourceMetadata meta = resolveSingleSource(path, config);
+                Map<String, Object> enrichedMeta = meta.statistics()
+                    .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
+                    .orElse(meta.sourceMetadata());
+                return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta, meta.config());
+            });
+            List<Attribute> schema = schemaEntry.toAttributes();
+            extMetadata = buildMetadataFromCache(schemaEntry, schema, config);
+        } else {
+            SourceMetadata metadata = resolveSingleSource(path, config);
+            extMetadata = wrapAsExternalSourceMetadata(metadata, config);
+            object = provider.newObject(storagePath);
+        }
+
         FileList singletonList = GlobExpander.fileListOf(
             List.of(new StorageEntry(storagePath, object.length(), object.lastModified())),
             path
@@ -189,11 +215,11 @@ public class ExternalSourceResolver {
         boolean hivePartitioning
     ) throws Exception {
         StoragePath storagePath = StoragePath.of(path);
+        StorageProvider provider = resolveProvider(storagePath, config);
 
         FormatReader.SchemaResolution schemaResolution = parseSchemaResolution(config);
 
         if (schemaResolution != FormatReader.SchemaResolution.FIRST_FILE_WINS) {
-            StorageProvider provider = resolveProvider(storagePath, config);
             int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
             int maxGlobExpansion = ExternalSourceSettings.MAX_GLOB_EXPANSION.get(settings);
             FileList raw = path.indexOf(',') >= 0
@@ -205,20 +231,17 @@ public class ExternalSourceResolver {
             return resolveMultiFileWithReconciliation(raw, config, schemaResolution);
         }
 
-        boolean cacheable = cacheService != null
-            && cacheService.isEnabled()
-            && "http".equals(storagePath.scheme()) == false
-            && "https".equals(storagePath.scheme()) == false;
+        boolean cacheable = isCacheable(provider);
 
         FileList listing;
         if (cacheable) {
             ListingCacheKey listingKey = ListingCacheKey.build(storagePath.scheme(), storagePath.host(), storagePath.path(), config);
             listing = cacheService.getOrComputeListing(
                 listingKey,
-                k -> expandAndCompact(path, config, hints, hivePartitioning, storagePath)
+                k -> expandAndCompact(path, provider, hints, hivePartitioning, storagePath)
             );
         } else {
-            listing = expandAndCompact(path, config, hints, hivePartitioning, storagePath);
+            listing = expandAndCompact(path, provider, hints, hivePartitioning, storagePath);
         }
 
         if (listing.fileCount() == 0) {
@@ -244,7 +267,7 @@ public class ExternalSourceResolver {
                 Map<String, Object> enrichedMeta = meta.statistics()
                     .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
                     .orElse(meta.sourceMetadata());
-                return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta);
+                return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta, meta.config());
             });
             List<Attribute> schema = schemaEntry.toAttributes();
             extMetadata = buildMetadataFromCache(schemaEntry, schema, config);
@@ -263,15 +286,23 @@ public class ExternalSourceResolver {
 
     private FileList expandAndCompact(
         String path,
-        Map<String, Object> config,
+        StorageProvider provider,
         @Nullable List<PartitionFilterHintExtractor.PartitionFilterHint> hints,
         boolean hivePartitioning,
         StoragePath storagePath
     ) throws Exception {
-        StorageProvider provider = resolveProvider(storagePath, config);
         int maxDiscoveredFiles = ExternalSourceSettings.MAX_DISCOVERED_FILES.get(settings);
         int maxGlobExpansion = ExternalSourceSettings.MAX_GLOB_EXPANSION.get(settings);
         return GlobExpander.expandAndCompact(path, provider, hints, hivePartitioning, storagePath, maxDiscoveredFiles, maxGlobExpansion);
+    }
+
+    /**
+     * Returns {@code true} when the schema cache can be consulted for the given provider.
+     * Providers that do not support stable metadata (e.g. HTTP) are excluded because
+     * mtime-based cache invalidation is not reliable for them.
+     */
+    private boolean isCacheable(StorageProvider provider) {
+        return cacheService != null && cacheService.isEnabled() && provider.supportsStableMetadata();
     }
 
     private StorageProvider resolveProvider(StoragePath storagePath, Map<String, Object> config) {
@@ -294,8 +325,21 @@ public class ExternalSourceResolver {
     private static ExternalSourceMetadata buildMetadataFromCache(
         SchemaCacheEntry entry,
         List<Attribute> schema,
-        Map<String, Object> config
+        Map<String, Object> queryConfig
     ) {
+        // Merge cached connector config (e.g. Flight endpoint/target) with query-level params.
+        // Query-level params take precedence, matching the merge in wrapAsExternalSourceMetadata.
+        Map<String, Object> cachedConnectorConfig = entry.connectorConfig();
+        Map<String, Object> mergedConfig;
+        if (cachedConnectorConfig != null && cachedConnectorConfig.isEmpty() == false) {
+            mergedConfig = new HashMap<>(cachedConnectorConfig);
+            if (queryConfig != null) {
+                mergedConfig.putAll(queryConfig);
+            }
+        } else {
+            mergedConfig = queryConfig != null ? queryConfig : Map.of();
+        }
+
         return new ExternalSourceMetadata() {
             @Override
             public String location() {
@@ -319,7 +363,7 @@ public class ExternalSourceResolver {
 
             @Override
             public Map<String, Object> config() {
-                return config != null ? config : Map.of();
+                return mergedConfig;
             }
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/RetryableStorageProvider.java
@@ -66,6 +66,11 @@ class RetryableStorageProvider implements StorageProvider {
     }
 
     @Override
+    public boolean supportsStableMetadata() {
+        return delegate.supportsStableMetadata();
+    }
+
+    @Override
     public void close() throws IOException {
         delegate.close();
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageEntry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageEntry.java
@@ -14,4 +14,10 @@ import java.time.Instant;
 /**
  * Metadata about an object returned from directory listing.
  */
-public record StorageEntry(StoragePath path, long length, Instant lastModified) {}
+public record StorageEntry(StoragePath path, long length, Instant lastModified) {
+    public StorageEntry {
+        if (lastModified == null) {
+            lastModified = Instant.EPOCH;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheEntry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/SchemaCacheEntry.java
@@ -31,6 +31,7 @@ public record SchemaCacheEntry(
     String sourceType,
     String location,
     Map<String, Object> safeMetadata,
+    Map<String, Object> connectorConfig,
     long cachedAtMillis
 ) {
     public SchemaCacheEntry {
@@ -40,9 +41,16 @@ public record SchemaCacheEntry(
             throw new IllegalArgumentException("All column arrays must have the same length");
         }
         safeMetadata = safeMetadata != null ? Map.copyOf(safeMetadata) : Map.of();
+        connectorConfig = connectorConfig != null ? Map.copyOf(connectorConfig) : Map.of();
     }
 
-    public static SchemaCacheEntry from(List<Attribute> schema, String sourceType, String location, Map<String, Object> metadata) {
+    public static SchemaCacheEntry from(
+        List<Attribute> schema,
+        String sourceType,
+        String location,
+        Map<String, Object> metadata,
+        Map<String, Object> connectorConfig
+    ) {
         int size = schema.size();
         String[] names = new String[size];
         DataType[] types = new DataType[size];
@@ -55,7 +63,17 @@ public record SchemaCacheEntry(
             nullabilities[i] = attr.nullable();
             synthetics[i] = attr.synthetic();
         }
-        return new SchemaCacheEntry(names, types, nullabilities, synthetics, sourceType, location, metadata, System.currentTimeMillis());
+        return new SchemaCacheEntry(
+            names,
+            types,
+            nullabilities,
+            synthetics,
+            sourceType,
+            location,
+            metadata,
+            connectorConfig,
+            System.currentTimeMillis()
+        );
     }
 
     /** Reconstructs fresh Attributes with fresh NameIds -- safe for concurrent queries */
@@ -92,6 +110,7 @@ public record SchemaCacheEntry(
         bytes += location != null ? location.length() * (long) Character.BYTES : 0;
         // rough estimate: ~100B per metadata entry (key String + value Object)
         bytes += safeMetadata.size() * 100L;
+        bytes += connectorConfig.size() * 100L;
         return bytes;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StorageProvider.java
@@ -44,4 +44,14 @@ public interface StorageProvider extends Closeable {
 
     /** Returns the URI schemes this provider handles (e.g., ["http", "https"]). */
     List<String> supportedSchemes();
+
+    /**
+     * Whether this provider's objects have reliable last-modified timestamps suitable
+     * for mtime-based cache invalidation. Returns {@code true} by default.
+     * Providers serving dynamic content (e.g. HTTP URLs) should return {@code false}
+     * so the schema cache is bypassed and metadata is resolved fresh on every query.
+     */
+    default boolean supportsStableMetadata() {
+        return true;
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -526,6 +526,78 @@ public class ExternalSourceResolverTests extends ESTestCase {
         }
     }
 
+    public void testSingleFileSchemaCacheHitAfterMiss() throws Exception {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER), attr("name", DataType.KEYWORD));
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/data/single.parquet", schema);
+
+        CountingStorageProvider countingProvider = new CountingStorageProvider(Map.of(), schemasByPath);
+
+        Settings settings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(settings)) {
+            ExternalSourceResolver resolver = createResolverWithCache(countingProvider, schemasByPath, cacheService);
+
+            PlainActionFuture<ExternalSourceResolution> f1 = new PlainActionFuture<>();
+            resolver.resolve(List.of("s3://bucket/data/single.parquet"), Map.of(), f1);
+            ExternalSourceResolution res1 = f1.actionGet();
+            assertNotNull(res1.resolvedSource("s3://bucket/data/single.parquet"));
+            assertEquals(1, res1.resolvedSource("s3://bucket/data/single.parquet").fileList().fileCount());
+
+            Map<String, Object> stats1 = cacheService.usageStats();
+            assertEquals(1L, stats1.get("schema_cache.misses"));
+            assertEquals(0L, stats1.get("schema_cache.hits"));
+            assertEquals(1, stats1.get("schema_cache.count"));
+
+            PlainActionFuture<ExternalSourceResolution> f2 = new PlainActionFuture<>();
+            resolver.resolve(List.of("s3://bucket/data/single.parquet"), Map.of(), f2);
+            ExternalSourceResolution res2 = f2.actionGet();
+            assertNotNull(res2.resolvedSource("s3://bucket/data/single.parquet"));
+            assertEquals(1, res2.resolvedSource("s3://bucket/data/single.parquet").fileList().fileCount());
+
+            Map<String, Object> stats2 = cacheService.usageStats();
+            assertEquals(1L, stats2.get("schema_cache.misses"));
+            assertEquals(1L, stats2.get("schema_cache.hits"));
+            assertEquals(1, stats2.get("schema_cache.count"));
+        }
+    }
+
+    public void testSingleFileCacheDisabledBypassesCache() throws Exception {
+        List<Attribute> schema = List.of(attr("val", DataType.LONG));
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/d/file.parquet", schema);
+
+        CountingStorageProvider countingProvider = new CountingStorageProvider(Map.of(), schemasByPath);
+
+        Settings settings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", false)
+            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(settings)) {
+            ExternalSourceResolver resolver = createResolverWithCache(countingProvider, schemasByPath, cacheService);
+
+            for (int i = 0; i < 3; i++) {
+                PlainActionFuture<ExternalSourceResolution> f = new PlainActionFuture<>();
+                resolver.resolve(List.of("s3://bucket/d/file.parquet"), Map.of(), f);
+                ExternalSourceResolution res = f.actionGet();
+                assertNotNull(res.resolvedSource("s3://bucket/d/file.parquet"));
+            }
+
+            Map<String, Object> stats = cacheService.usageStats();
+            assertEquals("schema cache should have no entries when disabled", 0, stats.get("schema_cache.count"));
+            assertEquals("schema cache should have no hits when disabled", 0L, stats.get("schema_cache.hits"));
+            assertEquals("schema cache should have no misses when disabled", 0L, stats.get("schema_cache.misses"));
+        }
+    }
+
     public void testCacheDisabledCallsLoaderEveryTime() throws Exception {
         List<Attribute> schema = List.of(attr("val", DataType.LONG));
         Map<String, List<Attribute>> schemasByPath = new HashMap<>();
@@ -556,6 +628,45 @@ public class ExternalSourceResolverTests extends ESTestCase {
                 3,
                 countingProvider.listCallCount.get()
             );
+        }
+    }
+
+    /**
+     * Regression test for #147371: single-file caching path must not NPE when
+     * StorageObject.lastModified() returns null (e.g. gRPC/Flight, GCS/Azure fixtures).
+     */
+    public void testSingleFileCacheWithNullLastModifiedDoesNotThrow() throws Exception {
+        List<Attribute> schema = List.of(attr("id", DataType.INTEGER));
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/data/null-mtime.parquet", schema);
+
+        NullMtimeStorageProvider nullMtimeProvider = new NullMtimeStorageProvider(schemasByPath);
+
+        Settings settings = Settings.builder()
+            .put("esql.source.cache.size", "10mb")
+            .put("esql.source.cache.enabled", true)
+            .put("esql.source.cache.schema.ttl", "5m")
+            .put("esql.source.cache.listing.ttl", "30s")
+            .build();
+
+        try (ExternalSourceCacheService cacheService = new ExternalSourceCacheService(settings)) {
+            ExternalSourceResolver resolver = createResolverWithCache(nullMtimeProvider, schemasByPath, cacheService);
+
+            PlainActionFuture<ExternalSourceResolution> f1 = new PlainActionFuture<>();
+            resolver.resolve(List.of("s3://bucket/data/null-mtime.parquet"), Map.of(), f1);
+            ExternalSourceResolution res1 = f1.actionGet();
+            assertNotNull(res1.resolvedSource("s3://bucket/data/null-mtime.parquet"));
+            assertEquals(1, res1.resolvedSource("s3://bucket/data/null-mtime.parquet").fileList().fileCount());
+
+            // Second resolve should hit the cache without NPE
+            PlainActionFuture<ExternalSourceResolution> f2 = new PlainActionFuture<>();
+            resolver.resolve(List.of("s3://bucket/data/null-mtime.parquet"), Map.of(), f2);
+            ExternalSourceResolution res2 = f2.actionGet();
+            assertNotNull(res2.resolvedSource("s3://bucket/data/null-mtime.parquet"));
+
+            Map<String, Object> stats = cacheService.usageStats();
+            assertEquals(1L, stats.get("schema_cache.misses"));
+            assertEquals(1L, stats.get("schema_cache.hits"));
         }
     }
 
@@ -907,6 +1018,58 @@ public class ExternalSourceResolverTests extends ESTestCase {
         @Override
         public StorageIterator listObjects(StoragePath prefix, boolean recursive) {
             listCallCount.incrementAndGet();
+            return delegate.listObjects(prefix, recursive);
+        }
+
+        @Override
+        public boolean exists(StoragePath path) {
+            return delegate.exists(path);
+        }
+
+        @Override
+        public List<String> supportedSchemes() {
+            return delegate.supportedSchemes();
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+    }
+
+    /**
+     * StorageProvider whose objects return null for lastModified(), reproducing the
+     * conditions that caused #147371 (GCS/Azure fixtures, gRPC/Flight).
+     */
+    private static class NullMtimeStorageProvider implements StorageProvider {
+        private final StubStorageProvider delegate;
+
+        NullMtimeStorageProvider(Map<String, List<Attribute>> schemasByPath) {
+            this.delegate = new StubStorageProvider(Map.of(), schemasByPath);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path) {
+            return new StubStorageObject(path) {
+                @Override
+                public Instant lastModified() {
+                    return null;
+                }
+            };
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length) {
+            return delegate.newObject(path, length);
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            return delegate.newObject(path, length, lastModified);
+        }
+
+        @Override
+        public StorageIterator listObjects(StoragePath prefix, boolean recursive) {
             return delegate.listObjects(prefix, recursive);
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ExternalSourceCacheServiceTests.java
@@ -351,7 +351,7 @@ public class ExternalSourceCacheServiceTests extends ESTestCase {
             new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD, Nullability.TRUE, null, false),
             new ReferenceAttribute(Source.EMPTY, null, "value", DataType.DOUBLE, Nullability.TRUE, null, false)
         );
-        return SchemaCacheEntry.from(schema, "parquet", "s3://bucket/data/file.parquet", Map.of());
+        return SchemaCacheEntry.from(schema, "parquet", "s3://bucket/data/file.parquet", Map.of(), Map.of());
     }
 
     private static FileList testGenericFileList() {


### PR DESCRIPTION
Re-applies the single-file schema caching from #147297 (reverted in
#147371) with a fix for the null `lastModified` NPE that caused the
revert.

`StorageObject.lastModified()` may return null per its SPI contract
but the original code called `.toEpochMilli()` without a null check,
causing NPEs for GCS, Azure, and gRPC/Flight providers that do not
expose modification time.

Two fixes:
- Guard the direct call in `ExternalSourceResolver` with a null check
- Normalize null to `Instant.EPOCH` in `StorageEntry`'s compact
  canonical constructor so all downstream consumers (`FileListCompactor`,
  `GenericFileList`, `GlobExpander`) are also protected

Closes #147211

Developed with AI-assisted tooling