### PR TITLE
[9.3] Add missing normalizer_skip_store feature check to test (#147500)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
@@ -317,7 +317,7 @@ synthetic_source text with normalized keyword with skip store original value:
 ---
 synthetic_source text with normalized keyword with default skip store original value:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.keyword.normalizer_skip_store_setting"]
       reason: "Source mode configured through index setting"
 
   - do:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Add missing normalizer_skip_store feature check to test (#147500)](https://github.com/elastic/elasticsearch/pull/147500)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)