### PR TITLE
Fix integer overflow in CuVSResourceManager.estimateNNDescentMemory

### DIFF
--- a/docs/changelog/147559.yaml
+++ b/docs/changelog/147559.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 147559
+summary: Fix integer overflow in CuVSResourceManager.estimateNNDescentMemory
+type: bug

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/CuVSResourceManager.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/CuVSResourceManager.java
@@ -76,7 +76,7 @@ public interface CuVSResourceManager {
             case INT, UINT -> Integer.BYTES;
             case BYTE -> Byte.BYTES;
         };
-        return (long) (GPU_COMPUTATION_MEMORY_FACTOR * numVectors * dims * elementTypeBytes);
+        return (long) (GPU_COMPUTATION_MEMORY_FACTOR * (long) numVectors * dims * elementTypeBytes);
     }
 
     /** Returns the system-wide pooling manager. */

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/CuVSResourceManagerTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/CuVSResourceManagerTests.java
@@ -225,6 +225,13 @@ public class CuVSResourceManagerTests extends ESTestCase {
         mgr.shutdown();
     }
 
+    public void testEstimateNNDescentMemoryOverflow() {
+        int numVectors = 500_000;
+        int dims = 1024;
+        long result = CuVSResourceManager.estimateNNDescentMemory(numVectors, dims, CuVSMatrix.DataType.FLOAT);
+        assertThat(result, equalTo(4_096_000_000L));
+    }
+
     private static CagraIndexParams createNnDescentParams() {
         return new CagraIndexParams.Builder().withCagraGraphBuildAlgo(CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT)
             .withNNDescentNumIterations(5)


### PR DESCRIPTION
This commit fixes a potential integer overflow in `estimateNNDescentMemory` by casting `numVectors` to `long` before multiplying with `dims` and `elementTypeBytes`. Without this, large inputs (e.g. 500k vectors, 1024 dims, float) silently overflow `int` range producing incorrect (negative) memory estimates. A new unit test that verifies the result for inputs whose product exceeds `Integer.MAX_VALUE`.

I didn't run into this bug in production, just ran across it during reading the coded.