### PR TITLE
[9.4] Run ml yamlRestTest in ml/qa/single-node-tests (+ migrate off legacy-java-rest-test) (#147350)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -46,6 +46,10 @@ restTestBlacklist.addAll(['getting_started/10_monitor_cluster_health/*'])
 // via restResources.restTests.includeXpack 'esql'. Skip them here to avoid running the same
 // suite twice in CI.
 restTestBlacklist.add('esql/*')
+// ML YAML rest tests are run by :x-pack:plugin:ml:qa:single-node-tests:yamlRestTest
+// via restResources.restTests.includeXpack 'ml'. Skip them here to avoid running the
+// same suite twice in CI.
+restTestBlacklist.add('ml/*')
 if (buildParams.snapshotBuild == false) {
   // these tests attempt to install basic/internal licenses signed against the dev/public.key
   // Since there is no infrastructure in place (anytime soon) to generate licenses using the production

--- a/x-pack/plugin/ml/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/single-node-tests/build.gradle
@@ -5,24 +5,36 @@
  * 2.0.
  */
 
-apply plugin: 'elasticsearch.legacy-java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 dependencies {
   javaRestTestImplementation(project(':modules:lang-mustache'))
+
+  yamlRestTestImplementation project(':test:yaml-rest-runner')
+  yamlRestTestImplementation(testArtifact(project(xpackModule('core'))))
+  // Pulls in MlModelServer and its bundled model resources used by ml/3rd_party_deployment.yml.
+  yamlRestTestImplementation(testArtifact(project(':x-pack:plugin:inference:qa:inference-service-tests'), "javaRestTest"))
 }
 
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.security.enabled', 'false'
-  setting 'xpack.license.self_generated.type', 'trial'
+restResources {
+  restApi {
+    include '*'
+  }
+  restTests {
+    includeXpack 'ml'
+  }
 }
 
-if (buildParams.inFipsJvm){
-  // Test clusters run with security disabled
-  tasks.named("javaRestTest").configure{enabled = false }
+if (buildParams.inFipsJvm) {
+  // Test cluster for javaRestTest runs with security disabled
+  tasks.named("javaRestTest").configure { enabled = false }
 }
 
-tasks.named('javaRestTestTestingConventions').configure {
-  baseClass "org.elasticsearch.xpack.ml.integration.InferenceTestCase"
-  baseClass "org.elasticsearch.test.rest.ESRestTestCase"
+tasks.named('yamlRestTest') {
+  usesDefaultDistribution("ml yaml rest tests require the default distribution")
+}
+
+tasks.named('javaRestTest') {
+  usesDefaultDistribution("ml java rest tests require the default distribution")
 }

--- a/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedWithoutSecurityRestIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedWithoutSecurityRestIT.java
@@ -11,8 +11,11 @@ import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.Before;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 
@@ -20,6 +23,18 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
 public class DatafeedWithoutSecurityRestIT extends ESRestTestCase {
+
+    @ClassRule
+    public static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     @Before
     public void setUpData() throws Exception {

--- a/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceTestCase.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceTestCase.java
@@ -11,8 +11,11 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.After;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -23,6 +26,18 @@ import java.util.Set;
 import static org.hamcrest.Matchers.equalTo;
 
 public abstract class InferenceTestCase extends ESRestTestCase {
+
+    @ClassRule
+    public static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     protected final Set<String> createdPipelines = new HashSet<>();
 

--- a/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlUsageIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlUsageIT.java
@@ -8,7 +8,10 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.client.Request;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.Map;
@@ -17,6 +20,18 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 // Test the phone home/telemetry data
 public class MlUsageIT extends ESRestTestCase {
+
+    @ClassRule
+    public static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     @SuppressWarnings("unchecked")
     public void testMLUsage() throws IOException {

--- a/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/transforms/PainlessDomainSplitIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/transforms/PainlessDomainSplitIT.java
@@ -11,7 +11,10 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.ClassRule;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -28,6 +31,18 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class PainlessDomainSplitIT extends ESRestTestCase {
+
+    @ClassRule
+    public static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     private static final String BASE_PATH = "/_ml/";
 

--- a/x-pack/plugin/ml/qa/single-node-tests/src/yamlRestTest/java/org/elasticsearch/xpack/ml/qa/MlYamlRestIT.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/yamlRestTest/java/org/elasticsearch/xpack/ml/qa/MlYamlRestIT.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.qa;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.apache.http.HttpStatus;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.test.SecuritySettingsSourceField;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestResponseException;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.elasticsearch.xpack.core.ml.integration.MlRestTestStateCleaner;
+import org.elasticsearch.xpack.inference.MlModelServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Runs the ML YAML REST test suite against a dedicated single-node cluster.
+ *
+ * <p>Previously these tests lived in the monolithic {@code :x-pack:plugin:yamlRestTest}
+ * suite alongside every other x-pack feature. They were relocated here so that ML
+ * can own its cluster configuration, state-cleanup helpers and {@link MlModelServer}
+ * class rule independently of unrelated features. The YAML test sources still live
+ * under {@code x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/} so
+ * that internal consumers using {@code restResources.restTests.includeXpack 'ml'}
+ * continue to work; this project pulls them in via the same mechanism.
+ */
+public class MlYamlRestIT extends ESClientYamlSuiteTestCase {
+
+    private static final String BASIC_AUTH_VALUE = basicAuthHeaderValue(
+        "x_pack_rest_user",
+        SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING
+    );
+
+    private static final MlModelServer ML_MODEL_SERVER = new MlModelServer();
+
+    private static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .name("ml-yamlRestTest")
+        .setting("xpack.ml.enabled", "true")
+        .setting("xpack.security.enabled", "true")
+        .setting("xpack.watcher.enabled", "false")
+        .setting("xpack.security.authc.token.enabled", "true")
+        .setting("xpack.security.authc.api_key.enabled", "true")
+        .setting("xpack.license.self_generated.type", "trial")
+        // Disable ILM history because several ML tests use _all index patterns.
+        .setting("indices.lifecycle.history_index_enabled", "false")
+        .keystore("bootstrap.password", "x-pack-test-password")
+        .user("x_pack_rest_user", "x-pack-test-password")
+        .build();
+
+    // Apply MlModelServer first so it is listening before the cluster boots.
+    @ClassRule
+    public static final TestRule ruleChain = RuleChain.outerRule(ML_MODEL_SERVER).around(cluster);
+
+    public MlYamlRestIT(ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return createParameters();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @Override
+    protected Settings restClientSettings() {
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", BASIC_AUTH_VALUE).build();
+    }
+
+    /**
+     * Point the cluster at our in-process {@link MlModelServer} so that tests which
+     * install 3rd-party trained models (e.g. {@code .elser_model_2}) can fetch them
+     * without hitting the public internet.
+     */
+    @Before
+    public void setMlModelRepository() throws IOException {
+        assertOK(ML_MODEL_SERVER.setMlModelRepository(adminClient()));
+    }
+
+    /**
+     * Wait for the trial license to be installed; some tests rely on it being active
+     * before their first request.
+     */
+    @Before
+    public void waitForLicense() {
+        awaitCallApi(
+            "license.get",
+            Map.of(),
+            List.of(),
+            response -> true,
+            () -> "Exception when waiting for initial license to be generated",
+            30
+        );
+    }
+
+    /**
+     * Reset ML state between tests (delete pipelines with inference processors and
+     * invoke {@code _features/_reset}) and drain any cluster-state updates it triggers
+     * before the base-class pending-tasks check runs.
+     */
+    @After
+    public void cleanup() throws Exception {
+        new MlRestTestStateCleaner(logger, adminClient()).resetFeatures();
+        // _features/_reset can enqueue async cluster-state updates (e.g. inference
+        // endpoint cache invalidation via ClearInferenceEndpointCacheAction). Drain
+        // them here so the subsequent waitForPendingTasks does not race with them.
+        waitForClusterUpdates();
+    }
+
+    private void awaitCallApi(
+        String apiName,
+        Map<String, String> params,
+        List<Map<String, Object>> bodies,
+        CheckedFunction<ClientYamlTestResponse, Boolean, IOException> success,
+        Supplier<String> error,
+        long maxWaitTimeInSeconds
+    ) {
+        try {
+            final AtomicReference<ClientYamlTestResponse> response = new AtomicReference<>();
+            assertBusy(() -> {
+                try {
+                    response.set(getAdminExecutionContext().callApi(apiName, params, bodies, Map.of()));
+                    assertEquals(HttpStatus.SC_OK, response.get().getStatusCode());
+                } catch (ClientYamlTestResponseException e) {
+                    throw new AssertionError("Failed to call API " + apiName, e);
+                }
+            }, maxWaitTimeInSeconds, TimeUnit.SECONDS);
+            success.apply(response.get());
+        } catch (Exception e) {
+            throw new IllegalStateException(error.get(), e);
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Run ml yamlRestTest in ml/qa/single-node-tests (+ migrate off legacy-java-rest-test) (#147350)