### PR TITLE
Add `input_index` to semantic chunks serializing input_index

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -256,6 +256,7 @@ public class IndexVersions {
     public static final IndexVersion TIME_SERIES_DISABLE_SEQUENCE_NUMBERS_DEFAULT = def(9_094_0_00, Version.LUCENE_10_4_0);
     public static final IndexVersion DEPRECATE_INTEGRATED_COUNTS_BINARY_DOC_VALUES = def(9_095_0_00, Version.LUCENE_10_4_0);
     public static final IndexVersion SEMANTIC_TEXT_LEGACY_FORMAT_FORBIDDEN = def(9_096_00_0, Version.LUCENE_10_4_0);
+    public static final IndexVersion SEMANTIC_TEXT_CHUNK_INPUT_INDEX = def(9_097_0_00, Version.LUCENE_10_4_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
@@ -85,7 +85,6 @@ import java.util.stream.Collectors;
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.inference.telemetry.InferenceStats.serviceAndResponseAttributes;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.toSemanticTextFieldChunks;
-import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.toSemanticTextFieldChunksLegacy;
 
 /**
  * A {@link MappedActionFilter} that intercepts {@link BulkShardRequest} to apply inference on fields specified
@@ -200,7 +199,9 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
      * @param field The target field.
      * @param sourceField The source field.
      * @param input The input to run inference on.
-     * @param inputOrder The original order of the input.
+     * @param inputOrder The original order of the input across all source fields for this target field
+     *                   (used only for sorting responses back into a stable order).
+     * @param sourceFieldInputIndex The 0-based index of this input within its source field's input array.
      * @param offsetAdjustment The adjustment to apply to the chunk text offsets.
      * @param chunkingSettings Additional explicitly specified chunking settings, or null to use model defaults
      */
@@ -210,6 +211,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
         String sourceField,
         String input,
         int inputOrder,
+        int sourceFieldInputIndex,
         int offsetAdjustment,
         ChunkingSettings chunkingSettings
     ) {}
@@ -220,6 +222,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
      * @param sourceField The input that was used to run inference.
      * @param input The input that was used to run inference.
      * @param inputOrder The original order of the input.
+     * @param sourceFieldInputIndex The 0-based index of this input within its source field's input array.
      * @param offsetAdjustment The adjustment to apply to the chunk text offsets.
      * @param model The model used to run inference.
      * @param chunkedResults The actual results.
@@ -229,6 +232,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
         String sourceField,
         String input,
         int inputOrder,
+        int sourceFieldInputIndex,
         int offsetAdjustment,
         Model model,
         ChunkedInference chunkedResults
@@ -430,6 +434,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
                                     request.sourceField(),
                                     useLegacyFormat ? request.input() : null,
                                     request.inputOrder(),
+                                    request.sourceFieldInputIndex(),
                                     request.offsetAdjustment(),
                                     inferenceProvider.model,
                                     result
@@ -565,7 +570,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
 
                         var slot = ensureResponseAccumulatorSlot(itemIndex);
                         slot.addOrUpdateResponse(
-                            new FieldInferenceResponse(field, sourceField, null, order++, 0, null, EMPTY_CHUNKED_INFERENCE)
+                            new FieldInferenceResponse(field, sourceField, null, order++, -1, 0, null, EMPTY_CHUNKED_INFERENCE)
                         );
                         continue;
                     }
@@ -596,6 +601,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
 
                     List<FieldInferenceRequest> requests = requestsMap.computeIfAbsent(inferenceId, k -> new ArrayList<>());
                     int offsetAdjustment = 0;
+                    int sourceFieldInputIndex = 0;
                     for (String v : values) {
                         if (incrementIndexingPressurePreInference(indexRequest, itemIndex) == false) {
                             return inputLength;
@@ -603,15 +609,34 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
 
                         if (v.isBlank()) {
                             slot.addOrUpdateResponse(
-                                new FieldInferenceResponse(field, sourceField, v, order++, 0, null, EMPTY_CHUNKED_INFERENCE)
+                                new FieldInferenceResponse(
+                                    field,
+                                    sourceField,
+                                    v,
+                                    order++,
+                                    sourceFieldInputIndex,
+                                    0,
+                                    null,
+                                    EMPTY_CHUNKED_INFERENCE
+                                )
                             );
                         } else {
                             requests.add(
-                                new FieldInferenceRequest(itemIndex, field, sourceField, v, order++, offsetAdjustment, chunkingSettings)
+                                new FieldInferenceRequest(
+                                    itemIndex,
+                                    field,
+                                    sourceField,
+                                    v,
+                                    order++,
+                                    sourceFieldInputIndex,
+                                    offsetAdjustment,
+                                    chunkingSettings
+                                )
                             );
                             inputLength += v.length();
                         }
 
+                        sourceFieldInputIndex++;
                         // When using the inference metadata fields format, all the input values are concatenated so that the
                         // chunk text offsets are expressed in the context of a single string. Calculate the offset adjustment
                         // to apply to account for this.
@@ -717,9 +742,14 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
                     }
 
                     var lst = chunkMap.computeIfAbsent(resp.sourceField, k -> new ArrayList<>());
-                    var chunks = useLegacyFormat
-                        ? toSemanticTextFieldChunksLegacy(resp.input, resp.chunkedResults, indexRequest.getContentType())
-                        : toSemanticTextFieldChunks(resp.offsetAdjustment, resp.chunkedResults, indexRequest.getContentType());
+                    var chunks = toSemanticTextFieldChunks(
+                        useLegacyFormat,
+                        resp.input,
+                        resp.sourceFieldInputIndex,
+                        resp.offsetAdjustment,
+                        resp.chunkedResults,
+                        indexRequest.getContentType()
+                    );
                     lst.addAll(chunks);
                 }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticFieldMapper.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.mapper;
 
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
@@ -75,6 +76,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.inference.TaskType.EMBEDDING;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKED_EMBEDDINGS_FIELD;
+import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKED_INPUT_INDEX_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKED_OFFSET_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKING_SETTINGS_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKS_FIELD;
@@ -753,6 +755,12 @@ public class SemanticFieldMapper extends FieldMapper implements InferenceFieldMa
                 offsetsField.parse(subContext);
             }
         }
+        if (chunk.inputIndex() >= 0) {
+            FieldMapper inputIndexField = fieldType.getInputIndexField();
+            if (inputIndexField != null) {
+                context.doc().add(new NumericDocValuesField(inputIndexField.fullPath(), chunk.inputIndex()));
+            }
+        }
     }
 
     protected SemanticFieldMapper addDynamicUpdate(DocumentParserContext context, SemanticTextField field) {
@@ -846,6 +854,11 @@ public class SemanticFieldMapper extends FieldMapper implements InferenceFieldMa
 
         public FieldMapper getOffsetsField() {
             return (FieldMapper) getChunksField().getMapper(CHUNKED_OFFSET_FIELD);
+        }
+
+        @Nullable
+        public FieldMapper getInputIndexField() {
+            return (FieldMapper) getChunksField().getMapper(CHUNKED_INPUT_INDEX_FIELD);
         }
 
         @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticFieldValueFetcher.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticFieldValueFetcher.java
@@ -146,6 +146,7 @@ class SemanticFieldValueFetcher implements ValueFetcher {
                     null,
                     offset.start(),
                     offset.end(),
+                    -1,
                     rawEmbeddings(embeddingsFieldLoader::write, source.sourceContentType())
                 )
             );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticFieldValueFetcher.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticFieldValueFetcher.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.inference.mapper;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -16,6 +17,7 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.util.BitSet;
+import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -61,6 +63,7 @@ class SemanticFieldValueFetcher implements ValueFetcher {
     private Scorer childScorer;
     private SourceLoader.SyntheticFieldLoader.DocValuesLoader dvLoader;
     private OffsetSourceField.OffsetSourceLoader offsetsLoader;
+    private NumericDocValues inputIndexDV;
 
     SemanticFieldValueFetcher(
         SemanticFieldMapper.SemanticFieldType fieldType,
@@ -94,6 +97,10 @@ class SemanticFieldValueFetcher implements ValueFetcher {
 
             var terms = context.reader().terms(getOffsetsFieldName(fieldType.name()));
             offsetsLoader = terms != null ? OffsetSourceField.loader(terms) : null;
+
+            inputIndexDV = fieldType.getInputIndexField() != null
+                ? context.reader().getNumericDocValues(fieldType.getInputIndexField().fullPath())
+                : null;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -123,7 +130,7 @@ class SemanticFieldValueFetcher implements ValueFetcher {
         Map<String, String> originalValueMap = new HashMap<>();
         List<Object> chunks = new ArrayList<>();
 
-        iterateChildDocs(doc, it, offset -> {
+        iterateChildDocs(doc, it, (offset, inputIndex) -> {
             var rawValue = originalValueMap.computeIfAbsent(offset.field(), k -> {
                 var valueObj = XContentMapValues.extractValue(offset.field(), source.source(), null);
                 var values = SemanticTextUtils.nodeStringValues(offset.field(), valueObj).stream().toList();
@@ -139,14 +146,14 @@ class SemanticFieldValueFetcher implements ValueFetcher {
     private List<Object> fetchFullField(Source source, int doc, DocIdSetIterator it) throws IOException {
         Map<String, List<SemanticTextField.Chunk>> chunkMap = new LinkedHashMap<>();
 
-        iterateChildDocs(doc, it, offset -> {
+        iterateChildDocs(doc, it, (offset, inputIndex) -> {
             var fullChunks = chunkMap.computeIfAbsent(offset.field(), k -> new ArrayList<>());
             fullChunks.add(
                 new SemanticTextField.Chunk(
                     null,
                     offset.start(),
                     offset.end(),
-                    -1,
+                    inputIndex,
                     rawEmbeddings(embeddingsFieldLoader::write, source.sourceContentType())
                 )
             );
@@ -172,8 +179,11 @@ class SemanticFieldValueFetcher implements ValueFetcher {
         );
     }
 
-    private void iterateChildDocs(int doc, DocIdSetIterator it, CheckedConsumer<OffsetSourceFieldMapper.OffsetSource, IOException> action)
-        throws IOException {
+    private void iterateChildDocs(
+        int doc,
+        DocIdSetIterator it,
+        CheckedBiConsumer<OffsetSourceFieldMapper.OffsetSource, Integer, IOException> action
+    ) throws IOException {
         while (it.docID() < doc) {
             if (mode == Mode.FULL_FIELD) {
                 if (dvLoader == null || dvLoader.advanceToDoc(it.docID()) == false) {
@@ -190,7 +200,12 @@ class SemanticFieldValueFetcher implements ValueFetcher {
                 );
             }
 
-            action.accept(offset);
+            int inputIndex = -1;
+            if (inputIndexDV != null && inputIndexDV.advanceExact(it.docID())) {
+                inputIndex = (int) inputIndexDV.longValue();
+            }
+
+            action.accept(offset, inputIndex);
 
             if (it.nextDoc() == DocIdSetIterator.NO_MORE_DOCS) {
                 break;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextField.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextField.java
@@ -117,6 +117,10 @@ public record SemanticTextField(
         return getChunksFieldName(fieldName) + "." + CHUNKED_OFFSET_FIELD;
     }
 
+    public static String getInputIndexFieldName(String fieldName) {
+        return getChunksFieldName(fieldName) + "." + CHUNKED_INPUT_INDEX_FIELD;
+    }
+
     protected record ParserContext(boolean useLegacyFormat, String fieldName, XContentType xContentType) {}
 
     static SemanticTextField parse(XContentParser parser, ParserContext context) throws IOException {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextField.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextField.java
@@ -75,6 +75,7 @@ public record SemanticTextField(
     static final String CHUNKED_OFFSET_FIELD = "offset";
     static final String CHUNKED_START_OFFSET_FIELD = "start_offset";
     static final String CHUNKED_END_OFFSET_FIELD = "end_offset";
+    static final String CHUNKED_INPUT_INDEX_FIELD = "input_index";
     public static final String MODEL_SETTINGS_FIELD = "model_settings";
     static final String CHUNKING_SETTINGS_FIELD = "chunking_settings";
 
@@ -85,7 +86,16 @@ public record SemanticTextField(
         Map<String, List<Chunk>> chunks
     ) {}
 
-    public record Chunk(@Nullable String text, int startOffset, int endOffset, BytesReference rawEmbeddings) {}
+    /**
+     * @param text          The chunk text, populated only when used by the legacy XContent serializer.
+     * @param startOffset   Start offset of the chunk within the (virtual) concatenated source-field input string. {@code -1} for legacy.
+     * @param endOffset     End offset of the chunk within the (virtual) concatenated source-field input string. {@code -1} for legacy.
+     * @param inputIndex    Index of the input value (within a source field's input array) that produced this chunk. {@code -1} when
+     *                      unknown — set by older nodes that did not yet include the field, or for legacy-format chunks where
+     *                      provenance is implicit by chunk position.
+     * @param rawEmbeddings Serialized embeddings for the chunk.
+     */
+    public record Chunk(@Nullable String text, int startOffset, int endOffset, int inputIndex, BytesReference rawEmbeddings) {}
 
     public static String getOriginalTextFieldName(String fieldName) {
         return fieldName + "." + TEXT_FIELD;
@@ -178,6 +188,9 @@ public record SemanticTextField(
                 } else {
                     builder.field(CHUNKED_START_OFFSET_FIELD, chunk.startOffset);
                     builder.field(CHUNKED_END_OFFSET_FIELD, chunk.endOffset);
+                    if (chunk.inputIndex >= 0) {
+                        builder.field(CHUNKED_INPUT_INDEX_FIELD, chunk.inputIndex);
+                    }
                 }
                 XContentParser parser = XContentHelper.createParserNotCompressed(
                     XContentParserConfiguration.EMPTY,
@@ -242,7 +255,13 @@ public record SemanticTextField(
             if (context.useLegacyFormat() && text == null) {
                 throw new IllegalArgumentException("Missing chunk text");
             }
-            return new Chunk(text, args[1] != null ? (int) args[1] : -1, args[2] != null ? (int) args[2] : -1, (BytesReference) args[3]);
+            return new Chunk(
+                text,
+                args[1] != null ? (int) args[1] : -1,
+                args[2] != null ? (int) args[2] : -1,
+                args[3] != null ? (int) args[3] : -1,
+                (BytesReference) args[4]
+            );
         }
     );
 
@@ -273,6 +292,7 @@ public record SemanticTextField(
         CHUNKS_PARSER.declareString(optionalConstructorArg(), new ParseField(TEXT_FIELD));
         CHUNKS_PARSER.declareInt(optionalConstructorArg(), new ParseField(CHUNKED_START_OFFSET_FIELD));
         CHUNKS_PARSER.declareInt(optionalConstructorArg(), new ParseField(CHUNKED_END_OFFSET_FIELD));
+        CHUNKS_PARSER.declareInt(optionalConstructorArg(), new ParseField(CHUNKED_INPUT_INDEX_FIELD));
         CHUNKS_PARSER.declareField(constructorArg(), (p, c) -> {
             XContentBuilder b = XContentBuilder.builder(p.contentType().xContent());
             b.copyCurrentStructure(p);
@@ -305,26 +325,60 @@ public record SemanticTextField(
     }
 
     /**
-     * Converts the provided {@link ChunkedInference} into a list of {@link Chunk}.
+     * Converts the provided {@link ChunkedInference} into a list of {@link Chunk}, choosing the legacy vs non-legacy chunk shape
+     * based on {@code useLegacyFormat}. This is the single entry point used by {@code ShardBulkInferenceActionFilter} so that the
+     * filter does not need to branch on the format itself.
+     *
+     * @param useLegacyFormat  Whether the destination index uses the legacy semantic_text format.
+     * @param input            The original input string for this chunk's source field. Used to extract chunk text in legacy mode;
+     *                         ignored in non-legacy mode.
+     * @param inputIndex       Index of the originating input value within its source-field input array. Ignored in legacy mode
+     *                         (where the resulting chunks always have {@code inputIndex == -1}).
+     * @param offsetAdjustment Adjustment applied to chunk offsets so they are expressed against the virtual concatenation of all
+     *                         source-field input values. Ignored in legacy mode (chunks always have {@code -1} offsets).
      */
-    public static List<Chunk> toSemanticTextFieldChunks(int offsetAdjustment, ChunkedInference results, XContentType contentType)
-        throws IOException {
+    public static List<Chunk> toSemanticTextFieldChunks(
+        boolean useLegacyFormat,
+        String input,
+        int inputIndex,
+        int offsetAdjustment,
+        ChunkedInference results,
+        XContentType contentType
+    ) throws IOException {
+        return useLegacyFormat
+            ? toSemanticTextFieldChunksLegacy(input, results, contentType)
+            : toSemanticTextFieldChunks(inputIndex, offsetAdjustment, results, contentType);
+    }
+
+    /**
+     * Converts the provided {@link ChunkedInference} into a list of {@link Chunk} for the non-legacy format.
+     *
+     * @param inputIndex       Index of the originating input value within its source-field input array. Pass {@code -1} when the chunks
+     *                         are produced by the legacy (text-only) format, where chunk provenance is implicit by position.
+     * @param offsetAdjustment Adjustment applied to chunk offsets so they are expressed against the virtual concatenation of all
+     *                         source-field input values. Pass {@code 0} for legacy chunks.
+     */
+    public static List<Chunk> toSemanticTextFieldChunks(
+        int inputIndex,
+        int offsetAdjustment,
+        ChunkedInference results,
+        XContentType contentType
+    ) throws IOException {
         List<Chunk> chunks = new ArrayList<>();
         Iterator<ChunkedInference.Chunk> it = results.chunksAsByteReference(contentType.xContent());
         while (it.hasNext()) {
-            chunks.add(toSemanticTextFieldChunk(offsetAdjustment, it.next()));
+            chunks.add(toSemanticTextFieldChunk(inputIndex, offsetAdjustment, it.next()));
         }
         return chunks;
     }
 
     /**
-     * Converts the provided {@link ChunkedInference} into a list of {@link Chunk}.
+     * Converts the provided {@link ChunkedInference} into a single {@link Chunk}.
      */
-    public static Chunk toSemanticTextFieldChunk(int offsetAdjustment, ChunkedInference.Chunk chunk) {
-        String text = null;
+    public static Chunk toSemanticTextFieldChunk(int inputIndex, int offsetAdjustment, ChunkedInference.Chunk chunk) {
         int startOffset = chunk.textOffset().start() + offsetAdjustment;
         int endOffset = chunk.textOffset().end() + offsetAdjustment;
-        return new Chunk(text, startOffset, endOffset, chunk.bytesReference());
+        return new Chunk(null, startOffset, endOffset, inputIndex, chunk.bytesReference());
     }
 
     public static List<Chunk> toSemanticTextFieldChunksLegacy(String input, ChunkedInference results, XContentType contentType)
@@ -339,7 +393,7 @@ public record SemanticTextField(
 
     public static Chunk toSemanticTextFieldChunkLegacy(String input, org.elasticsearch.inference.ChunkedInference.Chunk chunk) {
         var text = input.substring(chunk.textOffset().start(), chunk.textOffset().end());
-        return new Chunk(text, -1, -1, chunk.bytesReference());
+        return new Chunk(text, -1, -1, -1, chunk.bytesReference());
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MappingParserContext;
 import org.elasticsearch.index.mapper.NestedObjectMapper;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -63,6 +64,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.index.IndexVersions.NEW_SPARSE_VECTOR;
+import static org.elasticsearch.index.IndexVersions.SEMANTIC_TEXT_CHUNK_INPUT_INDEX;
 import static org.elasticsearch.index.IndexVersions.SEMANTIC_TEXT_DEFAULTS_TO_BBQ;
 import static org.elasticsearch.index.IndexVersions.SEMANTIC_TEXT_DEFAULTS_TO_BBQ_BACKPORT_8_X;
 import static org.elasticsearch.index.IndexVersions.SEMANTIC_TEXT_DEFAULTS_TO_BFLOAT16;
@@ -73,6 +75,7 @@ import static org.elasticsearch.inference.TaskType.SPARSE_EMBEDDING;
 import static org.elasticsearch.inference.TaskType.TEXT_EMBEDDING;
 import static org.elasticsearch.search.SearchService.DEFAULT_SIZE;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKED_EMBEDDINGS_FIELD;
+import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKED_INPUT_INDEX_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.CHUNKED_OFFSET_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.TEXT_FIELD;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getChunksFieldName;
@@ -318,6 +321,15 @@ public class SemanticTextFieldMapper extends SemanticFieldMapper {
                 chunksField.add(chunkTextField);
             } else {
                 chunksField.add(new OffsetSourceFieldMapper.Builder(CHUNKED_OFFSET_FIELD));
+                if (indexVersionCreated.onOrAfter(SEMANTIC_TEXT_CHUNK_INPUT_INDEX)) {
+                    chunksField.add(
+                        NumberFieldMapper.Builder.docValuesOnly(
+                            CHUNKED_INPUT_INDEX_FIELD,
+                            NumberFieldMapper.NumberType.INTEGER,
+                            indexSettings
+                        )
+                    );
+                }
             }
             return chunksField;
         }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
@@ -545,6 +545,64 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
         awaitLatch(chainExecuted, 10, TimeUnit.SECONDS);
     }
 
+    /**
+     * Verifies that when a source field carries an array of inputs, each chunk in the new format records the originating
+     * {@code input_index} (0-based) within that source-field input array.
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void testInputIndexForMultipleInputs() throws Exception {
+        assumeFalse("input_index is only emitted in the non-legacy format", useLegacyFormat);
+        final InferenceStats inferenceStats = InferenceStatsTests.mockInferenceStats();
+        StaticModel model = StaticModel.createRandomInstance(TaskType.SPARSE_EMBEDDING);
+        List<String> inputs = List.of("alpha input", "beta input", "gamma input");
+        for (String input : inputs) {
+            model.putResult(input, randomChunkedInferenceEmbedding(model, List.of(input)));
+        }
+
+        ShardBulkInferenceActionFilter filter = createFilter(
+            threadPool,
+            Map.of(model.getInferenceEntityId(), model),
+            NOOP_INDEXING_PRESSURE,
+            useLegacyFormat,
+            inferenceStats
+        );
+
+        CountDownLatch chainExecuted = new CountDownLatch(1);
+        ActionFilterChain actionFilterChain = (task, action, request, listener) -> {
+            try {
+                BulkShardRequest bulkShardRequest = (BulkShardRequest) request;
+                IndexRequest actualRequest = getIndexRequestOrNull(bulkShardRequest.items()[0].request());
+                Map<String, Object> inferenceFields = (Map<String, Object>) XContentMapValues.extractValue(
+                    InferenceMetadataFieldsMapper.NAME,
+                    actualRequest.sourceAsMap()
+                );
+                assertNotNull(inferenceFields);
+                List<Object> chunks = (List<Object>) XContentMapValues.extractValue("field1.inference.chunks.field1", inferenceFields);
+                assertNotNull(chunks);
+                assertThat(chunks.size(), equalTo(inputs.size()));
+                for (int i = 0; i < chunks.size(); i++) {
+                    Map<String, Object> chunkMap = (Map<String, Object>) chunks.get(i);
+                    assertThat("chunk " + i + " input_index", chunkMap.get("input_index"), equalTo(i));
+                }
+            } finally {
+                chainExecuted.countDown();
+            }
+        };
+        ActionListener actionListener = mock(ActionListener.class);
+        Task task = mock(Task.class);
+
+        Map<String, InferenceFieldMetadata> inferenceFieldMap = Map.of(
+            "field1",
+            new InferenceFieldMetadata("field1", model.getInferenceEntityId(), new String[] { "field1" }, null)
+        );
+        BulkItemRequest[] items = new BulkItemRequest[1];
+        items[0] = new BulkItemRequest(0, new IndexRequest("index").source(Map.of("field1", inputs)));
+        BulkShardRequest request = new BulkShardRequest(new ShardId("test", "test", 0), WriteRequest.RefreshPolicy.NONE, items);
+        request.setInferenceFieldMap(inferenceFieldMap);
+        filter.apply(task, TransportShardBulkAction.ACTION_NAME, request, actionListener, actionFilterChain);
+        awaitLatch(chainExecuted, 10, TimeUnit.SECONDS);
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testManyRandomDocs() throws Exception {
         final InferenceStats inferenceStats = InferenceStatsTests.mockInferenceStats();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -55,6 +55,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.NestedObjectMapper;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
@@ -1399,10 +1400,22 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
             assertThat(textMapper, instanceOf(KeywordFieldMapper.class));
             KeywordFieldMapper textFieldMapper = (KeywordFieldMapper) textMapper;
             assertThat(textFieldMapper.fieldType().indexType(), equalTo(IndexType.NONE));
+            assertNull(semanticTextFieldType.getInputIndexField());
         } else {
             assertNull(textMapper);
             var offsetMapper = semanticTextFieldType.getOffsetsField();
             assertThat(offsetMapper, instanceOf(OffsetSourceFieldMapper.class));
+
+            var inputIndexMapper = semanticTextFieldType.getInputIndexField();
+            if (indexVersion.onOrAfter(IndexVersions.SEMANTIC_TEXT_CHUNK_INPUT_INDEX)) {
+                assertThat(inputIndexMapper, instanceOf(NumberFieldMapper.class));
+                NumberFieldMapper inputIndexFieldMapper = (NumberFieldMapper) inputIndexMapper;
+                assertThat(inputIndexFieldMapper.fieldType().typeName(), equalTo("integer"));
+                assertFalse(inputIndexFieldMapper.fieldType().indexType().hasPoints());
+                assertTrue(inputIndexFieldMapper.fieldType().hasDocValues());
+            } else {
+                assertNull(inputIndexMapper);
+            }
         }
 
         if (expectedModelSettings) {
@@ -1652,6 +1665,66 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
                     assertEquals(0, topDocs.totalHits.value());
                 }
             });
+        }
+    }
+
+    public void testInputIndexDocValueIsWrittenForNonLegacyChunks() throws IOException {
+        assumeFalse("input_index doc value is only emitted in the non-legacy format", useLegacyFormat);
+
+        final String fieldName = "field1";
+        final TaskType taskType = TaskType.SPARSE_EMBEDDING;
+        final Model model = TestModel.createRandomInstance(taskType);
+        when(globalModelRegistry.getMinimalServiceSettings(anyString())).thenReturn(new MinimalServiceSettings(model));
+
+        final List<String> inputs = List.of("first input", "second input", "third input");
+        final IndexVersion indexVersion = IndexVersion.current();
+
+        XContentBuilder mapping = mapping(b -> addSemanticTextMapping(b, fieldName, model.getInferenceEntityId(), null, null, null));
+        MapperService mapperService = createMapperServiceWithIndexVersion(mapping, false, indexVersion);
+
+        SemanticTextField semanticTextField = randomSemanticText(false, fieldName, model, null, inputs, XContentType.JSON);
+
+        ParsedDocument doc = mapperService.documentMapper()
+            .parse(source(b -> addSemanticTextInferenceResults(false, b, List.of(semanticTextField))));
+
+        // Three chunk nested docs followed by the parent doc.
+        List<LuceneDocument> luceneDocs = doc.docs();
+        assertEquals(inputs.size() + 1, luceneDocs.size());
+
+        String inputIndexFieldName = SemanticTextField.getInputIndexFieldName(fieldName);
+        for (int i = 0; i < inputs.size(); i++) {
+            // Nested chunk docs are emitted in source order; randomSemanticText uses sequential inputIndex starting at 0.
+            IndexableField field = luceneDocs.get(i).getField(inputIndexFieldName);
+            assertNotNull("missing input_index doc value on chunk " + i, field);
+            assertEquals("unexpected input_index on chunk " + i, i, field.numericValue().intValue());
+        }
+    }
+
+    public void testInputIndexDocValueIsAbsentForPreGateIndex() throws IOException {
+        assumeFalse("input_index doc value is only emitted in the non-legacy format", useLegacyFormat);
+
+        final String fieldName = "field1";
+        final TaskType taskType = TaskType.SPARSE_EMBEDDING;
+        final Model model = TestModel.createRandomInstance(taskType);
+        when(globalModelRegistry.getMinimalServiceSettings(anyString())).thenReturn(new MinimalServiceSettings(model));
+
+        final List<String> inputs = List.of("first input", "second input");
+        final IndexVersion preGateVersion = IndexVersionUtils.getPreviousVersion(IndexVersions.SEMANTIC_TEXT_CHUNK_INPUT_INDEX);
+
+        XContentBuilder mapping = mapping(b -> addSemanticTextMapping(b, fieldName, model.getInferenceEntityId(), null, null, null));
+        MapperService mapperService = createMapperServiceWithIndexVersion(mapping, false, preGateVersion);
+
+        SemanticTextField semanticTextField = randomSemanticText(false, fieldName, model, null, inputs, XContentType.JSON);
+
+        ParsedDocument doc = mapperService.documentMapper()
+            .parse(source(b -> addSemanticTextInferenceResults(false, b, List.of(semanticTextField))));
+
+        String inputIndexFieldName = SemanticTextField.getInputIndexFieldName(fieldName);
+        for (int i = 0; i < inputs.size(); i++) {
+            assertNull(
+                "input_index doc value should be absent on pre-gate index for chunk " + i,
+                doc.docs().get(i).getField(inputIndexFieldName)
+            );
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldTests.java
@@ -429,9 +429,10 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
 
             inputIndex++;
             // When using the inference metadata fields format, all the input values are concatenated so that the
-            // chunk text offsets are expressed in the context of a single string. Calculate the offset adjustment
-            // to apply to account for this.
-            offsetAdjustment = input.length() + 1; // Add one for separator char length
+            // chunk text offsets are expressed in the context of a single string. Accumulate the offset adjustment
+            // across all preceding inputs (including their separator chars) so that the next chunk's offsets land at
+            // the correct position in the merged string.
+            offsetAdjustment += input.length() + 1; // Add one for separator char length
         }
 
         if (inputsIt.hasNext() || chunkIt.hasNext()) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldTests.java
@@ -96,6 +96,7 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
                 assertThat(actualChunk.text(), equalTo(expectedChunks.get(i).text()));
                 assertThat(actualChunk.startOffset(), equalTo(expectedChunks.get(i).startOffset()));
                 assertThat(actualChunk.endOffset(), equalTo(expectedChunks.get(i).endOffset()));
+                assertThat(actualChunk.inputIndex(), equalTo(expectedChunks.get(i).inputIndex()));
                 switch (modelSettings.taskType()) {
                     case TEXT_EMBEDDING -> {
                         int embeddingLength = DenseVectorFieldMapperTestUtils.getEmbeddingLength(
@@ -225,6 +226,32 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
             new SemanticTextField.ParserContext(useLegacyFormat, NAME, parser.contentType())
         );
         assertThat(parsed.inference().modelSettings().endpointMetadata(), equalTo(EndpointMetadata.EMPTY_INSTANCE));
+    }
+
+    /**
+     * Verifies that chunks serialized by older nodes (or older on-disk documents) — i.e. without an {@code input_index} field —
+     * still parse and default to {@code inputIndex == -1}. This is the wire-compat behavior we rely on for mixed clusters.
+     */
+    public void testNonLegacyChunksParseWithoutInputIndex() throws IOException {
+        assumeFalse("Only applies to the non-legacy chunk format", useLegacyFormat);
+        String json = "{"
+            + "\"inference\":{"
+            + "\"inference_id\":\"test-inference-id\","
+            + "\"model_settings\":{\"service\":\"test-service\",\"task_type\":\"sparse_embedding\"},"
+            + "\"chunks\":{"
+            + "\""
+            + NAME
+            + "\":[{\"start_offset\":0,\"end_offset\":5,\"embeddings\":{\"foo\":1.0}}]"
+            + "}"
+            + "}"
+            + "}";
+        XContentParser parser = createParser(XContentType.JSON.xContent(), json);
+        SemanticTextField parsed = SemanticTextField.parse(parser, new SemanticTextField.ParserContext(false, NAME, parser.contentType()));
+        List<SemanticTextField.Chunk> chunks = parsed.inference().chunks().get(NAME);
+        assertThat(chunks.size(), equalTo(1));
+        assertThat(chunks.get(0).inputIndex(), equalTo(-1));
+        assertThat(chunks.get(0).startOffset(), equalTo(0));
+        assertThat(chunks.get(0).endOffset(), equalTo(5));
     }
 
     public void testGetDenseVectorsAsSupplier() throws IOException {
@@ -388,13 +415,19 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
         // corresponding chunk.
         final List<SemanticTextField.Chunk> chunks = new ArrayList<>(inputs.size());
         int offsetAdjustment = 0;
+        int inputIndex = 0;
         Iterator<String> inputsIt = inputs.iterator();
         Iterator<ChunkedInference.Chunk> chunkIt = results.chunksAsByteReference(contentType.xContent());
         while (inputsIt.hasNext() && chunkIt.hasNext()) {
             String input = inputsIt.next();
             var chunk = chunkIt.next();
-            chunks.add(useLegacyFormat ? toSemanticTextFieldChunkLegacy(input, chunk) : toSemanticTextFieldChunk(offsetAdjustment, chunk));
+            chunks.add(
+                useLegacyFormat
+                    ? toSemanticTextFieldChunkLegacy(input, chunk)
+                    : toSemanticTextFieldChunk(inputIndex, offsetAdjustment, chunk)
+            );
 
+            inputIndex++;
             // When using the inference metadata fields format, all the input values are concatenated so that the
             // chunk text offsets are expressed in the context of a single string. Calculate the offset adjustment
             // to apply to account for this.

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SemanticTextUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SemanticTextUpgradeIT.java
@@ -51,6 +51,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 
 public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
     private static final String INDEX_BASE_NAME = "semantic_text_test_index";
+    private static final String INPUT_INDEX_BWC_INDEX_BASE_NAME = "semantic_text_input_index_bwc";
     private static final String SPARSE_FIELD = "sparse_field";
     private static final String DENSE_FIELD = "dense_field";
 
@@ -61,6 +62,19 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
         List.of("a test value", "with multiple test values"),
         DOC_2_ID,
         List.of("another test value")
+    );
+
+    private static final String INPUT_INDEX_BWC_DOC_OLD = "doc_old_phase";
+    private static final String INPUT_INDEX_BWC_DOC_MIXED = "doc_mixed_phase";
+    private static final String INPUT_INDEX_BWC_DOC_UPGRADED = "doc_upgraded_phase";
+    private static final Map<String, List<String>> INPUT_INDEX_BWC_DOC_VALUES = Map.of(
+        INPUT_INDEX_BWC_DOC_OLD,
+        // Multi-value source field exercises the per-input-index propagation.
+        List.of("alpha bwc input", "beta bwc input", "gamma bwc input"),
+        INPUT_INDEX_BWC_DOC_MIXED,
+        List.of("delta bwc input", "epsilon bwc input"),
+        INPUT_INDEX_BWC_DOC_UPGRADED,
+        List.of("zeta bwc input", "eta bwc input")
     );
 
     private static Model SPARSE_MODEL;
@@ -107,7 +121,11 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     private void createAndPopulateIndex() throws IOException {
-        final String indexName = getIndexName();
+        createSemanticIndex(getIndexName());
+        indexDoc(getIndexName(), DOC_1_ID, DOC_VALUES.get(DOC_1_ID));
+    }
+
+    private void createSemanticIndex(String indexName) throws IOException {
         final String mapping = Strings.format("""
             {
               "properties": {
@@ -129,26 +147,27 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
             mapping
         );
         assertThat(response.isAcknowledged(), equalTo(true));
-
-        indexDoc(DOC_1_ID, DOC_VALUES.get(DOC_1_ID));
     }
 
     private void performIndexQueryHighlightOps() throws IOException {
-        indexDoc(DOC_2_ID, DOC_VALUES.get(DOC_2_ID));
+        indexDoc(getIndexName(), DOC_2_ID, DOC_VALUES.get(DOC_2_ID));
 
-        ObjectPath sparseQueryObjectPath = semanticQuery(SPARSE_FIELD, SPARSE_MODEL, "test value", 3);
-        assertQueryResponseWithHighlights(sparseQueryObjectPath, SPARSE_FIELD);
+        ObjectPath sparseQueryObjectPath = semanticQuery(getIndexName(), SPARSE_FIELD, SPARSE_MODEL, "test value", 3);
+        assertQueryResponseWithHighlights(sparseQueryObjectPath, SPARSE_FIELD, DOC_VALUES, Set.of(DOC_1_ID, DOC_2_ID));
 
-        ObjectPath denseQueryObjectPath = semanticQuery(DENSE_FIELD, DENSE_MODEL, "test value", 3);
-        assertQueryResponseWithHighlights(denseQueryObjectPath, DENSE_FIELD);
+        ObjectPath denseQueryObjectPath = semanticQuery(getIndexName(), DENSE_FIELD, DENSE_MODEL, "test value", 3);
+        assertQueryResponseWithHighlights(denseQueryObjectPath, DENSE_FIELD, DOC_VALUES, Set.of(DOC_1_ID, DOC_2_ID));
     }
 
     private String getIndexName() {
         return INDEX_BASE_NAME + (useLegacyFormat ? "_legacy" : "_new");
     }
 
-    private void indexDoc(String id, List<String> semanticTextFieldValue) throws IOException {
-        final String indexName = getIndexName();
+    private String getInputIndexBwcIndexName() {
+        return INPUT_INDEX_BWC_INDEX_BASE_NAME + (useLegacyFormat ? "_legacy" : "_new");
+    }
+
+    private void indexDoc(String indexName, String id, List<String> semanticTextFieldValue) throws IOException {
         final SemanticTextField sparseFieldValue = randomSemanticText(
             useLegacyFormat,
             SPARSE_FIELD,
@@ -184,7 +203,8 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
         assertOK(response);
     }
 
-    private ObjectPath semanticQuery(String field, Model fieldModel, String query, Integer numOfHighlightFragments) throws IOException {
+    private ObjectPath semanticQuery(String indexName, String field, Model fieldModel, String query, Integer numOfHighlightFragments)
+        throws IOException {
         // We can't perform a real semantic query because that requires performing inference, so instead we perform an equivalent nested
         // query
         final String embeddingsFieldName = SemanticTextField.getEmbeddingsFieldName(field);
@@ -234,16 +254,21 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
         }
         builder.endObject();
 
-        Request request = new Request("GET", getIndexName() + "/_search");
+        Request request = new Request("GET", indexName + "/_search");
         request.setJsonEntity(Strings.toString(builder));
 
         Response response = client().performRequest(request);
         return assertOKAndCreateObjectPath(response);
     }
 
-    private static void assertQueryResponseWithHighlights(ObjectPath queryObjectPath, String field) throws IOException {
-        assertThat(queryObjectPath.evaluate("hits.total.value"), equalTo(2));
-        assertThat(queryObjectPath.evaluateArraySize("hits.hits"), equalTo(2));
+    private static void assertQueryResponseWithHighlights(
+        ObjectPath queryObjectPath,
+        String field,
+        Map<String, List<String>> expectedHighlightsById,
+        Set<String> expectedDocIds
+    ) throws IOException {
+        assertThat(queryObjectPath.evaluate("hits.total.value"), equalTo(expectedDocIds.size()));
+        assertThat(queryObjectPath.evaluateArraySize("hits.hits"), equalTo(expectedDocIds.size()));
 
         Set<String> docIds = new HashSet<>();
         List<Map<String, Object>> hits = queryObjectPath.evaluate("hits.hits");
@@ -252,11 +277,53 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
             assertThat(id, notNullValue());
             docIds.add(id);
 
-            List<String> expectedHighlight = DOC_VALUES.get(id);
+            List<String> expectedHighlight = expectedHighlightsById.get(id);
             assertThat(expectedHighlight, notNullValue());
             assertThat(ObjectPath.evaluate(hit, "highlight." + field), equalTo(expectedHighlight));
         }
 
-        assertThat(docIds, equalTo(Set.of(DOC_1_ID, DOC_2_ID)));
+        assertThat(docIds, equalTo(expectedDocIds));
+    }
+
+    /**
+     * Rolling-upgrade BWC test for the {@code input_index} field added to {@code SemanticTextField.Chunk} for the non-legacy
+     * semantic_text format. The scenario:
+     * <ol>
+     *   <li>OLD phase: create a non-legacy semantic_text index and ingest a document whose source field carries multiple
+     *       inputs. Documents written from the test client (running on the new code) embed {@code input_index} in
+     *       {@code _inference_fields}; the old-version cluster nodes that may receive the request must accept it
+     *       (relying on the parser's {@code ignoreUnknownFields=true} behavior for forward-compat).</li>
+     *   <li>MIXED phase: ingest another multi-input document. Coordinators are a mix of old and new nodes, so the
+     *       per-document write path may go either way. Both must produce queryable docs.</li>
+     *   <li>UPGRADED phase: ingest a third document, then run a semantic query with highlighting and assert that all
+     *       three documents are returned with highlights matching every input value of their source fields. This
+     *       exercises new code reading data potentially written by older code (chunks parsed with no
+     *       {@code input_index}, defaulting to {@code -1}) without losing highlight fidelity.</li>
+     * </ol>
+     */
+    public void testInputIndexBackwardCompatibility() throws Exception {
+        assumeFalse("input_index is only emitted in the non-legacy semantic_text format", useLegacyFormat);
+
+        final String indexName = getInputIndexBwcIndexName();
+        switch (CLUSTER_TYPE) {
+            case OLD -> {
+                createSemanticIndex(indexName);
+                indexDoc(indexName, INPUT_INDEX_BWC_DOC_OLD, INPUT_INDEX_BWC_DOC_VALUES.get(INPUT_INDEX_BWC_DOC_OLD));
+            }
+            case MIXED -> {
+                indexDoc(indexName, INPUT_INDEX_BWC_DOC_MIXED, INPUT_INDEX_BWC_DOC_VALUES.get(INPUT_INDEX_BWC_DOC_MIXED));
+            }
+            case UPGRADED -> {
+                indexDoc(indexName, INPUT_INDEX_BWC_DOC_UPGRADED, INPUT_INDEX_BWC_DOC_VALUES.get(INPUT_INDEX_BWC_DOC_UPGRADED));
+
+                final Set<String> expectedIds = Set.of(INPUT_INDEX_BWC_DOC_OLD, INPUT_INDEX_BWC_DOC_MIXED, INPUT_INDEX_BWC_DOC_UPGRADED);
+                ObjectPath sparseQueryObjectPath = semanticQuery(indexName, SPARSE_FIELD, SPARSE_MODEL, "bwc input", 5);
+                assertQueryResponseWithHighlights(sparseQueryObjectPath, SPARSE_FIELD, INPUT_INDEX_BWC_DOC_VALUES, expectedIds);
+
+                ObjectPath denseQueryObjectPath = semanticQuery(indexName, DENSE_FIELD, DENSE_MODEL, "bwc input", 5);
+                assertQueryResponseWithHighlights(denseQueryObjectPath, DENSE_FIELD, INPUT_INDEX_BWC_DOC_VALUES, expectedIds);
+            }
+            default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");
+        }
     }
 }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SemanticTextUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SemanticTextUpgradeIT.java
@@ -152,10 +152,11 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
     private void performIndexQueryHighlightOps() throws IOException {
         indexDoc(getIndexName(), DOC_2_ID, DOC_VALUES.get(DOC_2_ID));
 
-        ObjectPath sparseQueryObjectPath = semanticQuery(getIndexName(), SPARSE_FIELD, SPARSE_MODEL, "test value", 3);
+        int totalChunks = DOC_VALUES.values().stream().mapToInt(List::size).sum();
+        ObjectPath sparseQueryObjectPath = semanticQuery(getIndexName(), SPARSE_FIELD, SPARSE_MODEL, "test value", totalChunks, 3);
         assertQueryResponseWithHighlights(sparseQueryObjectPath, SPARSE_FIELD, DOC_VALUES, Set.of(DOC_1_ID, DOC_2_ID));
 
-        ObjectPath denseQueryObjectPath = semanticQuery(getIndexName(), DENSE_FIELD, DENSE_MODEL, "test value", 3);
+        ObjectPath denseQueryObjectPath = semanticQuery(getIndexName(), DENSE_FIELD, DENSE_MODEL, "test value", totalChunks, 3);
         assertQueryResponseWithHighlights(denseQueryObjectPath, DENSE_FIELD, DOC_VALUES, Set.of(DOC_1_ID, DOC_2_ID));
     }
 
@@ -203,8 +204,14 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
         assertOK(response);
     }
 
-    private ObjectPath semanticQuery(String indexName, String field, Model fieldModel, String query, Integer numOfHighlightFragments)
-        throws IOException {
+    private ObjectPath semanticQuery(
+        String indexName,
+        String field,
+        Model fieldModel,
+        String query,
+        int knnK,
+        Integer numOfHighlightFragments
+    ) throws IOException {
         // We can't perform a real semantic query because that requires performing inference, so instead we perform an equivalent nested
         // query
         final String embeddingsFieldName = SemanticTextField.getEmbeddingsFieldName(field);
@@ -229,7 +236,9 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
                     Arrays.fill(queryVector, 1.0f);
                 }
 
-                yield new KnnVectorQueryBuilder(embeddingsFieldName, queryVector, DOC_VALUES.size(), null, null, null, null);
+                // knnK must be at least the total number of expected child chunks across all expected docs; otherwise the nested
+                // promotion can collapse top-K children to fewer parents than the test asserts.
+                yield new KnnVectorQueryBuilder(embeddingsFieldName, queryVector, knnK, null, null, null, null);
             }
             default -> throw new UnsupportedOperationException("Unhandled task type [" + fieldModel.getTaskType() + "]");
         };
@@ -317,10 +326,11 @@ public class SemanticTextUpgradeIT extends AbstractUpgradeTestCase {
                 indexDoc(indexName, INPUT_INDEX_BWC_DOC_UPGRADED, INPUT_INDEX_BWC_DOC_VALUES.get(INPUT_INDEX_BWC_DOC_UPGRADED));
 
                 final Set<String> expectedIds = Set.of(INPUT_INDEX_BWC_DOC_OLD, INPUT_INDEX_BWC_DOC_MIXED, INPUT_INDEX_BWC_DOC_UPGRADED);
-                ObjectPath sparseQueryObjectPath = semanticQuery(indexName, SPARSE_FIELD, SPARSE_MODEL, "bwc input", 5);
+                int totalChunks = INPUT_INDEX_BWC_DOC_VALUES.values().stream().mapToInt(List::size).sum();
+                ObjectPath sparseQueryObjectPath = semanticQuery(indexName, SPARSE_FIELD, SPARSE_MODEL, "bwc input", totalChunks, 5);
                 assertQueryResponseWithHighlights(sparseQueryObjectPath, SPARSE_FIELD, INPUT_INDEX_BWC_DOC_VALUES, expectedIds);
 
-                ObjectPath denseQueryObjectPath = semanticQuery(indexName, DENSE_FIELD, DENSE_MODEL, "bwc input", 5);
+                ObjectPath denseQueryObjectPath = semanticQuery(indexName, DENSE_FIELD, DENSE_MODEL, "bwc input", totalChunks, 5);
                 assertQueryResponseWithHighlights(denseQueryObjectPath, DENSE_FIELD, INPUT_INDEX_BWC_DOC_VALUES, expectedIds);
             }
             default -> throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");


### PR DESCRIPTION
# Add `input_index` to semantic_text chunks

## Summary

Adds an `input_index` to each chunk in the non-legacy `semantic_text` wire format so that, when a `semantic_text` source field carries multiple input values (e.g. `body: ["paragraph 1", "paragraph 2", ...]`), every chunk records the 0-based index of the input value it was produced from. This is the storage/propagation half of the change; downstream consumers such as `SemanticTextHighlighter` can use it in a follow-up to map chunks back to their originating input value instead of substringing the merged-and-separator-joined source content.

While here, the legacy-vs-new branch in `ShardBulkInferenceActionFilter`'s chunk creation is collapsed into a single call into `SemanticTextField.toSemanticTextFieldChunks(useLegacyFormat, ...)`. The factory chooses the chunk shape; the filter no longer branches on the format itself.

## Changes

### Wire format
- `SemanticTextField.Chunk` gains an `int inputIndex` slot (5-arg record).
- `SemanticTextField.toXContent` writes the new optional `input_index` field for non-legacy chunks only, and only when `inputIndex >= 0`.
- `SemanticTextField`'s chunks `ConstructingObjectParser` declares `input_index` as an optional `int` and defaults missing values to `-1`. The parser is constructed with `ignoreUnknownFields=true` (existing behavior), so older nodes parsing newer documents simply skip the unknown field.
- Legacy-format chunks are unchanged on the wire (`{ text, embeddings }`).

### Filter consolidation
- `FieldInferenceRequest` and `FieldInferenceResponse` carry a per-source-field `sourceFieldInputIndex`.
- `ShardBulkInferenceActionFilter#addFieldInferenceRequests` increments a per-source-field counter alongside the existing `offsetAdjustment`.
- `ShardBulkInferenceActionFilter#applyInferenceResponses` calls a single new factory entry point — `SemanticTextField.toSemanticTextFieldChunks(useLegacyFormat, input, inputIndex, offsetAdjustment, results, contentType)` — instead of branching between legacy and non-legacy chunk constructors.

### Read path
- `SemanticFieldValueFetcher`, which reconstructs `Chunk` objects from indexed doc values during fetch, defaults `inputIndex` to `-1` (the offset doc-value side does not carry the new field).

## Backwards compatibility

- **Forward compat from new → old nodes (mixed cluster, write path):** A coordinator on the new code embeds `input_index` in `_inference_fields.<field>.inference.chunks.<sourceField>[]`. The bulk request body travels as raw bytes via `IndexSource.writeTo`, so it reaches the data node verbatim. An old data node parses chunks with the old `ConstructingObjectParser` (`ignoreUnknownFields=true`), silently skipping the unknown `input_index` field, and indexes the rest of the chunk normally. The original `_source` bytes — including `input_index` — are preserved on disk.
- **Backward compat from old → new nodes (read path / pre-upgrade data):** New code parsing chunks that lack `input_index` simply uses `-1` as the sentinel. Any future highlight logic that consumes `input_index` must treat `-1` as "unknown" and fall back to the existing offset-based behavior.
- **No transport version bump:** `SemanticTextField` and `Chunk` are not `Writeable`; the data only travels through the source bytes, which are passed through transport opaquely.
- **Legacy format on the wire is unchanged** — `input_index` is not emitted for legacy chunks (where chunk-to-input provenance is implicit by chunk position in the per-input array). Existing legacy-format indices behave exactly as before.
