### PR TITLE
[One workflow] Fixed workflow dataStream descriptor

### DIFF
--- a/docs/changelog/147460.yaml
+++ b/docs/changelog/147460.yaml
@@ -1,0 +1,5 @@
+area: Data streams
+issues: []
+pr: 147460
+summary: Fixed workflow `dataStream` descriptor
+type: bug

--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -53,7 +53,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
     private static final int WORKFLOWS_EXECUTION_LOGS_MAPPINGS_VERSION = 1;
 
     /** Log data stream registered in {@link #workflowsEventsSystemDataStreamDescriptor()}. */
-    public static final String WORKFLOWS_EVENTS_DATA_STREAM_NAME = ".workflows-events*";
+    public static final String WORKFLOWS_EVENTS_DATA_STREAM_NAME = ".workflows-events";
 
     /** Composable index template resource for {@value #WORKFLOWS_EVENTS_DATA_STREAM_NAME}. */
     public static final String WORKFLOWS_EVENTS_COMPOSABLE_TEMPLATE_RESOURCE = "workflows-events.json";
@@ -62,7 +62,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
     public static final String WORKFLOWS_EVENTS_MANAGED_INDEX_VERSION_VARIABLE = "kibana.workflows.events.managed.index.version";
 
     /** Log data stream registered in {@link #workflowsExecutionDataStreamLogsSystemDataStreamDescriptor()}. */
-    public static final String WORKFLOWS_EXECUTION_LOGS_DATA_STREAM_NAME = ".workflows-execution-data-stream-logs*";
+    public static final String WORKFLOWS_EXECUTION_LOGS_DATA_STREAM_NAME = ".workflows-execution-data-stream-logs";
 
     /** Composable index template resource for {@value #WORKFLOWS_EXECUTION_LOGS_DATA_STREAM_NAME}. */
     public static final String WORKFLOWS_EXECUTION_LOGS_COMPOSABLE_TEMPLATE_RESOURCE = "workflows-execution-data-stream-logs.json";


### PR DESCRIPTION
## Summary
Fixes incorrect data stream name constants used for Kibana workflows system data streams. The names included a trailing `*`, which does not match how system data stream descriptors and backing streams are registered and referenced. 

Before this change, we were getting this when trying to create a workflows system dataStream from kibana:

```
Unhandled Promise rejection detected:

{
  name: 'ResponseError',
  message: 'illegal_state_exception\n' +
    '\tRoot causes:\n' +
    '\t\tillegal_state_exception: system data stream descriptor not found for [.workflows-events]',
  stack: 'ResponseError: illegal_state_exception\n' +
    '\tRoot causes:\n' +
    '\t\tillegal_state_exception: system data stream descriptor not found for [.workflows-events]\n' +
    '    at KibanaTransport._request (/Projects/kibana/node_modules/@elastic/elasticsearch/node_modules/@elastic/transport/src/Transport.ts:649:17)\n' +
    '    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n' +
    '    at /Projects/kibana/node_modules/@elastic/elasticsearch/node_modules/@elastic/transport/src/Transport.ts:790:22\n' +
    '    at KibanaTransport.request (/Projects/kibana/node_modules/@elastic/elasticsearch/node_modules/@elastic/transport/src/Transport.ts:787:14)'
}

```