### PR TITLE
[docs] Add DLS toggle disabled in Serverless as known issue

### DIFF
--- a/docs/reference/search-connectors/es-connectors-known-issues.md
+++ b/docs/reference/search-connectors/es-connectors-known-issues.md
@@ -121,6 +121,22 @@ The connector service has the following known issues:
     As a result, true document volume will be under-reported by a factor of 1024.
 
 
+* **Document-Level Security (DLS) toggle is disabled in Serverless projects**
+
+    When setting up a connector in a Serverless project, the Document-Level Security toggle in the UI is incorrectly disabled. This is a UI-only bug. As a workaround, you can enable DLS via the [Update connector configuration API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-configuration):
+
+    ```console
+    PUT /_connector/{connector_id}/_configuration
+    {
+      "values": {
+        "use_document_level_security": true
+      }
+    }
+    ```
+    % TEST[skip:TODO]
+
+    Replace `{connector_id}` with your connector's ID.
+
 ## Individual connector known issues [es-connectors-known-issues-specific]
 
 Individual connectors may have additional known issues. Refer to [each connector’s reference documentation](/reference/search-connectors/index.md) for connector-specific known issues.

--- a/docs/reference/search-connectors/es-dls-overview.md
+++ b/docs/reference/search-connectors/es-dls-overview.md
@@ -34,6 +34,8 @@ At a very high level, there are two essential components that enable document le
 To enable DLS, you need to perform the following steps:
 
 ::::{note}
+:applies_to: serverless: ga
+
 In Serverless projects, the DLS toggle in the UI is currently disabled due to a known bug. You can enable DLS using the Dev Tools console as a workaround:
 
 ```console

--- a/docs/reference/search-connectors/es-dls-overview.md
+++ b/docs/reference/search-connectors/es-dls-overview.md
@@ -33,6 +33,22 @@ At a very high level, there are two essential components that enable document le
 
 To enable DLS, you need to perform the following steps:
 
+::::{note}
+In Serverless projects, the DLS toggle in the UI is currently disabled due to a known bug. You can enable DLS using the Dev Tools console as a workaround:
+
+```console
+PUT /_connector/{connector_id}/_configuration
+{
+  "values": {
+    "use_document_level_security": true
+  }
+}
+```
+% TEST[skip:TODO]
+
+Replace `{connector_id}` with your connector's ID.
+::::
+
 1. First **enable DLS** for your connector as part of the connector configuration.
 2. Run an **Access control** sync.
 3. This creates a hidden access control index prefixed with `.search-acl-filter-`. For example, if you named your connector index `search-sharepoint`, the access control index would be named `.search-acl-filter-search-sharepoint`.


### PR DESCRIPTION
## Summary
- Adds a known issue entry for the DLS toggle being disabled in Serverless project UIs
- Adds a note in the DLS overview "Enabling DLS" section alerting users to the issue and workaround
- The toggle is disabled due to a UI bug where `hasPlatinumLicense` is incorrectly set to false in Serverless

Relates elastic/connectors#3998

## Test plan
- [x] Verify known issues page renders correctly
- [x] Verify DLS overview page renders correctly
- [ ] Confirm API workaround snippet is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)