### PR TITLE
Auto-tune reindex batch size when byte limit is configured

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -545,6 +545,21 @@ public abstract class AbstractAsyncBulkByScrollAction<
                 notifyDone(thisBatchStartTimeNS, asyncResponse, 0);
                 return;
             }
+            final long maxBytes = maxBulkRequestBytes();
+            if (maxBytes >= 0 && request.estimatedSizeInBytes() > maxBytes) {
+                finishHim(
+                    new IllegalArgumentException(
+                        "Batch of ["
+                            + request.requests().size()
+                            + "] documents in reindex operation has estimated size ["
+                            + ByteSizeValue.ofBytes(request.estimatedSizeInBytes())
+                            + "] which exceeds the configured maximum of ["
+                            + ByteSizeValue.ofBytes(maxBytes)
+                            + "]. Reduce [scroll_size] or increase [reindex.max_batch_size_in_bytes]."
+                    )
+                );
+                return;
+            }
             request.timeout(mainRequest.getTimeout());
             request.waitForActiveShards(mainRequest.getWaitForActiveShards());
             sendBulkRequest(request, releaseBatchHits, () -> notifyDone(thisBatchStartTimeNS, asyncResponse, request.requests().size()));
@@ -802,6 +817,15 @@ public abstract class AbstractAsyncBulkByScrollAction<
                 listener.onFailure(failure);
             }
         }));
+    }
+
+    /**
+     * Returns the maximum number of bytes allowed in a single bulk request batch.
+     * A value of -1 (or any negative value) means no limit is enforced. Subclasses can override to
+     * impose a byte-size limit and fail the reindex request gracefully before the node runs out of memory.
+     */
+    protected long maxBulkRequestBytes() {
+        return -1L;
     }
 
     /**

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -546,19 +546,48 @@ public abstract class AbstractAsyncBulkByScrollAction<
                 return;
             }
             final long maxBytes = maxBulkRequestBytes();
-            if (maxBytes >= 0 && request.estimatedSizeInBytes() > maxBytes) {
-                finishHim(
-                    new IllegalArgumentException(
-                        "Batch of ["
-                            + request.requests().size()
-                            + "] documents in reindex operation has estimated size ["
-                            + ByteSizeValue.ofBytes(request.estimatedSizeInBytes())
-                            + "] which exceeds the configured maximum of ["
-                            + ByteSizeValue.ofBytes(maxBytes)
-                            + "]. Reduce [scroll_size] or increase [reindex.max_batch_size_in_bytes]."
-                    )
-                );
-                return;
+            if (maxBytes >= 0) {
+                final int docCount = request.requests().size();
+                final long estimatedBytes = request.estimatedSizeInBytes();
+                // Auto-tune the search batch size for subsequent fetches using the observed
+                // bytes-per-doc ratio. For PIT-based pagination this takes effect on the next
+                // search request. For scroll-based pagination the size is fixed after the initial
+                // search, so the update is recorded but has no effect on the current session.
+                if (docCount > 0 && estimatedBytes > 0) {
+                    final long avgBytesPerDoc = estimatedBytes / docCount;
+                    if (avgBytesPerDoc > 0) {
+                        final int currentSize = mainRequest.getSearchRequest().source().size();
+                        final int targetSize = (int) Math.min(maxBytes / avgBytesPerDoc, currentSize);
+                        if (targetSize > 0 && targetSize < currentSize) {
+                            logger.debug(
+                                "[{}]: reducing batch size from [{}] to [{}] docs to stay within [{}] per batch (avg [{}] bytes/doc)",
+                                task.getId(),
+                                currentSize,
+                                targetSize,
+                                ByteSizeValue.ofBytes(maxBytes),
+                                ByteSizeValue.ofBytes(avgBytesPerDoc)
+                            );
+                            mainRequest.getSearchRequest().source().size(targetSize);
+                        }
+                    }
+                }
+                // Fail gracefully if this batch still exceeds the limit — most likely on the
+                // first batch (before tuning has taken effect) or when a single document is
+                // larger than the configured maximum.
+                if (estimatedBytes > maxBytes) {
+                    finishHim(
+                        new IllegalArgumentException(
+                            "Batch of ["
+                                + docCount
+                                + "] documents in reindex operation has estimated size ["
+                                + ByteSizeValue.ofBytes(estimatedBytes)
+                                + "] which exceeds the configured maximum of ["
+                                + ByteSizeValue.ofBytes(maxBytes)
+                                + "]. Reduce [scroll_size] or increase [reindex.max_batch_size_in_bytes]."
+                        )
+                    );
+                    return;
+                }
             }
             request.timeout(mainRequest.getTimeout());
             request.waitForActiveShards(mainRequest.getWaitForActiveShards());

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexPlugin.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexPlugin.java
@@ -121,6 +121,7 @@ public class ReindexPlugin extends Plugin implements ActionPlugin, ExtensiblePlu
         final List<Setting<?>> settings = new ArrayList<>();
         settings.add(TransportReindexAction.REMOTE_CLUSTER_WHITELIST);
         settings.add(TransportReindexAction.REMOTE_CLUSTER_BLOCKLIST);
+        settings.add(TransportReindexAction.MAX_BATCH_SIZE);
         settings.addAll(ReindexSslConfig.getSettings());
         return settings;
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -270,6 +270,7 @@ public class Reindexer {
         return remoteVersion -> {
             ParentTaskAssigningClient assigningClient = new ParentTaskAssigningClient(client, clusterService.localNode(), task);
             ParentTaskAssigningClient assigningBulkClient = new ParentTaskAssigningClient(bulkClient, clusterService.localNode(), task);
+            final long maxBatchSizeBytes = TransportReindexAction.MAX_BATCH_SIZE.get(clusterService.getSettings()).getBytes();
             AsyncIndexBySearchAction searchAction = new AsyncIndexBySearchAction(
                 task,
                 logger,
@@ -282,7 +283,8 @@ public class Reindexer {
                 request,
                 listener,
                 remoteVersion,
-                reindexShutdownGracePeriod
+                reindexShutdownGracePeriod,
+                maxBatchSizeBytes
             );
             searchAction.start();
         };
@@ -921,6 +923,12 @@ public class Reindexer {
         private final IdFieldMapper destinationIndexIdMapper;
 
         /**
+         * Maximum estimated bulk-request size in bytes before we fail the reindex gracefully.
+         * A negative value means no limit. Set from {@link TransportReindexAction#MAX_BATCH_SIZE}.
+         */
+        private final long maxBatchSizeBytes;
+
+        /**
          * List of threads created by this process. Usually actions don't create threads in Elasticsearch. Instead they use the builtin
          * {@link ThreadPool}s. But reindex-from-remote uses Elasticsearch's {@link RestClient} which doesn't use the
          * {@linkplain ThreadPool}s because it uses httpasyncclient. It'd be a ton of trouble to work around creating those threads. So
@@ -940,7 +948,8 @@ public class Reindexer {
             ReindexRequest request,
             ActionListener<BulkByScrollResponse> listener,
             @Nullable Version remoteVersion,
-            TimeValue maxTaskShutdownGracePeriod
+            TimeValue maxTaskShutdownGracePeriod,
+            long maxBatchSizeBytes
         ) {
             super(
                 task,
@@ -963,6 +972,12 @@ public class Reindexer {
                 maxTaskShutdownGracePeriod
             );
             this.destinationIndexIdMapper = destinationIndexMode(state).idFieldMapperWithoutFieldData();
+            this.maxBatchSizeBytes = maxBatchSizeBytes;
+        }
+
+        @Override
+        protected long maxBulkRequestBytes() {
+            return maxBatchSizeBytes;
         }
 
         private IndexMode destinationIndexMode(ProjectState state) {

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.features.FeatureService;
@@ -45,6 +46,22 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
     public static final Setting<List<String>> REMOTE_CLUSTER_BLOCKLIST = Setting.stringListSetting(
         "reindex.remote.blocklist",
         Property.NodeScope
+    );
+
+    /**
+     * Maximum estimated byte size of a single reindex bulk-write batch. When a batch's estimated size
+     * exceeds this threshold the reindex operation fails with a descriptive error rather than allowing
+     * the node to run out of heap. A value of {@code -1} (the default) disables the limit.
+     *
+     * <p>This setting protects against scenarios where a large {@code scroll_size} combined with large
+     * documents causes each batch to consume hundreds of megabytes, cascading into node OOM. Operators
+     * with legitimately large batches can raise or remove the limit as needed.
+     */
+    public static final Setting<ByteSizeValue> MAX_BATCH_SIZE = Setting.byteSizeSetting(
+        "reindex.max_batch_size_in_bytes",
+        ByteSizeValue.MINUS_ONE,
+        Property.NodeScope,
+        Property.Dynamic
     );
 
     protected final ReindexValidator reindexValidator;

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -651,6 +651,45 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     /**
+     * Verifies that when a bulk-request batch's estimated byte size exceeds the configured maximum, the reindex
+     * operation fails gracefully with a descriptive {@link IllegalArgumentException} instead of sending the
+     * oversized bulk request and potentially causing a node OOM.
+     */
+    public void testBatchExceedingMaxBytesFailsGracefully() throws Exception {
+        boolean usePit = configurePitOrScroll();
+        // Each doc has a 1 000-byte source. With REQUEST_OVERHEAD=50 per doc, three docs → 3 * 1050 = 3150 bytes.
+        final byte[] docSource = new byte[1000];
+        final long maxBytes = 2000L; // less than 3150, so the limit is exceeded
+
+        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
+            @Override
+            protected RequestWrapper<?> buildRequest(Hit doc) {
+                return wrap(new IndexRequest("test").id(doc.getId()).source(doc.getSource(), doc.getXContentType()));
+            }
+
+            @Override
+            protected long maxBulkRequestBytes() {
+                return maxBytes;
+            }
+        };
+
+        List<PaginatedHitSource.BasicHit> hits = List.of(
+            new PaginatedHitSource.BasicHit("idx", "1", -1).setSource(new BytesArray(docSource), XContentType.JSON),
+            new PaginatedHitSource.BasicHit("idx", "2", -1).setSource(new BytesArray(docSource), XContentType.JSON),
+            new PaginatedHitSource.BasicHit("idx", "3", -1).setSource(new BytesArray(docSource), XContentType.JSON)
+        );
+        PaginatedHitSource.Response response = createPaginatedResponse(usePit, false, emptyList(), hits.size(), hits, null, null);
+        simulatePaginatedResponse(action, System.nanoTime(), 0, response, usePit);
+
+        ExecutionException e = expectThrows(ExecutionException.class, () -> listener.get());
+        assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
+        assertThat(e.getCause().getMessage(), containsString("exceeds the configured maximum"));
+        assertThat(e.getCause().getMessage(), containsString("reindex.max_batch_size_in_bytes"));
+        // No bulk request should have been sent
+        assertEquals(0, client.bulksAttempts.get());
+    }
+
+    /**
      * Verifies that concurrent calls to {@code releaseRemainingHits()} release each unconsumed hit exactly once.
      * This covers the race where {@link AbstractAsyncBulkByScrollAction#prepareBulkRequest} (via the
      * {@code requestFinishing} path) and {@link AbstractAsyncBulkByScrollAction#finishHim} both hold a reference

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -690,6 +690,52 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     /**
+     * Verifies that when {@link AbstractAsyncBulkByScrollAction#maxBulkRequestBytes()} is configured, the batch
+     * size on the underlying search request is reduced after each batch so that subsequent fetches stay within
+     * the byte limit. The reduction is based on the observed average bytes-per-document ratio.
+     */
+    public void testBatchSizeIsReducedWhenByteLimitIsConfigured() throws Exception {
+        boolean usePit = configurePitOrScroll();
+        // Each doc contributes 500 bytes of source + 50 bytes overhead = 550 bytes estimated.
+        // With an initial scroll_size of 10 and a limit of 3 000 bytes: target = 3000/550 = 5 docs.
+        final byte[] docSource = new byte[500];
+        final long maxBytes = 3000L;
+        final int initialScrollSize = 10;
+        testRequest.getSearchRequest().source().size(initialScrollSize);
+
+        // Capture the batch size update by inspecting the search request after prepareBulkRequest runs.
+        DummyAsyncBulkByScrollAction action = new DummyAsyncBulkByScrollAction() {
+            @Override
+            protected RequestWrapper<?> buildRequest(Hit doc) {
+                return wrap(new IndexRequest("test").id(doc.getId()).source(doc.getSource(), doc.getXContentType()));
+            }
+
+            @Override
+            protected long maxBulkRequestBytes() {
+                return maxBytes;
+            }
+        };
+
+        // Build a batch of initialScrollSize docs — total ~5 500 bytes, well above the 3 000-byte limit.
+        // Each doc is 550 bytes estimated; target = floor(3000/550) = 5.
+        List<PaginatedHitSource.BasicHit> hits = new ArrayList<>();
+        for (int i = 0; i < initialScrollSize; i++) {
+            hits.add(
+                new PaginatedHitSource.BasicHit("idx", Integer.toString(i), -1).setSource(new BytesArray(docSource), XContentType.JSON)
+            );
+        }
+        // The batch exceeds the limit, so the action should fail gracefully after updating the size.
+        PaginatedHitSource.Response response = createPaginatedResponse(usePit, false, emptyList(), hits.size(), hits, null, null);
+        simulatePaginatedResponse(action, System.nanoTime(), 0, response, usePit);
+
+        // The operation fails because the batch (10 * 550 = 5 500 bytes) exceeds maxBytes (3 000).
+        expectThrows(ExecutionException.class, () -> listener.get());
+        // The batch size should have been reduced to floor(3000/550) = 5 before the failure check.
+        int expectedSize = (int) (maxBytes / 550L);
+        assertEquals(expectedSize, testRequest.getSearchRequest().source().size());
+    }
+
+    /**
      * Verifies that concurrent calls to {@code releaseRemainingHits()} release each unconsumed hit exactly once.
      * This covers the race where {@link AbstractAsyncBulkByScrollAction#prepareBulkRequest} (via the
      * {@code requestFinishing} path) and {@link AbstractAsyncBulkByScrollAction#finishHim} both hold a reference

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
@@ -121,7 +121,8 @@ public class ReindexIdTests extends AbstractAsyncBulkByScrollActionTestCase<Rein
             request(),
             listener(),
             randomBoolean() ? null : Version.CURRENT,
-            randomPositiveTimeValue()
+            randomPositiveTimeValue(),
+            -1L
         );
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
@@ -85,7 +85,8 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
                 request(),
                 listener(),
                 randomBoolean() ? null : Version.CURRENT,
-                randomPositiveTimeValue()
+                randomPositiveTimeValue(),
+                -1L
             );
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
@@ -104,7 +104,8 @@ public class ReindexScriptTests extends AbstractAsyncBulkByScrollActionScriptTes
             request,
             listener(),
             randomBoolean() ? null : Version.CURRENT,
-            randomPositiveTimeValue()
+            randomPositiveTimeValue(),
+            -1L
         );
     }
 }


### PR DESCRIPTION
## Summary

Depends on #147523

Builds on the graceful-failure fix by automatically reducing the search `size` after each batch so subsequent fetches converge within the configured `reindex.max_batch_size_in_bytes` limit.

**Algorithm:** After `buildBulk()`, compute `avgBytesPerDoc = estimatedSizeInBytes / docCount` and set `newSize = floor(maxBytes / avgBytesPerDoc)`, capped at the current `scroll_size`. The updated size is written back to `mainRequest.getSearchRequest().source().size()`.

**PIT vs scroll:**
- **PIT-based pagination** (default when the `reindex_pit_search` feature flag is on): each batch is a fresh `SearchRequest`, so the reduced size takes effect immediately on the next fetch.
- **Scroll-based pagination**: the batch size is fixed after the initial search; the update is recorded but has no effect during the current scroll session.

The Option 1 check (`estimatedSizeInBytes > maxBytes → fail`) is retained as a safety net for:
- The first batch, before tuning has had a chance to act.
- Pathological cases where a single document is larger than the configured limit.

## Test plan

- [ ] `AsyncBulkByScrollActionTests#testBatchSizeIsReducedWhenByteLimitIsConfigured` — verifies that after a batch exceeding the limit the search request's `size` is reduced to `floor(maxBytes / avgBytesPerDoc)`.
- [ ] `AsyncBulkByScrollActionTests#testBatchExceedingMaxBytesFailsGracefully` — still passes (Option 1 check intact).
- [ ] Full `modules:reindex` test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)