### PR TITLE
Fetch PR base branch in repeat-changed-tests

### DIFF
--- a/.buildkite/scripts/repeat-changed-tests.ts
+++ b/.buildkite/scripts/repeat-changed-tests.ts
@@ -282,7 +282,13 @@ function main() {
   if (!targetBranch) {
     throw new Error("GITHUB_PR_TARGET_BRANCH environment variable is required");
   }
-  const mergeBase = execSync(`git merge-base ${targetBranch} HEAD`, { cwd: PROJECT_ROOT }).toString().trim();
+  // The Buildkite agent only fetches the PR head, so the target branch ref
+  // may not be present locally (e.g. for serverless patch base branches).
+  // Fetch it explicitly before computing merge-base.
+  execSync(`git fetch origin ${targetBranch}`, { cwd: PROJECT_ROOT, stdio: ["ignore", "inherit", "inherit"] });
+  const mergeBase = execSync(`git merge-base origin/${targetBranch} HEAD`, { cwd: PROJECT_ROOT })
+    .toString()
+    .trim();
   console.log(`Merge base: ${mergeBase}`);
 
   console.log("Getting changed files...");


### PR DESCRIPTION
## Summary

The `repeat-changed-tests` script computed the merge base against `GITHUB_PR_TARGET_BRANCH` directly, but the Buildkite agent only fetches the PR head ref (`refs/pull/<n>/head`). For PRs whose base is the default branch this happened to work because `origin/main` was populated by the cached mirror clone. For patch base branches such as `patch/serverless-fix` the ref is not available locally and `git merge-base` aborts with `fatal: Not a valid object name patch/serverless-fix`, breaking the `detect changed tests` step before the dynamic pipeline can be uploaded.

This PR fetches the target branch explicitly before computing the merge base, mirroring the pattern already used in [`.buildkite/scripts/pull-request/pipeline.ts`](https://github.com/elastic/elasticsearch/blob/main/.buildkite/scripts/pull-request/pipeline.ts#L166-L172). The fetch and `merge-base` are issued as two separate `execSync` calls so that a fetch failure surfaces directly instead of being masked by a stale `origin/<branch>` ref left over from the mirror clone.

## Reproducer

- PR: #147652 (base branch `patch/serverless-fix`)
- Failed build: https://buildkite.com/elastic/elasticsearch-pull-request/builds/140947
- Failed job log:
  ```
  $ bun .buildkite/scripts/repeat-changed-tests.ts
  Computing merge base...
  fatal: Not a valid object name patch/serverless-fix
  ```


Made with [Cursor](https://cursor.com)