### PR TITLE
`GET _reindex` correct permission handling

### DIFF
--- a/modules/reindex-management/src/main/java/org/elasticsearch/reindex/management/TransportListReindexAction.java
+++ b/modules/reindex-management/src/main/java/org/elasticsearch/reindex/management/TransportListReindexAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.admin.cluster.node.tasks.list.TransportListTasks
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.injection.guice.Inject;
@@ -27,6 +28,8 @@ import org.elasticsearch.transport.TransportService;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.action.admin.cluster.node.tasks.get.TransportGetTaskAction.TASKS_ORIGIN;
 
 /// Transport action for listing all running reindex tasks.
 /// Delegates to {@link TransportListTasksAction} to fan out to all nodes (which handles deduplication if we list a non-relocated and
@@ -40,7 +43,7 @@ public class TransportListReindexAction extends HandledTransportAction<ListReind
     @Inject
     public TransportListReindexAction(final TransportService transportService, final ActionFilters actionFilters, final Client client) {
         super(TYPE.name(), transportService, actionFilters, ListReindexRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
-        this.client = Objects.requireNonNull(client);
+        this.client = new OriginSettingClient(Objects.requireNonNull(client), TASKS_ORIGIN);
     }
 
     @Override

--- a/modules/reindex-management/src/test/java/org/elasticsearch/reindex/management/TransportListReindexActionTests.java
+++ b/modules/reindex-management/src/test/java/org/elasticsearch/reindex/management/TransportListReindexActionTests.java
@@ -14,10 +14,13 @@ import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.TransportListTasksAction;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
@@ -33,6 +36,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TransportListReindexActionTests extends ESTestCase {
 
@@ -45,6 +49,9 @@ public class TransportListReindexActionTests extends ESTestCase {
     @Before
     public void setup() {
         client = mock();
+        var threadPool = mock(ThreadPool.class);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         action = new TransportListReindexAction(mock(), mock(), client);
         responseRef = new AtomicReference<>();
         failureRef = new AtomicReference<>();

--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexWithSecurityIT.java
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexWithSecurityIT.java
@@ -71,6 +71,7 @@ public class ReindexWithSecurityIT extends ESRestTestCase {
             .user("minimal_user", "x-pack-test-password", "minimal", false)
             .user("minimal_with_task_user", "x-pack-test-password", "minimal_with_task", false)
             .user("minimal_with_reindex_get_user", "x-pack-test-password", "minimal_with_reindex_get", false)
+            .user("minimal_with_reindex_list_user", "x-pack-test-password", "minimal_with_reindex_list", false)
             .user("readonly_user", "x-pack-test-password", "readonly", false)
             .user("dest_only_user", "x-pack-test-password", "dest_only", false)
             .user("can_not_see_hidden_docs_user", "x-pack-test-password", "can_not_see_hidden_docs", false)

--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/10_reindex.yml
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/10_reindex.yml
@@ -428,3 +428,100 @@ setup:
       catch: forbidden
       reindex_get:
         task_id: $task
+
+---
+"List reindex works with only reindex/list permission":
+  - requires:
+      test_runner_features: [capabilities]
+      reason: Dedicated reindex list requires reindex management API
+      capabilities:
+        - method: GET
+          path: /_reindex
+          capabilities: [reindex_management_api]
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{ "create": { "_index": "source"} }'
+          - '{ "text": "test" }'
+          - '{ "create": { "_index": "source"} }'
+          - '{ "text": "test" }'
+          - '{ "create": { "_index": "source"} }'
+          - '{ "text": "test" }'
+          - '{ "create": { "_index": "source"} }'
+          - '{ "text": "test" }'
+          - '{ "create": { "_index": "source"} }'
+          - '{ "text": "test" }'
+
+  - do:
+      headers: {es-security-runas-user: minimal_with_reindex_list_user}
+      reindex:
+        wait_for_completion: false
+        requests_per_second: 0.000001
+        body:
+          source:
+            index: source
+            size: 1
+          dest:
+            index: dest
+  - set: {task: task}
+
+  - do:
+      headers: {es-security-runas-user: minimal_with_reindex_list_user}
+      reindex_list:
+        human: true
+        detailed: true
+  - is_true: reindex
+  - length: { reindex: 1 }
+  - match: { reindex.0.id: $task }
+  - match: { reindex.0.description: "reindex from [source] to [dest]" }
+  - match: { reindex.0.cancelled: false }
+  - is_false: reindex.0.original_task_id
+  - is_false: reindex.0.original_start_time
+  - is_false: reindex.0.original_start_time_in_millis
+  - exists: reindex.0.start_time
+  - exists: reindex.0.start_time_in_millis
+  - exists: reindex.0.running_time
+  - exists: reindex.0.running_time_in_nanos
+  - exists: reindex.0.status
+
+  # rethrottle as admin to speed up, then wait for completion to clean up
+  - do:
+      reindex_rethrottle:
+        task_id: $task
+        requests_per_second: -1
+  - do:
+      reindex_get:
+        task_id: $task
+        wait_for_completion: true
+
+---
+"List reindex forbidden without reindex/list permission":
+  - requires:
+      test_runner_features: [capabilities]
+      reason: Dedicated reindex list requires reindex management API
+      capabilities:
+        - method: GET
+          path: /_reindex
+          capabilities: [reindex_management_api]
+
+  - do:
+      headers: {es-security-runas-user: minimal_user}
+      catch: forbidden
+      reindex_list: {}
+
+---
+"List reindex forbidden for user with task permissions but no reindex/list permission":
+  - requires:
+      test_runner_features: [capabilities]
+      reason: Dedicated reindex list requires reindex management API
+      capabilities:
+        - method: GET
+          path: /_reindex
+          capabilities: [reindex_management_api]
+
+  - do:
+      headers: {es-security-runas-user: minimal_with_task_user}
+      catch: forbidden
+      reindex_list: {}

--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/resources/roles.yml
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/resources/roles.yml
@@ -70,6 +70,25 @@ minimal_with_reindex_get:
         - create_index
         - indices:admin/refresh
 
+# Same index privileges as minimal, plus the dedicated reindex list API (GET /_reindex)
+minimal_with_reindex_list:
+  cluster:
+    - cluster:monitor/main
+    - cluster:monitor/reindex/list
+  indices:
+    - names: source
+      privileges:
+        - read
+        - write
+        - create_index
+        - indices:admin/refresh
+    - names: dest
+      privileges:
+        - read
+        - write
+        - create_index
+        - indices:admin/refresh
+
 # Read only operations on indices
 readonly:
   cluster:


### PR DESCRIPTION
- Fix `GET _reindex` failing authz for user who has `cluster:monitor/reindex/list` but not `cluster:monitor/tasks/lists`

Closes https://github.com/elastic/elasticsearch-team/issues/2592
