### PR TITLE
[ML] Improve error message formulation 

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
@@ -87,7 +87,8 @@ public class TransportInferTrainedModelDeploymentAction extends TransportTasksAc
                 );
             }
             throw new ElasticsearchStatusException(
-                "Unable to find model deployment task [{}] please stop and start the deployment or try again momentarily",
+                "Unable to find model deployment task [{}] please stop and start the trained model deployment " 
+                + "or try again momentarily",
                 RestStatus.NOT_FOUND,
                 request.getId()
             );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
@@ -87,8 +87,8 @@ public class TransportInferTrainedModelDeploymentAction extends TransportTasksAc
                 );
             }
             throw new ElasticsearchStatusException(
-                "Unable to find model deployment task [{}] please stop and start the trained model deployment " 
-                + "or try again momentarily",
+                "Unable to find model deployment task [{}] please stop and start the trained model deployment "
+                    + "or try again momentarily",
                 RestStatus.NOT_FOUND,
                 request.getId()
             );


### PR DESCRIPTION
The word "deployment" in the error message "Unable to find model deployment task [.elser_model_2_linux-x86_64], please stop and start the deployment or try again momentarily" is ambiguous, as it can be interpreted as an Elastic Cloud deployment. This PR improves the formulation. 