### PR TITLE
Rename ByteVectorScorer* to Int8VectorScorer* and FloatVectorScorer* to Float32VectorScorer*

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerFloat32BulkBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerFloat32BulkBenchmark.java
@@ -143,9 +143,9 @@ public class VectorScorerFloat32BulkBenchmark extends VectorScorerBulkBenchmark 
                 }
                 break;
             case NATIVE:
-                scorer = factory.getFloatVectorScorerSupplier(function, in, values).orElseThrow().scorer();
+                scorer = factory.getFloat32VectorScorerSupplier(function, in, values).orElseThrow().scorer();
                 if (supportsHeapSegments()) {
-                    queryScorer = factory.getFloatVectorScorer(function.function(), values, ((VectorData) vectorData).queryVector)
+                    queryScorer = factory.getFloat32VectorScorer(function.function(), values, ((VectorData) vectorData).queryVector)
                         .orElseThrow();
                 }
                 break;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt8BulkBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerInt8BulkBenchmark.java
@@ -184,9 +184,9 @@ public class VectorScorerInt8BulkBenchmark extends VectorScorerBulkBenchmark {
                 }
                 break;
             case NATIVE:
-                scorer = factory.getByteVectorScorerSupplier(function, in, values).orElseThrow().scorer();
+                scorer = factory.getInt8VectorScorerSupplier(function, in, values).orElseThrow().scorer();
                 if (supportsHeapSegments()) {
-                    queryScorer = factory.getByteVectorScorer(function.function(), values, ((VectorData) vectorData).queryVector)
+                    queryScorer = factory.getInt8VectorScorer(function.function(), values, ((VectorData) vectorData).queryVector)
                         .orElseThrow();
                 }
                 break;

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactory.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactory.java
@@ -37,7 +37,7 @@ public interface VectorScorerFactory {
      * @param values the random access vector values
      * @return an optional containing the vector scorer supplier, or empty
      */
-    Optional<RandomVectorScorerSupplier> getFloatVectorScorerSupplier(
+    Optional<RandomVectorScorerSupplier> getFloat32VectorScorerSupplier(
         VectorSimilarityType similarityType,
         IndexInput input,
         FloatVectorValues values
@@ -71,7 +71,7 @@ public interface VectorScorerFactory {
      * @param values the random access vector values
      * @return an optional containing the vector scorer supplier, or empty
      */
-    Optional<RandomVectorScorerSupplier> getByteVectorScorerSupplier(
+    Optional<RandomVectorScorerSupplier> getInt8VectorScorerSupplier(
         VectorSimilarityType similarityType,
         IndexInput input,
         ByteVectorValues values
@@ -86,7 +86,7 @@ public interface VectorScorerFactory {
      * @param queryVector the query vector
      * @return an optional containing the vector scorer, or empty
      */
-    Optional<RandomVectorScorer> getFloatVectorScorer(VectorSimilarityFunction sim, FloatVectorValues values, float[] queryVector);
+    Optional<RandomVectorScorer> getFloat32VectorScorer(VectorSimilarityFunction sim, FloatVectorValues values, float[] queryVector);
 
     /**
      * Returns an optional containing a bfloat16 vector scorer for
@@ -108,7 +108,7 @@ public interface VectorScorerFactory {
      * @param queryVector the query vector
      * @return an optional containing the vector scorer, or empty
      */
-    Optional<RandomVectorScorer> getByteVectorScorer(VectorSimilarityFunction sim, ByteVectorValues values, byte[] queryVector);
+    Optional<RandomVectorScorer> getInt8VectorScorer(VectorSimilarityFunction sim, ByteVectorValues values, byte[] queryVector);
 
     /**
      * Returns an optional containing an int7 scalar quantized vector score supplier

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactoryImpl.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/VectorScorerFactoryImpl.java
@@ -20,16 +20,16 @@ import org.apache.lucene.util.quantization.QuantizedByteVectorValues;
 import org.elasticsearch.nativeaccess.NativeAccess;
 import org.elasticsearch.simdvec.internal.BFloat16VectorScorer;
 import org.elasticsearch.simdvec.internal.BFloat16VectorScorerSupplier;
-import org.elasticsearch.simdvec.internal.ByteVectorScorer;
-import org.elasticsearch.simdvec.internal.ByteVectorScorerSupplier;
-import org.elasticsearch.simdvec.internal.FloatVectorScorer;
-import org.elasticsearch.simdvec.internal.FloatVectorScorerSupplier;
+import org.elasticsearch.simdvec.internal.Float32VectorScorer;
+import org.elasticsearch.simdvec.internal.Float32VectorScorerSupplier;
 import org.elasticsearch.simdvec.internal.Int4VectorScorer;
 import org.elasticsearch.simdvec.internal.Int4VectorScorerSupplier;
 import org.elasticsearch.simdvec.internal.Int7SQVectorScorer;
 import org.elasticsearch.simdvec.internal.Int7SQVectorScorerSupplier;
 import org.elasticsearch.simdvec.internal.Int7uOSQVectorScorer;
 import org.elasticsearch.simdvec.internal.Int7uOSQVectorScorerSupplier;
+import org.elasticsearch.simdvec.internal.Int8VectorScorer;
+import org.elasticsearch.simdvec.internal.Int8VectorScorerSupplier;
 
 import java.util.Optional;
 
@@ -46,7 +46,7 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
     }
 
     @Override
-    public Optional<RandomVectorScorerSupplier> getFloatVectorScorerSupplier(
+    public Optional<RandomVectorScorerSupplier> getFloat32VectorScorerSupplier(
         VectorSimilarityType similarityType,
         IndexInput input,
         FloatVectorValues values
@@ -58,9 +58,9 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
         input = MemorySegmentAccessInputAccess.unwrap(input);
         checkInvariants(values.size(), values.dimension(), input);
         return switch (similarityType) {
-            case COSINE, DOT_PRODUCT -> Optional.of(new FloatVectorScorerSupplier.DotProductSupplier(input, values));
-            case EUCLIDEAN -> Optional.of(new FloatVectorScorerSupplier.EuclideanSupplier(input, values));
-            case MAXIMUM_INNER_PRODUCT -> Optional.of(new FloatVectorScorerSupplier.MaxInnerProductSupplier(input, values));
+            case COSINE, DOT_PRODUCT -> Optional.of(new Float32VectorScorerSupplier.DotProductSupplier(input, values));
+            case EUCLIDEAN -> Optional.of(new Float32VectorScorerSupplier.EuclideanSupplier(input, values));
+            case MAXIMUM_INNER_PRODUCT -> Optional.of(new Float32VectorScorerSupplier.MaxInnerProductSupplier(input, values));
         };
     }
 
@@ -84,7 +84,7 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
     }
 
     @Override
-    public Optional<RandomVectorScorerSupplier> getByteVectorScorerSupplier(
+    public Optional<RandomVectorScorerSupplier> getInt8VectorScorerSupplier(
         VectorSimilarityType similarityType,
         IndexInput input,
         ByteVectorValues values
@@ -96,16 +96,20 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
         input = MemorySegmentAccessInputAccess.unwrap(input);
         checkInvariants(values.size(), values.dimension(), input);
         return switch (similarityType) {
-            case COSINE -> Optional.of(new ByteVectorScorerSupplier.CosineSupplier(input, values));
-            case DOT_PRODUCT -> Optional.of(new ByteVectorScorerSupplier.DotProductSupplier(input, values));
-            case EUCLIDEAN -> Optional.of(new ByteVectorScorerSupplier.EuclideanSupplier(input, values));
-            case MAXIMUM_INNER_PRODUCT -> Optional.of(new ByteVectorScorerSupplier.MaxInnerProductSupplier(input, values));
+            case COSINE -> Optional.of(new Int8VectorScorerSupplier.CosineSupplier(input, values));
+            case DOT_PRODUCT -> Optional.of(new Int8VectorScorerSupplier.DotProductSupplier(input, values));
+            case EUCLIDEAN -> Optional.of(new Int8VectorScorerSupplier.EuclideanSupplier(input, values));
+            case MAXIMUM_INNER_PRODUCT -> Optional.of(new Int8VectorScorerSupplier.MaxInnerProductSupplier(input, values));
         };
     }
 
     @Override
-    public Optional<RandomVectorScorer> getFloatVectorScorer(VectorSimilarityFunction sim, FloatVectorValues values, float[] queryVector) {
-        return FloatVectorScorer.create(sim, values, queryVector);
+    public Optional<RandomVectorScorer> getFloat32VectorScorer(
+        VectorSimilarityFunction sim,
+        FloatVectorValues values,
+        float[] queryVector
+    ) {
+        return Float32VectorScorer.create(sim, values, queryVector);
     }
 
     @Override
@@ -118,8 +122,8 @@ final class VectorScorerFactoryImpl implements VectorScorerFactory {
     }
 
     @Override
-    public Optional<RandomVectorScorer> getByteVectorScorer(VectorSimilarityFunction sim, ByteVectorValues values, byte[] queryVector) {
-        return ByteVectorScorer.create(sim, values, queryVector);
+    public Optional<RandomVectorScorer> getInt8VectorScorer(VectorSimilarityFunction sim, ByteVectorValues values, byte[] queryVector) {
+        return Int8VectorScorer.create(sim, values, queryVector);
     }
 
     @Override

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Float32VectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Float32VectorScorer.java
@@ -28,7 +28,7 @@ import static org.elasticsearch.simdvec.internal.Similarities.squareDistanceF32;
 import static org.elasticsearch.simdvec.internal.Similarities.squareDistanceF32BulkSparse;
 import static org.elasticsearch.simdvec.internal.vectorization.JdkFeatures.SUPPORTS_HEAP_SEGMENTS;
 
-public abstract sealed class FloatVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
+public abstract sealed class Float32VectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
 
     final int dimensions;
     final int vectorByteSize;
@@ -56,7 +56,7 @@ public abstract sealed class FloatVectorScorer extends RandomVectorScorer.Abstra
         };
     }
 
-    FloatVectorScorer(IndexInput input, FloatVectorValues values, float[] queryVector) {
+    Float32VectorScorer(IndexInput input, FloatVectorValues values, float[] queryVector) {
         super(values);
         this.input = input;
         assert queryVector.length == values.dimension();
@@ -78,7 +78,7 @@ public abstract sealed class FloatVectorScorer extends RandomVectorScorer.Abstra
         }
     }
 
-    public static final class DotProductScorer extends FloatVectorScorer {
+    public static final class DotProductScorer extends Float32VectorScorer {
         public DotProductScorer(IndexInput in, FloatVectorValues values, float[] query) {
             super(in, values, query);
         }
@@ -127,7 +127,7 @@ public abstract sealed class FloatVectorScorer extends RandomVectorScorer.Abstra
         }
     }
 
-    public static final class EuclideanScorer extends FloatVectorScorer {
+    public static final class EuclideanScorer extends Float32VectorScorer {
         public EuclideanScorer(IndexInput in, FloatVectorValues values, float[] query) {
             super(in, values, query);
         }
@@ -175,7 +175,7 @@ public abstract sealed class FloatVectorScorer extends RandomVectorScorer.Abstra
         }
     }
 
-    public static final class MaxInnerProductScorer extends FloatVectorScorer {
+    public static final class MaxInnerProductScorer extends Float32VectorScorer {
         public MaxInnerProductScorer(IndexInput in, FloatVectorValues values, float[] query) {
             super(in, values, query);
         }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Float32VectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Float32VectorScorerSupplier.java
@@ -9,7 +9,8 @@
 
 package org.elasticsearch.simdvec.internal;
 
-import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
@@ -19,33 +20,34 @@ import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 
-// Scores pairs of indexed vectors (ordinal vs ordinal) for graph construction and segment merging.
-public abstract sealed class ByteVectorScorerSupplier implements RandomVectorScorerSupplier {
+import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
+import static org.apache.lucene.index.VectorSimilarityFunction.EUCLIDEAN;
+import static org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
+
+public abstract sealed class Float32VectorScorerSupplier implements RandomVectorScorerSupplier {
 
     final int dims;
-    final int maxOrd;
-    /**
-     * The length in bytes of one vector. For this scorer, it matches the pitch (the distance in memory between 2 vectors, when laid
-     * out consecutively) and the total vector size (no padding, no extra fields).
-     */
     final int vectorByteSize;
+    final int maxOrd;
     final IndexInput input;
-    final ByteVectorValues values;
+    final FloatVectorValues values;
+    final VectorSimilarityFunction fallbackScorer;
     final FixedSizeScratch firstScratch;
     final FixedSizeScratch secondScratch;
 
-    protected ByteVectorScorerSupplier(IndexInput input, ByteVectorValues values) {
+    protected Float32VectorScorerSupplier(IndexInput input, FloatVectorValues values, VectorSimilarityFunction fallbackScorer) {
         this.input = input;
         this.values = values;
         this.dims = values.dimension();
-        this.vectorByteSize = values.getVectorByteLength();
+        this.vectorByteSize = dims * Float.BYTES;
         this.maxOrd = values.size();
+        this.fallbackScorer = fallbackScorer;
         this.firstScratch = new FixedSizeScratch(vectorByteSize);
         this.secondScratch = new FixedSizeScratch(vectorByteSize);
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord >= maxOrd) {
+        if (ord < 0 || ord > maxOrd) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }
@@ -72,14 +74,11 @@ public abstract sealed class ByteVectorScorerSupplier implements RandomVectorSco
                 addrs -> maxScore[0] = bulkScoreFromSegment(addrs, query, MemorySegment.ofArray(scores), numNodes)
             );
             if (resolved == false) {
-                // fallback to per-vector scorer
+                // fallback to on-heap fallback scorer
+                var queryVector = values.vectorValue(firstOrd).clone();
                 for (int i = 0; i < numNodes; i++) {
-                    input.seek(offsets[i]);
-                    scores[i] = IndexInputUtils.withSlice(input, vectorByteSize, secondScratch::getScratch, vector -> {
-                        var score = scoreFromSegments(query, vector);
-                        maxScore[0] = Math.max(maxScore[0], score);
-                        return score;
-                    });
+                    scores[i] = fallbackScorer.compare(queryVector, values.vectorValue(ordinals[i]));
+                    maxScore[0] = Math.max(maxScore[0], scores[i]);
                 }
             }
             return maxScore[0];
@@ -130,62 +129,26 @@ public abstract sealed class ByteVectorScorerSupplier implements RandomVectorSco
         };
     }
 
-    public static final class CosineSupplier extends ByteVectorScorerSupplier {
+    public static final class EuclideanSupplier extends Float32VectorScorerSupplier {
 
-        public CosineSupplier(IndexInput input, ByteVectorValues values) {
-            super(input, values);
-        }
-
-        private static float normalize(float cosine) {
-            return (1 + cosine) / 2;
+        public EuclideanSupplier(IndexInput input, FloatVectorValues values) {
+            super(input, values, EUCLIDEAN);
         }
 
         @Override
         float scoreFromSegments(MemorySegment a, MemorySegment b) {
-            return normalize(Similarities.cosineI8(a, b, dims));
+            return VectorUtil.normalizeDistanceToUnitInterval(Similarities.squareDistanceF32(a, b, dims));
         }
 
         @Override
-        float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
-            Similarities.cosineI8BulkSparse(addresses, query, dims, numNodes, scores);
-
+        protected float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
+            Similarities.squareDistanceF32BulkSparse(addresses, query, dims, numNodes, scores);
             float max = Float.NEGATIVE_INFINITY;
             for (int i = 0; i < numNodes; ++i) {
                 float squareDistance = scores.getAtIndex(ValueLayout.JAVA_FLOAT, i);
-                float normalized = normalize(squareDistance);
-                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalized);
-                max = Math.max(max, normalized);
-            }
-            return max;
-        }
-
-        @Override
-        public CosineSupplier copy() {
-            return new CosineSupplier(input.clone(), values);
-        }
-    }
-
-    public static final class EuclideanSupplier extends ByteVectorScorerSupplier {
-
-        public EuclideanSupplier(IndexInput input, ByteVectorValues values) {
-            super(input, values);
-        }
-
-        @Override
-        float scoreFromSegments(MemorySegment a, MemorySegment b) {
-            return VectorUtil.normalizeDistanceToUnitInterval(Similarities.squareDistanceI8(a, b, dims));
-        }
-
-        @Override
-        float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
-            Similarities.squareDistanceI8BulkSparse(addresses, query, dims, numNodes, scores);
-
-            float max = Float.NEGATIVE_INFINITY;
-            for (int i = 0; i < numNodes; ++i) {
-                float squareDistance = scores.getAtIndex(ValueLayout.JAVA_FLOAT, i);
-                float normalized = VectorUtil.normalizeDistanceToUnitInterval(squareDistance);
-                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalized);
-                max = Math.max(max, normalized);
+                float normalizedScore = VectorUtil.normalizeDistanceToUnitInterval(squareDistance);
+                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalizedScore);
+                max = Math.max(max, normalizedScore);
             }
             return max;
         }
@@ -196,33 +159,26 @@ public abstract sealed class ByteVectorScorerSupplier implements RandomVectorSco
         }
     }
 
-    public static final class DotProductSupplier extends ByteVectorScorerSupplier {
+    public static final class DotProductSupplier extends Float32VectorScorerSupplier {
 
-        private final float denom = (float) (dims * (1 << 15));
-
-        public DotProductSupplier(IndexInput input, ByteVectorValues values) {
-            super(input, values);
-        }
-
-        private float normalize(float dotProduct) {
-            return 0.5f + dotProduct / denom;
+        public DotProductSupplier(IndexInput input, FloatVectorValues values) {
+            super(input, values, DOT_PRODUCT);
         }
 
         @Override
         float scoreFromSegments(MemorySegment a, MemorySegment b) {
-            return normalize(Similarities.dotProductI8(a, b, dims));
+            return VectorUtil.normalizeToUnitInterval(Similarities.dotProductF32(a, b, dims));
         }
 
         @Override
-        float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
-            Similarities.dotProductI8BulkSparse(addresses, query, dims, numNodes, scores);
-
+        protected float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
+            Similarities.dotProductF32BulkSparse(addresses, query, dims, numNodes, scores);
             float max = Float.NEGATIVE_INFINITY;
             for (int i = 0; i < numNodes; ++i) {
                 float dotProduct = scores.getAtIndex(ValueLayout.JAVA_FLOAT, i);
-                float normalized = normalize(dotProduct);
-                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalized);
-                max = Math.max(max, normalized);
+                float normalizedScore = VectorUtil.normalizeToUnitInterval(dotProduct);
+                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalizedScore);
+                max = Math.max(max, normalizedScore);
             }
             return max;
         }
@@ -233,27 +189,27 @@ public abstract sealed class ByteVectorScorerSupplier implements RandomVectorSco
         }
     }
 
-    public static final class MaxInnerProductSupplier extends ByteVectorScorerSupplier {
+    public static final class MaxInnerProductSupplier extends Float32VectorScorerSupplier {
 
-        public MaxInnerProductSupplier(IndexInput input, ByteVectorValues values) {
-            super(input, values);
+        public MaxInnerProductSupplier(IndexInput input, FloatVectorValues values) {
+            super(input, values, MAXIMUM_INNER_PRODUCT);
         }
 
         @Override
         float scoreFromSegments(MemorySegment a, MemorySegment b) {
-            return VectorUtil.scaleMaxInnerProductScore(Similarities.dotProductI8(a, b, dims));
+            return VectorUtil.scaleMaxInnerProductScore(Similarities.dotProductF32(a, b, dims));
         }
 
         @Override
-        float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
-            Similarities.dotProductI8BulkSparse(addresses, query, dims, numNodes, scores);
+        protected float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
+            Similarities.dotProductF32BulkSparse(addresses, query, dims, numNodes, scores);
 
             float max = Float.NEGATIVE_INFINITY;
             for (int i = 0; i < numNodes; ++i) {
                 float dotProduct = scores.getAtIndex(ValueLayout.JAVA_FLOAT, i);
-                float normalized = VectorUtil.scaleMaxInnerProductScore(dotProduct);
-                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalized);
-                max = Math.max(max, normalized);
+                float scaledScore = VectorUtil.scaleMaxInnerProductScore(dotProduct);
+                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, scaledScore);
+                max = Math.max(max, scaledScore);
             }
             return max;
         }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int8VectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int8VectorScorer.java
@@ -27,7 +27,7 @@ import static org.elasticsearch.simdvec.internal.Similarities.dotProductI8;
 import static org.elasticsearch.simdvec.internal.Similarities.squareDistanceI8;
 import static org.elasticsearch.simdvec.internal.vectorization.JdkFeatures.SUPPORTS_HEAP_SEGMENTS;
 
-public abstract sealed class ByteVectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
+public abstract sealed class Int8VectorScorer extends RandomVectorScorer.AbstractRandomVectorScorer {
 
     final int dimensions;
     final int vectorByteSize;
@@ -57,7 +57,7 @@ public abstract sealed class ByteVectorScorer extends RandomVectorScorer.Abstrac
         };
     }
 
-    ByteVectorScorer(IndexInput input, ByteVectorValues values, byte[] queryVector) {
+    Int8VectorScorer(IndexInput input, ByteVectorValues values, byte[] queryVector) {
         super(values);
         this.input = input;
         assert queryVector.length == values.dimension();
@@ -101,7 +101,7 @@ public abstract sealed class ByteVectorScorer extends RandomVectorScorer.Abstrac
         );
     }
 
-    public static final class DotProductScorer extends ByteVectorScorer {
+    public static final class DotProductScorer extends Int8VectorScorer {
         private final float denom = (float) (dimensions * (1 << 15));
 
         public DotProductScorer(IndexInput in, ByteVectorValues values, byte[] query) {
@@ -140,7 +140,7 @@ public abstract sealed class ByteVectorScorer extends RandomVectorScorer.Abstrac
         }
     }
 
-    public static final class CosineScorer extends ByteVectorScorer {
+    public static final class CosineScorer extends Int8VectorScorer {
         public CosineScorer(IndexInput in, ByteVectorValues values, byte[] query) {
             super(in, values, query);
         }
@@ -175,7 +175,7 @@ public abstract sealed class ByteVectorScorer extends RandomVectorScorer.Abstrac
         }
     }
 
-    public static final class EuclideanScorer extends ByteVectorScorer {
+    public static final class EuclideanScorer extends Int8VectorScorer {
         public EuclideanScorer(IndexInput in, ByteVectorValues values, byte[] query) {
             super(in, values, query);
         }
@@ -206,7 +206,7 @@ public abstract sealed class ByteVectorScorer extends RandomVectorScorer.Abstrac
         }
     }
 
-    public static final class MaxInnerProductScorer extends ByteVectorScorer {
+    public static final class MaxInnerProductScorer extends Int8VectorScorer {
         public MaxInnerProductScorer(IndexInput in, ByteVectorValues values, byte[] query) {
             super(in, values, query);
         }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int8VectorScorerSupplier.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int8VectorScorerSupplier.java
@@ -9,8 +9,7 @@
 
 package org.elasticsearch.simdvec.internal;
 
-import org.apache.lucene.index.FloatVectorValues;
-import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.index.ByteVectorValues;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.VectorUtil;
 import org.apache.lucene.util.hnsw.RandomVectorScorerSupplier;
@@ -20,34 +19,33 @@ import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 
-import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
-import static org.apache.lucene.index.VectorSimilarityFunction.EUCLIDEAN;
-import static org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
-
-public abstract sealed class FloatVectorScorerSupplier implements RandomVectorScorerSupplier {
+// Scores pairs of indexed vectors (ordinal vs ordinal) for graph construction and segment merging.
+public abstract sealed class Int8VectorScorerSupplier implements RandomVectorScorerSupplier {
 
     final int dims;
-    final int vectorByteSize;
     final int maxOrd;
+    /**
+     * The length in bytes of one vector. For this scorer, it matches the pitch (the distance in memory between 2 vectors, when laid
+     * out consecutively) and the total vector size (no padding, no extra fields).
+     */
+    final int vectorByteSize;
     final IndexInput input;
-    final FloatVectorValues values;
-    final VectorSimilarityFunction fallbackScorer;
+    final ByteVectorValues values;
     final FixedSizeScratch firstScratch;
     final FixedSizeScratch secondScratch;
 
-    protected FloatVectorScorerSupplier(IndexInput input, FloatVectorValues values, VectorSimilarityFunction fallbackScorer) {
+    protected Int8VectorScorerSupplier(IndexInput input, ByteVectorValues values) {
         this.input = input;
         this.values = values;
         this.dims = values.dimension();
-        this.vectorByteSize = dims * Float.BYTES;
+        this.vectorByteSize = values.getVectorByteLength();
         this.maxOrd = values.size();
-        this.fallbackScorer = fallbackScorer;
         this.firstScratch = new FixedSizeScratch(vectorByteSize);
         this.secondScratch = new FixedSizeScratch(vectorByteSize);
     }
 
     protected final void checkOrdinal(int ord) {
-        if (ord < 0 || ord > maxOrd) {
+        if (ord < 0 || ord >= maxOrd) {
             throw new IllegalArgumentException("illegal ordinal: " + ord);
         }
     }
@@ -74,11 +72,14 @@ public abstract sealed class FloatVectorScorerSupplier implements RandomVectorSc
                 addrs -> maxScore[0] = bulkScoreFromSegment(addrs, query, MemorySegment.ofArray(scores), numNodes)
             );
             if (resolved == false) {
-                // fallback to on-heap fallback scorer
-                var queryVector = values.vectorValue(firstOrd).clone();
+                // fallback to per-vector scorer
                 for (int i = 0; i < numNodes; i++) {
-                    scores[i] = fallbackScorer.compare(queryVector, values.vectorValue(ordinals[i]));
-                    maxScore[0] = Math.max(maxScore[0], scores[i]);
+                    input.seek(offsets[i]);
+                    scores[i] = IndexInputUtils.withSlice(input, vectorByteSize, secondScratch::getScratch, vector -> {
+                        var score = scoreFromSegments(query, vector);
+                        maxScore[0] = Math.max(maxScore[0], score);
+                        return score;
+                    });
                 }
             }
             return maxScore[0];
@@ -129,26 +130,62 @@ public abstract sealed class FloatVectorScorerSupplier implements RandomVectorSc
         };
     }
 
-    public static final class EuclideanSupplier extends FloatVectorScorerSupplier {
+    public static final class CosineSupplier extends Int8VectorScorerSupplier {
 
-        public EuclideanSupplier(IndexInput input, FloatVectorValues values) {
-            super(input, values, EUCLIDEAN);
+        public CosineSupplier(IndexInput input, ByteVectorValues values) {
+            super(input, values);
+        }
+
+        private static float normalize(float cosine) {
+            return (1 + cosine) / 2;
         }
 
         @Override
         float scoreFromSegments(MemorySegment a, MemorySegment b) {
-            return VectorUtil.normalizeDistanceToUnitInterval(Similarities.squareDistanceF32(a, b, dims));
+            return normalize(Similarities.cosineI8(a, b, dims));
         }
 
         @Override
-        protected float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
-            Similarities.squareDistanceF32BulkSparse(addresses, query, dims, numNodes, scores);
+        float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
+            Similarities.cosineI8BulkSparse(addresses, query, dims, numNodes, scores);
+
             float max = Float.NEGATIVE_INFINITY;
             for (int i = 0; i < numNodes; ++i) {
                 float squareDistance = scores.getAtIndex(ValueLayout.JAVA_FLOAT, i);
-                float normalizedScore = VectorUtil.normalizeDistanceToUnitInterval(squareDistance);
-                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalizedScore);
-                max = Math.max(max, normalizedScore);
+                float normalized = normalize(squareDistance);
+                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalized);
+                max = Math.max(max, normalized);
+            }
+            return max;
+        }
+
+        @Override
+        public CosineSupplier copy() {
+            return new CosineSupplier(input.clone(), values);
+        }
+    }
+
+    public static final class EuclideanSupplier extends Int8VectorScorerSupplier {
+
+        public EuclideanSupplier(IndexInput input, ByteVectorValues values) {
+            super(input, values);
+        }
+
+        @Override
+        float scoreFromSegments(MemorySegment a, MemorySegment b) {
+            return VectorUtil.normalizeDistanceToUnitInterval(Similarities.squareDistanceI8(a, b, dims));
+        }
+
+        @Override
+        float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
+            Similarities.squareDistanceI8BulkSparse(addresses, query, dims, numNodes, scores);
+
+            float max = Float.NEGATIVE_INFINITY;
+            for (int i = 0; i < numNodes; ++i) {
+                float squareDistance = scores.getAtIndex(ValueLayout.JAVA_FLOAT, i);
+                float normalized = VectorUtil.normalizeDistanceToUnitInterval(squareDistance);
+                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalized);
+                max = Math.max(max, normalized);
             }
             return max;
         }
@@ -159,26 +196,33 @@ public abstract sealed class FloatVectorScorerSupplier implements RandomVectorSc
         }
     }
 
-    public static final class DotProductSupplier extends FloatVectorScorerSupplier {
+    public static final class DotProductSupplier extends Int8VectorScorerSupplier {
 
-        public DotProductSupplier(IndexInput input, FloatVectorValues values) {
-            super(input, values, DOT_PRODUCT);
+        private final float denom = (float) (dims * (1 << 15));
+
+        public DotProductSupplier(IndexInput input, ByteVectorValues values) {
+            super(input, values);
+        }
+
+        private float normalize(float dotProduct) {
+            return 0.5f + dotProduct / denom;
         }
 
         @Override
         float scoreFromSegments(MemorySegment a, MemorySegment b) {
-            return VectorUtil.normalizeToUnitInterval(Similarities.dotProductF32(a, b, dims));
+            return normalize(Similarities.dotProductI8(a, b, dims));
         }
 
         @Override
-        protected float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
-            Similarities.dotProductF32BulkSparse(addresses, query, dims, numNodes, scores);
+        float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
+            Similarities.dotProductI8BulkSparse(addresses, query, dims, numNodes, scores);
+
             float max = Float.NEGATIVE_INFINITY;
             for (int i = 0; i < numNodes; ++i) {
                 float dotProduct = scores.getAtIndex(ValueLayout.JAVA_FLOAT, i);
-                float normalizedScore = VectorUtil.normalizeToUnitInterval(dotProduct);
-                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalizedScore);
-                max = Math.max(max, normalizedScore);
+                float normalized = normalize(dotProduct);
+                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalized);
+                max = Math.max(max, normalized);
             }
             return max;
         }
@@ -189,27 +233,27 @@ public abstract sealed class FloatVectorScorerSupplier implements RandomVectorSc
         }
     }
 
-    public static final class MaxInnerProductSupplier extends FloatVectorScorerSupplier {
+    public static final class MaxInnerProductSupplier extends Int8VectorScorerSupplier {
 
-        public MaxInnerProductSupplier(IndexInput input, FloatVectorValues values) {
-            super(input, values, MAXIMUM_INNER_PRODUCT);
+        public MaxInnerProductSupplier(IndexInput input, ByteVectorValues values) {
+            super(input, values);
         }
 
         @Override
         float scoreFromSegments(MemorySegment a, MemorySegment b) {
-            return VectorUtil.scaleMaxInnerProductScore(Similarities.dotProductF32(a, b, dims));
+            return VectorUtil.scaleMaxInnerProductScore(Similarities.dotProductI8(a, b, dims));
         }
 
         @Override
-        protected float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
-            Similarities.dotProductF32BulkSparse(addresses, query, dims, numNodes, scores);
+        float bulkScoreFromSegment(MemorySegment addresses, MemorySegment query, MemorySegment scores, int numNodes) {
+            Similarities.dotProductI8BulkSparse(addresses, query, dims, numNodes, scores);
 
             float max = Float.NEGATIVE_INFINITY;
             for (int i = 0; i < numNodes; ++i) {
                 float dotProduct = scores.getAtIndex(ValueLayout.JAVA_FLOAT, i);
-                float scaledScore = VectorUtil.scaleMaxInnerProductScore(dotProduct);
-                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, scaledScore);
-                max = Math.max(max, scaledScore);
+                float normalized = VectorUtil.scaleMaxInnerProductScore(dotProduct);
+                scores.setAtIndex(ValueLayout.JAVA_FLOAT, i, normalized);
+                max = Math.max(max, normalized);
             }
             return max;
         }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Float32VectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Float32VectorScorerFactoryTests.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.simdvec.VectorSimilarityType.MAXIMUM_INNER_PRODU
 import static org.elasticsearch.simdvec.internal.vectorization.JdkFeatures.SUPPORTS_HEAP_SEGMENTS;
 import static org.hamcrest.Matchers.closeTo;
 
-public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
+public class Float32VectorScorerFactoryTests extends AbstractVectorTestCase {
 
     private static final int TIMES = 100; // a loop iteration times
     private static final double DELTA = 1e-6;
@@ -58,14 +58,14 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
     public void testRandomMMap() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         try (Directory dir = new MMapDirectory(createTempDir("testRandomMMap"))) {
-            testRandomSupplier(dir, FloatVectorScorerFactoryTests::randomVector);
+            testRandomSupplier(dir, Float32VectorScorerFactoryTests::randomVector);
         }
     }
 
     public void testRandomNIO() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         try (Directory dir = new NIOFSDirectory(createTempDir("testRandomNIO"))) {
-            testRandomSupplier(dir, FloatVectorScorerFactoryTests::randomVector);
+            testRandomSupplier(dir, Float32VectorScorerFactoryTests::randomVector);
         }
     }
 
@@ -74,7 +74,7 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
         long maxChunkSize = randomLongBetween(32, 128);
         logger.info("maxChunkSize=" + maxChunkSize);
         try (Directory dir = new MMapDirectory(createTempDir("testRandomMaxChunkSizeSmall"), maxChunkSize)) {
-            testRandomSupplier(dir, FloatVectorScorerFactoryTests::randomVector);
+            testRandomSupplier(dir, Float32VectorScorerFactoryTests::randomVector);
         }
     }
 
@@ -88,14 +88,14 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
     public void testRandomBulkMMap() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         try (Directory dir = new MMapDirectory(createTempDir("testRandomBulkMMap"))) {
-            testRandomSupplierBulk(dir, FloatVectorScorerFactoryTests::randomVector);
+            testRandomSupplierBulk(dir, Float32VectorScorerFactoryTests::randomVector);
         }
     }
 
     public void testRandomBulkNIO() throws IOException {
         assumeTrue(notSupportedMsg(), supported());
         try (Directory dir = new NIOFSDirectory(createTempDir("testRandomBulkNIO"))) {
-            testRandomSupplierBulk(dir, FloatVectorScorerFactoryTests::randomVector);
+            testRandomSupplierBulk(dir, Float32VectorScorerFactoryTests::randomVector);
         }
     }
 
@@ -104,7 +104,7 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
         long maxChunkSize = randomLongBetween(32, 128);
         logger.info("maxChunkSize=" + maxChunkSize);
         try (Directory dir = new MMapDirectory(createTempDir("testRandomMaxChunkSizeSmallBulk"), maxChunkSize)) {
-            testRandomSupplierBulk(dir, FloatVectorScorerFactoryTests::randomVector);
+            testRandomSupplierBulk(dir, Float32VectorScorerFactoryTests::randomVector);
         }
     }
 
@@ -162,7 +162,7 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
             String fileName = "testDatasetGreaterThanChunkSize-" + dims;
             logger.info("Testing " + fileName);
 
-            writeTestDataFile(FloatVectorScorerFactoryTests::randomVector, dir, fileName, size, dims, vectors);
+            writeTestDataFile(Float32VectorScorerFactoryTests::randomVector, dir, fileName, size, dims, vectors);
 
             try (IndexInput in = dir.openInput(fileName, IOContext.DEFAULT)) {
                 for (int times = 0; times < TIMES; times++) {
@@ -187,7 +187,7 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
             String fileName = "testDatasetGreaterThanChunkSize-" + dims;
             logger.info("Testing " + fileName);
 
-            writeTestDataFile(FloatVectorScorerFactoryTests::randomVector, dir, fileName, size, dims, vectors);
+            writeTestDataFile(Float32VectorScorerFactoryTests::randomVector, dir, fileName, size, dims, vectors);
 
             try (IndexInput in = dir.openInput(fileName, IOContext.DEFAULT)) {
                 for (int times = 0; times < TIMES; times++) {
@@ -208,11 +208,11 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
 
         try (var dir = new MMapDirectory(createTempDir("testBulkScoreWithZeroNodes"))) {
             String fileName = "testBulkScoreWithZeroNodes-" + dims;
-            writeTestDataFile(FloatVectorScorerFactoryTests::randomVector, dir, fileName, size, dims, new float[size][]);
+            writeTestDataFile(Float32VectorScorerFactoryTests::randomVector, dir, fileName, size, dims, new float[size][]);
             try (IndexInput in = dir.openInput(fileName, IOContext.DEFAULT)) {
                 for (var sim : List.of(DOT_PRODUCT, EUCLIDEAN, MAXIMUM_INNER_PRODUCT)) {
                     var values = vectorValues(dims, size, in, sim.function());
-                    var supplier = factory.getFloatVectorScorerSupplier(sim, in, values).get();
+                    var supplier = factory.getFloat32VectorScorerSupplier(sim, in, values).get();
                     var scorer = supplier.scorer();
                     scorer.setScoringOrdinal(0);
                     float result = scorer.bulkScore(new int[0], new float[0], 0);
@@ -252,7 +252,7 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
             var values = vectorValues(dims, size, in, sim.function());
             float expected = luceneScore(sim, vectors[idx0], vectors[idx1]);
 
-            var supplier = factory.getFloatVectorScorerSupplier(sim, in, values).get();
+            var supplier = factory.getFloat32VectorScorerSupplier(sim, in, values).get();
             var scorer = supplier.scorer();
             scorer.setScoringOrdinal(idx0);
 
@@ -274,7 +274,7 @@ public class FloatVectorScorerFactoryTests extends AbstractVectorTestCase {
                 expected[idx1] = luceneScore(sim, vectors[idx0], vectors[idx1]);
             }
 
-            var supplier = factory.getFloatVectorScorerSupplier(sim, in, values).get();
+            var supplier = factory.getFloat32VectorScorerSupplier(sim, in, values).get();
             var scorer = supplier.scorer();
             scorer.setScoringOrdinal(idx0);
 

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int8VectorScorerFactoryTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/Int8VectorScorerFactoryTests.java
@@ -38,7 +38,7 @@ import static org.elasticsearch.simdvec.VectorSimilarityType.MAXIMUM_INNER_PRODU
 import static org.elasticsearch.simdvec.internal.vectorization.JdkFeatures.SUPPORTS_HEAP_SEGMENTS;
 import static org.hamcrest.Matchers.closeTo;
 
-public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
+public class Int8VectorScorerFactoryTests extends AbstractVectorTestCase {
 
     private static final double DELTA = 1e-6;
 
@@ -106,7 +106,7 @@ public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
                     var values = vectorValues(dims, size, in, sim.function());
                     float expected = luceneScore(sim, vectors[idx0], vectors[idx1]);
 
-                    var supplier = factory.getByteVectorScorerSupplier(sim, in, values).get();
+                    var supplier = factory.getInt8VectorScorerSupplier(sim, in, values).get();
                     var scorer = supplier.scorer();
                     scorer.setScoringOrdinal(idx0);
 
@@ -144,7 +144,7 @@ public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
                         var values = vectorValues(dims, size, in, sim.function());
                         float expected = luceneScore(sim, vector(idx0, dims), vector(idx1, dims));
 
-                        var supplier = factory.getByteVectorScorerSupplier(sim, in, values).get();
+                        var supplier = factory.getInt8VectorScorerSupplier(sim, in, values).get();
                         var scorer = supplier.scorer();
                         scorer.setScoringOrdinal(idx0);
 
@@ -200,7 +200,7 @@ public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
                     for (int i = 0; i < size; i++) {
                         expected[i] = luceneScore(sim, vectors[idx0], vectors[nodes[i]]);
                     }
-                    var supplier = factory.getByteVectorScorerSupplier(sim, in, values).get();
+                    var supplier = factory.getInt8VectorScorerSupplier(sim, in, values).get();
                     var scorer = supplier.scorer();
                     scorer.setScoringOrdinal(idx0);
                     scorer.bulkScore(nodes, scores, nodes.length);
@@ -215,7 +215,7 @@ public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
         }
     }
 
-    // -- Query-side scorer tests (ByteVectorScorer via getByteVectorScorer, JDK 22+) --
+    // -- Query-side scorer tests (Int8VectorScorer via getInt8VectorScorer, JDK 22+) --
     // These test the query scorer which accepts both MMap and DirectAccessInput (SNAP).
 
     public void testScorerWithMMap() throws IOException {
@@ -256,7 +256,7 @@ public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
                 for (var sim : List.of(DOT_PRODUCT, EUCLIDEAN, COSINE, MAXIMUM_INNER_PRODUCT)) {
                     var values = vectorValues(dims, size, in, sim.function());
                     float expected = luceneScore(sim, queryVector, vectors[idx]);
-                    var scorer = factory.getByteVectorScorer(sim.function(), values, queryVector).get();
+                    var scorer = factory.getInt8VectorScorer(sim.function(), values, queryVector).get();
                     double expectedDelta = Math.max(Math.abs(expected) * DELTA, DELTA);
                     assertThat(sim.toString(), (double) scorer.score(idx), closeTo(expected, expectedDelta));
                 }
@@ -317,7 +317,7 @@ public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
                     for (int i = 0; i < size; i++) {
                         expected[i] = luceneScore(sim, queryVector, vectors[nodes[i]]);
                     }
-                    var scorer = factory.getByteVectorScorer(sim.function(), values, queryVector).get();
+                    var scorer = factory.getInt8VectorScorer(sim.function(), values, queryVector).get();
                     scorer.bulkScore(nodes, scores, nodes.length);
                     for (int i = 0; i < size; i++) {
                         double expectedDelta = Math.max(Math.abs(expected[i]) * DELTA, DELTA);
@@ -352,7 +352,7 @@ public class ByteVectorScorerFactoryTests extends AbstractVectorTestCase {
             try (IndexInput in = dir.openInput(fileName, IOContext.DEFAULT)) {
                 for (var sim : List.of(DOT_PRODUCT, EUCLIDEAN, COSINE, MAXIMUM_INNER_PRODUCT)) {
                     var values = vectorValues(dims, size, in, sim.function());
-                    var scorer = factory.getByteVectorScorer(sim.function(), values, queryVector).get();
+                    var scorer = factory.getInt8VectorScorer(sim.function(), values, queryVector).get();
                     float result = scorer.bulkScore(new int[0], new float[0], 0);
                     assertEquals(Float.NEGATIVE_INFINITY, result, 0f);
                 }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93GenericFlatVectorScorer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93GenericFlatVectorScorer.java
@@ -60,12 +60,12 @@ public class ES93GenericFlatVectorScorer implements FlatVectorsScorer {
 
         if (FACTORY != null && vectorValues instanceof HasIndexSlice sl) {
             Optional<RandomVectorScorerSupplier> scorer = switch (vectorValues.getEncoding()) {
-                case BYTE -> FACTORY.getByteVectorScorerSupplier(
+                case BYTE -> FACTORY.getInt8VectorScorerSupplier(
                     VectorSimilarityType.of(similarityFunction),
                     sl.getSlice(),
                     (ByteVectorValues) vectorValues
                 );
-                case FLOAT32 -> FACTORY.getFloatVectorScorerSupplier(
+                case FLOAT32 -> FACTORY.getFloat32VectorScorerSupplier(
                     VectorSimilarityType.of(similarityFunction),
                     sl.getSlice(),
                     (FloatVectorValues) vectorValues
@@ -101,7 +101,7 @@ public class ES93GenericFlatVectorScorer implements FlatVectorsScorer {
         }
 
         if (FACTORY != null) {
-            var scorer = FACTORY.getFloatVectorScorer(similarityFunction, (FloatVectorValues) vectorValues, target);
+            var scorer = FACTORY.getFloat32VectorScorer(similarityFunction, (FloatVectorValues) vectorValues, target);
             if (scorer.isPresent()) {
                 return scorer.get();
             }
@@ -116,7 +116,7 @@ public class ES93GenericFlatVectorScorer implements FlatVectorsScorer {
         byte[] target
     ) throws IOException {
         if (FACTORY != null) {
-            var scorer = FACTORY.getByteVectorScorer(similarityFunction, (ByteVectorValues) vectorValues, target);
+            var scorer = FACTORY.getInt8VectorScorer(similarityFunction, (ByteVectorValues) vectorValues, target);
             if (scorer.isPresent()) {
                 return scorer.get();
             }


### PR DESCRIPTION
## Summary

- Renames `ByteVectorScorer` / `ByteVectorScorerSupplier` → `Int8VectorScorer` / `Int8VectorScorerSupplier`
- Renames `FloatVectorScorer` / `FloatVectorScorerSupplier` → `Float32VectorScorer` / `Float32VectorScorerSupplier`
- Renames the corresponding factory methods on `VectorScorerFactory` (`getByteVector*` → `getInt8Vector*`, `getFloatVector*` → `getFloat32Vector*`)
- Updates all call sites: `VectorScorerFactoryImpl`, `ES93GenericFlatVectorScorer`, test classes, and benchmarks

The `Int7SQ`, `Int7uOSQ`, `Int4`, and `BFloat16` scorer classes already used numeric bit-width naming; this change makes `Int8` and `Float32` consistent with that convention.