### PR TITLE
[9.4] Bump assertBusy timeout in race-condition migration test (#147447)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -270,92 +270,15 @@ tests:
 - class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
   method: test {yaml=rrf/310_rrf_retriever_simplified/Expansion to equivalent custom sub-retrievers returns the same results}
   issue: https://github.com/elastic/elasticsearch/issues/146464
-- class: org.elasticsearch.index.mapper.KeywordOffsetDocValuesLoaderTests
-  method: testOffsetArrayRandomHighCardinality
-  issue: https://github.com/elastic/elasticsearch/issues/147085
-- class: org.elasticsearch.index.mapper.IpOffsetDocValuesLoaderTests
-  method: testOffsetArrayRandomHighCardinality
-  issue: https://github.com/elastic/elasticsearch/issues/147086
-- class: org.elasticsearch.simdvec.ESVectorUtilTests
-  method: testLogSumExpDiff
-  issue: https://github.com/elastic/elasticsearch/issues/146700
-- class: org.elasticsearch.xpack.ml.integration.MlMemoryIT
-  method: testMemoryStats
-  issue: https://github.com/elastic/elasticsearch/issues/147122
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
-  method: test {csv-spec:stats.statsWithSubstitutedExpressionOverFilters}
-  issue: https://github.com/elastic/elasticsearch/issues/147125
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
-  method: test {csv-spec:k8s-timeseries-arithmetic.division_metric_metric_grouping_filtering_ts}
-  issue: https://github.com/elastic/elasticsearch/issues/147126
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
-  method: test {csv-spec:bucket.docsBucketMonthlyHistogram}
-  issue: https://github.com/elastic/elasticsearch/issues/147127
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
-  method: test {csv-spec:stats.commonFilterExtractionWithAliasing}
-  issue: https://github.com/elastic/elasticsearch/issues/147128
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testBulkOperations {useLegacyFormat=false useSyntheticSource=false}
-  issue: https://github.com/elastic/elasticsearch/issues/147130
-- class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
-  method: testSeqNoPrunedOnLeaderAfterFollowerCatchesUp
-  issue: https://github.com/elastic/elasticsearch/issues/147133
-- class: org.elasticsearch.xpack.esql.optimizer.ApproximationGoldenTests
-  method: testApproximationDisabled
-  issue: https://github.com/elastic/elasticsearch/issues/147144
-- class: org.elasticsearch.xpack.esql.plan.logical.CommandLicenseTests
-  method: testLicenseCheck
-  issue: https://github.com/elastic/elasticsearch/issues/147147
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/145901
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/145901
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec}
-  issue: https://github.com/elastic/elasticsearch/issues/147164
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testBulkOperations {useLegacyFormat=true useSyntheticSource=true}
-  issue: https://github.com/elastic/elasticsearch/issues/147169
-- class: org.elasticsearch.xpack.prometheus.PrometheusMetadataRestIT
-  method: testMultipleEntriesForSameMetricAcrossStreams
-  issue: https://github.com/elastic/elasticsearch/issues/147170
-- class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
-  method: testNonOperatorUserCanCallAnalyzeRepositoryAPI
-  issue: https://github.com/elastic/elasticsearch/issues/147171
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testBulkOperations {useLegacyFormat=false useSyntheticSource=true}
-  issue: https://github.com/elastic/elasticsearch/issues/147177
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=index/100_field_name_length_limit/Test field name length limit array}
-  issue: https://github.com/elastic/elasticsearch/issues/147205
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/KNN Vector similarity search only}
-  issue: https://github.com/elastic/elasticsearch/issues/147251
-- class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
-  method: testIndexingSyntheticSource
-  issue: https://github.com/elastic/elasticsearch/issues/147298
-- class: org.elasticsearch.compute.aggregation.blockhash.BlockHashRandomizedTests
-  issue: https://github.com/elastic/elasticsearch/issues/147361
-- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/145728
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
-  method: test {csv-spec:stats_sparkline.sparklineComplexWithGrouping}
-  issue: https://github.com/elastic/elasticsearch/issues/147378
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/250_high_cardinality_keyword/Test mv_min}
-  issue: https://github.com/elastic/elasticsearch/issues/147379
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/250_high_cardinality_keyword/Test avg length}
-  issue: https://github.com/elastic/elasticsearch/issues/147380
-- class: org.elasticsearch.search.fetch.ChunkedFetchPhaseCircuitBreakerTrippingIT
-  method: testCircuitBreakerTripsWithConcurrentSearches
-  issue: https://github.com/elastic/elasticsearch/issues/147391
-- class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
-  method: testReindexTaskRelocatesOnNodeShutdown
-  issue: https://github.com/elastic/elasticsearch/issues/147449
+- class: org.elasticsearch.xpack.security.authz.SnapshotUserRoleIntegTests
+  method: testSnapshotUserRoleIsReserved
+  issue: https://github.com/elastic/elasticsearch/issues/146972
+- class: org.elasticsearch.xpack.security.authz.SnapshotUserRoleIntegTests
+  method: testSnapshotUserRoleCanSnapshotAndSeeAllIndices
+  issue: https://github.com/elastic/elasticsearch/issues/146973
+- class: org.elasticsearch.xpack.security.authz.SnapshotUserRoleIntegTests
+  method: testSnapshotUserRoleUnathorizedForDestructiveActions
+  issue: https://github.com/elastic/elasticsearch/issues/146974
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -270,15 +270,92 @@ tests:
 - class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
   method: test {yaml=rrf/310_rrf_retriever_simplified/Expansion to equivalent custom sub-retrievers returns the same results}
   issue: https://github.com/elastic/elasticsearch/issues/146464
-- class: org.elasticsearch.xpack.security.authz.SnapshotUserRoleIntegTests
-  method: testSnapshotUserRoleIsReserved
-  issue: https://github.com/elastic/elasticsearch/issues/146972
-- class: org.elasticsearch.xpack.security.authz.SnapshotUserRoleIntegTests
-  method: testSnapshotUserRoleCanSnapshotAndSeeAllIndices
-  issue: https://github.com/elastic/elasticsearch/issues/146973
-- class: org.elasticsearch.xpack.security.authz.SnapshotUserRoleIntegTests
-  method: testSnapshotUserRoleUnathorizedForDestructiveActions
-  issue: https://github.com/elastic/elasticsearch/issues/146974
+- class: org.elasticsearch.index.mapper.KeywordOffsetDocValuesLoaderTests
+  method: testOffsetArrayRandomHighCardinality
+  issue: https://github.com/elastic/elasticsearch/issues/147085
+- class: org.elasticsearch.index.mapper.IpOffsetDocValuesLoaderTests
+  method: testOffsetArrayRandomHighCardinality
+  issue: https://github.com/elastic/elasticsearch/issues/147086
+- class: org.elasticsearch.simdvec.ESVectorUtilTests
+  method: testLogSumExpDiff
+  issue: https://github.com/elastic/elasticsearch/issues/146700
+- class: org.elasticsearch.xpack.ml.integration.MlMemoryIT
+  method: testMemoryStats
+  issue: https://github.com/elastic/elasticsearch/issues/147122
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
+  method: test {csv-spec:stats.statsWithSubstitutedExpressionOverFilters}
+  issue: https://github.com/elastic/elasticsearch/issues/147125
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
+  method: test {csv-spec:k8s-timeseries-arithmetic.division_metric_metric_grouping_filtering_ts}
+  issue: https://github.com/elastic/elasticsearch/issues/147126
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
+  method: test {csv-spec:bucket.docsBucketMonthlyHistogram}
+  issue: https://github.com/elastic/elasticsearch/issues/147127
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
+  method: test {csv-spec:stats.commonFilterExtractionWithAliasing}
+  issue: https://github.com/elastic/elasticsearch/issues/147128
+- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
+  method: testBulkOperations {useLegacyFormat=false useSyntheticSource=false}
+  issue: https://github.com/elastic/elasticsearch/issues/147130
+- class: org.elasticsearch.xpack.ccr.CcrSeqNoPruningIT
+  method: testSeqNoPrunedOnLeaderAfterFollowerCatchesUp
+  issue: https://github.com/elastic/elasticsearch/issues/147133
+- class: org.elasticsearch.xpack.esql.optimizer.ApproximationGoldenTests
+  method: testApproximationDisabled
+  issue: https://github.com/elastic/elasticsearch/issues/147144
+- class: org.elasticsearch.xpack.esql.plan.logical.CommandLicenseTests
+  method: testLicenseCheck
+  issue: https://github.com/elastic/elasticsearch/issues/147147
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/145901
+- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/145901
+- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
+  method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec}
+  issue: https://github.com/elastic/elasticsearch/issues/147164
+- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
+  method: testBulkOperations {useLegacyFormat=true useSyntheticSource=true}
+  issue: https://github.com/elastic/elasticsearch/issues/147169
+- class: org.elasticsearch.xpack.prometheus.PrometheusMetadataRestIT
+  method: testMultipleEntriesForSameMetricAcrossStreams
+  issue: https://github.com/elastic/elasticsearch/issues/147170
+- class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
+  method: testNonOperatorUserCanCallAnalyzeRepositoryAPI
+  issue: https://github.com/elastic/elasticsearch/issues/147171
+- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
+  method: testBulkOperations {useLegacyFormat=false useSyntheticSource=true}
+  issue: https://github.com/elastic/elasticsearch/issues/147177
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=index/100_field_name_length_limit/Test field name length limit array}
+  issue: https://github.com/elastic/elasticsearch/issues/147205
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/KNN Vector similarity search only}
+  issue: https://github.com/elastic/elasticsearch/issues/147251
+- class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
+  method: testIndexingSyntheticSource
+  issue: https://github.com/elastic/elasticsearch/issues/147298
+- class: org.elasticsearch.compute.aggregation.blockhash.BlockHashRandomizedTests
+  issue: https://github.com/elastic/elasticsearch/issues/147361
+- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/145728
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
+  method: test {csv-spec:stats_sparkline.sparklineComplexWithGrouping}
+  issue: https://github.com/elastic/elasticsearch/issues/147378
+- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
+  method: test {p0=esql/250_high_cardinality_keyword/Test mv_min}
+  issue: https://github.com/elastic/elasticsearch/issues/147379
+- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
+  method: test {p0=esql/250_high_cardinality_keyword/Test avg length}
+  issue: https://github.com/elastic/elasticsearch/issues/147380
+- class: org.elasticsearch.search.fetch.ChunkedFetchPhaseCircuitBreakerTrippingIT
+  method: testCircuitBreakerTripsWithConcurrentSearches
+  issue: https://github.com/elastic/elasticsearch/issues/147391
+- class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
+  method: testReindexTaskRelocatesOnNodeShutdown
+  issue: https://github.com/elastic/elasticsearch/issues/147449
 
 # Examples:
 #

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/system_indices/action/FeatureMigrationIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/system_indices/action/FeatureMigrationIT.java
@@ -124,12 +124,13 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         // We should see that the migration is in progress even though we just started the migration.
         assertThat(statusResponse.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.IN_PROGRESS));
 
-        // Now wait for the migration to finish (otherwise the test infra explodes)
+        // Now wait for the migration to finish (otherwise the test infra explodes). The feature upgrade may take longer than ten
+        // seconds when tests are running in parallel, so we give assertBusy a thirty-second timeout.
         assertBusy(() -> {
             GetFeatureUpgradeStatusResponse statusResp = client().execute(GetFeatureUpgradeStatusAction.INSTANCE, getStatusRequest).get();
             logger.info(Strings.toString(statusResp));
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     public void testMigrateSystemIndex() throws Exception {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Bump assertBusy timeout in race-condition migration test (#147447)](https://github.com/elastic/elasticsearch/pull/147447)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)