### PR TITLE
Match operator after MV_EXPAND

### DIFF
--- a/docs/changelog/147415.yaml
+++ b/docs/changelog/147415.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147415
+summary: Match operator after MV_EXPAND
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
@@ -1043,7 +1043,7 @@ constant_keyword-foo:keyword | keyword:keyword
 ;
 
 matchOperatorAfterMVExpand
-required_capability: match_operator_colon
+required_capability: match_operator_after_mv_expand
 
 FROM books 
 | MV_EXPAND author

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/match-operator.csv-spec
@@ -1041,3 +1041,37 @@ from all_types
 
 constant_keyword-foo:keyword | keyword:keyword
 ;
+
+matchOperatorAfterMVExpand
+required_capability: match_operator_colon
+
+FROM books 
+| MV_EXPAND author
+| WHERE author : "Faulkner"
+| keep book_no, author
+;
+
+book_no:keyword | author:text
+2883            | William Faulkner
+9896            | William Faulkner
+5404            | William Faulkner
+3870            | Keith Faulkner
+6151            | Keith Faulkner
+6151            | Rory Tyger
+3535            | Beverlie Manson
+3535            | Keith Faulkner
+4724            | William Faulkner
+4977            | William Faulkner
+8077            | William Faulkner
+2847            | Colleen Faulkner
+5119            | William Faulkner
+7381            | Bettilu Stein Faulkner
+5578            | William Faulkner
+4502            | Colleen Faulkner
+2378            | Carol Faulkner
+2378            | Holly Byers Ochoa
+2378            | Lucretia Mott
+2713            | William Faulkner
+8423            | Paul Faulkner
+3293            | Danny Faulkner
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2606,6 +2606,11 @@ public class EsqlCapabilities {
          */
         PROMQL_TIME_FUNCTIONS,
 
+        /**
+         * Support for match operator after MV_EXPAND.
+         */
+        MATCH_OPERATOR_AFTER_MV_EXPAND,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -281,10 +281,7 @@ public abstract class FullTextFunction extends Function
                 plan,
                 condition,
                 FullTextFunction.class,
-                lp -> (lp instanceof Limit == false)
-                    && (lp instanceof Aggregate == false)
-                    && (lp instanceof UnionAll == false)
-                    && (lp instanceof MvExpand == false),
+                lp -> (lp instanceof Limit == false) && (lp instanceof Aggregate == false) && (lp instanceof UnionAll == false),
                 m -> "[" + m.functionName() + "] " + m.functionType(),
                 failures
             );
@@ -454,7 +451,7 @@ public abstract class FullTextFunction extends Function
      * Resolves the given field expression to a {@link FieldAttribute} by following rename alias chains
      * through {@link Project} nodes in the plan.
      */
-    private FieldAttribute resolveToFieldAttribute(LogicalPlan plan, Expression field) {
+    static FieldAttribute resolveToFieldAttribute(LogicalPlan plan, Expression field) {
         FieldAttribute fa = fieldAsFieldAttribute(field);
         if (fa != null) {
             return fa;
@@ -485,6 +482,17 @@ public abstract class FullTextFunction extends Function
                         }
                         return;
                     }
+                }
+            }
+
+            if (p instanceof MvExpand mvExpand) {
+                if (mvExpand.expanded().id().equals(current.get().id())) {
+                    FieldAttribute candidate = fieldAsFieldAttribute(mvExpand.target());
+                    if (candidate != null) {
+                        resolved.set(candidate);
+                    }
+                    breakEarly.set(true);
+                    return;
                 }
             }
         });
@@ -527,7 +535,7 @@ public abstract class FullTextFunction extends Function
         return fieldName;
     }
 
-    protected FieldAttribute fieldAsFieldAttribute(Expression field) {
+    protected static FieldAttribute fieldAsFieldAttribute(Expression field) {
         Expression fieldExpression = field;
         // Field may be converted to other data type (field_name :: data_type), so we need to check the original field
         if (fieldExpression instanceof AbstractConvertFunction convertFunction) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryBuilderResolver.java
@@ -17,6 +17,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.esql.capabilities.RewriteableAware;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
@@ -26,7 +27,9 @@ import org.elasticsearch.xpack.esql.plugin.TransportActionServices;
 import org.elasticsearch.xpack.esql.session.IndexResolver;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -100,9 +103,7 @@ public final class QueryBuilderResolver {
                 Expression finalExpression = expr;
                 if (expr instanceof RewriteableAware rewriteableAware) {
                     QueryBuilder builder = rewriteableAware.queryBuilder(), initial = builder;
-                    builder = builder == null
-                        ? rewriteableAware.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER).toQueryBuilder()
-                        : builder;
+                    builder = builder == null ? buildQueryBuilder(rewriteableAware, plan) : builder;
                     try {
                         builder = builder.rewrite(ctx);
                     } catch (IOException e) {
@@ -119,5 +120,19 @@ public final class QueryBuilderResolver {
             }
             return updated.get() ? new FunctionsRewriteable(newPlan) : this;
         }
+
+        private static QueryBuilder buildQueryBuilder(RewriteableAware rewriteableAware, LogicalPlan plan) {
+            RewriteableAware querySource = rewriteableAware;
+            if (rewriteableAware instanceof SingleFieldFullTextFunction ftf && ftf.fieldAsFieldAttribute() == null) {
+                FieldAttribute resolved = FullTextFunction.resolveToFieldAttribute(plan, ftf.field());
+                if (resolved != null) {
+                    List<Expression> newChildren = new ArrayList<>(ftf.children());
+                    newChildren.set(0, resolved);
+                    querySource = (RewriteableAware) ftf.replaceChildren(newChildren);
+                }
+            }
+            return querySource.asQuery(LucenePushdownPredicates.DEFAULT, TranslatorHandler.TRANSLATOR_HANDLER).toQueryBuilder();
+        }
+
     }
 }


### PR DESCRIPTION
Removed MvExpand from the disallowed-commands check Full-text functions are now accepted after
MV_EXPAND.

Added MvExpand handling in resolveToFieldAttribute to trace the expanded ReferenceAttribute back to
the original FieldAttribute.

Added buildQueryBuilder in QueryBuilderResolver
that resolves the field through the plan before
calling asQuery().

Addresses: #142713