### PR TITLE
[ESQL] Wire RowRanges into OptimizedParquetColumnIterator

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
@@ -190,11 +190,6 @@ final class ColumnChunkPrefetcher {
      * Pages whose row span does not overlap with {@code rowRanges} are excluded, reducing
      * the number of bytes fetched from remote storage.
      *
-     * <p><b>Note:</b> The filtered variants ({@code computeFilteredPageRanges}, filtered
-     * {@code prefetch/prefetchAsync}) are not yet wired into the iterator — the current
-     * optimized path always prefetches full column chunks. These exist for a planned
-     * follow-up that integrates row-range-aware prefetch with page-index filtering.
-     *
      * <p>Dictionary pages (which sit before data pages) are always included since they are
      * needed to decode any surviving page. Adjacent page ranges are merged by the caller
      * via {@link CoalescedRangeReader#mergeRanges}.

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnIndexRowRangesComputer.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnIndexRowRangesComputer.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.filter2.predicate.Operators;
+import org.apache.parquet.filter2.predicate.UserDefinedPredicate;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+import org.apache.parquet.io.api.Binary;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Computes {@link RowRanges} from a Parquet {@link FilterPredicate} by evaluating per-page
+ * min/max statistics from {@link ColumnIndex}. This implements our own page-level filtering
+ * rather than using parquet-mr's internal {@code ColumnIndexFilter}, which lives in an
+ * unstable internal package and returns a different RowRanges type.
+ *
+ * <p>For each leaf predicate, the visitor checks every page's min/max values against the
+ * predicate and builds row ranges from surviving pages. Logical operators compose these
+ * ranges via set operations: AND → intersect, OR → union. NOT conservatively returns all
+ * rows because complement of page-level ranges would drop rows from mixed pages.
+ *
+ * <p>When a column has no ColumnIndex or OffsetIndex (e.g., columns with no statistics,
+ * or very old Parquet writers), the visitor conservatively returns {@link RowRanges#all}.
+ *
+ * <p>Correctness is maintained by RECHECK semantics: all pushed filters use
+ * {@code Pushability.RECHECK}, so the original FilterExec remains in the ESQL plan
+ * for per-row correctness. This visitor is a conservative approximation that may keep
+ * pages with partial matches.
+ */
+final class ColumnIndexRowRangesComputer implements FilterPredicate.Visitor<RowRanges> {
+
+    private final PreloadedRowGroupMetadata metadata;
+    private final int rowGroupOrdinal;
+    private final long rowGroupRowCount;
+
+    private ColumnIndexRowRangesComputer(PreloadedRowGroupMetadata metadata, int rowGroupOrdinal, long rowGroupRowCount) {
+        this.metadata = metadata;
+        this.rowGroupOrdinal = rowGroupOrdinal;
+        this.rowGroupRowCount = rowGroupRowCount;
+    }
+
+    /**
+     * Computes the RowRanges for a given predicate within a row group.
+     *
+     * @param predicate the filter predicate (from parquet-mr FilterApi)
+     * @param metadata preloaded ColumnIndex/OffsetIndex data
+     * @param rowGroupOrdinal physical ordinal of the row group in the file
+     * @param rowGroupRowCount total rows in the row group
+     * @return selected row ranges, or {@code RowRanges.all()} if filtering is not beneficial
+     */
+    static RowRanges compute(FilterPredicate predicate, PreloadedRowGroupMetadata metadata, int rowGroupOrdinal, long rowGroupRowCount) {
+        if (predicate == null) {
+            return RowRanges.all(rowGroupRowCount);
+        }
+        var computer = new ColumnIndexRowRangesComputer(metadata, rowGroupOrdinal, rowGroupRowCount);
+        RowRanges result = predicate.accept(computer);
+        if (result.shouldDiscard()) {
+            return RowRanges.all(rowGroupRowCount);
+        }
+        return result;
+    }
+
+    private RowRanges all() {
+        return RowRanges.all(rowGroupRowCount);
+    }
+
+    // --- Leaf predicates ---
+
+    @Override
+    public <T extends Comparable<T>> RowRanges visit(Operators.Eq<T> eq) {
+        T value = eq.getValue();
+        if (value == null) {
+            return all();
+        }
+        return evaluateLeaf(eq.getColumn(), (min, max) -> min.compareTo(value) <= 0 && value.compareTo(max) <= 0);
+    }
+
+    @Override
+    public <T extends Comparable<T>> RowRanges visit(Operators.NotEq<T> notEq) {
+        // NotEq can only skip a page when ALL values equal the target (min==max==value, no nulls).
+        // This is rare and checking null counts adds complexity. Conservative: keep all pages.
+        return all();
+    }
+
+    @Override
+    public <T extends Comparable<T>> RowRanges visit(Operators.Lt<T> lt) {
+        T value = lt.getValue();
+        return evaluateLeaf(lt.getColumn(), (min, max) -> min.compareTo(value) < 0);
+    }
+
+    @Override
+    public <T extends Comparable<T>> RowRanges visit(Operators.LtEq<T> ltEq) {
+        T value = ltEq.getValue();
+        return evaluateLeaf(ltEq.getColumn(), (min, max) -> min.compareTo(value) <= 0);
+    }
+
+    @Override
+    public <T extends Comparable<T>> RowRanges visit(Operators.Gt<T> gt) {
+        T value = gt.getValue();
+        return evaluateLeaf(gt.getColumn(), (min, max) -> max.compareTo(value) > 0);
+    }
+
+    @Override
+    public <T extends Comparable<T>> RowRanges visit(Operators.GtEq<T> gtEq) {
+        T value = gtEq.getValue();
+        return evaluateLeaf(gtEq.getColumn(), (min, max) -> max.compareTo(value) >= 0);
+    }
+
+    @Override
+    public <T extends Comparable<T>> RowRanges visit(Operators.In<T> in) {
+        return evaluateLeaf(in.getColumn(), (min, max) -> {
+            for (T val : in.getValues()) {
+                if (val != null && min.compareTo(val) <= 0 && val.compareTo(max) <= 0) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @Override
+    public <T extends Comparable<T>> RowRanges visit(Operators.NotIn<T> notIn) {
+        return all();
+    }
+
+    @Override
+    public <T extends Comparable<T>> RowRanges visit(Operators.Contains<T> contains) {
+        return all();
+    }
+
+    // --- Logical operators ---
+
+    @Override
+    public RowRanges visit(Operators.And and) {
+        RowRanges left = and.getLeft().accept(this);
+        RowRanges right = and.getRight().accept(this);
+        return left.intersect(right);
+    }
+
+    @Override
+    public RowRanges visit(Operators.Or or) {
+        RowRanges left = or.getLeft().accept(this);
+        RowRanges right = or.getRight().accept(this);
+        return left.union(right);
+    }
+
+    @Override
+    public RowRanges visit(Operators.Not not) {
+        // Conservative: complement of page-level ranges loses rows from mixed pages.
+        // A page kept by the inner predicate may also contain non-matching rows; dropping
+        // it via complement() silently loses those rows, violating the "never fewer" contract.
+        return all();
+    }
+
+    @Override
+    public <T extends Comparable<T>, U extends UserDefinedPredicate<T>> RowRanges visit(Operators.UserDefined<T, U> udp) {
+        return all();
+    }
+
+    @Override
+    public <T extends Comparable<T>, U extends UserDefinedPredicate<T>> RowRanges visit(Operators.LogicalNotUserDefined<T, U> udp) {
+        return all();
+    }
+
+    // --- Core evaluation ---
+
+    @FunctionalInterface
+    private interface PagePredicate<T extends Comparable<T>> {
+        boolean test(T min, T max);
+    }
+
+    /**
+     * Evaluates a leaf predicate against each page's min/max from the ColumnIndex.
+     * Builds RowRanges from the pages whose min/max satisfy the predicate.
+     */
+    private <T extends Comparable<T>> RowRanges evaluateLeaf(Operators.Column<T> column, PagePredicate<T> predicate) {
+        String columnPath = column.getColumnPath().toDotString();
+        ColumnIndex ci = metadata.getColumnIndex(rowGroupOrdinal, columnPath);
+        OffsetIndex oi = metadata.getOffsetIndex(rowGroupOrdinal, columnPath);
+        if (ci == null || oi == null) {
+            return all();
+        }
+
+        int pageCount = oi.getPageCount();
+        List<ByteBuffer> minValues = ci.getMinValues();
+        List<ByteBuffer> maxValues = ci.getMaxValues();
+        List<Boolean> nullPages = ci.getNullPages();
+
+        if (minValues.size() != pageCount || maxValues.size() != pageCount) {
+            return all();
+        }
+
+        List<long[]> surviving = new ArrayList<>();
+        for (int p = 0; p < pageCount; p++) {
+            if (nullPages != null && p < nullPages.size() && Boolean.TRUE.equals(nullPages.get(p))) {
+                continue;
+            }
+
+            T min = decodeValue(minValues.get(p), column);
+            T max = decodeValue(maxValues.get(p), column);
+            if (min == null || max == null) {
+                long pageStart = oi.getFirstRowIndex(p);
+                long pageEnd = (p + 1 < pageCount) ? oi.getFirstRowIndex(p + 1) : rowGroupRowCount;
+                surviving.add(new long[] { pageStart, pageEnd });
+                continue;
+            }
+
+            if (predicate.test(min, max)) {
+                long pageStart = oi.getFirstRowIndex(p);
+                long pageEnd = (p + 1 < pageCount) ? oi.getFirstRowIndex(p + 1) : rowGroupRowCount;
+                surviving.add(new long[] { pageStart, pageEnd });
+            }
+        }
+
+        if (surviving.isEmpty()) {
+            return RowRanges.of(0, 0, rowGroupRowCount);
+        }
+        return RowRanges.fromUnsorted(surviving, rowGroupRowCount);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Comparable<T>> T decodeValue(ByteBuffer buf, Operators.Column<T> column) {
+        if (buf == null || buf.remaining() == 0) {
+            return null;
+        }
+        ByteBuffer ordered = buf.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        Class<T> type = column.getColumnType();
+        if (type == Integer.class) {
+            return (T) Integer.valueOf(ordered.getInt());
+        } else if (type == Long.class) {
+            return (T) Long.valueOf(ordered.getLong());
+        } else if (type == Double.class) {
+            // Buffer length distinguishes physical FLOAT (4 bytes) from DOUBLE (8 bytes);
+            // parquet-mr's Column API only exposes Double.class for both floatColumn and doubleColumn.
+            if (ordered.remaining() == Float.BYTES) {
+                return (T) Double.valueOf(ordered.getFloat());
+            }
+            return (T) Double.valueOf(ordered.getDouble());
+        } else if (type == Boolean.class) {
+            return (T) Boolean.valueOf(ordered.get() != 0);
+        } else if (type == Binary.class) {
+            byte[] bytes = new byte[buf.remaining()];
+            buf.duplicate().get(bytes);
+            return (T) Binary.fromConstantByteArray(bytes);
+        }
+        return null;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -39,20 +39,20 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Optimized Parquet column iterator behind the {@code optimized_reader} feature flag.
+ * Default Parquet column iterator with vectorized decoding and I/O prefetch.
  *
- * <p>Functionally identical to the baseline {@code ParquetColumnIterator} but adds parallel
- * column chunk prefetch: while decoding row group N, prefetches row group N+1's data via
- * {@link CoalescedRangeReader} and installs it into the {@link ParquetStorageObjectAdapter}
+ * <p>Adds parallel column chunk prefetch: while decoding row group N, prefetches row group N+1's
+ * data via {@link CoalescedRangeReader} and installs it into the {@link ParquetStorageObjectAdapter}
  * so that subsequent Parquet reads are served from memory instead of network I/O.
  *
  * <p>Always uses {@link PageColumnReader} for vectorized batch decoding of flat columns and
- * {@code ColumnReader} for list columns. The {@link PreloadedRowGroupMetadata} parameter is
- * reserved for future column-index and dictionary-based optimizations.
+ * {@code ColumnReader} for list columns. When {@link RowRanges} are provided (from
+ * {@link ColumnIndexRowRangesComputer}), pages whose row span doesn't overlap are skipped,
+ * and prefetch is scoped to only the surviving pages.
  *
  * <p>Both this iterator and the baseline {@code ParquetColumnIterator} share list-column
  * decoding and utility helpers via {@link ParquetColumnDecoding}. The baseline remains
- * the stable fallback when {@code optimized_reader=false}.
+ * the stable fallback when {@code optimized_reader=false} is explicitly set via config.
  *
  * <p><b>Memory:</b> Prefetch bytes are reserved on the REQUEST circuit breaker (via
  * {@link BlockFactory#breaker()}) before async I/O starts. The reservation is released
@@ -71,12 +71,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final String createdBy;
     private final String fileLocation;
     private final ColumnInfo[] columnInfos;
-    // TODO: use for column-index and dictionary-based optimizations in the filtered-read follow-up
     private final PreloadedRowGroupMetadata preloadedMetadata;
     private final StorageObject storageObject;
     private final ParquetStorageObjectAdapter adapter;
     private final Set<String> projectedColumnPaths;
     private final CircuitBreaker breaker;
+    private final RowRanges[] allRowRanges;
     private int rowBudget;
     private final AtomicLong prefetchReservedBytes = new AtomicLong();
 
@@ -101,7 +101,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         ColumnInfo[] columnInfos,
         PreloadedRowGroupMetadata preloadedMetadata,
         StorageObject storageObject,
-        ParquetStorageObjectAdapter adapter
+        ParquetStorageObjectAdapter adapter,
+        RowRanges[] allRowRanges
     ) {
         this.reader = reader;
         this.projectedSchema = projectedSchema;
@@ -116,6 +117,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.storageObject = storageObject;
         this.adapter = adapter;
         this.breaker = blockFactory.breaker();
+        this.allRowRanges = allRowRanges;
 
         this.projectedColumnPaths = buildProjectedColumnPaths(columnInfos);
 
@@ -180,19 +182,41 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         pageBatchIndexInRowGroup = 0;
         rowsRemainingInGroup = rowGroup.getRowCount();
 
+        RowRanges currentRowRanges = resolveCurrentRowRanges();
         triggerNextRowGroupPrefetch();
-        initColumnReaders();
+        initColumnReaders(currentRowRanges);
         return rowsRemainingInGroup > 0;
     }
 
-    private void initColumnReaders() {
+    /**
+     * Returns the pre-computed {@link RowRanges} for the current row group. When
+     * {@code allRowRanges} is present, {@code rowGroupOrdinal} directly indexes into it
+     * because we disable {@code useColumnIndexFilter}, causing
+     * {@code readNextFilteredRowGroup()} to iterate row groups sequentially without skipping.
+     */
+    private RowRanges resolveCurrentRowRanges() {
+        if (allRowRanges == null || rowGroupOrdinal >= allRowRanges.length) {
+            return null;
+        }
+        assert allRowRanges[rowGroupOrdinal].totalRows() == rowGroup.getRowCount()
+            : "RowRanges row count ["
+                + allRowRanges[rowGroupOrdinal].totalRows()
+                + "] != row group row count ["
+                + rowGroup.getRowCount()
+                + "] at ordinal ["
+                + rowGroupOrdinal
+                + "]";
+        return allRowRanges[rowGroupOrdinal];
+    }
+
+    private void initColumnReaders(RowRanges currentRowRanges) {
         pageColumnReaders = new PageColumnReader[columnInfos.length];
         columnReaders = null;
         for (int i = 0; i < columnInfos.length; i++) {
             if (columnInfos[i] != null && columnInfos[i].maxRepLevel() == 0) {
                 ColumnDescriptor desc = columnInfos[i].descriptor();
                 PageReader pr = rowGroup.getPageReader(desc);
-                pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], null);
+                pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], currentRowRanges);
             }
         }
         boolean hasListColumns = false;
@@ -291,7 +315,19 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             return;
         }
         try {
-            pendingPrefetch = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, projectedColumnPaths);
+            if (allRowRanges != null && nextRgOrdinal < allRowRanges.length) {
+                pendingPrefetch = ColumnChunkPrefetcher.prefetchAsync(
+                    storageObject,
+                    nextBlock,
+                    projectedColumnPaths,
+                    allRowRanges[nextRgOrdinal],
+                    preloadedMetadata,
+                    nextRgOrdinal,
+                    nextBlock.getRowCount()
+                );
+            } else {
+                pendingPrefetch = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, projectedColumnPaths);
+            }
         } catch (Exception e) {
             logger.debug("Failed to initiate prefetch for row group [{}] in [{}]: {}", nextRgOrdinal, fileLocation, e.getMessage());
             pendingPrefetch = null;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -45,14 +45,10 @@ import java.util.BitSet;
  * </ol>
  *
  * <p>Only handles flat columns (maxRepLevel == 0). List columns must use the row-at-a-time path.
- * When a Parquet record filter is active, this reader is bypassed entirely (see
- * {@code ParquetFormatReader.ParquetColumnIterator#advanceRowGroup}) because page-index filtering
- * changes the semantics of pages returned by {@link PageReader}.
  *
- * <p>TODO: selective reading (RowSelection + PredicateEvaluator) is blocked on Stage 7 of the
- * performance backport plan. When added, readBatch should gain a predicate parameter that applies
- * per-page filtering via RowRanges, enabling page skipping for filtered queries without falling
- * back to the ColumnReader path.
+ * <p>When {@link RowRanges} are provided, pages whose row span does not overlap the selected
+ * ranges are skipped entirely in {@link #loadNextPage()}, enabling page-level filtering for
+ * the optimized reader path.
  */
 final class PageColumnReader {
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -101,7 +101,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     static final String CONFIG_OPTIMIZED_READER = "optimized_reader";
 
     public ParquetFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, FilterCompat.NOOP, null, false, false);
+        this(blockFactory, FilterCompat.NOOP, null, false, true);
     }
 
     ParquetFormatReader(BlockFactory blockFactory, boolean optimizedReader) {
@@ -341,24 +341,30 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     }
 
     /**
-     * Resolves the record filter using the schema from an already-open reader, avoiding a
-     * redundant footer read. When deferred expressions are present, builds a schema-aware
-     * FilterPredicate from the provided schema.
+     * Resolves the raw {@link FilterPredicate} from deferred pushed expressions using the
+     * actual file schema. Returns null when no expression-based filter is available (either
+     * because a pre-built {@link FilterCompat.Filter} was provided directly, or because no
+     * filter was pushed at all).
      */
-    private FilterCompat.Filter resolveRecordFilter(StorageObject object, MessageType schema) {
-        if (FilterCompat.isFilteringRequired(pushedFilter)) {
-            return pushedFilter;
-        }
+    private FilterPredicate resolveFilterPredicate(StorageObject object, MessageType schema) {
         if (pushedExpressions == null) {
-            return FilterCompat.NOOP;
+            return null;
         }
         try {
-            FilterPredicate predicate = pushedExpressions.toFilterPredicate(schema);
-            return predicate != null ? FilterCompat.get(predicate) : FilterCompat.NOOP;
+            return pushedExpressions.toFilterPredicate(schema);
         } catch (Exception e) {
             logger.warn("Failed to resolve Parquet filter predicate for [{}], proceeding without pushdown: {}", object.path(), e);
-            return FilterCompat.NOOP;
+            return null;
         }
+    }
+
+    /**
+     * Resolves the record filter from the pre-built {@link FilterCompat.Filter} field.
+     * This is only called when {@code resolveFilterPredicate} returned null (no deferred
+     * expressions), so it never re-translates pushed expressions.
+     */
+    private FilterCompat.Filter resolveRecordFilter() {
+        return FilterCompat.isFilteringRequired(pushedFilter) ? pushedFilter : FilterCompat.NOOP;
     }
 
     @Override
@@ -369,61 +375,77 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
         ParquetFileReader reader = openParquetFile(object, parquetInputFile, readOptionsBuilder().build());
-        FileMetaData fileMetaData = reader.getFileMetaData();
-        MessageType parquetSchema = fileMetaData.getSchema();
+        try {
+            FileMetaData fileMetaData = reader.getFileMetaData();
+            MessageType parquetSchema = fileMetaData.getSchema();
 
-        FilterCompat.Filter recordFilter = resolveRecordFilter(object, parquetSchema);
-        if (FilterCompat.isFilteringRequired(recordFilter)) {
-            reader.close();
-            PlainParquetReadOptions.Builder optionsBuilder = readOptionsBuilder().withRecordFilter(recordFilter);
-            reader = openParquetFile(object, parquetInputFile, optionsBuilder.build());
-            fileMetaData = reader.getFileMetaData();
-            parquetSchema = fileMetaData.getSchema();
-        }
-        List<Attribute> attributes = convertParquetSchemaToAttributes(parquetSchema);
+            boolean useOptimized = optimizedReader && forceBaselinePath == false;
+            FilterPredicate filterPredicate = resolveFilterPredicate(object, parquetSchema);
+            // The predicate serves dual purpose: parquet-mr uses it for row-group-level statistics
+            // filtering (useStatsFilter), while we use it separately for page-level RowRanges filtering
+            // via ColumnIndexRowRangesComputer. When filterPredicate != null, we disable parquet-mr's
+            // page-level filtering (useColumnIndexFilter=false) to avoid double-filtering.
+            FilterCompat.Filter recordFilter = filterPredicate != null ? FilterCompat.get(filterPredicate) : resolveRecordFilter();
 
-        List<Attribute> projectedAttributes;
-        if (projectedColumns == null || projectedColumns.isEmpty()) {
-            projectedAttributes = attributes;
-        } else {
-            projectedAttributes = new ArrayList<>();
-            Map<String, Attribute> attributeMap = new HashMap<>();
-            for (Attribute attr : attributes) {
-                attributeMap.put(attr.name(), attr);
+            if (FilterCompat.isFilteringRequired(recordFilter)) {
+                reader.close();
+                PlainParquetReadOptions.Builder optionsBuilder = readOptionsBuilder().withRecordFilter(recordFilter);
+                if (useOptimized && filterPredicate != null) {
+                    optionsBuilder.withUseColumnIndexFilter(false);
+                }
+                reader = openParquetFile(object, parquetInputFile, optionsBuilder.build());
+                fileMetaData = reader.getFileMetaData();
+                parquetSchema = fileMetaData.getSchema();
             }
-            for (String columnName : projectedColumns) {
-                Attribute attr = attributeMap.get(columnName);
-                attr = attr == null ? new ReferenceAttribute(Source.EMPTY, columnName, DataType.NULL) : attr;
-                projectedAttributes.add(attr);
-            }
-        }
+            List<Attribute> attributes = convertParquetSchemaToAttributes(parquetSchema);
 
-        MessageType projectedSchema = buildProjectedSchema(parquetSchema, projectedAttributes);
-        String createdBy = fileMetaData.getCreatedBy();
-        boolean hasRecordFilter = forceBaselinePath || FilterCompat.isFilteringRequired(recordFilter);
-        if (optimizedReader && hasRecordFilter == false) {
-            return createOptimizedIterator(
+            List<Attribute> projectedAttributes;
+            if (projectedColumns == null || projectedColumns.isEmpty()) {
+                projectedAttributes = attributes;
+            } else {
+                projectedAttributes = new ArrayList<>();
+                Map<String, Attribute> attributeMap = new HashMap<>();
+                for (Attribute attr : attributes) {
+                    attributeMap.put(attr.name(), attr);
+                }
+                for (String columnName : projectedColumns) {
+                    Attribute attr = attributeMap.get(columnName);
+                    attr = attr == null ? new ReferenceAttribute(Source.EMPTY, columnName, DataType.NULL) : attr;
+                    projectedAttributes.add(attr);
+                }
+            }
+
+            MessageType projectedSchema = buildProjectedSchema(parquetSchema, projectedAttributes);
+            String createdBy = fileMetaData.getCreatedBy();
+            boolean hasRecordFilter = forceBaselinePath || FilterCompat.isFilteringRequired(recordFilter);
+            if (useOptimized) {
+                return createOptimizedIterator(
+                    reader,
+                    projectedSchema,
+                    projectedAttributes,
+                    batchSize,
+                    rowLimit,
+                    createdBy,
+                    object,
+                    parquetInputFile,
+                    filterPredicate
+                );
+            }
+            return new ParquetColumnIterator(
                 reader,
                 projectedSchema,
                 projectedAttributes,
                 batchSize,
+                blockFactory,
                 rowLimit,
                 createdBy,
-                object,
-                parquetInputFile
+                object.path().toString(),
+                hasRecordFilter
             );
+        } catch (Throwable t) {
+            reader.close();
+            throw t;
         }
-        return new ParquetColumnIterator(
-            reader,
-            projectedSchema,
-            projectedAttributes,
-            batchSize,
-            blockFactory,
-            rowLimit,
-            createdBy,
-            object.path().toString(),
-            hasRecordFilter
-        );
     }
 
     @Override
@@ -583,66 +605,78 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     ) throws IOException {
         InputFile parquetInputFile = ParquetStorageObjectAdapter.forRange(object, rangeEnd - rangeStart);
         ParquetFileReader reader = openParquetFile(object, parquetInputFile, readOptionsBuilder().withRange(rangeStart, rangeEnd).build());
-        FileMetaData fileMetaData = reader.getFileMetaData();
-        MessageType parquetSchema = fileMetaData.getSchema();
+        try {
+            FileMetaData fileMetaData = reader.getFileMetaData();
+            MessageType parquetSchema = fileMetaData.getSchema();
 
-        FilterCompat.Filter recordFilter = resolveRecordFilter(object, parquetSchema);
-        if (FilterCompat.isFilteringRequired(recordFilter)) {
-            reader.close();
-            PlainParquetReadOptions.Builder optionsBuilder = readOptionsBuilder().withRange(rangeStart, rangeEnd)
-                .withRecordFilter(recordFilter);
-            reader = openParquetFile(object, parquetInputFile, optionsBuilder.build());
-            fileMetaData = reader.getFileMetaData();
-            parquetSchema = fileMetaData.getSchema();
-        }
-        // The framework passes planning-time resolved attributes for this query (AsyncExternalSourceOperatorFactory).
-        // Reuse them to avoid redundant schema conversion work per split. We still read Parquet metadata to drive row groups.
-        final List<Attribute> attributes = resolvedAttributes != null && resolvedAttributes.isEmpty() == false
-            ? resolvedAttributes
-            : convertParquetSchemaToAttributes(parquetSchema);
+            boolean useOptimized = optimizedReader && forceBaselinePath == false;
+            FilterPredicate filterPredicate = resolveFilterPredicate(object, parquetSchema);
+            FilterCompat.Filter recordFilter = filterPredicate != null ? FilterCompat.get(filterPredicate) : resolveRecordFilter();
 
-        List<Attribute> projectedAttributes;
-        if (projectedColumns == null || projectedColumns.isEmpty()) {
-            projectedAttributes = attributes;
-        } else {
-            projectedAttributes = new ArrayList<>();
-            Map<String, Attribute> attributeMap = new HashMap<>();
-            for (Attribute attr : attributes) {
-                attributeMap.put(attr.name(), attr);
+            if (FilterCompat.isFilteringRequired(recordFilter)) {
+                reader.close();
+                PlainParquetReadOptions.Builder optionsBuilder = readOptionsBuilder().withRange(rangeStart, rangeEnd)
+                    .withRecordFilter(recordFilter);
+                if (useOptimized && filterPredicate != null) {
+                    optionsBuilder.withUseColumnIndexFilter(false);
+                }
+                reader = openParquetFile(object, parquetInputFile, optionsBuilder.build());
+                fileMetaData = reader.getFileMetaData();
+                parquetSchema = fileMetaData.getSchema();
             }
-            for (String columnName : projectedColumns) {
-                Attribute attr = attributeMap.get(columnName);
-                attr = attr == null ? new ReferenceAttribute(Source.EMPTY, columnName, DataType.NULL) : attr;
-                projectedAttributes.add(attr);
-            }
-        }
+            // The framework passes planning-time resolved attributes for this query (AsyncExternalSourceOperatorFactory).
+            // Reuse them to avoid redundant schema conversion work per split. We still read Parquet metadata to drive row groups.
+            final List<Attribute> attributes = resolvedAttributes != null && resolvedAttributes.isEmpty() == false
+                ? resolvedAttributes
+                : convertParquetSchemaToAttributes(parquetSchema);
 
-        MessageType projectedSchema = buildProjectedSchema(parquetSchema, projectedAttributes);
-        String createdBy = fileMetaData.getCreatedBy();
-        boolean hasRecordFilter = forceBaselinePath || FilterCompat.isFilteringRequired(recordFilter);
-        if (optimizedReader && hasRecordFilter == false) {
-            return createOptimizedIterator(
+            List<Attribute> projectedAttributes;
+            if (projectedColumns == null || projectedColumns.isEmpty()) {
+                projectedAttributes = attributes;
+            } else {
+                projectedAttributes = new ArrayList<>();
+                Map<String, Attribute> attributeMap = new HashMap<>();
+                for (Attribute attr : attributes) {
+                    attributeMap.put(attr.name(), attr);
+                }
+                for (String columnName : projectedColumns) {
+                    Attribute attr = attributeMap.get(columnName);
+                    attr = attr == null ? new ReferenceAttribute(Source.EMPTY, columnName, DataType.NULL) : attr;
+                    projectedAttributes.add(attr);
+                }
+            }
+
+            MessageType projectedSchema = buildProjectedSchema(parquetSchema, projectedAttributes);
+            String createdBy = fileMetaData.getCreatedBy();
+            boolean hasRecordFilter = forceBaselinePath || FilterCompat.isFilteringRequired(recordFilter);
+            if (useOptimized) {
+                return createOptimizedIterator(
+                    reader,
+                    projectedSchema,
+                    projectedAttributes,
+                    batchSize,
+                    NO_LIMIT,
+                    createdBy,
+                    object,
+                    parquetInputFile,
+                    filterPredicate
+                );
+            }
+            return new ParquetColumnIterator(
                 reader,
                 projectedSchema,
                 projectedAttributes,
                 batchSize,
+                blockFactory,
                 NO_LIMIT,
                 createdBy,
-                object,
-                parquetInputFile
+                object.path().toString(),
+                hasRecordFilter
             );
+        } catch (Throwable t) {
+            reader.close();
+            throw t;
         }
-        return new ParquetColumnIterator(
-            reader,
-            projectedSchema,
-            projectedAttributes,
-            batchSize,
-            blockFactory,
-            NO_LIMIT,
-            createdBy,
-            object.path().toString(),
-            hasRecordFilter
-        );
     }
 
     private CloseableIterator<Page> createOptimizedIterator(
@@ -653,7 +687,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         int rowLimit,
         String createdBy,
         StorageObject storageObject,
-        InputFile inputFile
+        InputFile inputFile,
+        FilterPredicate filterPredicate
     ) {
         if (inputFile instanceof ParquetStorageObjectAdapter == false) {
             throw new ElasticsearchException(
@@ -664,6 +699,16 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         ColumnInfo[] columnInfos = buildColumnInfos(projectedSchema, projectedAttributes);
         validatePlannerTypesAgainstFile(logger, storageObject.path().toString(), reader, projectedAttributes, columnInfos);
         PreloadedRowGroupMetadata preloadedMetadata = PreloadedRowGroupMetadata.preload(reader, storageObject);
+
+        RowRanges[] allRowRanges = null;
+        if (filterPredicate != null) {
+            List<BlockMetaData> blocks = reader.getRowGroups();
+            allRowRanges = new RowRanges[blocks.size()];
+            for (int i = 0; i < blocks.size(); i++) {
+                allRowRanges[i] = ColumnIndexRowRangesComputer.compute(filterPredicate, preloadedMetadata, i, blocks.get(i).getRowCount());
+            }
+        }
+
         return new OptimizedParquetColumnIterator(
             reader,
             projectedSchema,
@@ -676,7 +721,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             columnInfos,
             preloadedMetadata,
             storageObject,
-            adapter
+            adapter,
+            allRowRanges
         );
     }
 
@@ -966,9 +1012,6 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             pageBatchIndexInRowGroup = 0;
             rowsRemainingInGroup = rowGroup.getRowCount();
 
-            // TODO: when selective reading (Stage 7) is implemented, pass filter-derived RowRanges
-            // instead of RowRanges.all(), and remove the hasRecordFilter bypass so PageColumnReader
-            // handles page-index filtering natively.
             if (hasRecordFilter == false) {
                 RowRanges allRows = RowRanges.all(rowsRemainingInGroup);
                 pageColumnReaders = new PageColumnReader[columnInfos.length];

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainParquetReadOptions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainParquetReadOptions.java
@@ -110,6 +110,11 @@ final class PlainParquetReadOptions {
             return this;
         }
 
+        Builder withUseColumnIndexFilter(boolean useColumnIndexFilter) {
+            this.useColumnIndexFilter = useColumnIndexFilter;
+            return this;
+        }
+
         Builder withMaxAllocationInBytes(int maxAllocationSize) {
             this.maxAllocationSize = maxAllocationSize;
             return this;

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnIndexRowRangesComputerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnIndexRowRangesComputerTests.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.filter2.predicate.FilterApi;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.format.BoundaryOrder;
+import org.apache.parquet.format.ColumnIndex;
+import org.apache.parquet.format.OffsetIndex;
+import org.apache.parquet.format.PageLocation;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Unit tests for {@link ColumnIndexRowRangesComputer} verifying that page-level min/max
+ * evaluation produces correct RowRanges for various predicate types.
+ */
+public class ColumnIndexRowRangesComputerTests extends ESTestCase {
+
+    private static final long ROW_GROUP_ROW_COUNT = 1000;
+    private static final int PAGE_SIZE = 100;
+    private static final int PAGE_COUNT = 10;
+
+    public void testEqIntIncludesMatchingPage() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.eq(FilterApi.intColumn("id"), 550);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page containing 550 should be included", result.overlaps(500, 600));
+        assertFalse("Page [0,100) should be excluded", result.overlaps(0, 100));
+        assertFalse("Page [200,300) should be excluded", result.overlaps(200, 300));
+    }
+
+    public void testEqIntExcludesAllPages() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.eq(FilterApi.intColumn("id"), 5000);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+        assertEquals("No pages should match value outside range", 0, result.selectedRowCount());
+    }
+
+    public void testGtIntIncludesHighPages() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.gt(FilterApi.intColumn("id"), 700);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page [700,800) should be included (max=799 > 700)", result.overlaps(700, 800));
+        assertTrue("Page [800,900) should be included", result.overlaps(800, 900));
+        assertTrue("Page [900,1000) should be included", result.overlaps(900, 1000));
+        assertFalse("Page [0,100) should be excluded (max=99, not > 700)", result.overlaps(0, 100));
+    }
+
+    public void testGtEqIntIncludesMatchingPages() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.gtEq(FilterApi.intColumn("id"), 500);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page [500,600) should be included", result.overlaps(500, 600));
+        assertTrue("Page [900,1000) should be included", result.overlaps(900, 1000));
+        assertFalse("Page [0,100) should be excluded", result.overlaps(0, 100));
+    }
+
+    public void testLtIntIncludesLowPages() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.lt(FilterApi.intColumn("id"), 200);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page [0,100) should be included", result.overlaps(0, 100));
+        assertTrue("Page [100,200) should be included (min=100 < 200)", result.overlaps(100, 200));
+        assertFalse("Page [300,400) should be excluded (min=300, not < 200)", result.overlaps(300, 400));
+    }
+
+    public void testLtEqIntIncludesMatchingPages() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.ltEq(FilterApi.intColumn("id"), 199);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page [0,100) should be included", result.overlaps(0, 100));
+        assertTrue("Page [100,200) should be included (min=100 <= 199)", result.overlaps(100, 200));
+        assertFalse("Page [200,300) should be excluded (min=200, not <= 199)", result.overlaps(200, 300));
+    }
+
+    public void testNotEqReturnsAll() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.notEq(FilterApi.intColumn("id"), 500);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("NotEq should conservatively return all rows", result.isAll());
+    }
+
+    public void testAndIntersectsRanges() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.and(FilterApi.gtEq(FilterApi.intColumn("id"), 300), FilterApi.lt(FilterApi.intColumn("id"), 600));
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page [300,400) should be in intersection", result.overlaps(300, 400));
+        assertTrue("Page [400,500) should be in intersection", result.overlaps(400, 500));
+        assertTrue("Page [500,600) should be in intersection", result.overlaps(500, 600));
+        assertFalse("Page [0,100) should not be in intersection", result.overlaps(0, 100));
+        assertFalse("Page [700,800) should not be in intersection", result.overlaps(700, 800));
+    }
+
+    public void testOrUnionsRanges() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.or(FilterApi.eq(FilterApi.intColumn("id"), 50), FilterApi.eq(FilterApi.intColumn("id"), 950));
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page [0,100) should be included (contains 50)", result.overlaps(0, 100));
+        assertTrue("Page [900,1000) should be included (contains 950)", result.overlaps(900, 1000));
+        assertFalse("Page [400,500) should be excluded", result.overlaps(400, 500));
+    }
+
+    public void testNotReturnsAllConservatively() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.not(FilterApi.eq(FilterApi.intColumn("id"), 550));
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertEquals(
+            "NOT must conservatively return all rows (complement would drop mixed pages)",
+            ROW_GROUP_ROW_COUNT,
+            result.selectedRowCount()
+        );
+    }
+
+    public void testInIncludesMatchingPages() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.in(FilterApi.intColumn("id"), Set.of(150, 750));
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page [100,200) should be included (contains 150)", result.overlaps(100, 200));
+        assertTrue("Page [700,800) should be included (contains 750)", result.overlaps(700, 800));
+        assertFalse("Page [400,500) should be excluded", result.overlaps(400, 500));
+    }
+
+    public void testMissingColumnIndexReturnsAll() {
+        PreloadedRowGroupMetadata metadata = PreloadedRowGroupMetadata.empty();
+        FilterPredicate pred = FilterApi.eq(FilterApi.intColumn("missing_col"), 42);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Missing ColumnIndex should return all rows", result.isAll());
+    }
+
+    public void testNullPredicateReturnsAll() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(null, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Null predicate should return all rows", result.isAll());
+    }
+
+    public void testEqWithNullValueReturnsAll() {
+        PreloadedRowGroupMetadata metadata = buildIntMetadata("id", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.eq(FilterApi.intColumn("id"), null);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Eq with null value (IS NULL) should return all rows", result.isAll());
+    }
+
+    public void testLongColumnEq() {
+        PreloadedRowGroupMetadata metadata = buildLongMetadata("ts", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.eq(FilterApi.longColumn("ts"), 550L);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page containing 550 should be included", result.overlaps(500, 600));
+        assertFalse("Page [0,100) should be excluded", result.overlaps(0, 100));
+    }
+
+    public void testDoubleColumnGtEq() {
+        PreloadedRowGroupMetadata metadata = buildDoubleMetadata("score", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.gtEq(FilterApi.doubleColumn("score"), 800.0);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page [800,900) should be included", result.overlaps(800, 900));
+        assertTrue("Page [900,1000) should be included", result.overlaps(900, 1000));
+        assertFalse("Page [0,100) should be excluded", result.overlaps(0, 100));
+    }
+
+    public void testBinaryColumnEq() {
+        PreloadedRowGroupMetadata metadata = buildBinaryMetadata("name", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.eq(FilterApi.binaryColumn("name"), Binary.fromString("page_5"));
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("Page with matching min/max should be included", result.overlaps(500, 600));
+    }
+
+    public void testBooleanColumnEq() {
+        PreloadedRowGroupMetadata metadata = buildBooleanMetadata("flag", PAGE_COUNT, PAGE_SIZE);
+        FilterPredicate pred = FilterApi.eq(FilterApi.booleanColumn("flag"), true);
+
+        RowRanges result = ColumnIndexRowRangesComputer.compute(pred, metadata, 0, ROW_GROUP_ROW_COUNT);
+
+        assertTrue("At least some pages should match true", result.selectedRowCount() > 0);
+    }
+
+    // --- Metadata builders ---
+
+    private static PreloadedRowGroupMetadata buildIntMetadata(String columnPath, int pageCount, int pageSize) {
+        List<ByteBuffer> minValues = new ArrayList<>();
+        List<ByteBuffer> maxValues = new ArrayList<>();
+        List<Boolean> nullPages = new ArrayList<>();
+        List<PageLocation> pageLocations = new ArrayList<>();
+
+        for (int p = 0; p < pageCount; p++) {
+            int min = p * pageSize;
+            int max = (p + 1) * pageSize - 1;
+            minValues.add(intToBuffer(min));
+            maxValues.add(intToBuffer(max));
+            nullPages.add(false);
+            pageLocations.add(new PageLocation(p * 1000L, pageSize * 4, p * pageSize));
+        }
+
+        ColumnIndex ci = new ColumnIndex(nullPages, minValues, maxValues, BoundaryOrder.ASCENDING);
+        OffsetIndex oi = new OffsetIndex(pageLocations);
+
+        PrimitiveType ptype = Types.required(PrimitiveType.PrimitiveTypeName.INT32).named(columnPath);
+        org.apache.parquet.internal.column.columnindex.ColumnIndex typedCi = ParquetMetadataConverter.fromParquetColumnIndex(ptype, ci);
+        org.apache.parquet.internal.column.columnindex.OffsetIndex typedOi = ParquetMetadataConverter.fromParquetOffsetIndex(oi);
+
+        return buildMetadata(columnPath, typedCi, typedOi);
+    }
+
+    private static PreloadedRowGroupMetadata buildLongMetadata(String columnPath, int pageCount, int pageSize) {
+        List<ByteBuffer> minValues = new ArrayList<>();
+        List<ByteBuffer> maxValues = new ArrayList<>();
+        List<Boolean> nullPages = new ArrayList<>();
+        List<PageLocation> pageLocations = new ArrayList<>();
+
+        for (int p = 0; p < pageCount; p++) {
+            long min = (long) p * pageSize;
+            long max = (long) (p + 1) * pageSize - 1;
+            minValues.add(longToBuffer(min));
+            maxValues.add(longToBuffer(max));
+            nullPages.add(false);
+            pageLocations.add(new PageLocation(p * 1000L, pageSize * 8, p * pageSize));
+        }
+
+        ColumnIndex ci = new ColumnIndex(nullPages, minValues, maxValues, BoundaryOrder.ASCENDING);
+        OffsetIndex oi = new OffsetIndex(pageLocations);
+
+        PrimitiveType ptype = Types.required(PrimitiveType.PrimitiveTypeName.INT64).named(columnPath);
+        org.apache.parquet.internal.column.columnindex.ColumnIndex typedCi = ParquetMetadataConverter.fromParquetColumnIndex(ptype, ci);
+        org.apache.parquet.internal.column.columnindex.OffsetIndex typedOi = ParquetMetadataConverter.fromParquetOffsetIndex(oi);
+
+        return buildMetadata(columnPath, typedCi, typedOi);
+    }
+
+    private static PreloadedRowGroupMetadata buildDoubleMetadata(String columnPath, int pageCount, int pageSize) {
+        List<ByteBuffer> minValues = new ArrayList<>();
+        List<ByteBuffer> maxValues = new ArrayList<>();
+        List<Boolean> nullPages = new ArrayList<>();
+        List<PageLocation> pageLocations = new ArrayList<>();
+
+        for (int p = 0; p < pageCount; p++) {
+            double min = (double) p * pageSize;
+            double max = (double) (p + 1) * pageSize - 1;
+            minValues.add(doubleToBuffer(min));
+            maxValues.add(doubleToBuffer(max));
+            nullPages.add(false);
+            pageLocations.add(new PageLocation(p * 1000L, pageSize * 8, p * pageSize));
+        }
+
+        ColumnIndex ci = new ColumnIndex(nullPages, minValues, maxValues, BoundaryOrder.ASCENDING);
+        OffsetIndex oi = new OffsetIndex(pageLocations);
+
+        PrimitiveType ptype = Types.required(PrimitiveType.PrimitiveTypeName.DOUBLE).named(columnPath);
+        org.apache.parquet.internal.column.columnindex.ColumnIndex typedCi = ParquetMetadataConverter.fromParquetColumnIndex(ptype, ci);
+        org.apache.parquet.internal.column.columnindex.OffsetIndex typedOi = ParquetMetadataConverter.fromParquetOffsetIndex(oi);
+
+        return buildMetadata(columnPath, typedCi, typedOi);
+    }
+
+    private static PreloadedRowGroupMetadata buildBinaryMetadata(String columnPath, int pageCount, int pageSize) {
+        List<ByteBuffer> minValues = new ArrayList<>();
+        List<ByteBuffer> maxValues = new ArrayList<>();
+        List<Boolean> nullPages = new ArrayList<>();
+        List<PageLocation> pageLocations = new ArrayList<>();
+
+        for (int p = 0; p < pageCount; p++) {
+            Binary min = Binary.fromString("page_" + p);
+            Binary max = Binary.fromString("page_" + p + "_z");
+            minValues.add(ByteBuffer.wrap(min.getBytes()));
+            maxValues.add(ByteBuffer.wrap(max.getBytes()));
+            nullPages.add(false);
+            pageLocations.add(new PageLocation(p * 1000L, pageSize * 10, p * pageSize));
+        }
+
+        ColumnIndex ci = new ColumnIndex(nullPages, minValues, maxValues, BoundaryOrder.ASCENDING);
+        OffsetIndex oi = new OffsetIndex(pageLocations);
+
+        PrimitiveType ptype = Types.required(PrimitiveType.PrimitiveTypeName.BINARY).named(columnPath);
+        org.apache.parquet.internal.column.columnindex.ColumnIndex typedCi = ParquetMetadataConverter.fromParquetColumnIndex(ptype, ci);
+        org.apache.parquet.internal.column.columnindex.OffsetIndex typedOi = ParquetMetadataConverter.fromParquetOffsetIndex(oi);
+
+        return buildMetadata(columnPath, typedCi, typedOi);
+    }
+
+    private static PreloadedRowGroupMetadata buildBooleanMetadata(String columnPath, int pageCount, int pageSize) {
+        List<ByteBuffer> minValues = new ArrayList<>();
+        List<ByteBuffer> maxValues = new ArrayList<>();
+        List<Boolean> nullPages = new ArrayList<>();
+        List<PageLocation> pageLocations = new ArrayList<>();
+
+        for (int p = 0; p < pageCount; p++) {
+            boolean min = p % 2 == 0;
+            boolean max = true;
+            minValues.add(ByteBuffer.wrap(new byte[] { (byte) (min ? 1 : 0) }));
+            maxValues.add(ByteBuffer.wrap(new byte[] { (byte) (max ? 1 : 0) }));
+            nullPages.add(false);
+            pageLocations.add(new PageLocation(p * 1000L, pageSize, p * pageSize));
+        }
+
+        ColumnIndex ci = new ColumnIndex(nullPages, minValues, maxValues, BoundaryOrder.UNORDERED);
+        OffsetIndex oi = new OffsetIndex(pageLocations);
+
+        PrimitiveType ptype = Types.required(PrimitiveType.PrimitiveTypeName.BOOLEAN).named(columnPath);
+        org.apache.parquet.internal.column.columnindex.ColumnIndex typedCi = ParquetMetadataConverter.fromParquetColumnIndex(ptype, ci);
+        org.apache.parquet.internal.column.columnindex.OffsetIndex typedOi = ParquetMetadataConverter.fromParquetOffsetIndex(oi);
+
+        return buildMetadata(columnPath, typedCi, typedOi);
+    }
+
+    private static PreloadedRowGroupMetadata buildMetadata(
+        String columnPath,
+        org.apache.parquet.internal.column.columnindex.ColumnIndex ci,
+        org.apache.parquet.internal.column.columnindex.OffsetIndex oi
+    ) {
+        Map<String, org.apache.parquet.internal.column.columnindex.ColumnIndex> columnIndexes = new HashMap<>();
+        Map<String, org.apache.parquet.internal.column.columnindex.OffsetIndex> offsetIndexes = new HashMap<>();
+        columnIndexes.put("0:" + columnPath, ci);
+        offsetIndexes.put("0:" + columnPath, oi);
+        return new PreloadedRowGroupMetadata(columnIndexes, offsetIndexes);
+    }
+
+    private static ByteBuffer intToBuffer(int value) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value).flip();
+    }
+
+    private static ByteBuffer longToBuffer(long value) {
+        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(value).flip();
+    }
+
+    private static ByteBuffer doubleToBuffer(double value) {
+        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(value).flip();
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedFilteredReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedFilteredReaderTests.java
@@ -1,0 +1,598 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.predicate.FilterApi;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Integration tests verifying that the optimized reader produces correct results when
+ * filters are active and that page-level RowRanges filtering actually reduces I/O.
+ * Sorted data with small page sizes ensures ColumnIndex is useful for page skipping.
+ */
+public class OptimizedFilteredReaderTests extends ESTestCase {
+
+    private static final int TOTAL_ROWS = 1000;
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    /**
+     * Filtered optimized reads produce the same rows as filtered baseline reads.
+     */
+    public void testFilteredOptimizedMatchesBaseline() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+        FilterPredicate filter = FilterApi.and(
+            FilterApi.gtEq(FilterApi.intColumn("id"), 200),
+            FilterApi.lt(FilterApi.intColumn("id"), 400)
+        );
+
+        List<Page> baselinePages = readWithFilter(parquetData, filter, false);
+        List<Page> optimizedPages = readWithFilter(parquetData, filter, true);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Equality filter on sorted data: optimized path should produce same results as baseline.
+     */
+    public void testEqualityFilterParity() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+        FilterPredicate filter = FilterApi.eq(FilterApi.intColumn("id"), 500);
+
+        List<Page> baselinePages = readWithFilter(parquetData, filter, false);
+        List<Page> optimizedPages = readWithFilter(parquetData, filter, true);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * OR of equality filters: optimized path should produce same results as baseline.
+     */
+    public void testOrEqualityFilterParity() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+        FilterPredicate filter = FilterApi.or(FilterApi.eq(FilterApi.intColumn("id"), 100), FilterApi.eq(FilterApi.intColumn("id"), 900));
+
+        List<Page> baselinePages = readWithFilter(parquetData, filter, false);
+        List<Page> optimizedPages = readWithFilter(parquetData, filter, true);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Optimized path with no filter still works (regression check).
+     */
+    public void testOptimizedWithoutFilter() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+
+        List<Page> baselinePages = readWithFilter(parquetData, null, false);
+        List<Page> optimizedPages = readWithFilter(parquetData, null, true);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Multi-column file with filter: optimized path produces correct results
+     * for projected columns alongside the filtered column.
+     */
+    public void testMultiColumnFilteredParity() throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(INT32)
+            .named("id")
+            .required(INT64)
+            .named("big_id")
+            .required(DOUBLE)
+            .named("score")
+            .required(BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .named("multi_col_test");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < TOTAL_ROWS; i++) {
+                groups.add(
+                    factory.newGroup().append("id", i).append("big_id", (long) i * 1000).append("score", i * 1.5).append("name", "row_" + i)
+                );
+            }
+            return groups;
+        });
+
+        FilterPredicate filter = FilterApi.and(
+            FilterApi.gtEq(FilterApi.intColumn("id"), 100),
+            FilterApi.lt(FilterApi.intColumn("id"), 300)
+        );
+
+        List<Page> baselinePages = readWithFilter(parquetData, filter, false);
+        List<Page> optimizedPages = readWithFilter(parquetData, filter, true);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    /**
+     * Filter that eliminates all rows: both paths should produce no data.
+     */
+    public void testFilterEliminatesAllRows() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+        FilterPredicate filter = FilterApi.eq(FilterApi.intColumn("id"), -1);
+
+        List<Page> baselinePages = readWithFilter(parquetData, filter, false);
+        List<Page> optimizedPages = readWithFilter(parquetData, filter, true);
+
+        int baselineRows = baselinePages.stream().mapToInt(Page::getPositionCount).sum();
+        int optimizedRows = optimizedPages.stream().mapToInt(Page::getPositionCount).sum();
+        assertEquals(baselineRows, optimizedRows);
+        assertEquals(0, optimizedRows);
+        assertEquals("No pages should be emitted when all rows eliminated", 0, optimizedPages.size());
+    }
+
+    /**
+     * Filter that matches all rows: both paths should produce same data.
+     */
+    public void testFilterMatchesAllRows() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+        FilterPredicate filter = FilterApi.and(
+            FilterApi.gtEq(FilterApi.intColumn("id"), 0),
+            FilterApi.lt(FilterApi.intColumn("id"), TOTAL_ROWS)
+        );
+
+        List<Page> baselinePages = readWithFilter(parquetData, filter, false);
+        List<Page> optimizedPages = readWithFilter(parquetData, filter, true);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    // --- PushedExpressions path tests (exercises ColumnIndexRowRangesComputer → RowRanges) ---
+
+    /**
+     * Range filter via PushedExpressions: exercises the RowRanges code path and
+     * verifies parity against both the baseline reader and the FilterCompat optimized reader.
+     */
+    public void testPushedExpressionsRangeFilterParity() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+
+        FilterPredicate filterCompat = FilterApi.and(
+            FilterApi.gtEq(FilterApi.intColumn("id"), 200),
+            FilterApi.lt(FilterApi.intColumn("id"), 400)
+        );
+        Expression esqlFilter = new org.elasticsearch.xpack.esql.expression.predicate.logical.And(
+            Source.EMPTY,
+            new GreaterThanOrEqual(Source.EMPTY, intAttr("id"), intLit(200), null),
+            new LessThan(Source.EMPTY, intAttr("id"), intLit(400), null)
+        );
+
+        List<Page> baselinePages = readWithFilter(parquetData, filterCompat, false);
+        List<Page> optimizedCompatPages = readWithFilter(parquetData, filterCompat, true);
+        List<Page> optimizedPushedPages = readWithPushedExpressions(parquetData, esqlFilter);
+
+        assertPagesEqual(baselinePages, optimizedCompatPages);
+        assertPagesEqual(baselinePages, optimizedPushedPages);
+    }
+
+    /**
+     * Equality filter via PushedExpressions: verifies the RowRanges path produces
+     * identical results to both baseline and FilterCompat optimized paths.
+     */
+    public void testPushedExpressionsEqualityFilterParity() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+
+        FilterPredicate filterCompat = FilterApi.eq(FilterApi.intColumn("id"), 500);
+        Expression esqlFilter = new Equals(Source.EMPTY, intAttr("id"), intLit(500), null);
+
+        List<Page> baselinePages = readWithFilter(parquetData, filterCompat, false);
+        List<Page> optimizedCompatPages = readWithFilter(parquetData, filterCompat, true);
+        List<Page> optimizedPushedPages = readWithPushedExpressions(parquetData, esqlFilter);
+
+        assertPagesEqual(baselinePages, optimizedCompatPages);
+        assertPagesEqual(baselinePages, optimizedPushedPages);
+    }
+
+    /**
+     * Filter eliminating all rows via PushedExpressions: RowRanges path should also produce zero rows.
+     */
+    public void testPushedExpressionsEliminatesAllRows() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+
+        Expression esqlFilter = new Equals(Source.EMPTY, intAttr("id"), intLit(-1), null);
+
+        List<Page> pushedPages = readWithPushedExpressions(parquetData, esqlFilter);
+        int totalRows = pushedPages.stream().mapToInt(Page::getPositionCount).sum();
+        assertEquals(0, totalRows);
+    }
+
+    /**
+     * Filter matching all rows via PushedExpressions: RowRanges path should return every row.
+     */
+    public void testPushedExpressionsMatchesAllRows() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+
+        Expression esqlFilter = new org.elasticsearch.xpack.esql.expression.predicate.logical.And(
+            Source.EMPTY,
+            new GreaterThanOrEqual(Source.EMPTY, intAttr("id"), intLit(0), null),
+            new LessThan(Source.EMPTY, intAttr("id"), intLit(TOTAL_ROWS), null)
+        );
+
+        List<Page> baselinePages = readWithFilter(parquetData, null, false);
+        List<Page> pushedPages = readWithPushedExpressions(parquetData, esqlFilter);
+        assertPagesEqual(baselinePages, pushedPages);
+    }
+
+    /**
+     * Multi-column file with PushedExpressions filter: verifies that all projected columns
+     * produce correct values when the RowRanges path is active.
+     */
+    public void testPushedExpressionsMultiColumnParity() throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(INT32)
+            .named("id")
+            .required(INT64)
+            .named("big_id")
+            .required(DOUBLE)
+            .named("score")
+            .required(BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .named("multi_col_test");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < TOTAL_ROWS; i++) {
+                groups.add(
+                    factory.newGroup().append("id", i).append("big_id", (long) i * 1000).append("score", i * 1.5).append("name", "row_" + i)
+                );
+            }
+            return groups;
+        });
+
+        FilterPredicate filterCompat = FilterApi.and(
+            FilterApi.gtEq(FilterApi.intColumn("id"), 100),
+            FilterApi.lt(FilterApi.intColumn("id"), 300)
+        );
+        Expression esqlFilter = new org.elasticsearch.xpack.esql.expression.predicate.logical.And(
+            Source.EMPTY,
+            new GreaterThanOrEqual(Source.EMPTY, intAttr("id"), intLit(100), null),
+            new LessThan(Source.EMPTY, intAttr("id"), intLit(300), null)
+        );
+
+        List<Page> baselinePages = readWithFilter(parquetData, filterCompat, false);
+        List<Page> pushedPages = readWithPushedExpressions(parquetData, esqlFilter);
+        assertPagesEqual(baselinePages, pushedPages);
+    }
+
+    /**
+     * NOT(Eq) via PushedExpressions: verifies the RowRanges path returns all rows that
+     * the baseline returns — i.e. NOT does not drop rows from mixed pages.
+     */
+    public void testPushedExpressionsNotEqualityParity() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+
+        FilterPredicate filterCompat = FilterApi.not(FilterApi.eq(FilterApi.intColumn("id"), 500));
+        Expression esqlFilter = new Not(Source.EMPTY, new Equals(Source.EMPTY, intAttr("id"), intLit(500), null));
+
+        List<Page> baselinePages = readWithFilter(parquetData, filterCompat, false);
+        List<Page> pushedPages = readWithPushedExpressions(parquetData, esqlFilter);
+        assertPagesEqual(baselinePages, pushedPages);
+    }
+
+    /**
+     * NOT(OR(Eq, Eq)) via PushedExpressions: compound NOT that cannot be simplified to
+     * NotEq by De Morgan. Verifies conservative RowRanges for compound negations.
+     */
+    public void testPushedExpressionsNotCompoundParity() throws IOException {
+        byte[] parquetData = createSortedIntFile();
+
+        FilterPredicate innerCompat = FilterApi.or(
+            FilterApi.eq(FilterApi.intColumn("id"), 100),
+            FilterApi.eq(FilterApi.intColumn("id"), 900)
+        );
+        FilterPredicate filterCompat = FilterApi.not(innerCompat);
+        Expression innerEsql = new org.elasticsearch.xpack.esql.expression.predicate.logical.Or(
+            Source.EMPTY,
+            new Equals(Source.EMPTY, intAttr("id"), intLit(100), null),
+            new Equals(Source.EMPTY, intAttr("id"), intLit(900), null)
+        );
+        Expression esqlFilter = new Not(Source.EMPTY, innerEsql);
+
+        List<Page> baselinePages = readWithFilter(parquetData, filterCompat, false);
+        List<Page> pushedPages = readWithPushedExpressions(parquetData, esqlFilter);
+        assertPagesEqual(baselinePages, pushedPages);
+    }
+
+    /**
+     * Multi-row-group file where all row groups have the same row count, exercising
+     * the simplified row-group alignment logic (rowGroupOrdinal direct indexing).
+     */
+    public void testSameRowCountMultiRowGroupParity() throws IOException {
+        MessageType schema = Types.buildMessage().required(INT32).named("id").named("same_rg_test");
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 2000; i++) {
+                groups.add(factory.newGroup().append("id", i));
+            }
+            return groups;
+        });
+
+        FilterPredicate filterCompat = FilterApi.and(
+            FilterApi.gtEq(FilterApi.intColumn("id"), 500),
+            FilterApi.lt(FilterApi.intColumn("id"), 1500)
+        );
+        Expression esqlFilter = new org.elasticsearch.xpack.esql.expression.predicate.logical.And(
+            Source.EMPTY,
+            new GreaterThanOrEqual(Source.EMPTY, intAttr("id"), intLit(500), null),
+            new LessThan(Source.EMPTY, intAttr("id"), intLit(1500), null)
+        );
+
+        List<Page> baselinePages = readWithFilter(parquetData, filterCompat, false);
+        List<Page> pushedPages = readWithPushedExpressions(parquetData, esqlFilter);
+        assertPagesEqual(baselinePages, pushedPages);
+    }
+
+    // --- Helpers ---
+
+    private static ReferenceAttribute intAttr(String name) {
+        return new ReferenceAttribute(Source.EMPTY, name, DataType.INTEGER);
+    }
+
+    private static Literal intLit(int value) {
+        return new Literal(Source.EMPTY, value, DataType.INTEGER);
+    }
+
+    private byte[] createSortedIntFile() throws IOException {
+        MessageType schema = Types.buildMessage().required(INT32).named("id").named("sorted_test");
+        return createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < TOTAL_ROWS; i++) {
+                groups.add(factory.newGroup().append("id", i));
+            }
+            return groups;
+        });
+    }
+
+    @FunctionalInterface
+    interface GroupCreator {
+        List<Group> create(SimpleGroupFactory factory);
+    }
+
+    private byte[] createParquetFile(MessageType schema, GroupCreator groupCreator) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        List<Group> groups = groupCreator.create(groupFactory);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withRowGroupSize(10 * 1024 * 1024)
+                .withPageSize(64)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            for (Group group : groups) {
+                writer.write(group);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
+    private List<Page> readWithFilter(byte[] parquetData, FilterPredicate filter, boolean optimized) throws IOException {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, optimized);
+        if (filter != null) {
+            reader = reader.withPushedFilter(FilterCompat.get(filter));
+        }
+        StorageObject storageObject = createStorageObject(parquetData);
+        try (CloseableIterator<Page> iter = reader.read(storageObject, FormatReadContext.of(null, 1024))) {
+            List<Page> pages = new ArrayList<>();
+            while (iter.hasNext()) {
+                pages.add(iter.next());
+            }
+            return pages;
+        }
+    }
+
+    /**
+     * Reads using the optimized path with a {@link ParquetPushedExpressions} filter.
+     * This exercises the full RowRanges code path: resolveFilterPredicate → ColumnIndexRowRangesComputer
+     * → RowRanges[] → PageColumnReader page skipping + ColumnChunkPrefetcher filtered prefetch.
+     */
+    private List<Page> readWithPushedExpressions(byte[] parquetData, Expression esqlFilter) throws IOException {
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(esqlFilter));
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        StorageObject storageObject = createStorageObject(parquetData);
+        try (CloseableIterator<Page> iter = reader.read(storageObject, FormatReadContext.of(null, 1024))) {
+            List<Page> pages = new ArrayList<>();
+            while (iter.hasNext()) {
+                pages.add(iter.next());
+            }
+            return pages;
+        }
+    }
+
+    private void assertPagesEqual(List<Page> expected, List<Page> actual) {
+        int expectedRows = expected.stream().mapToInt(Page::getPositionCount).sum();
+        int actualRows = actual.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("total row count mismatch", actualRows, equalTo(expectedRows));
+
+        int ep = 0, ePos = 0;
+        int ap = 0, aPos = 0;
+        for (int row = 0; row < expectedRows; row++) {
+            Page ePage = expected.get(ep);
+            Page aPage = actual.get(ap);
+            for (int b = 0; b < ePage.getBlockCount(); b++) {
+                assertBlockValueEqual(ePage.getBlock(b), ePos, aPage.getBlock(b), aPos, row, b);
+            }
+            ePos++;
+            if (ePos >= ePage.getPositionCount()) {
+                ep++;
+                ePos = 0;
+            }
+            aPos++;
+            if (aPos >= aPage.getPositionCount()) {
+                ap++;
+                aPos = 0;
+            }
+        }
+    }
+
+    private void assertBlockValueEqual(Block expected, int ePos, Block actual, int aPos, int row, int block) {
+        String ctx = "row " + row + " block " + block;
+        assertThat(ctx + " null", actual.isNull(aPos), equalTo(expected.isNull(ePos)));
+        if (expected.isNull(ePos)) {
+            return;
+        }
+        if (expected instanceof IntBlock eb && actual instanceof IntBlock ab) {
+            assertThat(ctx, ab.getInt(ab.getFirstValueIndex(aPos)), equalTo(eb.getInt(eb.getFirstValueIndex(ePos))));
+        } else if (expected instanceof LongBlock eb && actual instanceof LongBlock ab) {
+            assertThat(ctx, ab.getLong(ab.getFirstValueIndex(aPos)), equalTo(eb.getLong(eb.getFirstValueIndex(ePos))));
+        } else if (expected instanceof DoubleBlock eb && actual instanceof DoubleBlock ab) {
+            assertThat(ctx, ab.getDouble(ab.getFirstValueIndex(aPos)), equalTo(eb.getDouble(eb.getFirstValueIndex(ePos))));
+        } else if (expected instanceof BooleanBlock eb && actual instanceof BooleanBlock ab) {
+            assertThat(ctx, ab.getBoolean(ab.getFirstValueIndex(aPos)), equalTo(eb.getBoolean(eb.getFirstValueIndex(ePos))));
+        } else if (expected instanceof BytesRefBlock eb && actual instanceof BytesRefBlock ab) {
+            assertThat(
+                ctx,
+                ab.getBytesRef(ab.getFirstValueIndex(aPos), new BytesRef()),
+                equalTo(eb.getBytesRef(eb.getFirstValueIndex(ePos), new BytesRef()))
+            );
+        }
+    }
+
+    private StorageObject createStorageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://filtered_test.parquet");
+            }
+        };
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream outputStream) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return createPositionOutputStream(outputStream);
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return createPositionOutputStream(outputStream);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+
+            @Override
+            public String getPath() {
+                return "memory://filtered_test.parquet";
+            }
+        };
+    }
+
+    private static PositionOutputStream createPositionOutputStream(ByteArrayOutputStream outputStream) {
+        return new PositionOutputStream() {
+            @Override
+            public long getPos() {
+                return outputStream.size();
+            }
+
+            @Override
+            public void write(int b) {
+                outputStream.write(b);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) {
+                outputStream.write(b, off, len);
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -84,13 +84,13 @@ public class OptimizedParquetReaderTests extends ESTestCase {
     public void testWithConfigOptimizedReaderTrue() {
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
         ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(Map.of("optimized_reader", true));
-        assertNotSame(reader, configured);
+        assertSame(reader, configured);
     }
 
     public void testWithConfigOptimizedReaderFalse() {
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
         ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(Map.of("optimized_reader", false));
-        assertSame(reader, configured);
+        assertNotSame(reader, configured);
     }
 
     public void testWithConfigDefaults() {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -413,7 +413,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         }
 
         // Check that we read at least 1 page and that all memory has been released
-        assertThat(pageCount.get(), greaterThan(1));
+        assertThat(pageCount.get(), greaterThan(0));
         assertEquals(0, limitedBreaker.getUsed());
     }
 
@@ -2064,19 +2064,19 @@ public class ParquetFormatReaderTests extends ESTestCase {
     public void testWithConfigOptimizedReaderTrue() {
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
         ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(Map.of("optimized_reader", true));
-        assertNotSame(reader, configured);
+        assertSame(reader, configured);
     }
 
     public void testWithConfigOptimizedReaderFalse() {
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
         ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(Map.of("optimized_reader", false));
-        assertSame(reader, configured);
+        assertNotSame(reader, configured);
     }
 
     public void testWithConfigOptimizedReaderStringTrue() {
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
         ParquetFormatReader configured = (ParquetFormatReader) reader.withConfig(Map.of("optimized_reader", "true"));
-        assertNotSame(reader, configured);
+        assertSame(reader, configured);
     }
 
     public void testWithConfigDefaults() {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPageIndexFilteringTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPageIndexFilteringTests.java
@@ -22,18 +22,28 @@ import org.apache.parquet.schema.Types;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
@@ -112,6 +122,102 @@ public class ParquetPageIndexFilteringTests extends ESTestCase {
         );
     }
 
+    /**
+     * Optimized reader with PushedExpressions (our RowRanges path): an equality filter on sorted
+     * data should skip pages AND return the same data as the baseline reader.
+     */
+    public void testOptimizedReaderPageSkippingWithPushedExpressions() throws IOException {
+        byte[] parquetData = createSortedParquetFile();
+
+        Expression esqlFilter = new Equals(
+            Source.EMPTY,
+            new ReferenceAttribute(Source.EMPTY, "id", DataType.INTEGER),
+            new Literal(Source.EMPTY, 500, DataType.INTEGER),
+            null
+        );
+        FilterPredicate parquetFilter = FilterApi.eq(FilterApi.intColumn("id"), 500);
+
+        List<Integer> baselineIds = readIdsWithBaselineFilter(parquetData, parquetFilter);
+        List<Integer> optimizedIds = readIdsWithPushedExpressions(parquetData, esqlFilter);
+
+        assertTrue("Expected some rows from the page containing id=500", optimizedIds.size() > 0);
+        assertTrue(
+            "Expected RowRanges to skip most pages (got " + optimizedIds.size() + " of " + TOTAL_ROWS + ")",
+            optimizedIds.size() < TOTAL_ROWS / 2
+        );
+        assertTrue("Optimized result must be a superset of baseline (baseline=" + baselineIds + ")", optimizedIds.containsAll(baselineIds));
+    }
+
+    /**
+     * Optimized reader with PushedExpressions (our RowRanges path): a range filter on sorted
+     * data should return the same data as the baseline reader.
+     */
+    public void testOptimizedReaderRangeFilterWithPushedExpressions() throws IOException {
+        byte[] parquetData = createSortedParquetFile();
+
+        Expression esqlFilter = new org.elasticsearch.xpack.esql.expression.predicate.logical.And(
+            Source.EMPTY,
+            new GreaterThanOrEqual(
+                Source.EMPTY,
+                new ReferenceAttribute(Source.EMPTY, "id", DataType.INTEGER),
+                new Literal(Source.EMPTY, 100, DataType.INTEGER),
+                null
+            ),
+            new LessThan(
+                Source.EMPTY,
+                new ReferenceAttribute(Source.EMPTY, "id", DataType.INTEGER),
+                new Literal(Source.EMPTY, 200, DataType.INTEGER),
+                null
+            )
+        );
+        FilterPredicate parquetFilter = FilterApi.and(
+            FilterApi.gtEq(FilterApi.intColumn("id"), 100),
+            FilterApi.lt(FilterApi.intColumn("id"), 200)
+        );
+
+        List<Integer> baselineIds = readIdsWithBaselineFilter(parquetData, parquetFilter);
+        List<Integer> optimizedIds = readIdsWithPushedExpressions(parquetData, esqlFilter);
+
+        assertTrue("Expected rows in the [100, 200) range", optimizedIds.size() > 0);
+        assertTrue(
+            "Expected RowRanges to skip most pages (got " + optimizedIds.size() + " of " + TOTAL_ROWS + ")",
+            optimizedIds.size() < TOTAL_ROWS / 2
+        );
+        assertTrue(
+            "Optimized result must be a superset of baseline (baseline size=" + baselineIds.size() + ")",
+            optimizedIds.containsAll(baselineIds)
+        );
+    }
+
+    /**
+     * Multiple row groups with PushedExpressions: tests row-group skip + page-level filter,
+     * and verifies data parity against the baseline reader.
+     */
+    public void testMultiRowGroupWithRowGroupSkipAndPageFiltering() throws IOException {
+        byte[] parquetData = createMultiRowGroupFile();
+
+        Expression esqlFilter = new Equals(
+            Source.EMPTY,
+            new ReferenceAttribute(Source.EMPTY, "id", DataType.INTEGER),
+            new Literal(Source.EMPTY, 1500, DataType.INTEGER),
+            null
+        );
+        FilterPredicate parquetFilter = FilterApi.eq(FilterApi.intColumn("id"), 1500);
+
+        List<Integer> baselineIds = readIdsWithBaselineFilter(parquetData, parquetFilter);
+        List<Integer> optimizedIds = readIdsWithPushedExpressions(parquetData, esqlFilter);
+
+        assertTrue("Expected some rows from the page containing id=1500", optimizedIds.size() > 0);
+        assertTrue(
+            "Row group 1 should be skipped, page filtering should skip most pages in row group 2 (got " + optimizedIds.size() + " of 2000)",
+            optimizedIds.size() < 2000 / 4
+        );
+        assertTrue(
+            "Optimized result must be a superset of baseline (baseline size=" + baselineIds.size() + ")",
+            optimizedIds.containsAll(baselineIds)
+        );
+    }
+
     // --- helpers ---
 
     /**
@@ -155,6 +261,72 @@ public class ParquetPageIndexFilteringTests extends ESTestCase {
             }
         }
         return totalRows;
+    }
+
+    /**
+     * Reads using the baseline (non-optimized) reader with a FilterCompat filter.
+     * This is the ground truth — parquet-mr handles all filtering.
+     */
+    private List<Integer> readIdsWithBaselineFilter(byte[] parquetData, FilterPredicate filter) throws IOException {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, false);
+        if (filter != null) {
+            reader = reader.withPushedFilter(FilterCompat.get(filter));
+        }
+        return collectIds(reader, createStorageObject(parquetData));
+    }
+
+    /**
+     * Reads using the optimized reader with PushedExpressions, exercising the full
+     * RowRanges code path (ColumnIndexRowRangesComputer → PageColumnReader page skipping).
+     */
+    private List<Integer> readIdsWithPushedExpressions(byte[] parquetData, Expression filter) throws IOException {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true);
+        if (filter != null) {
+            reader = reader.withPushedFilter(new ParquetPushedExpressions(List.of(filter)));
+        }
+        return collectIds(reader, createStorageObject(parquetData));
+    }
+
+    private List<Integer> collectIds(ParquetFormatReader reader, StorageObject storageObject) throws IOException {
+        List<Integer> ids = new ArrayList<>();
+        try (CloseableIterator<Page> iter = reader.read(storageObject, FormatReadContext.of(List.of("id"), 1000))) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                IntBlock block = page.getBlock(0);
+                for (int pos = 0; pos < block.getPositionCount(); pos++) {
+                    if (block.isNull(pos) == false) {
+                        ids.add(block.getInt(block.getFirstValueIndex(pos)));
+                    }
+                }
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * Creates a file with 2 row groups: first contains ids 0-999, second contains 1000-1999.
+     * Small row group size forces the split; sorted data within each group enables page filtering.
+     */
+    private byte[] createMultiRowGroupFile() throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory factory = new SimpleGroupFactory(SCHEMA);
+
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new org.apache.parquet.conf.PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(SCHEMA)
+                .withRowGroupSize(4 * 1024)
+                .withPageSize(64)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            for (int i = 0; i < 2000; i++) {
+                writer.write(factory.newGroup().append("id", i));
+            }
+        }
+        return outputStream.toByteArray();
     }
 
     private StorageObject createStorageObject(byte[] data) {


### PR DESCRIPTION
Enable page-level filtering in the optimized Parquet reader path.
Previously, filtered queries fell back to the baseline iterator,
losing vectorized decoding and prefetch. Now the optimized path
computes RowRanges from ColumnIndex metadata via a new
FilterPredicate.Visitor and passes them to PageColumnReader for
page skipping and to ColumnChunkPrefetcher for filtered prefetch.

The optimized reader is now enabled by default for all Parquet reads,
providing vectorized decoding and prefetch without requiring explicit
config. The baseline path remains available via optimized_reader=false.

Developed with AI-assisted tooling