### PR TITLE
Include index and shard id in shard failure exception message

### DIFF
--- a/docs/changelog/147566.yaml
+++ b/docs/changelog/147566.yaml
@@ -1,0 +1,6 @@
+area: Search
+issues:
+ - 113489
+pr: 147566
+summary: Include index and shard id in shard failure exception message
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/action/ShardOperationFailedException.java
+++ b/server/src/main/java/org/elasticsearch/action/ShardOperationFailedException.java
@@ -75,4 +75,13 @@ public abstract class ShardOperationFailedException extends Exception implements
     public final Throwable getCause() {
         return cause;
     }
+
+    /**
+     * Returns a short message describing the failed shard.
+     * Subclasses that carry richer context (for example a node id) may override this further.
+     */
+    @Override
+    public String getMessage() {
+        return "shard [" + (index == null ? "_na" : index) + "][" + shardId + "]";
+    }
 }

--- a/server/src/test/java/org/elasticsearch/action/ShardOperationFailedExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ShardOperationFailedExceptionTests.java
@@ -65,6 +65,29 @@ public class ShardOperationFailedExceptionTests extends ESTestCase {
         new Failure(null, randomInt(), randomAlphaOfLengthBetween(5, 10), randomFrom(RestStatus.values()), new IllegalArgumentException());
     }
 
+    public void testGetMessageIncludesIndexAndShard() {
+        Failure failure = new Failure(
+            "books",
+            7,
+            randomAlphaOfLengthBetween(5, 10),
+            randomFrom(RestStatus.values()),
+            new IllegalArgumentException()
+        );
+        assertEquals("shard [books][7]", failure.getMessage());
+        assertEquals("org.elasticsearch.action.ShardOperationFailedExceptionTests$Failure: shard [books][7]", failure.toString());
+    }
+
+    public void testGetMessageWhenIndexIsNull() {
+        Failure failure = new Failure(
+            null,
+            -1,
+            randomAlphaOfLengthBetween(5, 10),
+            randomFrom(RestStatus.values()),
+            new IllegalArgumentException()
+        );
+        assertEquals("shard [_na][-1]", failure.getMessage());
+    }
+
     private static class Failure extends ShardOperationFailedException {
 
         Failure(@Nullable String index, int shardId, String reason, RestStatus status, Throwable cause) {


### PR DESCRIPTION
Override `getMessage()` on `ShardOperationFailedException` so the exception's detail message carries the failing index and shard id.
Previously the message was never populated, so log lines and `Throwable.toString()` stack-trace headers surfaced `ShardSearchFailure: null` instead of useful context (see the log sample on the linked issue).

Closes #113489