### PR TITLE
[ESQL] Add per-query concurrency budget for S3 connections

### DIFF
--- a/docs/changelog/147598.yaml
+++ b/docs/changelog/147598.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147598
+summary: Add per-query concurrency budget for S3 connections
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -31,6 +32,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -40,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils.drainPagesAsync;
 
@@ -93,6 +96,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     private final int parsingParallelism;
     private final List<Expression> pushedExpressions;
     private final FilterPushdownSupport pushdownSupport;
+    private final Closeable onClose;
+    private final AtomicInteger operatorRefCount = new AtomicInteger(0);
 
     private AsyncExternalSourceOperatorFactory(
         StorageProvider storageProvider,
@@ -110,7 +115,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         ErrorPolicy errorPolicy,
         int parsingParallelism,
         @Nullable List<Expression> pushedExpressions,
-        @Nullable FilterPushdownSupport pushdownSupport
+        @Nullable FilterPushdownSupport pushdownSupport,
+        @Nullable Closeable onClose
     ) {
         if (storageProvider == null) {
             throw new IllegalArgumentException("storageProvider cannot be null");
@@ -150,6 +156,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         this.parsingParallelism = Math.max(1, parsingParallelism);
         this.pushedExpressions = pushedExpressions != null ? pushedExpressions : List.of();
         this.pushdownSupport = pushdownSupport;
+        this.onClose = onClose;
     }
 
     public static Builder builder(
@@ -189,6 +196,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         private int parsingParallelism = 1;
         private List<Expression> pushedExpressions;
         private FilterPushdownSupport pushdownSupport;
+        private Closeable onClose;
 
         private Builder(
             StorageProvider storageProvider,
@@ -253,6 +261,19 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             return this;
         }
 
+        /**
+         * @param onClose lifecycle callback owned by this factory, invoked exactly once when the last
+         *                operator created by {@link AsyncExternalSourceOperatorFactory#get} completes
+         *                (ref count drops to zero). Used by the per-source concurrency budget to
+         *                deregister from the allocator. May be {@code null} when no per-source cleanup
+         *                is needed. Callers must ensure that {@code get()} is called at least once;
+         *                otherwise the callback never fires and the resource it guards leaks.
+         */
+        public Builder onClose(@Nullable Closeable onClose) {
+            this.onClose = onClose;
+            return this;
+        }
+
         public AsyncExternalSourceOperatorFactory build() {
             return new AsyncExternalSourceOperatorFactory(
                 storageProvider,
@@ -270,35 +291,42 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 errorPolicy,
                 parsingParallelism,
                 pushedExpressions,
-                pushdownSupport
+                pushdownSupport,
+                onClose
             );
         }
     }
 
     @Override
     public SourceOperator get(DriverContext driverContext) {
-        long maxBufferBytes = (long) maxBufferSize * Operator.TARGET_PAGE_SIZE;
-        AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
-        driverContext.addAsyncAction();
+        operatorRefCount.incrementAndGet();
+        try {
+            long maxBufferBytes = (long) maxBufferSize * Operator.TARGET_PAGE_SIZE;
+            AsyncExternalSourceBuffer buffer = new AsyncExternalSourceBuffer(maxBufferBytes);
+            driverContext.addAsyncAction();
 
-        if (sliceQueue != null) {
-            startSliceQueueRead(buffer, driverContext);
-        } else if (fileList != null && fileList.isResolved()) {
-            VirtualColumnInjector injector = buildInjector(driverContext);
-            List<String> projectedColumns = projectedColumns(injector);
-            startMultiFileRead(projectedColumns, buffer, driverContext, injector);
-        } else {
-            VirtualColumnInjector injector = buildInjector(driverContext);
-            List<String> projectedColumns = projectedColumns(injector);
-            StorageObject storageObject = storageProvider.newObject(path);
-            if (formatReader.supportsNativeAsync()) {
-                startNativeAsyncRead(storageObject, projectedColumns, buffer, driverContext, injector);
+            if (sliceQueue != null) {
+                startSliceQueueRead(buffer, driverContext);
+            } else if (fileList != null && fileList.isResolved()) {
+                VirtualColumnInjector injector = buildInjector(driverContext);
+                List<String> projectedColumns = projectedColumns(injector);
+                startMultiFileRead(projectedColumns, buffer, driverContext, injector);
             } else {
-                startSyncWrapperRead(storageObject, projectedColumns, buffer, driverContext, injector);
+                VirtualColumnInjector injector = buildInjector(driverContext);
+                List<String> projectedColumns = projectedColumns(injector);
+                StorageObject storageObject = storageProvider.newObject(path);
+                if (formatReader.supportsNativeAsync()) {
+                    startNativeAsyncRead(storageObject, projectedColumns, buffer, driverContext, injector);
+                } else {
+                    startSyncWrapperRead(storageObject, projectedColumns, buffer, driverContext, injector);
+                }
             }
-        }
 
-        return new AsyncExternalSourceOperator(buffer);
+            return new AsyncExternalSourceOperator(buffer);
+        } catch (Exception e) {
+            releaseOperator();
+            throw e;
+        }
     }
 
     private VirtualColumnInjector buildInjector(DriverContext driverContext) {
@@ -389,9 +417,11 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         ActionListener<Void> completionListener = ActionListener.assertOnce(ActionListener.wrap(v -> {
             buffer.finish(false);
             driverContext.removeAsyncAction();
+            releaseOperator();
         }, e -> {
             buffer.onFailure(e);
             driverContext.removeAsyncAction();
+            releaseOperator();
         }));
         ProducerState state = new ProducerState(sliceQueue, null, null, null, buffer, driverContext, rowLimit);
         try {
@@ -416,9 +446,11 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         ActionListener<Void> completionListener = ActionListener.assertOnce(ActionListener.wrap(v -> {
             buffer.finish(false);
             driverContext.removeAsyncAction();
+            releaseOperator();
         }, e -> {
             buffer.onFailure(e);
             driverContext.removeAsyncAction();
+            releaseOperator();
         }));
         ProducerState state = new ProducerState(null, fileList, projectedColumns, injector, buffer, driverContext, rowLimit);
         state.schemaInfo = schemaInfo;
@@ -746,6 +778,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         }, e -> {
             buffer.onFailure(e);
             driverContext.removeAsyncAction();
+            releaseOperator();
         }));
     }
 
@@ -792,6 +825,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 ActionListener.runAfter(ActionListener.wrap(v -> buffer.finish(false), e -> buffer.onFailure(e)), () -> {
                     closeQuietly(wrapped);
                     driverContext.removeAsyncAction();
+                    releaseOperator();
                 })
             );
         }));
@@ -807,6 +841,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             closeQuietly(pages);
             buffer.onFailure(e);
             driverContext.removeAsyncAction();
+            releaseOperator();
         });
         executor.execute(ActionRunnable.run(failureListener, () -> {
             CloseableIterator<Page> wrapped = wrapWithInjector(pages, injector);
@@ -817,6 +852,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 ActionListener.runAfter(ActionListener.wrap(v -> buffer.finish(false), e -> buffer.onFailure(e)), () -> {
                     closeQuietly(wrapped);
                     driverContext.removeAsyncAction();
+                    releaseOperator();
                 })
             );
         }));
@@ -888,13 +924,21 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         });
     }
 
+    private void releaseOperator() {
+        if (operatorRefCount.decrementAndGet() == 0 && onClose != null) {
+            closeQuietly(onClose);
+        }
+    }
+
+    private static void closeQuietly(Closeable closeable) {
+        if (closeable != null) {
+            IOUtils.closeWhileHandlingException(closeable);
+        }
+    }
+
     private static void closeQuietly(CloseableIterator<?> iterator) {
         if (iterator != null) {
-            try {
-                iterator.close();
-            } catch (Exception e) {
-                // Ignore - closeExpectNoException semantics
-            }
+            IOUtils.closeWhileHandlingException(iterator);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyBudgetAllocator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyBudgetAllocator.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages per-query concurrency budgets across active queries. Each registered query receives a
+ * fair share of the total concurrency budget ({@code max(MIN_PERMITS_PER_QUERY, totalBudget / activeQueries)}),
+ * dynamically rebalanced as queries register and deregister. When the total budget is 0
+ * (concurrency limiting disabled), all registrations return unlimited budgets.
+ */
+class ConcurrencyBudgetAllocator {
+
+    private static final Logger logger = LogManager.getLogger(ConcurrencyBudgetAllocator.class);
+
+    static final int MIN_PERMITS_PER_QUERY = 2;
+
+    private final int totalBudget;
+    private final long acquireTimeoutMs;
+    private final Set<QueryConcurrencyBudget> activeBudgets = ConcurrentHashMap.newKeySet();
+
+    ConcurrencyBudgetAllocator(int totalBudget, long acquireTimeoutMs) {
+        this.totalBudget = totalBudget;
+        this.acquireTimeoutMs = acquireTimeoutMs;
+    }
+
+    ConcurrencyBudgetAllocator(int totalBudget) {
+        this(totalBudget, 60_000L);
+    }
+
+    /**
+     * Registers a new query and returns its concurrency budget. Existing budgets are rebalanced
+     * to accommodate the new query.
+     */
+    QueryConcurrencyBudget register() {
+        if (totalBudget <= 0) {
+            return QueryConcurrencyBudget.UNLIMITED;
+        }
+        int perQuery = computePerQuery(activeBudgets.size() + 1);
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(perQuery, acquireTimeoutMs, this);
+        activeBudgets.add(budget);
+        rebalance();
+        logger.debug("Registered query budget, active queries [{}], per-query permits [{}]", activeBudgets.size(), perQuery);
+        return budget;
+    }
+
+    /**
+     * Removes a query's budget and rebalances remaining active budgets.
+     */
+    void deregister(QueryConcurrencyBudget budget) {
+        if (activeBudgets.remove(budget)) {
+            rebalance();
+            int count = activeBudgets.size();
+            logger.debug("Deregistered query budget, active queries [{}], per-query permits [{}]", count, computePerQuery(count));
+        }
+    }
+
+    private void rebalance() {
+        int count = activeBudgets.size();
+        if (count == 0) {
+            return;
+        }
+        int perQuery = computePerQuery(count);
+        for (QueryConcurrencyBudget budget : activeBudgets) {
+            if (budget.isClosed() == false) {
+                budget.updateMaxPermits(perQuery);
+            }
+        }
+    }
+
+    private int computePerQuery(int activeCount) {
+        if (activeCount <= 0) {
+            return totalBudget;
+        }
+        return Math.max(MIN_PERMITS_PER_QUERY, totalBudget / activeCount);
+    }
+
+    int activeQueryCount() {
+        return activeBudgets.size();
+    }
+
+    int totalBudget() {
+        return totalBudget;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyBudgetAllocator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyBudgetAllocator.java
@@ -14,10 +14,15 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Manages per-query concurrency budgets across active queries. Each registered query receives a
- * fair share of the total concurrency budget ({@code max(MIN_PERMITS_PER_QUERY, totalBudget / activeQueries)}),
- * dynamically rebalanced as queries register and deregister. When the total budget is 0
- * (concurrency limiting disabled), all registrations return unlimited budgets.
+ * Manages per-source-node concurrency budgets across active external-source operators. Each
+ * registered source plan node receives a fair share of the total concurrency budget
+ * ({@code max(MIN_PERMITS_PER_QUERY, totalBudget / activeCount)}), dynamically rebalanced as
+ * operators register and deregister. When the total budget is 0 (concurrency limiting disabled),
+ * all registrations return unlimited budgets.
+ *
+ * <p>Note: a single ESQL query with multiple external-file sources (joins, unions, LOOKUP, etc.)
+ * will register separate budgets for each source plan node. This is intentional — each source
+ * operates independently and may target different files/prefixes.
  */
 class ConcurrencyBudgetAllocator {
 
@@ -39,18 +44,18 @@ class ConcurrencyBudgetAllocator {
     }
 
     /**
-     * Registers a new query and returns its concurrency budget. Existing budgets are rebalanced
-     * to accommodate the new query.
+     * Registers a new source-node and returns its concurrency budget. Existing budgets are
+     * rebalanced to accommodate the new entrant.
      */
     QueryConcurrencyBudget register() {
         if (totalBudget <= 0) {
             return QueryConcurrencyBudget.UNLIMITED;
         }
-        int perQuery = computePerQuery(activeBudgets.size() + 1);
-        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(perQuery, acquireTimeoutMs, this);
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(MIN_PERMITS_PER_QUERY, acquireTimeoutMs, this);
         activeBudgets.add(budget);
         rebalance();
-        logger.debug("Registered query budget, active queries [{}], per-query permits [{}]", activeBudgets.size(), perQuery);
+        int count = activeBudgets.size();
+        logger.debug("Registered query budget, active sources [{}], per-source permits [{}]", count, computePerQuery(count));
         return budget;
     }
 
@@ -61,10 +66,16 @@ class ConcurrencyBudgetAllocator {
         if (activeBudgets.remove(budget)) {
             rebalance();
             int count = activeBudgets.size();
-            logger.debug("Deregistered query budget, active queries [{}], per-query permits [{}]", count, computePerQuery(count));
+            logger.debug("Deregistered query budget, active sources [{}], per-source permits [{}]", count, computePerQuery(count));
         }
     }
 
+    /**
+     * Rebalances permits across all active budgets. Iteration over the {@code ConcurrentHashMap}-backed
+     * set is weakly consistent — a concurrent register/deregister may or may not be visible. This is
+     * intentional: every register/deregister call invokes rebalance at the end, so convergence is
+     * guaranteed within one additional registration cycle.
+     */
     private void rebalance() {
         int count = activeBudgets.size();
         if (count == 0) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyLimitedStorageObject.java
@@ -160,7 +160,7 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
             throw new EsRejectedExecutionException("Failed to acquire concurrency permit for cloud API call: " + e.getMessage());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new EsRejectedExecutionException("Interrupted while waiting for concurrency permit");
+            throw new EsRejectedExecutionException("Interrupted while waiting for concurrency permit: " + e);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -21,8 +21,10 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
@@ -150,6 +152,14 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 ? format.filterPushdownSupport()
                 : null;
 
+            Closeable onClose = null;
+            ConcurrencyBudgetAllocator allocator = storageRegistry.allocatorForScheme(path.scheme().toLowerCase(Locale.ROOT));
+            if (allocator != null) {
+                QueryBudgetedStorageProvider budgeted = new QueryBudgetedStorageProvider(storage, allocator.register());
+                storage = budgeted;
+                onClose = budgeted;
+            }
+
             Executor readExecutor = context.fileReadExecutor() != null ? context.fileReadExecutor() : context.executor();
             return AsyncExternalSourceOperatorFactory.builder(
                 storage,
@@ -169,6 +179,7 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 .parsingParallelism(context.parsingParallelism())
                 .pushedExpressions(pushedExpressions)
                 .pushdownSupport(pushdownSupport)
+                .onClose(onClose)
                 .build();
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObject.java
@@ -164,7 +164,7 @@ class QueryBudgetedStorageObject implements StorageObject {
             throw new EsRejectedExecutionException("Failed to acquire query concurrency budget permit: " + e.getMessage());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new EsRejectedExecutionException("Interrupted while waiting for query concurrency budget permit");
+            throw new EsRejectedExecutionException("Interrupted while waiting for query concurrency budget permit: " + e);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObject.java
@@ -21,18 +21,22 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Decorates a {@link StorageObject} with concurrency limiting. Each I/O operation
- * acquires a permit before executing and releases it when the operation completes.
- * For stream-returning methods, the permit is released when the stream is closed.
+ * Decorates a {@link StorageObject} with per-query concurrency budget enforcement. Each I/O
+ * operation acquires a permit from the query's {@link QueryConcurrencyBudget} before delegating
+ * and releases it when the operation completes. For stream-returning methods, the permit is
+ * held until the stream is closed.
+ * <p>
+ * This wrapper is applied on top of the global {@link ConcurrencyLimitedStorageObject} to provide
+ * two-level concurrency control: per-query fairness (this layer) + global hard cap (inner layer).
  */
-class ConcurrencyLimitedStorageObject implements StorageObject {
+class QueryBudgetedStorageObject implements StorageObject {
 
     private final StorageObject delegate;
-    private final ConcurrencyLimiter limiter;
+    private final QueryConcurrencyBudget budget;
 
-    ConcurrencyLimitedStorageObject(StorageObject delegate, ConcurrencyLimiter limiter) {
+    QueryBudgetedStorageObject(StorageObject delegate, QueryConcurrencyBudget budget) {
         this.delegate = delegate;
-        this.limiter = limiter;
+        this.budget = budget;
     }
 
     @Override
@@ -40,9 +44,9 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
         acquirePermit();
         try {
             InputStream stream = delegate.newStream();
-            return new PermitReleasingInputStream(stream, limiter);
+            return new PermitReleasingInputStream(stream, budget);
         } catch (Exception e) {
-            limiter.release();
+            budget.release();
             throw e;
         }
     }
@@ -52,9 +56,9 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
         acquirePermit();
         try {
             InputStream stream = delegate.newStream(position, length);
-            return new PermitReleasingInputStream(stream, limiter);
+            return new PermitReleasingInputStream(stream, budget);
         } catch (Exception e) {
-            limiter.release();
+            budget.release();
             throw e;
         }
     }
@@ -65,7 +69,7 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
         try {
             return delegate.length();
         } finally {
-            limiter.release();
+            budget.release();
         }
     }
 
@@ -75,7 +79,7 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
         try {
             return delegate.lastModified();
         } finally {
-            limiter.release();
+            budget.release();
         }
     }
 
@@ -85,7 +89,7 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
         try {
             return delegate.exists();
         } finally {
-            limiter.release();
+            budget.release();
         }
     }
 
@@ -100,7 +104,7 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
         try {
             return delegate.readBytes(position, target);
         } finally {
-            limiter.release();
+            budget.release();
         }
     }
 
@@ -114,14 +118,14 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
         }
         try {
             delegate.readBytesAsync(position, length, executor, ActionListener.wrap(result -> {
-                limiter.release();
+                budget.release();
                 listener.onResponse(result);
             }, e -> {
-                limiter.release();
+                budget.release();
                 listener.onFailure(e);
             }));
         } catch (Exception e) {
-            limiter.release();
+            budget.release();
             listener.onFailure(e);
         }
     }
@@ -136,14 +140,14 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
         }
         try {
             delegate.readBytesAsync(position, target, executor, ActionListener.wrap(result -> {
-                limiter.release();
+                budget.release();
                 listener.onResponse(result);
             }, e -> {
-                limiter.release();
+                budget.release();
                 listener.onFailure(e);
             }));
         } catch (Exception e) {
-            limiter.release();
+            budget.release();
             listener.onFailure(e);
         }
     }
@@ -155,25 +159,22 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
 
     private void acquirePermit() {
         try {
-            limiter.acquire();
+            budget.acquire();
         } catch (TimeoutException e) {
-            throw new EsRejectedExecutionException("Failed to acquire concurrency permit for cloud API call: " + e.getMessage());
+            throw new EsRejectedExecutionException("Failed to acquire query concurrency budget permit: " + e.getMessage());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new EsRejectedExecutionException("Interrupted while waiting for concurrency permit");
+            throw new EsRejectedExecutionException("Interrupted while waiting for query concurrency budget permit");
         }
     }
 
-    /**
-     * InputStream wrapper that releases the concurrency permit when closed.
-     */
     private static class PermitReleasingInputStream extends FilterInputStream {
-        private final ConcurrencyLimiter limiter;
+        private final QueryConcurrencyBudget budget;
         private boolean released;
 
-        PermitReleasingInputStream(InputStream in, ConcurrencyLimiter limiter) {
+        PermitReleasingInputStream(InputStream in, QueryConcurrencyBudget budget) {
             super(in);
-            this.limiter = limiter;
+            this.budget = budget;
         }
 
         @Override
@@ -183,7 +184,7 @@ class ConcurrencyLimitedStorageObject implements StorageObject {
             } finally {
                 if (released == false) {
                     released = true;
-                    limiter.release();
+                    budget.release();
                 }
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Decorates a {@link StorageProvider} with per-query concurrency budget enforcement. Each
+ * {@link StorageObject} created by this provider is wrapped with a {@link QueryBudgetedStorageObject}
+ * that acquires from the query's {@link QueryConcurrencyBudget} before each I/O operation.
+ * <p>
+ * Implements {@link Closeable} to release the query's budget when the query completes.
+ * Closing this provider closes the underlying budget, which deregisters from the
+ * {@link ConcurrencyBudgetAllocator} and triggers rebalancing of remaining active queries.
+ */
+class QueryBudgetedStorageProvider implements StorageProvider, Closeable {
+
+    private final StorageProvider delegate;
+    private final QueryConcurrencyBudget budget;
+
+    QueryBudgetedStorageProvider(StorageProvider delegate, QueryConcurrencyBudget budget) {
+        this.delegate = delegate;
+        this.budget = budget;
+    }
+
+    @Override
+    public StorageObject newObject(StoragePath path) {
+        return new QueryBudgetedStorageObject(delegate.newObject(path), budget);
+    }
+
+    @Override
+    public StorageObject newObject(StoragePath path, long length) {
+        return new QueryBudgetedStorageObject(delegate.newObject(path, length), budget);
+    }
+
+    @Override
+    public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+        return new QueryBudgetedStorageObject(delegate.newObject(path, length, lastModified), budget);
+    }
+
+    @Override
+    public StorageIterator listObjects(StoragePath prefix, boolean recursive) throws IOException {
+        return delegate.listObjects(prefix, recursive);
+    }
+
+    @Override
+    public boolean exists(StoragePath path) throws IOException {
+        return delegate.exists(path);
+    }
+
+    @Override
+    public List<String> supportedSchemes() {
+        return delegate.supportedSchemes();
+    }
+
+    @Override
+    public void close() throws IOException {
+        budget.close();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageProvider.java
@@ -11,7 +11,6 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
@@ -21,11 +20,11 @@ import java.util.List;
  * {@link StorageObject} created by this provider is wrapped with a {@link QueryBudgetedStorageObject}
  * that acquires from the query's {@link QueryConcurrencyBudget} before each I/O operation.
  * <p>
- * Implements {@link Closeable} to release the query's budget when the query completes.
+ * Implements {@link java.io.Closeable} to release the query's budget when the query completes.
  * Closing this provider closes the underlying budget, which deregisters from the
  * {@link ConcurrencyBudgetAllocator} and triggers rebalancing of remaining active queries.
  */
-class QueryBudgetedStorageProvider implements StorageProvider, Closeable {
+class QueryBudgetedStorageProvider implements StorageProvider {
 
     private final StorageProvider delegate;
     private final QueryConcurrencyBudget budget;
@@ -65,6 +64,10 @@ class QueryBudgetedStorageProvider implements StorageProvider, Closeable {
         return delegate.supportedSchemes();
     }
 
+    /**
+     * Closes the per-query budget only; the delegate provider is shared (registry-owned) and
+     * intentionally not closed here.
+     */
     @Override
     public void close() throws IOException {
         budget.close();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryConcurrencyBudget.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryConcurrencyBudget.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Per-query concurrency budget that limits the number of concurrent in-flight storage API requests
+ * for a single query. Budgets are dynamically resizable: the {@link ConcurrencyBudgetAllocator}
+ * adjusts each budget's max permits as queries start and finish to maintain fair-share allocation.
+ */
+class QueryConcurrencyBudget implements Closeable {
+
+    private static final Logger logger = LogManager.getLogger(QueryConcurrencyBudget.class);
+
+    private final ReentrantLock lock = new ReentrantLock(true);
+    private final Condition permitAvailable = lock.newCondition();
+    private int inFlight;
+    private volatile int maxPermits;
+    private final long acquireTimeoutMs;
+    private final ConcurrencyBudgetAllocator allocator;
+    private volatile boolean closed;
+
+    private final AtomicLong lastWarnLogTime = new AtomicLong(0);
+    private static final long WARN_LOG_INTERVAL_MS = 30_000;
+    private static final long WARN_WAIT_THRESHOLD_MS = 5_000;
+
+    static final QueryConcurrencyBudget UNLIMITED = new QueryConcurrencyBudget(0, 60_000L, null);
+
+    QueryConcurrencyBudget(int maxPermits, long acquireTimeoutMs, ConcurrencyBudgetAllocator allocator) {
+        this.maxPermits = maxPermits;
+        this.acquireTimeoutMs = acquireTimeoutMs;
+        this.allocator = allocator;
+    }
+
+    /**
+     * Acquires a permit, blocking if the query is at its budget limit. Throws immediately if the
+     * budget has been closed.
+     */
+    void acquire() throws TimeoutException, InterruptedException {
+        if (maxPermits <= 0) {
+            return;
+        }
+        if (closed) {
+            throw new TimeoutException("Budget is closed");
+        }
+        long startNanos = System.nanoTime();
+        lock.lock();
+        try {
+            long deadline = System.currentTimeMillis() + acquireTimeoutMs;
+            while (inFlight >= maxPermits) {
+                if (closed) {
+                    throw new TimeoutException("Budget was closed while waiting for permit");
+                }
+                long waitMs = deadline - System.currentTimeMillis();
+                if (waitMs <= 0) {
+                    throw new TimeoutException(
+                        "Timed out waiting for query concurrency budget permit after ["
+                            + acquireTimeoutMs
+                            + "]ms (max permits ["
+                            + maxPermits
+                            + "])"
+                    );
+                }
+                permitAvailable.await(waitMs, TimeUnit.MILLISECONDS);
+            }
+            if (closed) {
+                throw new TimeoutException("Budget was closed while waiting for permit");
+            }
+            inFlight++;
+        } finally {
+            lock.unlock();
+        }
+        long waitMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        if (waitMs > WARN_WAIT_THRESHOLD_MS) {
+            long lastWarn = lastWarnLogTime.get();
+            long now = System.currentTimeMillis();
+            if (now - lastWarn > WARN_LOG_INTERVAL_MS && lastWarnLogTime.compareAndSet(lastWarn, now)) {
+                logger.warn(
+                    "per-query storage API request waited [{}]ms for concurrency budget permit (max permits [{}])",
+                    waitMs,
+                    maxPermits
+                );
+            }
+        }
+    }
+
+    /**
+     * Releases a permit, waking one blocked acquirer.
+     */
+    void release() {
+        if (maxPermits <= 0) {
+            return;
+        }
+        lock.lock();
+        try {
+            if (inFlight > 0) {
+                inFlight--;
+            }
+            permitAvailable.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Dynamically adjusts the maximum permits. Only signals blocked acquirers when the budget
+     * increases to avoid thundering herd on shrink.
+     */
+    void updateMaxPermits(int newMax) {
+        int old = maxPermits;
+        maxPermits = newMax;
+        if (newMax > old) {
+            lock.lock();
+            try {
+                permitAvailable.signalAll();
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    int inFlight() {
+        lock.lock();
+        try {
+            return inFlight;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    int maxPermits() {
+        return maxPermits;
+    }
+
+    boolean isClosed() {
+        return closed;
+    }
+
+    boolean isEnabled() {
+        return maxPermits > 0;
+    }
+
+    /**
+     * Closes the budget, unblocking any waiting acquirers and deregistering from the allocator.
+     */
+    @Override
+    public void close() {
+        closed = true;
+        lock.lock();
+        try {
+            permitAvailable.signalAll();
+        } finally {
+            lock.unlock();
+        }
+        if (allocator != null) {
+            allocator.deregister(this);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryConcurrencyBudget.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/QueryConcurrencyBudget.java
@@ -38,6 +38,9 @@ class QueryConcurrencyBudget implements Closeable {
     private static final long WARN_LOG_INTERVAL_MS = 30_000;
     private static final long WARN_WAIT_THRESHOLD_MS = 5_000;
 
+    // Shared singleton for the disabled/unlimited case. Because acquire() short-circuits on
+    // maxPermits <= 0, none of the mutable state (lock, condition, closed) is ever exercised.
+    // Closing this instance is harmless (and must remain so).
     static final QueryConcurrencyBudget UNLIMITED = new QueryConcurrencyBudget(0, 60_000L, null);
 
     QueryConcurrencyBudget(int maxPermits, long acquireTimeoutMs, ConcurrencyBudgetAllocator allocator) {
@@ -58,15 +61,15 @@ class QueryConcurrencyBudget implements Closeable {
             throw new TimeoutException("Budget is closed");
         }
         long startNanos = System.nanoTime();
+        long deadlineNanos = startNanos + TimeUnit.MILLISECONDS.toNanos(acquireTimeoutMs);
         lock.lock();
         try {
-            long deadline = System.currentTimeMillis() + acquireTimeoutMs;
             while (inFlight >= maxPermits) {
                 if (closed) {
                     throw new TimeoutException("Budget was closed while waiting for permit");
                 }
-                long waitMs = deadline - System.currentTimeMillis();
-                if (waitMs <= 0) {
+                long waitNanos = deadlineNanos - System.nanoTime();
+                if (waitNanos <= 0) {
                     throw new TimeoutException(
                         "Timed out waiting for query concurrency budget permit after ["
                             + acquireTimeoutMs
@@ -75,7 +78,7 @@ class QueryConcurrencyBudget implements Closeable {
                             + "])"
                     );
                 }
-                permitAvailable.await(waitMs, TimeUnit.MILLISECONDS);
+                permitAvailable.awaitNanos(waitNanos);
             }
             if (closed) {
                 throw new TimeoutException("Budget was closed while waiting for permit");
@@ -99,7 +102,8 @@ class QueryConcurrencyBudget implements Closeable {
     }
 
     /**
-     * Releases a permit, waking one blocked acquirer.
+     * Releases a permit, waking one blocked acquirer. Must be paired with a preceding
+     * successful {@link #acquire()}.
      */
     void release() {
         if (maxPermits <= 0) {
@@ -107,6 +111,7 @@ class QueryConcurrencyBudget implements Closeable {
         }
         lock.lock();
         try {
+            assert inFlight > 0 : "release() called without a matching acquire(), inFlight=" + inFlight;
             if (inFlight > 0) {
                 inFlight--;
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageProviderRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageProviderRegistry.java
@@ -52,6 +52,7 @@ public class StorageProviderRegistry implements Closeable {
     private final List<StorageProvider> createdProviders = new ArrayList<>();
 
     private final Map<String, ConcurrencyLimiter> limiters = new ConcurrentHashMap<>();
+    private final Map<String, ConcurrencyBudgetAllocator> allocators = new ConcurrentHashMap<>();
     private final Map<String, AdaptiveBackoff> backoffs = new ConcurrentHashMap<>();
 
     private final Settings settings;
@@ -137,6 +138,21 @@ public class StorageProviderRegistry implements Closeable {
         RetryPolicy retryPolicy = buildRetryPolicy(backoff);
         StorageProvider limited = new ConcurrencyLimitedStorageProvider(provider, limiter);
         return new RetryableStorageProvider(limited, retryPolicy);
+    }
+
+    /**
+     * Returns a per-query concurrency budget allocator for the given scheme, or {@code null}
+     * if per-query budgeting is not applicable (file scheme or concurrency limiting disabled).
+     */
+    public ConcurrencyBudgetAllocator allocatorForScheme(String scheme) {
+        if ("file".equals(scheme)) {
+            return null;
+        }
+        int permits = maxConcurrentRequests;
+        if (permits <= 0) {
+            return null;
+        }
+        return allocators.computeIfAbsent(scheme, k -> new ConcurrencyBudgetAllocator(permits));
     }
 
     private ConcurrencyLimiter limiterForScheme(String scheme) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyBudgetAllocatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ConcurrencyBudgetAllocatorTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class ConcurrencyBudgetAllocatorTests extends ESTestCase {
+
+    public void testSingleQueryGetsFullBudget() {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(50);
+        QueryConcurrencyBudget budget = allocator.register();
+        assertEquals(50, budget.maxPermits());
+        assertEquals(1, allocator.activeQueryCount());
+        budget.close();
+    }
+
+    public void testTwoQueriesGetHalf() {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(50);
+        QueryConcurrencyBudget b1 = allocator.register();
+        QueryConcurrencyBudget b2 = allocator.register();
+
+        assertEquals(2, allocator.activeQueryCount());
+        assertEquals(25, b1.maxPermits());
+        assertEquals(25, b2.maxPermits());
+
+        b1.close();
+        b2.close();
+    }
+
+    public void testFiveQueriesGetTenEach() {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(50);
+        QueryConcurrencyBudget[] budgets = new QueryConcurrencyBudget[5];
+        for (int i = 0; i < 5; i++) {
+            budgets[i] = allocator.register();
+        }
+        assertEquals(5, allocator.activeQueryCount());
+        for (QueryConcurrencyBudget b : budgets) {
+            assertEquals(10, b.maxPermits());
+        }
+        for (QueryConcurrencyBudget b : budgets) {
+            b.close();
+        }
+    }
+
+    public void testMinPermitsFloor() {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(10);
+        QueryConcurrencyBudget[] budgets = new QueryConcurrencyBudget[50];
+        for (int i = 0; i < 50; i++) {
+            budgets[i] = allocator.register();
+        }
+        assertEquals(50, allocator.activeQueryCount());
+        for (QueryConcurrencyBudget b : budgets) {
+            assertEquals(ConcurrencyBudgetAllocator.MIN_PERMITS_PER_QUERY, b.maxPermits());
+        }
+        for (QueryConcurrencyBudget b : budgets) {
+            b.close();
+        }
+    }
+
+    public void testRebalanceOnDeregister() {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(50);
+        QueryConcurrencyBudget b1 = allocator.register();
+        QueryConcurrencyBudget b2 = allocator.register();
+        assertEquals(25, b1.maxPermits());
+        assertEquals(25, b2.maxPermits());
+
+        b1.close();
+        assertEquals(1, allocator.activeQueryCount());
+        assertEquals(50, b2.maxPermits());
+
+        b2.close();
+    }
+
+    public void testDisabledWithZeroBudget() {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(0);
+        QueryConcurrencyBudget budget = allocator.register();
+        assertSame(QueryConcurrencyBudget.UNLIMITED, budget);
+        assertFalse(budget.isEnabled());
+        assertEquals(0, allocator.activeQueryCount());
+    }
+
+    public void testRegisterDeregisterCycle() {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(50);
+
+        QueryConcurrencyBudget b1 = allocator.register();
+        assertEquals(50, b1.maxPermits());
+        assertEquals(1, allocator.activeQueryCount());
+
+        QueryConcurrencyBudget b2 = allocator.register();
+        assertEquals(25, b1.maxPermits());
+        assertEquals(25, b2.maxPermits());
+
+        QueryConcurrencyBudget b3 = allocator.register();
+        assertEquals(16, b1.maxPermits());
+        assertEquals(16, b2.maxPermits());
+        assertEquals(16, b3.maxPermits());
+
+        b2.close();
+        assertEquals(25, b1.maxPermits());
+        assertEquals(25, b3.maxPermits());
+
+        b1.close();
+        assertEquals(50, b3.maxPermits());
+
+        b3.close();
+        assertEquals(0, allocator.activeQueryCount());
+    }
+
+    public void testDoubleDeregister() {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(50);
+        QueryConcurrencyBudget budget = allocator.register();
+        assertEquals(1, allocator.activeQueryCount());
+
+        budget.close();
+        assertEquals(0, allocator.activeQueryCount());
+
+        // Double close should be safe
+        budget.close();
+        assertEquals(0, allocator.activeQueryCount());
+    }
+
+    public void testTotalBudget() {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(42);
+        assertEquals(42, allocator.totalBudget());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/QueryBudgetedStorageObjectTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class QueryBudgetedStorageObjectTests extends ESTestCase {
+
+    public void testStreamCloseReleasesBudget() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(3, 60_000L, null);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.newStream()).thenReturn(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)));
+        when(delegate.path()).thenReturn(StoragePath.of("s3://bucket/key"));
+
+        QueryBudgetedStorageObject obj = new QueryBudgetedStorageObject(delegate, budget);
+        assertEquals(0, budget.inFlight());
+
+        InputStream stream = obj.newStream();
+        assertEquals(1, budget.inFlight());
+
+        stream.close();
+        assertEquals(0, budget.inFlight());
+    }
+
+    public void testStreamDoubleCloseIsSafe() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(3, 60_000L, null);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.newStream()).thenReturn(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)));
+
+        QueryBudgetedStorageObject obj = new QueryBudgetedStorageObject(delegate, budget);
+        InputStream stream = obj.newStream();
+        stream.close();
+        stream.close();
+        assertEquals(0, budget.inFlight());
+    }
+
+    public void testReadBytesReleasesOnException() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(3, 60_000L, null);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.readBytes(anyLong(), any(ByteBuffer.class))).thenThrow(new IOException("read error"));
+
+        QueryBudgetedStorageObject obj = new QueryBudgetedStorageObject(delegate, budget);
+        expectThrows(IOException.class, () -> obj.readBytes(0, ByteBuffer.allocate(10)));
+        assertEquals(0, budget.inFlight());
+    }
+
+    public void testLengthReleasesBudget() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(3, 60_000L, null);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.length()).thenReturn(42L);
+
+        QueryBudgetedStorageObject obj = new QueryBudgetedStorageObject(delegate, budget);
+        assertEquals(42L, obj.length());
+        assertEquals(0, budget.inFlight());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testAsyncReadReleasesBudgetOnSuccess() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(3, 60_000L, null);
+        StorageObject delegate = mock(StorageObject.class);
+        ByteBuffer result = ByteBuffer.wrap("data".getBytes(StandardCharsets.UTF_8));
+        doAnswer(inv -> {
+            ActionListener<ByteBuffer> listener = inv.getArgument(3);
+            listener.onResponse(result);
+            return null;
+        }).when(delegate).readBytesAsync(anyLong(), anyLong(), any(), any(ActionListener.class));
+
+        QueryBudgetedStorageObject obj = new QueryBudgetedStorageObject(delegate, budget);
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ByteBuffer> response = new AtomicReference<>();
+
+        obj.readBytesAsync(0, 4, Runnable::run, ActionListener.wrap(r -> {
+            response.set(r);
+            latch.countDown();
+        }, e -> latch.countDown()));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertSame(result, response.get());
+        assertEquals(0, budget.inFlight());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testAsyncReadReleasesBudgetOnFailure() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(3, 60_000L, null);
+        StorageObject delegate = mock(StorageObject.class);
+        doAnswer(inv -> {
+            ActionListener<ByteBuffer> listener = inv.getArgument(3);
+            listener.onFailure(new IOException("async error"));
+            return null;
+        }).when(delegate).readBytesAsync(anyLong(), anyLong(), any(), any(ActionListener.class));
+
+        QueryBudgetedStorageObject obj = new QueryBudgetedStorageObject(delegate, budget);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        obj.readBytesAsync(0, 4, Runnable::run, ActionListener.wrap(r -> latch.countDown(), e -> latch.countDown()));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals(0, budget.inFlight());
+    }
+
+    public void testNewStreamReleasesOnDelegateException() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(3, 60_000L, null);
+        StorageObject delegate = mock(StorageObject.class);
+        when(delegate.newStream()).thenThrow(new IOException("connection refused"));
+
+        QueryBudgetedStorageObject obj = new QueryBudgetedStorageObject(delegate, budget);
+        expectThrows(IOException.class, obj::newStream);
+        assertEquals(0, budget.inFlight());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/QueryConcurrencyBudgetTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/QueryConcurrencyBudgetTests.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class QueryConcurrencyBudgetTests extends ESTestCase {
+
+    public void testAcquireAndRelease() throws Exception {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(10);
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(5, 60_000L, allocator);
+        assertEquals(5, budget.maxPermits());
+        assertEquals(0, budget.inFlight());
+
+        budget.acquire();
+        assertEquals(1, budget.inFlight());
+
+        budget.release();
+        assertEquals(0, budget.inFlight());
+    }
+
+    public void testBlocksAtLimit() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(1, 60_000L, null);
+        budget.acquire();
+        assertEquals(1, budget.inFlight());
+
+        AtomicBoolean acquired = new AtomicBoolean(false);
+        CountDownLatch started = new CountDownLatch(1);
+        Thread blocker = new Thread(() -> {
+            started.countDown();
+            try {
+                budget.acquire();
+                acquired.set(true);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        blocker.start();
+        started.await(5, TimeUnit.SECONDS);
+
+        Thread.sleep(100);
+        assertFalse(acquired.get());
+
+        budget.release();
+        blocker.join(5000);
+        assertTrue(acquired.get());
+        budget.release();
+    }
+
+    public void testTimeoutThrows() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(1, 50L, null);
+        budget.acquire();
+
+        expectThrows(TimeoutException.class, budget::acquire);
+
+        budget.release();
+    }
+
+    public void testDynamicResizeUp() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(1, 60_000L, null);
+        budget.acquire();
+
+        AtomicBoolean acquired = new AtomicBoolean(false);
+        CountDownLatch started = new CountDownLatch(1);
+        Thread blocker = new Thread(() -> {
+            started.countDown();
+            try {
+                budget.acquire();
+                acquired.set(true);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        blocker.start();
+        started.await(5, TimeUnit.SECONDS);
+        Thread.sleep(100);
+        assertFalse(acquired.get());
+
+        budget.updateMaxPermits(2);
+        blocker.join(5000);
+        assertTrue(acquired.get());
+
+        budget.release();
+        budget.release();
+    }
+
+    public void testDynamicResizeDown() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(5, 60_000L, null);
+        budget.acquire();
+        budget.acquire();
+        assertEquals(2, budget.inFlight());
+
+        budget.updateMaxPermits(1);
+        assertEquals(2, budget.inFlight());
+        assertEquals(1, budget.maxPermits());
+
+        budget.release();
+        budget.release();
+    }
+
+    public void testAcquireOnClosedBudget() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(5, 60_000L, null);
+        budget.close();
+        assertTrue(budget.isClosed());
+
+        expectThrows(TimeoutException.class, budget::acquire);
+    }
+
+    public void testCloseWakesBlockedAcquirers() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(1, 60_000L, null);
+        budget.acquire();
+
+        AtomicReference<Exception> caught = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch finished = new CountDownLatch(1);
+        Thread blocker = new Thread(() -> {
+            started.countDown();
+            try {
+                budget.acquire();
+            } catch (Exception e) {
+                caught.set(e);
+            }
+            finished.countDown();
+        });
+        blocker.start();
+        started.await(5, TimeUnit.SECONDS);
+        Thread.sleep(100);
+
+        budget.close();
+        assertTrue(finished.await(5, TimeUnit.SECONDS));
+        assertNotNull(caught.get());
+        assertTrue(caught.get() instanceof TimeoutException);
+        assertTrue(caught.get().getMessage().contains("closed"));
+
+        budget.release();
+    }
+
+    public void testCloseDeregisters() throws Exception {
+        ConcurrencyBudgetAllocator allocator = new ConcurrencyBudgetAllocator(50);
+        QueryConcurrencyBudget budget = allocator.register();
+        assertEquals(1, allocator.activeQueryCount());
+
+        budget.close();
+        assertEquals(0, allocator.activeQueryCount());
+    }
+
+    public void testUnlimitedBudget() throws Exception {
+        assertFalse(QueryConcurrencyBudget.UNLIMITED.isEnabled());
+        assertEquals(0, QueryConcurrencyBudget.UNLIMITED.maxPermits());
+        QueryConcurrencyBudget.UNLIMITED.acquire();
+        QueryConcurrencyBudget.UNLIMITED.release();
+    }
+
+    public void testReleaseWithoutAcquire() {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(5, 60_000L, null);
+        budget.release();
+        assertEquals(0, budget.inFlight());
+    }
+
+    public void testConcurrentAcquireRelease() throws Exception {
+        QueryConcurrencyBudget budget = new QueryConcurrencyBudget(10, 60_000L, null);
+        int threadCount = 20;
+        int iterations = 100;
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch go = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        AtomicReference<Exception> failure = new AtomicReference<>();
+
+        for (int t = 0; t < threadCount; t++) {
+            new Thread(() -> {
+                ready.countDown();
+                try {
+                    go.await(10, TimeUnit.SECONDS);
+                    for (int i = 0; i < iterations; i++) {
+                        budget.acquire();
+                        Thread.yield();
+                        budget.release();
+                    }
+                } catch (Exception e) {
+                    failure.compareAndSet(null, e);
+                }
+                done.countDown();
+            }).start();
+        }
+        ready.await(10, TimeUnit.SECONDS);
+        go.countDown();
+        assertTrue(done.await(30, TimeUnit.SECONDS));
+        assertNull(failure.get());
+        assertEquals(0, budget.inFlight());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/QueryConcurrencyBudgetTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/QueryConcurrencyBudgetTests.java
@@ -15,6 +15,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class QueryConcurrencyBudgetTests extends ESTestCase {
 
     public void testAcquireAndRelease() throws Exception {
@@ -164,7 +166,8 @@ public class QueryConcurrencyBudgetTests extends ESTestCase {
 
     public void testReleaseWithoutAcquire() {
         QueryConcurrencyBudget budget = new QueryConcurrencyBudget(5, 60_000L, null);
-        budget.release();
+        AssertionError e = expectThrows(AssertionError.class, budget::release);
+        assertThat(e.getMessage(), containsString("release() called without a matching acquire()"));
         assertEquals(0, budget.inFlight());
     }
 


### PR DESCRIPTION
Prevent a single query from monopolizing all S3 connections on a node by
introducing a two-level concurrency permit system: per-query budgets for
fairness on top of the existing global ConcurrencyLimiter hard cap.

Each query gets a fair share of permits (totalBudget / activeQueries,
min 2) that is dynamically rebalanced as queries start and finish. A
single query gets the full budget; two queries each get half, etc.

Developed with AI-assisted tooling