### PR TITLE
ESQL: Fix test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -438,9 +438,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=index/100_field_name_length_limit/Test field name length limit}
   issue: https://github.com/elastic/elasticsearch/issues/147494
-- class: org.elasticsearch.compute.operator.topn.GroupedTopNOperatorTests
-  method: testSplitOnSize
-  issue: https://github.com/elastic/elasticsearch/issues/147533
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeApproximationIT
   method: test {csv-spec:external-basic.complexQuery}
   issue: https://github.com/elastic/elasticsearch/issues/147536

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -2163,6 +2163,15 @@ public class TopNOperatorTests extends OperatorTestCase {
             maxPageSize += PageCacheRecycler.PAGE_SIZE_IN_BYTES;
         }
         int[] gk = groupKeys();
+        if (gk.length > 0) {
+            /*
+             * Grouped TopN initializes builders sized to total rows remaining,
+             * not maxPageSize. That inflates estimatedBytes() above jumboPageBytes
+             * before any data is written, so the first row always triggers an
+             * early break. A single-row page holds at minimum byteLength bytes.
+             */
+            minPageSize = Math.min(minPageSize, byteLength);
+        }
         int expectedTotal = gk.length > 0 ? inputPageRows * inputPageCount : topCount;
         try (
             Operator op = createTopNOperatorFactory(


### PR DESCRIPTION
The test made some memory assumptions that aren't true for grouped topn. This fixes it.

closes #147533
