### PR TITLE
[ESQL] Return null blocks for range fields with doc_values disabled

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.plain.BinaryIndexFieldData;
+import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.index.mapper.blockloader.docvalues.DateRangeDocValuesLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -354,13 +355,13 @@ public class RangeFieldMapper extends FieldMapper {
 
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
+            if (hasDocValues() == false) {
+                return ConstantNull.INSTANCE;
+            }
             if (rangeType != RangeType.DATE) {
                 throw new UnsupportedOperationException("loading blocks is only supported for date fields");
             }
-            if (hasDocValues()) {
-                return new DateRangeDocValuesLoader(name());
-            }
-            throw new IllegalStateException("Cannot load blocks without doc values");
+            return new DateRangeDocValuesLoader(name());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateRangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateRangeFieldMapperTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.AssumptionViolatedException;
@@ -134,6 +135,22 @@ public class DateRangeFieldMapperTests extends RangeFieldMapperTests {
                 }
             }
         }
+    }
+
+    /**
+     * Test that block loader returns constant nulls when doc_values is disabled.
+     * Querying a date_range field with doc_values:false should produce null values
+     * rather than throwing an exception.
+     */
+    public void testNoDocValuesBlockLoader() throws IOException {
+        MapperService mapper = createSytheticSourceMapperService(mapping(b -> {
+            b.startObject("field");
+            b.field("type", "date_range");
+            b.field("doc_values", false);
+            b.endObject();
+        }));
+        BlockLoader loader = mapper.fieldType("field").blockLoader(new DummyBlockLoaderContext.MapperServiceBlockLoaderContext(mapper));
+        assertSame(ConstantNull.INSTANCE, loader);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/IntegerRangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IntegerRangeFieldMapperTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.index.mapper.blockloader.ConstantNull;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.AssumptionViolatedException;
 
@@ -55,6 +56,38 @@ public class IntegerRangeFieldMapperTests extends RangeFieldMapperTests {
     @Override
     protected RangeType rangeType() {
         return RangeType.INTEGER;
+    }
+
+    /**
+     * Test that block loader returns constant nulls when doc_values is disabled for a non-DATE range type.
+     * This is the behavior after reordering the checks in {@code blockLoader}: doc_values is checked before
+     * range type, so a non-DATE range with doc_values disabled returns null rather than throwing.
+     */
+    public void testNoDocValuesBlockLoader() throws IOException {
+        MapperService mapper = createSytheticSourceMapperService(mapping(b -> {
+            b.startObject("field");
+            b.field("type", "integer_range");
+            b.field("doc_values", false);
+            b.endObject();
+        }));
+        BlockLoader loader = mapper.fieldType("field").blockLoader(new DummyBlockLoaderContext.MapperServiceBlockLoaderContext(mapper));
+        assertSame(ConstantNull.INSTANCE, loader);
+    }
+
+    /**
+     * Test that a non-DATE range type with doc_values enabled still throws UnsupportedOperationException,
+     * since only date_range supports block loading via doc values.
+     */
+    public void testBlockLoaderWithDocValues() throws IOException {
+        MapperService mapper = createSytheticSourceMapperService(mapping(b -> {
+            b.startObject("field");
+            b.field("type", "integer_range");
+            b.endObject();
+        }));
+        expectThrows(
+            UnsupportedOperationException.class,
+            () -> mapper.fieldType("field").blockLoader(new DummyBlockLoaderContext.MapperServiceBlockLoaderContext(mapper))
+        );
     }
 
     @Override

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -292,6 +292,28 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
         new Test("version").test(randomVersionString());
     }
 
+    /**
+     * Querying a date_range field with doc_values disabled should return null for every document
+     * rather than throwing an exception. Before the fix, this caused a full query failure because
+     * the block loader tried to access doc values that were not present.
+     */
+    public void testDateRangeNoDocValues() throws IOException {
+        assumeDateRangeFieldTypeSupported();
+        createIndex("test", index -> {
+            index.startObject("properties");
+            index.startObject("dates");
+            index.field("type", "date_range");
+            index.field("doc_values", false);
+            index.endObject();
+            index.endObject();
+        });
+        index("test", """
+            {"dates": {"gte": "2024-01-01", "lte": "2024-12-31"}}""");
+
+        Map<String, Object> result = runEsql("FROM test* | LIMIT 10");
+        assertResultMap(result, List.of(columnInfo("dates", "date_range")), List.of(matchesList().item(null)));
+    }
+
     public void testGeoPoint() throws IOException {
         new Test("geo_point")
             // TODO we should support loading geo_point from doc values if source isn't enabled
@@ -1520,6 +1542,12 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
         var capsName = EsqlCapabilities.Cap.REPORT_ORIGINAL_TYPES.name().toLowerCase(Locale.ROOT);
         boolean requiredClusterCapability = clusterHasCapability("POST", "/_query", List.of(), List.of(capsName)).orElse(false);
         assumeTrue("This test makes sense for versions that report original types", requiredClusterCapability);
+    }
+
+    private void assumeDateRangeFieldTypeSupported() throws IOException {
+        var capsName = EsqlCapabilities.Cap.DATE_RANGE_FIELD_TYPE_V2.name().toLowerCase(Locale.ROOT);
+        boolean requiredClusterCapability = clusterHasCapability("POST", "/_query", List.of(), List.of(capsName)).orElse(false);
+        assumeTrue("date_range field type not supported in this version", requiredClusterCapability);
     }
 
     private void assumeSuggestedCastReported() throws IOException {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -1545,7 +1545,7 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
     }
 
     private void assumeDateRangeFieldTypeSupported() throws IOException {
-        var capsName = EsqlCapabilities.Cap.DATE_RANGE_FIELD_TYPE_V2.name().toLowerCase(Locale.ROOT);
+        var capsName = EsqlCapabilities.Cap.DATE_RANGE_FIELD_TYPE_V3.name().toLowerCase(Locale.ROOT);
         boolean requiredClusterCapability = clusterHasCapability("POST", "/_query", List.of(), List.of(capsName)).orElse(false);
         assumeTrue("date_range field type not supported in this version", requiredClusterCapability);
     }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRandomMappingRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRandomMappingRestTest.java
@@ -58,11 +58,6 @@ public abstract class GenerativeRandomMappingRestTest extends GenerativeRestTest
 
     private static volatile List<GeneratedIndex> generatedIndices;
 
-    private static final Pattern CANNOT_LOAD_BLOCKS_WITHOUT_DOC_VALUES = Pattern.compile(
-        ".*Cannot load blocks without doc values.*",
-        Pattern.DOTALL
-    );
-
     // FORK converts UnsupportedAttribute to a plain ReferenceAttribute(UNSUPPORTED), stripping the
     // Unresolvable marker. Functions then reject the argument with a generic "type [unsupported]" error
     // instead of the proper "Cannot use field" message. https://github.com/elastic/elasticsearch/issues/147094
@@ -226,11 +221,6 @@ public abstract class GenerativeRandomMappingRestTest extends GenerativeRestTest
 
     private static boolean isAdditionalAllowedError(String errorMessage, String query) {
         if (errorMessage == null) return false;
-        // RangeFieldMapper throws "Cannot load blocks without doc values" for *_range fields
-        // with doc_values:false. https://github.com/elastic/elasticsearch/issues/146527
-        if (isAllowedError(errorMessage, CANNOT_LOAD_BLOCKS_WITHOUT_DOC_VALUES) && hasRangeFieldType()) {
-            return true;
-        }
         // FORK converts UnsupportedAttribute to ReferenceAttribute(UNSUPPORTED), causing functions
         // to reject the field with a generic "type [unsupported]" error.
         // https://github.com/elastic/elasticsearch/issues/147094
@@ -242,21 +232,6 @@ public abstract class GenerativeRandomMappingRestTest extends GenerativeRestTest
         // https://github.com/elastic/elasticsearch/issues/147610
         if (query != null && isAllowedError(errorMessage, FAILED_TO_CREATE_QUERY) && queryContainsFullTextFunction(query)) {
             return true;
-        }
-        return false;
-    }
-
-    private static boolean hasRangeFieldType() {
-        List<GeneratedIndex> indices = generatedIndices;
-        if (indices == null) {
-            return false;
-        }
-        for (GeneratedIndex idx : indices) {
-            for (RandomMappingGenerator.FieldDef field : idx.fields()) {
-                if (field.esType().endsWith("_range")) {
-                    return true;
-                }
-            }
         }
         return false;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1797,8 +1797,9 @@ public class EsqlCapabilities {
 
         /**
          * Support for the DATE_RANGE field type, RANGE_WITHIN, TO_DATE_RANGE(string), RANGE_MIN, RANGE_MAX.
+         * V3: DATE_RANGE fields with {@code doc_values: false} now return null instead of throwing an exception.
          */
-        DATE_RANGE_FIELD_TYPE_V2(Build.current().isSnapshot()),
+        DATE_RANGE_FIELD_TYPE_V3(Build.current().isSnapshot()),
 
         /**
          * Network direction function.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -4406,7 +4406,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
         try (XContentBuilder report = JsonXContent.contentBuilder().humanReadable(true).prettyPrint().lfAtEnd()) {
             report.startObject();
             List<String> namesAndAliases = new ArrayList<>(DataType.namesAndAliases());
-            if (EsqlCapabilities.Cap.DATE_RANGE_FIELD_TYPE_V2.isEnabled() == false) {
+            if (EsqlCapabilities.Cap.DATE_RANGE_FIELD_TYPE_V3.isEnabled() == false) {
                 // Some types do not have a converter function if the capability is disabled
                 namesAndAliases.removeAll(List.of("date_range"));
             }


### PR DESCRIPTION
`RangeFieldMapper.blockLoader()` was throwing `IllegalStateException("Cannot load blocks without doc values")` when querying a `*_range` field whose `doc_values` is disabled. This caused ES|QL queries to fail with unexpected partial results instead of returning nulls for those fields.

- `RangeFieldMapper.blockLoader()` now returns `ConstantNull.INSTANCE` when `doc_values` is disabled, consistent with how other field types handle this case.
- Removes the `CANNOT_LOAD_BLOCKS_WITHOUT_DOC_VALUES` / `hasRangeFieldType()` workaround from `GenerativeRandomMappingRestTest` that was suppressing these errors.
- Adds `testNoDocValuesBlockLoader()` to `DateRangeFieldMapperTests` to cover the fixed behaviour.

Closes #146527.
