### PR TITLE
Fix FsBlobContainerTests failing with tests.iters

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -323,7 +323,7 @@ public class FsBlobContainerTests extends ESTestCase {
     }
 
     public void testAtomicWriteMetadataWithoutAtomicOverwrite() throws IOException {
-        this.fileSystem = new FilterFileSystemProvider("nooverwritefs://", fileSystem) {
+        FileSystem noOverwriteFs = new FilterFileSystemProvider("nooverwritefs://", fileSystem) {
             @Override
             public void move(Path source, Path target, CopyOption... options) throws IOException {
                 if (Set.of(options).contains(StandardCopyOption.ATOMIC_MOVE) && Files.exists(target)) {
@@ -334,8 +334,12 @@ public class FsBlobContainerTests extends ESTestCase {
                 }
             }
         }.getFileSystem(null);
-        PathUtilsForTesting.installMock(fileSystem); // restored by restoreFileSystem in ESTestCase
-        checkAtomicWrite();
+        PathUtilsForTesting.installMock(noOverwriteFs);
+        try {
+            checkAtomicWrite();
+        } finally {
+            PathUtilsForTesting.installMock(fileSystem);
+        }
     }
 
     public void testAtomicWriteDefaultFs() throws Exception {

--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -323,7 +323,7 @@ public class FsBlobContainerTests extends ESTestCase {
     }
 
     public void testAtomicWriteMetadataWithoutAtomicOverwrite() throws IOException {
-        FileSystem noOverwriteFs = new FilterFileSystemProvider("nooverwritefs://", fileSystem) {
+        final var noOverwriteFs = new FilterFileSystemProvider("nooverwritefs://", fileSystem) {
             @Override
             public void move(Path source, Path target, CopyOption... options) throws IOException {
                 if (Set.of(options).contains(StandardCopyOption.ATOMIC_MOVE) && Files.exists(target)) {


### PR DESCRIPTION
Recently, the CI started running changed tests in a loop. The testAtomicWriteMetadataWithoutAtomicOverwrite method fails when used with `-Dtests.iters`.

The test method was making the test context dirty. With this change it correctly cleans up the test execution.

Relates: https://github.com/elastic/elasticsearch/pull/147405#issuecomment-4312973386
