### PR TITLE
ES|QL: report correct location for SET errors

### DIFF
--- a/docs/changelog/147582.yaml
+++ b/docs/changelog/147582.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 145873
+pr: 147582
+summary: Report correct location for SET errors
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2622,6 +2622,12 @@ public class EsqlCapabilities {
          */
         INFERENCE_ACCEPT_TIMEOUT,
 
+        /**
+         * Fix for SET reporting wrong line/column number (-1:-1) in validation errors.
+         * see <a href="https://github.com/elastic/elasticsearch/issues/145873">ES|QL: wrong line/column number #145873</a>
+         */
+        FIX_SET_WRONG_LINE_COLUMN,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
@@ -188,10 +188,10 @@ public class QuerySettings {
             try {
                 error = def.validator().validate(setting.value(), ctx);
             } catch (Exception e) {
-                throw new ParsingException("Error validating setting [" + setting.name() + "]: " + e.getMessage());
+                throw new ParsingException(setting.source(), "Error validating setting [" + setting.name() + "]: " + e.getMessage());
             }
             if (error != null) {
-                throw new ParsingException("Error validating setting [" + setting.name() + "]: " + error);
+                throw new ParsingException(setting.source(), "Error validating setting [" + setting.name() + "]: " + error);
             }
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QuerySettingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QuerySettingsTests.java
@@ -125,6 +125,15 @@ public class QuerySettingsTests extends ESTestCase {
                     + Arrays.toString(values)
             );
         }
+
+        Source settingSource = new Source(3, 10, "SET unmapped_fields = \"UNKNOWN\"");
+        assertInvalidWithSource(
+            setting.name(),
+            settingSource,
+            of("UNKNOWN"),
+            "line 3:11: Error validating setting [unmapped_fields]: Invalid unmapped_fields resolution [UNKNOWN], must be one of "
+                + Arrays.toString(values)
+        );
     }
 
     public void testValidate_Approximation() {
@@ -237,7 +246,12 @@ public class QuerySettingsTests extends ESTestCase {
         assertInvalidWithSource(settingName, Source.EMPTY, ctx, valueExpression, expectedMessage);
     }
 
-    private static void assertInvalidWithSource(String settingName, Source settingSource, Expression valueExpression, String expectedMessage) {
+    private static void assertInvalidWithSource(
+        String settingName,
+        Source settingSource,
+        Expression valueExpression,
+        String expectedMessage
+    ) {
         assertInvalidWithSource(settingName, settingSource, SNAPSHOT_CTX_WITH_CPS_ENABLED, valueExpression, expectedMessage);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QuerySettingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QuerySettingsTests.java
@@ -164,38 +164,44 @@ public class QuerySettingsTests extends ESTestCase {
             equalTo(new ApproximationSettings(10000, 0.9))
         );
 
-        assertInvalid(
+        Source settingSource = new Source(2, 5, "SET approximation = ...");
+        assertInvalidWithSource(
             def.name(),
+            settingSource,
             new MapExpression(Source.EMPTY, List.of(Literal.keyword(Source.EMPTY, "rows"), Literal.integer(Source.EMPTY, 9999))),
-            "line -1:-1: Error validating setting [approximation]: Approximation configuration [rows] must be at least 10000"
+            "line 2:6: Error validating setting [approximation]: Approximation configuration [rows] must be at least 10000"
         );
 
-        assertInvalid(
+        assertInvalidWithSource(
             def.name(),
+            settingSource,
             new MapExpression(
                 Source.EMPTY,
                 List.of(Literal.keyword(Source.EMPTY, "confidence_level"), Literal.fromDouble(Source.EMPTY, 0.999))
             ),
-            "line -1:-1: Error validating setting [approximation]: "
+            "line 2:6: Error validating setting [approximation]: "
                 + "Approximation configuration [confidence_level] must be between 0.5 and 0.95"
         );
 
-        assertInvalid(
+        assertInvalidWithSource(
             def.name(),
+            settingSource,
             Literal.integer(Source.EMPTY, 12),
-            "line -1:-1: Error validating setting [approximation]: Invalid approximation configuration [12]"
+            "line 2:6: Error validating setting [approximation]: Invalid approximation configuration [12]"
         );
 
-        assertInvalid(
+        assertInvalidWithSource(
             def.name(),
+            settingSource,
             Literal.keyword(Source.EMPTY, "foo"),
-            "line -1:-1: Error validating setting [approximation]: Invalid approximation configuration [foo]"
+            "line 2:6: Error validating setting [approximation]: Invalid approximation configuration [foo]"
         );
 
-        assertInvalid(
+        assertInvalidWithSource(
             def.name(),
+            settingSource,
             new MapExpression(Source.EMPTY, List.of(Literal.keyword(Source.EMPTY, "foo"), Literal.integer(Source.EMPTY, 10))),
-            "line -1:-1: Error validating setting [approximation]: Approximation configuration contains unknown key [foo]"
+            "line 2:6: Error validating setting [approximation]: Approximation configuration contains unknown key [foo]"
         );
     }
 
@@ -228,7 +234,21 @@ public class QuerySettingsTests extends ESTestCase {
         Expression valueExpression,
         String expectedMessage
     ) {
-        QuerySetting setting = new QuerySetting(Source.EMPTY, new Alias(Source.EMPTY, settingName, valueExpression));
+        assertInvalidWithSource(settingName, Source.EMPTY, ctx, valueExpression, expectedMessage);
+    }
+
+    private static void assertInvalidWithSource(String settingName, Source settingSource, Expression valueExpression, String expectedMessage) {
+        assertInvalidWithSource(settingName, settingSource, SNAPSHOT_CTX_WITH_CPS_ENABLED, valueExpression, expectedMessage);
+    }
+
+    private static void assertInvalidWithSource(
+        String settingName,
+        Source settingSource,
+        SettingsValidationContext ctx,
+        Expression valueExpression,
+        String expectedMessage
+    ) {
+        QuerySetting setting = new QuerySetting(settingSource, new Alias(Source.EMPTY, settingName, valueExpression));
         EsqlStatement statement = new EsqlStatement(null, List.of(setting));
         assertThat(
             expectThrows(ParsingException.class, () -> QuerySettings.validate(statement, ctx)).getMessage(),

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/100_bug_fix.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/100_bug_fix.yml
@@ -439,3 +439,22 @@
           query: 'FROM test_limit_zero_cols | EVAL x = "test" | KEEP x | DROP x | LIMIT 5'
   - length: { columns: 0 }
   - length: { values: 5 }
+
+---
+"SET reports correct line/column in validation errors #145873":
+  - requires:
+      test_runner_features: [capabilities, contains]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [fix_set_wrong_line_column]
+      reason: "fixed SET reporting -1:-1 instead of actual line/column in validation errors"
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          query: 'SET unmapped_fields = "INVALID"; ROW x = 1'
+  - match: { status: 400 }
+  - match: { error.type: parsing_exception }
+  - contains: { error.reason: 'line 1:1: Error validating setting [unmapped_fields]: Invalid unmapped_fields resolution [INVALID]' }


### PR DESCRIPTION
Two ParsingException throws in QuerySettings.validate() were missing setting.source(), causing SET errors to report line -1:-1.  
Fixed by passing setting.source() to both throws, consistent with the rest of the method.

Closes #145873

Assisted by Claude