### PR TITLE
Fix NativeBinaryQuantizedVectorScorer.bulkScore segfault  (#147581)

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES93BinaryQuantizedVectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES93BinaryQuantizedVectorScorer.java
@@ -20,6 +20,7 @@ import static org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRO
 public abstract class ES93BinaryQuantizedVectorScorer {
 
     protected static final float FOUR_BIT_SCALE = 1f / ((1 << 4) - 1);
+    public static final int BBQ_CORRECTIONS_BYTES = (Float.BYTES * 3) + Short.BYTES;
     protected final int dimensions;
     protected final int numBytes;
     protected final int byteSize;
@@ -27,7 +28,7 @@ public abstract class ES93BinaryQuantizedVectorScorer {
     public ES93BinaryQuantizedVectorScorer(int dimensions, int numBytes) {
         this.dimensions = dimensions;
         this.numBytes = numBytes;
-        this.byteSize = numBytes + (Float.BYTES * 3) + Short.BYTES;
+        this.byteSize = numBytes + BBQ_CORRECTIONS_BYTES;
     }
 
     public abstract float score(

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/NativeBinaryQuantizedVectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/NativeBinaryQuantizedVectorScorer.java
@@ -85,7 +85,7 @@ public class NativeBinaryQuantizedVectorScorer extends DefaultES93BinaryQuantize
         }
 
         float[] maxScore = new float[] { Float.NEGATIVE_INFINITY };
-        boolean resolved = IndexInputUtils.withSliceAddresses(slice, vectorOffsets, numBytes, bulkSize, addrs -> {
+        boolean resolved = IndexInputUtils.withSliceAddresses(slice, vectorOffsets, byteSize, bulkSize, addrs -> {
             var scoresSegment = MemorySegment.ofArray(scores);
             Similarities.dotProductD1Q4BulkSparse(addrs, MemorySegment.ofArray(q), numBytes, bulkSize, scoresSegment);
             maxScore[0] = ScoreCorrections.nativeBbqApplyCorrectionsBulk(

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/BaseVectorizationTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/BaseVectorizationTests.java
@@ -9,8 +9,17 @@
 
 package org.elasticsearch.simdvec.internal.vectorization;
 
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.DirectAccessInput;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
 
 public class BaseVectorizationTests extends ESTestCase {
 
@@ -25,5 +34,71 @@ public class BaseVectorizationTests extends ESTestCase {
 
     public static ESVectorizationProvider maybePanamaProvider() {
         return ESVectorizationProvider.lookup(true);
+    }
+
+    /**
+     * Opens {@code name} from {@code dir} and returns it routed through
+     * {@link #wrapForAssertion}. Use in place of
+     * {@code dir.openInput(name, IOContext.DEFAULT)} in tests that want
+     * to assert per-slice byte lengths.
+     */
+    static IndexInput openTestInput(Directory dir, String name, int expectedSliceLength) throws IOException {
+        return wrapForAssertion(dir.openInput(name, IOContext.DEFAULT), expectedSliceLength);
+    }
+
+    /**
+     * Wraps {@code in} with an asserting filter if it exposes one of the
+     * optional fast-path interfaces consumed by
+     * {@code IndexInputUtils.withSlice} / {@code withSliceAddresses}. The
+     * filter verifies that every per-slice byte length the requested by
+     * the caller equals {@code expectedSliceLength}, then delegates to the
+     * wrapped implementation.
+     *
+     * <p>If {@code in} does not expose a fast-path interface this method
+     * returns it unchanged.
+     *
+     * <p>Currently only the {@link DirectAccessInput} path is asserted.
+     * TODO: add an MSAI asserter.
+     */
+    static IndexInput wrapForAssertion(IndexInput in, int expectedSliceLength) {
+        IndexInput unwrapped = FilterIndexInput.unwrapOnlyTest(in);
+        if (unwrapped instanceof DirectAccessInput) {
+            return new AssertingDelegatingDirectAccessInput("asserting(" + unwrapped + ")", unwrapped, expectedSliceLength);
+        }
+        return unwrapped;
+    }
+
+    /**
+     * A {@link FilterIndexInput} that also implements
+     * {@link DirectAccessInput}: each direct-access call asserts that the
+     * requested slice length matches the configured expected length, then
+     * delegates to the wrapped input's own DAI implementation. The wrapped
+     * input must itself be a {@link DirectAccessInput}.
+     */
+    static final class AssertingDelegatingDirectAccessInput extends FilterIndexInput implements DirectAccessInput {
+        private final DirectAccessInput delegate;
+        private final int expectedSliceLength;
+
+        private AssertingDelegatingDirectAccessInput(String resourceDescription, IndexInput delegate, int expectedSliceLength) {
+            super(resourceDescription, delegate);
+            if (delegate instanceof DirectAccessInput == false) {
+                throw new IllegalArgumentException("delegate must implement DirectAccessInput; got " + delegate.getClass().getName());
+            }
+            this.delegate = (DirectAccessInput) delegate;
+            this.expectedSliceLength = expectedSliceLength;
+        }
+
+        @Override
+        public boolean withByteBufferSlice(long offset, long length, CheckedConsumer<ByteBuffer, IOException> action) throws IOException {
+            assertEquals("unexpected slice length", expectedSliceLength, (int) length);
+            return delegate.withByteBufferSlice(offset, length, action);
+        }
+
+        @Override
+        public boolean withByteBufferSlices(long[] offsets, int length, int count, CheckedConsumer<ByteBuffer[], IOException> action)
+            throws IOException {
+            assertEquals("unexpected slice length", expectedSliceLength, length);
+            return delegate.withByteBufferSlices(offsets, length, count, action);
+        }
     }
 }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/ES93BinaryQuantizedVectorScorerTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/ES93BinaryQuantizedVectorScorerTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.simdvec.internal.vectorization;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -21,6 +22,7 @@ import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.index.codec.vectors.BQVectorUtils;
 import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
+import org.elasticsearch.xpack.searchablesnapshots.store.SearchableSnapshotDirectoryFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -28,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.simdvec.ES93BinaryQuantizedVectorScorer.BBQ_CORRECTIONS_BYTES;
 import static org.elasticsearch.simdvec.internal.vectorization.VectorScorerTestUtils.createBinarizedIndexData;
 import static org.elasticsearch.simdvec.internal.vectorization.VectorScorerTestUtils.createBinarizedQueryData;
 import static org.elasticsearch.simdvec.internal.vectorization.VectorScorerTestUtils.writeBinarizedVectorData;
@@ -36,7 +39,8 @@ public class ES93BinaryQuantizedVectorScorerTests extends BaseVectorizationTests
 
     public enum DirectoryType {
         NIOFS,
-        MMAP
+        MMAP,
+        SNAP
     }
 
     private final DirectoryType directoryType;
@@ -52,6 +56,7 @@ public class ES93BinaryQuantizedVectorScorerTests extends BaseVectorizationTests
         return switch (directoryType) {
             case NIOFS -> new NIOFSDirectory(createTempDir());
             case MMAP -> new MMapDirectory(createTempDir());
+            case SNAP -> SearchableSnapshotDirectoryFactory.newDirectory(createTempDir());
         };
     }
 
@@ -69,6 +74,8 @@ public class ES93BinaryQuantizedVectorScorerTests extends BaseVectorizationTests
                 var indexData = createBinarizedIndexData(vectorValues, centroid, quantizer, dims);
                 writeBinarizedVectorData(out, indexData);
             }
+            // Required by the SNAP directory factory; harmless for NIOFS/MMAP.
+            CodecUtil.writeFooter(out);
         }
     }
 
@@ -83,16 +90,17 @@ public class ES93BinaryQuantizedVectorScorerTests extends BaseVectorizationTests
         float[] vectorValues = new float[dims];
         OptimizedScalarQuantizer quantizer = new OptimizedScalarQuantizer(similarityFunction);
 
+        final int vectorLengthInBytes = BQVectorUtils.discretize(dims, 64) / 8;
+        final int perVectorBytes = vectorLengthInBytes + BBQ_CORRECTIONS_BYTES;
+
         try (Directory dir = newParametrizedDirectory()) {
             createTestFile(dir, numVectors, vectorValues, centroid, quantizer, dims);
 
             VectorScorerTestUtils.randomVector(random(), vectorValues, similarityFunction);
             var queryData = createBinarizedQueryData(vectorValues, centroid, quantizer, dims);
 
-            try (IndexInput in = dir.openInput("testScore.bin", IOContext.DEFAULT)) {
-                final int vectorLengthInBytes = BQVectorUtils.discretize(dims, 64) / 8;
-                final int perVectorBytes = vectorLengthInBytes + 14;
-                assertEquals(in.length(), (long) numVectors * perVectorBytes);
+            try (IndexInput in = openTestInput(dir, "testScore.bin", perVectorBytes)) {
+                assertEquals(in.length(), (long) numVectors * perVectorBytes + CodecUtil.footerLength());
 
                 final var defaultScorer = defaultProvider().newES93BinaryQuantizedVectorScorer(in, dims, vectorLengthInBytes);
                 final var panamaScorer = maybePanamaProvider().newES93BinaryQuantizedVectorScorer(in, dims, vectorLengthInBytes);
@@ -136,16 +144,17 @@ public class ES93BinaryQuantizedVectorScorerTests extends BaseVectorizationTests
         float[] vectorValues = new float[dims];
         OptimizedScalarQuantizer quantizer = new OptimizedScalarQuantizer(similarityFunction);
 
+        final int vectorLengthInBytes = BQVectorUtils.discretize(dims, 64) / 8;
+        final int perVectorBytes = vectorLengthInBytes + BBQ_CORRECTIONS_BYTES;
+
         try (Directory dir = newParametrizedDirectory()) {
             createTestFile(dir, numVectors, vectorValues, centroid, quantizer, dims);
 
             VectorScorerTestUtils.randomVector(random(), vectorValues, similarityFunction);
             var queryData = createBinarizedQueryData(vectorValues, centroid, quantizer, dims);
 
-            try (IndexInput in = dir.openInput("testScore.bin", IOContext.DEFAULT)) {
-                final int vectorLengthInBytes = BQVectorUtils.discretize(dims, 64) / 8;
-                final int perVectorBytes = vectorLengthInBytes + 14;
-                assertEquals(in.length(), (long) numVectors * perVectorBytes);
+            try (IndexInput in = openTestInput(dir, "testScore.bin", perVectorBytes)) {
+                assertEquals(in.length(), (long) numVectors * perVectorBytes + CodecUtil.footerLength());
 
                 final var defaultScorer = defaultProvider().newES93BinaryQuantizedVectorScorer(in, dims, vectorLengthInBytes);
                 final var panamaScorer = maybePanamaProvider().newES93BinaryQuantizedVectorScorer(in, dims, vectorLengthInBytes);


### PR DESCRIPTION
This PR solves a bug that caused a segfault when using the native score correction code for BBQ: the native code assumes the whole vector data + corrections is accessible, but the Java code was creating segments mapping only data (14 bytes less); at page boundaries, this caused a segmentation fault.

The PR also adds SNAP tests that exercise the faulty path (DirectAccessInput), with an asserting wrapper that helps catching this kind of errors.

(cherry picked from commit 75c1bc02455beef21114dffa8808425b70bc8ba0)
