### PR TITLE
[ESQL] Deduplicate Parquet iterator decode logic

### DIFF
--- a/docs/changelog/147584.yaml
+++ b/docs/changelog/147584.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147584
+summary: Deduplicate Parquet iterator decode logic
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
@@ -15,13 +14,7 @@ import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
-import org.apache.parquet.io.api.Converter;
-import org.apache.parquet.io.api.GroupConverter;
-import org.apache.parquet.io.api.PrimitiveConverter;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -30,9 +23,7 @@ import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
@@ -56,8 +47,9 @@ import java.util.concurrent.CompletableFuture;
  * {@code ColumnReader} for list columns. The {@link PreloadedRowGroupMetadata} parameter is
  * reserved for future column-index and dictionary-based optimizations.
  *
- * <p>The existing baseline {@code ParquetColumnIterator} is never modified — it remains as the
- * stable fallback when {@code optimized_reader=false}.
+ * <p>Both this iterator and the baseline {@code ParquetColumnIterator} share list-column
+ * decoding and utility helpers via {@link ParquetColumnDecoding}. The baseline remains
+ * the stable fallback when {@code optimized_reader=false}.
  *
  * <p><b>Memory:</b> Prefetching an entire next row group's projected column bytes can be
  * significant on wide schemas. A future refinement may cap the prefetch budget or integrate
@@ -66,8 +58,6 @@ import java.util.concurrent.CompletableFuture;
 final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
 
     private static final Logger logger = LogManager.getLogger(OptimizedParquetColumnIterator.class);
-
-    private static final char[] HEX = "0123456789abcdef".toCharArray();
 
     private final ParquetFileReader reader;
     private final MessageType projectedSchema;
@@ -207,7 +197,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         if (hasListColumns) {
             ColumnReadStoreImpl store = new ColumnReadStoreImpl(
                 rowGroup,
-                new NoOpGroupConverter(projectedSchema),
+                new ParquetColumnDecoding.NoOpGroupConverter(projectedSchema),
                 projectedSchema,
                 createdBy
             );
@@ -374,166 +364,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             return blockFactory.newConstantNullBlock(rowsToRead);
         }
         if (info.maxRepLevel() > 0) {
-            return readListColumn(cr, info, rowsToRead);
+            return ParquetColumnDecoding.readListColumn(cr, info, rowsToRead, blockFactory);
         }
-        skipValues(cr, rowsToRead);
+        ParquetColumnDecoding.skipValues(cr, rowsToRead);
         return blockFactory.newConstantNullBlock(rowsToRead);
-    }
-
-    // --- List column readers ---
-
-    private Block readListColumn(ColumnReader cr, ColumnInfo info, int rows) {
-        DataType elementType = info.esqlType();
-        int maxDef = info.maxDefLevel();
-        return switch (elementType) {
-            case INTEGER -> readListIntColumn(cr, maxDef, rows);
-            case LONG -> readListLongColumn(cr, maxDef, rows);
-            case DOUBLE -> readListDoubleColumn(cr, maxDef, rows);
-            case BOOLEAN -> readListBooleanColumn(cr, maxDef, rows);
-            case KEYWORD, TEXT -> readListBytesRefColumn(cr, maxDef, rows);
-            case DATETIME -> readListDatetimeColumn(cr, info, rows);
-            default -> {
-                skipListValues(cr, maxDef, rows);
-                yield blockFactory.newConstantNullBlock(rows);
-            }
-        };
-    }
-
-    private static void skipListValues(ColumnReader cr, int maxDef, int rows) {
-        for (int row = 0; row < rows; row++) {
-            cr.consume();
-            while (cr.getCurrentRepetitionLevel() > 0) {
-                cr.consume();
-            }
-        }
-    }
-
-    private Block readListIntColumn(ColumnReader cr, int maxDef, int rows) {
-        try (var builder = blockFactory.newIntBlockBuilder(rows)) {
-            for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, () -> builder.appendInt(cr.getInteger()));
-            }
-            return builder.build();
-        }
-    }
-
-    private Block readListLongColumn(ColumnReader cr, int maxDef, int rows) {
-        try (var builder = blockFactory.newLongBlockBuilder(rows)) {
-            for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, () -> builder.appendLong(cr.getLong()));
-            }
-            return builder.build();
-        }
-    }
-
-    private Block readListDoubleColumn(ColumnReader cr, int maxDef, int rows) {
-        try (var builder = blockFactory.newDoubleBlockBuilder(rows)) {
-            for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, () -> builder.appendDouble(cr.getDouble()));
-            }
-            return builder.build();
-        }
-    }
-
-    private Block readListBooleanColumn(ColumnReader cr, int maxDef, int rows) {
-        try (var builder = blockFactory.newBooleanBlockBuilder(rows)) {
-            for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, () -> builder.appendBoolean(cr.getBoolean()));
-            }
-            return builder.build();
-        }
-    }
-
-    private Block readListBytesRefColumn(ColumnReader cr, int maxDef, int rows) {
-        try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
-            for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, () -> builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes())));
-            }
-            return builder.build();
-        }
-    }
-
-    private Block readListDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
-        try (var builder = blockFactory.newLongBlockBuilder(rows)) {
-            int maxDef = info.maxDefLevel();
-            for (int row = 0; row < rows; row++) {
-                readListRow(cr, maxDef, builder, () -> builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType())));
-            }
-            return builder.build();
-        }
-    }
-
-    @FunctionalInterface
-    private interface ValueAppender {
-        void append();
-    }
-
-    private static void readListRow(ColumnReader cr, int maxDef, Block.Builder builder, ValueAppender appender) {
-        int def = cr.getCurrentDefinitionLevel();
-        if (def >= maxDef) {
-            builder.beginPositionEntry();
-            appender.append();
-            cr.consume();
-            while (cr.getCurrentRepetitionLevel() > 0) {
-                if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                    appender.append();
-                }
-                cr.consume();
-            }
-            builder.endPositionEntry();
-        } else {
-            cr.consume();
-            boolean hasValues = false;
-            while (cr.getCurrentRepetitionLevel() > 0) {
-                if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                    if (hasValues == false) {
-                        builder.beginPositionEntry();
-                        hasValues = true;
-                    }
-                    appender.append();
-                }
-                cr.consume();
-            }
-            if (hasValues) {
-                builder.endPositionEntry();
-            } else {
-                builder.appendNull();
-            }
-        }
-    }
-
-    // --- Utilities ---
-
-    private static long convertTimestampToMillis(long raw, LogicalTypeAnnotation logicalType) {
-        if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
-            return switch (ts.getUnit()) {
-                case MILLIS -> raw;
-                case MICROS -> raw / 1_000;
-                case NANOS -> raw / 1_000_000;
-            };
-        }
-        return raw;
-    }
-
-    private static void skipValues(ColumnReader cr, int rows) {
-        for (int i = 0; i < rows; i++) {
-            cr.consume();
-        }
-    }
-
-    static String formatUuid(byte[] bytes) {
-        if (bytes == null || bytes.length < 16) {
-            throw new QlIllegalArgumentException("UUID requires 16 bytes, got " + (bytes == null ? "null" : bytes.length));
-        }
-        StringBuilder sb = new StringBuilder(36);
-        for (int i = 0; i < 16; i++) {
-            sb.append(HEX[(bytes[i] >> 4) & 0xF]);
-            sb.append(HEX[bytes[i] & 0xF]);
-            if (i == 3 || i == 5 || i == 7 || i == 9) {
-                sb.append('-');
-            }
-        }
-        return sb.toString();
     }
 
     @Override
@@ -549,28 +383,4 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         }
     }
 
-    /**
-     * Minimal GroupConverter that satisfies {@link ColumnReadStoreImpl}'s constructor.
-     */
-    private static class NoOpGroupConverter extends GroupConverter {
-        private final GroupType schema;
-
-        NoOpGroupConverter(GroupType schema) {
-            this.schema = schema;
-        }
-
-        @Override
-        public Converter getConverter(int fieldIndex) {
-            Type field = schema.getType(fieldIndex);
-            return field.isPrimitive() ? new NoOpPrimitiveConverter() : new NoOpGroupConverter(field.asGroupType());
-        }
-
-        @Override
-        public void start() {}
-
-        @Override
-        public void end() {}
-    }
-
-    private static class NoOpPrimitiveConverter extends PrimitiveConverter {}
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -861,7 +861,7 @@ final class PageColumnReader {
                 int fromPage = Math.min(remaining, availableInPage());
                 BytesRef[] vals = readBinaryValues(fromPage);
                 for (int i = 0; i < fromPage; i++) {
-                    allValues[produced + i] = isUuid ? new BytesRef(ParquetFormatReader.formatUuid(vals[i].bytes)) : vals[i];
+                    allValues[produced + i] = isUuid ? new BytesRef(ParquetColumnDecoding.formatUuid(vals[i].bytes)) : vals[i];
                 }
                 advancePosition(fromPage);
                 produced += fromPage;
@@ -892,7 +892,7 @@ final class PageColumnReader {
                 if (pageNulls.get(i)) {
                     allNulls.set(produced + i);
                 } else if (isUuid) {
-                    allValues[produced + i] = new BytesRef(ParquetFormatReader.formatUuid(vals[valIdx++].bytes));
+                    allValues[produced + i] = new BytesRef(ParquetColumnDecoding.formatUuid(vals[valIdx++].bytes));
                 } else {
                     allValues[produced + i] = vals[valIdx++];
                 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.io.api.Converter;
+import org.apache.parquet.io.api.GroupConverter;
+import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.Type;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.util.BitSet;
+
+/**
+ * Shared Parquet decode helpers used by both the baseline {@code ParquetColumnIterator}
+ * and {@link OptimizedParquetColumnIterator}. Centralises list-column decoding,
+ * timestamp conversion, UUID formatting, and other utilities so that bug fixes in one
+ * decode path are automatically reflected in the other.
+ */
+final class ParquetColumnDecoding {
+
+    private ParquetColumnDecoding() {}
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    // ---- Timestamp helpers ----
+
+    static long convertTimestampToMillis(long raw, LogicalTypeAnnotation logicalType) {
+        if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
+            return switch (ts.getUnit()) {
+                case MILLIS -> raw;
+                case MICROS -> raw / 1_000;
+                case NANOS -> raw / 1_000_000;
+            };
+        }
+        return raw;
+    }
+
+    // ---- UUID formatting ----
+
+    /**
+     * Formats a 16-byte UUID in big-endian layout as the standard 8-4-4-4-12 hex string.
+     * Requires exactly 16 bytes; shorter or longer arrays indicate an upstream bug since
+     * Parquet {@code FIXED_LEN_BYTE_ARRAY(16)} is always exactly 16 bytes.
+     */
+    static String formatUuid(byte[] bytes) {
+        if (bytes == null || bytes.length != 16) {
+            throw new QlIllegalArgumentException("UUID requires exactly 16 bytes, got " + (bytes == null ? "null" : bytes.length));
+        }
+        StringBuilder sb = new StringBuilder(36);
+        for (int i = 0; i < 16; i++) {
+            sb.append(HEX[(bytes[i] >> 4) & 0xF]);
+            sb.append(HEX[bytes[i] & 0xF]);
+            if (i == 3 || i == 5 || i == 7 || i == 9) {
+                sb.append('-');
+            }
+        }
+        return sb.toString();
+    }
+
+    // ---- Skip helpers ----
+
+    static void skipValues(ColumnReader cr, int rows) {
+        for (int i = 0; i < rows; i++) {
+            cr.consume();
+        }
+    }
+
+    /**
+     * Skips all Parquet values for the given number of rows in a LIST column,
+     * respecting repetition levels to consume entire lists per row.
+     */
+    static void skipListValues(ColumnReader cr, int rows) {
+        for (int row = 0; row < rows; row++) {
+            cr.consume();
+            while (cr.getCurrentRepetitionLevel() > 0) {
+                cr.consume();
+            }
+        }
+    }
+
+    // ---- Null bitmap helper ----
+
+    static BitSet toBitSet(boolean[] isNull, int length) {
+        BitSet bits = new BitSet(length);
+        for (int i = 0; i < length; i++) {
+            if (isNull[i]) {
+                bits.set(i);
+            }
+        }
+        return bits;
+    }
+
+    // ---- List column reading ----
+
+    /**
+     * Reads a LIST column using repetition levels to determine list boundaries,
+     * producing multi-valued ESQL blocks. Dispatches to the appropriate typed reader
+     * based on the ESQL element type. Handles null lists, empty lists, and null
+     * elements within lists correctly. Unsupported types are skipped and returned
+     * as a constant null block.
+     */
+    static Block readListColumn(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
+        DataType elementType = info.esqlType();
+        int maxDef = info.maxDefLevel();
+        return switch (elementType) {
+            case INTEGER -> readListIntColumn(cr, maxDef, rows, blockFactory);
+            case LONG -> readListLongColumn(cr, maxDef, rows, blockFactory);
+            case DOUBLE -> readListDoubleColumn(cr, maxDef, rows, blockFactory);
+            case BOOLEAN -> readListBooleanColumn(cr, maxDef, rows, blockFactory);
+            case KEYWORD, TEXT -> readListBytesRefColumn(cr, maxDef, rows, blockFactory);
+            case DATETIME -> readListDatetimeColumn(cr, info, rows, blockFactory);
+            default -> {
+                skipListValues(cr, rows);
+                yield blockFactory.newConstantNullBlock(rows);
+            }
+        };
+    }
+
+    /**
+     * Reads a single list row from the Parquet column reader, handling repetition and
+     * definition levels to produce multi-valued ESQL block entries. The supplied
+     * {@link Runnable} is invoked once per element to append the current value from
+     * the column reader into the block builder.
+     *
+     * <p>The caller must have positioned the column reader at the start of the row.
+     * After this method returns, the reader is positioned at the start of the next row
+     * (repetition level == 0).
+     */
+    private static void readListRow(ColumnReader cr, int maxDef, Block.Builder builder, Runnable appender) {
+        int def = cr.getCurrentDefinitionLevel();
+        if (def >= maxDef) {
+            builder.beginPositionEntry();
+            appender.run();
+            cr.consume();
+            while (cr.getCurrentRepetitionLevel() > 0) {
+                if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                    appender.run();
+                }
+                cr.consume();
+            }
+            builder.endPositionEntry();
+        } else {
+            cr.consume();
+            boolean hasValues = false;
+            while (cr.getCurrentRepetitionLevel() > 0) {
+                if (cr.getCurrentDefinitionLevel() >= maxDef) {
+                    if (hasValues == false) {
+                        builder.beginPositionEntry();
+                        hasValues = true;
+                    }
+                    appender.run();
+                }
+                cr.consume();
+            }
+            if (hasValues) {
+                builder.endPositionEntry();
+            } else {
+                builder.appendNull();
+            }
+        }
+    }
+
+    private static Block readListIntColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        try (var builder = blockFactory.newIntBlockBuilder(rows)) {
+            Runnable appender = () -> builder.appendInt(cr.getInteger());
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, appender);
+            }
+            return builder.build();
+        }
+    }
+
+    private static Block readListLongColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        try (var builder = blockFactory.newLongBlockBuilder(rows)) {
+            Runnable appender = () -> builder.appendLong(cr.getLong());
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, appender);
+            }
+            return builder.build();
+        }
+    }
+
+    private static Block readListDoubleColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        try (var builder = blockFactory.newDoubleBlockBuilder(rows)) {
+            Runnable appender = () -> builder.appendDouble(cr.getDouble());
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, appender);
+            }
+            return builder.build();
+        }
+    }
+
+    private static Block readListBooleanColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        try (var builder = blockFactory.newBooleanBlockBuilder(rows)) {
+            Runnable appender = () -> builder.appendBoolean(cr.getBoolean());
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, appender);
+            }
+            return builder.build();
+        }
+    }
+
+    private static Block readListBytesRefColumn(ColumnReader cr, int maxDef, int rows, BlockFactory blockFactory) {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
+            Runnable appender = () -> builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, appender);
+            }
+            return builder.build();
+        }
+    }
+
+    private static Block readListDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows, BlockFactory blockFactory) {
+        try (var builder = blockFactory.newLongBlockBuilder(rows)) {
+            int maxDef = info.maxDefLevel();
+            Runnable appender = () -> builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
+            for (int row = 0; row < rows; row++) {
+                readListRow(cr, maxDef, builder, appender);
+            }
+            return builder.build();
+        }
+    }
+
+    // ---- NoOp converters for ColumnReadStoreImpl ----
+
+    /**
+     * Minimal GroupConverter that satisfies
+     * {@link org.apache.parquet.column.impl.ColumnReadStoreImpl}'s constructor.
+     * We never call {@code writeCurrentValueToConverter()}, so all converters are no-ops.
+     */
+    static final class NoOpGroupConverter extends GroupConverter {
+        private final GroupType schema;
+
+        NoOpGroupConverter(GroupType schema) {
+            this.schema = schema;
+        }
+
+        @Override
+        public Converter getConverter(int fieldIndex) {
+            Type field = schema.getType(fieldIndex);
+            return field.isPrimitive() ? new NoOpPrimitiveConverter() : new NoOpGroupConverter(field.asGroupType());
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void end() {}
+    }
+
+    private static final class NoOpPrimitiveConverter extends PrimitiveConverter {}
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -24,9 +24,6 @@ import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.api.Binary;
-import org.apache.parquet.io.api.Converter;
-import org.apache.parquet.io.api.GroupConverter;
-import org.apache.parquet.io.api.PrimitiveConverter;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -799,26 +796,6 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     /** Julian day number for Unix epoch (1970-01-01). */
     private static final int JULIAN_EPOCH_OFFSET = 2_440_588;
 
-    private static final char[] HEX = "0123456789abcdef".toCharArray();
-
-    /**
-     * Formats a 16-byte UUID in big-endian layout as the standard 8-4-4-4-12 hex string.
-     */
-    static String formatUuid(byte[] bytes) {
-        if (bytes == null || bytes.length < 16) {
-            throw new QlIllegalArgumentException("UUID requires 16 bytes, got " + (bytes == null ? "null" : bytes.length));
-        }
-        StringBuilder sb = new StringBuilder(36);
-        for (int i = 0; i < 16; i++) {
-            sb.append(HEX[(bytes[i] >> 4) & 0xF]);
-            sb.append(HEX[bytes[i] & 0xF]);
-            if (i == 3 || i == 5 || i == 7 || i == 9) {
-                sb.append('-');
-            }
-        }
-        return sb.toString();
-    }
-
     /**
      * When the query plan type cannot be satisfied from this file's Parquet-derived ESQL type (after
      * applying the same widening rules as {@link EsqlDataTypeConverter#commonType}, plus KEYWORD/TEXT
@@ -1009,7 +986,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             if (hasRecordFilter || hasListColumns) {
                 ColumnReadStoreImpl store = new ColumnReadStoreImpl(
                     rowGroup,
-                    new NoOpGroupConverter(projectedSchema),
+                    new ParquetColumnDecoding.NoOpGroupConverter(projectedSchema),
                     projectedSchema,
                     createdBy
                 );
@@ -1121,7 +1098,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
         private Block readColumnBlock(ColumnReader cr, ColumnInfo info, int rowsToRead, int colIndex) {
             if (info.maxRepLevel() > 0) {
-                return readListColumn(cr, info, rowsToRead);
+                return ParquetColumnDecoding.readListColumn(cr, info, rowsToRead, blockFactory);
             }
             return switch (info.esqlType()) {
                 case BOOLEAN -> readBooleanColumn(cr, info.maxDefLevel(), rowsToRead);
@@ -1140,7 +1117,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 }
                 case DATETIME -> readDatetimeColumn(cr, info, rowsToRead);
                 default -> {
-                    skipValues(cr, rowsToRead);
+                    ParquetColumnDecoding.skipValues(cr, rowsToRead);
                     yield blockFactory.newConstantNullBlock(rowsToRead);
                 }
             };
@@ -1162,7 +1139,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             if (noNulls) {
                 return blockFactory.newBooleanArrayVector(values, rows).asBlock();
             }
-            return blockFactory.newBooleanArrayBlock(values, rows, null, toBitSet(isNull, rows), Block.MvOrdering.UNORDERED);
+            return blockFactory.newBooleanArrayBlock(
+                values,
+                rows,
+                null,
+                ParquetColumnDecoding.toBitSet(isNull, rows),
+                Block.MvOrdering.UNORDERED
+            );
         }
 
         private Block readIntColumn(ColumnReader cr, int maxDef, int rows) {
@@ -1181,7 +1164,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             if (noNulls) {
                 return blockFactory.newIntArrayVector(values, rows).asBlock();
             }
-            return blockFactory.newIntArrayBlock(values, rows, null, toBitSet(isNull, rows), Block.MvOrdering.UNORDERED);
+            return blockFactory.newIntArrayBlock(
+                values,
+                rows,
+                null,
+                ParquetColumnDecoding.toBitSet(isNull, rows),
+                Block.MvOrdering.UNORDERED
+            );
         }
 
         /**
@@ -1294,7 +1283,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                     if (info.maxDefLevel() > 0 && cr.getCurrentDefinitionLevel() < info.maxDefLevel()) {
                         builder.appendNull();
                     } else if (isUuid) {
-                        builder.appendBytesRef(new BytesRef(formatUuid(cr.getBinary().getBytes())));
+                        builder.appendBytesRef(new BytesRef(ParquetColumnDecoding.formatUuid(cr.getBinary().getBytes())));
                     } else {
                         builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
                     }
@@ -1320,22 +1309,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                     values[i] = cr.getInteger() * MILLIS_PER_DAY;
                 } else {
                     long raw = cr.getLong();
-                    values[i] = convertTimestampToMillis(raw, info.logicalType());
+                    values[i] = ParquetColumnDecoding.convertTimestampToMillis(raw, info.logicalType());
                 }
                 cr.consume();
             }
             return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
-        }
-
-        private static long convertTimestampToMillis(long raw, LogicalTypeAnnotation logicalType) {
-            if (logicalType instanceof LogicalTypeAnnotation.TimestampLogicalTypeAnnotation ts) {
-                return switch (ts.getUnit()) {
-                    case MILLIS -> raw;
-                    case MICROS -> raw / 1_000;
-                    case NANOS -> raw / 1_000_000;
-                };
-            }
-            return raw;
         }
 
         /**
@@ -1363,292 +1341,6 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             return ColumnBlockConversions.longColumn(blockFactory, values, rows, noNulls, false, isNull);
         }
 
-        /**
-         * Reads a LIST column using repetition levels to determine list boundaries,
-         * producing multi-valued ESQL blocks. Handles null lists, empty lists, and
-         * null elements within lists correctly.
-         */
-        private Block readListColumn(ColumnReader cr, ColumnInfo info, int rows) {
-            DataType elementType = info.esqlType();
-            int maxDef = info.maxDefLevel();
-            return switch (elementType) {
-                case INTEGER -> readListIntColumn(cr, maxDef, rows);
-                case LONG -> readListLongColumn(cr, maxDef, rows);
-                case DOUBLE -> readListDoubleColumn(cr, maxDef, rows);
-                case BOOLEAN -> readListBooleanColumn(cr, maxDef, rows);
-                case KEYWORD, TEXT -> readListBytesRefColumn(cr, maxDef, rows);
-                case DATETIME -> readListDatetimeColumn(cr, info, rows);
-                default -> {
-                    skipListValues(cr, maxDef, rows);
-                    yield blockFactory.newConstantNullBlock(rows);
-                }
-            };
-        }
-
-        /**
-         * Skips all Parquet values for the given number of rows in a LIST column,
-         * respecting repetition levels to consume entire lists per row.
-         */
-        private static void skipListValues(ColumnReader cr, int maxDef, int rows) {
-            for (int row = 0; row < rows; row++) {
-                cr.consume();
-                while (cr.getCurrentRepetitionLevel() > 0) {
-                    cr.consume();
-                }
-            }
-        }
-
-        private Block readListIntColumn(ColumnReader cr, int maxDef, int rows) {
-            try (var builder = blockFactory.newIntBlockBuilder(rows)) {
-                for (int row = 0; row < rows; row++) {
-                    int def = cr.getCurrentDefinitionLevel();
-                    if (def >= maxDef) {
-                        builder.beginPositionEntry();
-                        builder.appendInt(cr.getInteger());
-                        cr.consume();
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                builder.appendInt(cr.getInteger());
-                            }
-                            cr.consume();
-                        }
-                        builder.endPositionEntry();
-                    } else {
-                        cr.consume();
-                        boolean hasValues = false;
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                if (hasValues == false) {
-                                    builder.beginPositionEntry();
-                                    hasValues = true;
-                                }
-                                builder.appendInt(cr.getInteger());
-                            }
-                            cr.consume();
-                        }
-                        if (hasValues) {
-                            builder.endPositionEntry();
-                        } else {
-                            builder.appendNull();
-                        }
-                    }
-                }
-                return builder.build();
-            }
-        }
-
-        private Block readListLongColumn(ColumnReader cr, int maxDef, int rows) {
-            try (var builder = blockFactory.newLongBlockBuilder(rows)) {
-                for (int row = 0; row < rows; row++) {
-                    int def = cr.getCurrentDefinitionLevel();
-                    if (def >= maxDef) {
-                        builder.beginPositionEntry();
-                        builder.appendLong(cr.getLong());
-                        cr.consume();
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                builder.appendLong(cr.getLong());
-                            }
-                            cr.consume();
-                        }
-                        builder.endPositionEntry();
-                    } else {
-                        cr.consume();
-                        boolean hasValues = false;
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                if (hasValues == false) {
-                                    builder.beginPositionEntry();
-                                    hasValues = true;
-                                }
-                                builder.appendLong(cr.getLong());
-                            }
-                            cr.consume();
-                        }
-                        if (hasValues) {
-                            builder.endPositionEntry();
-                        } else {
-                            builder.appendNull();
-                        }
-                    }
-                }
-                return builder.build();
-            }
-        }
-
-        private Block readListDoubleColumn(ColumnReader cr, int maxDef, int rows) {
-            try (var builder = blockFactory.newDoubleBlockBuilder(rows)) {
-                for (int row = 0; row < rows; row++) {
-                    int def = cr.getCurrentDefinitionLevel();
-                    if (def >= maxDef) {
-                        builder.beginPositionEntry();
-                        builder.appendDouble(cr.getDouble());
-                        cr.consume();
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                builder.appendDouble(cr.getDouble());
-                            }
-                            cr.consume();
-                        }
-                        builder.endPositionEntry();
-                    } else {
-                        cr.consume();
-                        boolean hasValues = false;
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                if (hasValues == false) {
-                                    builder.beginPositionEntry();
-                                    hasValues = true;
-                                }
-                                builder.appendDouble(cr.getDouble());
-                            }
-                            cr.consume();
-                        }
-                        if (hasValues) {
-                            builder.endPositionEntry();
-                        } else {
-                            builder.appendNull();
-                        }
-                    }
-                }
-                return builder.build();
-            }
-        }
-
-        private Block readListBooleanColumn(ColumnReader cr, int maxDef, int rows) {
-            try (var builder = blockFactory.newBooleanBlockBuilder(rows)) {
-                for (int row = 0; row < rows; row++) {
-                    int def = cr.getCurrentDefinitionLevel();
-                    if (def >= maxDef) {
-                        builder.beginPositionEntry();
-                        builder.appendBoolean(cr.getBoolean());
-                        cr.consume();
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                builder.appendBoolean(cr.getBoolean());
-                            }
-                            cr.consume();
-                        }
-                        builder.endPositionEntry();
-                    } else {
-                        cr.consume();
-                        boolean hasValues = false;
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                if (hasValues == false) {
-                                    builder.beginPositionEntry();
-                                    hasValues = true;
-                                }
-                                builder.appendBoolean(cr.getBoolean());
-                            }
-                            cr.consume();
-                        }
-                        if (hasValues) {
-                            builder.endPositionEntry();
-                        } else {
-                            builder.appendNull();
-                        }
-                    }
-                }
-                return builder.build();
-            }
-        }
-
-        private Block readListBytesRefColumn(ColumnReader cr, int maxDef, int rows) {
-            try (var builder = blockFactory.newBytesRefBlockBuilder(rows)) {
-                for (int row = 0; row < rows; row++) {
-                    int def = cr.getCurrentDefinitionLevel();
-                    if (def >= maxDef) {
-                        builder.beginPositionEntry();
-                        builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
-                        cr.consume();
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
-                            }
-                            cr.consume();
-                        }
-                        builder.endPositionEntry();
-                    } else {
-                        cr.consume();
-                        boolean hasValues = false;
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                if (hasValues == false) {
-                                    builder.beginPositionEntry();
-                                    hasValues = true;
-                                }
-                                builder.appendBytesRef(new BytesRef(cr.getBinary().getBytes()));
-                            }
-                            cr.consume();
-                        }
-                        if (hasValues) {
-                            builder.endPositionEntry();
-                        } else {
-                            builder.appendNull();
-                        }
-                    }
-                }
-                return builder.build();
-            }
-        }
-
-        private Block readListDatetimeColumn(ColumnReader cr, ColumnInfo info, int rows) {
-            try (var builder = blockFactory.newLongBlockBuilder(rows)) {
-                int maxDef = info.maxDefLevel();
-                for (int row = 0; row < rows; row++) {
-                    int def = cr.getCurrentDefinitionLevel();
-                    if (def >= maxDef) {
-                        builder.beginPositionEntry();
-                        builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
-                        cr.consume();
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
-                            }
-                            cr.consume();
-                        }
-                        builder.endPositionEntry();
-                    } else {
-                        cr.consume();
-                        boolean hasValues = false;
-                        while (cr.getCurrentRepetitionLevel() > 0) {
-                            if (cr.getCurrentDefinitionLevel() >= maxDef) {
-                                if (hasValues == false) {
-                                    builder.beginPositionEntry();
-                                    hasValues = true;
-                                }
-                                builder.appendLong(convertTimestampToMillis(cr.getLong(), info.logicalType()));
-                            }
-                            cr.consume();
-                        }
-                        if (hasValues) {
-                            builder.endPositionEntry();
-                        } else {
-                            builder.appendNull();
-                        }
-                    }
-                }
-                return builder.build();
-            }
-        }
-
-        private static void skipValues(ColumnReader cr, int rows) {
-            for (int i = 0; i < rows; i++) {
-                cr.consume();
-            }
-        }
-
-        private static java.util.BitSet toBitSet(boolean[] isNull, int length) {
-            java.util.BitSet bits = new java.util.BitSet(length);
-            for (int i = 0; i < length; i++) {
-                if (isNull[i]) {
-                    bits.set(i);
-                }
-            }
-            return bits;
-        }
-
         @Override
         public void close() throws IOException {
             try {
@@ -1661,29 +1353,4 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         }
     }
 
-    /**
-     * Minimal GroupConverter that satisfies {@link ColumnReadStoreImpl}'s constructor.
-     * We never call {@code writeCurrentValueToConverter()}, so all converters are no-ops.
-     */
-    private static class NoOpGroupConverter extends GroupConverter {
-        private final GroupType schema;
-
-        NoOpGroupConverter(GroupType schema) {
-            this.schema = schema;
-        }
-
-        @Override
-        public Converter getConverter(int fieldIndex) {
-            Type field = schema.getType(fieldIndex);
-            return field.isPrimitive() ? new NoOpPrimitiveConverter() : new NoOpGroupConverter(field.asGroupType());
-        }
-
-        @Override
-        public void start() {}
-
-        @Override
-        public void end() {}
-    }
-
-    private static class NoOpPrimitiveConverter extends PrimitiveConverter {}
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -61,7 +61,7 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         for (int i = 0; i < 16; i++) {
             bytes[i] = (byte) (i * 16 + i);
         }
-        String uuid = OptimizedParquetColumnIterator.formatUuid(bytes);
+        String uuid = ParquetColumnDecoding.formatUuid(bytes);
         assertNotNull(uuid);
         assertEquals(36, uuid.length());
         assertEquals('-', uuid.charAt(8));
@@ -71,19 +71,13 @@ public class OptimizedParquetReaderTests extends ESTestCase {
     }
 
     public void testFormatUuidNullThrows() {
-        QlIllegalArgumentException e = expectThrows(
-            QlIllegalArgumentException.class,
-            () -> OptimizedParquetColumnIterator.formatUuid(null)
-        );
+        QlIllegalArgumentException e = expectThrows(QlIllegalArgumentException.class, () -> ParquetColumnDecoding.formatUuid(null));
         assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("null"));
     }
 
     public void testFormatUuidTooShortThrows() {
         byte[] bytes = new byte[10];
-        QlIllegalArgumentException e = expectThrows(
-            QlIllegalArgumentException.class,
-            () -> OptimizedParquetColumnIterator.formatUuid(bytes)
-        );
+        QlIllegalArgumentException e = expectThrows(QlIllegalArgumentException.class, () -> ParquetColumnDecoding.formatUuid(bytes));
         assertThat(e.getMessage(), org.hamcrest.Matchers.containsString("10"));
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1270,7 +1270,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
     public void testFormatUuid() {
         UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
         byte[] bytes = toUuidBytes(uuid);
-        String formatted = ParquetFormatReader.formatUuid(bytes);
+        String formatted = ParquetColumnDecoding.formatUuid(bytes);
         assertEquals("550e8400-e29b-41d4-a716-446655440000", formatted);
     }
 


### PR DESCRIPTION
Extract shared decode helpers from `ParquetColumnIterator` and
`OptimizedParquetColumnIterator` into a new `ParquetColumnDecoding`
utility class. This consolidates list-column decoding, timestamp
conversion, UUID formatting, skip helpers, null bitmap conversion,
and NoOp converters so that bug fixes apply to both iterators
automatically instead of requiring parallel changes.

Removes ~530 lines of duplicated code, replacing with delegation
to the shared utility. The scalar `ColumnReader` decode path remains
in the baseline iterator since it is only used when record filters
are active.

Developed with AI-assisted tooling