### PR TITLE
`ServerlessPublic` settings must be index-scoped

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -174,10 +174,9 @@ public class Setting<T> implements ToXContentObject {
         IndexSettingDeprecatedInV9AndRemovedInV10,
 
         /**
-         * Indicates that this setting is accessible by non-operator users (public) in serverless
+         * Indicates that this index-level setting is accessible by non-operator users (public) in serverless.
          * Users will be allowed to set and see values of this setting.
-         * All other settings will be rejected when used on a PUT request
-         * and filtered out on a GET
+         * All other settings will be rejected when used on a PUT request and filtered out on a GET.
          */
         ServerlessPublic,
 
@@ -243,6 +242,7 @@ public class Setting<T> implements ToXContentObject {
             checkPropertyRequiresIndexScope(propertiesAsSet, Property.IndexSettingDeprecatedInV7AndRemovedInV8);
             checkPropertyRequiresIndexScope(propertiesAsSet, Property.IndexSettingDeprecatedInV8AndRemovedInV9);
             checkPropertyRequiresIndexScope(propertiesAsSet, Property.IndexSettingDeprecatedInV9AndRemovedInV10);
+            checkPropertyRequiresIndexScope(propertiesAsSet, Property.ServerlessPublic);
             checkPropertyRequiresNodeScope(propertiesAsSet);
             this.properties = propertiesAsSet;
         }

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -1526,7 +1526,7 @@ public class SettingTests extends ESTestCase {
     }
 
     public void testCheckForDeprecationWithSkipSetting() {
-        final String settingName = "foo.bar.hide.this";
+        final String settingName = randomIdentifier("foo.bar.hide.this.");
         final String settingValue = "blat";
         final Setting<String> setting = Setting.simpleString(settingName, settingValue);
         final Settings settings = Settings.builder().put(settingName, settingValue).build();

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -1192,6 +1192,14 @@ public class SettingTests extends ESTestCase {
         assertThat(e, hasToString(containsString("non-index-scoped setting [foo.bar] can not have property [PrivateIndex]")));
     }
 
+    public void testRejectNonIndexScopedServerlessPublicSetting() {
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> Setting.simpleString("foo.bar", Property.ServerlessPublic)
+        );
+        assertThat(e, hasToString(containsString("non-index-scoped setting [foo.bar] can not have property [ServerlessPublic]")));
+    }
+
     public void testTimeValue() {
         final TimeValue random = randomTimeValue();
 


### PR DESCRIPTION
Users cannot control node-scoped and cluster-scoped settings in
serverless, so `Property.ServerlessPublic` only makes sense on index
settings. This commit adds validation to enforce this rule.