### PR TITLE
Prevent reindex rethrottle race in relocations

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -688,7 +688,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
                             pitIdForResume,
                             searchAfterValues,
                             startTimeEpochMillis.get(),
-                            worker.getStatus(),
+                            worker.getStatusForRelocation(),
                             remoteVersion
                         );
                     } else {
@@ -698,7 +698,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
                         workerResumeInfo = new ResumeInfo.ScrollWorkerResumeInfo(
                             paginatedHitSourceResponse.getScrollId(),
                             startTimeEpochMillis.get(),
-                            worker.getStatus(),
+                            worker.getStatusForRelocation(),
                             remoteVersion
                         );
                     }
@@ -710,7 +710,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
                     BytesReference pitId = paginatedHitSource instanceof PitPaginatedHitSource pit ? pit.getPitId() : null;
                     final BulkByScrollResponse response = new BulkByScrollResponse(
                         TimeValue.MINUS_ONE,
-                        task.getStatus(),
+                        workerResumeInfo.status(),
                         List.of(),
                         List.of(),
                         false,

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportRethrottleAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportRethrottleAction.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.reindex;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.TaskOperationFailure;
@@ -21,6 +22,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.LeaderBulkByScrollTaskState;
 import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskInfo;
@@ -97,15 +99,36 @@ public class TransportRethrottleAction extends TransportTasksAction<BulkByScroll
         final int runningSubtasks = leaderState.runningSliceSubTasks();
 
         if (runningSubtasks > 0) {
+            // Pre-check: a child already completed for relocation, we can't rethrottle since it's rate is baked into Status for relocation.
+            if (leaderState.anySliceCompletedDueToRelocation()) {
+                listener.onFailure(new ElasticsearchStatusException("cannot rethrottle, task is being relocated", RestStatus.CONFLICT));
+                return;
+            }
+
             RethrottleRequest subRequest = new RethrottleRequest();
             subRequest.setRequestsPerSecond(newRequestsPerSecond / runningSubtasks);
             subRequest.setTargetParentTaskId(new TaskId(localNodeId, task.getId()));
             logger.debug("rethrottling children of task [{}] to [{}] requests per second", task.getId(), subRequest.getRequestsPerSecond());
             client.execute(ReindexPlugin.RETHROTTLE_ACTION, subRequest, listener.delegateFailureAndWrap((l, r) -> {
+                // Post-check: a child completed for relocation after the first check, and might not have been rethrottled.
+                if (leaderState.anySliceCompletedDueToRelocation()) {
+                    l.onFailure(new ElasticsearchStatusException("cannot rethrottle, task is being relocated", RestStatus.CONFLICT));
+                    return;
+                }
+                for (TaskOperationFailure failure : r.getTaskFailures()) {
+                    if (failure.getCause() instanceof ElasticsearchStatusException ese && ese.status() == RestStatus.CONFLICT) {
+                        l.onFailure(ese);
+                        return;
+                    }
+                }
                 r.rethrowFailures("Rethrottle");
                 l.onResponse(task.taskInfoGivenSubtaskInfo(localNodeId, r.getTasks()));
             }));
         } else {
+            if (leaderState.anySliceCompletedDueToRelocation()) {
+                listener.onFailure(new ElasticsearchStatusException("cannot rethrottle, task is being relocated", RestStatus.CONFLICT));
+                return;
+            }
             logger.debug("children of task [{}] are already finished, nothing to rethrottle", task.getId());
             listener.onResponse(task.taskInfo(localNodeId, true));
         }
@@ -119,7 +142,12 @@ public class TransportRethrottleAction extends TransportTasksAction<BulkByScroll
         ActionListener<TaskInfo> listener
     ) {
         logger.debug("rethrottling local task [{}] to [{}] requests per second", task.getId(), newRequestsPerSecond);
-        task.getWorkerState().rethrottle(newRequestsPerSecond);
+        try {
+            task.getWorkerState().rethrottle(newRequestsPerSecond);
+        } catch (ElasticsearchStatusException e) {
+            listener.onFailure(e);
+            return;
+        }
         listener.onResponse(task.taskInfo(localNodeId, true));
     }
 

--- a/server/src/main/java/org/elasticsearch/index/reindex/LeaderBulkByScrollTaskState.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/LeaderBulkByScrollTaskState.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -49,6 +50,8 @@ public class LeaderBulkByScrollTaskState {
      * The latest PIT ID from slice responses. Updated on each completion so we close the most recent context.
      */
     private final AtomicReference<BytesReference> latestPitId = new AtomicReference<>();
+    /// Is {@code true} if any slice has completed in preparation to be relocated.
+    private final AtomicBoolean anySliceCompletedDueToRelocation = new AtomicBoolean();
 
     public LeaderBulkByScrollTaskState(BulkByScrollTask task, int slices) {
         this.task = task;
@@ -91,6 +94,11 @@ public class LeaderBulkByScrollTaskState {
         return runningSubtasks.get();
     }
 
+    /// Returns {@code true} if any slice has completed in preparation to be relocated.
+    public boolean anySliceCompletedDueToRelocation() {
+        return anySliceCompletedDueToRelocation.get();
+    }
+
     private void addResultsToList(List<BulkByScrollTask.StatusOrException> sliceStatuses) {
         for (Result t : results.asList()) {
             if (t.response != null) {
@@ -106,6 +114,9 @@ public class LeaderBulkByScrollTaskState {
      */
     public void onSliceResponse(ActionListener<BulkByScrollResponse> listener, int sliceId, BulkByScrollResponse response) {
         results.setOnce(sliceId, new Result(sliceId, response));
+        if (response != null && response.getTaskResumeInfo().isPresent()) {
+            anySliceCompletedDueToRelocation.set(true);
+        }
         if (response != null && response.getPitId().isPresent()) {
             latestPitId.set(response.getPitId().get());
         }

--- a/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByScrollTaskState.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/WorkerBulkByScrollTaskState.java
@@ -12,10 +12,12 @@ package org.elasticsearch.index.reindex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -78,6 +80,11 @@ public class WorkerBulkByScrollTaskState implements SuccessfullyProcessed {
      * Reference to any the last delayed prepareBulkRequest call. Used during rethrottling and canceling to reschedule the request.
      */
     private final AtomicReference<DelayedPrepareBulkRequest> delayedPrepareBulkRequestReference = new AtomicReference<>();
+    /// Set to {@code true} by {@link #getStatusForRelocation()} to indicate a worker's status (most importantly requests_per_second)
+    /// has been snapshotted for relocation. Once set, {@link #rethrottle} must fail RPS changes because they will not take effect, the task
+    /// will continue running on relocation node with snapshotted RPS rate.
+    /// Guarded by {@code synchronized (delayedPrepareBulkRequestReference)} so no need for volatile.
+    private boolean statusCapturedForRelocation = false;
 
     public WorkerBulkByScrollTaskState(BulkByScrollTask task, Integer sliceId, float requestsPerSecond) {
         this.task = task;
@@ -103,6 +110,17 @@ public class WorkerBulkByScrollTaskState implements SuccessfullyProcessed {
             task.getReasonCancelled(),
             throttledUntil()
         );
+    }
+
+    /// Captures/snapshots the worker status for relocation and sets the {@link #statusCapturedForRelocation} flag so that concurrent
+    /// {@link #rethrottle} calls are rejected. The flag and status read are performed atomically under the same lock
+    /// that rethrottle acquires, preventing a race where rethrottle will set a new RPS rate, which isn't in the status and therefore
+    /// won't be the RPS we use once relocated.
+    public BulkByScrollTask.Status getStatusForRelocation() {
+        synchronized (delayedPrepareBulkRequestReference) {
+            statusCapturedForRelocation = true;
+            return getStatus();
+        }
     }
 
     /**
@@ -263,6 +281,9 @@ public class WorkerBulkByScrollTaskState implements SuccessfullyProcessed {
      */
     public void rethrottle(float newRequestsPerSecond) {
         synchronized (delayedPrepareBulkRequestReference) {
+            if (statusCapturedForRelocation) {
+                throw new ElasticsearchStatusException("cannot rethrottle, task is being relocated", RestStatus.CONFLICT);
+            }
             logger.debug("[{}]: rethrottling to [{}] requests per second", task.getId(), newRequestsPerSecond);
             setRequestsPerSecond(newRequestsPerSecond);
 


### PR DESCRIPTION
Make sure that we return a `HTTP 409` if you rethrottle a reindex task that is relocating, and therefore might not have your provided `requests_per_second` once it relocates.

Checks:
A. Leader checks before rethrottling whether any slice has already completed in preparation for relocation, and will therefore have a stale RPS.
B. Leader checks after rethrottling whether any slice has completed in preparation for relocation after the last check, it could've completed before rethrottle operation got to it.
C. Worker checks whether incoming rethrottle is performed after status is captured for relocation, therefore would be stale. Required mainly because we need a check for single-sliced reindexes without leader checks, but also for sliced since task might not complete before second Leader check but still have already captured stale status.

What we handle:
- Non-sliced (worker only): handled by C.
- Sliced (child completed before A): handled by A.
- Sliced (child completes after A): handled by B.
- Sliced (rethrottle finds child, but it already captured Status): handled by C.
- If no relocations (whether reindex, or UBQ/DBQ), nothing happens.
