### PR TITLE
  ES|QL Use LongSwissHash in VALUES aggregation and related components to improve performance

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregator.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.util.LongHashTable;
-import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.aggregation.blockhash.HashImplFactory;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregator.java
@@ -13,7 +13,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
-import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.IntArray;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesDoubleAggregator.java
@@ -13,7 +13,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
-import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.DoubleArray;
@@ -97,10 +96,10 @@ class ValuesDoubleAggregator {
     }
 
     public static class SingleState implements AggregatorState {
-        private final LongHash values;
+        private final LongHashTable values;
 
         private SingleState(BigArrays bigArrays) {
-            values = new LongHash(1, bigArrays);
+            values = HashImplFactory.newLongHash(bigArrays);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesDoubleAggregator.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.util.LongHashTable;
-import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.aggregation.blockhash.HashImplFactory;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesFloatAggregator.java
@@ -13,7 +13,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
-import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.FloatArray;
@@ -97,10 +96,10 @@ class ValuesFloatAggregator {
     }
 
     public static class SingleState implements AggregatorState {
-        private final LongHash values;
+        private final LongHashTable values;
 
         private SingleState(BigArrays bigArrays) {
-            values = new LongHash(1, bigArrays);
+            values = HashImplFactory.newLongHash(bigArrays);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesFloatAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesFloatAggregator.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.util.LongHashTable;
-import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.FloatArray;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.aggregation.blockhash.HashImplFactory;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesIntAggregator.java
@@ -13,7 +13,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
-import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.IntArray;
@@ -97,10 +96,10 @@ class ValuesIntAggregator {
     }
 
     public static class SingleState implements AggregatorState {
-        private final LongHash values;
+        private final LongHashTable values;
 
         private SingleState(BigArrays bigArrays) {
-            values = new LongHash(1, bigArrays);
+            values = HashImplFactory.newLongHash(bigArrays);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesIntAggregator.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.util.LongHashTable;
-import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.aggregation.blockhash.HashImplFactory;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesLongAggregator.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.util.LongHashTable;
-import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.aggregation.blockhash.HashImplFactory;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/ValuesLongAggregator.java
@@ -13,7 +13,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
-import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.LongArray;
@@ -97,10 +96,10 @@ class ValuesLongAggregator {
     }
 
     public static class SingleState implements AggregatorState {
-        private final LongHash values;
+        private final LongHashTable values;
 
         private SingleState(BigArrays bigArrays) {
-            values = new LongHash(1, bigArrays);
+            values = HashImplFactory.newLongHash(bigArrays);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesNextLongLong.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesNextLongLong.java
@@ -7,7 +7,8 @@
 
 package org.elasticsearch.compute.aggregation;
 
-import org.elasticsearch.common.util.LongLongHash;
+import org.elasticsearch.common.util.LongLongHashTable;
+import org.elasticsearch.compute.aggregation.blockhash.HashImplFactory;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.core.Releasable;
@@ -20,11 +21,11 @@ import org.elasticsearch.core.Releasables;
  */
 public class ValuesNextLongLong implements Releasable {
     private final BlockFactory blockFactory;
-    private final LongLongHash hashes;
+    private final LongLongHashTable hashes;
 
     public ValuesNextLongLong(BlockFactory blockFactory) {
         this.blockFactory = blockFactory;
-        this.hashes = new LongLongHash(1, blockFactory.bigArrays());
+        this.hashes = HashImplFactory.newLongLongHash(blockFactory);
     }
 
     void add(int groupId, long v) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesNextPreparedForEmitting.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesNextPreparedForEmitting.java
@@ -9,7 +9,7 @@ package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.LongHashTable;
-import org.elasticsearch.common.util.LongLongHash;
+import org.elasticsearch.common.util.LongLongHashTable;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.core.Releasable;
@@ -17,9 +17,9 @@ import org.elasticsearch.core.Releasables;
 
 public class ValuesNextPreparedForEmitting implements Releasable {
     /**
-     * Build for a {@link LongLongHash}.
+     * Build for a {@link LongLongHashTable}.
      */
-    static ValuesNextPreparedForEmitting build(BlockFactory blockFactory, IntVector selected, LongLongHash hashes) {
+    static ValuesNextPreparedForEmitting build(BlockFactory blockFactory, IntVector selected, LongLongHashTable hashes) {
         ValuesNextPreparedForEmitting result = new ValuesNextPreparedForEmitting(blockFactory, selected);
         if (hashes.size() == 0) {
             return result;
@@ -100,7 +100,7 @@ public class ValuesNextPreparedForEmitting implements Releasable {
      * flip the sign on all the actually selected groups. Negative values in
      * this array are always unselected groups.
      */
-    private void countSelected(LongLongHash hashes) {
+    private void countSelected(LongLongHashTable hashes) {
         int selectedCountsLen = max + 1 - min;
         reserveBytesForIntArray(selectedCountsLen);
         this.selectedCounts = new int[selectedCountsLen];
@@ -186,7 +186,7 @@ public class ValuesNextPreparedForEmitting implements Releasable {
      *     {@code 3, 4, -2, 5, 9}.
      * </p>
      */
-    private void buildIds(int total, LongLongHash hashes) {
+    private void buildIds(int total, LongLongHashTable hashes) {
         reserveBytesForIntArray(total);
         ids = new int[total];
         for (int id = 0; id < hashes.size(); id++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ValuesAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ValuesAggregator.java.st
@@ -14,7 +14,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.util.LongHashTable;
-import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.$if(BytesRef)$Int$else$$Type$$endif$Array;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.aggregation.blockhash.HashImplFactory;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ValuesAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ValuesAggregator.java.st
@@ -13,7 +13,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.common.util.BytesRefHash;
-import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.common.util.$if(BytesRef)$Int$else$$Type$$endif$Array;
@@ -143,14 +142,14 @@ $if(BytesRef)$
         private final BytesRefHash values;
 
 $else$
-        private final LongHash values;
+        private final LongHashTable values;
 
 $endif$
         private SingleState(BigArrays bigArrays) {
 $if(BytesRef)$
             values = new BytesRefHash(1, bigArrays);
 $else$
-            values = new LongHash(1, bigArrays);
+            values = HashImplFactory.newLongHash(bigArrays);
 $endif$
         }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRef2BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRef2BlockHash.java
@@ -11,7 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
-import org.elasticsearch.common.util.LongHash;
+import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -34,7 +34,7 @@ final class BytesRef2BlockHash extends BlockHash {
     private final int channel2;
     private final BytesRefBlockHash hash1;
     private final BytesRefBlockHash hash2;
-    private final LongHash finalHash;
+    private final LongHashTable finalHash;
 
     BytesRef2BlockHash(BlockFactory blockFactory, int channel1, int channel2, int emitBatchSize) {
         super(blockFactory);
@@ -45,7 +45,7 @@ final class BytesRef2BlockHash extends BlockHash {
         try {
             this.hash1 = new BytesRefBlockHash(channel1, blockFactory);
             this.hash2 = new BytesRefBlockHash(channel2, blockFactory);
-            this.finalHash = new LongHash(1, blockFactory.bigArrays());
+            this.finalHash = HashImplFactory.newLongHash(blockFactory);
             success = true;
         } finally {
             if (success == false) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/HashImplFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/HashImplFactory.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.aggregation.blockhash;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.util.BytesRefHashTable;
 import org.elasticsearch.common.util.LongHash;
@@ -37,6 +39,19 @@ public class HashImplFactory {
             return SWISS_HASH_FACTORY.newLongSwissHash(bf.bigArrays().recycler(), bf.breaker());
         } else {
             return new LongHash(1, bf.bigArrays());
+        }
+    }
+
+    /**
+     * Creates a new {@link LongHashTable} using only a {@link BigArrays} for memory accounting.
+     * Used by aggregator state classes that don't have a {@link BlockFactory} in scope.
+     */
+    public static LongHashTable newLongHash(BigArrays bigArrays) {
+        if (SWISS_HASH_FACTORY != null) {
+            CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+            return SWISS_HASH_FACTORY.newLongSwissHash(bigArrays.recycler(), breaker);
+        } else {
+            return new LongHash(1, bigArrays);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/HashImplFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/HashImplFactory.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.aggregation.blockhash;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.common.util.BytesRefHashTable;
@@ -48,7 +49,9 @@ public class HashImplFactory {
      */
     public static LongHashTable newLongHash(BigArrays bigArrays) {
         if (SWISS_HASH_FACTORY != null) {
-            CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+            CircuitBreaker breaker = bigArrays.breakerService() != null
+                ? bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST)
+                : new NoopCircuitBreaker(CircuitBreaker.REQUEST);
             return SWISS_HASH_FACTORY.newLongSwissHash(bigArrays.recycler(), breaker);
         } else {
             return new LongHash(1, bigArrays);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongTopNBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongTopNBlockHash.java
@@ -10,7 +10,7 @@ package org.elasticsearch.compute.aggregation.blockhash;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
-import org.elasticsearch.common.util.LongHash;
+import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
@@ -33,7 +33,7 @@ final class LongTopNBlockHash extends BlockHash {
     private final boolean asc;
     private final boolean nullsFirst;
     private final int limit;
-    private final LongHash hash;
+    private final LongHashTable hash;
     private final LongTopNSet topValues;
 
     /**
@@ -55,7 +55,7 @@ final class LongTopNBlockHash extends BlockHash {
 
         boolean success = false;
         try {
-            this.hash = new LongHash(1, blockFactory.bigArrays());
+            this.hash = HashImplFactory.newLongHash(blockFactory);
             this.topValues = new LongTopNSet(blockFactory.bigArrays(), asc ? SortOrder.ASC : SortOrder.DESC, limit);
             success = true;
         } finally {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/mvdedupe/TopNMultivalueDedupeLong.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/mvdedupe/TopNMultivalueDedupeLong.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.compute.operator.mvdedupe;
 
 import org.apache.lucene.util.ArrayUtil;
-import org.elasticsearch.common.util.LongHash;
+import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
@@ -68,7 +68,7 @@ public class TopNMultivalueDedupeLong {
      * their hashes. This block is suitable for passing as the grouping block
      * to a {@link GroupingAggregatorFunction}.
      */
-    public MultivalueDedupe.HashResult hashAdd(BlockFactory blockFactory, LongHash hash) {
+    public MultivalueDedupe.HashResult hashAdd(BlockFactory blockFactory, LongHashTable hash) {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             boolean sawNull = false;
             for (int p = 0; p < block.getPositionCount(); p++) {
@@ -106,7 +106,7 @@ public class TopNMultivalueDedupeLong {
      * Dedupe values and build an {@link IntBlock} of their hashes. This block is
      * suitable for passing as the grouping block to a {@link GroupingAggregatorFunction}.
      */
-    public IntBlock hashLookup(BlockFactory blockFactory, LongHash hash) {
+    public IntBlock hashLookup(BlockFactory blockFactory, LongHashTable hash) {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             for (int p = 0; p < block.getPositionCount(); p++) {
                 int count = block.getValueCount(p);
@@ -195,7 +195,7 @@ public class TopNMultivalueDedupeLong {
     /**
      * Writes an already deduplicated {@link #work} to a hash.
      */
-    private void hashAddUniquedWork(LongHash hash, IntBlock.Builder builder) {
+    private void hashAddUniquedWork(LongHashTable hash, IntBlock.Builder builder) {
         if (w == 0) {
             builder.appendNull();
             return;
@@ -216,7 +216,7 @@ public class TopNMultivalueDedupeLong {
     /**
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashAddSortedWork(LongHash hash, IntBlock.Builder builder) {
+    private void hashAddSortedWork(LongHashTable hash, IntBlock.Builder builder) {
         if (w == 0) {
             builder.appendNull();
             return;
@@ -242,7 +242,7 @@ public class TopNMultivalueDedupeLong {
     /**
      * Looks up an already deduplicated {@link #work} to a hash.
      */
-    private void hashLookupUniquedWork(LongHash hash, IntBlock.Builder builder) {
+    private void hashLookupUniquedWork(LongHashTable hash, IntBlock.Builder builder) {
         if (w == 0) {
             builder.appendNull();
             return;
@@ -305,7 +305,7 @@ public class TopNMultivalueDedupeLong {
     /**
      * Looks up a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashLookupSortedWork(LongHash hash, IntBlock.Builder builder) {
+    private void hashLookupSortedWork(LongHashTable hash, IntBlock.Builder builder) {
         if (w == 1) {
             hashLookupSingle(builder, hash, work[0]);
             return;
@@ -379,7 +379,7 @@ public class TopNMultivalueDedupeLong {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hashAdd(IntBlock.Builder builder, LongHash hash, long v) {
+    private void hashAdd(IntBlock.Builder builder, LongHashTable hash, long v) {
         if (isAcceptable.test(v)) {
             hashAddNoCheck(builder, hash, v);
         } else {
@@ -387,15 +387,15 @@ public class TopNMultivalueDedupeLong {
         }
     }
 
-    private void hashAddNoCheck(IntBlock.Builder builder, LongHash hash, long v) {
+    private void hashAddNoCheck(IntBlock.Builder builder, LongHashTable hash, long v) {
         appendFound(builder, hash.add(v));
     }
 
-    private long hashLookup(LongHash hash, long v) {
+    private long hashLookup(LongHashTable hash, long v) {
         return isAcceptable.test(v) ? hash.find(v) : -1;
     }
 
-    private void hashLookupSingle(IntBlock.Builder builder, LongHash hash, long v) {
+    private void hashLookupSingle(IntBlock.Builder builder, LongHashTable hash, long v) {
         long found = hashLookup(hash, v);
         if (found >= 0) {
             appendFound(builder, found);


### PR DESCRIPTION

## Summary

Extends the `LongSwissHash` rollout to aggregation components that were previously bypassing `HashImplFactory` and directly constructing `LongHash`/`LongLongHash`.

- Adds `HashImplFactory.newLongHash(BigArrays)` overload for callers (aggregator `SingleState` inner classes) that don't have a `BlockFactory` in scope.
- Migrates `ValuesDouble/Float/Int/Long` aggregators, `ValuesNextLongLong`, `BytesRef2BlockHash`, `LongTopNBlockHash`, and `TopNMultivalueDedupeLong` to use the factory, enabling `LongSwissHash` when available.
- Switches all declared types from `LongHash`/`LongLongHash` to the `LongHashTable`/`LongLongHashTable` interfaces.
- Updates the `X-ValuesAggregator.java.st` template and regenerates all derived files.
- Fixes NPE in the `BigArrays` overload when `bigArrays.breakerService()` is null (e.g. `BigArrays.NON_RECYCLING_INSTANCE` used in benchmarks) — falls back to a `NoopCircuitBreaker` so the Swiss hash path is still used.


Covered by existing tests:

- `ValuesLongAggregatorFunctionTests`, `ValuesIntAggregatorFunctionTests`, `ValuesDoubleAggregatorFunctionTests`, `ValuesFloatAggregatorFunctionTests` — exercise both `SingleState` and `GroupingState` paths of the migrated aggregators.
- `BlockHashTests` / `BlockHashRandomizedTests` — cover `BytesRef2BlockHash`.
- `TopNBlockHashTests` — covers `LongTopNBlockHash`.
- `MultivalueDedupeTests` — covers `TopNMultivalueDedupeLong`; explicitly instantiates and tests both the Swiss hash and standard `LongHash` implementations side by side.
- `ValuesAggregatorBenchmarkTests` — reproduces the NPE fix (benchmark uses `BigArrays.NON_RECYCLING_INSTANCE` which has no `CircuitBreakerService`).

Assisted by Cursor/Claude