### PR TITLE
[9.3] Bump assertBusy timeout in race-condition migration test (#147447)

### DIFF
--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/system_indices/action/FeatureMigrationIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/system_indices/action/FeatureMigrationIT.java
@@ -124,12 +124,13 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         // We should see that the migration is in progress even though we just started the migration.
         assertThat(statusResponse.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.IN_PROGRESS));
 
-        // Now wait for the migration to finish (otherwise the test infra explodes)
+        // Now wait for the migration to finish (otherwise the test infra explodes). The feature upgrade may take longer than ten
+        // seconds when tests are running in parallel, so we give assertBusy a thirty-second timeout.
         assertBusy(() -> {
             GetFeatureUpgradeStatusResponse statusResp = client().execute(GetFeatureUpgradeStatusAction.INSTANCE, getStatusRequest).get();
             logger.info(Strings.toString(statusResp));
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     public void testMigrateSystemIndex() throws Exception {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Bump assertBusy timeout in race-condition migration test (#147447)](https://github.com/elastic/elasticsearch/pull/147447)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)