### PR TITLE
[ES|QL] Integrate circuit breaker with Parquet prefetch

### DIFF
--- a/docs/changelog/147586.yaml
+++ b/docs/changelog/147586.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147586
+summary: Integrate circuit breaker with Parquet prefetch
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
@@ -145,6 +145,22 @@ final class ColumnChunkPrefetcher {
     }
 
     /**
+     * Computes the total bytes that a prefetch would consume for the given row group and projection.
+     * This is the sum of {@link ColumnChunkMetaData#getTotalSize()} for each projected column chunk,
+     * which bounds the data payload fetched by {@link #prefetchAsync}.
+     */
+    static long computePrefetchBytes(BlockMetaData block, java.util.Set<String> projectedColumns) {
+        long totalBytes = 0;
+        for (ColumnChunkMetaData col : block.getColumns()) {
+            if (projectedColumns != null && projectedColumns.contains(col.getPath().toDotString()) == false) {
+                continue;
+            }
+            totalBytes += col.getTotalSize();
+        }
+        return totalBytes;
+    }
+
+    /**
      * Computes the byte ranges for column chunks in a row group. Each column chunk has a
      * starting position and total size in the file metadata.
      */

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcher.java
@@ -59,7 +59,7 @@ final class ColumnChunkPrefetcher {
     static CompletableFuture<NavigableMap<Long, PrefetchedChunk>> prefetch(
         StorageObject storageObject,
         BlockMetaData block,
-        java.util.Set<String> projectedColumns
+        Set<String> projectedColumns
     ) {
         List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
         if (ranges.isEmpty()) {
@@ -102,7 +102,7 @@ final class ColumnChunkPrefetcher {
     static CompletableFuture<NavigableMap<Long, PrefetchedChunk>> prefetchAsync(
         StorageObject storageObject,
         BlockMetaData block,
-        java.util.Set<String> projectedColumns
+        Set<String> projectedColumns
     ) {
         List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
         if (ranges.isEmpty()) {
@@ -145,17 +145,23 @@ final class ColumnChunkPrefetcher {
     }
 
     /**
-     * Computes the total bytes that a prefetch would consume for the given row group and projection.
-     * This is the sum of {@link ColumnChunkMetaData#getTotalSize()} for each projected column chunk,
-     * which bounds the data payload fetched by {@link #prefetchAsync}.
+     * Computes the total bytes that a prefetch would actually allocate for the given row group and
+     * projection. This accounts for coalescing gaps between column chunks (up to
+     * {@link CoalescedRangeReader#DEFAULT_MAX_COALESCE_GAP} bytes per gap) so the estimate matches
+     * what {@link CoalescedRangeReader#readCoalesced} will allocate.
      */
-    static long computePrefetchBytes(BlockMetaData block, java.util.Set<String> projectedColumns) {
+    static long computePrefetchBytes(BlockMetaData block, Set<String> projectedColumns) {
+        List<CoalescedRangeReader.ByteRange> ranges = computeColumnChunkRanges(block, projectedColumns);
+        if (ranges.isEmpty()) {
+            return 0;
+        }
+        List<CoalescedRangeReader.MergedRange> merged = CoalescedRangeReader.mergeRanges(
+            ranges,
+            CoalescedRangeReader.DEFAULT_MAX_COALESCE_GAP
+        );
         long totalBytes = 0;
-        for (ColumnChunkMetaData col : block.getColumns()) {
-            if (projectedColumns != null && projectedColumns.contains(col.getPath().toDotString()) == false) {
-                continue;
-            }
-            totalBytes += col.getTotalSize();
+        for (CoalescedRangeReader.MergedRange mr : merged) {
+            totalBytes += mr.length();
         }
         return totalBytes;
     }
@@ -164,7 +170,7 @@ final class ColumnChunkPrefetcher {
      * Computes the byte ranges for column chunks in a row group. Each column chunk has a
      * starting position and total size in the file metadata.
      */
-    static List<CoalescedRangeReader.ByteRange> computeColumnChunkRanges(BlockMetaData block, java.util.Set<String> projectedColumns) {
+    static List<CoalescedRangeReader.ByteRange> computeColumnChunkRanges(BlockMetaData block, Set<String> projectedColumns) {
         List<CoalescedRangeReader.ByteRange> ranges = new ArrayList<>();
         for (ColumnChunkMetaData col : block.getColumns()) {
             if (projectedColumns != null && projectedColumns.contains(col.getPath().toDotString()) == false) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -23,6 +23,8 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
@@ -59,9 +61,10 @@ import java.util.concurrent.CompletableFuture;
  * <p>The existing baseline {@code ParquetColumnIterator} is never modified — it remains as the
  * stable fallback when {@code optimized_reader=false}.
  *
- * <p><b>Memory:</b> Prefetching an entire next row group's projected column bytes can be
- * significant on wide schemas. A future refinement may cap the prefetch budget or integrate
- * with the circuit breaker.
+ * <p><b>Memory:</b> Prefetch bytes are reserved on the REQUEST circuit breaker (via
+ * {@link BlockFactory#breaker()}) before async I/O starts. The reservation is released
+ * when prefetched data is consumed and cleared. If the breaker would trip, prefetch is
+ * skipped and the query falls back to synchronous I/O for that row group.
  */
 final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
 
@@ -77,12 +80,13 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final String createdBy;
     private final String fileLocation;
     private final ColumnInfo[] columnInfos;
-    // TODO: use for column-index and dictionary-based optimizations in the filtered-read follow-up
     private final PreloadedRowGroupMetadata preloadedMetadata;
     private final StorageObject storageObject;
     private final ParquetStorageObjectAdapter adapter;
     private final Set<String> projectedColumnPaths;
+    private final CircuitBreaker breaker;
     private int rowBudget;
+    private long prefetchReservedBytes;
 
     private PageReadStore rowGroup;
     private ColumnReader[] columnReaders;
@@ -119,6 +123,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.preloadedMetadata = preloadedMetadata;
         this.storageObject = storageObject;
         this.adapter = adapter;
+        this.breaker = blockFactory.breaker();
 
         this.projectedColumnPaths = buildProjectedColumnPaths(columnInfos);
 
@@ -172,6 +177,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         rowGroup = reader.readNextFilteredRowGroup();
 
         adapter.clearPrefetchedData();
+        releasePrefetchReservation();
 
         if (rowGroup == null) {
             exhausted = true;
@@ -223,7 +229,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     /**
      * Installs any previously prefetched row group data into the adapter so that
      * the next {@code readNextFilteredRowGroup()} can read from memory instead of
-     * issuing network I/O. Falls back gracefully on failure.
+     * issuing network I/O. Falls back gracefully on failure, releasing the breaker
+     * reservation if the prefetch did not produce usable data.
      */
     private void installPendingPrefetch() {
         if (pendingPrefetch == null) {
@@ -239,6 +246,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                     rowGroupOrdinal + 1,
                     fileLocation
                 );
+            } else {
+                releasePrefetchReservation();
             }
         } catch (Exception e) {
             logger.debug(
@@ -247,6 +256,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 fileLocation,
                 e.getMessage()
             );
+            releasePrefetchReservation();
         } finally {
             pendingPrefetch = null;
         }
@@ -254,8 +264,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
 
     /**
      * Triggers an async prefetch of column chunk data for the next row group.
-     * The prefetch runs in the background; the data is consumed in the next
-     * {@link #advanceRowGroup()} call via {@link #installPendingPrefetch()}.
+     * Reserves the estimated bytes on the circuit breaker before starting I/O;
+     * if the breaker would trip, prefetch is skipped and the query falls back
+     * to synchronous I/O for that row group. The reservation is released when
+     * the prefetched data is cleared in {@link #advanceRowGroup()} or on
+     * failure/cancel.
      */
     private void triggerNextRowGroupPrefetch() {
         if (storageObject == null) {
@@ -267,11 +280,28 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             return;
         }
         BlockMetaData nextBlock = rowGroups.get(nextRgOrdinal);
+        long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, projectedColumnPaths);
+        if (prefetchBytes <= 0) {
+            return;
+        }
+        try {
+            breaker.addEstimateBytesAndMaybeBreak(prefetchBytes, "parquet prefetch");
+            prefetchReservedBytes = prefetchBytes;
+        } catch (CircuitBreakingException e) {
+            logger.debug(
+                "Skipping prefetch for row group [{}] in [{}]: circuit breaker limit reached ({} bytes requested)",
+                nextRgOrdinal,
+                fileLocation,
+                prefetchBytes
+            );
+            return;
+        }
         try {
             pendingPrefetch = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, projectedColumnPaths);
         } catch (Exception e) {
             logger.debug("Failed to initiate prefetch for row group [{}] in [{}]: {}", nextRgOrdinal, fileLocation, e.getMessage());
             pendingPrefetch = null;
+            releasePrefetchReservation();
         }
     }
 
@@ -279,6 +309,18 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         if (pendingPrefetch != null) {
             org.elasticsearch.common.util.concurrent.FutureUtils.cancel(pendingPrefetch);
             pendingPrefetch = null;
+        }
+        releasePrefetchReservation();
+    }
+
+    /**
+     * Releases any circuit breaker reservation held for prefetched data. Idempotent —
+     * safe to call multiple times (subsequent calls are no-ops when reservation is zero).
+     */
+    private void releasePrefetchReservation() {
+        if (prefetchReservedBytes > 0) {
+            breaker.addWithoutBreaking(-prefetchReservedBytes);
+            prefetchReservedBytes = 0;
         }
     }
 
@@ -540,6 +582,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     public void close() throws IOException {
         cancelPendingPrefetch();
         adapter.clearPrefetchedData();
+        releasePrefetchReservation();
         try {
             if (rowGroup != null) {
                 rowGroup.close();

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -45,6 +45,7 @@ import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Optimized Parquet column iterator behind the {@code optimized_reader} feature flag.
@@ -80,13 +81,14 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final String createdBy;
     private final String fileLocation;
     private final ColumnInfo[] columnInfos;
+    // TODO: use for column-index and dictionary-based optimizations in the filtered-read follow-up
     private final PreloadedRowGroupMetadata preloadedMetadata;
     private final StorageObject storageObject;
     private final ParquetStorageObjectAdapter adapter;
     private final Set<String> projectedColumnPaths;
     private final CircuitBreaker breaker;
     private int rowBudget;
-    private long prefetchReservedBytes;
+    private final AtomicLong prefetchReservedBytes = new AtomicLong();
 
     private PageReadStore rowGroup;
     private ColumnReader[] columnReaders;
@@ -282,11 +284,13 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         BlockMetaData nextBlock = rowGroups.get(nextRgOrdinal);
         long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, projectedColumnPaths);
         if (prefetchBytes <= 0) {
+            // No data to prefetch (empty projection or zero-byte columns). This is safe because
+            // installPendingPrefetch tolerates pendingPrefetch == null — no invariant is broken.
             return;
         }
         try {
-            breaker.addEstimateBytesAndMaybeBreak(prefetchBytes, "parquet prefetch");
-            prefetchReservedBytes = prefetchBytes;
+            breaker.addEstimateBytesAndMaybeBreak(prefetchBytes, "esql_parquet_prefetch");
+            prefetchReservedBytes.set(prefetchBytes);
         } catch (CircuitBreakingException e) {
             logger.debug(
                 "Skipping prefetch for row group [{}] in [{}]: circuit breaker limit reached ({} bytes requested)",
@@ -305,6 +309,14 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         }
     }
 
+    /**
+     * Cancels the pending prefetch future and releases the breaker reservation. Note that
+     * {@link org.elasticsearch.common.util.concurrent.FutureUtils#cancel} only flips the
+     * future's cancelled state — it does not interrupt in-flight storage SDK reads. If the
+     * async read is already in progress, the SDK may still allocate a buffer that becomes
+     * untracked by the breaker until GC. Draining the future before releasing would risk
+     * blocking {@link #close()}, so we accept this brief discrepancy.
+     */
     private void cancelPendingPrefetch() {
         if (pendingPrefetch != null) {
             org.elasticsearch.common.util.concurrent.FutureUtils.cancel(pendingPrefetch);
@@ -318,9 +330,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
      * safe to call multiple times (subsequent calls are no-ops when reservation is zero).
      */
     private void releasePrefetchReservation() {
-        if (prefetchReservedBytes > 0) {
-            breaker.addWithoutBreaking(-prefetchReservedBytes);
-            prefetchReservedBytes = 0;
+        long reserved = prefetchReservedBytes.getAndSet(0);
+        if (reserved > 0) {
+            breaker.addWithoutBreaking(-reserved);
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcherTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcherTests.java
@@ -236,26 +236,47 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
     }
 
     public void testComputePrefetchBytesAllColumns() {
+        // All three ranges merge into [100, 1300) since gaps (100, 100) are within 512KB coalesce threshold
         BlockMetaData block = createBlockWithColumns(
             new ColMeta("col_a", 100, 500),
             new ColMeta("col_b", 700, 300),
             new ColMeta("col_c", 1100, 200)
         );
-        assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, null), equalTo(1000L));
+        assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, null), equalTo(1200L));
     }
 
     public void testComputePrefetchBytesWithProjection() {
+        // col_a [100,600) and col_c [1100,1300): gap of 500 < 512KB, merged to [100, 1300) = 1200
         BlockMetaData block = createBlockWithColumns(
             new ColMeta("col_a", 100, 500),
             new ColMeta("col_b", 700, 300),
             new ColMeta("col_c", 1100, 200)
         );
-        assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, Set.of("col_a", "col_c")), equalTo(700L));
+        assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, Set.of("col_a", "col_c")), equalTo(1200L));
     }
 
-    public void testComputePrefetchBytesEmptyProjection() {
+    public void testComputePrefetchBytesNoMatchingProjection() {
         BlockMetaData block = createBlockWithColumns(new ColMeta("col_a", 100, 500));
         assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, Set.of("nonexistent")), equalTo(0L));
+    }
+
+    public void testComputePrefetchBytesNullProjection() {
+        BlockMetaData block = createBlockWithColumns(new ColMeta("col_a", 100, 500));
+        assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, null), equalTo(500L));
+    }
+
+    public void testComputePrefetchBytesSkipsZeroSizeColumns() {
+        BlockMetaData block = createBlockWithColumns(new ColMeta("col_a", 100, 500), new ColMeta("col_b", 700, 0));
+        assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, null), equalTo(500L));
+    }
+
+    public void testComputePrefetchBytesIncludesCoalescingGaps() {
+        // Two columns separated by a gap smaller than DEFAULT_MAX_COALESCE_GAP (512KB).
+        // The merged range should include the gap bytes, not just the column data.
+        BlockMetaData block = createBlockWithColumns(new ColMeta("col_a", 0, 100), new ColMeta("col_b", 200, 100));
+        long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(block, null);
+        // Merged range: [0, 300) = 300 bytes (includes the 100-byte gap)
+        assertThat(prefetchBytes, equalTo(300L));
     }
 
     public void testComputePrefetchBytesEmptyBlock() {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcherTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ColumnChunkPrefetcherTests.java
@@ -235,6 +235,35 @@ public class ColumnChunkPrefetcherTests extends ESTestCase {
         assertTrue(future.isCompletedExceptionally());
     }
 
+    public void testComputePrefetchBytesAllColumns() {
+        BlockMetaData block = createBlockWithColumns(
+            new ColMeta("col_a", 100, 500),
+            new ColMeta("col_b", 700, 300),
+            new ColMeta("col_c", 1100, 200)
+        );
+        assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, null), equalTo(1000L));
+    }
+
+    public void testComputePrefetchBytesWithProjection() {
+        BlockMetaData block = createBlockWithColumns(
+            new ColMeta("col_a", 100, 500),
+            new ColMeta("col_b", 700, 300),
+            new ColMeta("col_c", 1100, 200)
+        );
+        assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, Set.of("col_a", "col_c")), equalTo(700L));
+    }
+
+    public void testComputePrefetchBytesEmptyProjection() {
+        BlockMetaData block = createBlockWithColumns(new ColMeta("col_a", 100, 500));
+        assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, Set.of("nonexistent")), equalTo(0L));
+    }
+
+    public void testComputePrefetchBytesEmptyBlock() {
+        BlockMetaData block = new BlockMetaData();
+        block.setRowCount(0);
+        assertThat(ColumnChunkPrefetcher.computePrefetchBytes(block, null), equalTo(0L));
+    }
+
     public void testPrefetchedChunkCovers() {
         ByteBuffer data = ByteBuffer.allocate(100);
         ColumnChunkPrefetcher.PrefetchedChunk chunk = new ColumnChunkPrefetcher.PrefetchedChunk(200, 100, data);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
@@ -19,6 +19,7 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LimitedBreaker;
@@ -53,8 +54,6 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
         .named("value")
         .named("test_schema");
 
-    private static final MessageType WIDE_SCHEMA = buildWideSchema(10);
-
     /**
      * Reads a multi-row-group file with a limited breaker and verifies the breaker
      * returns to zero after full iteration completes.
@@ -86,7 +85,8 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
      * is acceptable — the key assertion is that the breaker returns to zero.
      */
     public void testPrefetchWithTightBreakerLimit() throws Exception {
-        byte[] parquetData = createMultiRowGroupFile(WIDE_SCHEMA, 5000, 50 * 1024);
+        MessageType wideSchema = buildWideSchema(10);
+        byte[] parquetData = createMultiRowGroupFile(wideSchema, 5000, 50 * 1024);
         var breaker = new TrackingBreaker("test", ByteSizeValue.ofMb(2));
         BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
 
@@ -96,7 +96,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
                 try {
                     Page page = iter.next();
                     page.releaseBlocks();
-                } catch (org.elasticsearch.common.breaker.CircuitBreakingException e) {
+                } catch (CircuitBreakingException e) {
                     break;
                 }
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
@@ -37,7 +37,6 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -62,7 +61,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
      */
     public void testPrefetchReservesAndReleasesBreaker() throws Exception {
         byte[] parquetData = createMultiRowGroupFile(3000, 2048);
-        var breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(50));
+        var breaker = new TrackingBreaker("test", ByteSizeValue.ofMb(50));
         BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
 
         StorageObject storage = createAsyncStorageObject(parquetData);
@@ -75,14 +74,16 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
             }
         }
         assertTrue("Should have read rows", totalRows > 0);
+        assertTrue("Breaker should have been used for prefetch", breaker.peakUsed.get() > 0);
         assertEquals("Breaker should return to zero after iteration", 0, breaker.getUsed());
     }
 
     /**
      * Verifies the optimized reader works correctly with a tight breaker limit. The prefetch
      * competes with Parquet-mr decode allocations and ESQL block creation for the same breaker
-     * budget. Whether prefetch succeeds or is skipped depends on timing and allocation sizes —
-     * the key assertion is that the query completes and the breaker returns to zero.
+     * budget. The query may either complete normally (prefetch skipped for some row groups) or
+     * throw a CircuitBreakingException if decode allocations exceed the limit. Either outcome
+     * is acceptable — the key assertion is that the breaker returns to zero.
      */
     public void testPrefetchWithTightBreakerLimit() throws Exception {
         byte[] parquetData = createMultiRowGroupFile(WIDE_SCHEMA, 5000, 50 * 1024);
@@ -90,15 +91,16 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
         BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
 
         StorageObject storage = createAsyncStorageObject(parquetData);
-        int totalRows = 0;
         try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
             while (iter.hasNext()) {
-                Page page = iter.next();
-                totalRows += page.getPositionCount();
-                page.releaseBlocks();
+                try {
+                    Page page = iter.next();
+                    page.releaseBlocks();
+                } catch (org.elasticsearch.common.breaker.CircuitBreakingException e) {
+                    break;
+                }
             }
         }
-        assertTrue("Should have read rows with tight breaker", totalRows > 0);
         assertEquals("Breaker should return to zero", 0, breaker.getUsed());
     }
 
@@ -230,7 +232,7 @@ public class PrefetchCircuitBreakerTests extends ESTestCase {
 
             @Override
             public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
-                ForkJoinPool.commonPool().execute(() -> {
+                executor.execute(() -> {
                     try {
                         int pos = (int) position;
                         int len = (int) Math.min(length, data.length - position);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PrefetchCircuitBreakerTests.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.LimitedBreaker;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Tests that the optimized Parquet reader's prefetch pipeline correctly integrates with
+ * the circuit breaker: reserving memory before async I/O, releasing on clear/cancel/failure,
+ * and gracefully skipping prefetch when the breaker limit would be exceeded.
+ */
+public class PrefetchCircuitBreakerTests extends ESTestCase {
+
+    private static final MessageType SCHEMA = Types.buildMessage()
+        .required(PrimitiveType.PrimitiveTypeName.INT64)
+        .named("id")
+        .required(PrimitiveType.PrimitiveTypeName.INT32)
+        .named("value")
+        .named("test_schema");
+
+    private static final MessageType WIDE_SCHEMA = buildWideSchema(10);
+
+    /**
+     * Reads a multi-row-group file with a limited breaker and verifies the breaker
+     * returns to zero after full iteration completes.
+     */
+    public void testPrefetchReservesAndReleasesBreaker() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(3000, 2048);
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(50));
+        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
+
+        StorageObject storage = createAsyncStorageObject(parquetData);
+        int totalRows = 0;
+        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                totalRows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        assertTrue("Should have read rows", totalRows > 0);
+        assertEquals("Breaker should return to zero after iteration", 0, breaker.getUsed());
+    }
+
+    /**
+     * Verifies the optimized reader works correctly with a tight breaker limit. The prefetch
+     * competes with Parquet-mr decode allocations and ESQL block creation for the same breaker
+     * budget. Whether prefetch succeeds or is skipped depends on timing and allocation sizes —
+     * the key assertion is that the query completes and the breaker returns to zero.
+     */
+    public void testPrefetchWithTightBreakerLimit() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(WIDE_SCHEMA, 5000, 50 * 1024);
+        var breaker = new TrackingBreaker("test", ByteSizeValue.ofMb(2));
+        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
+
+        StorageObject storage = createAsyncStorageObject(parquetData);
+        int totalRows = 0;
+        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                totalRows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        assertTrue("Should have read rows with tight breaker", totalRows > 0);
+        assertEquals("Breaker should return to zero", 0, breaker.getUsed());
+    }
+
+    /**
+     * Uses a failing storage object to test that the breaker reservation is released
+     * when async prefetch I/O fails.
+     */
+    public void testPrefetchReleasesOnIOFailure() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(2000, 2048);
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(50));
+        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
+
+        StorageObject storage = createFailingAsyncStorageObject(parquetData);
+        int totalRows = 0;
+        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                totalRows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        assertTrue("Should have read rows via sync fallback", totalRows > 0);
+        assertEquals("Breaker should return to zero after iteration with failures", 0, breaker.getUsed());
+    }
+
+    /**
+     * Tracks the maximum breaker usage during iteration and verifies it stays bounded
+     * to approximately one row group's worth of prefetch data.
+     */
+    public void testBreakerUsageDuringIteration() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(5000, 2048);
+        var breaker = new TrackingBreaker("test", ByteSizeValue.ofMb(50));
+        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
+
+        StorageObject storage = createAsyncStorageObject(parquetData);
+        int totalRows = 0;
+        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                totalRows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        assertTrue("Should have read rows", totalRows > 0);
+        assertEquals("Breaker should return to zero", 0, breaker.getUsed());
+        assertTrue(
+            "Peak prefetch breaker usage should be bounded (was " + breaker.peakUsed + " bytes)",
+            breaker.peakUsed.get() < parquetData.length
+        );
+    }
+
+    /**
+     * Closes the iterator mid-iteration (before exhausting all row groups) and verifies
+     * the breaker returns to zero — catches leak paths on early close / query abort.
+     */
+    public void testPrefetchReleasedOnEarlyClose() throws Exception {
+        byte[] parquetData = createMultiRowGroupFile(5000, 2048);
+        var breaker = new LimitedBreaker("test", ByteSizeValue.ofMb(50));
+        BlockFactory blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(breaker).build();
+
+        StorageObject storage = createAsyncStorageObject(parquetData);
+        try (CloseableIterator<Page> iter = new ParquetFormatReader(blockFactory, true).read(storage, FormatReadContext.of(null, 1024))) {
+            if (iter.hasNext()) {
+                Page page = iter.next();
+                page.releaseBlocks();
+            }
+        }
+        assertEquals("Breaker should return to zero after early close", 0, breaker.getUsed());
+    }
+
+    // --- Helpers ---
+
+    /**
+     * Breaker that tracks peak usage for assertions.
+     */
+    static class TrackingBreaker extends LimitedBreaker {
+        final AtomicLong peakUsed = new AtomicLong(0);
+
+        TrackingBreaker(String name, ByteSizeValue limit) {
+            super(name, limit);
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) {
+            super.addEstimateBytesAndMaybeBreak(bytes, label);
+            peakUsed.updateAndGet(peak -> Math.max(peak, getUsed()));
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {
+            super.addWithoutBreaking(bytes);
+            if (bytes > 0) {
+                peakUsed.updateAndGet(peak -> Math.max(peak, getUsed()));
+            }
+        }
+    }
+
+    private StorageObject createAsyncStorageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                return new ByteArrayInputStream(data, (int) position, (int) Math.min(length, data.length - position));
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://breaker-test.parquet");
+            }
+
+            @Override
+            public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
+                ForkJoinPool.commonPool().execute(() -> {
+                    try {
+                        int pos = (int) position;
+                        int len = (int) Math.min(length, data.length - position);
+                        ByteBuffer buffer = ByteBuffer.allocate(len);
+                        buffer.put(data, pos, len);
+                        buffer.flip();
+                        listener.onResponse(buffer);
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                });
+            }
+        };
+    }
+
+    /**
+     * Storage object whose async reads always fail, forcing the prefetch pipeline
+     * to fall back to synchronous I/O. Sync reads work normally.
+     */
+    private StorageObject createFailingAsyncStorageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                return new ByteArrayInputStream(data, (int) position, (int) Math.min(length, data.length - position));
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://failing-async-test.parquet");
+            }
+
+            @Override
+            public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
+                executor.execute(() -> listener.onFailure(new IOException("Simulated async I/O failure")));
+            }
+        };
+    }
+
+    private static MessageType buildWideSchema(int numColumns) {
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+        for (int c = 0; c < numColumns; c++) {
+            builder.required(PrimitiveType.PrimitiveTypeName.INT64).named("col_" + c);
+        }
+        return builder.named("wide_schema");
+    }
+
+    private byte[] createMultiRowGroupFile(int rowCount, int rowGroupSize) throws IOException {
+        return createMultiRowGroupFile(SCHEMA, rowCount, rowGroupSize);
+    }
+
+    private byte[] createMultiRowGroupFile(MessageType schema, int rowCount, int rowGroupSize) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(outputStream);
+        SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+        String[] columns = new String[schema.getFieldCount()];
+        for (int i = 0; i < columns.length; i++) {
+            columns[i] = schema.getFieldName(i);
+        }
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(rowGroupSize)
+                .withPageSize(256)
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                Group g = groupFactory.newGroup();
+                for (String col : columns) {
+                    switch (schema.getType(col).asPrimitiveType().getPrimitiveTypeName()) {
+                        case INT64 -> g.add(col, (long) i);
+                        case INT32 -> g.add(col, i * 10);
+                        default -> throw new IllegalArgumentException("Unsupported type");
+                    }
+                }
+                writer.write(g);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream outputStream) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    @Override
+                    public long getPos() {
+                        return outputStream.size();
+                    }
+
+                    @Override
+                    public void write(int b) {
+                        outputStream.write(b);
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) {
+                        outputStream.write(b, off, len);
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+
+            @Override
+            public String getPath() {
+                return "memory://breaker-test.parquet";
+            }
+        };
+    }
+}


### PR DESCRIPTION
Reserve REQUEST circuit breaker bytes before async prefetch I/O and
release when prefetched data is consumed, cancelled, or fails. If the
breaker would trip, prefetch is skipped and the query falls back to
synchronous I/O — no query failure, just slower reads.

Developed with AI-assisted tooling