### PR TITLE
ESQL: Shared metadata byte cache for Parquet and ORC

### DIFF
--- a/docs/changelog/147493.yaml
+++ b/docs/changelog/147493.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147493
+summary: Shared metadata byte cache for Parquet and ORC
+type: enhancement

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcStorageObjectAdapter.java
@@ -17,11 +17,13 @@ import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Progressable;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.datasources.cache.FooterByteCache;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Adapter that provides a Hadoop {@link FileSystem} backed by a {@link StorageObject}.
@@ -63,6 +65,10 @@ public class OrcStorageObjectAdapter extends FileSystem {
     @Override
     public FSDataInputStream open(Path f) throws IOException {
         return open(f, 4096);
+    }
+
+    static void clearCacheForTests() {
+        FooterByteCache.getInstance().invalidateAll();
     }
 
     @Override
@@ -128,6 +134,7 @@ public class OrcStorageObjectAdapter extends FileSystem {
      */
     static class StorageObjectInputStream extends InputStream implements Seekable, PositionedReadable {
         private final StorageObject storageObject;
+        private final FooterByteCache.Key cacheKey;
         private InputStream currentStream;
         private long position;
         private long streamStartPosition;
@@ -136,6 +143,7 @@ public class OrcStorageObjectAdapter extends FileSystem {
         StorageObjectInputStream(StorageObject storageObject) throws IOException {
             this.storageObject = storageObject;
             this.length = storageObject.length();
+            this.cacheKey = new FooterByteCache.Key(storageObject.path().toString(), this.length);
             this.position = 0;
             this.streamStartPosition = 0;
             this.currentStream = storageObject.newStream();
@@ -182,13 +190,83 @@ public class OrcStorageObjectAdapter extends FileSystem {
 
         @Override
         public int read(long pos, byte[] buffer, int offset, int len) throws IOException {
-            try (InputStream stream = storageObject.newStream(pos, len)) {
-                return stream.read(buffer, offset, len);
+            int fromCache = readFromTailCache(pos, buffer, offset, len);
+            if (fromCache >= 0) {
+                return fromCache;
             }
+
+            int bytesRead;
+            try (InputStream stream = storageObject.newStream(pos, len)) {
+                bytesRead = stream.read(buffer, offset, len);
+            }
+
+            if (bytesRead > 0 && pos + bytesRead == length) {
+                byte[] tailBytes = new byte[bytesRead];
+                System.arraycopy(buffer, offset, tailBytes, 0, bytesRead);
+                FooterByteCache.getInstance().put(cacheKey, tailBytes);
+            }
+            return bytesRead;
         }
 
         @Override
         public void readFully(long pos, byte[] buffer, int offset, int len) throws IOException {
+            FooterByteCache tailCache = FooterByteCache.getInstance();
+            boolean isTailRead = pos + len == length;
+
+            if (isTailRead && len > 0 && len <= tailCache.maxEntryBytes()) {
+                try {
+                    byte[] tailBytes = tailCache.getOrLoad(cacheKey, k -> {
+                        byte[] loaded = new byte[len];
+                        readFullyFromStorage(pos, loaded, 0, len);
+                        return loaded;
+                    });
+                    if (tailBytes.length > 0) {
+                        long cachedStart = length - tailBytes.length;
+                        if (pos >= cachedStart && pos + len <= length) {
+                            int from = (int) (pos - cachedStart);
+                            System.arraycopy(tailBytes, from, buffer, offset, len);
+                            return;
+                        }
+                    }
+                } catch (ExecutionException e) {
+                    // fall through to direct I/O
+                }
+            }
+
+            int fromCache = readFromTailCache(pos, buffer, offset, len);
+            if (fromCache == len) {
+                return;
+            }
+
+            readFullyFromStorage(pos, buffer, offset, len);
+
+            if (pos + len == length) {
+                byte[] tailBytes = new byte[len];
+                System.arraycopy(buffer, offset, tailBytes, 0, len);
+                tailCache.put(cacheKey, tailBytes);
+            }
+        }
+
+        @Override
+        public void readFully(long pos, byte[] buffer) throws IOException {
+            readFully(pos, buffer, 0, buffer.length);
+        }
+
+        private int readFromTailCache(long pos, byte[] buffer, int offset, int len) {
+            byte[] cached = FooterByteCache.getInstance().get(cacheKey);
+            if (cached == null || cached.length == 0) {
+                return -1;
+            }
+            long cachedStart = length - cached.length;
+            if (pos >= cachedStart && pos + len <= length) {
+                int from = (int) (pos - cachedStart);
+                System.arraycopy(cached, from, buffer, offset, len);
+                return len;
+            }
+            return -1;
+        }
+
+        private void readFullyFromStorage(long pos, byte[] buffer, int offset, int len) throws IOException {
             try (InputStream stream = storageObject.newStream(pos, len)) {
                 int remaining = len;
                 int off = offset;
@@ -201,11 +279,6 @@ public class OrcStorageObjectAdapter extends FileSystem {
                     remaining -= bytesRead;
                 }
             }
-        }
-
-        @Override
-        public void readFully(long pos, byte[] buffer) throws IOException {
-            readFully(pos, buffer, 0, buffer.length);
         }
 
         // --- InputStream ---

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcStorageObjectAdapter.java
@@ -16,6 +16,8 @@ import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Progressable;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.datasources.cache.FooterByteCache;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
@@ -33,6 +35,7 @@ import java.util.concurrent.ExecutionException;
  * any storage provider (HTTP, S3, local) without a real Hadoop installation.
  */
 public class OrcStorageObjectAdapter extends FileSystem {
+    private static final Logger logger = LogManager.getLogger(OrcStorageObjectAdapter.class);
 
     private final StorageObject storageObject;
     private final Path path;
@@ -143,7 +146,7 @@ public class OrcStorageObjectAdapter extends FileSystem {
         StorageObjectInputStream(StorageObject storageObject) throws IOException {
             this.storageObject = storageObject;
             this.length = storageObject.length();
-            this.cacheKey = new FooterByteCache.Key(storageObject.path().toString(), this.length);
+            this.cacheKey = FooterByteCache.Key.keyFor(storageObject, this.length);
             this.position = 0;
             this.streamStartPosition = 0;
             this.currentStream = storageObject.newStream();
@@ -200,6 +203,10 @@ public class OrcStorageObjectAdapter extends FileSystem {
                 bytesRead = stream.read(buffer, offset, len);
             }
 
+            // Opportunistic cache fill: uses pos + bytesRead (actual bytes returned) rather than
+            // pos + len (requested bytes) because PositionedReadable.read may return a short read.
+            // This caches a smaller suffix [length - bytesRead, length) which readFromTailCache
+            // handles correctly — its bounds check rejects requests that span outside the cached region.
             if (bytesRead > 0 && pos + bytesRead == length) {
                 byte[] tailBytes = new byte[bytesRead];
                 System.arraycopy(buffer, offset, tailBytes, 0, bytesRead);
@@ -229,7 +236,7 @@ public class OrcStorageObjectAdapter extends FileSystem {
                         }
                     }
                 } catch (ExecutionException e) {
-                    // fall through to direct I/O
+                    logger.debug("footer cache load failed; retrying direct I/O", e.getCause());
                 }
             }
 

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -66,6 +66,7 @@ public class OrcFormatReaderTests extends ESTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        OrcStorageObjectAdapter.clearCacheForTests();
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
     }
 

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcStorageObjectAdapterTests.java
@@ -19,8 +19,15 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class OrcStorageObjectAdapterTests extends ESTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        OrcStorageObjectAdapter.clearCacheForTests();
+    }
 
     public void testNullStorageObjectThrows() {
         expectThrows(QlIllegalArgumentException.class, () -> new OrcStorageObjectAdapter(null));
@@ -188,7 +195,77 @@ public class OrcStorageObjectAdapterTests extends ESTestCase {
         };
     }
 
+    /**
+     * Verifies that two readFully calls for the same tail region result in only one actual
+     * storage read, with the second served from FooterByteCache.
+     */
+    public void testTailCacheCoalescesRepeatedReadFully() throws IOException {
+        byte[] data = new byte[4096];
+        random().nextBytes(data);
+        AtomicInteger rangeReadCount = new AtomicInteger();
+
+        StorageObject countingStorage = createCountingRangeReadStorageObject(data, rangeReadCount);
+        OrcStorageObjectAdapter adapter = new OrcStorageObjectAdapter(countingStorage);
+
+        int tailLen = 512;
+        long tailPos = data.length - tailLen;
+
+        byte[] first = new byte[tailLen];
+        try (FSDataInputStream stream = adapter.open(new Path("memory://cache-test.orc"))) {
+            stream.readFully(tailPos, first);
+        }
+        assertEquals(1, rangeReadCount.get());
+
+        byte[] second = new byte[tailLen];
+        try (FSDataInputStream stream = adapter.open(new Path("memory://cache-test.orc"))) {
+            stream.readFully(tailPos, second);
+        }
+        assertEquals("Second tail read should be served from cache", 1, rangeReadCount.get());
+        assertArrayEquals(first, second);
+
+        byte[] expected = new byte[tailLen];
+        System.arraycopy(data, (int) tailPos, expected, 0, tailLen);
+        assertArrayEquals(expected, first);
+    }
+
+    /**
+     * Verifies that positioned reads that hit the cache still return correct bytes.
+     */
+    public void testPositionedReadFromTailCache() throws IOException {
+        byte[] data = new byte[2048];
+        random().nextBytes(data);
+        AtomicInteger rangeReadCount = new AtomicInteger();
+
+        StorageObject countingStorage = createCountingRangeReadStorageObject(data, rangeReadCount);
+        OrcStorageObjectAdapter adapter = new OrcStorageObjectAdapter(countingStorage);
+
+        int tailLen = 1024;
+        long tailPos = data.length - tailLen;
+
+        byte[] fullTail = new byte[tailLen];
+        try (FSDataInputStream stream = adapter.open(new Path("memory://pos-test.orc"))) {
+            stream.readFully(tailPos, fullTail);
+        }
+        assertEquals(1, rangeReadCount.get());
+
+        byte[] subRange = new byte[256];
+        long subPos = data.length - 256;
+        try (FSDataInputStream stream = adapter.open(new Path("memory://pos-test.orc"))) {
+            int read = stream.read(subPos, subRange, 0, 256);
+            assertEquals(256, read);
+        }
+        assertEquals("Sub-range read within cached tail should not cause extra storage reads", 1, rangeReadCount.get());
+
+        byte[] expected = new byte[256];
+        System.arraycopy(data, (int) subPos, expected, 0, 256);
+        assertArrayEquals(expected, subRange);
+    }
+
     private StorageObject createRangeReadStorageObject(byte[] data) {
+        return createCountingRangeReadStorageObject(data, new AtomicInteger());
+    }
+
+    private StorageObject createCountingRangeReadStorageObject(byte[] data, AtomicInteger rangeReadCount) {
         return new StorageObject() {
             @Override
             public InputStream newStream() throws IOException {
@@ -197,6 +274,7 @@ public class OrcStorageObjectAdapterTests extends ESTestCase {
 
             @Override
             public InputStream newStream(long position, long length) throws IOException {
+                rangeReadCount.incrementAndGet();
                 int pos = (int) position;
                 int len = (int) Math.min(length, data.length - position);
                 return new ByteArrayInputStream(data, pos, len);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -8,7 +8,10 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.parquet.io.SeekableInputStream;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.datasources.cache.FooterByteCache;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
@@ -17,6 +20,7 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Adapter that wraps a StorageObject to implement Parquet's InputFile interface.
@@ -30,9 +34,11 @@ import java.util.NavigableMap;
  * </ul>
  */
 public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputFile {
+    private static final Logger logger = LogManager.getLogger(ParquetStorageObjectAdapter.class);
 
     private final StorageObject storageObject;
     private final long length;
+    private final FooterByteCache.Key cacheKey;
     private final int windowSize;
     private volatile NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> prefetchedChunks;
 
@@ -72,6 +78,11 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read storage object length for [" + storageObject.path() + "]", e);
         }
+        this.cacheKey = FooterByteCache.Key.keyFor(storageObject, this.length);
+    }
+
+    static void clearFooterCacheForTests() {
+        FooterByteCache.getInstance().invalidateAll();
     }
 
     /**
@@ -94,7 +105,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
 
     @Override
     public SeekableInputStream newStream() throws IOException {
-        return new WindowedSeekableInputStream(storageObject, length, windowSize, this);
+        return new WindowedSeekableInputStream(storageObject, cacheKey, length, windowSize, this);
     }
 
     /**
@@ -115,6 +126,7 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         private static final int STREAM_READ_CHUNK_SIZE = 256 * 1024;
 
         private final StorageObject storageObject;
+        private final FooterByteCache.Key cacheKey;
         private final long length;
         private final int windowSize;
         private final byte[] window;
@@ -125,8 +137,15 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
         private long position;
         private boolean closed;
 
-        WindowedSeekableInputStream(StorageObject storageObject, long length, int windowSize, ParquetStorageObjectAdapter adapter) {
+        WindowedSeekableInputStream(
+            StorageObject storageObject,
+            FooterByteCache.Key cacheKey,
+            long length,
+            int windowSize,
+            ParquetStorageObjectAdapter adapter
+        ) {
             this.storageObject = storageObject;
+            this.cacheKey = cacheKey;
             this.length = length;
             this.windowSize = windowSize;
             this.window = new byte[windowSize];
@@ -176,6 +195,23 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 return;
             }
 
+            FooterByteCache tailCache = FooterByteCache.getInstance();
+            if (fillFromTailCache(tailCache, pos, (int) toRead)) {
+                return;
+            }
+
+            boolean isTailRead = pos + toRead == length;
+            if (isTailRead && toRead <= tailCache.maxEntryBytes()) {
+                try {
+                    byte[] tailBytes = tailCache.getOrLoad(cacheKey, k -> readTailBytes(pos, (int) toRead));
+                    if (tailBytes.length > 0 && fillFromCachedTail(tailBytes, pos, (int) toRead)) {
+                        return;
+                    }
+                } catch (ExecutionException e) {
+                    logger.debug("footer cache load failed; retrying direct I/O", e.getCause());
+                }
+            }
+
             windowStart = -1;
             windowLength = 0;
 
@@ -198,6 +234,55 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
                 windowStart = pos;
                 windowLength = totalRead;
             }
+
+            if (windowLength > 0 && windowStart + windowLength == length) {
+                byte[] tailBytes = new byte[windowLength];
+                System.arraycopy(window, 0, tailBytes, 0, windowLength);
+                tailCache.put(cacheKey, tailBytes);
+            }
+        }
+
+        private byte[] readTailBytes(long pos, int toRead) throws IOException {
+            byte[] buf = new byte[toRead];
+            try (InputStream in = storageObject.newStream(pos, toRead)) {
+                int totalRead = 0;
+                while (totalRead < toRead) {
+                    int chunk = Math.min(STREAM_READ_CHUNK_SIZE, toRead - totalRead);
+                    int n = in.read(buf, totalRead, chunk);
+                    if (n < 0) {
+                        break;
+                    }
+                    totalRead += n;
+                }
+                if (totalRead <= 0) {
+                    return new byte[0];
+                }
+                if (totalRead == toRead) {
+                    return buf;
+                }
+                byte[] result = new byte[totalRead];
+                System.arraycopy(buf, 0, result, 0, totalRead);
+                return result;
+            }
+        }
+
+        private boolean fillFromTailCache(FooterByteCache tailCache, long pos, int toRead) {
+            byte[] cached = tailCache.get(cacheKey);
+            return cached != null && fillFromCachedTail(cached, pos, toRead);
+        }
+
+        private boolean fillFromCachedTail(byte[] cached, long pos, int toRead) {
+            long cachedStart = length - cached.length;
+            if (pos >= cachedStart && pos + toRead <= length) {
+                int from = (int) (pos - cachedStart);
+                windowStart = -1;
+                windowLength = 0;
+                System.arraycopy(cached, from, window, 0, toRead);
+                windowStart = pos;
+                windowLength = toRead;
+                return true;
+            }
+            return false;
         }
 
         /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -78,6 +78,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapterTests.java
@@ -49,6 +49,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class ParquetStorageObjectAdapterTests extends ESTestCase {
 
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        ParquetStorageObjectAdapter.clearFooterCacheForTests();
+    }
+
     public void testNullStorageObjectThrowsException() {
         QlIllegalArgumentException e = expectThrows(QlIllegalArgumentException.class, () -> new ParquetStorageObjectAdapter(null));
         assertEquals("storageObject cannot be null", e.getMessage());
@@ -577,7 +583,8 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             stream.seek(tailStart);
             stream.readFully(second);
         }
-        assertEquals(2, rangeReadCount[0]);
+        // Second tail read is served from the JVM-wide FooterByteCache — no additional range read
+        assertEquals(1, rangeReadCount[0]);
         assertArrayEquals(first, second);
     }
 
@@ -1250,7 +1257,8 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
             s.readFully(w);
             assertArrayEquals(expected, w);
         }
-        assertEquals("Second adapter should issue its own tail range read", 2, rangeReadCount[0]);
+        // Both adapters share the same (path, length) cache key, so the second read is a cache hit
+        assertEquals("FooterByteCache coalesces reads for same path+length", 1, rangeReadCount[0]);
     }
 
     /**
@@ -1337,7 +1345,9 @@ public class ParquetStorageObjectAdapterTests extends ESTestCase {
         if (failure != null) {
             throw failure;
         }
-        assertEquals("Each of 8 concurrent tail reads should open its own range stream", 8, rangeReadCount.get());
+        // FooterByteCache provides thundering-herd protection: concurrent tail reads for the same
+        // (path, length) coalesce into a single I/O via Cache.computeIfAbsent
+        assertEquals("FooterByteCache should coalesce concurrent tail reads into one range read", 1, rangeReadCount.get());
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCache.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCache.java
@@ -66,6 +66,8 @@ public class FooterByteCache {
      * Entries expire after this many seconds of inactivity. Chosen to comfortably cover the
      * duration of a single query (where concurrent splits keep the entry alive via access-time
      * resets) while ensuring that file modifications between queries trigger a fresh read.
+     * Hard-coded for now; worth exposing as a {@code Setting.timeSetting} when this cache
+     * graduates from a temporary static singleton to a proper cluster service.
      */
     static final long EXPIRE_AFTER_ACCESS_SECONDS = 30;
 
@@ -73,9 +75,18 @@ public class FooterByteCache {
      * Cache key identifying a file by its storage path and total length. Uses {@code (path, length)}
      * only — not {@code lastModified} — so that all range splits of the same file share one cache
      * entry regardless of any timing jitter in {@code StorageObject.lastModified()}.
-     * Callers must use a consistent, canonical path representation (e.g. normalized URI).
      */
-    public record Key(String path, long fileLength) {}
+    public record Key(String path, long fileLength) {
+
+        /**
+         * Creates a key from a {@link org.elasticsearch.xpack.esql.datasources.spi.StorageObject},
+         * using its path string as the canonical identifier. All callers should prefer this factory
+         * over constructing {@code Key} directly so that path canonicalization happens in one place.
+         */
+        public static Key keyFor(org.elasticsearch.xpack.esql.datasources.spi.StorageObject storageObject, long length) {
+            return new Key(storageObject.path().toString(), length);
+        }
+    }
 
     private static final FooterByteCache INSTANCE = new FooterByteCache(DEFAULT_MAX_BYTES, DEFAULT_MAX_ENTRY_BYTES);
 
@@ -108,6 +119,10 @@ public class FooterByteCache {
      *
      * <p>If the loaded entry is empty or exceeds {@link #maxEntryBytes()}, it is returned to the
      * caller but immediately evicted so it does not consume cache budget or prevent future loads.
+     * This means oversized entries briefly occupy the cache between {@code computeIfAbsent} and
+     * {@code invalidate}. The alternative — manual {@code get}/{@code put} — was rejected because
+     * it loses thundering-herd protection for <em>all</em> first loads: N concurrent callers
+     * seeing {@code get(key) == null} would each invoke the loader independently.
      *
      * @throws ExecutionException if the loader throws an exception or returns null
      */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCache.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCache.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.common.cache.CacheLoader;
+import org.elasticsearch.core.TimeValue;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * JVM-wide cache for file footer bytes (Parquet footers, ORC postscripts) shared across columnar
+ * format readers. Backed by the Elasticsearch {@link Cache} utility which provides:
+ * <ul>
+ *   <li>LRU eviction with a configurable byte budget via {@link CacheBuilder#setMaximumWeight}</li>
+ *   <li>Thundering-herd protection via {@link Cache#computeIfAbsent} — concurrent callers for the
+ *       same key coalesce into a single load; exactly one thread performs I/O while others wait
+ *       for the result</li>
+ *   <li>Time-based expiration via {@link CacheBuilder#setExpireAfterAccess} — entries expire after
+ *       {@value #EXPIRE_AFTER_ACCESS_SECONDS}s of inactivity so that file modifications between
+ *       queries are detected. Within a single query, concurrent splits keep the entry alive by
+ *       resetting the access timer on every read.</li>
+ * </ul>
+ *
+ * <h2>Why a JVM-wide singleton instead of per-query / per-reader?</h2>
+ * A per-query cache would avoid cross-query staleness entirely (no need for TTL) and is the
+ * cleaner design. However, the current architecture makes it impractical:
+ * <ol>
+ *   <li>A single query fans out into ~N independent split readers (one per thread), each of which
+ *       creates its own {@code ParquetStorageObjectAdapter} or {@code OrcStorageObjectAdapter}.
+ *       These adapters share no common parent or query-scoped context — they are created deep in
+ *       the format reader call chain ({@code FormatReader.read(StorageObject, ...)}) with no
+ *       mechanism to pass shared state between them.</li>
+ *   <li>The thundering-herd benefit requires a single cache visible to all concurrent split readers.
+ *       Without a shared object, each adapter would issue its own tail read — exactly the redundant
+ *       I/O this cache exists to prevent.</li>
+ * </ol>
+ * When a query-scoped context is introduced into the format reader API, this cache should migrate
+ * from a static singleton to an instance held by that context. Until then, the access-based TTL
+ * ({@value #EXPIRE_AFTER_ACCESS_SECONDS}s) bounds cross-query staleness.
+ *
+ * <h2>Cache key design</h2>
+ * The key is {@code (path, fileLength)}. Adding {@code lastModified} was considered but rejected
+ * because range splits are created via {@code StorageProvider.newObject(path, length)} with no
+ * pre-populated modification time — calling {@code lastModified()} would trigger an extra HEAD
+ * request per split, defeating the purpose of the cache. The access-based TTL provides bounded
+ * staleness instead.
+ *
+ * <p>Cached {@code byte[]} entries must be treated as immutable by all callers.
+ */
+public class FooterByteCache {
+
+    /** Default cache budget across the JVM (8 MiB). */
+    public static final long DEFAULT_MAX_BYTES = 8L * 1024 * 1024;
+
+    /** Default max single entry (2 MiB). Prevents caching unusually large footers. */
+    public static final long DEFAULT_MAX_ENTRY_BYTES = 2L * 1024 * 1024;
+
+    /**
+     * Entries expire after this many seconds of inactivity. Chosen to comfortably cover the
+     * duration of a single query (where concurrent splits keep the entry alive via access-time
+     * resets) while ensuring that file modifications between queries trigger a fresh read.
+     */
+    static final long EXPIRE_AFTER_ACCESS_SECONDS = 30;
+
+    /**
+     * Cache key identifying a file by its storage path and total length. Uses {@code (path, length)}
+     * only — not {@code lastModified} — so that all range splits of the same file share one cache
+     * entry regardless of any timing jitter in {@code StorageObject.lastModified()}.
+     * Callers must use a consistent, canonical path representation (e.g. normalized URI).
+     */
+    public record Key(String path, long fileLength) {}
+
+    private static final FooterByteCache INSTANCE = new FooterByteCache(DEFAULT_MAX_BYTES, DEFAULT_MAX_ENTRY_BYTES);
+
+    private final Cache<Key, byte[]> cache;
+    private final long maxEntryBytes;
+
+    FooterByteCache(long maxBytes, long maxEntryBytes) {
+        this.maxEntryBytes = maxEntryBytes;
+        this.cache = CacheBuilder.<Key, byte[]>builder()
+            .setMaximumWeight(maxBytes)
+            .setExpireAfterAccess(TimeValue.timeValueSeconds(EXPIRE_AFTER_ACCESS_SECONDS))
+            .weigher((key, value) -> value.length)
+            .build();
+    }
+
+    /** Returns the JVM-wide singleton instance. */
+    public static FooterByteCache getInstance() {
+        return INSTANCE;
+    }
+
+    /** Maximum byte size for a single cache entry. */
+    public long maxEntryBytes() {
+        return maxEntryBytes;
+    }
+
+    /**
+     * Returns cached footer bytes for the given key, or loads them via the provided loader.
+     * The loader is invoked at most once per key, even under concurrent access — additional
+     * callers for the same key wait until the first load completes.
+     *
+     * <p>If the loaded entry is empty or exceeds {@link #maxEntryBytes()}, it is returned to the
+     * caller but immediately evicted so it does not consume cache budget or prevent future loads.
+     *
+     * @throws ExecutionException if the loader throws an exception or returns null
+     */
+    public byte[] getOrLoad(Key key, CacheLoader<Key, byte[]> loader) throws ExecutionException {
+        byte[] result = cache.computeIfAbsent(key, loader);
+        if (result.length == 0 || result.length > maxEntryBytes) {
+            cache.invalidate(key);
+        }
+        return result;
+    }
+
+    /**
+     * Returns cached footer bytes or {@code null} if not present. Does not start a load,
+     * but may block briefly if another thread is currently loading the same key.
+     */
+    public byte[] get(Key key) {
+        return cache.get(key);
+    }
+
+    /**
+     * Stores footer bytes directly, e.g. from an opportunistic read that reached the end of
+     * a file. Entries larger than {@link #maxEntryBytes()} are silently skipped.
+     */
+    public void put(Key key, byte[] bytes) {
+        if (bytes.length > 0 && bytes.length <= maxEntryBytes) {
+            cache.put(key, bytes);
+        }
+    }
+
+    /** Removes all entries. Intended for test isolation. */
+    public void invalidateAll() {
+        cache.invalidateAll();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCacheTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/FooterByteCacheTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class FooterByteCacheTests extends ESTestCase {
+
+    private FooterByteCache cache;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        FooterByteCache.getInstance().invalidateAll();
+        cache = new FooterByteCache(1024 * 1024, 512 * 1024);
+    }
+
+    public void testGetReturnsNullOnMiss() {
+        FooterByteCache.Key key = new FooterByteCache.Key("file.parquet", 1000);
+        assertNull(cache.get(key));
+    }
+
+    public void testPutAndGet() {
+        FooterByteCache.Key key = new FooterByteCache.Key("file.parquet", 1000);
+        byte[] data = randomByteArrayOfLength(256);
+        cache.put(key, data);
+        assertArrayEquals(data, cache.get(key));
+    }
+
+    public void testPutSkipsOversizedEntries() {
+        FooterByteCache cache = new FooterByteCache(1024 * 1024, 100);
+        FooterByteCache.Key key = new FooterByteCache.Key("file.parquet", 1000);
+        byte[] oversized = randomByteArrayOfLength(200);
+        cache.put(key, oversized);
+        assertNull(cache.get(key));
+    }
+
+    public void testGetOrLoadPopulatesCache() throws ExecutionException {
+        FooterByteCache.Key key = new FooterByteCache.Key("file.parquet", 1000);
+        byte[] expected = randomByteArrayOfLength(256);
+        byte[] result = cache.getOrLoad(key, k -> expected);
+        assertArrayEquals(expected, result);
+        assertArrayEquals(expected, cache.get(key));
+    }
+
+    public void testGetOrLoadEvictsOversizedEntries() throws ExecutionException {
+        FooterByteCache smallMaxEntry = new FooterByteCache(1024 * 1024, 100);
+        FooterByteCache.Key key = new FooterByteCache.Key("file.parquet", 1000);
+        byte[] oversized = randomByteArrayOfLength(200);
+
+        byte[] result = smallMaxEntry.getOrLoad(key, k -> oversized);
+        assertArrayEquals(oversized, result);
+        assertNull("Oversized entry should be evicted after getOrLoad", smallMaxEntry.get(key));
+    }
+
+    public void testGetOrLoadEvictsEmptyEntries() throws ExecutionException {
+        FooterByteCache.Key key = new FooterByteCache.Key("file.parquet", 1000);
+        byte[] result = cache.getOrLoad(key, k -> new byte[0]);
+        assertEquals(0, result.length);
+        assertNull("Empty entry should be evicted after getOrLoad", cache.get(key));
+    }
+
+    public void testLruEviction() {
+        FooterByteCache tinyCache = new FooterByteCache(300, 200);
+        byte[] data1 = randomByteArrayOfLength(150);
+        byte[] data2 = randomByteArrayOfLength(150);
+        byte[] data3 = randomByteArrayOfLength(150);
+
+        FooterByteCache.Key key1 = new FooterByteCache.Key("a.parquet", 1000);
+        FooterByteCache.Key key2 = new FooterByteCache.Key("b.parquet", 2000);
+        FooterByteCache.Key key3 = new FooterByteCache.Key("c.parquet", 3000);
+
+        tinyCache.put(key1, data1);
+        tinyCache.put(key2, data2);
+        tinyCache.put(key3, data3);
+
+        assertNull("Oldest entry should be evicted", tinyCache.get(key1));
+        assertNotNull(tinyCache.get(key3));
+    }
+
+    public void testInvalidateAll() {
+        FooterByteCache.Key key = new FooterByteCache.Key("file.parquet", 1000);
+        cache.put(key, randomByteArrayOfLength(100));
+        assertNotNull(cache.get(key));
+        cache.invalidateAll();
+        assertNull(cache.get(key));
+    }
+
+    public void testSamePathDifferentLengthAreDifferentKeys() {
+        FooterByteCache.Key key1 = new FooterByteCache.Key("file.parquet", 1000);
+        FooterByteCache.Key key2 = new FooterByteCache.Key("file.parquet", 2000);
+        byte[] data1 = randomByteArrayOfLength(100);
+        byte[] data2 = randomByteArrayOfLength(100);
+
+        cache.put(key1, data1);
+        cache.put(key2, data2);
+
+        assertArrayEquals(data1, cache.get(key1));
+        assertArrayEquals(data2, cache.get(key2));
+    }
+
+    public void testSamePathSameLengthSharesCacheEntry() throws ExecutionException {
+        FooterByteCache.Key key1 = new FooterByteCache.Key("file.parquet", 1000);
+        FooterByteCache.Key key2 = new FooterByteCache.Key("file.parquet", 1000);
+        byte[] data = randomByteArrayOfLength(100);
+
+        cache.getOrLoad(key1, k -> data);
+        AtomicInteger loadCount = new AtomicInteger();
+        byte[] result = cache.getOrLoad(key2, k -> {
+            loadCount.incrementAndGet();
+            return randomByteArrayOfLength(100);
+        });
+
+        assertEquals("Loader should not have been called for existing key", 0, loadCount.get());
+        assertArrayEquals(data, result);
+    }
+
+    /**
+     * Verifies thundering-herd protection: concurrent getOrLoad calls for the same key
+     * invoke the loader exactly once.
+     */
+    public void testThunderingHerdCoalescesConcurrentLoads() throws Exception {
+        FooterByteCache.Key key = new FooterByteCache.Key("shared.parquet", 5000);
+        byte[] expected = randomByteArrayOfLength(256);
+        AtomicInteger loadCount = new AtomicInteger();
+        CountDownLatch start = new CountDownLatch(1);
+        int threadCount = randomIntBetween(4, 16);
+        AtomicReference<AssertionError> failure = new AtomicReference<>();
+        List<Thread> threads = new ArrayList<>(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            Thread t = new Thread(() -> {
+                try {
+                    start.await(10, TimeUnit.SECONDS);
+                    byte[] result = cache.getOrLoad(key, k -> {
+                        loadCount.incrementAndGet();
+                        return expected;
+                    });
+                    assertArrayEquals(expected, result);
+                } catch (AssertionError e) {
+                    failure.compareAndSet(null, e);
+                } catch (Exception e) {
+                    failure.compareAndSet(null, new AssertionError("Unexpected exception", e));
+                }
+            }, "herd-" + i);
+            t.start();
+            threads.add(t);
+        }
+
+        start.countDown();
+        for (Thread t : threads) {
+            t.join(TimeUnit.SECONDS.toMillis(10));
+            assertFalse("Thread " + t.getName() + " did not finish in time", t.isAlive());
+        }
+
+        AssertionError err = failure.get();
+        if (err != null) {
+            throw err;
+        }
+        assertEquals("Loader should have been called exactly once", 1, loadCount.get());
+    }
+
+    public void testGetOrLoadPropagatesLoaderException() {
+        FooterByteCache.Key key = new FooterByteCache.Key("bad.parquet", 1000);
+        ExecutionException ex = expectThrows(ExecutionException.class, () -> cache.getOrLoad(key, k -> {
+            throw new RuntimeException("simulated I/O failure");
+        }));
+        assertNotNull(ex.getCause());
+        assertEquals("simulated I/O failure", ex.getCause().getMessage());
+    }
+
+    public void testSingletonInstance() {
+        FooterByteCache instance1 = FooterByteCache.getInstance();
+        FooterByteCache instance2 = FooterByteCache.getInstance();
+        assertSame(instance1, instance2);
+    }
+}


### PR DESCRIPTION
Replace the custom FooterCache in ParquetStorageObjectAdapter with a
shared MetadataByteCache backed by ES's Cache utility, which provides
LRU eviction with byte budget and thundering-herd protection via
computeIfAbsent. Wire the same cache into OrcStorageObjectAdapter's
positioned reads so both formats benefit from cached file tails.

This eliminates ~80 lines of hand-rolled LRU/eviction/CompletableFuture
code and replaces it with ~5 lines delegating to the battle-tested ES
Cache. Both the default direct-read path and the windowed path in
Parquet now consult the cache for tail reads.

Developed with AI-assisted tooling