### PR TITLE
Allow checking int range vectors

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
@@ -80,6 +80,15 @@ public sealed interface IntVector extends Vector permits ConstantIntVector, IntA
     int max();
 
     /**
+     * Returns {@code true} if the values in this vector has a contiguous range from {@link #min()} to {@link #max()}.
+     * Implementations may return {@code false} even when the range is contiguous, but a {@code true} result is guaranteed
+     * to be correct.
+     */
+    default boolean contiguousRange() {
+        return false;
+    }
+
+    /**
      * Compares the given object with this vector for equality. Returns {@code true} if and only if the
      * given object is a IntVector, and both vectors are {@link #equals(IntVector, IntVector) equal}.
      */

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/IntRangeVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/IntRangeVector.java
@@ -114,6 +114,11 @@ final class IntRangeVector extends AbstractVector implements IntVector {
     }
 
     @Override
+    public boolean contiguousRange() {
+        return getPositionCount() > 0;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.INT;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -137,6 +137,15 @@ $if(int)$
      */
     int max();
 
+    /**
+     * Returns {@code true} if the values in this vector has a contiguous range from {@link #min()} to {@link #max()}.
+     * Implementations may return {@code false} even when the range is contiguous, but a {@code true} result is guaranteed
+     * to be correct.
+     */
+    default boolean contiguousRange() {
+        return false;
+    }
+
 $elseif(boolean)$
     /**
      * Are all values {@code true}? This will scan all values to check and always answer accurately.


### PR DESCRIPTION
The IntRangeVector is used in `selected` when emitting grouping aggregations. With chunking outputs, we can detect contiguous ranges and enable optimizations when loading keys.