### PR TITLE
Fix flakiness in ChunkedFetchPhaseCircuitBreakerTrippingIT#testCircuitBreakerTripsWithConcurrentSearches and unmute it.

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -321,9 +321,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/250_high_cardinality_keyword/Test avg length}
   issue: https://github.com/elastic/elasticsearch/issues/147380
-- class: org.elasticsearch.search.fetch.ChunkedFetchPhaseCircuitBreakerTrippingIT
-  method: testCircuitBreakerTripsWithConcurrentSearches
-  issue: https://github.com/elastic/elasticsearch/issues/147391
 - class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
   method: testReindexTaskRelocatesOnNodeShutdown
   issue: https://github.com/elastic/elasticsearch/issues/147449

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/ChunkedFetchPhaseCircuitBreakerTrippingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/ChunkedFetchPhaseCircuitBreakerTrippingIT.java
@@ -170,7 +170,7 @@ public class ChunkedFetchPhaseCircuitBreakerTrippingIT extends ESIntegTestCase {
                 var client = internalCluster().client(coordinatorNode);
                 var resp = client.prepareSearch(INDEX_NAME)
                     .setQuery(matchAllQuery())
-                    .setSize(4)
+                    .setSize(5)
                     .setAllowPartialSearchResults(false)
                     .addSort(SORT_FIELD, SortOrder.ASC)
                     .get();


### PR DESCRIPTION
Bump `setSize(4)` -> `setSize(5)` in `testCircuitBreakerTripsWithConcurrentSearches` so each individual search requests 5 × 1.5MB ≈ 7.5MB and reliably exceeds the 5MB request breaker limit on its own.

Closes #147391
