### PR TITLE
[ESQL] Fix Parquet sliding-window cache corruption

### DIFF
--- a/docs/changelog/147470.yaml
+++ b/docs/changelog/147470.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147470
+summary: Fix Parquet sliding-window cache corruption
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -8,50 +8,31 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.parquet.io.SeekableInputStream;
-import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Adapter that wraps a StorageObject to implement Parquet's InputFile interface.
- * This allows using our storage abstraction with Parquet's ParquetFileReader.
  *
- * <p>Two {@link SeekableInputStream} implementations are available, selected by
- * {@link #windowCacheEnabled}:
+ * <p>Key features:
  * <ul>
- *   <li><b>Direct</b> (default): each request issues a fresh positional read via
- *       {@link StorageObject#readBytes}. Correctness-safe fallback while the window cache bug
- *       is being investigated, see <a href="https://github.com/elastic/esql-planning/issues/585">esql-planning#585</a>.
- *       May increase the number of range requests on remote storage (S3, HTTP).</li>
- *   <li><b>Windowed</b> (currently disabled): sliding window cache (default 4 MiB) that amortizes
- *       seeks and avoids {@link java.io.InputStream#skip}. Also consults the JVM-wide footer cache
- *       and any prefetched column chunks installed via {@link #installPrefetchedData}.</li>
+ *   <li>Uses <strong>only</strong> range reads ({@code newStream(position, length)}) — never full-object GET</li>
+ *   <li>Sliding window cache (default 4MB) to amortize seeks and avoid {@code InputStream.skip}</li>
+ *   <li>Optimized for remote storage (S3, HTTP) where full GET and skip-download are expensive</li>
+ *   <li>No Hadoop dependencies — uses pure Java InputStream</li>
  * </ul>
- *
- * <p>Both paths use <strong>only</strong> range reads ({@code newStream(position, length)})
- * and {@link StorageObject#readBytes} — never a full-object GET — and have no Hadoop dependencies.
- *
- * <p>A JVM-wide {@link FooterCache} (8 MiB budget) caches the tail bytes of Parquet files
- * to avoid redundant footer reads across splits. Thundering-herd protection ensures that
- * concurrent tail reads for the same file coalesce into a single I/O via {@link CompletableFuture}.
  */
 public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputFile {
 
-    private static final Logger logger = LogManager.getLogger(ParquetStorageObjectAdapter.class);
-
     private final StorageObject storageObject;
     private final long length;
-    private final FooterCacheKey footerCacheKey;
     private final int windowSize;
     private volatile NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetchedChunks;
 
@@ -60,34 +41,6 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
 
     /** Maximum window size (16MB). Caps adaptive window hints to prevent unbounded memory allocation. */
     static final int MAX_WINDOW_SIZE = 16 * 1024 * 1024;
-
-    /** Footer cache budget across the JVM (8MB). */
-    static final int FOOTER_CACHE_MAX_BYTES = 8 * 1024 * 1024;
-
-    /** Max single footer entry (2MB). Prevents caching unusually large footers. */
-    static final int FOOTER_CACHE_MAX_ENTRY_BYTES = 2 * 1024 * 1024;
-
-    /**
-     * Controls whether the sliding-window read cache is active. Disabled by default due to a
-     * non-deterministic correctness bug where seeks within the cached window can serve stale
-     * bytes, corrupting dictionary-encoded column values.
-     *
-     * <p>Visible for testing only. Production code should not mutate this field; tests flip it
-     * via {@link #setWindowCacheEnabledForTests(boolean)} and must restore the previous value.
-     */
-    static volatile boolean windowCacheEnabled = false;
-
-    /**
-     * Test-only hook to toggle the window cache in a single test method. Returns the previous
-     * value so the caller can restore it (typically in a {@code @After} method).
-     */
-    static boolean setWindowCacheEnabledForTests(boolean enabled) {
-        boolean previous = windowCacheEnabled;
-        windowCacheEnabled = enabled;
-        return previous;
-    }
-
-    private static final FooterCache FOOTER_CACHE = new FooterCache(FOOTER_CACHE_MAX_BYTES, FOOTER_CACHE_MAX_ENTRY_BYTES);
 
     /**
      * Creates an adapter with the default 4MB sliding window.
@@ -100,11 +53,6 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
      * Creates an adapter with an adaptive window sized to cover the given byte range.
      * This allows all column chunks within a small row-group split to be fetched in a single I/O
      * instead of incurring multiple range GETs with the default 4 MiB window.
-     *
-     * <p>Note: the configured window size is only honored when {@link #windowCacheEnabled} is
-     * {@code true}. With the default direct-read path, this factory is equivalent to the
-     * no-arg constructor — the window buffer itself is only allocated when
-     * {@link #newStream()} actually instantiates {@code RangeFirstSeekableInputStream}.
      *
      * @param rangeBytes byte span of the range being read; clamped to [{@link #DEFAULT_WINDOW_SIZE}, {@link #MAX_WINDOW_SIZE}]
      */
@@ -124,7 +72,6 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read storage object length for [" + storageObject.path() + "]", e);
         }
-        this.footerCacheKey = buildFooterCacheKey(storageObject, this.length);
     }
 
     /**
@@ -147,29 +94,27 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
 
     @Override
     public SeekableInputStream newStream() throws IOException {
-        if (windowCacheEnabled) {
-            return new RangeFirstSeekableInputStream(storageObject, footerCacheKey, length, windowSize, this);
-        }
-        return new DirectSeekableInputStream(storageObject, length);
-    }
-
-    static void clearFooterCacheForTests() {
-        FOOTER_CACHE.clear();
-    }
-
-    private static FooterCacheKey buildFooterCacheKey(StorageObject storageObject, long length) {
-        return new FooterCacheKey(storageObject.path().toString(), length);
+        return new WindowedSeekableInputStream(storageObject, length, windowSize, this);
     }
 
     /**
-     * SeekableInputStream that uses only range reads and a sliding window cache.
-     * Never calls {@link StorageObject#newStream()} (full GET) or {@link java.io.InputStream#skip(long)}.
+     * SeekableInputStream backed by a sliding window cache over range reads.
+     * Never calls {@link StorageObject#newStream()} (full GET) or {@link InputStream#skip(long)}.
      * On seek: if the target position is within the current window, only the cursor is updated;
-     * otherwise a new range is fetched via {@code newStream(position, windowSize)}.
+     * otherwise a new range is fetched via {@link StorageObject#newStream(long, long)}.
+     *
+     * <p>Window fills use {@link StorageObject#newStream(long, long)} with chunked
+     * {@link InputStream#read(byte[], int, int)} calls capped to {@link #STREAM_READ_CHUNK_SIZE}
+     * to prevent the JDK's thread-local direct ByteBuffer pool from growing to window size.
+     * The window is invalidated before each I/O so a partial-read failure never leaves
+     * stale data visible to subsequent reads.
      */
-    private static class RangeFirstSeekableInputStream extends SeekableInputStream {
+    private static class WindowedSeekableInputStream extends SeekableInputStream {
+
+        /** Caps each {@link InputStream#read(byte[], int, int)} to limit JDK thread-local direct buffer use. */
+        private static final int STREAM_READ_CHUNK_SIZE = 256 * 1024;
+
         private final StorageObject storageObject;
-        private final FooterCacheKey footerCacheKey;
         private final long length;
         private final int windowSize;
         private final byte[] window;
@@ -180,15 +125,8 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         private long position;
         private boolean closed;
 
-        RangeFirstSeekableInputStream(
-            StorageObject storageObject,
-            FooterCacheKey footerCacheKey,
-            long length,
-            int windowSize,
-            ParquetStorageObjectAdapter adapter
-        ) {
+        WindowedSeekableInputStream(StorageObject storageObject, long length, int windowSize, ParquetStorageObjectAdapter adapter) {
             this.storageObject = storageObject;
-            this.footerCacheKey = footerCacheKey;
             this.length = length;
             this.windowSize = windowSize;
             this.window = new byte[windowSize];
@@ -238,61 +176,27 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 return;
             }
 
-            boolean isTailRead = pos + toRead == length;
+            windowStart = -1;
+            windowLength = 0;
 
-            FooterCacheEntry cached = FOOTER_CACHE.getCompleted(footerCacheKey);
-            if (cached != null && cached.covers(pos, (int) toRead)) {
-                int from = (int) (pos - cached.startOffset());
-                System.arraycopy(cached.bytes(), from, window, 0, (int) toRead);
-                windowStart = pos;
-                windowLength = (int) toRead;
-                return;
-            }
-
-            if (isTailRead) {
-                cached = FOOTER_CACHE.getOrAwaitPending(footerCacheKey);
-                if (cached != null && cached.covers(pos, (int) toRead)) {
-                    int from = (int) (pos - cached.startOffset());
-                    System.arraycopy(cached.bytes(), from, window, 0, (int) toRead);
-                    windowStart = pos;
-                    windowLength = (int) toRead;
-                    return;
-                }
-
-                CompletableFuture<FooterCacheEntry> future = new CompletableFuture<>();
-                if (FOOTER_CACHE.tryRegisterPending(footerCacheKey, future)) {
-                    try {
-                        windowStart = pos;
-                        windowLength = 0;
-                        ByteBuffer target = ByteBuffer.wrap(window, 0, (int) toRead);
-                        int bytesRead = storageObject.readBytes(pos, target);
-                        windowLength = bytesRead < 0 ? 0 : bytesRead;
-                        FOOTER_CACHE.completePending(footerCacheKey, windowStart, window, windowLength);
-                    } catch (IOException e) {
-                        FOOTER_CACHE.failPending(footerCacheKey);
-                        throw e;
+            int target = (int) toRead;
+            try (InputStream in = storageObject.newStream(pos, toRead)) {
+                int totalRead = 0;
+                while (totalRead < target) {
+                    int chunk = Math.min(STREAM_READ_CHUNK_SIZE, target - totalRead);
+                    int n = in.read(window, totalRead, chunk);
+                    if (n < 0) {
+                        throw new IOException(
+                            "Unexpected end of stream while filling window at position " + pos + "; read " + totalRead + " of " + target
+                        );
                     }
-                } else {
-                    cached = FOOTER_CACHE.getOrAwaitPending(footerCacheKey);
-                    if (cached != null && cached.covers(pos, (int) toRead)) {
-                        int from = (int) (pos - cached.startOffset());
-                        System.arraycopy(cached.bytes(), from, window, 0, (int) toRead);
-                        windowStart = pos;
-                        windowLength = (int) toRead;
-                    } else {
-                        windowStart = pos;
-                        windowLength = 0;
-                        ByteBuffer target = ByteBuffer.wrap(window, 0, (int) toRead);
-                        int bytesRead = storageObject.readBytes(pos, target);
-                        windowLength = bytesRead < 0 ? 0 : bytesRead;
+                    if (n == 0 && chunk > 0) {
+                        throw new IOException("InputStream.read returned 0 while " + chunk + " bytes were requested");
                     }
+                    totalRead += n;
                 }
-            } else {
                 windowStart = pos;
-                windowLength = 0;
-                ByteBuffer target = ByteBuffer.wrap(window, 0, (int) toRead);
-                int bytesRead = storageObject.readBytes(pos, target);
-                windowLength = bytesRead < 0 ? 0 : bytesRead;
+                windowLength = totalRead;
             }
         }
 
@@ -322,6 +226,8 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
             src.position(offsetInChunk);
             int available = src.remaining();
             int toCopy = Math.min(toRead, available);
+            windowStart = -1;
+            windowLength = 0;
             src.get(window, 0, toCopy);
             windowStart = pos;
             windowLength = toCopy;
@@ -472,352 +378,6 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 int toRead = Math.min(transfer.length, buf.remaining());
                 readFully(transfer, 0, toRead);
                 buf.put(transfer, 0, toRead);
-            }
-        }
-    }
-
-    /**
-     * SeekableInputStream that issues a fresh positional read for every request,
-     * bypassing the sliding-window cache entirely. Correctness-safe fallback while
-     * the window cache bug is investigated.
-     *
-     * <p>Not thread-safe: the single-byte scratch buffer and the {@code position} cursor are
-     * mutable per-stream state. Each consumer must open its own stream.
-     */
-    private static class DirectSeekableInputStream extends SeekableInputStream {
-        private final StorageObject storageObject;
-        private final long length;
-        // Reused on every single-byte read() to avoid allocating a fresh byte[1]/ByteBuffer pair
-        // per call — critical on remote storage where that would translate to a 1-byte range GET.
-        private final byte[] singleByte = new byte[1];
-        private final ByteBuffer singleByteBuf = ByteBuffer.wrap(singleByte);
-        private long position;
-        private boolean closed;
-
-        DirectSeekableInputStream(StorageObject storageObject, long length) {
-            this.storageObject = storageObject;
-            this.length = length;
-            this.position = 0;
-            this.closed = false;
-        }
-
-        @Override
-        public long getPos() throws IOException {
-            return position;
-        }
-
-        @Override
-        public void seek(long newPos) throws IOException {
-            if (closed) {
-                throw new IOException("Stream is closed");
-            }
-            if (newPos < 0) {
-                throw new IOException("Cannot seek to negative position: " + newPos);
-            }
-            if (newPos > length) {
-                throw new IOException("Cannot seek beyond end of file: " + newPos + " > " + length);
-            }
-            position = newPos;
-        }
-
-        @Override
-        public int read() throws IOException {
-            if (closed) {
-                throw new IOException("Stream is closed");
-            }
-            if (position >= length) {
-                return -1;
-            }
-            singleByteBuf.clear();
-            int n = storageObject.readBytes(position, singleByteBuf);
-            if (n <= 0) {
-                return -1;
-            }
-            position++;
-            return singleByte[0] & 0xFF;
-        }
-
-        @Override
-        public int read(byte[] b) throws IOException {
-            return read(b, 0, b.length);
-        }
-
-        @Override
-        public int read(byte[] b, int off, int len) throws IOException {
-            if (closed) {
-                throw new IOException("Stream is closed");
-            }
-            if (position >= length) {
-                return -1;
-            }
-            if (len <= 0) {
-                return 0;
-            }
-            int toRead = (int) Math.min(len, length - position);
-            ByteBuffer target = ByteBuffer.wrap(b, off, toRead);
-            int bytesRead = storageObject.readBytes(position, target);
-            if (bytesRead <= 0) {
-                return -1;
-            }
-            position += bytesRead;
-            return bytesRead;
-        }
-
-        @Override
-        public long skip(long n) throws IOException {
-            if (n <= 0) {
-                return 0;
-            }
-            long newPos = Math.min(position + n, length);
-            long skipped = newPos - position;
-            seek(newPos);
-            return skipped;
-        }
-
-        @Override
-        public int available() throws IOException {
-            if (closed || position >= length) {
-                return 0;
-            }
-            return (int) Math.min(length - position, Integer.MAX_VALUE);
-        }
-
-        @Override
-        public void close() throws IOException {
-            closed = true;
-        }
-
-        @Override
-        public void readFully(byte[] bytes) throws IOException {
-            readFully(bytes, 0, bytes.length);
-        }
-
-        @Override
-        public void readFully(byte[] bytes, int start, int len) throws IOException {
-            int offset = start;
-            int remaining = len;
-            while (remaining > 0) {
-                int bytesRead = read(bytes, offset, remaining);
-                if (bytesRead < 0) {
-                    throw new IOException("Reached end of stream before reading " + len + " bytes");
-                }
-                offset += bytesRead;
-                remaining -= bytesRead;
-            }
-        }
-
-        /**
-         * Reads into the caller's buffer in a single {@link StorageObject#readBytes} call, regardless
-         * of whether it is heap-backed or direct. The buffer's {@code limit} is temporarily narrowed
-         * so we never read past EOF, and restored before returning. This delegates any provider-specific
-         * chunking (e.g. S3/HTTP direct-buffer transfer sizes) to the provider itself instead of
-         * issuing many small range requests from this class.
-         */
-        @Override
-        public int read(java.nio.ByteBuffer buf) throws IOException {
-            if (buf.hasRemaining() == false) {
-                return 0;
-            }
-            if (closed) {
-                throw new IOException("Stream is closed");
-            }
-            if (position >= length) {
-                return -1;
-            }
-            int toRead = (int) Math.min(buf.remaining(), length - position);
-            int savedLimit = buf.limit();
-            buf.limit(buf.position() + toRead);
-            int bytesRead;
-            try {
-                bytesRead = storageObject.readBytes(position, buf);
-            } finally {
-                buf.limit(savedLimit);
-            }
-            if (bytesRead <= 0) {
-                return -1;
-            }
-            position += bytesRead;
-            return bytesRead;
-        }
-
-        @Override
-        public void readFully(java.nio.ByteBuffer buf) throws IOException {
-            while (buf.hasRemaining()) {
-                int bytesRead = read(buf);
-                if (bytesRead < 0) {
-                    throw new IOException("Reached end of stream before filling ByteBuffer");
-                }
-            }
-        }
-    }
-
-    /**
-     * Cache key for Parquet footer bytes. Uses {@code (path, length)} only — not {@code lastModified}
-     * — so that all range splits of the same file share one cache entry regardless of any timing
-     * jitter in {@link StorageObject#lastModified()}.
-     *
-     * <p>This is safe for immutable object stores (S3, GCS, Azure Blob) where objects are never
-     * overwritten in place. For mutable filesystems (local, NFS), same-path same-length overwrites
-     * can serve stale footer bytes until the entry is evicted or the JVM restarts.
-     */
-    // package-private for tests
-    record FooterCacheKey(String path, long length) {}
-
-    private record FooterCacheEntry(long startOffset, byte[] bytes) {
-        boolean covers(long position, int length) {
-            if (length <= 0) {
-                return true;
-            }
-            long start = startOffset;
-            long endExclusive = startOffset + bytes.length;
-            long requestedEnd = position + length;
-            return position >= start && requestedEnd <= endExclusive;
-        }
-    }
-
-    /**
-     * JVM-wide footer cache with thundering-herd protection. Completed entries live in a
-     * byte-budget LRU ({@code completed}); in-flight reads are tracked in a separate
-     * {@code pending} map so concurrent callers coalesce into a single I/O via
-     * {@link CompletableFuture}.
-     *
-     * <p>Thread-safety: {@code completed} and byte accounting are guarded by {@code synchronized(this)};
-     * {@code pending} is a {@link ConcurrentHashMap} so registration/removal is lock-free.
-     * {@link #clear()} synchronizes on both to ensure no orphaned futures.
-     */
-    // package-private for tests
-    static class FooterCache {
-        private final int maxBytes;
-        private final int maxEntryBytes;
-        private final LinkedHashMap<FooterCacheKey, FooterCacheEntry> completed = new LinkedHashMap<>(16, 0.75f, true);
-        private final ConcurrentHashMap<FooterCacheKey, CompletableFuture<FooterCacheEntry>> pending = new ConcurrentHashMap<>();
-        private int totalBytes;
-
-        FooterCache(int maxBytes, int maxEntryBytes) {
-            this.maxBytes = maxBytes;
-            this.maxEntryBytes = maxEntryBytes;
-        }
-
-        /** Returns a completed cache entry, or {@code null}. Never blocks. */
-        synchronized FooterCacheEntry getCompleted(FooterCacheKey key) {
-            return completed.get(key);
-        }
-
-        /**
-         * Returns a completed entry if available, otherwise awaits any in-flight pending read
-         * for this key. If the pending read completes before this call, falls back to the
-         * completed map. Returns {@code null} only when no entry exists and no pending read
-         * is in progress.
-         */
-        FooterCacheEntry getOrAwaitPending(FooterCacheKey key) {
-            synchronized (this) {
-                FooterCacheEntry cached = completed.get(key);
-                if (cached != null) {
-                    return cached;
-                }
-            }
-            CompletableFuture<FooterCacheEntry> future = pending.get(key);
-            if (future != null) {
-                FooterCacheEntry result = awaitFuture(future);
-                if (result != null) {
-                    return result;
-                }
-            }
-            synchronized (this) {
-                return completed.get(key);
-            }
-        }
-
-        /**
-         * Registers this caller as the owner of the pending read for the given key.
-         * Returns {@code true} if registration succeeded (caller should perform I/O),
-         * {@code false} if another caller already registered (caller should call
-         * {@link #getOrAwaitPending}).
-         */
-        boolean tryRegisterPending(FooterCacheKey key, CompletableFuture<FooterCacheEntry> future) {
-            return pending.putIfAbsent(key, future) == null;
-        }
-
-        /**
-         * Completes a pending read: stores the entry in the LRU cache (if within size budget),
-         * removes the pending future, and completes it so waiters unblock.
-         *
-         * <p>When the footer exceeds {@code maxEntryBytes}, it is not cached but the future is
-         * still completed with {@code null} — waiters will fall through and perform their own I/O.
-         * This matches the pre-coalescing behavior for oversized footers.
-         */
-        void completePending(FooterCacheKey key, long startOffset, byte[] buffer, int length) {
-            FooterCacheEntry entry = null;
-            if (length > 0 && length <= maxEntryBytes) {
-                byte[] bytes = new byte[length];
-                System.arraycopy(buffer, 0, bytes, 0, length);
-                entry = new FooterCacheEntry(startOffset, bytes);
-                synchronized (this) {
-                    FooterCacheEntry previous = completed.put(key, entry);
-                    if (previous != null) {
-                        totalBytes -= previous.bytes().length;
-                    }
-                    totalBytes += bytes.length;
-                    evictIfNeeded();
-                }
-            }
-            CompletableFuture<FooterCacheEntry> future = pending.remove(key);
-            if (future != null) {
-                future.complete(entry);
-            }
-        }
-
-        /** Signals that a pending read failed, allowing waiters to retry or fall through. */
-        void failPending(FooterCacheKey key) {
-            CompletableFuture<FooterCacheEntry> future = pending.remove(key);
-            if (future != null) {
-                future.complete(null);
-            }
-        }
-
-        synchronized void putTailIfEligible(FooterCacheKey key, long startOffset, byte[] buffer, int length) {
-            if (length <= 0 || length > maxEntryBytes) {
-                return;
-            }
-            byte[] bytes = new byte[length];
-            System.arraycopy(buffer, 0, bytes, 0, length);
-
-            FooterCacheEntry previous = completed.put(key, new FooterCacheEntry(startOffset, bytes));
-            if (previous != null) {
-                totalBytes -= previous.bytes().length;
-            }
-            totalBytes += bytes.length;
-            evictIfNeeded();
-        }
-
-        private void evictIfNeeded() {
-            while (totalBytes > maxBytes && completed.isEmpty() == false) {
-                Map.Entry<FooterCacheKey, FooterCacheEntry> eldest = completed.entrySet().iterator().next();
-                FooterCacheEntry removed = eldest.getValue();
-                completed.remove(eldest.getKey());
-                totalBytes -= removed.bytes().length;
-            }
-        }
-
-        /**
-         * Clears all cached and pending entries. Pending futures are completed with {@code null}
-         * before removal so that any thread blocked in {@link #getOrAwaitPending} unblocks.
-         */
-        synchronized void clear() {
-            completed.clear();
-            totalBytes = 0;
-            for (Map.Entry<FooterCacheKey, CompletableFuture<FooterCacheEntry>> entry : pending.entrySet()) {
-                entry.getValue().complete(null);
-            }
-            pending.clear();
-        }
-
-        private FooterCacheEntry awaitFuture(CompletableFuture<FooterCacheEntry> future) {
-            try {
-                return future.join();
-            } catch (java.util.concurrent.CancellationException | java.util.concurrent.CompletionException e) {
-                logger.debug("footer cache await failed", e);
-                return null;
             }
         }
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1771,11 +1771,9 @@ public class ParquetFormatReaderTests extends ESTestCase {
     /**
      * End-to-end test: reads a multi-row-group Parquet file with a filter via {@code read()},
      * then reads via per-range {@code readRange()} with the same filter. Asserts the union of
-     * range reads produces identical rows to the full read, proving the footer cache does not
-     * cause splits to miss or duplicate rows.
+     * range reads produces identical rows to the full read.
      */
     public void testReadRangeWithFilterProducesCorrectResults() throws Exception {
-        ParquetStorageObjectAdapter.clearFooterCacheForTests();
         byte[] parquetData = createWideMultiRowGroupFile(500);
         StorageObject storageObject = createStorageObject(parquetData);
         FilterPredicate filter = FilterApi.gt(FilterApi.longColumn("id"), -1L);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
-import org.junit.After;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -49,21 +48,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ParquetStorageObjectAdapterTests extends ESTestCase {
-
-    private boolean savedWindowCacheFlag;
-
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        savedWindowCacheFlag = ParquetStorageObjectAdapter.windowCacheEnabled;
-        ParquetStorageObjectAdapter.clearFooterCacheForTests();
-    }
-
-    @After
-    public void resetWindowCacheFlag() {
-        // Always restore the flag so a test that fails mid-way cannot bleed state into the next one.
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(savedWindowCacheFlag);
-    }
 
     public void testNullStorageObjectThrowsException() {
         QlIllegalArgumentException e = expectThrows(QlIllegalArgumentException.class, () -> new ParquetStorageObjectAdapter(null));
@@ -519,7 +503,6 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             }
         };
 
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(countingStorageObject);
 
         try (SeekableInputStream stream = adapter.newStream()) {
@@ -535,8 +518,10 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         assertTrue("Expected few range reads (window reuse); got " + rangeReadCount[0], rangeReadCount[0] <= 2);
     }
 
-    public void testFooterCacheServesTailReadsWithoutExtraRangeRequest() throws IOException {
-        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+    /**
+     * Each new stream fetches the tail independently; there is no cross-stream footer cache.
+     */
+    public void testSeparateStreamsEachFetchTailViaRangeRead() throws IOException {
         byte[] data = new byte[1024 * 1024];
         randomBytes(data);
         final int[] rangeReadCount = { 0 };
@@ -577,7 +562,6 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             }
         };
 
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(countingStorageObject);
         long tailStart = data.length - 1024;
 
@@ -593,12 +577,11 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             stream.seek(tailStart);
             stream.readFully(second);
         }
-        assertEquals(1, rangeReadCount[0]);
+        assertEquals(2, rangeReadCount[0]);
         assertArrayEquals(first, second);
     }
 
     public void testReadFullyCrossesWindowBoundaries() throws IOException {
-        ParquetStorageObjectAdapter.clearFooterCacheForTests();
         int size = ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE + 123;
         byte[] data = new byte[size];
         randomBytes(data);
@@ -639,13 +622,13 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             }
         };
 
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(rangeOnlyCounting);
         byte[] read = new byte[size];
         try (SeekableInputStream stream = adapter.newStream()) {
             stream.readFully(read);
         }
         assertArrayEquals(data, read);
+        // Exactly 2: one full 4 MiB window, one for the remaining 123-byte tail.
         assertEquals(2, rangeReadCount[0]);
     }
 
@@ -751,7 +734,6 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
     }
 
     public void testAdaptiveWindowReducesRangeRequests() throws IOException {
-        ParquetStorageObjectAdapter.clearFooterCacheForTests();
         int size = 6 * 1024 * 1024; // 6 MiB
         byte[] data = new byte[size];
         randomBytes(data);
@@ -791,8 +773,6 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
                 return StoragePath.of("memory://test-adaptive.parquet");
             }
         };
-
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
 
         // With default 4 MiB window, reading 6 MiB requires 2 range requests
         ParquetStorageObjectAdapter defaultAdapter = new ParquetStorageObjectAdapter(countingStorageObject);
@@ -858,7 +838,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
     public void testPrefetchedDataServedFromMemory() throws IOException {
         byte[] data = new byte[2048];
         randomBytes(data);
-        AtomicInteger readBytesCalls = new AtomicInteger();
+        AtomicInteger rangeStreamOpens = new AtomicInteger();
         StorageObject tracked = new StorageObject() {
             @Override
             public InputStream newStream() {
@@ -867,13 +847,8 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
 
             @Override
             public InputStream newStream(long position, long length) {
+                rangeStreamOpens.incrementAndGet();
                 return new ByteArrayInputStream(data, (int) position, (int) length);
-            }
-
-            @Override
-            public int readBytes(long position, ByteBuffer target) throws IOException {
-                readBytesCalls.incrementAndGet();
-                return StorageObject.super.readBytes(position, target);
             }
 
             @Override
@@ -897,7 +872,6 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             }
         };
 
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(tracked);
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = new TreeMap<>();
         int chunkLen = data.length - 100;
@@ -905,7 +879,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         chunks.put(100L, new ColumnChunkPrefetcher.PrefetchedChunk(100, chunkLen, prefetchedBuf.slice()));
         adapter.installPrefetchedData(chunks);
 
-        readBytesCalls.set(0);
+        rangeStreamOpens.set(0);
         try (SeekableInputStream stream = adapter.newStream()) {
             stream.seek(100);
             byte[] result = new byte[100];
@@ -914,7 +888,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
                 assertEquals(data[100 + i], result[i]);
             }
         }
-        assertEquals(0, readBytesCalls.get());
+        assertEquals(0, rangeStreamOpens.get());
     }
 
     public void testPrefetchedDataFallbackOnMiss() throws IOException {
@@ -941,7 +915,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
     public void testClearPrefetchedData() throws IOException {
         byte[] data = new byte[2048];
         randomBytes(data);
-        AtomicInteger readBytesCalls = new AtomicInteger();
+        AtomicInteger rangeStreamOpens = new AtomicInteger();
         StorageObject tracked = new StorageObject() {
             @Override
             public InputStream newStream() {
@@ -950,13 +924,8 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
 
             @Override
             public InputStream newStream(long position, long length) {
+                rangeStreamOpens.incrementAndGet();
                 return new ByteArrayInputStream(data, (int) position, (int) length);
-            }
-
-            @Override
-            public int readBytes(long position, ByteBuffer target) throws IOException {
-                readBytesCalls.incrementAndGet();
-                return StorageObject.super.readBytes(position, target);
             }
 
             @Override
@@ -987,13 +956,13 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         adapter.installPrefetchedData(chunks);
         adapter.clearPrefetchedData();
 
-        readBytesCalls.set(0);
+        rangeStreamOpens.set(0);
         try (SeekableInputStream stream = adapter.newStream()) {
             stream.seek(100);
             byte[] result = new byte[100];
             stream.readFully(result);
         }
-        assertTrue(readBytesCalls.get() > 0);
+        assertTrue(rangeStreamOpens.get() > 0);
     }
 
     public void testNoPrefetchedDataDoesNotAffectBaseline() throws IOException {
@@ -1012,16 +981,15 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
     }
 
     /**
-     * Verifies that seek+read sequences return correct data when the window cache is disabled
-     * (direct reads). This pattern mimics Parquet's column chunk access: seek to a dictionary
-     * page, read it, seek to a data page, read it, possibly seek back.
+     * Verifies that seek+read sequences return correct data with the sliding window. This pattern
+     * mimics Parquet's column chunk access: seek to a dictionary page, read it, seek to a data
+     * page, read it, possibly seek back.
      */
     public void testDirectStreamSeekAndReadCorrectness() throws IOException {
         byte[] data = new byte[64 * 1024];
         randomBytes(data);
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(false);
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
         try (SeekableInputStream stream = adapter.newStream()) {
@@ -1046,42 +1014,26 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         }
     }
 
-    /**
-     * Verifies that reading the full data with both window-cached and direct streams
-     * produces identical results. This is a parity test: any divergence indicates a
-     * correctness bug in one of the two paths.
-     */
-    public void testWindowedVsDirectReadParity() throws IOException {
-        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+    public void testReadFullyMatchesSourceData() throws IOException {
         int size = ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE + 12345;
         byte[] data = new byte[size];
         randomBytes(data);
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
-        ParquetStorageObjectAdapter windowedAdapter = new ParquetStorageObjectAdapter(storageObject);
-        byte[] windowedResult = new byte[size];
-        try (SeekableInputStream stream = windowedAdapter.newStream()) {
-            stream.readFully(windowedResult);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+        byte[] result = new byte[size];
+        try (SeekableInputStream stream = adapter.newStream()) {
+            stream.readFully(result);
         }
 
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(false);
-        ParquetStorageObjectAdapter directAdapter = new ParquetStorageObjectAdapter(storageObject);
-        byte[] directResult = new byte[size];
-        try (SeekableInputStream stream = directAdapter.newStream()) {
-            stream.readFully(directResult);
-        }
-
-        assertArrayEquals(windowedResult, directResult);
+        assertArrayEquals(data, result);
     }
 
     /**
-     * Verifies that interleaved seek+read of non-overlapping regions returns correct
-     * bytes with both window modes. This simulates Parquet reading dictionary and data
-     * pages from different column chunks within a row group.
+     * Verifies that interleaved seek+read of non-overlapping regions returns correct bytes.
+     * This simulates Parquet reading dictionary and data pages from different column chunks within a row group.
      */
     public void testInterleavedSeekReadParity() throws IOException {
-        ParquetStorageObjectAdapter.clearFooterCacheForTests();
         int size = 8 * 1024 * 1024;
         byte[] data = new byte[size];
         randomBytes(data);
@@ -1096,34 +1048,29 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             { 2_000_000, 32768 },
             { 0, 4096 } };
 
-        for (boolean windowEnabled : new boolean[] { true, false }) {
-            ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(windowEnabled);
-            ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+        ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
-            try (SeekableInputStream stream = adapter.newStream()) {
-                for (int[] region : readRegions) {
-                    int offset = region[0];
-                    int len = region[1];
-                    byte[] buf = new byte[len];
-                    stream.seek(offset);
-                    stream.readFully(buf);
-                    for (int i = 0; i < len; i++) {
-                        assertEquals("Mismatch at offset " + (offset + i) + " (window=" + windowEnabled + ")", data[offset + i], buf[i]);
-                    }
+        try (SeekableInputStream stream = adapter.newStream()) {
+            for (int[] region : readRegions) {
+                int offset = region[0];
+                int len = region[1];
+                byte[] buf = new byte[len];
+                stream.seek(offset);
+                stream.readFully(buf);
+                for (int i = 0; i < len; i++) {
+                    assertEquals("Mismatch at offset " + (offset + i), data[offset + i], buf[i]);
                 }
             }
         }
     }
 
     /**
-     * Verifies the direct stream handles single-byte reads, ByteBuffer reads,
-     * and skip operations correctly.
+     * Verifies single-byte reads, ByteBuffer reads, and skip operations on the windowed stream.
      */
     public void testDirectStreamOperations() throws IOException {
         byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(false);
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
         try (SeekableInputStream stream = adapter.newStream()) {
@@ -1158,17 +1105,10 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
     }
 
     /**
-     * End-to-end regression test for the non-deterministic dictionary-encoded SUM/COUNT bug that
-     * motivated disabling the sliding-window cache by default. Writes a Parquet file with a
+     * End-to-end regression test for dictionary-encoded SUM/COUNT correctness. Writes a Parquet file with a
      * dictionary-encoded {@code int64} column spanning multiple data pages, then fully decodes
-     * it via {@link ParquetFileReader} (which drives {@link ParquetStorageObjectAdapter}) in
-     * both windowed and direct modes across multiple iterations. Any per-iteration drift in the
-     * sum or row count would be a correctness bug.
-     *
-     * <p>With the window cache disabled by default, this test must pass deterministically. If a
-     * future change re-enables the cache without fixing the underlying bug
-     * (<a href="https://github.com/elastic/esql-planning/issues/585">esql-planning#585</a>),
-     * this is the first test expected to go red.
+     * it via {@link ParquetFileReader} (which drives {@link ParquetStorageObjectAdapter}) across
+     * multiple iterations. Any per-iteration drift in the sum or row count would be a correctness bug.
      */
     public void testDictionaryEncodedSumCountRegression() throws IOException {
         MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("v").named("dict_regression");
@@ -1191,39 +1131,31 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         // HadoopParquetConfiguration, which fails in tests without Woodstox on the classpath.
         ParquetReadOptions options = PlainParquetReadOptions.builder(new PlainCompressionCodecFactory()).build();
         for (int iter = 0; iter < iterations; iter++) {
-            for (boolean windowEnabled : new boolean[] { false, true }) {
-                ParquetStorageObjectAdapter.clearFooterCacheForTests();
-                ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(windowEnabled);
-                ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
+            ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
-                long sum = 0;
-                long count = 0;
-                try (ParquetFileReader reader = ParquetFileReader.open(adapter, options)) {
-                    MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(schema);
-                    PageReadStore pages;
-                    while ((pages = reader.readNextRowGroup()) != null) {
-                        RecordReader<Group> recordReader = columnIO.getRecordReader(pages, new GroupRecordConverter(schema));
-                        long rgRows = pages.getRowCount();
-                        for (long i = 0; i < rgRows; i++) {
-                            Group g = recordReader.read();
-                            sum += g.getLong(0, 0);
-                            count++;
-                        }
+            long sum = 0;
+            long count = 0;
+            try (ParquetFileReader reader = ParquetFileReader.open(adapter, options)) {
+                MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(schema);
+                PageReadStore pages;
+                while ((pages = reader.readNextRowGroup()) != null) {
+                    RecordReader<Group> recordReader = columnIO.getRecordReader(pages, new GroupRecordConverter(schema));
+                    long rgRows = pages.getRowCount();
+                    for (long i = 0; i < rgRows; i++) {
+                        Group g = recordReader.read();
+                        sum += g.getLong(0, 0);
+                        count++;
                     }
                 }
-
-                assertEquals("COUNT mismatch on iter=" + iter + " window=" + windowEnabled, rowCount, count);
-                assertEquals("SUM mismatch on iter=" + iter + " window=" + windowEnabled, expectedSum, sum);
             }
+
+            assertEquals("COUNT mismatch on iter=" + iter, rowCount, count);
+            assertEquals("SUM mismatch on iter=" + iter, expectedSum, sum);
         }
     }
 
     /**
-     * Concurrency stress test for the windowed-path code (<code>RangeFirstSeekableInputStream</code>).
-     * Exercises the scenario Parquet uses in practice: one adapter shared, many streams opened from it.
-     * If the suspected thread-safety bug is the root cause of
-     * <a href="https://github.com/elastic/esql-planning/issues/585">esql-planning#585</a>, this test
-     * will flake or fail with a stale-byte mismatch under {@code windowCacheEnabled = true}.
+     * Concurrency stress test for {@code WindowedSeekableInputStream}: one adapter shared, many streams opened from it.
      *
      * <p>Target runtime is capped at ~2s regardless of hardware to avoid flaking CI.
      */
@@ -1233,8 +1165,6 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         randomBytes(data);
         StorageObject storageObject = createRangeReadStorageObject(data);
 
-        ParquetStorageObjectAdapter.clearFooterCacheForTests();
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
         ParquetStorageObjectAdapter adapter = new ParquetStorageObjectAdapter(storageObject);
 
         int threadCount = randomIntBetween(4, 8);
@@ -1289,11 +1219,10 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
     }
 
     /**
-     * Validates that the simplified {@code (path, length)} cache key means different
-     * {@code lastModified} values still produce a cache hit for the same file.
+     * Two adapters wrapping different {@link StorageObject} instances (same path and bytes, different
+     * {@code lastModified}) each perform their own range reads; there is no cross-adapter cache.
      */
-    public void testFooterCacheKeyIgnoresLastModified() throws IOException {
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
+    public void testSeparateAdaptersDoNotShareCachedRanges() throws IOException {
         byte[] data = new byte[1024 * 1024];
         random().nextBytes(data);
         final int[] rangeReadCount = { 0 };
@@ -1321,15 +1250,14 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             s.readFully(w);
             assertArrayEquals(expected, w);
         }
-        assertEquals("Second adapter should use cache, no additional I/O", 1, rangeReadCount[0]);
+        assertEquals("Second adapter should issue its own tail range read", 2, rangeReadCount[0]);
     }
 
     /**
-     * Validates thundering-herd coalescing: 8 concurrent threads reading the same tail
-     * should produce exactly 1 I/O, not 8.
+     * Concurrent threads each open their own stream and read the tail; without a shared footer cache,
+     * each stream performs its own range read(s).
      */
-    public void testThunderingHerdCoalescesConcurrentFooterReads() throws Exception {
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
+    public void testConcurrentTailReadsEachIssueRangeRequest() throws Exception {
         byte[] data = new byte[1024 * 1024];
         random().nextBytes(data);
         final AtomicInteger rangeReadCount = new AtomicInteger();
@@ -1409,35 +1337,7 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         if (failure != null) {
             throw failure;
         }
-        assertTrue(
-            "Expected at most 2 range reads (1 tail + possibly 1 early non-tail), got " + rangeReadCount.get(),
-            rangeReadCount.get() <= 2
-        );
-    }
-
-    /**
-     * Validates LRU eviction behavior of the footer cache after the thundering-herd redesign.
-     */
-    public void testFooterCacheLruEvictionStillWorks() {
-        ParquetStorageObjectAdapter.FooterCache cache = new ParquetStorageObjectAdapter.FooterCache(10_000, 5_000);
-        byte[] bytes5000 = new byte[5000];
-        byte[] bytes500 = new byte[500];
-        random().nextBytes(bytes5000);
-        random().nextBytes(bytes500);
-
-        ParquetStorageObjectAdapter.FooterCacheKey key1 = new ParquetStorageObjectAdapter.FooterCacheKey("file1", 10000);
-        ParquetStorageObjectAdapter.FooterCacheKey key2 = new ParquetStorageObjectAdapter.FooterCacheKey("file2", 20000);
-        ParquetStorageObjectAdapter.FooterCacheKey key3 = new ParquetStorageObjectAdapter.FooterCacheKey("file3", 30000);
-
-        cache.putTailIfEligible(key1, 5000, bytes5000, 5000);
-        cache.putTailIfEligible(key2, 15000, bytes5000, 5000);
-
-        assertNotNull("key1 should be in cache", cache.getCompleted(key1));
-        assertNotNull("key2 should be in cache", cache.getCompleted(key2));
-
-        cache.putTailIfEligible(key3, 29500, bytes500, 500);
-        assertNotNull("key3 should be in cache", cache.getCompleted(key3));
-        assertNull("key1 should have been evicted by LRU", cache.getCompleted(key1));
+        assertEquals("Each of 8 concurrent tail reads should open its own range stream", 8, rangeReadCount.get());
     }
 
     /**
@@ -1445,7 +1345,6 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
      * sequential reads, forward seeks, backward seeks, tail reads, and ByteBuffer reads.
      */
     public void testAdapterReadsIdenticalBytesToVanillaStream() throws IOException {
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
         int n = 2 * ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE + 500;
         byte[] data = new byte[n];
         random().nextBytes(data);
@@ -1488,7 +1387,6 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
      * default-window adapter for identical seek/read sequences.
      */
     public void testForRangeAdapterReadsIdenticalData() throws IOException {
-        ParquetStorageObjectAdapter.setWindowCacheEnabledForTests(true);
         int n = 2 * ParquetStorageObjectAdapter.DEFAULT_WINDOW_SIZE + 500;
         byte[] data = new byte[n];
         random().nextBytes(data);


### PR DESCRIPTION
## Summary

Replace ByteBuffer-based `readBytes` path with stream-based reads in the Parquet adapter's sliding-window cache. The new `fetchWindowAt` uses `StorageObject.newStream(pos, len)` with chunked `InputStream.read(byte[], off, len)` calls capped to 256 KiB to limit JDK thread-local direct buffer allocation.

### Key changes
- **`fetchWindowAt`**: uses `newStream` + chunked `InputStream.read` (256 KiB) instead of `readBytes(pos, ByteBuffer)` — caps direct memory at 256 KiB/thread instead of window-sized (4-16 MiB)
- **Window invalidation**: `windowStart`/`windowLength` are reset before each I/O so a partial-read failure never leaves stale data visible to subsequent reads
- **Zero-byte read guard**: throws `IOException` if `InputStream.read` returns 0 for a non-empty request
- **Removed footer cache**: the JVM-wide `FooterCache` (LRU `LinkedHashMap` + thundering-herd `CompletableFuture`) and all related types deleted — eliminates cross-adapter shared mutable state
- **Removed `windowCacheEnabled` flag and `DirectSeekableInputStream`**: the bypass from #147404 is no longer needed
- **Renamed** `RangeFirstSeekableInputStream` → `WindowedSeekableInputStream` — now the only impl
- **Tests**: preserved `testDictionaryEncodedSumCountRegression` (the gold-standard end-to-end regression test), `testConcurrentWindowedReadsProduceConsistentBytes` (multi-threaded stress test), removed footer-cache-specific tests, kept all correctness tests

Developed with AI-assisted tooling