### PR TITLE
Re-apply "Enforce single values for text fields and ip fields when multi_value=no is configured in the mapping (multi_value=no part 3/5)"

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -911,6 +911,11 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue().isSingleValued();
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         final var value = context.parser().optimizedTextOrNull();
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldStorageVerifier;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
@@ -815,5 +816,28 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
                 assertThat(docs.totalHits.relation(), equalTo(TotalHits.Relation.EQUAL_TO));
             }
         }
+    }
+
+    public void testSingleValueIsAcceptedWhenMultiValueNo() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "match_only_text").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(5))));
+    }
+
+    public void testSecondValueIsRejectedWhenMultiValueNo() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "match_only_text").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", randomAlphanumericOfLength(3), randomAlphanumericOfLength(4))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
     }
 }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -430,12 +430,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
   method: testDeploymentSurvivesRestart {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/145728
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mapping/40_doc_values_multi_value/multi_value=no on multi-field parent rejects parent array}
-  issue: https://github.com/elastic/elasticsearch/issues/147375
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mapping/40_doc_values_multi_value/multi_value=no on multi-field sub rejects parent array}
-  issue: https://github.com/elastic/elasticsearch/issues/147376
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
   method: test {csv-spec:stats_sparkline.sparklineComplexWithGrouping}
   issue: https://github.com/elastic/elasticsearch/issues/147378

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
@@ -1,0 +1,143 @@
+---
+"multi_value=no is enforced per document not per segment":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value"]
+      reason: "multi_value doc values parameter support"
+
+  - do:
+      indices.create:
+        index: test_per_document
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: "no"
+
+  - do:
+      index:
+        index: test_per_document
+        id: "1"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          kw: "value_a"
+
+  - do:
+      index:
+        index: test_per_document
+        id: "2"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          kw: "value_b"
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test_per_document
+        body:
+          query:
+            match_all: {}
+  - match: { hits.total.value: 2 }
+
+---
+"multi_value=no mapping serialization roundtrip":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value"]
+      reason: "multi_value doc values parameter support"
+
+  - do:
+      indices.create:
+        index: test_roundtrip
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: "no"
+
+  - do:
+      indices.get_mapping:
+        index: test_roundtrip
+
+  - match: { test_roundtrip.mappings.properties.kw.doc_values.multi_value: "no" }
+
+---
+"multi_value=no on multi-field sub rejects parent array":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value"]
+      reason: "multi_value doc values parameter support"
+
+  - do:
+      indices.create:
+        index: test_multifield_sub
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              parent:
+                type: keyword
+                fields:
+                  child:
+                    type: keyword
+                    doc_values:
+                      multi_value: "no"
+
+  # The first value is accepted by both the parent and child fields.
+  - do:
+      index:
+        index: test_multifield_sub
+        id: "1"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          parent: "a"
+
+  # The second value is rejected by the child field.
+  - do:
+      catch: /configured with \[multi_value=no\] but encountered multiple values in the same document/
+      index:
+        index: test_multifield_sub
+        id: "2"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          parent: ["a", "b"]
+
+---
+"multi_value=no on multi-field parent rejects parent array":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value"]
+      reason: "multi_value doc values parameter support"
+
+  - do:
+      indices.create:
+        index: test_multifield_parent
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              parent:
+                type: keyword
+                doc_values:
+                  multi_value: "no"
+                fields:
+                  child:
+                    type: keyword
+
+  # The second value is rejected by the parent field.
+  - do:
+      catch: /configured with \[multi_value=no\] but encountered multiple values in the same document/
+      index:
+        index: test_multifield_parent
+        id: "1"
+        body:
+          "@timestamp": "2024-01-01T00:00:00Z"
+          parent: ["a", "b"]

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
@@ -72,8 +72,8 @@
 ---
 "multi_value=no on multi-field sub rejects parent array":
   - requires:
-      cluster_features: ["mapper.doc_values.multi_value"]
-      reason: "multi_value doc values parameter support"
+      cluster_features: ["mapper.doc_values.multi_value_enforcement"]
+      reason: "multi_value=no enforcement on indexing"
 
   - do:
       indices.create:
@@ -113,8 +113,8 @@
 ---
 "multi_value=no on multi-field parent rejects parent array":
   - requires:
-      cluster_features: ["mapper.doc_values.multi_value"]
-      reason: "multi_value doc values parameter support"
+      cluster_features: ["mapper.doc_values.multi_value_enforcement"]
+      reason: "multi_value=no enforcement on indexing"
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -176,6 +176,7 @@ public abstract class DocumentParserContext {
 
     private final Set<String> ignoredFields;
     private final List<IgnoredSourceFieldMapper.NameValue> ignoredFieldValues;
+    private final Set<String> singleValuedFields;
     private Scope currentScope;
 
     private final Map<String, List<Mapper.Builder>> dynamicMappers;
@@ -228,13 +229,15 @@ public abstract class DocumentParserContext {
         Set<String> mappingCopyToFields,
         Set<String> copyToFields,
         DynamicMapperSize dynamicMapperSize,
-        boolean recordedSource
+        boolean recordedSource,
+        Set<String> singleValuedFields
     ) {
         this.mappingLookup = mappingLookup;
         this.mappingParserContext = mappingParserContext;
         this.sourceToParse = sourceToParse;
         this.ignoredFields = ignoreFields;
         this.ignoredFieldValues = ignoredFieldValues;
+        this.singleValuedFields = singleValuedFields;
         this.currentScope = currentScope;
         this.dynamicMappers = dynamicMappers;
         this.dynamicObjectMappers = dynamicObjectMappers;
@@ -277,7 +280,8 @@ public abstract class DocumentParserContext {
             in.mappingCopyToFields,
             in.copyToFields,
             in.dynamicMappersSize,
-            in.recordedSource
+            in.recordedSource,
+            in.singleValuedFields
         );
     }
 
@@ -309,7 +313,8 @@ public abstract class DocumentParserContext {
             mappingLookup.fieldTypesLookup().getCopyToDestinationFields(),
             new HashSet<>(),
             new DynamicMapperSize(),
-            false
+            false,
+            new HashSet<>()
         );
     }
 
@@ -351,6 +356,19 @@ public abstract class DocumentParserContext {
 
     public final String routing() {
         return mappingParserContext.getIndexSettings().getMode() == IndexMode.TIME_SERIES ? null : sourceToParse.routing();
+    }
+
+    /**
+     * Enforces that a field configured with {@code multi_value=no} receives at most one value per document. The first call for a given
+     * field name succeeds; a subsequent call for the same name throws {@link IllegalArgumentException}. Shared across all child contexts
+     * so the constraint is respected regardless of which context sub-tree the duplicate value comes from.
+     */
+    public final void enforceSingleValue(String fieldName) {
+        if (singleValuedFields.add(fieldName) == false) {
+            throw new IllegalArgumentException(
+                "Field [" + fieldName + "] is configured with [multi_value=no] but encountered multiple values in the same document"
+            );
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -196,6 +196,9 @@ public abstract class FieldMapper extends Mapper {
             if (builderParams.hasScript) {
                 throwIndexingWithScriptParam();
             }
+            if (isSingleValueEnforced()) {
+                context.enforceSingleValue(fullPath());
+            }
 
             parseCreateField(context);
         } catch (Exception e) {
@@ -265,6 +268,14 @@ public abstract class FieldMapper extends Mapper {
      * current failing token
      */
     protected abstract void parseCreateField(DocumentParserContext context) throws IOException;
+
+    /**
+     * Whether this mapper enforces single-valued semantics (ie. {@code multi_value=no}). When {@code true}, a second value for the same
+     * document throws. Override on mappers that expose the {@code multi_value} doc values mapping parameter.
+     */
+    protected boolean isSingleValueEnforced() {
+        return false;
+    }
 
     /**
      * @return whether this field mapper uses a script to generate its values

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -687,6 +687,11 @@ public class IpFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue().isSingleValued();
+    }
+
+    @Override
     public IpFieldType fieldType() {
         return (IpFieldType) super.fieldType();
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1375,6 +1375,11 @@ public final class KeywordFieldMapper extends FieldMapper {
         return docValuesParameters;
     }
 
+    @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue().isSingleValued();
+    }
+
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         var value = context.parser().optimizedTextOrNull();
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -81,6 +81,7 @@ public class MapperFeatures implements FeatureSpecification {
         "mapper.dense_vector.dynamic_template_dotted_field_fix"
     );
     public static final NodeFeature DOC_VALUES_MULTI_VALUE = new NodeFeature("mapper.doc_values.multi_value");
+    public static final NodeFeature DOC_VALUES_MULTI_VALUE_ENFORCEMENT = new NodeFeature("mapper.doc_values.multi_value_enforcement");
     static final NodeFeature DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX = new NodeFeature(
         "mapper.dense_vector.dynamic_template_nested_object_fix"
     );
@@ -145,6 +146,7 @@ public class MapperFeatures implements FeatureSpecification {
             TEXT_FIELD_DOC_VALUES,
             DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX,
             DOC_VALUES_MULTI_VALUE,
+            DOC_VALUES_MULTI_VALUE_ENFORCEMENT,
             DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX,
             FLATTENED_MAPPED_SUBFIELDS_FEATURE,
             ES940_DISK_BBQ,

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1712,6 +1712,11 @@ public final class TextFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue().isSingleValued();
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         final String value = context.parser().textOrNull();
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
@@ -535,6 +535,98 @@ public class IpFieldMapperTests extends MapperTestCase {
         );
     }
 
+    public void testMultiValueNoAcceptsSingleValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "ip").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        mapper.parse(source(b -> b.field("field", "::1")));
+    }
+
+    public void testMultiValueNoRejectsArray() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "ip").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", "::1", "::2")))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * Single malformed value routes to the {@code _ignored} fallback. Only one {@link FieldMapper#parse(DocumentParserContext)} call
+     * fires, so enforcement does not trip.
+     */
+    public void testMultiValueNoAcceptsSingleIgnoreMalformedValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "ip").field("ignore_malformed", true);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        mapper.parse(source(b -> b.field("field", "not-an-ip")));
+    }
+
+    /**
+     * Both values are malformed and would route to the {@code _ignored} fallback. Enforcement still throws on the second
+     * {@link FieldMapper#parse(DocumentParserContext)} call before either is handled.
+     */
+    public void testMultiValueNoRejectsTwoIgnoreMalformedFallbacks() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "ip").field("ignore_malformed", true);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", "not-an-ip", "also-not-an-ip")))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    public void testMultiValueNoRejectsNormalPlusIgnoreMalformedFallback() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "ip").field("ignore_malformed", true);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", "::1", "not-an-ip")))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * Mirror of {@link #testMultiValueNoRejectsNormalPlusIgnoreMalformedFallback} with the order reversed: first value is malformed
+     * and would route to the {@code _ignored} fallback, second is a valid IP. Enforcement still fires on the second parse call.
+     */
+    public void testMultiValueNoRejectsIgnoreMalformedFallbackPlusNormal() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "ip").field("ignore_malformed", true);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", "not-an-ip", "::1")))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
     @Override
     protected String randomSyntheticSourceKeep() {
         return "all";

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -1117,6 +1117,269 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
     }
 
+    public void testSingleValueIsAcceptedWhenMultiValueNo() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(5))));
+        assertEquals(1, doc.rootDoc().getFields("field").stream().filter(f -> f.fieldType().docValuesType() != DocValuesType.NONE).count());
+    }
+
+    public void testSecondValueIsRejectedWhenMultiValueNo() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", randomAlphanumericOfLength(3), randomAlphanumericOfLength(4))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * First value is parsed normally and is stored under the regular field. Second value exceeds {@code ignore_above} and would be written
+     * to the {@code field._original} fallback field. Enforcement fires at the document-level, so the multi-valued input is rejected
+     * regardless of which suffix the second write would have targeted.
+     */
+    public void testMultiValueNoRejectsNormalPlusIgnoreAboveFallback() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createSytheticSourceMapperService(
+            fieldMapping(
+                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "no").endObject()
+            )
+        ).documentMapper();
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", randomAlphanumericOfLength(3), randomAlphanumericOfLength(20))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * Mirror of {@link #testMultiValueNoRejectsNormalPlusIgnoreAboveFallback} with the order reversed: first value routes to the
+     * {@code field._original} fallback and the second indexes normally.
+     */
+    public void testMultiValueNoRejectsIgnoreAboveFallbackPlusNormal() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createSytheticSourceMapperService(
+            fieldMapping(
+                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "no").endObject()
+            )
+        ).documentMapper();
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", randomAlphanumericOfLength(20), randomAlphanumericOfLength(3))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * Both values exceed {@code ignore_above}, so both would route to {@code field._original}. Enforcement throws on the second value.
+     */
+    public void testMultiValueNoRejectsTwoIgnoreAboveFallbacks() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createSytheticSourceMapperService(
+            fieldMapping(
+                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "no").endObject()
+            )
+        ).documentMapper();
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", randomAlphanumericOfLength(20), randomAlphanumericOfLength(20))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    public void testMultiValueNoAcceptsSingleIgnoreAboveValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createSytheticSourceMapperService(
+            fieldMapping(
+                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "no").endObject()
+            )
+        ).documentMapper();
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(20))));
+        assertThat(doc.rootDoc().getFields("_ignored").stream().anyMatch(f -> "field".equals(f.stringValue())), equalTo(true));
+    }
+
+    /**
+     * The {@code copy_to} target is configured with {@code multi_value=no}. The source field writes one value, then the destination field
+     * receives a direct value - giving the destination two values and tripping enforcement.
+     */
+    public void testMultiValueNoRejectsCopyToTargetWithDirectValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("source").field("type", "keyword").field("copy_to", "target").endObject();
+            b.startObject("target").field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject().endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.field("source", randomAlphanumericOfLength(3)).field("target", randomAlphanumericOfLength(4))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * Every source element is copied to the target, so the target receives two values and its own {@code multi_value=no} enforcement fires.
+     */
+    public void testMultiValueNoRejectsCopyToTargetFromSourceArray() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("source").field("type", "keyword").field("copy_to", "target").endObject();
+            b.startObject("target").field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject().endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("source", randomAlphanumericOfLength(3), randomAlphanumericOfLength(4))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * Source field itself has {@code multi_value=no}. A multi-valued array on the source is rejected before {@code copy_to} runs, so
+     * the target never sees the values.
+     */
+    public void testMultiValueNoRejectsCopyToSourceWithMultipleValues() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("source")
+                .field("type", "keyword")
+                .field("copy_to", "target")
+                .startObject("doc_values")
+                .field("multi_value", "no")
+                .endObject()
+                .endObject();
+            b.startObject("target").field("type", "keyword").endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("source", randomAlphanumericOfLength(3), randomAlphanumericOfLength(4))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * null still counts as a value, so the second value is rejected.
+     */
+    public void testMultiValueNoRejectsNullThenValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        DocumentParsingException e = expectThrows(DocumentParsingException.class, () -> mapper.parse(source(b -> {
+            b.startArray("field").nullValue().value(randomAlphanumericOfLength(5)).endArray();
+        })));
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * Mirror of {@link #testMultiValueNoRejectsNullThenValue} with the order reversed: first value is non-null, second is null.
+     */
+    public void testMultiValueNoRejectsValueThenNull() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        DocumentParsingException e = expectThrows(DocumentParsingException.class, () -> mapper.parse(source(b -> {
+            b.startArray("field").value(randomAlphanumericOfLength(5)).nullValue().endArray();
+        })));
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    public void testMultiValueNoAcceptsSingleNull() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        mapper.parse(source(b -> b.nullField("field")));
+    }
+
+    /**
+     * A sub-field configures {@code multi_value=no}. Parent field has two values, each of which triggers a sub-field parse so enforcement
+     * on the sub-field fires twice and throws, rejecting the second value.
+     */
+    public void testMultiValueNoOnMultiFieldRejectsParentSecondValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("parent").field("type", "keyword");
+            b.startObject("fields");
+            b.startObject("child").field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject().endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("parent", randomAlphanumericOfLength(3), randomAlphanumericOfLength(4))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    public void testMultiValueNoOnMultiFieldAcceptsParentSingleValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("parent").field("type", "keyword");
+            b.startObject("fields");
+            b.startObject("child").field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject().endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        mapper.parse(source(b -> b.field("parent", randomAlphanumericOfLength(5))));
+    }
+
+    /**
+     * Parent has {@code multi_value=no}. Enforcement on the parent's slot fires before multi-fields are processed, so the second value
+     * throws on the parent's path.
+     */
+    public void testMultiValueNoOnParentWithMultiFieldRejectsParentArray() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("parent").field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("fields");
+            b.startObject("child").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("parent", randomAlphanumericOfLength(3), randomAlphanumericOfLength(4))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
     public void testFieldTypeWithSkipDocValues_LogsDbModeDisabledSetting() throws IOException {
         final MapperService mapperService = createMapperService(
             Settings.builder()

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
@@ -389,4 +389,23 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
         assertEquals(value, storedField.binaryValue());
     }
 
+    /**
+     * This test verifies that we're not double storing field names in keyedFields ({@link LuceneDocument}) and singleValuedFields
+     * ({@link DocumentParserContext}). This ensures that we're not double storing.
+     */
+    public void testMultiValueNoDoesNotStoreInKeyedFields() {
+        // given
+        LuceneDocument doc = new LuceneDocument();
+
+        // when
+        DocValuesFieldFactory factory = new DocValuesFieldFactory(MultiValue.NO, false, IndexVersion.current());
+        factory.addBinaryField(doc, "field", new BytesRef(randomAlphanumericOfLength(10)), ValueOrdering.SORTED_UNIQUE);
+
+        // then — field is NOT registered in keyedFields; only in the Lucene fields list. Single-value enforcement is handled at the
+        // DocumentParserContext level, not by keyed dedup.
+        assertNull(doc.getByKey("field"));
+        assertNull(doc.getByKey("field.counts"));
+        assertNull(doc.getField("field.counts"));
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -2772,4 +2772,99 @@ public class TextFieldMapperTests extends MapperTestCase {
         assertThat(syntheticSource, containsString(shortValue));
         assertThat(syntheticSource, containsString(longValue));
     }
+
+    public void testSingleValueIsAcceptedWhenMultiValueNo() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(5))));
+    }
+
+    public void testSecondValueIsRejectedWhenMultiValueNo() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", randomAlphanumericOfLength(3), randomAlphanumericOfLength(4))))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    public void testSingleFallbackValueIsAcceptedWhenMultiValueNo() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        String longValue = randomAlphanumericOfLength(IndexWriter.MAX_TERM_LENGTH + 1);
+        mapper.parse(source(b -> b.field("field", longValue)));
+    }
+
+    /**
+     * We have two values for a field: normal value, and a value that exceeds MAX_TERM_LENGTH.
+     * <p>
+     * First value routes to SortedSet doc values; second exceeds MAX_TERM_LENGTH and would route to the {@code ._original} fallback field.
+     * While these are technically two separate fields, single values are enforced on a document-level, so the second value is rejected.
+     */
+    public void testSecondValueInFallbackFieldIsRejectedWhenMultiValueNoAndFirstValueInRegularField() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        String shortValue = randomAlphanumericOfLength(5);
+        String longValue = randomAlphanumericOfLength(IndexWriter.MAX_TERM_LENGTH + 1);
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", shortValue, longValue)))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * Mirror of {@link #testSecondValueInFallbackFieldIsRejectedWhenMultiValueNoAndFirstValueInRegularField} with the order reversed.
+     */
+    public void testSecondValueInRegularFieldIsRejectedWhenMultiValueNoAndFirstValueInFallbackField() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        String longValue = randomAlphanumericOfLength(IndexWriter.MAX_TERM_LENGTH + 1);
+        String shortValue = randomAlphanumericOfLength(5);
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", longValue, shortValue)))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * We have two values for a field, both of which exceed MAX_TERM_LENGTH and would route to the {@code ._original} fallback field.
+     */
+    public void testSecondValueInFallbackFieldIsRejectedWhenMultiValueNo() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+        );
+        String longValue1 = randomAlphanumericOfLength(IndexWriter.MAX_TERM_LENGTH + 1);
+        String longValue2 = randomAlphanumericOfLength(IndexWriter.MAX_TERM_LENGTH + 1);
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", longValue1, longValue2)))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
 }


### PR DESCRIPTION
Reapplying https://github.com/elastic/elasticsearch/pull/147071 after it was reverted.

Also fixes:
- https://github.com/elastic/elasticsearch/issues/147375
- https://github.com/elastic/elasticsearch/issues/147376