### PR TITLE
[9.3] Filter out duplicate Path implemenations in entitlement instrumentation (#147442)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/PathInstrumentation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/config/PathInstrumentation.java
@@ -32,7 +32,7 @@ public class PathInstrumentation implements InstrumentationConfig {
         List<? extends Class<? extends Path>> pathClasses = StreamSupport.stream(
             FileSystems.getDefault().getRootDirectories().spliterator(),
             false
-        ).map(Path::getClass).toList();
+        ).map(Path::getClass).distinct().toList();
 
         builder.on(pathClasses, rule -> {
             rule.calling(Path::toRealPath, LinkOption[].class).enforce((path, options) -> {


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Filter out duplicate Path implemenations in entitlement instrumentation (#147442)