### PR TITLE
[9.4] ESQL: Fix KNN with LIMIT BY (#146844)

### DIFF
--- a/docs/changelog/146844.yaml
+++ b/docs/changelog/146844.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 146844
+summary: Fix KNN with LIMIT BY
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushLimitToKnn.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushLimitToKnn.java
@@ -14,8 +14,10 @@ import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LimitBy;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.plan.logical.TopNBy;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Rerank;
 
 /**
@@ -46,9 +48,13 @@ public class PushLimitToKnn extends OptimizerRules.ParameterizedOptimizerRule<Li
                 // Break if it's not the initial limit
                 breakerReached.set(firstLimit.get());
                 firstLimit.set(true);
-            } else if (plan instanceof TopN || plan instanceof Rerank || plan instanceof Aggregate) {
-                breakerReached.set(true);
-            }
+            } else if (plan instanceof TopN
+                || plan instanceof TopNBy
+                || plan instanceof LimitBy
+                || plan instanceof Rerank
+                || plan instanceof Aggregate) {
+                    breakerReached.set(true);
+                }
 
             return plan;
         });

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -9254,6 +9254,33 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         assertThat(knn.implicitK(), equalTo(100));
     }
 
+    /**
+     * {@code LIMIT N BY g} doesn't work like a LIMIT, but a LIMIT per group, which is unbounded.
+     * The outer {@code LIMIT M} must not be pushed past a {@link org.elasticsearch.xpack.esql.plan.logical.LimitBy} into KNN.
+     * <p>
+     *     A clear example of this is the query {@code FROM five_rows | WHERE KNN(field, ...) | LIMIT 1 BY x | LIMIT 2}:
+     *     if most rows have the same "x" but one, KNN could return only rows with the same x,
+     *     when LIMIT BY would still need more to fill the buckets.
+     * </p>
+     */
+    public void testKnnWithLimitBy() {
+        assertThat(
+            typesError("from types | where knn(dense_vector, [0, 1, 2]) | limit 10 by keyword | limit 5"),
+            containsString("Knn function must be used with a LIMIT clause")
+        );
+    }
+
+    /**
+     * Same reasoning as {@link #testKnnWithLimitBy()} but with the optimizer-created
+     * {@link org.elasticsearch.xpack.esql.plan.logical.TopNBy} (from {@code SORT ... | LIMIT N BY g}).
+     */
+    public void testKnnWithTopNBy() {
+        assertThat(
+            typesError("from types metadata _score | where knn(dense_vector, [0, 1, 2]) | sort _score | limit 10 by keyword | limit 5"),
+            containsString("Knn function must be used with a LIMIT clause")
+        );
+    }
+
     private LogicalPlanOptimizer getCustomRulesLogicalPlanOptimizer(
         List<RuleExecutor.Batch<LogicalPlan>> batches,
         TransportVersion minimumVersion


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ESQL: Fix KNN with LIMIT BY (#146844)