### PR TITLE
[9.4] Fix Streaming Lookup Join BWC issue (#147440)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/LookupQueryOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/LookupQueryOperator.java
@@ -334,6 +334,8 @@ public final class LookupQueryOperator implements Operator {
             Status::new
         );
 
+        private static final TransportVersion ESQL_STREAMING_LOOKUP_JOIN = TransportVersion.fromName("esql_streaming_lookup_join");
+
         private final int pagesReceived;
         private final int pagesEmitted;
         private final long rowsReceived;
@@ -424,7 +426,7 @@ public final class LookupQueryOperator implements Operator {
 
         @Override
         public TransportVersion getMinimalSupportedVersion() {
-            return TransportVersion.current();
+            return ESQL_STREAMING_LOOKUP_JOIN;
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/StreamingLookupFromIndexOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/StreamingLookupFromIndexOperator.java
@@ -836,7 +836,7 @@ public class StreamingLookupFromIndexOperator implements Operator {
 
         @Override
         public TransportVersion getMinimalSupportedVersion() {
-            return TransportVersion.current();
+            return ESQL_LOOKUP_PLAN_STRING;
         }
 
         @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix Streaming Lookup Join BWC issue (#147440)](https://github.com/elastic/elasticsearch/pull/147440)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)