### PR TITLE
[ESQL] Widen numeric stats values during merge for UNION_BY_NAME

### DIFF
--- a/docs/changelog/147502.yaml
+++ b/docs/changelog/147502.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147502
+summary: Widen numeric stats values during merge for UNION_BY_NAME
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -13,10 +13,12 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 
 /**
  * Serializes and deserializes {@link SourceStatistics} to/from a flat {@code Map<String, Object>}
@@ -216,6 +218,8 @@ public final class SourceStatisticsSerializer {
         Map<String, Comparable[]> mins = new HashMap<>();
         Map<String, Comparable[]> maxs = new HashMap<>();
         Map<String, long[]> colSizeBytes = new HashMap<>();
+        Set<String> poisonedMins = new HashSet<>();
+        Set<String> poisonedMaxs = new HashSet<>();
 
         for (Map<String, Object> stats : splitStats) {
             if (stats == null || stats.containsKey(STATS_ROW_COUNT) == false) {
@@ -239,33 +243,34 @@ public final class SourceStatisticsSerializer {
                         return a;
                     });
                 } else if (key.endsWith(MIN_SUFFIX) && entry.getValue() instanceof Comparable c) {
-                    mins.merge(key, new Comparable[] { c }, (a, b) -> {
-                        if (a[0].getClass() == b[0].getClass()) {
-                            if (a[0].compareTo(b[0]) > 0) a[0] = b[0];
-                        } else {
-                            Object[] widened = SplitStats.widenNumericPair(a[0], b[0]);
-                            if (widened != null) {
-                                Comparable wA = (Comparable) widened[0];
-                                Comparable wB = (Comparable) widened[1];
-                                a[0] = wA.compareTo(wB) <= 0 ? (Comparable) widened[0] : (Comparable) widened[1];
+                    if (poisonedMins.contains(key) == false) {
+                        // Map.merge removes the entry when the remapping function returns null
+                        mins.merge(key, new Comparable[] { c }, (a, b) -> {
+                            Object merged = SplitStats.mergedMin(a[0], b[0]);
+                            if (merged == null) {
+                                return null;
                             }
+                            a[0] = (Comparable) merged;
+                            return a;
+                        });
+                        if (mins.containsKey(key) == false) {
+                            poisonedMins.add(key);
                         }
-                        return a;
-                    });
+                    }
                 } else if (key.endsWith(MAX_SUFFIX) && entry.getValue() instanceof Comparable c) {
-                    maxs.merge(key, new Comparable[] { c }, (a, b) -> {
-                        if (a[0].getClass() == b[0].getClass()) {
-                            if (a[0].compareTo(b[0]) < 0) a[0] = b[0];
-                        } else {
-                            Object[] widened = SplitStats.widenNumericPair(a[0], b[0]);
-                            if (widened != null) {
-                                Comparable wA = (Comparable) widened[0];
-                                Comparable wB = (Comparable) widened[1];
-                                a[0] = wA.compareTo(wB) >= 0 ? (Comparable) widened[0] : (Comparable) widened[1];
+                    if (poisonedMaxs.contains(key) == false) {
+                        maxs.merge(key, new Comparable[] { c }, (a, b) -> {
+                            Object merged = SplitStats.mergedMax(a[0], b[0]);
+                            if (merged == null) {
+                                return null;
                             }
+                            a[0] = (Comparable) merged;
+                            return a;
+                        });
+                        if (maxs.containsKey(key) == false) {
+                            poisonedMaxs.add(key);
                         }
-                        return a;
-                    });
+                    }
                 } else if (key.endsWith(SIZE_BYTES_SUFFIX) && entry.getValue() instanceof Number sbNum) {
                     colSizeBytes.merge(key, new long[] { sbNum.longValue() }, (a, b) -> {
                         a[0] += b[0];

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -240,14 +240,30 @@ public final class SourceStatisticsSerializer {
                     });
                 } else if (key.endsWith(MIN_SUFFIX) && entry.getValue() instanceof Comparable c) {
                     mins.merge(key, new Comparable[] { c }, (a, b) -> {
-                        int cmp = a[0].compareTo(b[0]);
-                        if (cmp > 0) a[0] = b[0];
+                        if (a[0].getClass() == b[0].getClass()) {
+                            if (a[0].compareTo(b[0]) > 0) a[0] = b[0];
+                        } else {
+                            Object[] widened = SplitStats.widenNumericPair(a[0], b[0]);
+                            if (widened != null) {
+                                Comparable wA = (Comparable) widened[0];
+                                Comparable wB = (Comparable) widened[1];
+                                a[0] = wA.compareTo(wB) <= 0 ? (Comparable) widened[0] : (Comparable) widened[1];
+                            }
+                        }
                         return a;
                     });
                 } else if (key.endsWith(MAX_SUFFIX) && entry.getValue() instanceof Comparable c) {
                     maxs.merge(key, new Comparable[] { c }, (a, b) -> {
-                        int cmp = a[0].compareTo(b[0]);
-                        if (cmp < 0) a[0] = b[0];
+                        if (a[0].getClass() == b[0].getClass()) {
+                            if (a[0].compareTo(b[0]) < 0) a[0] = b[0];
+                        } else {
+                            Object[] widened = SplitStats.widenNumericPair(a[0], b[0]);
+                            if (widened != null) {
+                                Comparable wA = (Comparable) widened[0];
+                                Comparable wB = (Comparable) widened[1];
+                                a[0] = wA.compareTo(wB) >= 0 ? (Comparable) widened[0] : (Comparable) widened[1];
+                            }
+                        }
                         return a;
                     });
                 } else if (key.endsWith(SIZE_BYTES_SUFFIX) && entry.getValue() instanceof Number sbNum) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -279,49 +280,74 @@ public final class SplitStats implements Writeable {
     }
 
     /**
-     * Widens two numeric stat values to a common Java type for safe comparison. Returns a
-     * 2-element array {@code [widenedA, widenedB]} with both values promoted to the same type,
-     * or {@code null} if the types are incompatible.
+     * Merges two min stat values with cross-type numeric widening. Handles nulls: if one side
+     * is null the other is returned. Returns {@code null} when both inputs are non-null but
+     * incompatible (e.g. Long + Double) — callers should treat this as "unknown" and clear
+     * the stat so it is not fed into stats-driven optimizations with a wrong value.
      * <p>
-     * Widening rules (mirroring {@link SchemaReconciliation#schemaWiden}):
-     * <ul>
-     *   <li>Integer + Long → both as Long (lossless: int32 ⊆ int64)</li>
-     *   <li>Integer + Double → both as Double (lossless: int32 ≤ 2^31 &lt; 2^53)</li>
-     *   <li>Integer + Float → both as Double (int32 fits in double; float ⊂ double)</li>
-     *   <li>Float + Double → both as Double (float ⊂ double)</li>
-     * </ul>
-     * Long + Double and Long + Float return {@code null} because long → double is lossy above 2^53.
+     * Covers {@link SchemaReconciliation#schemaWiden} cases at the stats-value level
+     * (Integer+Long→Long, Integer+Double→Double), plus Parquet FLOAT vs DOUBLE which both
+     * map to ESQL {@code DOUBLE} at the schema level but retain distinct Java stat types.
+     * Long+Double and Long+Float are intentionally incompatible (lossy above 2^53).
+     * DATETIME/DATE_NANOS is not handled — both are {@code Long} at the Java level so
+     * the same-class fast path covers them; if different epoch resolutions ever surface
+     * as different Java types in stats, they will fall through to the incompatible path.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Nullable
+    static Object mergedMin(@Nullable Object existing, @Nullable Object incoming) {
+        if (existing == null) return incoming;
+        if (incoming == null) return existing;
+        if (existing.getClass() == incoming.getClass()) {
+            if (existing instanceof Comparable c) {
+                return c.compareTo(incoming) <= 0 ? existing : incoming;
+            }
+            return null;
+        }
+        return crossTypeExtremum(existing, incoming, true);
+    }
+
+    /**
+     * Merges two max stat values with cross-type numeric widening. Same contract as
+     * {@link #mergedMin} — returns {@code null} for incompatible non-null inputs.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Nullable
+    static Object mergedMax(@Nullable Object existing, @Nullable Object incoming) {
+        if (existing == null) return incoming;
+        if (incoming == null) return existing;
+        if (existing.getClass() == incoming.getClass()) {
+            if (existing instanceof Comparable c) {
+                return c.compareTo(incoming) >= 0 ? existing : incoming;
+            }
+            return null;
+        }
+        return crossTypeExtremum(existing, incoming, false);
+    }
+
+    /**
+     * Selects the min ({@code selectMin=true}) or max of two values whose Java types differ,
+     * promoting both to a common numeric type. Returns the winner in the widened type, or
+     * {@code null} if the pair is incompatible. Zero-allocation beyond the return-value autobox.
      */
     @Nullable
-    static Object[] widenNumericPair(Object a, Object b) {
-        if (a instanceof Integer ai) {
-            if (b instanceof Long) {
-                return new Object[] { ai.longValue(), b };
-            }
-            if (b instanceof Double) {
-                return new Object[] { ai.doubleValue(), b };
-            }
-            if (b instanceof Float bf) {
-                return new Object[] { ai.doubleValue(), bf.doubleValue() };
-            }
-        } else if (a instanceof Long) {
-            if (b instanceof Integer bi) {
-                return new Object[] { a, bi.longValue() };
-            }
-        } else if (a instanceof Float af) {
-            if (b instanceof Double) {
-                return new Object[] { af.doubleValue(), b };
-            }
-            if (b instanceof Integer bi) {
-                return new Object[] { af.doubleValue(), bi.doubleValue() };
-            }
-        } else if (a instanceof Double) {
-            if (b instanceof Integer bi) {
-                return new Object[] { a, bi.doubleValue() };
-            }
-            if (b instanceof Float bf) {
-                return new Object[] { a, bf.doubleValue() };
-            }
+    private static Object crossTypeExtremum(Object a, Object b, boolean selectMin) {
+        if (a instanceof Integer ai && b instanceof Long bl) {
+            long la = ai.longValue();
+            return (selectMin ? la <= bl : la >= bl) ? la : bl;
+        }
+        if (a instanceof Long al && b instanceof Integer bi) {
+            long lb = bi.longValue();
+            return (selectMin ? al <= lb : al >= lb) ? al : lb;
+        }
+        // Long + Double/Float is intentionally incompatible (lossy above 2^53)
+        if (a instanceof Long || b instanceof Long) {
+            return null;
+        }
+        // Remaining pairs: Integer, Float, Double — all safely promotable to double
+        if (a instanceof Number na && b instanceof Number nb) {
+            double da = na.doubleValue(), db = nb.doubleValue();
+            return (selectMin ? da <= db : da >= db) ? da : db;
         }
         return null;
     }
@@ -334,14 +360,14 @@ public final class SplitStats implements Writeable {
      * <p>
      * When min/max values have different numeric Java types across splits (e.g. {@code Integer}
      * from a Parquet INT32 file vs {@code Long} from an INT64 file after UNION_BY_NAME widening),
-     * both values are promoted to a common type via {@link #widenNumericPair} before comparison.
-     * For incompatible types (e.g. Long + Double), the existing accumulated value is retained
-     * and the new value is skipped. This makes the result order-dependent for incompatible pairs;
-     * the value from whichever split appears first in the list wins.
+     * both values are promoted to a common type via {@link #mergedMin}/{@link #mergedMax}.
+     * Incompatible types (e.g. Long + Double) cause the stat to be cleared to {@code null},
+     * preventing wrong-result pushdown. This should not happen when
+     * {@link SchemaReconciliation#schemaWiden} has correctly unified the schema and indicates
+     * a bug worth investigating.
      *
      * @return the merged stats, or {@code null} if the list is null or empty
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Nullable
     public static SplitStats merge(List<SplitStats> statsList) {
         if (statsList == null || statsList.isEmpty()) {
@@ -356,6 +382,8 @@ public final class SplitStats implements Writeable {
         boolean hasSize = false;
         Map<String, Integer> columnOrdinals = new LinkedHashMap<>();
         StringBuilder nameBuf = new StringBuilder();
+        BitSet poisonedMins = new BitSet();
+        BitSet poisonedMaxs = new BitSet();
 
         for (SplitStats stats : statsList) {
             totalRows += stats.rowCount;
@@ -381,57 +409,41 @@ public final class SplitStats implements Writeable {
                     if (existingNc >= 0 && newNc >= 0) {
                         builder.nullCount(ord, existingNc + newNc);
                     }
-                    // Min of mins (widen numeric types if needed)
-                    Object existingMin = builder.minsList.get(ord);
-                    Object newMin = stats.mins[i];
-                    if (existingMin != null && newMin != null) {
-                        if (existingMin instanceof Comparable eMin
-                            && newMin instanceof Comparable nMin
-                            && existingMin.getClass() == newMin.getClass()) {
-                            builder.min(ord, eMin.compareTo(nMin) <= 0 ? existingMin : newMin);
-                        } else {
-                            Object[] widened = widenNumericPair(existingMin, newMin);
-                            if (widened != null) {
-                                Comparable wA = (Comparable) widened[0];
-                                Comparable wB = (Comparable) widened[1];
-                                builder.min(ord, wA.compareTo(wB) <= 0 ? widened[0] : widened[1]);
-                            } else {
-                                logger.trace(
-                                    "retaining existing min for column [{}]: incompatible types [{}/{}]",
+                    // Min of mins (widen numeric types if needed; null on incompatible)
+                    if (poisonedMins.get(ord) == false) {
+                        Object existingMin = builder.minsList.get(ord);
+                        Object newMin = stats.mins[i];
+                        Object merged = mergedMin(existingMin, newMin);
+                        if (merged == null && existingMin != null && newMin != null) {
+                            poisonedMins.set(ord);
+                            if (existingMin.getClass() != newMin.getClass()) {
+                                logger.warn(
+                                    "clearing min stat for column [{}]: incompatible types [{}/{}]",
                                     colName,
                                     existingMin.getClass().getSimpleName(),
                                     newMin.getClass().getSimpleName()
                                 );
                             }
                         }
-                    } else if (newMin != null) {
-                        builder.min(ord, newMin);
+                        builder.min(ord, merged);
                     }
-                    // Max of maxes (widen numeric types if needed)
-                    Object existingMax = builder.maxsList.get(ord);
-                    Object newMax = stats.maxs[i];
-                    if (existingMax != null && newMax != null) {
-                        if (existingMax instanceof Comparable eMax
-                            && newMax instanceof Comparable nMax
-                            && existingMax.getClass() == newMax.getClass()) {
-                            builder.max(ord, eMax.compareTo(nMax) >= 0 ? existingMax : newMax);
-                        } else {
-                            Object[] widened = widenNumericPair(existingMax, newMax);
-                            if (widened != null) {
-                                Comparable wA = (Comparable) widened[0];
-                                Comparable wB = (Comparable) widened[1];
-                                builder.max(ord, wA.compareTo(wB) >= 0 ? widened[0] : widened[1]);
-                            } else {
-                                logger.trace(
-                                    "retaining existing max for column [{}]: incompatible types [{}/{}]",
+                    // Max of maxes (widen numeric types if needed; null on incompatible)
+                    if (poisonedMaxs.get(ord) == false) {
+                        Object existingMax = builder.maxsList.get(ord);
+                        Object newMax = stats.maxs[i];
+                        Object merged = mergedMax(existingMax, newMax);
+                        if (merged == null && existingMax != null && newMax != null) {
+                            poisonedMaxs.set(ord);
+                            if (existingMax.getClass() != newMax.getClass()) {
+                                logger.warn(
+                                    "clearing max stat for column [{}]: incompatible types [{}/{}]",
                                     colName,
                                     existingMax.getClass().getSimpleName(),
                                     newMax.getClass().getSimpleName()
                                 );
                             }
                         }
-                    } else if (newMax != null) {
-                        builder.max(ord, newMax);
+                        builder.max(ord, merged);
                     }
                     // Sum sizes
                     long existingSb = builder.sizesBytesList.get(ord);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
@@ -11,6 +11,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 
 import java.io.IOException;
@@ -36,6 +38,8 @@ import java.util.Objects;
  * request processing thread.
  */
 public final class SplitStats implements Writeable {
+
+    private static final Logger logger = LogManager.getLogger(SplitStats.class);
 
     /** Empty stats with zero rows and no columns. */
     public static final SplitStats EMPTY = new SplitStats(
@@ -275,10 +279,65 @@ public final class SplitStats implements Writeable {
     }
 
     /**
+     * Widens two numeric stat values to a common Java type for safe comparison. Returns a
+     * 2-element array {@code [widenedA, widenedB]} with both values promoted to the same type,
+     * or {@code null} if the types are incompatible.
+     * <p>
+     * Widening rules (mirroring {@link SchemaReconciliation#schemaWiden}):
+     * <ul>
+     *   <li>Integer + Long → both as Long (lossless: int32 ⊆ int64)</li>
+     *   <li>Integer + Double → both as Double (lossless: int32 ≤ 2^31 &lt; 2^53)</li>
+     *   <li>Integer + Float → both as Double (int32 fits in double; float ⊂ double)</li>
+     *   <li>Float + Double → both as Double (float ⊂ double)</li>
+     * </ul>
+     * Long + Double and Long + Float return {@code null} because long → double is lossy above 2^53.
+     */
+    @Nullable
+    static Object[] widenNumericPair(Object a, Object b) {
+        if (a instanceof Integer ai) {
+            if (b instanceof Long) {
+                return new Object[] { ai.longValue(), b };
+            }
+            if (b instanceof Double) {
+                return new Object[] { ai.doubleValue(), b };
+            }
+            if (b instanceof Float bf) {
+                return new Object[] { ai.doubleValue(), bf.doubleValue() };
+            }
+        } else if (a instanceof Long) {
+            if (b instanceof Integer bi) {
+                return new Object[] { a, bi.longValue() };
+            }
+        } else if (a instanceof Float af) {
+            if (b instanceof Double) {
+                return new Object[] { af.doubleValue(), b };
+            }
+            if (b instanceof Integer bi) {
+                return new Object[] { af.doubleValue(), bi.doubleValue() };
+            }
+        } else if (a instanceof Double) {
+            if (b instanceof Integer bi) {
+                return new Object[] { a, bi.doubleValue() };
+            }
+            if (b instanceof Float bf) {
+                return new Object[] { a, bf.doubleValue() };
+            }
+        }
+        return null;
+    }
+
+    /**
      * Merges multiple {@link SplitStats} instances into a single one. Row counts and column
      * sizes are summed, null counts are summed, mins take the minimum, maxes take the maximum.
      * Columns present in some splits but not others are included in the result with partial
      * data from the splits where they appear.
+     * <p>
+     * When min/max values have different numeric Java types across splits (e.g. {@code Integer}
+     * from a Parquet INT32 file vs {@code Long} from an INT64 file after UNION_BY_NAME widening),
+     * both values are promoted to a common type via {@link #widenNumericPair} before comparison.
+     * For incompatible types (e.g. Long + Double), the existing accumulated value is retained
+     * and the new value is skipped. This makes the result order-dependent for incompatible pairs;
+     * the value from whichever split appears first in the list wins.
      *
      * @return the merged stats, or {@code null} if the list is null or empty
      */
@@ -322,7 +381,7 @@ public final class SplitStats implements Writeable {
                     if (existingNc >= 0 && newNc >= 0) {
                         builder.nullCount(ord, existingNc + newNc);
                     }
-                    // Min of mins (only compare values of the same type)
+                    // Min of mins (widen numeric types if needed)
                     Object existingMin = builder.minsList.get(ord);
                     Object newMin = stats.mins[i];
                     if (existingMin != null && newMin != null) {
@@ -330,11 +389,25 @@ public final class SplitStats implements Writeable {
                             && newMin instanceof Comparable nMin
                             && existingMin.getClass() == newMin.getClass()) {
                             builder.min(ord, eMin.compareTo(nMin) <= 0 ? existingMin : newMin);
+                        } else {
+                            Object[] widened = widenNumericPair(existingMin, newMin);
+                            if (widened != null) {
+                                Comparable wA = (Comparable) widened[0];
+                                Comparable wB = (Comparable) widened[1];
+                                builder.min(ord, wA.compareTo(wB) <= 0 ? widened[0] : widened[1]);
+                            } else {
+                                logger.trace(
+                                    "retaining existing min for column [{}]: incompatible types [{}/{}]",
+                                    colName,
+                                    existingMin.getClass().getSimpleName(),
+                                    newMin.getClass().getSimpleName()
+                                );
+                            }
                         }
                     } else if (newMin != null) {
                         builder.min(ord, newMin);
                     }
-                    // Max of maxes (only compare values of the same type)
+                    // Max of maxes (widen numeric types if needed)
                     Object existingMax = builder.maxsList.get(ord);
                     Object newMax = stats.maxs[i];
                     if (existingMax != null && newMax != null) {
@@ -342,6 +415,20 @@ public final class SplitStats implements Writeable {
                             && newMax instanceof Comparable nMax
                             && existingMax.getClass() == newMax.getClass()) {
                             builder.max(ord, eMax.compareTo(nMax) >= 0 ? existingMax : newMax);
+                        } else {
+                            Object[] widened = widenNumericPair(existingMax, newMax);
+                            if (widened != null) {
+                                Comparable wA = (Comparable) widened[0];
+                                Comparable wB = (Comparable) widened[1];
+                                builder.max(ord, wA.compareTo(wB) >= 0 ? widened[0] : widened[1]);
+                            } else {
+                                logger.trace(
+                                    "retaining existing max for column [{}]: incompatible types [{}/{}]",
+                                    colName,
+                                    existingMax.getClass().getSimpleName(),
+                                    newMax.getClass().getSimpleName()
+                                );
+                            }
                         }
                     } else if (newMax != null) {
                         builder.max(ord, newMax);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
@@ -97,6 +97,59 @@ public class SourceStatisticsSerializerTests extends ESTestCase {
         assertNull(SourceStatisticsSerializer.extractColumnSizeBytes(null, "age"));
     }
 
+    public void testMergeStatisticsCrossTypeIntegerLong() {
+        Map<String, Object> s1 = new HashMap<>();
+        s1.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        s1.put(SourceStatisticsSerializer.columnMinKey("price"), 10);
+        s1.put(SourceStatisticsSerializer.columnMaxKey("price"), 50);
+
+        Map<String, Object> s2 = new HashMap<>();
+        s2.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 200L);
+        s2.put(SourceStatisticsSerializer.columnMinKey("price"), 5L);
+        s2.put(SourceStatisticsSerializer.columnMaxKey("price"), 60L);
+
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(s1, s2));
+        assertNotNull(result);
+        assertEquals(300L, result.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        assertEquals(5L, result.get(SourceStatisticsSerializer.columnMinKey("price")));
+        assertEquals(60L, result.get(SourceStatisticsSerializer.columnMaxKey("price")));
+    }
+
+    public void testMergeStatisticsCrossTypeIntegerDouble() {
+        Map<String, Object> s1 = new HashMap<>();
+        s1.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        s1.put(SourceStatisticsSerializer.columnMinKey("score"), 3);
+        s1.put(SourceStatisticsSerializer.columnMaxKey("score"), 80);
+
+        Map<String, Object> s2 = new HashMap<>();
+        s2.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 200L);
+        s2.put(SourceStatisticsSerializer.columnMinKey("score"), 1.5);
+        s2.put(SourceStatisticsSerializer.columnMaxKey("score"), 99.9);
+
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(s1, s2));
+        assertNotNull(result);
+        assertEquals(1.5, result.get(SourceStatisticsSerializer.columnMinKey("score")));
+        assertEquals(99.9, result.get(SourceStatisticsSerializer.columnMaxKey("score")));
+    }
+
+    public void testMergeStatisticsCrossTypeLongDoubleIncompatible() {
+        Map<String, Object> s1 = new HashMap<>();
+        s1.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        s1.put(SourceStatisticsSerializer.columnMinKey("val"), 10L);
+        s1.put(SourceStatisticsSerializer.columnMaxKey("val"), 50L);
+
+        Map<String, Object> s2 = new HashMap<>();
+        s2.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 200L);
+        s2.put(SourceStatisticsSerializer.columnMinKey("val"), 5.0);
+        s2.put(SourceStatisticsSerializer.columnMaxKey("val"), 60.0);
+
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(s1, s2));
+        assertNotNull(result);
+        // Long + Double is incompatible — first value retained
+        assertEquals(10L, result.get(SourceStatisticsSerializer.columnMinKey("val")));
+        assertEquals(50L, result.get(SourceStatisticsSerializer.columnMaxKey("val")));
+    }
+
     public void testMergeStatistics_sumsSizeBytes() {
         Map<String, Object> s1 = new HashMap<>();
         s1.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializerTests.java
@@ -132,7 +132,7 @@ public class SourceStatisticsSerializerTests extends ESTestCase {
         assertEquals(99.9, result.get(SourceStatisticsSerializer.columnMaxKey("score")));
     }
 
-    public void testMergeStatisticsCrossTypeLongDoubleIncompatible() {
+    public void testMergeStatisticsCrossTypeLongDoubleIncompatibleClearsStats() {
         Map<String, Object> s1 = new HashMap<>();
         s1.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
         s1.put(SourceStatisticsSerializer.columnMinKey("val"), 10L);
@@ -145,9 +145,48 @@ public class SourceStatisticsSerializerTests extends ESTestCase {
 
         Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(s1, s2));
         assertNotNull(result);
-        // Long + Double is incompatible — first value retained
-        assertEquals(10L, result.get(SourceStatisticsSerializer.columnMinKey("val")));
-        assertEquals(50L, result.get(SourceStatisticsSerializer.columnMaxKey("val")));
+        assertNull("incompatible types should clear min entry", result.get(SourceStatisticsSerializer.columnMinKey("val")));
+        assertNull("incompatible types should clear max entry", result.get(SourceStatisticsSerializer.columnMaxKey("val")));
+    }
+
+    public void testMergeStatisticsCrossTypeLongDoubleIncompatibleReversed() {
+        Map<String, Object> s1 = new HashMap<>();
+        s1.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 200L);
+        s1.put(SourceStatisticsSerializer.columnMinKey("val"), 5.0);
+        s1.put(SourceStatisticsSerializer.columnMaxKey("val"), 60.0);
+
+        Map<String, Object> s2 = new HashMap<>();
+        s2.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        s2.put(SourceStatisticsSerializer.columnMinKey("val"), 10L);
+        s2.put(SourceStatisticsSerializer.columnMaxKey("val"), 50L);
+
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(s1, s2));
+        assertNotNull(result);
+        assertNull("incompatible types should clear min regardless of order", result.get(SourceStatisticsSerializer.columnMinKey("val")));
+        assertNull("incompatible types should clear max regardless of order", result.get(SourceStatisticsSerializer.columnMaxKey("val")));
+    }
+
+    public void testMergeStatisticsIncompatibleStaysPoisonedWithThirdSplit() {
+        Map<String, Object> s1 = new HashMap<>();
+        s1.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 100L);
+        s1.put(SourceStatisticsSerializer.columnMinKey("val"), 10L);
+        s1.put(SourceStatisticsSerializer.columnMaxKey("val"), 50L);
+
+        Map<String, Object> s2 = new HashMap<>();
+        s2.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 200L);
+        s2.put(SourceStatisticsSerializer.columnMinKey("val"), 5.0);
+        s2.put(SourceStatisticsSerializer.columnMaxKey("val"), 60.0);
+
+        Map<String, Object> s3 = new HashMap<>();
+        s3.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 300L);
+        s3.put(SourceStatisticsSerializer.columnMinKey("val"), 1L);
+        s3.put(SourceStatisticsSerializer.columnMaxKey("val"), 100L);
+
+        Map<String, Object> result = SourceStatisticsSerializer.mergeStatistics(List.of(s1, s2, s3));
+        assertNotNull(result);
+        assertEquals(600L, result.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        assertNull("once poisoned, min must stay cleared", result.get(SourceStatisticsSerializer.columnMinKey("val")));
+        assertNull("once poisoned, max must stay cleared", result.get(SourceStatisticsSerializer.columnMaxKey("val")));
     }
 
     public void testMergeStatistics_sumsSizeBytes() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitStatsTests.java
@@ -526,7 +526,7 @@ public class SplitStatsTests extends ESTestCase {
         assertEquals(100L, merged.columnMax("price"));
     }
 
-    public void testMergeLongDoubleIncompatibleKeepsFirst() {
+    public void testMergeLongDoubleIncompatibleClearsStats() {
         SplitStats.Builder b1 = new SplitStats.Builder().rowCount(100);
         b1.addColumn("val", 0L, 10L, 50L, 400);
         SplitStats s1 = b1.build();
@@ -538,9 +538,59 @@ public class SplitStatsTests extends ESTestCase {
         SplitStats merged = SplitStats.merge(List.of(s1, s2));
         assertNotNull(merged);
         assertEquals(300, merged.rowCount());
-        // Long + Double is incompatible — first split's value is retained
-        assertEquals(10L, merged.columnMin("val"));
-        assertEquals(50L, merged.columnMax("val"));
+        assertNull("incompatible types should clear min", merged.columnMin("val"));
+        assertNull("incompatible types should clear max", merged.columnMax("val"));
+    }
+
+    public void testMergeLongDoubleIncompatibleClearsStatsReversed() {
+        SplitStats.Builder b1 = new SplitStats.Builder().rowCount(200);
+        b1.addColumn("val", 0L, 5.0, 60.0, 800);
+        SplitStats s1 = b1.build();
+
+        SplitStats.Builder b2 = new SplitStats.Builder().rowCount(100);
+        b2.addColumn("val", 0L, 10L, 50L, 400);
+        SplitStats s2 = b2.build();
+
+        SplitStats merged = SplitStats.merge(List.of(s1, s2));
+        assertNotNull(merged);
+        assertEquals(300, merged.rowCount());
+        assertNull("incompatible types should clear min regardless of order", merged.columnMin("val"));
+        assertNull("incompatible types should clear max regardless of order", merged.columnMax("val"));
+    }
+
+    public void testMergeLongFloatIncompatibleClearsStats() {
+        SplitStats.Builder b1 = new SplitStats.Builder().rowCount(100);
+        b1.addColumn("val", 0L, 10L, 50L, 400);
+        SplitStats s1 = b1.build();
+
+        SplitStats.Builder b2 = new SplitStats.Builder().rowCount(200);
+        b2.addColumn("val", 0L, 5.0f, 60.0f, 800);
+        SplitStats s2 = b2.build();
+
+        SplitStats merged = SplitStats.merge(List.of(s1, s2));
+        assertNotNull(merged);
+        assertNull("Long + Float is incompatible, should clear min", merged.columnMin("val"));
+        assertNull("Long + Float is incompatible, should clear max", merged.columnMax("val"));
+    }
+
+    public void testMergeIncompatibleStaysPoisonedWithThirdSplit() {
+        SplitStats.Builder b1 = new SplitStats.Builder().rowCount(100);
+        b1.addColumn("val", 0L, 10L, 50L, 400);
+        SplitStats s1 = b1.build();
+
+        SplitStats.Builder b2 = new SplitStats.Builder().rowCount(200);
+        b2.addColumn("val", 0L, 5.0, 60.0, 800);
+        SplitStats s2 = b2.build();
+
+        SplitStats.Builder b3 = new SplitStats.Builder().rowCount(300);
+        b3.addColumn("val", 0L, 1L, 100L, 1200);
+        SplitStats s3 = b3.build();
+
+        SplitStats merged = SplitStats.merge(List.of(s1, s2, s3));
+        assertNotNull(merged);
+        assertEquals(600, merged.rowCount());
+        assertNull("once poisoned by incompatibility, min must stay null", merged.columnMin("val"));
+        assertNull("once poisoned by incompatibility, max must stay null", merged.columnMax("val"));
     }
 
     public void testMergeCrossTypeIntegerLongReversedOrder() {
@@ -559,75 +609,94 @@ public class SplitStatsTests extends ESTestCase {
         assertEquals(60L, merged.columnMax("price"));
     }
 
-    // --- widenNumericPair unit tests ---
+    // --- mergedMin / mergedMax unit tests ---
 
-    public void testWidenNumericPairSameTypeReturnsNull() {
-        assertNull(SplitStats.widenNumericPair(1, 2));
-        assertNull(SplitStats.widenNumericPair(1L, 2L));
-        assertNull(SplitStats.widenNumericPair(1.0, 2.0));
+    public void testMergedMinNullHandling() {
+        assertNull(SplitStats.mergedMin(null, null));
+        assertEquals(10, SplitStats.mergedMin(null, 10));
+        assertEquals(10, SplitStats.mergedMin(10, null));
     }
 
-    public void testWidenNumericPairIntegerLong() {
-        Object[] result = SplitStats.widenNumericPair(10, 20L);
-        assertNotNull(result);
-        assertEquals(10L, result[0]);
-        assertEquals(20L, result[1]);
-
-        result = SplitStats.widenNumericPair(20L, 10);
-        assertNotNull(result);
-        assertEquals(20L, result[0]);
-        assertEquals(10L, result[1]);
+    public void testMergedMaxNullHandling() {
+        assertNull(SplitStats.mergedMax(null, null));
+        assertEquals(10, SplitStats.mergedMax(null, 10));
+        assertEquals(10, SplitStats.mergedMax(10, null));
     }
 
-    public void testWidenNumericPairIntegerDouble() {
-        Object[] result = SplitStats.widenNumericPair(10, 20.5);
-        assertNotNull(result);
-        assertEquals(10.0, result[0]);
-        assertEquals(20.5, result[1]);
-
-        result = SplitStats.widenNumericPair(20.5, 10);
-        assertNotNull(result);
-        assertEquals(20.5, result[0]);
-        assertEquals(10.0, result[1]);
+    public void testMergedMinSameType() {
+        assertEquals(5, SplitStats.mergedMin(10, 5));
+        assertEquals(5L, SplitStats.mergedMin(5L, 20L));
+        assertEquals(1.5, SplitStats.mergedMin(1.5, 3.0));
+        assertEquals("Alice", SplitStats.mergedMin("Alice", "Zara"));
     }
 
-    public void testWidenNumericPairFloatDouble() {
-        Object[] result = SplitStats.widenNumericPair(10.0f, 20.0);
-        assertNotNull(result);
-        assertEquals(10.0, result[0]);
-        assertEquals(20.0, result[1]);
-
-        result = SplitStats.widenNumericPair(20.0, 10.0f);
-        assertNotNull(result);
-        assertEquals(20.0, result[0]);
-        assertEquals(10.0, result[1]);
+    public void testMergedMaxSameType() {
+        assertEquals(10, SplitStats.mergedMax(10, 5));
+        assertEquals(20L, SplitStats.mergedMax(5L, 20L));
+        assertEquals(3.0, SplitStats.mergedMax(1.5, 3.0));
+        assertEquals("Zara", SplitStats.mergedMax("Alice", "Zara"));
     }
 
-    public void testWidenNumericPairIntegerFloat() {
-        Object[] result = SplitStats.widenNumericPair(10, 20.0f);
-        assertNotNull(result);
-        assertEquals(10.0, result[0]);
-        assertEquals(20.0, (double) result[1], 0.001);
-
-        result = SplitStats.widenNumericPair(20.0f, 10);
-        assertNotNull(result);
-        assertEquals(20.0, (double) result[0], 0.001);
-        assertEquals(10.0, result[1]);
+    public void testMergedMinCrossTypeIntegerLong() {
+        assertEquals(5L, SplitStats.mergedMin(10, 5L));
+        assertEquals(5L, SplitStats.mergedMin(5L, 10));
+        assertEquals(10L, SplitStats.mergedMin(10, 20L));
     }
 
-    public void testWidenNumericPairLongDoubleIncompatible() {
-        assertNull(SplitStats.widenNumericPair(10L, 20.0));
-        assertNull(SplitStats.widenNumericPair(20.0, 10L));
+    public void testMergedMaxCrossTypeIntegerLong() {
+        assertEquals(10L, SplitStats.mergedMax(10, 5L));
+        assertEquals(10L, SplitStats.mergedMax(5L, 10));
+        assertEquals(20L, SplitStats.mergedMax(10, 20L));
     }
 
-    public void testWidenNumericPairLongFloatIncompatible() {
-        assertNull(SplitStats.widenNumericPair(10L, 20.0f));
-        assertNull(SplitStats.widenNumericPair(20.0f, 10L));
+    public void testMergedMinCrossTypeIntegerDouble() {
+        assertEquals(1.5, SplitStats.mergedMin(3, 1.5));
+        assertEquals(3.0, SplitStats.mergedMin(3, 5.0));
     }
 
-    public void testWidenNumericPairStringIncompatible() {
-        assertNull(SplitStats.widenNumericPair("hello", 10));
-        assertNull(SplitStats.widenNumericPair(10, "hello"));
+    public void testMergedMaxCrossTypeIntegerDouble() {
+        assertEquals(5.0, SplitStats.mergedMax(3, 5.0));
+        assertEquals(3.0, SplitStats.mergedMax(3, 1.5));
+    }
+
+    public void testMergedMinCrossTypeFloatDouble() {
+        assertEquals(5.0, SplitStats.mergedMin(10.0f, 5.0));
+        assertEquals(10.0, SplitStats.mergedMin(10.0f, 20.0));
+    }
+
+    public void testMergedMaxCrossTypeFloatDouble() {
+        assertEquals(20.0, SplitStats.mergedMax(10.0f, 20.0));
+        assertEquals(10.0, SplitStats.mergedMax(10.0f, 5.0));
+    }
+
+    public void testMergedMinCrossTypeIntegerFloat() {
+        assertEquals(5.0, SplitStats.mergedMin(10, 5.0f));
+        assertEquals(10.0, SplitStats.mergedMin(10, 20.0f));
+    }
+
+    public void testMergedMaxCrossTypeIntegerFloat() {
+        assertEquals(20.0, SplitStats.mergedMax(10, 20.0f));
+        assertEquals(10.0, SplitStats.mergedMax(10, 5.0f));
+    }
+
+    public void testMergedMinLongDoubleIncompatible() {
+        assertNull("Long + Double incompatible", SplitStats.mergedMin(10L, 5.0));
+        assertNull("Double + Long incompatible", SplitStats.mergedMin(5.0, 10L));
+    }
+
+    public void testMergedMaxLongDoubleIncompatible() {
+        assertNull("Long + Double incompatible", SplitStats.mergedMax(10L, 50.0));
+        assertNull("Double + Long incompatible", SplitStats.mergedMax(50.0, 10L));
+    }
+
+    public void testMergedMinLongFloatIncompatible() {
+        assertNull("Long + Float incompatible", SplitStats.mergedMin(10L, 5.0f));
+        assertNull("Float + Long incompatible", SplitStats.mergedMin(5.0f, 10L));
+    }
+
+    public void testMergedMinStringNumericIncompatible() {
+        assertNull(SplitStats.mergedMin("hello", 10));
+        assertNull(SplitStats.mergedMin(10, "hello"));
     }
 
     private static FileSplit fileSplitWithStats(SplitStats stats) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitStatsTests.java
@@ -443,6 +443,193 @@ public class SplitStatsTests extends ESTestCase {
         assertNull(SplitStats.merge(List.of()));
     }
 
+    // --- cross-type merge tests (type widening for UNION_BY_NAME) ---
+
+    public void testMergeCrossTypeIntegerLongMinMax() {
+        SplitStats.Builder b1 = new SplitStats.Builder().rowCount(100);
+        b1.addColumn("price", 0L, 10, 50, 400);
+        SplitStats s1 = b1.build();
+
+        SplitStats.Builder b2 = new SplitStats.Builder().rowCount(200);
+        b2.addColumn("price", 0L, 5L, 60L, 800);
+        SplitStats s2 = b2.build();
+
+        SplitStats merged = SplitStats.merge(List.of(s1, s2));
+        assertNotNull(merged);
+        assertEquals(300, merged.rowCount());
+        assertEquals(5L, merged.columnMin("price"));
+        assertEquals(60L, merged.columnMax("price"));
+    }
+
+    public void testMergeCrossTypeIntegerDoubleMinMax() {
+        SplitStats.Builder b1 = new SplitStats.Builder().rowCount(100);
+        b1.addColumn("score", 0L, 3, 80, 400);
+        SplitStats s1 = b1.build();
+
+        SplitStats.Builder b2 = new SplitStats.Builder().rowCount(200);
+        b2.addColumn("score", 0L, 1.5, 99.9, 800);
+        SplitStats s2 = b2.build();
+
+        SplitStats merged = SplitStats.merge(List.of(s1, s2));
+        assertNotNull(merged);
+        assertEquals(1.5, merged.columnMin("score"));
+        assertEquals(99.9, merged.columnMax("score"));
+    }
+
+    public void testMergeCrossTypeFloatDoubleMinMax() {
+        SplitStats.Builder b1 = new SplitStats.Builder().rowCount(100);
+        b1.addColumn("temp", 0L, 10.0f, 30.0f, 400);
+        SplitStats s1 = b1.build();
+
+        SplitStats.Builder b2 = new SplitStats.Builder().rowCount(200);
+        b2.addColumn("temp", 0L, 5.0, 40.0, 800);
+        SplitStats s2 = b2.build();
+
+        SplitStats merged = SplitStats.merge(List.of(s1, s2));
+        assertNotNull(merged);
+        assertEquals(5.0, merged.columnMin("temp"));
+        assertEquals(40.0, merged.columnMax("temp"));
+    }
+
+    public void testMergeCrossTypeIntegerFloatMinMax() {
+        SplitStats.Builder b1 = new SplitStats.Builder().rowCount(100);
+        b1.addColumn("val", 0L, 10, 50, 400);
+        SplitStats s1 = b1.build();
+
+        SplitStats.Builder b2 = new SplitStats.Builder().rowCount(200);
+        b2.addColumn("val", 0L, 5.0f, 60.0f, 800);
+        SplitStats s2 = b2.build();
+
+        SplitStats merged = SplitStats.merge(List.of(s1, s2));
+        assertNotNull(merged);
+        assertEquals(5.0, merged.columnMin("val"));
+        assertEquals(60.0, merged.columnMax("val"));
+    }
+
+    public void testMergeThreeWayCrossType() {
+        SplitStats.Builder b1 = new SplitStats.Builder().rowCount(100);
+        b1.addColumn("price", 0L, 10, 50, 400);
+        SplitStats s1 = b1.build();
+
+        SplitStats.Builder b2 = new SplitStats.Builder().rowCount(200);
+        b2.addColumn("price", 0L, 5L, 60L, 800);
+        SplitStats s2 = b2.build();
+
+        SplitStats.Builder b3 = new SplitStats.Builder().rowCount(300);
+        b3.addColumn("price", 0L, 3L, 100L, 1200);
+        SplitStats s3 = b3.build();
+
+        SplitStats merged = SplitStats.merge(List.of(s1, s2, s3));
+        assertNotNull(merged);
+        assertEquals(600, merged.rowCount());
+        assertEquals(3L, merged.columnMin("price"));
+        assertEquals(100L, merged.columnMax("price"));
+    }
+
+    public void testMergeLongDoubleIncompatibleKeepsFirst() {
+        SplitStats.Builder b1 = new SplitStats.Builder().rowCount(100);
+        b1.addColumn("val", 0L, 10L, 50L, 400);
+        SplitStats s1 = b1.build();
+
+        SplitStats.Builder b2 = new SplitStats.Builder().rowCount(200);
+        b2.addColumn("val", 0L, 5.0, 60.0, 800);
+        SplitStats s2 = b2.build();
+
+        SplitStats merged = SplitStats.merge(List.of(s1, s2));
+        assertNotNull(merged);
+        assertEquals(300, merged.rowCount());
+        // Long + Double is incompatible — first split's value is retained
+        assertEquals(10L, merged.columnMin("val"));
+        assertEquals(50L, merged.columnMax("val"));
+    }
+
+    public void testMergeCrossTypeIntegerLongReversedOrder() {
+        // Verify widening works regardless of which split comes first
+        SplitStats.Builder b1 = new SplitStats.Builder().rowCount(100);
+        b1.addColumn("price", 0L, 5L, 60L, 400);
+        SplitStats s1 = b1.build();
+
+        SplitStats.Builder b2 = new SplitStats.Builder().rowCount(200);
+        b2.addColumn("price", 0L, 10, 50, 800);
+        SplitStats s2 = b2.build();
+
+        SplitStats merged = SplitStats.merge(List.of(s1, s2));
+        assertNotNull(merged);
+        assertEquals(5L, merged.columnMin("price"));
+        assertEquals(60L, merged.columnMax("price"));
+    }
+
+    // --- widenNumericPair unit tests ---
+
+    public void testWidenNumericPairSameTypeReturnsNull() {
+        assertNull(SplitStats.widenNumericPair(1, 2));
+        assertNull(SplitStats.widenNumericPair(1L, 2L));
+        assertNull(SplitStats.widenNumericPair(1.0, 2.0));
+    }
+
+    public void testWidenNumericPairIntegerLong() {
+        Object[] result = SplitStats.widenNumericPair(10, 20L);
+        assertNotNull(result);
+        assertEquals(10L, result[0]);
+        assertEquals(20L, result[1]);
+
+        result = SplitStats.widenNumericPair(20L, 10);
+        assertNotNull(result);
+        assertEquals(20L, result[0]);
+        assertEquals(10L, result[1]);
+    }
+
+    public void testWidenNumericPairIntegerDouble() {
+        Object[] result = SplitStats.widenNumericPair(10, 20.5);
+        assertNotNull(result);
+        assertEquals(10.0, result[0]);
+        assertEquals(20.5, result[1]);
+
+        result = SplitStats.widenNumericPair(20.5, 10);
+        assertNotNull(result);
+        assertEquals(20.5, result[0]);
+        assertEquals(10.0, result[1]);
+    }
+
+    public void testWidenNumericPairFloatDouble() {
+        Object[] result = SplitStats.widenNumericPair(10.0f, 20.0);
+        assertNotNull(result);
+        assertEquals(10.0, result[0]);
+        assertEquals(20.0, result[1]);
+
+        result = SplitStats.widenNumericPair(20.0, 10.0f);
+        assertNotNull(result);
+        assertEquals(20.0, result[0]);
+        assertEquals(10.0, result[1]);
+    }
+
+    public void testWidenNumericPairIntegerFloat() {
+        Object[] result = SplitStats.widenNumericPair(10, 20.0f);
+        assertNotNull(result);
+        assertEquals(10.0, result[0]);
+        assertEquals(20.0, (double) result[1], 0.001);
+
+        result = SplitStats.widenNumericPair(20.0f, 10);
+        assertNotNull(result);
+        assertEquals(20.0, (double) result[0], 0.001);
+        assertEquals(10.0, result[1]);
+    }
+
+    public void testWidenNumericPairLongDoubleIncompatible() {
+        assertNull(SplitStats.widenNumericPair(10L, 20.0));
+        assertNull(SplitStats.widenNumericPair(20.0, 10L));
+    }
+
+    public void testWidenNumericPairLongFloatIncompatible() {
+        assertNull(SplitStats.widenNumericPair(10L, 20.0f));
+        assertNull(SplitStats.widenNumericPair(20.0f, 10L));
+    }
+
+    public void testWidenNumericPairStringIncompatible() {
+        assertNull(SplitStats.widenNumericPair("hello", 10));
+        assertNull(SplitStats.widenNumericPair(10, "hello"));
+    }
+
     private static FileSplit fileSplitWithStats(SplitStats stats) {
         Map<String, Object> statsMap = stats.toMap();
         return new FileSplit("parquet", StoragePath.of("file:///test.parquet"), 0, 100, "parquet", Map.of(), Map.of(), null, statsMap);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -466,6 +466,22 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
         assertEquals(99.9, as(page.getBlock(1), DoubleBlock.class).getDouble(0), 0.001);
     }
 
+    /**
+     * When splits have incompatible stat types (Long + Double), merged stats are cleared
+     * to null and pushdown must NOT produce a misleading constant. The rule should fall
+     * back to the original aggregate.
+     */
+    public void testMinMaxWithIncompatibleLongDoubleStatsDoesNotPushDown() {
+        SplitStats split1 = buildSplitStatsWithMinMax("score", 10L, 50L, 500L, 0L);
+        SplitStats split2 = buildSplitStatsWithMinMax("score", 5.0, 60.0, 500L, 0L);
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), split1, split2);
+        var agg = aggregateExec(ext, alias("mn", new Min(Source.EMPTY, SCORE)), alias("mx", new Max(Source.EMPTY, SCORE)));
+
+        PhysicalPlan result = applyRule(agg);
+        // Should NOT be pushed down to LocalSourceExec — stats are incompatible and cleared
+        as(result, AggregateExec.class);
+    }
+
     // --- filter tests ---
 
     public void testCountPushedThroughOrFilterAllResolve() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSourceTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -424,6 +425,45 @@ public class PushStatsToExternalSourceTests extends ESTestCase {
 
         LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
         assertEquals(1000L, as(local.supplier().get().getBlock(0), LongBlock.class).getLong(0));
+    }
+
+    // --- cross-type stats merge tests (UNION_BY_NAME type widening) ---
+
+    /**
+     * When splits come from files with different physical types for the same column
+     * (e.g. INTEGER in file A, LONG in file B after UNION_BY_NAME widening), the
+     * optimizer should correctly merge Integer and Long stats and push down MIN/MAX.
+     */
+    public void testMinMaxWithCrossTypeStatsAcrossSplits() {
+        SplitStats split1 = buildSplitStatsWithMinMax("salary", 30000, 80000, 500L, 0L);
+        SplitStats split2 = buildSplitStatsWithMinMax("salary", 25000L, 90000L, 500L, 0L);
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), split1, split2);
+        var agg = aggregateExec(ext, alias("mn", new Min(Source.EMPTY, SALARY)), alias("mx", new Max(Source.EMPTY, SALARY)));
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(2, local.output().size());
+        Page page = local.supplier().get();
+        assertNotNull(page);
+        // Min(Integer(30000), Long(25000)) → Long(25000), coerced to Integer block by buildBlock
+        assertEquals(25000, as(page.getBlock(0), IntBlock.class).getInt(0));
+        // Max(Integer(80000), Long(90000)) → Long(90000), coerced to Integer block by buildBlock
+        assertEquals(90000, as(page.getBlock(1), IntBlock.class).getInt(0));
+    }
+
+    public void testMinMaxWithCrossTypeIntegerDoubleStatsAcrossSplits() {
+        SplitStats split1 = buildSplitStatsWithMinMax("score", 3, 80, 500L, 0L);
+        SplitStats split2 = buildSplitStatsWithMinMax("score", 1.5, 99.9, 500L, 0L);
+        ExternalSourceExec ext = externalSourceWithSplits(Map.of(), split1, split2);
+        var agg = aggregateExec(ext, alias("mn", new Min(Source.EMPTY, SCORE)), alias("mx", new Max(Source.EMPTY, SCORE)));
+
+        LocalSourceExec local = as(applyRule(agg), LocalSourceExec.class);
+        assertEquals(2, local.output().size());
+        Page page = local.supplier().get();
+        assertNotNull(page);
+        // Min(Integer(3), Double(1.5)) → Double(1.5), coerced to DoubleBlock
+        assertEquals(1.5, as(page.getBlock(0), DoubleBlock.class).getDouble(0), 0.001);
+        // Max(Integer(80), Double(99.9)) → Double(99.9), coerced to DoubleBlock
+        assertEquals(99.9, as(page.getBlock(1), DoubleBlock.class).getDouble(0), 0.001);
     }
 
     // --- filter tests ---


### PR DESCRIPTION
When UNION_BY_NAME widens a column type (e.g., INTEGER in file A,
LONG in file B), statistics min/max values retain their original
Java types. SplitStats.merge() required class equality for comparison,
silently dropping stats when types differed. SourceStatisticsSerializer
used raw Comparable.compareTo() which could throw ClassCastException
for mismatched types.

Add widenNumericPair() utility that promotes numeric stat values to a
common type before comparison (Integer+Long→Long, Integer+Double→Double,
Float+Double→Double), mirroring SchemaReconciliation.schemaWiden() rules.
Both merge paths now use this shared utility.

Developed with AI-assisted tooling