### PR TITLE
ESQL: Fix Streaming Lookup Join BWC issue

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/LookupQueryOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/LookupQueryOperator.java
@@ -334,6 +334,8 @@ public final class LookupQueryOperator implements Operator {
             Status::new
         );
 
+        private static final TransportVersion ESQL_STREAMING_LOOKUP_JOIN = TransportVersion.fromName("esql_streaming_lookup_join");
+
         private final int pagesReceived;
         private final int pagesEmitted;
         private final long rowsReceived;
@@ -424,7 +426,7 @@ public final class LookupQueryOperator implements Operator {
 
         @Override
         public TransportVersion getMinimalSupportedVersion() {
-            return TransportVersion.current();
+            return ESQL_STREAMING_LOOKUP_JOIN;
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/StreamingLookupFromIndexOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/StreamingLookupFromIndexOperator.java
@@ -836,7 +836,7 @@ public class StreamingLookupFromIndexOperator implements Operator {
 
         @Override
         public TransportVersion getMinimalSupportedVersion() {
-            return TransportVersion.current();
+            return ESQL_LOOKUP_PLAN_STRING;
         }
 
         @Override


### PR DESCRIPTION
## Summary
  Fixes a BWC crash where a 9.4 data node serializes a `streaming_lookup`
  (or `lookup_query`) `OperatorStatus` to a pre-9.4 coordinator, which
  crashes with `Unknown NamedWriteable`.
  The version guard in `OperatorStatus.writeTo` was bypassed because both
  statuses returned `TransportVersion.current()` from
  `getMinimalSupportedVersion()`. On 9.4 that resolves to id `9348001`,
  which happens to be owned by `inference_sagemaker_similarity_required`,
  whose CSV `9361000,9348001,9250012,9185025` declares a backport at
  `9250012` (the 9.3 wire version). `TransportVersion.supports` walks that
  patch chain and concludes `9250012.supports(9348001) == true` — a true
  statement for the inference feature, false for streaming lookup join, but
  `supports()` can't tell them apart because both ride the same numeric id.

 ## Fix
  Return the `esql_streaming_lookup_join` TV (the actual feature
  version these statuses were introduced with, no backports) from both
  `getMinimalSupportedVersion()` implementations. The guard now filters
  correctly; old coordinators receive the operator name with a `null`
  status payload and query results are unaffected.
  Closes #147381
