### PR TITLE
Reject pathPrefix containing consecutive slashes

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
@@ -202,7 +202,7 @@ public final class RestClientBuilder {
      * it is not intended for other purposes and it should not be supplied in other scenarios.
      *
      * @throws NullPointerException if {@code pathPrefix} is {@code null}.
-     * @throws IllegalArgumentException if {@code pathPrefix} is empty, or ends with more than one '/'.
+     * @throws IllegalArgumentException if {@code pathPrefix} is empty or contains consecutive slashes.
      */
     public RestClientBuilder setPathPrefix(String pathPrefix) {
         this.pathPrefix = cleanPathPrefix(pathPrefix);
@@ -216,6 +216,10 @@ public final class RestClientBuilder {
             throw new IllegalArgumentException("pathPrefix must not be empty");
         }
 
+        if (pathPrefix.contains("//")) {
+            throw new IllegalArgumentException("pathPrefix is malformed. consecutive slashes are not allowed: [" + pathPrefix + "]");
+        }
+
         String cleanPathPrefix = pathPrefix;
         if (cleanPathPrefix.startsWith("/") == false) {
             cleanPathPrefix = "/" + cleanPathPrefix;
@@ -224,10 +228,6 @@ public final class RestClientBuilder {
         // best effort to ensure that it looks like "/base/path" rather than "/base/path/"
         if (cleanPathPrefix.endsWith("/") && cleanPathPrefix.length() > 1) {
             cleanPathPrefix = cleanPathPrefix.substring(0, cleanPathPrefix.length() - 1);
-
-            if (cleanPathPrefix.endsWith("/")) {
-                throw new IllegalArgumentException("pathPrefix is malformed. too many trailing slashes: [" + pathPrefix + "]");
-            }
         }
         return cleanPathPrefix;
     }

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
@@ -235,6 +235,11 @@ public class RestClientBuilderTests extends RestClientTestCase {
     public void testSetPathPrefixMalformed() {
         assertSetPathPrefixThrows("//");
         assertSetPathPrefixThrows("base/path//");
+        assertSetPathPrefixThrows("/base/path//");
+        assertSetPathPrefixThrows("/base//path");
+        assertSetPathPrefixThrows("/base//path/");
+        assertSetPathPrefixThrows("//base/path");
+        assertSetPathPrefixThrows("base//path");
     }
 
     private static void assertSetPathPrefixThrows(final String pathPrefix) {

--- a/docs/changelog/147541.yaml
+++ b/docs/changelog/147541.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 117048
+pr: 147541
+summary: Reject `pathPrefix` containing consecutive slashes
+type: enhancement


### PR DESCRIPTION
`RestClientBuilder.cleanPathPrefix` rejected only the special case where the input ended in two consecutive slashes. Embedded consecutive slashes were silently accepted: `/base//path/` was returned as `/base//path` and propagated verbatim into every request URI built by `RestClient.buildUri`.

This change validates the raw input for any `//` and throws `IllegalArgumentException`, consistent with the existing rejection of null, empty, and trailing-double-slash inputs. The Javadoc is updated to match, and the trailing-slash trim is now unconditional after validation.

Closes #117048