### PR TITLE
[8.19] Handle CHERRY_PICK_HEAD when resolving transport version base ref (#147191)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/ResolveTransportVersionConflictFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/ResolveTransportVersionConflictFuncTest.groovy
@@ -174,6 +174,7 @@ class ResolveTransportVersionConflictFuncTest extends AbstractTransportVersionFu
 
         then:
         assertResolveAndValidateSuccess(result)
+        assertOutputContains(result.output, "Resolving transport version conflicts by accepting upstream changes...")
         assertReferableDefinition("upstream_new_tv2", "8125000,8012002")
         assertUpperBound("9.2", "upstream_new_tv2,8125000")
         assertUpperBound("9.1", "upstream_new_tv2,8012002")

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
@@ -292,6 +292,8 @@ public abstract class TransportVersionResourcesService implements BuildService<T
                 String refName;
                 if (refExists("MERGE_HEAD")) {
                     refName = gitCommand("rev-parse", "--verify", "MERGE_HEAD").strip();
+                } else if (refExists("CHERRY_PICK_HEAD")) {
+                    refName = gitCommand("rev-parse", "--verify", "CHERRY_PICK_HEAD").strip();
                 } else {
                     String upstreamRef = findUpstreamRef();
                     refName = gitCommand("merge-base", upstreamRef, "HEAD").strip();


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Handle CHERRY_PICK_HEAD when resolving transport version base ref (#147191)