### PR TITLE
[ESQL] Parquet footer cache: simplify key, add thundering-herd protection

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -8,16 +8,19 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.parquet.io.SeekableInputStream;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
-import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Adapter that wraps a StorageObject to implement Parquet's InputFile interface.
@@ -37,8 +40,15 @@ import java.util.NavigableMap;
  *
  * <p>Both paths use <strong>only</strong> range reads ({@code newStream(position, length)})
  * and {@link StorageObject#readBytes} — never a full-object GET — and have no Hadoop dependencies.
+ *
+ * <p>A JVM-wide {@link FooterCache} (8 MiB budget) caches the tail bytes of Parquet files
+ * to avoid redundant footer reads across splits. Thundering-herd protection ensures that
+ * concurrent tail reads for the same file coalesce into a single I/O via {@link CompletableFuture}.
  */
 public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputFile {
+
+    private static final Logger logger = LogManager.getLogger(ParquetStorageObjectAdapter.class);
+
     private final StorageObject storageObject;
     private final long length;
     private final FooterCacheKey footerCacheKey;
@@ -148,14 +158,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
     }
 
     private static FooterCacheKey buildFooterCacheKey(StorageObject storageObject, long length) {
-        Instant lastModified;
-        try {
-            lastModified = storageObject.lastModified();
-        } catch (IOException e) {
-            lastModified = null;
-        }
-        Long lastModifiedMillis = lastModified == null ? null : lastModified.toEpochMilli();
-        return new FooterCacheKey(storageObject.path().toString(), length, lastModifiedMillis);
+        return new FooterCacheKey(storageObject.path().toString(), length);
     }
 
     /**
@@ -235,7 +238,9 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 return;
             }
 
-            FooterCacheEntry cached = FOOTER_CACHE.get(footerCacheKey);
+            boolean isTailRead = pos + toRead == length;
+
+            FooterCacheEntry cached = FOOTER_CACHE.getCompleted(footerCacheKey);
             if (cached != null && cached.covers(pos, (int) toRead)) {
                 int from = (int) (pos - cached.startOffset());
                 System.arraycopy(cached.bytes(), from, window, 0, (int) toRead);
@@ -244,14 +249,50 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 return;
             }
 
-            windowStart = pos;
-            windowLength = 0;
-            ByteBuffer target = ByteBuffer.wrap(window, 0, (int) toRead);
-            int bytesRead = storageObject.readBytes(pos, target);
-            windowLength = bytesRead < 0 ? 0 : bytesRead;
+            if (isTailRead) {
+                cached = FOOTER_CACHE.getOrAwaitPending(footerCacheKey);
+                if (cached != null && cached.covers(pos, (int) toRead)) {
+                    int from = (int) (pos - cached.startOffset());
+                    System.arraycopy(cached.bytes(), from, window, 0, (int) toRead);
+                    windowStart = pos;
+                    windowLength = (int) toRead;
+                    return;
+                }
 
-            if (windowLength > 0 && windowStart + windowLength == length) {
-                FOOTER_CACHE.putTailIfEligible(footerCacheKey, windowStart, window, windowLength);
+                CompletableFuture<FooterCacheEntry> future = new CompletableFuture<>();
+                if (FOOTER_CACHE.tryRegisterPending(footerCacheKey, future)) {
+                    try {
+                        windowStart = pos;
+                        windowLength = 0;
+                        ByteBuffer target = ByteBuffer.wrap(window, 0, (int) toRead);
+                        int bytesRead = storageObject.readBytes(pos, target);
+                        windowLength = bytesRead < 0 ? 0 : bytesRead;
+                        FOOTER_CACHE.completePending(footerCacheKey, windowStart, window, windowLength);
+                    } catch (IOException e) {
+                        FOOTER_CACHE.failPending(footerCacheKey);
+                        throw e;
+                    }
+                } else {
+                    cached = FOOTER_CACHE.getOrAwaitPending(footerCacheKey);
+                    if (cached != null && cached.covers(pos, (int) toRead)) {
+                        int from = (int) (pos - cached.startOffset());
+                        System.arraycopy(cached.bytes(), from, window, 0, (int) toRead);
+                        windowStart = pos;
+                        windowLength = (int) toRead;
+                    } else {
+                        windowStart = pos;
+                        windowLength = 0;
+                        ByteBuffer target = ByteBuffer.wrap(window, 0, (int) toRead);
+                        int bytesRead = storageObject.readBytes(pos, target);
+                        windowLength = bytesRead < 0 ? 0 : bytesRead;
+                    }
+                }
+            } else {
+                windowStart = pos;
+                windowLength = 0;
+                ByteBuffer target = ByteBuffer.wrap(window, 0, (int) toRead);
+                int bytesRead = storageObject.readBytes(pos, target);
+                windowLength = bytesRead < 0 ? 0 : bytesRead;
             }
         }
 
@@ -610,7 +651,17 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         }
     }
 
-    private record FooterCacheKey(String path, long length, Long lastModifiedMillis) {}
+    /**
+     * Cache key for Parquet footer bytes. Uses {@code (path, length)} only — not {@code lastModified}
+     * — so that all range splits of the same file share one cache entry regardless of any timing
+     * jitter in {@link StorageObject#lastModified()}.
+     *
+     * <p>This is safe for immutable object stores (S3, GCS, Azure Blob) where objects are never
+     * overwritten in place. For mutable filesystems (local, NFS), same-path same-length overwrites
+     * can serve stale footer bytes until the entry is evicted or the JVM restarts.
+     */
+    // package-private for tests
+    record FooterCacheKey(String path, long length) {}
 
     private record FooterCacheEntry(long startOffset, byte[] bytes) {
         boolean covers(long position, int length) {
@@ -624,10 +675,22 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         }
     }
 
-    private static class FooterCache {
+    /**
+     * JVM-wide footer cache with thundering-herd protection. Completed entries live in a
+     * byte-budget LRU ({@code completed}); in-flight reads are tracked in a separate
+     * {@code pending} map so concurrent callers coalesce into a single I/O via
+     * {@link CompletableFuture}.
+     *
+     * <p>Thread-safety: {@code completed} and byte accounting are guarded by {@code synchronized(this)};
+     * {@code pending} is a {@link ConcurrentHashMap} so registration/removal is lock-free.
+     * {@link #clear()} synchronizes on both to ensure no orphaned futures.
+     */
+    // package-private for tests
+    static class FooterCache {
         private final int maxBytes;
         private final int maxEntryBytes;
-        private final LinkedHashMap<FooterCacheKey, FooterCacheEntry> map = new LinkedHashMap<>(16, 0.75f, true);
+        private final LinkedHashMap<FooterCacheKey, FooterCacheEntry> completed = new LinkedHashMap<>(16, 0.75f, true);
+        private final ConcurrentHashMap<FooterCacheKey, CompletableFuture<FooterCacheEntry>> pending = new ConcurrentHashMap<>();
         private int totalBytes;
 
         FooterCache(int maxBytes, int maxEntryBytes) {
@@ -635,8 +698,81 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             this.maxEntryBytes = maxEntryBytes;
         }
 
-        synchronized FooterCacheEntry get(FooterCacheKey key) {
-            return map.get(key);
+        /** Returns a completed cache entry, or {@code null}. Never blocks. */
+        synchronized FooterCacheEntry getCompleted(FooterCacheKey key) {
+            return completed.get(key);
+        }
+
+        /**
+         * Returns a completed entry if available, otherwise awaits any in-flight pending read
+         * for this key. If the pending read completes before this call, falls back to the
+         * completed map. Returns {@code null} only when no entry exists and no pending read
+         * is in progress.
+         */
+        FooterCacheEntry getOrAwaitPending(FooterCacheKey key) {
+            synchronized (this) {
+                FooterCacheEntry cached = completed.get(key);
+                if (cached != null) {
+                    return cached;
+                }
+            }
+            CompletableFuture<FooterCacheEntry> future = pending.get(key);
+            if (future != null) {
+                FooterCacheEntry result = awaitFuture(future);
+                if (result != null) {
+                    return result;
+                }
+            }
+            synchronized (this) {
+                return completed.get(key);
+            }
+        }
+
+        /**
+         * Registers this caller as the owner of the pending read for the given key.
+         * Returns {@code true} if registration succeeded (caller should perform I/O),
+         * {@code false} if another caller already registered (caller should call
+         * {@link #getOrAwaitPending}).
+         */
+        boolean tryRegisterPending(FooterCacheKey key, CompletableFuture<FooterCacheEntry> future) {
+            return pending.putIfAbsent(key, future) == null;
+        }
+
+        /**
+         * Completes a pending read: stores the entry in the LRU cache (if within size budget),
+         * removes the pending future, and completes it so waiters unblock.
+         *
+         * <p>When the footer exceeds {@code maxEntryBytes}, it is not cached but the future is
+         * still completed with {@code null} — waiters will fall through and perform their own I/O.
+         * This matches the pre-coalescing behavior for oversized footers.
+         */
+        void completePending(FooterCacheKey key, long startOffset, byte[] buffer, int length) {
+            FooterCacheEntry entry = null;
+            if (length > 0 && length <= maxEntryBytes) {
+                byte[] bytes = new byte[length];
+                System.arraycopy(buffer, 0, bytes, 0, length);
+                entry = new FooterCacheEntry(startOffset, bytes);
+                synchronized (this) {
+                    FooterCacheEntry previous = completed.put(key, entry);
+                    if (previous != null) {
+                        totalBytes -= previous.bytes().length;
+                    }
+                    totalBytes += bytes.length;
+                    evictIfNeeded();
+                }
+            }
+            CompletableFuture<FooterCacheEntry> future = pending.remove(key);
+            if (future != null) {
+                future.complete(entry);
+            }
+        }
+
+        /** Signals that a pending read failed, allowing waiters to retry or fall through. */
+        void failPending(FooterCacheKey key) {
+            CompletableFuture<FooterCacheEntry> future = pending.remove(key);
+            if (future != null) {
+                future.complete(null);
+            }
         }
 
         synchronized void putTailIfEligible(FooterCacheKey key, long startOffset, byte[] buffer, int length) {
@@ -646,7 +782,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             byte[] bytes = new byte[length];
             System.arraycopy(buffer, 0, bytes, 0, length);
 
-            FooterCacheEntry previous = map.put(key, new FooterCacheEntry(startOffset, bytes));
+            FooterCacheEntry previous = completed.put(key, new FooterCacheEntry(startOffset, bytes));
             if (previous != null) {
                 totalBytes -= previous.bytes().length;
             }
@@ -655,17 +791,34 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         }
 
         private void evictIfNeeded() {
-            while (totalBytes > maxBytes && map.isEmpty() == false) {
-                Map.Entry<FooterCacheKey, FooterCacheEntry> eldest = map.entrySet().iterator().next();
+            while (totalBytes > maxBytes && completed.isEmpty() == false) {
+                Map.Entry<FooterCacheKey, FooterCacheEntry> eldest = completed.entrySet().iterator().next();
                 FooterCacheEntry removed = eldest.getValue();
-                map.remove(eldest.getKey());
+                completed.remove(eldest.getKey());
                 totalBytes -= removed.bytes().length;
             }
         }
 
+        /**
+         * Clears all cached and pending entries. Pending futures are completed with {@code null}
+         * before removal so that any thread blocked in {@link #getOrAwaitPending} unblocks.
+         */
         synchronized void clear() {
-            map.clear();
+            completed.clear();
             totalBytes = 0;
+            for (Map.Entry<FooterCacheKey, CompletableFuture<FooterCacheEntry>> entry : pending.entrySet()) {
+                entry.getValue().complete(null);
+            }
+            pending.clear();
+        }
+
+        private FooterCacheEntry awaitFuture(CompletableFuture<FooterCacheEntry> future) {
+            try {
+                return future.join();
+            } catch (java.util.concurrent.CancellationException | java.util.concurrent.CompletionException e) {
+                logger.debug("footer cache await failed", e);
+                return null;
+            }
         }
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -12,6 +12,9 @@ import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.NanoTime;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.predicate.FilterApi;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -57,6 +60,7 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -1762,6 +1766,69 @@ public class ParquetFormatReaderTests extends ESTestCase {
         }
 
         assertEquals("Sum of rows across splits must equal the row count written", numRows, totalRowsFromRanges);
+    }
+
+    /**
+     * End-to-end test: reads a multi-row-group Parquet file with a filter via {@code read()},
+     * then reads via per-range {@code readRange()} with the same filter. Asserts the union of
+     * range reads produces identical rows to the full read, proving the footer cache does not
+     * cause splits to miss or duplicate rows.
+     */
+    public void testReadRangeWithFilterProducesCorrectResults() throws Exception {
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+        byte[] parquetData = createWideMultiRowGroupFile(500);
+        StorageObject storageObject = createStorageObject(parquetData);
+        FilterPredicate filter = FilterApi.gt(FilterApi.longColumn("id"), -1L);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory).withPushedFilter(FilterCompat.get(filter));
+
+        List<String> fullRows = new ArrayList<>();
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 500)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                LongBlock ids = (LongBlock) page.getBlock(0);
+                BytesRefBlock payloads = (BytesRefBlock) page.getBlock(1);
+                BytesRef scratch = new BytesRef();
+                for (int row = 0; row < page.getPositionCount(); row++) {
+                    fullRows.add(ids.getLong(row) + "|" + payloads.getBytesRef(row, scratch).utf8ToString());
+                }
+            }
+        }
+
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        assertTrue("Need at least 2 ranges for this test, got " + ranges.size(), ranges.size() >= 2);
+
+        List<String> rangeRows = new ArrayList<>();
+        for (RangeAwareFormatReader.SplitRange range : ranges) {
+            long rangeStart = range.offset();
+            long rangeEnd = rangeStart + range.length();
+            try (
+                CloseableIterator<Page> iterator = reader.readRange(
+                    storageObject,
+                    null,
+                    500,
+                    rangeStart,
+                    rangeEnd,
+                    List.of(),
+                    ErrorPolicy.STRICT
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    Page page = iterator.next();
+                    LongBlock ids = (LongBlock) page.getBlock(0);
+                    BytesRefBlock payloads = (BytesRefBlock) page.getBlock(1);
+                    BytesRef scratch = new BytesRef();
+                    for (int row = 0; row < page.getPositionCount(); row++) {
+                        rangeRows.add(ids.getLong(row) + "|" + payloads.getBytesRef(row, scratch).utf8ToString());
+                    }
+                }
+            }
+        }
+
+        assertEquals(fullRows.size(), rangeRows.size());
+        Comparator<String> byId = Comparator.comparingLong(s -> Long.parseLong(s.split("\\|", 2)[0]));
+        fullRows.sort(byId);
+        rangeRows.sort(byId);
+        assertEquals(fullRows, rangeRows);
     }
 
     // --- Test helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -56,6 +56,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         savedWindowCacheFlag = ParquetStorageObjectAdapter.windowCacheEnabled;
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
     }
 
     @After
@@ -1285,6 +1286,282 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         if (failure != null) {
             throw failure;
         }
+    }
+
+    /**
+     * Validates that the simplified {@code (path, length)} cache key means different
+     * {@code lastModified} values still produce a cache hit for the same file.
+     */
+    public void testFooterCacheKeyIgnoresLastModified() throws IOException {
+        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
+        byte[] data = new byte[1024 * 1024];
+        random().nextBytes(data);
+        final int[] rangeReadCount = { 0 };
+        final StoragePath path = StoragePath.of("memory://cache-key-test.parquet");
+
+        StorageObject obj1 = createCountingStorageObject(data, path, Instant.ofEpochMilli(100), rangeReadCount);
+        StorageObject obj2 = createCountingStorageObject(data, path, Instant.ofEpochMilli(500), rangeReadCount);
+
+        int tailStart = data.length - 1024;
+        byte[] expected = java.util.Arrays.copyOfRange(data, tailStart, data.length);
+
+        ParquetStorageObjectAdapter first = new ParquetStorageObjectAdapter(obj1);
+        try (SeekableInputStream s = first.newStream()) {
+            s.seek(tailStart);
+            byte[] w = new byte[1024];
+            s.readFully(w);
+            assertArrayEquals(expected, w);
+        }
+        assertEquals(1, rangeReadCount[0]);
+
+        ParquetStorageObjectAdapter second = new ParquetStorageObjectAdapter(obj2);
+        try (SeekableInputStream s = second.newStream()) {
+            s.seek(tailStart);
+            byte[] w = new byte[1024];
+            s.readFully(w);
+            assertArrayEquals(expected, w);
+        }
+        assertEquals("Second adapter should use cache, no additional I/O", 1, rangeReadCount[0]);
+    }
+
+    /**
+     * Validates thundering-herd coalescing: 8 concurrent threads reading the same tail
+     * should produce exactly 1 I/O, not 8.
+     */
+    public void testThunderingHerdCoalescesConcurrentFooterReads() throws Exception {
+        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
+        byte[] data = new byte[1024 * 1024];
+        random().nextBytes(data);
+        final AtomicInteger rangeReadCount = new AtomicInteger();
+        final StoragePath path = StoragePath.of("memory://thundering-herd.parquet");
+        final java.util.concurrent.CyclicBarrier barrier = new java.util.concurrent.CyclicBarrier(8);
+
+        StorageObject obj = new StorageObject() {
+            @Override
+            public InputStream newStream() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                rangeReadCount.incrementAndGet();
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() throws IOException {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() throws IOException {
+                return Instant.ofEpochMilli(100);
+            }
+
+            @Override
+            public boolean exists() throws IOException {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return path;
+            }
+        };
+
+        int tailStart = data.length - 1024;
+        byte[] expected = java.util.Arrays.copyOfRange(data, tailStart, data.length);
+        Thread[] threads = new Thread[8];
+        AtomicReference<AssertionError> firstFailure = new AtomicReference<>();
+
+        for (int i = 0; i < 8; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(obj);
+                    try (SeekableInputStream s = adapter.newStream()) {
+                        barrier.await(5, TimeUnit.SECONDS);
+                        s.seek(tailStart);
+                        byte[] w = new byte[1024];
+                        s.readFully(w);
+                        assertArrayEquals(expected, w);
+                    }
+                } catch (AssertionError e) {
+                    firstFailure.compareAndSet(null, e);
+                } catch (Exception e) {
+                    firstFailure.compareAndSet(null, new AssertionError("Unexpected exception", e));
+                }
+            });
+            threads[i].start();
+        }
+
+        for (Thread t : threads) {
+            t.join(TimeUnit.SECONDS.toMillis(10));
+        }
+
+        AssertionError failure = firstFailure.get();
+        if (failure != null) {
+            throw failure;
+        }
+        assertTrue(
+            "Expected at most 2 range reads (1 tail + possibly 1 early non-tail), got " + rangeReadCount.get(),
+            rangeReadCount.get() <= 2
+        );
+    }
+
+    /**
+     * Validates LRU eviction behavior of the footer cache after the thundering-herd redesign.
+     */
+    public void testFooterCacheLruEvictionStillWorks() {
+        ParquetStorageObjectAdapter.FooterCache cache = new ParquetStorageObjectAdapter.FooterCache(10_000, 5_000);
+        byte[] bytes5000 = new byte[5000];
+        byte[] bytes500 = new byte[500];
+        random().nextBytes(bytes5000);
+        random().nextBytes(bytes500);
+
+        ParquetStorageObjectAdapter.FooterCacheKey key1 = new ParquetStorageObjectAdapter.FooterCacheKey("file1", 10000);
+        ParquetStorageObjectAdapter.FooterCacheKey key2 = new ParquetStorageObjectAdapter.FooterCacheKey("file2", 20000);
+        ParquetStorageObjectAdapter.FooterCacheKey key3 = new ParquetStorageObjectAdapter.FooterCacheKey("file3", 30000);
+
+        cache.putTailIfEligible(key1, 5000, bytes5000, 5000);
+        cache.putTailIfEligible(key2, 15000, bytes5000, 5000);
+
+        assertNotNull("key1 should be in cache", cache.getCompleted(key1));
+        assertNotNull("key2 should be in cache", cache.getCompleted(key2));
+
+        cache.putTailIfEligible(key3, 29500, bytes500, 500);
+        assertNotNull("key3 should be in cache", cache.getCompleted(key3));
+        assertNull("key1 should have been evicted by LRU", cache.getCompleted(key1));
+    }
+
+    /**
+     * Validates byte-for-byte correctness of the sliding-window adapter against raw data:
+     * sequential reads, forward seeks, backward seeks, tail reads, and ByteBuffer reads.
+     */
+    public void testAdapterReadsIdenticalBytesToVanillaStream() throws IOException {
+        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
+        int n = 2 * ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE + 500;
+        byte[] data = new byte[n];
+        random().nextBytes(data);
+        StorageObject storageObject = createRangeReadStorageObject(data);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+
+        try (SeekableInputStream stream = adapter.newStream()) {
+            byte[] got = new byte[100];
+            assertEquals(100, stream.read(got));
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, 0, 100), got);
+
+            stream.seek(1000);
+            got = new byte[200];
+            assertEquals(200, stream.read(got, 0, 200));
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, 1000, 1200), got);
+
+            stream.seek(500);
+            got = new byte[300];
+            assertEquals(300, stream.read(got, 0, 300));
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, 500, 800), got);
+
+            long endPos = data.length - 100L;
+            stream.seek(endPos);
+            got = new byte[100];
+            stream.readFully(got);
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, (int) endPos, data.length), got);
+
+            stream.seek(2048);
+            ByteBuffer buf = ByteBuffer.allocate(64);
+            stream.readFully(buf);
+            buf.flip();
+            byte[] bufBytes = new byte[64];
+            buf.get(bufBytes);
+            assertArrayEquals(java.util.Arrays.copyOfRange(data, 2048, 2048 + 64), bufBytes);
+        }
+    }
+
+    /**
+     * Validates that the {@code forRange} adaptive-window adapter reads the same bytes as the
+     * default-window adapter for identical seek/read sequences.
+     */
+    public void testForRangeAdapterReadsIdenticalData() throws IOException {
+        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
+        int n = 2 * ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE + 500;
+        byte[] data = new byte[n];
+        random().nextBytes(data);
+        StorageObject storage = createRangeReadStorageObject(data);
+        ParquetStorageObjectAdapter defaultAdapter = new ParquetStorageObjectAdapter(storage);
+        ParquetStorageObjectAdapter rangeAdapter = ParquetStorageObjectAdapter.forRange(storage, 8L * 1024 * 1024);
+
+        try (SeekableInputStream a = defaultAdapter.newStream(); SeekableInputStream b = rangeAdapter.newStream()) {
+            byte[] g1 = new byte[100];
+            byte[] g2 = new byte[100];
+            assertEquals(a.read(g1), b.read(g2));
+            assertArrayEquals(g1, g2);
+
+            a.seek(1000);
+            b.seek(1000);
+            g1 = new byte[200];
+            g2 = new byte[200];
+            assertEquals(a.read(g1, 0, 200), b.read(g2, 0, 200));
+            assertArrayEquals(g1, g2);
+
+            a.seek(500);
+            b.seek(500);
+            g1 = new byte[300];
+            g2 = new byte[300];
+            assertEquals(a.read(g1, 0, 300), b.read(g2, 0, 300));
+            assertArrayEquals(g1, g2);
+
+            long endPos = data.length - 100L;
+            a.seek(endPos);
+            b.seek(endPos);
+            g1 = new byte[100];
+            g2 = new byte[100];
+            a.readFully(g1);
+            b.readFully(g2);
+            assertArrayEquals(g1, g2);
+        }
+    }
+
+    private StorageObject createCountingStorageObject(byte[] data, StoragePath path, Instant lastModified, int[] counter) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() throws IOException {
+                throw new UnsupportedOperationException("Full GET not supported");
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) throws IOException {
+                counter[0]++;
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() throws IOException {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() throws IOException {
+                return lastModified;
+            }
+
+            @Override
+            public boolean exists() throws IOException {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return path;
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
Simplify FooterCacheKey to (path, length) so all splits of the same
file share one cache entry. Add CompletableFuture-based coalescing so
concurrent readers for the same footer block on a single I/O instead
of issuing redundant range GETs. Harden clear() to complete in-flight
futures before removing them.

Add integration tests validating byte-for-byte correctness of the
sliding-window adapter, forRange adaptive window, cross-adapter cache
sharing, and filtered readRange consistency against full reads.

Developed with AI-assisted tooling