### PR TITLE
Unmute 160_union_types/suggested_type

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -91,12 +91,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.common.spatial.H3SphericalGeometryTests
   method: testIndexPoints
   issue: https://github.com/elastic/elasticsearch/issues/142439
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
-  method: test {p0=esql/160_union_types/suggested_type}
-  issue: https://github.com/elastic/elasticsearch/issues/142525
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/160_union_types/suggested_type}
-  issue: https://github.com/elastic/elasticsearch/issues/142525
 - class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
   method: testQuantizedXY
   issue: https://github.com/elastic/elasticsearch/issues/141234


### PR DESCRIPTION
Could not reproduce locally.  
Unmuting but If this `[default_metric] is deprecated`  reappears we may need fix similar to https://github.com/elastic/elasticsearch/pull/144040 

Closes #142525 