### PR TITLE
[9.4] Refactor chunk fetching to use ThrottledIterator (#146204)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
@@ -19,8 +19,10 @@ import org.elasticsearch.logging.Logger;
 
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public class ThrottledIterator<T> implements Releasable {
 
@@ -50,7 +52,45 @@ public class ThrottledIterator<T> implements Releasable {
      * @param onCompletion   Executed when all items are completed.
      */
     public static <T> void run(Iterator<T> iterator, BiConsumer<Releasable, T> itemConsumer, int maxConcurrency, Runnable onCompletion) {
-        try (var throttledIterator = new ThrottledIterator<>(iterator, itemConsumer, maxConcurrency, onCompletion)) {
+        run(iterator, itemConsumer, maxConcurrency, onCompletion, EsExecutors.DIRECT_EXECUTOR_SERVICE, e -> {});
+    }
+
+    /**
+     * Like {@link #run(Iterator, BiConsumer, int, Runnable)} but dispatches continuation work to the given executor when an item's
+     * {@link Releasable} is closed after the initial call to {@link #run} has returned. Up to {@code maxConcurrency} items may be
+     * processed on the calling thread before {@link #run} returns; once it has returned, further items are processed on threads
+     * that the supplied executor picks. Note that if an {@code itemConsumer} closes its {@link Releasable} synchronously, the
+     * resulting continuation can be dispatched to the executor even while the initial call is still looping.
+     * <p>
+     * When using {@link EsExecutors#DIRECT_EXECUTOR_SERVICE}, exceptions from {@code iterator.hasNext()}/{@code iterator.next()} propagate
+     * directly to the caller of {@link Releasable#close()}, preserving the same behavior as the executor-less overload. With a real
+     * executor, such exceptions cannot propagate across threads; they are surfaced to the caller via {@code onContinuationFailure}
+     * and the iteration terminates.
+     *
+     * @param executor Executor to dispatch {@link #run()} from {@link #onItemRelease()}.
+     *                 Must not be {@code null}. Use {@link EsExecutors#DIRECT_EXECUTOR_SERVICE} for inline execution
+     *                 (same behaviour as the executor-less overload).
+     *
+     * @param onContinuationFailure Invoked when a continuation fails or is rejected by {@code executor}.
+     */
+    public static <T> void run(
+        Iterator<T> iterator,
+        BiConsumer<Releasable, T> itemConsumer,
+        int maxConcurrency,
+        Runnable onCompletion,
+        Executor executor,
+        Consumer<Exception> onContinuationFailure
+    ) {
+        try (
+            var throttledIterator = new ThrottledIterator<>(
+                iterator,
+                itemConsumer,
+                maxConcurrency,
+                onCompletion,
+                executor,
+                onContinuationFailure
+            )
+        ) {
             throttledIterator.run();
         }
     }
@@ -59,9 +99,18 @@ public class ThrottledIterator<T> implements Releasable {
     private final Iterator<T> iterator;
     private final BiConsumer<Releasable, T> itemConsumer;
     private final AtomicInteger permits;
+    private final Executor executor;
+    private final Consumer<Exception> onContinuationFailure;
     private final Releasable itemReleasable = this::onItemRelease;
 
-    private ThrottledIterator(Iterator<T> iterator, BiConsumer<Releasable, T> itemConsumer, int maxConcurrency, Runnable onCompletion) {
+    private ThrottledIterator(
+        Iterator<T> iterator,
+        BiConsumer<Releasable, T> itemConsumer,
+        int maxConcurrency,
+        Runnable onCompletion,
+        Executor executor,
+        Consumer<Exception> onContinuationFailure
+    ) {
         this.iterator = Objects.requireNonNull(iterator);
         this.itemConsumer = Objects.requireNonNull(itemConsumer);
         if (maxConcurrency <= 0) {
@@ -69,6 +118,8 @@ public class ThrottledIterator<T> implements Releasable {
         }
         this.permits = new AtomicInteger(maxConcurrency);
         this.refs = AbstractRefCounted.of(onCompletion);
+        this.executor = Objects.requireNonNull(executor);
+        this.onContinuationFailure = Objects.requireNonNull(onContinuationFailure);
     }
 
     private void run() {
@@ -98,8 +149,32 @@ public class ThrottledIterator<T> implements Releasable {
     private void onItemRelease() {
         try {
             if (permits.getAndIncrement() == 0) {
-                // implies we are not already within an invocation of run(), so there's no risk of a stack overflow
-                run();
+                if (executor == EsExecutors.DIRECT_EXECUTOR_SERVICE) {
+                    run();
+                } else {
+                    refs.mustIncRef();
+                    executor.execute(new AbstractRunnable() {
+                        @Override
+                        protected void doRun() {
+                            ThrottledIterator.this.run();
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            onContinuationFailure.accept(e);
+                        }
+
+                        @Override
+                        public void onRejection(Exception e) {
+                            onContinuationFailure.accept(e);
+                        }
+
+                        @Override
+                        public void onAfter() {
+                            refs.decRef();
+                        }
+                    });
+                }
             }
         } finally {
             refs.decRef();

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1139,7 +1139,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         FetchPhaseResponseChunk.Writer writer,
         ActionListener<FetchSearchResult> listener
     ) {
-        getExecutor(readerContext.indexShard()).execute(new AbstractRunnable() {
+        final Executor searchExecutor = getExecutor(readerContext.indexShard());
+        searchExecutor.execute(new AbstractRunnable() {
             private volatile SearchContext searchContext;
 
             private final Releasable closeOnce = Releasables.releaseOnce(Releasables.wrap(() -> {
@@ -1169,6 +1170,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                         null,
                         writer,
                         fetchPhaseMaxInFlightChunks,
+                        searchExecutor,
                         newFetchBuildListener(opsListener, searchContext, startTime, closeOnce),
                         newFetchCompletionListener(listener, fetchResult)
                     );

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntConsumer;
@@ -90,7 +91,7 @@ public final class FetchPhase {
     public void execute(SearchContext context, int[] docIdsToLoad, RankDocShardInfo rankDocs) {
         // Synchronous wrapper for backward compatibility,
         PlainActionFuture<Void> future = new PlainActionFuture<>();
-        execute(context, docIdsToLoad, rankDocs, null, null, null, null, future);
+        execute(context, docIdsToLoad, rankDocs, null, null, null, null, null, future);
         try {
             future.actionGet();
         } catch (UncategorizedExecutionException e) {
@@ -111,7 +112,7 @@ public final class FetchPhase {
     public void execute(SearchContext context, int[] docIdsToLoad, RankDocShardInfo rankDocs, @Nullable IntConsumer memoryChecker) {
         // Synchronous wrapper for backward compatibility,
         PlainActionFuture<Void> future = new PlainActionFuture<>();
-        execute(context, docIdsToLoad, rankDocs, memoryChecker, null, null, null, future);
+        execute(context, docIdsToLoad, rankDocs, memoryChecker, null, null, null, null, future);
         try {
             future.actionGet();
         } catch (UncategorizedExecutionException e) {
@@ -134,6 +135,11 @@ public final class FetchPhase {
      * @param rankDocs ranking information
      * @param memoryChecker optional callback for memory tracking, may be {@code null}
      * @param writer optional chunk writer for streaming mode, may be {@code null}
+     * @param continuationExecutor executor for dispatching chunk production after ACK-driven continuation in streaming mode.
+     *                             When a chunk ACK arrives on a network thread, this executor ensures the next chunk is produced
+     *                             on a search thread rather than inline on the network thread. Required when {@code writer} is
+     *                             non-{@code null} (streaming mode); ignored otherwise. May be {@code null} only in non-streaming
+     *                             mode.
      * @param buildListener optional listener invoked when all {@link SearchHit} objects have been constructed
      *                      (and, in streaming mode, serialized into chunks and dispatched to the writer).
      *                      In non-streaming mode this fires immediately after the hits are built, just like {@code listener}.
@@ -151,6 +157,7 @@ public final class FetchPhase {
         @Nullable IntConsumer memoryChecker,
         @Nullable FetchPhaseResponseChunk.Writer writer,
         @Nullable Integer maxInFlightChunks,
+        @Nullable Executor continuationExecutor,
         @Nullable ActionListener<Void> buildListener,
         ActionListener<Void> listener
     ) {
@@ -204,6 +211,7 @@ public final class FetchPhase {
         if (writer == null) {
             buildSearchHits(context, docIdsToLoad, docsIterator, resolvedBuildListener, hitsListener);
         } else {
+            assert continuationExecutor != null : "continuationExecutor is required in streaming mode";
             int resolvedMaxInFlightChunks = maxInFlightChunks != null
                 ? maxInFlightChunks
                 : SearchService.FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS.get(context.getSearchExecutionContext().getIndexSettings().getSettings());
@@ -213,6 +221,7 @@ public final class FetchPhase {
                 docsIterator,
                 writer,
                 resolvedMaxInFlightChunks,
+                continuationExecutor,
                 resolvedBuildListener,
                 hitsListener
             );
@@ -437,6 +446,7 @@ public final class FetchPhase {
         StreamingFetchPhaseDocsIterator docsIterator,
         FetchPhaseResponseChunk.Writer writer,
         int maxInFlightChunks,
+        Executor continuationExecutor,
         ActionListener<Void> buildListener,
         ActionListener<SearchHitsWithSizeBytes> listener
     ) {
@@ -485,6 +495,7 @@ public final class FetchPhase {
             maxInFlightChunks,
             sendFailure,
             context::isCancelled,
+            continuationExecutor,
             new ActionListener<>() {
                 @Override
                 public void onResponse(FetchPhaseDocsIterator.IterateResult result) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/StreamingFetchPhaseDocsIterator.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/StreamingFetchPhaseDocsIterator.java
@@ -16,8 +16,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.ThrottledTaskRunner;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.ThrottledIterator;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.shard.ShardId;
@@ -28,7 +28,11 @@ import org.elasticsearch.tasks.TaskCancelledException;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 /**
@@ -36,18 +40,19 @@ import java.util.function.Supplier;
  * via {@link #iterateAsync}. The synchronous {@link #iterate} method from the
  * parent class remains available for non-streaming use.
  * <p>
- * Uses {@link ThrottledTaskRunner} with {@link EsExecutors#DIRECT_EXECUTOR_SERVICE} to
- * manage chunk sends:
+ * Uses {@link ThrottledIterator} to process chunks of documents across threads:
  * <ul>
- *   <li>Fetches documents and creates chunks</li>
- *   <li>Send tasks are enqueued directly to ThrottledTaskRunner</li>
- *   <li>Tasks run inline when under maxInFlightChunks capacity</li>
- *   <li>When at capacity, tasks queue internally until ACKs arrive</li>
- *   <li>ACK callbacks signal task completion, triggering queued tasks</li>
+ *   <li>A {@link ChunkProducingIterator} yields serialized chunks by performing Lucene I/O</li>
+ *   <li>A send consumer initiates asynchronous network sends for each chunk</li>
+ *   <li>The {@link ThrottledIterator} releasable is closed on send ACK, triggering the next chunk</li>
  * </ul>
- * <b>Threading:</b> All Lucene operations execute on the calling thread to satisfy
- * Lucene's thread-affinity requirements. Send tasks run inline (DIRECT_EXECUTOR) when
- * under capacity; ACK handling occurs asynchronously on network threads.
+ * <b>Threading:</b> The search thread produces up to {@code maxInFlightChunks} chunks in the
+ * initial burst, then returns to the thread pool. Subsequent chunks are produced on whatever
+ * thread ACKs a previous send. Per-leaf Lucene readers are re-acquired via {@link #setNextReader}
+ * (clone-per-chunk) whenever production crosses a leaf boundary or moves to a different thread,
+ * satisfying Lucene's thread-affinity assertions. If consecutive chunks stay within the same leaf
+ * on the same producer thread, the previous leaf setup is reused to avoid rebuilding stored-field
+ * loaders, doc-values, and sub-phase processor state on every chunk.
  * <p>
  * <b>Memory Management:</b> The circuit breaker tracks recycler page allocations via the
  * {@link RecyclerBytesStreamOutput} passed from the chunk writer. If the breaker trips
@@ -55,12 +60,13 @@ import java.util.function.Supplier;
  * {@link org.elasticsearch.common.breaker.CircuitBreakingException}, preventing unbounded
  * memory growth. Pages are released (and the breaker decremented) when the
  * {@link ReleasableBytesReference} from {@link RecyclerBytesStreamOutput#moveToBytesReference()}
- * is closed — either on ACK for intermediate chunks or when the last chunk is consumed.
+ * is closed -- either on ACK for intermediate chunks or when the last chunk is consumed.
  * <p>
- * <b>Backpressure:</b> {@link ThrottledTaskRunner} limits concurrent in-flight sends to
- * {@code maxInFlightChunks}. The circuit breaker provides the memory limit.
+ * <b>Backpressure:</b> {@link ThrottledIterator}'s {@code maxConcurrency} limits concurrent
+ * in-flight sends to {@code maxInFlightChunks}. The circuit breaker provides the memory limit.
  * <p>
- * <b>Cancellation:</b> The producer checks the cancellation flag periodically.
+ * <b>Cancellation:</b> The producer checks the cancellation flag periodically and in
+ * {@link ChunkProducingIterator#hasNext()}.
  */
 abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
 
@@ -71,7 +77,7 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
     static final int DEFAULT_TARGET_CHUNK_BYTES = 256 * 1024;
 
     /**
-     * Asynchronous iteration using {@link ThrottledTaskRunner} for streaming mode.
+     * Asynchronous iteration using {@link ThrottledIterator} for streaming mode.
      *
      * @param shardTarget         the shard being fetched from
      * @param indexReader         the index reader
@@ -82,6 +88,7 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
      * @param maxInFlightChunks   maximum concurrent unacknowledged chunks
      * @param sendFailure         atomic reference to capture send failures
      * @param isCancelled         supplier for cancellation checking
+     * @param continuationExecutor executor for dispatching chunk production after ACKs
      * @param listener            receives the result with the last chunk bytes
      */
     void iterateAsync(
@@ -94,6 +101,7 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
         int maxInFlightChunks,
         AtomicReference<Throwable> sendFailure,
         Supplier<Boolean> isCancelled,
+        Executor continuationExecutor,
         ActionListener<IterateResult> listener
     ) {
         if (docIds == null || docIds.length == 0) {
@@ -104,12 +112,99 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
         final AtomicReference<PendingChunk> lastChunkHolder = new AtomicReference<>();
         final AtomicReference<Throwable> producerError = new AtomicReference<>();
 
-        // ThrottledTaskRunner manages send concurrency
-        final ThrottledTaskRunner sendRunner = new ThrottledTaskRunner("fetch", maxInFlightChunks, EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        DocIdToIndex[] docs = sortDocsByDocId(docIds);
+        Iterator<PendingChunk> chunkIterator = new ChunkProducingIterator(
+            docs,
+            indexReader,
+            chunkWriter,
+            targetChunkBytes,
+            isCancelled,
+            sendFailure,
+            producerError
+        );
 
-        // RefCountingListener fires completion callback when all refs are released.
-        final RefCountingListener completionRefs = new RefCountingListener(ActionListener.wrap(ignored -> {
+        BiConsumer<Releasable, PendingChunk> sendConsumer = createSendConsumer(
+            chunkWriter,
+            shardTarget.getShardId(),
+            docIds.length,
+            sendFailure,
+            chunkCompletionRefs,
+            isCancelled,
+            lastChunkHolder
+        );
 
+        // Dispatch rawCompletion off the ACK / producer thread; it fires the listener itself and never throws.
+        Runnable rawCompletion = createCompletionHandler(listener, producerError, sendFailure, isCancelled, lastChunkHolder);
+        Runnable onCompletion = () -> continuationExecutor.execute(new AbstractRunnable() {
+            @Override
+            protected void doRun() {
+                rawCompletion.run();
+            }
+
+            @Override
+            public void onRejection(Exception e) {
+                rawCompletion.run();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                // rawCompletion never throws.
+                assert false : e;
+            }
+        });
+
+        ThrottledIterator.run(
+            chunkIterator,
+            sendConsumer,
+            maxInFlightChunks,
+            onCompletion,
+            continuationExecutor,
+            e -> producerError.compareAndSet(null, e)
+        );
+    }
+
+    private static DocIdToIndex[] sortDocsByDocId(int[] docIds) {
+        DocIdToIndex[] docs = new DocIdToIndex[docIds.length];
+        for (int i = 0; i < docIds.length; i++) {
+            docs[i] = new DocIdToIndex(docIds[i], i);
+        }
+        Arrays.sort(docs);
+        return docs;
+    }
+
+    private static BiConsumer<Releasable, PendingChunk> createSendConsumer(
+        FetchPhaseResponseChunk.Writer chunkWriter,
+        ShardId shardId,
+        int totalDocs,
+        AtomicReference<Throwable> sendFailure,
+        RefCountingListener chunkCompletionRefs,
+        Supplier<Boolean> isCancelled,
+        AtomicReference<PendingChunk> lastChunkHolder
+    ) {
+        return (releasable, chunk) -> {
+            try {
+                if (chunk.isLast) {
+                    lastChunkHolder.set(chunk);
+                    releasable.close();
+                    return;
+                }
+                sendChunk(chunk, releasable, chunkWriter, shardId, totalDocs, sendFailure, chunkCompletionRefs, isCancelled);
+            } catch (Exception e) {
+                sendFailure.compareAndSet(null, e);
+                chunk.close();
+                releasable.close();
+            }
+        };
+    }
+
+    private static Runnable createCompletionHandler(
+        ActionListener<IterateResult> listener,
+        AtomicReference<Throwable> producerError,
+        AtomicReference<Throwable> sendFailure,
+        Supplier<Boolean> isCancelled,
+        AtomicReference<PendingChunk> lastChunkHolder
+    ) {
+        return () -> {
             final Throwable pError = producerError.get();
             if (pError != null) {
                 cleanupLastChunk(lastChunkHolder);
@@ -140,154 +235,142 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
                 listener.onResponse(new IterateResult(lastChunk.bytes, lastChunk.hitCount, lastChunk.sequenceStart));
             } catch (Exception e) {
                 lastChunk.close();
-                throw e;
             }
-        }, e -> {
-            cleanupLastChunk(lastChunkHolder);
-            listener.onFailure(e);
-        }));
-
-        try {
-            produceChunks(
-                shardTarget.getShardId(),
-                indexReader,
-                docIds,
-                chunkWriter,
-                targetChunkBytes,
-                sendRunner,
-                completionRefs,
-                lastChunkHolder,
-                sendFailure,
-                chunkCompletionRefs,
-                isCancelled
-            );
-        } catch (Exception e) {
-            producerError.set(e);
-        } finally {
-            completionRefs.close();
-        }
+        };
     }
 
     /**
-     * Produces chunks and enqueues send tasks to ThrottledTaskRunner.
+     * Yields serialized chunks by fetching documents from Lucene in doc-ID order.
      * <p>
-     * Documents are sorted by doc ID for efficient sequential Lucene access, matching the
-     * non-streaming {@link FetchPhaseDocsIterator#iterate} path. Each leaf reader is visited
-     * exactly once with the full set of leaf-relative doc IDs passed to
-     * {@link #setNextReader(org.apache.lucene.index.LeafReaderContext, int[])}. Each serialized
-     * hit is prefixed with its original score-order position (as a vInt) so the coordinator can
-     * reassemble results in the correct order.
+     * Documents are sorted by doc ID for efficient sequential Lucene access, matching
+     * the non-streaming {@link FetchPhaseDocsIterator#iterate} path. Each serialized
+     * hit is prefixed with its original score-order position (as a vInt) so the
+     * coordinator can reassemble results in the correct order.
      * <p>
-     * For each chunk:
-     * <ol>
-     *   <li>Fetch documents in doc-ID order and serialize to bytes with position prefixes</li>
-     *   <li>For intermediate chunks: acquire ref and enqueue send task to ThrottledTaskRunner</li>
-     *   <li>For last chunk: store in lastChunkHolder (returned via listener after all ACKs)</li>
-     * </ol>
+     * <b>Clone-per-chunk:</b> Per-leaf Lucene readers are re-acquired via
+     * {@link #setNextReaderAndGetLeafEndIndex} whenever production crosses a leaf boundary or
+     * moves to a different thread than the one that last set up the current leaf. This creates
+     * fresh clones of {@code StoredFields}, {@code DocValues}, etc. bound to the calling thread,
+     * satisfying Lucene's thread-affinity assertions when chunks are produced across different
+     * threads. When consecutive chunks stay within the same leaf on the same thread the previous
+     * setup is reused, avoiding redundant loader and sub-phase processor rebuilds.
+     * <p>
+     * <b>Error safety:</b> All exceptions from Lucene I/O are caught and stored in
+     * {@code producerError}. This is critical because {@link ThrottledIterator} does not
+     * catch exceptions from {@code iterator.next()} -- an uncaught exception in
+     * {@code onItemRelease -> run -> next} would propagate unhandled on an ACK thread.
+     * <p>
+     * <b>Iterator contract:</b> Uses a read-ahead pattern: {@link #hasNext} eagerly
+     * produces the next chunk (buffered in {@code pendingNext}) and returns {@code false}
+     * if production fails, is cancelled, or no docs remain. {@link #next} returns the
+     * buffered chunk or throws {@link NoSuchElementException}, honouring the
+     * {@link Iterator} contract (never returns {@code null}).
      */
-    private void produceChunks(
-        ShardId shardId,
-        IndexReader indexReader,
-        int[] docIds,
-        FetchPhaseResponseChunk.Writer chunkWriter,
-        int targetChunkBytes,
-        ThrottledTaskRunner sendRunner,
-        RefCountingListener completionRefs,
-        AtomicReference<PendingChunk> lastChunkHolder,
-        AtomicReference<Throwable> sendFailure,
-        RefCountingListener chunkCompletionRefs,
-        Supplier<Boolean> isCancelled
-    ) throws Exception {
-        int totalDocs = docIds.length;
+    private class ChunkProducingIterator implements Iterator<PendingChunk> {
+        private final DocIdToIndex[] docs;
+        private final IndexReader indexReader;
+        private final FetchPhaseResponseChunk.Writer chunkWriter;
+        private final int targetChunkBytes;
+        private final Supplier<Boolean> isCancelled;
+        private final AtomicReference<Throwable> sendFailure;
+        private final AtomicReference<Throwable> producerError;
 
-        DocIdToIndex[] docs = new DocIdToIndex[totalDocs];
-        for (int i = 0; i < totalDocs; i++) {
-            docs[i] = new DocIdToIndex(docIds[i], i);
+        private int currentIdx;
+        private int endReaderIdx;
+        // Thread that last ran setNextReaderAndGetLeafEndIndex; null until the first leaf setup.
+        // Used to skip redundant per-leaf rebuilds when consecutive chunks stay on the same
+        // thread within the same leaf (Lucene's thread-affinity invariant still holds).
+        private Thread leafSetupThread;
+        private PendingChunk pendingNext;
+
+        ChunkProducingIterator(
+            DocIdToIndex[] docs,
+            IndexReader indexReader,
+            FetchPhaseResponseChunk.Writer chunkWriter,
+            int targetChunkBytes,
+            Supplier<Boolean> isCancelled,
+            AtomicReference<Throwable> sendFailure,
+            AtomicReference<Throwable> producerError
+        ) {
+            this.docs = docs;
+            this.indexReader = indexReader;
+            this.chunkWriter = chunkWriter;
+            this.targetChunkBytes = targetChunkBytes;
+            this.isCancelled = isCancelled;
+            this.sendFailure = sendFailure;
+            this.producerError = producerError;
         }
-        Arrays.sort(docs);
 
-        int endReaderIdx = setNextReaderAndGetLeafEndIndex(indexReader, docs, 0);
-        RecyclerBytesStreamOutput chunkBuffer = null;
-        try {
-            chunkBuffer = chunkWriter.newNetworkBytesStream();
-            int chunkStartIndex = 0;
-            int hitsInChunk = 0;
-
-            for (int i = 0; i < docs.length; i++) {
-                if (i % 32 == 0) {
-                    if (isCancelled.get()) {
-                        throw new TaskCancelledException("cancelled");
-                    }
-                    Throwable failure = sendFailure.get();
-                    if (failure != null) {
-                        throw failure instanceof Exception ? (Exception) failure : new RuntimeException(failure);
-                    }
-                }
-
-                if (i >= endReaderIdx) {
-                    endReaderIdx = setNextReaderAndGetLeafEndIndex(indexReader, docs, i);
-                }
-
-                SearchHit hit = nextDoc(docs[i].docId);
-                try {
-                    chunkBuffer.writeVInt(docs[i].index);
-                    hit.writeTo(chunkBuffer);
-                } finally {
-                    hit.decRef();
-                }
-                hitsInChunk++;
-
-                boolean isLast = (i == docs.length - 1);
-                boolean bufferFull = chunkBuffer.size() >= targetChunkBytes;
-
-                if (bufferFull || isLast) {
-                    final ReleasableBytesReference chunkBytes = chunkBuffer.moveToBytesReference();
-                    chunkBuffer = null;
-
-                    try {
-                        PendingChunk chunk = new PendingChunk(chunkBytes, hitsInChunk, chunkStartIndex, isLast);
-
-                        if (isLast) {
-                            lastChunkHolder.set(chunk);
-                        } else {
-                            ActionListener<Void> completionRef = null;
-                            try {
-                                completionRef = completionRefs.acquire();
-                                sendRunner.enqueueTask(
-                                    new SendChunkTask(
-                                        chunk,
-                                        completionRef,
-                                        chunkWriter,
-                                        shardId,
-                                        totalDocs,
-                                        sendFailure,
-                                        chunkCompletionRefs,
-                                        isCancelled
-                                    )
-                                );
-                                completionRef = null;
-                            } finally {
-                                if (completionRef != null) {
-                                    completionRef.onResponse(null);
-                                    chunk.close();
-                                }
-                            }
-                        }
-
-                        if (isLast == false) {
-                            chunkBuffer = chunkWriter.newNetworkBytesStream();
-                            chunkStartIndex = i + 1;
-                            hitsInChunk = 0;
-                        }
-                    } catch (Exception e) {
-                        Releasables.closeWhileHandlingException(chunkBytes);
-                        throw e;
-                    }
-                }
+        @Override
+        public boolean hasNext() {
+            if (pendingNext != null) {
+                return true;
             }
-        } finally {
-            if (chunkBuffer != null) {
-                Releasables.closeWhileHandlingException(chunkBuffer);
+            if (currentIdx >= docs.length || producerError.get() != null || sendFailure.get() != null || isCancelled.get()) {
+                return false;
+            }
+            pendingNext = produceNext();
+            return pendingNext != null;
+        }
+
+        @Override
+        public PendingChunk next() {
+            if (hasNext() == false) {
+                throw new NoSuchElementException();
+            }
+            PendingChunk chunk = pendingNext;
+            pendingNext = null;
+            return chunk;
+        }
+
+        private PendingChunk produceNext() {
+            RecyclerBytesStreamOutput chunkBuffer = null;
+            try {
+                chunkBuffer = chunkWriter.newNetworkBytesStream();
+                int chunkStartIndex = currentIdx;
+                int hitsInChunk = 0;
+
+                while (currentIdx < docs.length) {
+                    if (hitsInChunk > 0) {
+                        if (isCancelled.get()) {
+                            throw new TaskCancelledException("cancelled");
+                        }
+                        Throwable failure = sendFailure.get();
+                        if (failure != null) {
+                            throw failure instanceof Exception ? (Exception) failure : new RuntimeException(failure);
+                        }
+                    }
+
+                    if (currentIdx >= endReaderIdx || (hitsInChunk == 0 && Thread.currentThread() != leafSetupThread)) {
+                        endReaderIdx = setNextReaderAndGetLeafEndIndex(indexReader, docs, currentIdx);
+                        leafSetupThread = Thread.currentThread();
+                    }
+
+                    SearchHit hit = nextDoc(docs[currentIdx].docId);
+                    try {
+                        chunkBuffer.writeVInt(docs[currentIdx].index);
+                        hit.writeTo(chunkBuffer);
+                    } finally {
+                        hit.decRef();
+                    }
+                    currentIdx++;
+                    hitsInChunk++;
+
+                    if (currentIdx == docs.length || chunkBuffer.size() >= targetChunkBytes) {
+                        break;
+                    }
+                }
+
+                ReleasableBytesReference chunkBytes = chunkBuffer.moveToBytesReference();
+                chunkBuffer = null;
+                boolean isLast = (currentIdx == docs.length);
+                return new PendingChunk(chunkBytes, hitsInChunk, chunkStartIndex, isLast);
+            } catch (Exception e) {
+                producerError.compareAndSet(null, e);
+                if (chunkBuffer != null) {
+                    Releasables.closeWhileHandlingException(chunkBuffer);
+                }
+                return null;
             }
         }
     }
@@ -302,63 +385,13 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
     }
 
     /**
-     * Task that sends a single chunk. Implements {@link ActionListener} to receive
-     * the throttle releasable from {@link ThrottledTaskRunner}.
-     */
-    private static final class SendChunkTask implements ActionListener<Releasable> {
-        private final PendingChunk chunk;
-        private final ActionListener<Void> completionRef;
-        private final FetchPhaseResponseChunk.Writer writer;
-        private final ShardId shardId;
-        private final int totalDocs;
-        private final AtomicReference<Throwable> sendFailure;
-        private final RefCountingListener chunkCompletionRefs;
-        private final Supplier<Boolean> isCancelled;
-
-        private SendChunkTask(
-            PendingChunk chunk,
-            ActionListener<Void> completionRef,
-            FetchPhaseResponseChunk.Writer writer,
-            ShardId shardId,
-            int totalDocs,
-            AtomicReference<Throwable> sendFailure,
-            RefCountingListener chunkCompletionRefs,
-            Supplier<Boolean> isCancelled
-        ) {
-            this.chunk = chunk;
-            this.completionRef = completionRef;
-            this.writer = writer;
-            this.shardId = shardId;
-            this.totalDocs = totalDocs;
-            this.sendFailure = sendFailure;
-            this.chunkCompletionRefs = chunkCompletionRefs;
-            this.isCancelled = isCancelled;
-        }
-
-        @Override
-        public void onResponse(Releasable throttleReleasable) {
-            sendChunk(chunk, throttleReleasable, completionRef, writer, shardId, totalDocs, sendFailure, chunkCompletionRefs, isCancelled);
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            chunk.close();
-            sendFailure.compareAndSet(null, e);
-            completionRef.onFailure(e);
-        }
-    }
-
-    /**
-     * Sends a single chunk. Called by ThrottledTaskRunner.
-     * <p>
-     * The send is asynchronous - this method initiates the network write and returns immediately.
-     * The ACK callback handles cleanup and signals task completion to ThrottledTaskRunner.
-     * Page-level CB tracking is released when the {@link ReleasableBytesReference} is closed.
+     * Sends a single intermediate chunk. Initiates an asynchronous network write and
+     * closes the {@link ThrottledIterator} releasable on ACK (or failure), which triggers
+     * production of the next chunk.
      */
     private static void sendChunk(
         PendingChunk chunk,
-        Releasable throttleReleasable,
-        ActionListener<Void> completionRef,
+        Releasable iteratorReleasable,
         FetchPhaseResponseChunk.Writer writer,
         ShardId shardId,
         int totalDocs,
@@ -368,17 +401,14 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
     ) {
         if (isCancelled.get()) {
             chunk.close();
-            completionRef.onResponse(null);
-            throttleReleasable.close();
+            iteratorReleasable.close();
             return;
         }
 
-        // Check for prior failure before sending
         final Throwable failure = sendFailure.get();
         if (failure != null) {
             chunk.close();
-            completionRef.onResponse(null);
-            throttleReleasable.close();
+            iteratorReleasable.close();
             return;
         }
 
@@ -395,14 +425,12 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
             writer.writeResponseChunk(responseChunk, ActionListener.wrap(v -> {
                 chunkToClose.close();
                 finalAckRef.onResponse(null);
-                completionRef.onResponse(null);
-                throttleReleasable.close();
+                iteratorReleasable.close();
             }, e -> {
                 chunkToClose.close();
                 sendFailure.compareAndSet(null, e);
                 finalAckRef.onFailure(e);
-                completionRef.onFailure(e);
-                throttleReleasable.close();
+                iteratorReleasable.close();
             }));
 
             responseChunk = null;
@@ -416,8 +444,7 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
             if (ackRef != null) {
                 ackRef.onFailure(e);
             }
-            completionRef.onFailure(e);
-            throttleReleasable.close();
+            iteratorReleasable.close();
         }
     }
 
@@ -433,7 +460,7 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
      * the page-level circuit breaker release callback from {@link RecyclerBytesStreamOutput#moveToBytesReference()}.
      */
     static class PendingChunk implements AutoCloseable {
-        final ReleasableBytesReference bytes;
+        ReleasableBytesReference bytes;
         final int hitCount;
         final int sequenceStart;
         final boolean isLast;
@@ -447,8 +474,10 @@ abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
 
         @Override
         public void close() {
-            if (bytes != null) {
-                Releasables.closeWhileHandlingException(bytes);
+            ReleasableBytesReference toClose = bytes;
+            bytes = null;
+            if (toClose != null) {
+                Releasables.closeWhileHandlingException(toClose);
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThrottledIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThrottledIteratorTests.java
@@ -21,14 +21,20 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.instanceOf;
 
 public class ThrottledIteratorTests extends ESTestCase {
     private static final String CONSTRAINED = "constrained";
@@ -66,7 +72,8 @@ public class ThrottledIteratorTests extends ESTestCase {
             );
             final var blockPermits = new Semaphore(between(0, Math.min(maxRelaxedThreads, maxConcurrency) - 1));
 
-            ThrottledIterator.run(new SerialAccessAssertingIterator<>(IntStream.range(0, items).boxed().iterator()), (releasable, item) -> {
+            final var iterator = new SerialAccessAssertingIterator<>(IntStream.range(0, items).boxed().iterator());
+            final BiConsumer<Releasable, Integer> itemConsumer = (releasable, item) -> {
                 try (var refs = new RefCountingRunnable(() -> {
                     completedItems.incrementAndGet();
                     releasable.close();
@@ -115,7 +122,19 @@ public class ThrottledIteratorTests extends ESTestCase {
                         itemPermits.release();
                     }
                 }
-            }, maxConcurrency, completionLatch::countDown);
+            };
+            if (randomBoolean()) {
+                ThrottledIterator.run(
+                    iterator,
+                    itemConsumer,
+                    maxConcurrency,
+                    completionLatch::countDown,
+                    threadPool.executor(RELAXED),
+                    ESTestCase::fail
+                );
+            } else {
+                ThrottledIterator.run(iterator, itemConsumer, maxConcurrency, completionLatch::countDown);
+            }
 
             assertTrue(completionLatch.await(30, TimeUnit.SECONDS));
             assertEquals(items, completedItems.get());
@@ -124,6 +143,128 @@ public class ThrottledIteratorTests extends ESTestCase {
         } finally {
             ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
         }
+    }
+
+    public void testRunContinuesOnContinuationExecutorAfterPermitRelease() throws Exception {
+        final var threadPool = new TestThreadPool(
+            "test",
+            new FixedExecutorBuilder(Settings.EMPTY, CONSTRAINED, 1, 10, CONSTRAINED, EsExecutors.TaskTrackingConfig.DO_NOT_TRACK)
+        );
+        try {
+            final List<String> processingThreads = new CopyOnWriteArrayList<>();
+            final AtomicReference<Releasable> firstItemReleasable = new AtomicReference<>();
+            final var firstItemSeen = new CountDownLatch(1);
+            final var completionLatch = new CountDownLatch(1);
+            final var completionCalls = new AtomicInteger();
+            final var callerThreadName = Thread.currentThread().getName();
+            final var releaseThreadName = "permit-release-thread";
+
+            ThrottledIterator.run(List.of(0, 1, 2).iterator(), (releasable, item) -> {
+                processingThreads.add(Thread.currentThread().getName());
+                if (item == 0) {
+                    firstItemReleasable.set(releasable);
+                    firstItemSeen.countDown();
+                } else {
+                    releasable.close();
+                }
+            }, 1, () -> {
+                completionCalls.incrementAndGet();
+                completionLatch.countDown();
+            }, threadPool.executor(CONSTRAINED), e -> {}); // Continuation executor
+
+            assertTrue(firstItemSeen.await(10, TimeUnit.SECONDS));
+            assertEquals(List.of(callerThreadName), processingThreads);
+
+            Thread releaser = new Thread(() -> firstItemReleasable.get().close(), releaseThreadName);
+            releaser.start();
+            releaser.join();
+
+            assertTrue(completionLatch.await(10, TimeUnit.SECONDS));
+            assertEquals(1, completionCalls.get());
+            assertEquals(3, processingThreads.size());
+            assertEquals(callerThreadName, processingThreads.get(0));
+            assertTrue(processingThreads.get(1), processingThreads.get(1).contains("[constrained]"));
+            assertTrue(processingThreads.get(2), processingThreads.get(2).contains("[constrained]"));
+            assertNotEquals(releaseThreadName, processingThreads.get(1));
+            assertNotEquals(releaseThreadName, processingThreads.get(2));
+        } finally {
+            ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testIteratorExceptionPropagatesWithDirectExecutor() {
+        final var completed = new AtomicBoolean();
+        final var releasableRef = new AtomicReference<Releasable>();
+        final var processedItems = new CopyOnWriteArrayList<Integer>();
+
+        Iterator<Integer> throwingIterator = new Iterator<>() {
+            int index = 0;
+
+            @Override
+            public boolean hasNext() {
+                return index < 3;
+            }
+
+            @Override
+            public Integer next() {
+                int current = index++;
+                if (current == 1) {
+                    throw new RuntimeException("iterator failure on item 1");
+                }
+                return current;
+            }
+        };
+
+        ThrottledIterator.run(throwingIterator, (releasable, item) -> {
+            processedItems.add(item);
+            if (item == 0) {
+                releasableRef.set(releasable);
+            } else {
+                releasable.close();
+            }
+        }, 1, () -> completed.set(true));
+
+        assertEquals(List.of(0), processedItems);
+        assertFalse(completed.get());
+
+        RuntimeException e = expectThrows(RuntimeException.class, () -> releasableRef.get().close());
+        assertEquals("iterator failure on item 1", e.getMessage());
+
+        assertTrue(completed.get());
+        assertEquals(List.of(0), processedItems);
+    }
+
+    public void testExecutorRejectionStillCompletes() {
+        final var threadPool = new TestThreadPool(
+            "test",
+            new FixedExecutorBuilder(Settings.EMPTY, CONSTRAINED, 1, 10, CONSTRAINED, EsExecutors.TaskTrackingConfig.DO_NOT_TRACK)
+        );
+        final var continuationExecutor = threadPool.executor(CONSTRAINED);
+        assertTrue(ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS));
+
+        final var completed = new AtomicBoolean();
+        final var releasableRef = new AtomicReference<Releasable>();
+        final var processedItems = new CopyOnWriteArrayList<Integer>();
+        final var surfacedFailure = new AtomicReference<Exception>();
+
+        ThrottledIterator.run(List.of(0, 1, 2).iterator(), (releasable, item) -> {
+            processedItems.add(item);
+            if (item == 0) {
+                releasableRef.set(releasable);
+            } else {
+                releasable.close();
+            }
+        }, 1, () -> completed.set(true), continuationExecutor, e -> surfacedFailure.compareAndSet(null, e));
+
+        assertEquals(List.of(0), processedItems);
+        assertFalse(completed.get());
+
+        releasableRef.get().close();
+
+        assertTrue(completed.get());
+        assertEquals(List.of(0), processedItems);
+        assertNotNull("rejection must be surfaced to the hook", surfacedFailure.get());
+        assertThat(surfacedFailure.get(), instanceOf(EsRejectedExecutionException.class));
     }
 
     private static class SerialAccessAssertingIterator<T> implements Iterator<T> {

--- a/server/src/test/java/org/elasticsearch/search/fetch/FetchPhaseDocsIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/FetchPhaseDocsIteratorTests.java
@@ -12,7 +12,10 @@ package org.elasticsearch.search.fetch;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.store.Directory;
@@ -26,6 +29,7 @@ import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.cache.query.TrivialQueryCachingPolicy;
 import org.elasticsearch.index.shard.ShardId;
@@ -38,15 +42,21 @@ import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.BytesRefRecycler;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,6 +68,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -184,6 +195,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
             4,
             sendFailure,
             cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             future
         );
 
@@ -205,7 +217,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
     }
 
     public void testIterateAsyncSingleDocument() throws Exception {
-        LuceneDocs docs = createDocs(1);
+        LuceneDocs docs = createDocs(1, false);
         CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
         TestChunkWriter chunkWriter = new TestChunkWriter(circuitBreaker);
         AtomicReference<Throwable> sendFailure = new AtomicReference<>();
@@ -225,6 +237,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
             4,
             sendFailure,
             cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             future
         );
 
@@ -251,7 +264,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
     }
 
     public void testIterateAsyncAllDocsInSingleChunk() throws Exception {
-        LuceneDocs docs = createDocs(5);
+        LuceneDocs docs = createDocs(5, false);
         CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
         TestChunkWriter chunkWriter = new TestChunkWriter(circuitBreaker);
         AtomicReference<Throwable> sendFailure = new AtomicReference<>();
@@ -271,6 +284,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
             4,
             sendFailure,
             cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             future
         );
 
@@ -291,7 +305,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
     }
 
     public void testIterateAsyncMultipleChunks() throws Exception {
-        LuceneDocs docs = createDocs(100);
+        LuceneDocs docs = createDocs(100, false);
         CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
         TestChunkWriter chunkWriter = new TestChunkWriter(circuitBreaker);
         AtomicReference<Throwable> sendFailure = new AtomicReference<>();
@@ -311,6 +325,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
             4,
             sendFailure,
             cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             future
         );
 
@@ -345,8 +360,62 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
         docs.directory.close();
     }
 
+    public void testIterateAsyncRespectsMaxInFlightWithDelayedAcks() throws Exception {
+        for (int maxInFlightChunks : List.of(1, 2, 3)) {
+            LuceneDocs docs = createDocs(100, false);
+            CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
+            InFlightTrackingChunkWriter chunkWriter = new InFlightTrackingChunkWriter(circuitBreaker);
+            AtomicReference<Throwable> sendFailure = new AtomicReference<>();
+            AtomicBoolean cancelled = new AtomicBoolean(false);
+
+            PlainActionFuture<IterateResult> future = new PlainActionFuture<>();
+            CountDownLatch refsComplete = new CountDownLatch(1);
+            RefCountingListener refs = new RefCountingListener(ActionListener.running(refsComplete::countDown));
+
+            createStreamingIterator().iterateAsync(
+                createShardTarget(),
+                docs.reader,
+                docs.docIds,
+                chunkWriter,
+                1,
+                refs,
+                maxInFlightChunks,
+                sendFailure,
+                cancelled::get,
+                EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                future
+            );
+
+            assertThat(chunkWriter.getSentChunks().size(), equalTo(maxInFlightChunks));
+            assertThat(chunkWriter.getMaxInFlight(), equalTo(maxInFlightChunks));
+            assertFalse(future.isDone());
+
+            assertBusy(() -> {
+                chunkWriter.ackAll();
+                assertTrue(future.isDone());
+            }, 10, TimeUnit.SECONDS);
+
+            IterateResult result = future.get(10, TimeUnit.SECONDS);
+
+            refs.close();
+            assertTrue(refsComplete.await(10, TimeUnit.SECONDS));
+
+            assertThat(chunkWriter.getMaxInFlight(), lessThanOrEqualTo(maxInFlightChunks));
+            assertThat(result.lastChunkBytes, notNullValue());
+
+            int totalHits = chunkWriter.getSentChunks().stream().mapToInt(c -> c.hitCount).sum() + result.lastChunkHitCount;
+            assertThat(totalHits, equalTo(100));
+
+            result.close();
+            assertThat(circuitBreaker.getUsed(), equalTo(0L));
+
+            docs.reader.close();
+            docs.directory.close();
+        }
+    }
+
     public void testIterateAsyncCircuitBreakerTrips() throws Exception {
-        LuceneDocs docs = createDocs(100);
+        LuceneDocs docs = createDocs(100, false);
         CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(100L));
         TestChunkWriter chunkWriter = new TestChunkWriter(true, circuitBreaker);
         AtomicReference<Throwable> sendFailure = new AtomicReference<>();
@@ -366,6 +435,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
             4,
             sendFailure,
             cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             future
         );
         chunkWriter.ackAll();
@@ -384,7 +454,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
     }
 
     public void testIterateAsyncCancellationBeforeFetchStart() throws Exception {
-        LuceneDocs docs = createDocs(100);
+        LuceneDocs docs = createDocs(100, false);
         CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
         TestChunkWriter chunkWriter = new TestChunkWriter(circuitBreaker);
         AtomicReference<Throwable> sendFailure = new AtomicReference<>();
@@ -404,6 +474,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
             4,
             sendFailure,
             cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             future
         );
 
@@ -423,7 +494,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
     }
 
     public void testIterateAsyncCancellationDuringDocProduction() throws Exception {
-        LuceneDocs docs = createDocs(1000);
+        LuceneDocs docs = createDocs(1000, false);
         CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
         TestChunkWriter chunkWriter = new TestChunkWriter(circuitBreaker);
         AtomicReference<Throwable> sendFailure = new AtomicReference<>();
@@ -448,7 +519,19 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
         CountDownLatch refsComplete = new CountDownLatch(1);
         RefCountingListener refs = new RefCountingListener(ActionListener.running(refsComplete::countDown));
 
-        it.iterateAsync(createShardTarget(), docs.reader, docs.docIds, chunkWriter, 50, refs, 4, sendFailure, cancelled::get, future);
+        it.iterateAsync(
+            createShardTarget(),
+            docs.reader,
+            docs.docIds,
+            chunkWriter,
+            50,
+            refs,
+            4,
+            sendFailure,
+            cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            future
+        );
 
         Exception e = expectThrows(Exception.class, () -> future.get(10, TimeUnit.SECONDS));
         assertTrue(
@@ -466,7 +549,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
     }
 
     public void testIterateAsyncDocProducerException() throws Exception {
-        LuceneDocs docs = createDocs(100);
+        LuceneDocs docs = createDocs(100, false);
         CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
         TestChunkWriter chunkWriter = new TestChunkWriter(circuitBreaker);
         AtomicReference<Throwable> sendFailure = new AtomicReference<>();
@@ -492,7 +575,19 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
         CountDownLatch refsComplete = new CountDownLatch(1);
         RefCountingListener refs = new RefCountingListener(ActionListener.running(refsComplete::countDown));
 
-        it.iterateAsync(createShardTarget(), docs.reader, docs.docIds, chunkWriter, 50, refs, 4, sendFailure, cancelled::get, future);
+        it.iterateAsync(
+            createShardTarget(),
+            docs.reader,
+            docs.docIds,
+            chunkWriter,
+            50,
+            refs,
+            4,
+            sendFailure,
+            cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            future
+        );
 
         Exception e = expectThrows(Exception.class, () -> future.get(10, TimeUnit.SECONDS));
         assertThat(e.getCause().getMessage(), containsString("Simulated producer failure"));
@@ -507,7 +602,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
     }
 
     public void testIterateAsyncPreExistingSendFailure() throws Exception {
-        LuceneDocs docs = createDocs(100);
+        LuceneDocs docs = createDocs(100, false);
         CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
         TestChunkWriter chunkWriter = new TestChunkWriter(circuitBreaker);
         AtomicReference<Throwable> sendFailure = new AtomicReference<>(new IOException("Pre-existing failure")); // Send Failure
@@ -527,6 +622,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
             4,
             sendFailure,
             cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             future
         );
 
@@ -544,7 +640,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
     }
 
     public void testIterateAsyncSendFailure() throws Exception {
-        LuceneDocs docs = createDocs(100);
+        LuceneDocs docs = createDocs(100, false);
         CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
         // Chunk writer that fails after first chunk
         AtomicInteger chunkCount = new AtomicInteger(0);
@@ -576,6 +672,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
             4,
             sendFailure,
             cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
             future
         );
 
@@ -595,11 +692,11 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
     public void testIterateAsyncVisitsLeavesInDocIdOrder() throws Exception {
         int docCount = 200;
         Directory directory = newDirectory();
-        RandomIndexWriter writer = new RandomIndexWriter(
-            random(),
-            directory,
-            newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE)
-        );
+        // Use plain IndexWriter (not RandomIndexWriter) so that segments are produced exactly at our
+        // explicit commit() points. RandomIndexWriter performs random extra flushes that, combined
+        // with NoMergePolicy, can produce many tiny single-doc segments and cause the assertion
+        // "at least one leaf should have multiple docs" to flake.
+        IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
         for (int i = 0; i < docCount; i++) {
             Document doc = new Document();
             doc.add(new StringField("field", "value" + i, Field.Store.NO));
@@ -609,7 +706,7 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
             }
         }
         writer.commit();
-        IndexReader reader = writer.getReader();
+        IndexReader reader = DirectoryReader.open(writer);
         writer.close();
 
         assertTrue("Need multiple leaves to test leaf ordering", reader.leaves().size() > 1);
@@ -643,7 +740,19 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
         CountDownLatch refsComplete = new CountDownLatch(1);
         RefCountingListener refs = new RefCountingListener(ActionListener.running(refsComplete::countDown));
 
-        it.iterateAsync(createShardTarget(), reader, docIds, chunkWriter, 1024 * 1024, refs, 4, sendFailure, cancelled::get, future);
+        it.iterateAsync(
+            createShardTarget(),
+            reader,
+            docIds,
+            chunkWriter,
+            1024 * 1024,
+            refs,
+            4,
+            sendFailure,
+            cancelled::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            future
+        );
 
         IterateResult result = future.get(10, TimeUnit.SECONDS);
         refs.close();
@@ -743,6 +852,237 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
         directory.close();
     }
 
+    public void testSameLeafSameThreadReusesLeafSetup() throws Exception {
+        LuceneDocs docs = createDocs(100, true);
+        assertThat("need one leaf", docs.reader.leaves().size(), equalTo(1));
+
+        CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
+        TestChunkWriter chunkWriter = new TestChunkWriter(circuitBreaker);
+        RecordingStreamingIterator it = new RecordingStreamingIterator();
+
+        PlainActionFuture<IterateResult> future = new PlainActionFuture<>();
+        CountDownLatch refsComplete = new CountDownLatch(1);
+        RefCountingListener refs = new RefCountingListener(ActionListener.running(refsComplete::countDown));
+
+        it.iterateAsync(
+            createShardTarget(),
+            docs.reader,
+            docs.docIds,
+            chunkWriter,
+            50, // tiny chunk size -> many chunks
+            refs,
+            4,
+            new AtomicReference<>(),
+            new AtomicBoolean(false)::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            future
+        );
+
+        IterateResult result = future.get(10, TimeUnit.SECONDS);
+        refs.close();
+        assertTrue(refsComplete.await(10, TimeUnit.SECONDS));
+
+        assertThat("producer should have emitted multiple chunks", chunkWriter.getSentChunks().size(), greaterThan(1));
+        assertThat(
+            "setNextReader must be called exactly once when all chunks stay on one thread within a single leaf",
+            it.setupCount(),
+            equalTo(1)
+        );
+        assertThat("leaf setup must be recorded from a single thread", it.distinctThreads().size(), equalTo(1));
+
+        int totalHits = chunkWriter.getSentChunks().stream().mapToInt(c -> c.hitCount).sum() + result.lastChunkHitCount;
+        assertThat(totalHits, equalTo(docs.docIds.length));
+
+        result.close();
+        assertThat(circuitBreaker.getUsed(), equalTo(0L));
+
+        docs.reader.close();
+        docs.directory.close();
+    }
+
+    public void testCrossLeafOnSameThreadRebuilds() throws Exception {
+        LuceneDocs docs = createDocs(200, false);
+        assertThat("need multiple leaves to exercise cross-leaf rebuild", docs.reader.leaves().size(), greaterThan(1));
+
+        CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
+        TestChunkWriter chunkWriter = new TestChunkWriter(circuitBreaker);
+        RecordingStreamingIterator it = new RecordingStreamingIterator();
+
+        PlainActionFuture<IterateResult> future = new PlainActionFuture<>();
+        CountDownLatch refsComplete = new CountDownLatch(1);
+        RefCountingListener refs = new RefCountingListener(ActionListener.running(refsComplete::countDown));
+
+        it.iterateAsync(
+            createShardTarget(),
+            docs.reader,
+            docs.docIds,
+            chunkWriter,
+            50,
+            refs,
+            4,
+            new AtomicReference<>(),
+            new AtomicBoolean(false)::get,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            future
+        );
+
+        IterateResult result = future.get(10, TimeUnit.SECONDS);
+        refs.close();
+        assertTrue(refsComplete.await(10, TimeUnit.SECONDS));
+
+        int expectedLeaves = docs.reader.leaves().size();
+        assertThat(
+            "setNextReader must be called exactly once per leaf when all chunks stay on one thread",
+            it.setupCount(),
+            equalTo(expectedLeaves)
+        );
+        List<Integer> ordinals = it.leafOrdinals();
+        for (int i = 1; i < ordinals.size(); i++) {
+            assertThat("leaf ordinals must strictly increase: " + ordinals, ordinals.get(i), greaterThan(ordinals.get(i - 1)));
+        }
+        assertThat("all cross-leaf rebuilds stay on a single thread here", it.distinctThreads().size(), equalTo(1));
+
+        int totalHits = chunkWriter.getSentChunks().stream().mapToInt(c -> c.hitCount).sum() + result.lastChunkHitCount;
+        assertThat(totalHits, equalTo(docs.docIds.length));
+
+        result.close();
+        assertThat(circuitBreaker.getUsed(), equalTo(0L));
+
+        docs.reader.close();
+        docs.directory.close();
+    }
+
+    public void testCrossThreadWithinSameLeafRebuildsSetup() throws Exception {
+        LuceneDocs docs = createDocs(150, true);
+        CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
+        InFlightTrackingChunkWriter chunkWriter = new InFlightTrackingChunkWriter(circuitBreaker);
+        AtomicReference<Throwable> sendFailure = new AtomicReference<>();
+        RecordingStreamingIterator it = new RecordingStreamingIterator();
+
+        ThreadPool threadPool = new TestThreadPool(getTestName());
+        try {
+            PlainActionFuture<IterateResult> future = new PlainActionFuture<>();
+            CountDownLatch refsComplete = new CountDownLatch(1);
+            RefCountingListener refs = new RefCountingListener(ActionListener.running(refsComplete::countDown));
+
+            it.iterateAsync(
+                createShardTarget(),
+                docs.reader,
+                docs.docIds,
+                chunkWriter,
+                50,
+                refs,
+                1, // every ACK dispatches a continuation on the executor
+                sendFailure,
+                new AtomicBoolean(false)::get,
+                threadPool.generic(),
+                future
+            );
+
+            Thread testThread = Thread.currentThread();
+            // Drain all chunks
+            long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+            while (future.isDone() == false && System.nanoTime() < deadlineNanos) {
+                chunkWriter.ackAll();
+                Thread.yield();
+            }
+
+            IterateResult result = future.get(10, TimeUnit.SECONDS);
+            refs.close();
+            assertTrue(refsComplete.await(10, TimeUnit.SECONDS));
+
+            assertThat("no send failure", sendFailure.get(), nullValue());
+
+            Set<String> threadsSeen = it.distinctThreads();
+            assertThat("leaf setup must have been recorded on at least two distinct threads", threadsSeen.size(), greaterThanOrEqualTo(2));
+            assertTrue("first leaf setup must come from the caller thread", threadsSeen.contains(testThread.getName()));
+            assertThat(
+                "every recorded setup must come from the thread running that produceNext",
+                it.setupCount(),
+                greaterThanOrEqualTo(threadsSeen.size())
+            );
+
+            int totalHits = chunkWriter.getSentChunks().stream().mapToInt(c -> c.hitCount).sum() + result.lastChunkHitCount;
+            assertThat(totalHits, equalTo(docs.docIds.length));
+            assertThat(result.lastChunkBytes, notNullValue());
+
+            result.close();
+            assertThat(circuitBreaker.getUsed(), equalTo(0L));
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+
+        docs.reader.close();
+        docs.directory.close();
+    }
+
+    public void testIterateAsyncConcurrentLeafSetupStress() throws Exception {
+        ThreadPool threadPool = new TestThreadPool(getTestName());
+        Executor continuationExecutor = threadPool.generic();
+        try {
+            int iterations = 20;
+            for (int i = 0; i < iterations; i++) {
+                final int iter = i;
+                int docCount = randomIntBetween(100, 500);
+                boolean singleLeaf = randomBoolean();
+                LuceneDocs docs = singleLeaf ? createDocs(docCount, true) : createDocs(docCount, false);
+                try {
+                    int maxInFlight = randomIntBetween(1, 4);
+                    int chunkBytes = randomFrom(1, 20, 50, 200);
+
+                    final CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
+                    InFlightTrackingChunkWriter chunkWriter = new InFlightTrackingChunkWriter(circuitBreaker);
+                    AtomicReference<Throwable> sendFailure = new AtomicReference<>();
+                    RecordingStreamingIterator it = new RecordingStreamingIterator();
+
+                    PlainActionFuture<IterateResult> future = new PlainActionFuture<>();
+                    CountDownLatch refsComplete = new CountDownLatch(1);
+                    RefCountingListener refs = new RefCountingListener(ActionListener.running(refsComplete::countDown));
+
+                    it.iterateAsync(
+                        createShardTarget(),
+                        docs.reader,
+                        docs.docIds,
+                        chunkWriter,
+                        chunkBytes,
+                        refs,
+                        maxInFlight,
+                        sendFailure,
+                        new AtomicBoolean(false)::get,
+                        continuationExecutor,
+                        future
+                    );
+
+                    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+                    while (future.isDone() == false && System.nanoTime() < deadlineNanos) {
+                        if (randomBoolean()) {
+                            chunkWriter.ackAll();
+                        } else {
+                            threadPool.generic().execute(chunkWriter::ackAll);
+                        }
+                        Thread.yield();
+                    }
+
+                    IterateResult result = future.get(10, TimeUnit.SECONDS);
+                    refs.close();
+                    assertTrue(refsComplete.await(10, TimeUnit.SECONDS));
+
+                    assertThat("no send failure on iter=" + iter, sendFailure.get(), nullValue());
+                    int totalHits = chunkWriter.getSentChunks().stream().mapToInt(c -> c.hitCount).sum() + result.lastChunkHitCount;
+                    assertThat("hit count matches on iter=" + iter, totalHits, equalTo(docs.docIds.length));
+
+                    result.close();
+                    assertBusy(() -> assertThat("circuit breaker released on iter=" + iter, circuitBreaker.getUsed(), equalTo(0L)));
+                } finally {
+                    docs.reader.close();
+                    docs.directory.close();
+                }
+            }
+        } finally {
+            ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
     private static int[] randomDocIds(int maxDoc) {
         List<Integer> integers = new ArrayList<>();
         int v = 0;
@@ -773,30 +1113,79 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
         };
     }
 
-    private LuceneDocs createDocs(int numDocs) throws IOException {
+    private LuceneDocs createDocs(int numDocs, boolean singleLeaf) throws IOException {
         Directory directory = newDirectory();
-        RandomIndexWriter writer = new RandomIndexWriter(random(), directory);
-        for (int i = 0; i < numDocs; i++) {
-            Document doc = new Document();
-            doc.add(new StringField("field", "value" + i, Field.Store.NO));
-            writer.addDocument(doc);
-            if (i % 30 == 0) {
-                writer.commit();  // Create multiple segments
+        IndexReader reader;
+        if (singleLeaf) {
+            RandomIndexWriter writer = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                doc.add(new StringField("field", "value" + i, Field.Store.NO));
+                writer.addDocument(doc);
             }
+            writer.forceMerge(1);
+            writer.commit();
+            reader = writer.getReader();
+            writer.close();
+        } else {
+            IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE));
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                doc.add(new StringField("field", "value" + i, Field.Store.NO));
+                writer.addDocument(doc);
+                if (i % 30 == 0) {
+                    writer.commit();
+                }
+            }
+            writer.commit();
+            reader = DirectoryReader.open(writer);
+            writer.close();
         }
-        writer.commit();
-        IndexReader reader = writer.getReader();
-        writer.close();
 
         int[] docIds = new int[numDocs];
         for (int i = 0; i < numDocs; i++) {
             docIds[i] = i;
         }
-
         return new LuceneDocs(directory, reader, docIds);
     }
 
     private record LuceneDocs(Directory directory, IndexReader reader, int[] docIds) {}
+
+    private static class RecordingStreamingIterator extends StreamingFetchPhaseDocsIterator {
+        private final List<SetupEvent> setups = new CopyOnWriteArrayList<>();
+
+        @Override
+        protected void setNextReader(LeafReaderContext ctx, int[] docsInLeaf) {
+            setups.add(new SetupEvent(Thread.currentThread().getName(), ctx.ord, docsInLeaf.clone()));
+        }
+
+        @Override
+        protected SearchHit nextDoc(int doc) {
+            return new SearchHit(doc);
+        }
+
+        int setupCount() {
+            return setups.size();
+        }
+
+        Set<String> distinctThreads() {
+            Set<String> names = new HashSet<>();
+            for (SetupEvent e : setups) {
+                names.add(e.threadName);
+            }
+            return names;
+        }
+
+        List<Integer> leafOrdinals() {
+            List<Integer> ords = new ArrayList<>(setups.size());
+            for (SetupEvent e : setups) {
+                ords.add(e.leafOrd);
+            }
+            return ords;
+        }
+
+        private record SetupEvent(String threadName, int leafOrd, int[] docsInLeaf) {}
+    }
 
     /**
      * Simple record to track sent chunk info
@@ -845,6 +1234,42 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
 
         public List<SentChunkInfo> getSentChunks() {
             return sentChunks;
+        }
+    }
+
+    private static class InFlightTrackingChunkWriter extends TestChunkWriter {
+        private final ConcurrentLinkedQueue<ActionListener<Void>> pendingAcks = new ConcurrentLinkedQueue<>();
+        private final AtomicInteger inFlightChunks = new AtomicInteger();
+        private final AtomicInteger maxInFlightChunks = new AtomicInteger();
+
+        InFlightTrackingChunkWriter(CircuitBreaker circuitBreaker) {
+            super(true, circuitBreaker);
+        }
+
+        @Override
+        public void writeResponseChunk(FetchPhaseResponseChunk chunk, ActionListener<Void> listener) {
+            sentChunks.add(new SentChunkInfo(chunk.hitCount(), chunk.sequenceStart(), chunk.expectedTotalDocs()));
+            int currentInFlight = inFlightChunks.incrementAndGet();
+            maxInFlightChunks.accumulateAndGet(currentInFlight, Math::max);
+            pendingAcks.add(ActionListener.wrap(v -> {
+                inFlightChunks.decrementAndGet();
+                listener.onResponse(v);
+            }, e -> {
+                inFlightChunks.decrementAndGet();
+                listener.onFailure(e);
+            }));
+        }
+
+        @Override
+        public void ackAll() {
+            ActionListener<Void> ack;
+            while ((ack = pendingAcks.poll()) != null) {
+                ack.onResponse(null);
+            }
+        }
+
+        int getMaxInFlight() {
+            return maxInFlightChunks.get();
         }
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Refactor chunk fetching to use ThrottledIterator (#146204)