### PR TITLE
Refine ES|QL Views Changelog entry

### DIFF
--- a/docs/changelog/134995.yaml
+++ b/docs/changelog/134995.yaml
@@ -7,6 +7,8 @@ highlight:
   title: "ES|QL Views support"
   notable: true
   body: |-
-    ES|QL now supports Views, allowing users to create reusable query components that can be referenced in multiple queries.
-    This feature enhances query modularity and maintainability,
-    making it easier to manage complex queries by breaking them down into simpler, reusable parts.
+    ES|QL now supports Views: virtual indices whose fields are produced by an ES|QL query.
+    A view is referenced inside a `FROM` clause exactly like a regular index, alongside other indices, views, and wildcards.
+    Complex processing pipelines can be hidden behind a view, exposing a stable set of columns without requiring callers to know the underlying source structure.
+    A single query can combine multiple pre-processed data sources by listing several views in one `FROM` clause, with each view's pipeline running independently.
+    Common transformations such as renames, type conversions, derived fields, and aggregations can be defined once in a view and reused across many queries, dashboards, and alerts.


### PR DESCRIPTION
The original entry was based on the original specification for views, which emphasized views as named subqueries. However, we've been refocusing views as _virtual indexes_ to be more forward compatible with future plans.

Assisted by Claude