### PR TITLE
[9.2] Fix FsBlobContainerTests failing with tests.iters (#147410)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -321,7 +321,7 @@ public class FsBlobContainerTests extends ESTestCase {
     }
 
     public void testAtomicWriteMetadataWithoutAtomicOverwrite() throws IOException {
-        this.fileSystem = new FilterFileSystemProvider("nooverwritefs://", fileSystem) {
+        final var noOverwriteFs = new FilterFileSystemProvider("nooverwritefs://", fileSystem) {
             @Override
             public void move(Path source, Path target, CopyOption... options) throws IOException {
                 if (Set.of(options).contains(StandardCopyOption.ATOMIC_MOVE) && Files.exists(target)) {
@@ -332,8 +332,12 @@ public class FsBlobContainerTests extends ESTestCase {
                 }
             }
         }.getFileSystem(null);
-        PathUtilsForTesting.installMock(fileSystem); // restored by restoreFileSystem in ESTestCase
-        checkAtomicWrite();
+        PathUtilsForTesting.installMock(noOverwriteFs);
+        try {
+            checkAtomicWrite();
+        } finally {
+            PathUtilsForTesting.installMock(fileSystem);
+        }
     }
 
     public void testAtomicWriteDefaultFs() throws Exception {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix FsBlobContainerTests failing with tests.iters (#147410)