### PR TITLE
[9.4] Test fix 146781 146464 (#147336)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -267,9 +267,6 @@ tests:
 - class: org.elasticsearch.xpack.entsearch.EnterpriseSearchRestIT
   method: test {p0=entsearch/rules/40_rule_query_search/Perform a rule query with an organic query that must be rewritten to another query type}
   issue: https://github.com/elastic/elasticsearch/issues/146106
-- class: org.elasticsearch.xpack.rank.rrf.RRFRankClientYamlTestSuiteIT
-  method: test {yaml=rrf/310_rrf_retriever_simplified/Expansion to equivalent custom sub-retrievers returns the same results}
-  issue: https://github.com/elastic/elasticsearch/issues/146464
 - class: org.elasticsearch.xpack.security.authz.SnapshotUserRoleIntegTests
   method: testSnapshotUserRoleIsReserved
   issue: https://github.com/elastic/elasticsearch/issues/146972

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_half_byte_quantized.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_half_byte_quantized.yml
@@ -454,7 +454,7 @@ setup:
         index: hnsw_byte_quantized_merge_cosine
         id: "2"
         body:
-          embedding: [0.0, 0.0, 0.0, 1.0, 1.0, 0.5]
+          embedding: [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
 
   # Flush in order to provoke a merge later
   - do:
@@ -467,7 +467,7 @@ setup:
         index: hnsw_byte_quantized_merge_cosine
         id: "3"
         body:
-          embedding: [0.0, 0.0, 0.0, 0.0, 0.0, 10.5]
+          embedding: [0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
 
   - do:
       allowed_warnings: ["Parameter [confidence_interval] in [index_options] for dense_vector field [embedding] is deprecated and will be removed in a future version"]
@@ -488,7 +488,7 @@ setup:
           query:
             knn:
               field: embedding
-              query_vector: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+              query_vector: [0.5, 0.5, 0.5, 0.5, 0.5, 1.0]
               num_candidates: 10
 
   - length: { hits.hits: 3 }

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/310_rrf_retriever_simplified.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/310_rrf_retriever_simplified.yml
@@ -531,9 +531,9 @@ setup:
 
   - match: { hits.total.value: 3 }
   - length: { hits.hits: 3 }
-  - match: { hits.hits.0._id: "2" }
-  - match: { hits.hits.1._id: "1" }
-  - match: { hits.hits.2._id: "3" }
+  - set: { hits.hits.0._id: expected_hit_0 }
+  - set: { hits.hits.1._id: expected_hit_1 }
+  - set: { hits.hits.2._id: expected_hit_2 }
 
   - do:
       search:
@@ -563,9 +563,9 @@ setup:
 
   - match: { hits.total.value: 3 }
   - length: { hits.hits: 3 }
-  - match: { hits.hits.0._id: "2" }
-  - match: { hits.hits.1._id: "1" }
-  - match: { hits.hits.2._id: "3" }
+  - match: { hits.hits.0._id: $expected_hit_0 }
+  - match: { hits.hits.1._id: $expected_hit_1 }
+  - match: { hits.hits.2._id: $expected_hit_2 }
 
 ---
 "Queries multiple indices using default_field":


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Test fix 146781 146464 (#147336)](https://github.com/elastic/elasticsearch/pull/147336)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)