### PR TITLE
Support indexPatterns for resolved views for CPS

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ResolvedView.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ResolvedView.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.view;
+
+/**
+ * Information about a view that was concretely resolved during view resolution.
+ * <p>
+ * The {@code indexPattern} field is a comma-separated index expression suitable for use as a
+ * field-caps target. It includes the view name followed by any exclusion patterns that appeared
+ * <em>after</em> the view's referencing position in the parent UR — exclusions earlier in the
+ * pattern list do not apply, since index resolution processes patterns left-to-right and an
+ * exclusion only narrows the indices accumulated up to that point.
+ * <p>
+ * Example: given {@code v1 = FROM v2,metrics*,-*2025}, when resolving {@code v1}'s body the parent
+ * pattern is {@code v2,metrics*,-*2025}. The view {@code v2} appears at position 0, and the only
+ * later exclusion is {@code -*2025}, so {@code v2}'s {@code indexPattern} is {@code "v2,-*2025"} —
+ * matching the lenient call {@code field-caps-lenient(v2,-*2025)} from
+ * <a href="https://github.com/elastic/esql-planning/issues/543">esql-planning#543</a>.
+ * <p>
+ * Position-aware example: given {@code FROM v_a,-staleA-*,v_b,-staleB-*}, the indexPattern for
+ * {@code v_a} is {@code "v_a,-staleA-*,-staleB-*"} (both later exclusions apply) and for
+ * {@code v_b} is {@code "v_b,-staleB-*"} (only the trailing exclusion applies — {@code -staleA-*}
+ * comes before {@code v_b} in the pattern list and does not affect it).
+ */
+public record ResolvedView(String name, String query, String indexPattern) {
+    public ResolvedView(String name, String query) {
+        this(name, query, name);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/view/ViewResolver.java
@@ -105,9 +105,29 @@ public class ViewResolver {
     }
 
     /**
-     * Result of view resolution containing both the rewritten plan and the view queries.
+     * Result of view resolution containing the rewritten plan and metadata about the views that were
+     * concretely resolved while building it.
+     * <p>
+     * {@link #resolvedViews} maps each resolved view name to a {@link ResolvedView} carrying the view's
+     * query body and any exclusion patterns from its parent referencing UR. The latter is what CPS
+     * needs to issue per-view field-caps lenient calls that mirror the local exclusion scope (see
+     * <a href="https://github.com/elastic/esql-planning/issues/543">esql-planning#543</a>).
+     * <p>
+     * {@link #viewQueries()} is provided for callers that only need the {@code name -> query} mapping
+     * (for example, source-text deserialization via {@code Configuration.viewQueries}).
      */
-    public record ViewResolutionResult(LogicalPlan plan, Map<String, String> viewQueries) {}
+    public record ViewResolutionResult(LogicalPlan plan, Map<String, ResolvedView> resolvedViews) {
+        /**
+         * Convenience projection of {@link #resolvedViews} to {@code name -> query}.
+         */
+        public Map<String, String> viewQueries() {
+            Map<String, String> queries = new HashMap<>(resolvedViews.size());
+            for (ResolvedView rv : resolvedViews.values()) {
+                queries.put(rv.name(), rv.query());
+            }
+            return queries;
+        }
+    }
 
     /**
      * Replaces views in the logical plan with their subqueries recursively.
@@ -134,16 +154,16 @@ public class ViewResolver {
         BiFunction<String, String, LogicalPlan> parser,
         ActionListener<ViewResolutionResult> listener
     ) {
-        Map<String, String> viewQueries = new HashMap<>();
+        Map<String, ResolvedView> resolvedViews = new LinkedHashMap<>();
         if (viewsFeatureEnabled() == false || getMetadata().views().isEmpty()) {
-            listener.onResponse(new ViewResolutionResult(plan, viewQueries));
+            listener.onResponse(new ViewResolutionResult(plan, resolvedViews));
             return;
         }
-        replaceViews(plan, parser, new LinkedHashSet<>(), viewQueries, 0, listener.delegateFailureAndWrap((l, rewritten) -> {
+        replaceViews(plan, parser, new LinkedHashSet<>(), resolvedViews, 0, listener.delegateFailureAndWrap((l, rewritten) -> {
             LogicalPlan postProcessed = rewriteUnionAllsWithNamedSubqueries(rewritten);
             postProcessed = compactNestedViewUnionAlls(postProcessed);
             postProcessed = postProcessed.transformDown(NamedSubquery.class, UnaryPlan::child);
-            listener.onResponse(new ViewResolutionResult(postProcessed, viewQueries));
+            listener.onResponse(new ViewResolutionResult(postProcessed, resolvedViews));
         }));
     }
 
@@ -151,7 +171,7 @@ public class ViewResolver {
         LogicalPlan plan,
         BiFunction<String, String, LogicalPlan> parser,
         LinkedHashSet<String> seenViews,
-        Map<String, String> viewQueries,
+        Map<String, ResolvedView> resolvedViews,
         int depth,
         ActionListener<LogicalPlan> listener
     ) {
@@ -179,7 +199,7 @@ public class ViewResolver {
                     return;
                 }
                 case Fork fork -> {
-                    replaceViewsFork(fork, parser, seenInner, viewQueries, depth, planListener.delegateFailureAndWrap((l, result) -> {
+                    replaceViewsFork(fork, parser, seenInner, resolvedViews, depth, planListener.delegateFailureAndWrap((l, result) -> {
                         plan.forEachDown(resolvedPlans::add);
                         result.forEachDown(resolvedPlans::add);
                         l.onResponse(result);
@@ -192,7 +212,7 @@ public class ViewResolver {
                         parser,
                         seenInner,
                         seenWildcards,
-                        viewQueries,
+                        resolvedViews,
                         depth,
                         planListener.delegateFailureAndWrap((l, result) -> {
                             plan.forEachDown(resolvedPlans::add);
@@ -215,7 +235,7 @@ public class ViewResolver {
         Fork fork,
         BiFunction<String, String, LogicalPlan> parser,
         LinkedHashSet<String> seenViews,
-        Map<String, String> viewQueries,
+        Map<String, ResolvedView> resolvedViews,
         int depth,
         ActionListener<LogicalPlan> listener
     ) {
@@ -229,7 +249,7 @@ public class ViewResolver {
                     subplan,
                     parser,
                     seenViews,
-                    viewQueries,
+                    resolvedViews,
                     depth + 1,
                     l.delegateFailureAndWrap((subListener, newPlan) -> {
                         if (newPlan instanceof Subquery sq && sq.child() instanceof NamedSubquery named) {
@@ -262,7 +282,7 @@ public class ViewResolver {
         BiFunction<String, String, LogicalPlan> parser,
         LinkedHashSet<String> seenViews,
         HashSet<String> seenWildcards,
-        Map<String, String> viewQueries,
+        Map<String, ResolvedView> resolvedViews,
         int depth,
         ActionListener<LogicalPlan> listener
     ) {
@@ -284,6 +304,14 @@ public class ViewResolver {
             }
         }
 
+        // For each position in the parent UR's pattern list, the exclusion patterns that appear
+        // strictly after it. Index resolution is left-to-right: an exclusion only narrows what's
+        // already been accumulated, so a view referenced at position i is only affected by
+        // exclusions at positions > i. Per esql-planning#543, CPS uses the per-view indexPattern
+        // (view name + applicable later exclusions) as the target for its lenient field-caps call.
+        String[] urPatterns = unresolvedRelation.indexPattern().indexPattern().split(",");
+        List<List<String>> exclusionsAfter = computeExclusionsAfterByPosition(urPatterns);
+
         var req = new EsqlResolveViewAction.Request(REST_MASTER_TIMEOUT_DEFAULT);
         req.indices(patterns);
 
@@ -293,7 +321,12 @@ public class ViewResolver {
                 return;
             }
 
-            final HashMap<String, ViewPlan> resolvedViews = new HashMap<>();
+            // Map each resolved view name to the earliest position in urPatterns at which it was
+            // matched (broadest applicable-exclusion set). Earliest-position wins so we don't drop
+            // exclusions that the user wrote after a wildcard match of the same view.
+            Map<String, Integer> viewToEarliestPosition = computeViewToEarliestPosition(urPatterns, response);
+
+            final HashMap<String, ViewPlan> resolvedViewPlans = new HashMap<>();
             final LinkedHashSet<String> ancestorViews = new LinkedHashSet<>(seenViews);
             SubscribableListener<Void> chain = SubscribableListener.newForked(l2 -> l2.onResponse(null));
             for (var view : response.views()) {
@@ -301,22 +334,31 @@ public class ViewResolver {
                     // Make sure we don't block sibling branches from containing the same views
                     LinkedHashSet<String> branchSeenViews = new LinkedHashSet<>(ancestorViews);
                     validateViewReferenceAndMarkSeen(view.name(), branchSeenViews);
+                    // Record this view with its position-aware indexPattern before recursing into its
+                    // body — ensures even a circular-reference failure deeper in the tree still leaves
+                    // the already-discovered views visible to consumers.
+                    Integer pos = viewToEarliestPosition.get(view.name());
+                    List<String> applicableExclusions = (pos != null) ? exclusionsAfter.get(pos) : List.of();
+                    String indexPattern = applicableExclusions.isEmpty()
+                        ? view.name()
+                        : view.name() + "," + String.join(",", applicableExclusions);
+                    resolvedViews.putIfAbsent(view.name(), new ResolvedView(view.name(), view.query(), indexPattern));
                     replaceViews(
-                        resolve(view, parser, viewQueries),
+                        resolve(view, parser),
                         parser,
                         branchSeenViews,
-                        viewQueries,
+                        resolvedViews,
                         depth + 1,
                         l2.delegateFailureAndWrap((l3, fullyResolved) -> {
                             ViewPlan viewPlan = new ViewPlan(view.name(), fullyResolved);
-                            resolvedViews.put(view.name(), viewPlan);
+                            resolvedViewPlans.put(view.name(), viewPlan);
                             l3.onResponse(null);
                         })
                     );
                 });
             }
             chain.andThenApply(ignored -> {
-                List<ViewPlan> subqueries = buildOrderedSubqueries(unresolvedRelation, response, resolvedViews, patterns);
+                List<ViewPlan> subqueries = buildOrderedSubqueries(unresolvedRelation, response, resolvedViewPlans, patterns);
                 if (subqueries.size() == 1) {
                     return subqueries.getFirst().plan();
                 }
@@ -442,6 +484,56 @@ public class ViewResolver {
 
     private static boolean patternIsExclusion(String pattern) {
         return pattern.startsWith("-");
+    }
+
+    /**
+     * For each position {@code i} in {@code urPatterns}, computes the list of exclusion patterns at
+     * positions {@code j > i}, preserving original order. Used to attach position-aware exclusions
+     * to each resolved view (see {@link ResolvedView#indexPattern()}).
+     */
+    private static List<List<String>> computeExclusionsAfterByPosition(String[] urPatterns) {
+        List<List<String>> exclusionsAfter = new ArrayList<>(urPatterns.length);
+        List<String> later = new ArrayList<>();
+        for (int i = urPatterns.length - 1; i >= 0; i--) {
+            // Snapshot what's accumulated so far before potentially adding the current pattern.
+            exclusionsAfter.add(0, List.copyOf(later));
+            if (patternIsExclusion(urPatterns[i])) {
+                later.add(0, urPatterns[i]);
+            }
+        }
+        return exclusionsAfter;
+    }
+
+    /**
+     * Maps each resolved view name to the earliest position in {@code urPatterns} at which it was
+     * matched. When a view appears at multiple positions (e.g. matched both by a wildcard pattern
+     * earlier in the list and by an explicit name later), earliest wins, giving the broadest set of
+     * later exclusions — the most conservative reading for CPS lenient calls.
+     */
+    private static Map<String, Integer> computeViewToEarliestPosition(String[] urPatterns, EsqlResolveViewAction.Response response) {
+        Set<String> resolvedViewNames = new HashSet<>();
+        for (var view : response.views()) {
+            resolvedViewNames.add(view.name());
+        }
+        Map<String, Integer> viewToEarliestPosition = new HashMap<>();
+        for (var expr : response.getResolvedIndexExpressions().expressions()) {
+            int position = -1;
+            for (int i = 0; i < urPatterns.length; i++) {
+                if (urPatterns[i].equals(expr.original())) {
+                    position = i;
+                    break;
+                }
+            }
+            if (position < 0) {
+                continue;
+            }
+            for (String index : expr.localExpressions().indices()) {
+                if (resolvedViewNames.contains(index)) {
+                    viewToEarliestPosition.merge(index, position, Math::min);
+                }
+            }
+        }
+        return viewToEarliestPosition;
     }
 
     /**
@@ -819,11 +911,8 @@ public class ViewResolver {
         }
     }
 
-    private LogicalPlan resolve(View view, BiFunction<String, String, LogicalPlan> parser, Map<String, String> viewQueries) {
+    private LogicalPlan resolve(View view, BiFunction<String, String, LogicalPlan> parser) {
         log.debug("Resolving view '{}'", view.name());
-        // Store the view query so it can be used during Source deserialization
-        viewQueries.put(view.name(), view.query());
-
         // Parse the view query with the view name, which causes all Source objects
         // to be tagged with the view name during parsing
         LogicalPlan subquery = parser.apply(view.query(), view.name());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/view/InMemoryViewServiceTests.java
@@ -289,6 +289,99 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
         assertThat(replaceViews(plan), matchesPlan(query("FROM (FROM inner-b,outer-*),(FROM inner-*,-*b)")));
     }
 
+    /**
+     * Reproduces the example from <a href="https://github.com/elastic/esql-planning/issues/543">esql-planning#543</a>:
+     * the {@link ViewResolver.ViewResolutionResult#resolvedViews()} map exposes each concretely-resolved
+     * view together with a per-view {@code indexPattern} (view name + exclusions appearing after its
+     * referencing position in the parent UR). CPS uses these as the targets for its lenient field-caps
+     * calls, so the lookup mirrors the local exclusion scope exactly.
+     */
+    public void testResolvedViewsExposesIndexPatternFromParentBody() {
+        addIndex("logs-001");
+        addIndex("metrics-001");
+        addView("v2", "FROM logs*,-*2026");
+        addView("v1", "FROM v2,metrics*,-*2025");
+        addView("v0", "FROM v1");
+
+        ViewResolver.ViewResolutionResult result = replaceViewsResult(query("FROM v0"));
+
+        Map<String, ResolvedView> resolved = result.resolvedViews();
+        assertThat(resolved.keySet(), containsInAnyOrder("v0", "v1", "v2"));
+
+        // v0 referenced from outer "FROM v0" — no later exclusions.
+        assertThat(resolved.get("v0").indexPattern(), equalTo("v0"));
+        // v1 referenced from v0's body "FROM v1" — no later exclusions.
+        assertThat(resolved.get("v1").indexPattern(), equalTo("v1"));
+        // v2 referenced from v1's body "FROM v2,metrics*,-*2025" — -*2025 follows v2, so it applies.
+        assertThat(resolved.get("v2").indexPattern(), equalTo("v2,-*2025"));
+
+        // Sanity: the queries are still recoverable via the convenience projection.
+        assertThat(result.viewQueries().get("v0"), equalTo("FROM v1"));
+        assertThat(result.viewQueries().get("v1"), equalTo("FROM v2,metrics*,-*2025"));
+        assertThat(result.viewQueries().get("v2"), equalTo("FROM logs*,-*2026"));
+    }
+
+    /**
+     * Trailing exclusions in the outer query are picked up by views earlier in the pattern list.
+     */
+    public void testResolvedViewsIndexPatternIncludesOuterQueryExclusion() {
+        addIndex("idx-keep");
+        addIndex("idx-bad");
+        addView("filtered", "FROM idx-*");
+        ViewResolver.ViewResolutionResult result = replaceViewsResult(query("FROM filtered,-idx-bad"));
+        assertThat(result.resolvedViews().get("filtered").indexPattern(), equalTo("filtered,-idx-bad"));
+    }
+
+    /**
+     * An exclusion that only follows some of the views applies only to those views, not to ones
+     * appearing after it in the pattern list. Reproduces the {@code FROM v_a,-staleA-*,v_b,-staleB-*}
+     * case from the API discussion.
+     */
+    public void testResolvedViewsIndexPatternRespectsExclusionPosition() {
+        addView("v_a", "FROM emp");
+        addView("v_b", "FROM emp");
+        ViewResolver.ViewResolutionResult result = replaceViewsResult(query("FROM v_a,-staleA-*,v_b,-staleB-*"));
+        // v_a at position 0, both -staleA-* (pos 1) and -staleB-* (pos 3) follow it.
+        assertThat(result.resolvedViews().get("v_a").indexPattern(), equalTo("v_a,-staleA-*,-staleB-*"));
+        // v_b at position 2, only -staleB-* (pos 3) follows it; -staleA-* came before and does not apply.
+        assertThat(result.resolvedViews().get("v_b").indexPattern(), equalTo("v_b,-staleB-*"));
+    }
+
+    /**
+     * A leading exclusion (before any positive pattern) does not apply to any subsequently-resolved
+     * view, since the exclusion's effect is on the empty accumulated set.
+     */
+    public void testResolvedViewsIndexPatternIgnoresLeadingExclusion() {
+        addView("v_a", "FROM emp");
+        ViewResolver.ViewResolutionResult result = replaceViewsResult(query("FROM -stale-*,v_a"));
+        assertThat(result.resolvedViews().get("v_a").indexPattern(), equalTo("v_a"));
+    }
+
+    /**
+     * Sibling views that all share the same trailing exclusion each get it in their indexPattern.
+     */
+    public void testResolvedViewsIndexPatternForSharedTrailingExclusion() {
+        addIndex("idx-1");
+        addView("va", "FROM idx-1");
+        addView("vb", "FROM idx-1");
+        ViewResolver.ViewResolutionResult result = replaceViewsResult(query("FROM va,vb,-stale-*"));
+        assertThat(result.resolvedViews().get("va").indexPattern(), equalTo("va,-stale-*"));
+        assertThat(result.resolvedViews().get("vb").indexPattern(), equalTo("vb,-stale-*"));
+    }
+
+    /**
+     * Views matched via a wildcard pattern are recorded under their concrete names, with the
+     * trailing exclusions of that wildcard's position attached.
+     */
+    public void testResolvedViewsIndexPatternForWildcardMatchedViews() {
+        addView("v_a", "FROM emp");
+        addView("v_b", "FROM emp");
+        ViewResolver.ViewResolutionResult result = replaceViewsResult(query("FROM v_*,-stale-*"));
+        assertThat(result.resolvedViews().keySet(), containsInAnyOrder("v_a", "v_b"));
+        assertThat(result.resolvedViews().get("v_a").indexPattern(), equalTo("v_a,-stale-*"));
+        assertThat(result.resolvedViews().get("v_b").indexPattern(), equalTo("v_b,-stale-*"));
+    }
+
     public void testExclusionMultipleViews() {
         addView("view1", "FROM emp1");
         addView("view2", "FROM emp2");
@@ -1969,9 +2062,17 @@ public class InMemoryViewServiceTests extends AbstractStatementParserTests {
     }
 
     private LogicalPlan replaceViews(LogicalPlan plan, ViewResolver resolver) {
+        return replaceViewsResult(plan, resolver).plan();
+    }
+
+    private ViewResolver.ViewResolutionResult replaceViewsResult(LogicalPlan plan) {
+        return replaceViewsResult(plan, viewResolver);
+    }
+
+    private ViewResolver.ViewResolutionResult replaceViewsResult(LogicalPlan plan, ViewResolver resolver) {
         PlainActionFuture<ViewResolver.ViewResolutionResult> future = new PlainActionFuture<>();
         resolver.replaceViews(plan, this::parse, future);
-        return future.actionGet().plan();
+        return future.actionGet();
     }
 
     private LogicalPlan replaceViewsWithCPS(LogicalPlan plan) {


### PR DESCRIPTION
This is in support of CPS requirement that all locally resolved views could potentially match remote views, but we need to maintain the index patterns including exclusions for this to cover edge cases.

Requirements: https://github.com/elastic/esql-planning/issues/543

## `ResolvedView.indexPattern()` examples

The `indexPattern` is the view name followed by the exclusions that appear **strictly after** the view's earliest matching position in the parent UR's pattern list. Index resolution is left-to-right, so an exclusion only narrows the indices accumulated up to that point — exclusions before a view do not affect it.

| Parent UR pattern | Resolved view → indexPattern |
|---|---|
| `FROM v0` | `v0` → `v0` |
| `FROM v2,metrics*,-*2025` | `v2` → `v2,-*2025` |
| `FROM filtered,-idx-bad` | `filtered` → `filtered,-idx-bad` |
| `FROM v_a,-staleA-*,v_b,-staleB-*` | `v_a` → `v_a,-staleA-*,-staleB-*`, `v_b` → `v_b,-staleB-*` |
| `FROM -stale-*,v_a` | `v_a` → `v_a` (leading exclusion ignored) |
| `FROM v_*,-stale-*` | `v_a` → `v_a,-stale-*`, `v_b` → `v_b,-stale-*` |

