### PR TITLE
Add missing normalizer_skip_store feature check to test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -343,9 +343,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=mapping/20_synthetic_source/synthetic_source text with ignored multi-field and multiple values in the same doc}
   issue: https://github.com/elastic/elasticsearch/issues/147064
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mapping/20_synthetic_source/synthetic_source text with normalized keyword with default skip store original value}
-  issue: https://github.com/elastic/elasticsearch/issues/147064
 - class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
   method: test {yaml=rrf/310_rrf_retriever_simplified/Expansion to equivalent custom sub-retrievers returns the same results}
   issue: https://github.com/elastic/elasticsearch/issues/146464

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
@@ -317,7 +317,7 @@ synthetic_source text with normalized keyword with skip store original value:
 ---
 synthetic_source text with normalized keyword with default skip store original value:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.keyword.normalizer_skip_store_setting"]
       reason: "Source mode configured through index setting"
 
   - do:


### PR DESCRIPTION
Missed a test in #147075, this PR adds the check to that test.