### PR TITLE
ESQL:DS: emit Warning headers on failure

### DIFF
--- a/docs/changelog/147500.yaml
+++ b/docs/changelog/147500.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147500
+summary: Surface skipped/null-filled external rows as response `Warning` headers
+type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -449,7 +450,15 @@ public class CsvFormatReader implements SegmentableFormatReader {
             effectiveSchema = resolvedSchema;
         }
         ErrorPolicy effective = context.errorPolicy() != null ? context.errorPolicy() : defaultErrorPolicy();
-        return new CsvBatchIterator(reader, stream, context.projectedColumns(), context.batchSize(), effectiveSchema, effective);
+        return new CsvBatchIterator(
+            reader,
+            stream,
+            context.projectedColumns(),
+            context.batchSize(),
+            effectiveSchema,
+            effective,
+            object.path().toString()
+        );
     }
 
     @Override
@@ -579,13 +588,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     /**
-     * Returns accumulated warnings from a CSV iterator, for testing.
+     * Returns the number of skip/null-fill detail warnings emitted on the response for this iterator.
+     * Used by tests; the warnings themselves are only observable via the thread context response headers.
      */
-    static List<String> getWarnings(CloseableIterator<Page> iterator) {
-        if (iterator instanceof CsvBatchIterator cbi) {
-            return List.copyOf(cbi.warnings);
+    static int emittedWarnings(CloseableIterator<Page> iterator) {
+        if (iterator instanceof CsvBatchIterator cbi && cbi.skipWarnings != null) {
+            return cbi.skipWarnings.added();
         }
-        return List.of();
+        return 0;
     }
 
     private class CsvBatchIterator implements CloseableIterator<Page> {
@@ -602,8 +612,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private final String nullValueStr;
         private final DateTimeFormatter datetimeFormatter;
         private final boolean bracketMultiValues;
-        private static final int MAX_WARNINGS = 20;
-        private final List<String> warnings = new ArrayList<>();
+        private final String sourceLocation;
+        private final SkipWarnings skipWarnings;
         private List<Attribute> schema;
         private int[] projectedIdx;
         private DataType[] projectedTypes;
@@ -625,7 +635,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
             List<String> projectedColumns,
             int batchSize,
             List<Attribute> preResolvedSchema,
-            ErrorPolicy errorPolicy
+            ErrorPolicy errorPolicy,
+            String sourceLocation
         ) {
             this.reader = reader;
             this.stream = stream;
@@ -640,6 +651,16 @@ public class CsvFormatReader implements SegmentableFormatReader {
             this.nullValueStr = options.nullValue();
             this.datetimeFormatter = options.datetimeFormatter();
             this.bracketMultiValues = options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS;
+            this.sourceLocation = sourceLocation;
+            this.skipWarnings = errorPolicy.isStrict()
+                ? null
+                : new SkipWarnings(
+                    "CSV read from ["
+                        + sourceLocation
+                        + "] produced recoverable errors (policy: "
+                        + errorPolicy.mode().name().toLowerCase(Locale.ROOT)
+                        + "); affected rows/fields are listed below"
+                );
         }
 
         @Override
@@ -1199,7 +1220,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 throw new EsqlIllegalArgumentException(cause, message);
             }
             errorCount++;
-            addWarning("Row [" + totalRowCount + "] error: " + message);
+            skipWarnings.add("Row [" + totalRowCount + "] error: " + message);
             if (logErrors) {
                 logger.warn(
                     "Skipping malformed CSV row [{}] (error {}/{}): {}",
@@ -1214,7 +1235,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         private void onFieldError(String message, String value, Attribute attr) {
             errorCount++;
-            addWarning("Row [" + totalRowCount + "] field [" + attr.name() + "] value [" + value + "]: " + message);
+            skipWarnings.add("Row [" + totalRowCount + "] field [" + attr.name() + "] value [" + value + "]: " + message);
             if (logErrors) {
                 logger.warn(
                     "Null-filling unparseable field [{}] value [{}] in row [{}] (error {}/{}): {}",
@@ -1229,16 +1250,21 @@ public class CsvFormatReader implements SegmentableFormatReader {
             checkBudget(message, null);
         }
 
-        private void addWarning(String warning) {
-            if (warnings.size() < MAX_WARNINGS) {
-                warnings.add(warning);
-            } else if (warnings.size() == MAX_WARNINGS) {
-                warnings.add("... further warnings suppressed (total errors so far: " + errorCount + ")");
-            }
-        }
-
         private void checkBudget(String message, Exception cause) {
             if (errorPolicy.isBudgetExceeded(errorCount, totalRowCount)) {
+                // Surface the budget-exceeded condition as a warning too so clients see which row tripped it
+                // even when the request itself fails.
+                skipWarnings.add(
+                    "CSV error budget exceeded at row ["
+                        + totalRowCount
+                        + "]: ["
+                        + errorCount
+                        + "] errors, maximum ["
+                        + errorPolicy.maxErrors()
+                        + "] or ratio ["
+                        + errorPolicy.maxErrorRatio()
+                        + "]"
+                );
                 throw new EsqlIllegalArgumentException(
                     cause,
                     "CSV error budget exceeded: [{}] errors in [{}] rows, maximum allowed is [{}] errors or [{}] ratio",

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -587,17 +587,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
         };
     }
 
-    /**
-     * Returns the number of skip/null-fill detail warnings emitted on the response for this iterator.
-     * Used by tests; the warnings themselves are only observable via the thread context response headers.
-     */
-    static int emittedWarnings(CloseableIterator<Page> iterator) {
-        if (iterator instanceof CsvBatchIterator cbi && cbi.skipWarnings != null) {
-            return cbi.skipWarnings.added();
-        }
-        return 0;
-    }
-
     private class CsvBatchIterator implements CloseableIterator<Page> {
         private final BufferedReader reader;
         private final InputStream stream;
@@ -652,15 +641,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
             this.datetimeFormatter = options.datetimeFormatter();
             this.bracketMultiValues = options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS;
             this.sourceLocation = sourceLocation;
-            this.skipWarnings = errorPolicy.isStrict()
-                ? null
-                : new SkipWarnings(
-                    "CSV read from ["
-                        + sourceLocation
-                        + "] produced recoverable errors (policy: "
-                        + errorPolicy.mode().name().toLowerCase(Locale.ROOT)
-                        + "); affected rows/fields are listed below"
-                );
+            this.skipWarnings = SkipWarnings.of(
+                errorPolicy,
+                "CSV read from ["
+                    + sourceLocation
+                    + "] encountered parse errors handled per policy (policy: "
+                    + errorPolicy.modeName()
+                    + "); affected rows/fields are listed below"
+            );
         }
 
         @Override

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -64,6 +64,9 @@ public class CsvFormatReaderTests extends ESTestCase {
     @After
     public void clearWarningHeaders() {
         if (threadContext != null) {
+            // Swap in a fresh empty context (we deliberately do not restore() - the parent
+            // ESTestCase provides a fresh threadContext for the next test, so the stashed one
+            // can be discarded).
             threadContext.stashContext();
         }
     }
@@ -2231,7 +2234,6 @@ public class CsvFormatReaderTests extends ESTestCase {
             while (iterator.hasNext()) {
                 iterator.next();
             }
-            assertEquals(2, CsvFormatReader.emittedWarnings(iterator));
         }
         // 1 summary + 2 details
         List<String> warnings = drainWarnings();
@@ -2262,7 +2264,6 @@ public class CsvFormatReaderTests extends ESTestCase {
             while (iterator.hasNext()) {
                 iterator.next();
             }
-            assertEquals(2, CsvFormatReader.emittedWarnings(iterator));
         }
         // 1 summary + 2 details
         List<String> warnings = drainWarnings();
@@ -2289,7 +2290,6 @@ public class CsvFormatReaderTests extends ESTestCase {
             while (iterator.hasNext()) {
                 iterator.next();
             }
-            assertEquals(20, CsvFormatReader.emittedWarnings(iterator));
         }
         // 1 summary + 20 details + 1 overflow
         List<String> warnings = drainWarnings();

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasource.csv;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -31,6 +32,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.junit.After;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -51,6 +53,19 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    /**
+     * Several tests below exercise non-strict {@link ErrorPolicy} paths which now emit response-header
+     * warnings via {@link HeaderWarning#addWarning(String, Object[])}. Drop them here so the parent
+     * {@code ensureNoWarnings} post-check passes; tests that want to assert on them call
+     * {@code drainWarnings()} from inside the test method.
+     */
+    @After
+    public void clearWarningHeaders() {
+        if (threadContext != null) {
+            threadContext.stashContext();
+        }
     }
 
     public void testSchema() throws IOException {
@@ -2216,11 +2231,14 @@ public class CsvFormatReaderTests extends ESTestCase {
             while (iterator.hasNext()) {
                 iterator.next();
             }
-            List<String> warnings = CsvFormatReader.getWarnings(iterator);
-            assertEquals(2, warnings.size());
-            assertTrue("Warning should include row number, got: " + warnings.get(0), warnings.get(0).startsWith("Row [2]"));
-            assertTrue("Warning should include row number, got: " + warnings.get(1), warnings.get(1).startsWith("Row [4]"));
+            assertEquals(2, CsvFormatReader.emittedWarnings(iterator));
         }
+        // 1 summary + 2 details
+        List<String> warnings = drainWarnings();
+        assertEquals(3, warnings.size());
+        assertTrue("Summary should mention skip_row, got: " + warnings.get(0), warnings.get(0).contains("policy: skip_row"));
+        assertTrue("Detail should include row number, got: " + warnings.get(1), warnings.get(1).contains("Row [2]"));
+        assertTrue("Detail should include row number, got: " + warnings.get(2), warnings.get(2).contains("Row [4]"));
     }
 
     public void testWarningsIncludeFieldNameInPermissiveMode() throws IOException {
@@ -2244,12 +2262,15 @@ public class CsvFormatReaderTests extends ESTestCase {
             while (iterator.hasNext()) {
                 iterator.next();
             }
-            List<String> warnings = CsvFormatReader.getWarnings(iterator);
-            assertEquals(2, warnings.size());
-            assertTrue("Warning should include field name, got: " + warnings.get(0), warnings.get(0).contains("field [id]"));
-            assertTrue("Warning should include field name, got: " + warnings.get(1), warnings.get(1).contains("field [score]"));
-            assertTrue("Warning should include row number, got: " + warnings.get(0), warnings.get(0).contains("Row [2]"));
+            assertEquals(2, CsvFormatReader.emittedWarnings(iterator));
         }
+        // 1 summary + 2 details
+        List<String> warnings = drainWarnings();
+        assertEquals(3, warnings.size());
+        assertTrue("Summary should mention null_field, got: " + warnings.get(0), warnings.get(0).contains("policy: null_field"));
+        assertTrue("Detail should include field name, got: " + warnings.get(1), warnings.get(1).contains("field [id]"));
+        assertTrue("Detail should include field name, got: " + warnings.get(2), warnings.get(2).contains("field [score]"));
+        assertTrue("Detail should include row number, got: " + warnings.get(1), warnings.get(1).contains("Row [2]"));
     }
 
     public void testWarningsOverflowMessage() throws IOException {
@@ -2268,14 +2289,29 @@ public class CsvFormatReaderTests extends ESTestCase {
             while (iterator.hasNext()) {
                 iterator.next();
             }
-            List<String> warnings = CsvFormatReader.getWarnings(iterator);
-            assertEquals(21, warnings.size());
-            assertTrue("First warning should have row number, got: " + warnings.get(0), warnings.get(0).startsWith("Row [1]"));
-            assertTrue(
-                "Last warning should note suppression, got: " + warnings.get(20),
-                warnings.get(20).contains("further warnings suppressed")
-            );
+            assertEquals(20, CsvFormatReader.emittedWarnings(iterator));
         }
+        // 1 summary + 20 details + 1 overflow
+        List<String> warnings = drainWarnings();
+        assertEquals(22, warnings.size());
+        assertTrue("Summary should mention skip_row, got: " + warnings.get(0), warnings.get(0).contains("policy: skip_row"));
+        assertTrue("First detail should have row number, got: " + warnings.get(1), warnings.get(1).contains("Row [1]"));
+        assertTrue(
+            "Last warning should note suppression, got: " + warnings.get(21),
+            warnings.get(21).contains("further warnings suppressed")
+        );
+    }
+
+    /**
+     * Reads the response-header warnings emitted on the test thread and clears them so the
+     * {@link ESTestCase#after()} no-warnings post-check passes. Returns the unwrapped warning
+     * messages (without the "299 Elasticsearch-... " prefix and surrounding quotes).
+     */
+    private List<String> drainWarnings() {
+        List<String> raw = threadContext.getResponseHeaders().getOrDefault("Warning", List.of());
+        List<String> messages = raw.stream().map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false)).toList();
+        threadContext.stashContext();
+        return messages;
     }
 
     // --- Boolean case-insensitive tests (#309) ---

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -43,7 +43,6 @@ import java.io.InputStream;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -97,15 +96,14 @@ public class NdJsonPageDecoder implements Closeable {
         this.input = input;
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
         this.errorPolicy = errorPolicy;
-        this.skipWarnings = errorPolicy.isStrict()
-            ? null
-            : new SkipWarnings(
-                "NDJSON read from ["
-                    + sourceLocation
-                    + "] produced recoverable errors (policy: "
-                    + errorPolicy.mode().name().toLowerCase(Locale.ROOT)
-                    + "); affected rows are listed below"
-            );
+        this.skipWarnings = SkipWarnings.of(
+            errorPolicy,
+            "NDJSON read from ["
+                + sourceLocation
+                + "] encountered parse errors handled per policy (policy: "
+                + errorPolicy.modeName()
+                + "); affected rows are listed below"
+        );
 
         List<Attribute> fullSchema = attributes;
         var projectedAttributes = attributes;

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -42,6 +43,7 @@ import java.io.InputStream;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -66,6 +68,7 @@ public class NdJsonPageDecoder implements Closeable {
     // the number of positions that were added.
     private final BitSet blockTracker;
     private final ErrorPolicy errorPolicy;
+    private final SkipWarnings skipWarnings;
     private long totalRowCount;
     private long errorCount;
 
@@ -88,11 +91,21 @@ public class NdJsonPageDecoder implements Closeable {
         List<String> projectedColumns,
         int batchSize,
         BlockFactory blockFactory,
-        ErrorPolicy errorPolicy
+        ErrorPolicy errorPolicy,
+        String sourceLocation
     ) throws IOException {
         this.input = input;
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
         this.errorPolicy = errorPolicy;
+        this.skipWarnings = errorPolicy.isStrict()
+            ? null
+            : new SkipWarnings(
+                "NDJSON read from ["
+                    + sourceLocation
+                    + "] produced recoverable errors (policy: "
+                    + errorPolicy.mode().name().toLowerCase(Locale.ROOT)
+                    + "); affected rows are listed below"
+            );
 
         List<Attribute> fullSchema = attributes;
         var projectedAttributes = attributes;
@@ -131,7 +144,28 @@ public class NdJsonPageDecoder implements Closeable {
             throw new EsqlIllegalArgumentException(e, "Malformed NDJSON [{}]: {}", phaseLabel, e.getOriginalMessage());
         }
         errorCount++;
+        skipWarnings.add(
+            (e instanceof JsonEOFException ? "Truncated" : "Malformed")
+                + " NDJSON at logical row ["
+                + logicalRowIndex
+                + "] ("
+                + phaseLabel
+                + "): "
+                + e.getOriginalMessage()
+        );
         if (errorPolicy.isBudgetExceeded(errorCount, totalRowCount)) {
+            // Surface the budget-exceeded condition as a warning so clients see exactly what tripped it.
+            skipWarnings.add(
+                "NDJSON error budget exceeded at row ["
+                    + totalRowCount
+                    + "]: ["
+                    + errorCount
+                    + "] errors, maximum ["
+                    + errorPolicy.maxErrors()
+                    + "] or ratio ["
+                    + errorPolicy.maxErrorRatio()
+                    + "]"
+            );
             throw new EsqlIllegalArgumentException(
                 "NDJSON error budget exceeded: [{}] errors in [{}] rows, maximum allowed is [{}] errors or [{}] ratio",
                 errorCount,

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
@@ -52,15 +52,24 @@ final class NdJsonPageIterator implements CloseableIterator<Page> {
         ErrorPolicy errorPolicy
     ) throws IOException {
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
+        String sourceLocation = object.path().toString();
         InputStream inputStream = object.newStream();
         if (skipFirstLine) {
             skipToNextLine(inputStream);
         }
         if (trimLastPartialLine) {
-            inputStream = trimLastPartialLine(inputStream, errorPolicy);
+            inputStream = trimLastPartialLine(inputStream, errorPolicy, sourceLocation);
         }
         this.rowLimit = rowLimit;
-        this.pageDecoder = new NdJsonPageDecoder(inputStream, resolvedAttributes, projectedColumns, batchSize, blockFactory, errorPolicy);
+        this.pageDecoder = new NdJsonPageDecoder(
+            inputStream,
+            resolvedAttributes,
+            projectedColumns,
+            batchSize,
+            blockFactory,
+            errorPolicy,
+            sourceLocation
+        );
     }
 
     @Override
@@ -148,8 +157,8 @@ final class NdJsonPageIterator implements CloseableIterator<Page> {
      * the last {@code '\n'}, without materializing the whole stream in memory. The delegate is closed
      * when the returned stream is closed. Oversized partial lines follow {@code errorPolicy}.
      */
-    static InputStream trimLastPartialLine(InputStream in, ErrorPolicy errorPolicy) {
+    static InputStream trimLastPartialLine(InputStream in, ErrorPolicy errorPolicy, String sourceLocation) {
         // TODO: thread in a centralized error counter?
-        return new TrimLastPartialLineInputStream(in, errorPolicy);
+        return new TrimLastPartialLineInputStream(in, errorPolicy, sourceLocation);
     }
 }

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonSchemaInferrer.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonSchemaInferrer.java
@@ -183,6 +183,12 @@ public class NdJsonSchemaInferrer {
 
     /** Build the list of Attribute by recursively traversing the FieldInfo tree */
     private static void buildSchema(FieldInfo field, String parentName, List<Attribute> attributes) {
+        if (field.children == null) {
+            // No children were ever observed. Happens for the root when every sampled line was
+            // malformed (so {@link FieldInfo#getChild} was never called), or legitimately for
+            // leaf fields during recursion. Nothing to contribute to the schema either way.
+            return;
+        }
         for (Map.Entry<String, FieldInfo> entry : field.children.entrySet()) {
             // TODO: disallow dots in names (or replace them) as it may cause issues when decoding
             var name = entry.getKey();

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/TrimLastPartialLineInputStream.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/TrimLastPartialLineInputStream.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-import java.util.Locale;
 
 /**
  * Wraps an NDJSON byte stream and exposes only bytes through the last {@code '\n'} in the stream,
@@ -72,15 +71,10 @@ final class TrimLastPartialLineInputStream extends InputStream {
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
         this.chunk = new byte[chunkSize];
         this.errorPolicy = errorPolicy;
-        this.skipWarnings = errorPolicy.isStrict()
-            ? null
-            : new SkipWarnings(
-                "NDJSON read from ["
-                    + sourceLocation
-                    + "] discarded oversized partial lines (policy: "
-                    + errorPolicy.mode().name().toLowerCase(Locale.ROOT)
-                    + ")"
-            );
+        this.skipWarnings = SkipWarnings.of(
+            errorPolicy,
+            "NDJSON read from [" + sourceLocation + "] discarded an oversized partial line (policy: " + errorPolicy.modeName() + ")"
+        );
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/TrimLastPartialLineInputStream.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/TrimLastPartialLineInputStream.java
@@ -15,10 +15,12 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * Wraps an NDJSON byte stream and exposes only bytes through the last {@code '\n'} in the stream,
@@ -49,6 +51,7 @@ final class TrimLastPartialLineInputStream extends InputStream {
     private final InputStream delegate;
     private final byte[] chunk;
     private final ErrorPolicy errorPolicy;
+    private final SkipWarnings skipWarnings;
 
     /** Bytes after the last {@code '\n'} observed across all chunks read so far; discarded at EOF. */
     private byte[] carry;
@@ -59,16 +62,25 @@ final class TrimLastPartialLineInputStream extends InputStream {
     private boolean eof;
     private final byte[] single = new byte[1];
 
-    TrimLastPartialLineInputStream(InputStream delegate, ErrorPolicy errorPolicy) {
-        this(delegate, DEFAULT_TRIM_CHUNK_SIZE, errorPolicy);
+    TrimLastPartialLineInputStream(InputStream delegate, ErrorPolicy errorPolicy, String sourceLocation) {
+        this(delegate, DEFAULT_TRIM_CHUNK_SIZE, errorPolicy, sourceLocation);
     }
 
-    TrimLastPartialLineInputStream(InputStream delegate, int chunkSize, ErrorPolicy errorPolicy) {
+    TrimLastPartialLineInputStream(InputStream delegate, int chunkSize, ErrorPolicy errorPolicy, String sourceLocation) {
         this.delegate = delegate;
         Check.isTrue(chunkSize > 0, "chunkSize must strictly positive");
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
         this.chunk = new byte[chunkSize];
         this.errorPolicy = errorPolicy;
+        this.skipWarnings = errorPolicy.isStrict()
+            ? null
+            : new SkipWarnings(
+                "NDJSON read from ["
+                    + sourceLocation
+                    + "] discarded oversized partial lines (policy: "
+                    + errorPolicy.mode().name().toLowerCase(Locale.ROOT)
+                    + ")"
+            );
     }
 
     @Override
@@ -154,6 +166,15 @@ final class TrimLastPartialLineInputStream extends InputStream {
 
     /** Same level choice as {@link NdJsonPageDecoder#onNdjsonLineParseError}. */
     private void logDiscardedOversizedPartial(long discardedBytes, String kind) {
+        skipWarnings.add(
+            "Skipping NDJSON ["
+                + kind
+                + "] of approximately ["
+                + discardedBytes
+                + "] bytes while trimming split suffix; limit is ["
+                + MAX_CARRY
+                + "]"
+        );
         logger.log(
             errorPolicy.logErrors() ? Level.INFO : Level.DEBUG,
             LoggerMessageFormat.format(

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -70,6 +70,9 @@ public class NdJsonPageIteratorTests extends ESTestCase {
     @After
     public void clearWarningHeaders() {
         if (threadContext != null) {
+            // Swap in a fresh empty context (we deliberately do not restore() - the parent
+            // ESTestCase provides a fresh threadContext for the next test, so the stashed one
+            // can be discarded).
             threadContext.stashContext();
         }
     }

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.formatter.TextFormat;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.hamcrest.Matchers;
+import org.junit.After;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -59,6 +60,18 @@ public class NdJsonPageIteratorTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    /**
+     * Tests below exercise non-strict {@link ErrorPolicy} paths which now emit response-header
+     * warnings via {@code HeaderWarning.addWarning(...)}. Drop them so the parent
+     * {@code ensureNoWarnings} post-check passes.
+     */
+    @After
+    public void clearWarningHeaders() {
+        if (threadContext != null) {
+            threadContext.stashContext();
+        }
     }
 
     public void testIterator() throws IOException {
@@ -195,7 +208,8 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         try (
             InputStream trimmed = NdJsonPageIterator.trimLastPartialLine(
                 new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)),
-                ErrorPolicy.STRICT
+                ErrorPolicy.STRICT,
+                "test://input"
             )
         ) {
             assertEquals("{\"id\":1}\n{\"id\":2}\n", new String(trimmed.readAllBytes(), StandardCharsets.UTF_8));
@@ -206,7 +220,8 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         try (
             InputStream trimmed = NdJsonPageIterator.trimLastPartialLine(
                 new ByteArrayInputStream("partial-only".getBytes(StandardCharsets.UTF_8)),
-                ErrorPolicy.STRICT
+                ErrorPolicy.STRICT,
+                "test://input"
             )
         ) {
             assertEquals(0, trimmed.readAllBytes().length);
@@ -214,7 +229,13 @@ public class NdJsonPageIteratorTests extends ESTestCase {
     }
 
     public void testTrimLastPartialLineEmptyStream() throws IOException {
-        try (InputStream trimmed = NdJsonPageIterator.trimLastPartialLine(new ByteArrayInputStream(new byte[0]), ErrorPolicy.STRICT)) {
+        try (
+            InputStream trimmed = NdJsonPageIterator.trimLastPartialLine(
+                new ByteArrayInputStream(new byte[0]),
+                ErrorPolicy.STRICT,
+                "test://input"
+            )
+        ) {
             assertEquals(0, trimmed.readAllBytes().length);
         }
     }
@@ -222,7 +243,9 @@ public class NdJsonPageIteratorTests extends ESTestCase {
     /** Input already ends on a line feed: nothing after the last delimiter to trim. */
     public void testTrimLastPartialLineInputEndsWithNewline() throws IOException {
         byte[] data = "{\"x\":1}\n".getBytes(StandardCharsets.UTF_8);
-        try (InputStream trimmed = NdJsonPageIterator.trimLastPartialLine(new ByteArrayInputStream(data), ErrorPolicy.STRICT)) {
+        try (
+            InputStream trimmed = NdJsonPageIterator.trimLastPartialLine(new ByteArrayInputStream(data), ErrorPolicy.STRICT, "test://input")
+        ) {
             assertArrayEquals(data, trimmed.readAllBytes());
         }
     }
@@ -233,7 +256,14 @@ public class NdJsonPageIteratorTests extends ESTestCase {
      */
     public void testTrimLastPartialLineAcrossSmallChunks() throws IOException {
         byte[] payload = "aa\nbb\nPART".getBytes(StandardCharsets.UTF_8);
-        try (InputStream trimmed = new TrimLastPartialLineInputStream(new ByteArrayInputStream(payload), 4, ErrorPolicy.STRICT)) {
+        try (
+            InputStream trimmed = new TrimLastPartialLineInputStream(
+                new ByteArrayInputStream(payload),
+                4,
+                ErrorPolicy.STRICT,
+                "test://input"
+            )
+        ) {
             assertEquals("aa\nbb\n", new String(trimmed.readAllBytes(), StandardCharsets.UTF_8));
         }
     }
@@ -258,7 +288,14 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         terminal[3000] = '\n';
         parts.add(terminal);
 
-        try (InputStream trimmed = new TrimLastPartialLineInputStream(new ChainedByteChunksStream(parts), trimChunk, ErrorPolicy.STRICT)) {
+        try (
+            InputStream trimmed = new TrimLastPartialLineInputStream(
+                new ChainedByteChunksStream(parts),
+                trimChunk,
+                ErrorPolicy.STRICT,
+                "test://input"
+            )
+        ) {
             assertEquals(2000, trimmed.readNBytes(2000).length);
             byte[] tail = trimmed.readAllBytes();
             assertEquals(5001 - 2000 + (4L * trimChunk) + 3001, tail.length);
@@ -326,7 +363,12 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         int chunk = 8192;
         long streamLen = TrimLastPartialLineInputStream.MAX_CARRY_BYTES + chunk;
         try (
-            InputStream trimmed = new TrimLastPartialLineInputStream(new FiniteBytesWithoutNewline(streamLen), chunk, ErrorPolicy.STRICT)
+            InputStream trimmed = new TrimLastPartialLineInputStream(
+                new FiniteBytesWithoutNewline(streamLen),
+                chunk,
+                ErrorPolicy.STRICT,
+                "test://input"
+            )
         ) {
             IOException ex = expectThrows(IOException.class, trimmed::readAllBytes);
             assertThat(ex.getMessage(), Matchers.containsString(TrimLastPartialLineInputStream.MAX_CARRY.toString()));
@@ -341,7 +383,12 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         int chunk = 8192;
         long streamLen = TrimLastPartialLineInputStream.MAX_CARRY_BYTES + chunk;
         try (
-            InputStream trimmed = new TrimLastPartialLineInputStream(new FiniteBytesWithoutNewline(streamLen), chunk, ErrorPolicy.LENIENT)
+            InputStream trimmed = new TrimLastPartialLineInputStream(
+                new FiniteBytesWithoutNewline(streamLen),
+                chunk,
+                ErrorPolicy.LENIENT,
+                "test://input"
+            )
         ) {
             assertEquals(0, trimmed.readAllBytes().length);
         }
@@ -491,6 +538,74 @@ public class NdJsonPageIteratorTests extends ESTestCase {
             assertEquals(3, id.getInt(1));
             assertFalse(iterator.hasNext());
         }
+    }
+
+    public void testMalformedLineEmitsResponseWarningHeader() throws IOException {
+        String ndjson = """
+            {"id":1}
+            {{{not-an-object
+            {"id":3}
+            """;
+        var object = new BytesStorageObject("memory://warn.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        try (
+            var iterator = reader.read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(100).errorPolicy(ErrorPolicy.LENIENT).build()
+            )
+        ) {
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+        }
+        List<String> warnings = drainWarnings();
+        // 1 summary + 1 detail
+        assertEquals(2, warnings.size());
+        assertTrue("Summary should mention skip_row, got: " + warnings.get(0), warnings.get(0).contains("policy: skip_row"));
+        assertTrue("Summary should mention the file path, got: " + warnings.get(0), warnings.get(0).contains("memory://warn.ndjson"));
+        assertTrue("Detail should mention the malformed row, got: " + warnings.get(1), warnings.get(1).contains("Malformed NDJSON"));
+    }
+
+    public void testMalformedLinesOverflowEmitsCappedHeaders() throws IOException {
+        // Mix valid and invalid lines so the SKIP_ROW path triggers more than MAX_ADDED_WARNINGS times.
+        StringBuilder ndjson = new StringBuilder();
+        for (int i = 1; i <= 30; i++) {
+            ndjson.append("{{{not-an-object-").append(i).append('\n');
+        }
+        var object = new BytesStorageObject("memory://overflow.ndjson", ndjson.toString().getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        try (
+            var iterator = reader.read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(50).errorPolicy(ErrorPolicy.LENIENT).build()
+            )
+        ) {
+            while (iterator.hasNext()) {
+                iterator.next();
+            }
+        }
+        List<String> warnings = drainWarnings();
+        // 1 summary + up to 20 details + 1 overflow notice (= 22). NDJSON message variants may differ
+        // slightly per line, so we check the bounds rather than an exact equality.
+        assertTrue("expected at least summary + 20 details + overflow, got: " + warnings.size(), warnings.size() >= 22);
+        assertTrue("First warning should be the summary, got: " + warnings.get(0), warnings.get(0).contains("policy: skip_row"));
+        assertTrue(
+            "Last warning should mention overflow, got: " + warnings.get(warnings.size() - 1),
+            warnings.get(warnings.size() - 1).contains("further warnings suppressed")
+        );
+    }
+
+    /**
+     * Reads the response-header warnings emitted on the test thread and clears them so the parent
+     * {@code ensureNoWarnings} post-check passes. Returns the unwrapped warning messages.
+     */
+    private List<String> drainWarnings() {
+        List<String> raw = threadContext.getResponseHeaders().getOrDefault("Warning", List.of());
+        List<String> messages = raw.stream()
+            .map(s -> org.elasticsearch.common.logging.HeaderWarning.extractWarningValueFromWarningHeader(s, false))
+            .toList();
+        threadContext.stashContext();
+        return messages;
     }
 
     public void testFailFastOnMalformedNdjsonLine() throws IOException {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -53,6 +53,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
@@ -845,7 +846,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     /**
      * When the query plan type cannot be satisfied from this file's Parquet-derived ESQL type (after
      * applying the same widening rules as {@link EsqlDataTypeConverter#commonType}, plus KEYWORD/TEXT
-     * interchangeability), log a warning and read the column as null instead of failing at decode time.
+     * interchangeability), emit a response Warning header (and log a warning) and read the column as
+     * null instead of failing at decode time. The warning header lets clients see — alongside other
+     * recoverable ES|QL warnings — exactly which columns were silently null-replaced.
      */
     private static void validatePlannerTypesAgainstFile(
         Logger logger,
@@ -855,6 +858,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         ColumnInfo[] columnInfos
     ) {
         MessageType fullSchema = reader.getFileMetaData().getSchema();
+        SkipWarnings skipWarnings = null;
         for (int i = 0; i < attributes.size(); i++) {
             if (columnInfos[i] == null) {
                 continue;
@@ -868,6 +872,25 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             }
             DataType actualInFile = convertParquetTypeToEsql(fullSchema.getType(attr.name()));
             if (plannerTypeCompatibleWithFileDerivedType(attr.dataType(), actualInFile) == false) {
+                if (skipWarnings == null) {
+                    skipWarnings = new SkipWarnings(
+                        "Parquet file ["
+                            + fileLocation
+                            + "] has columns whose on-disk type is incompatible with the planner type; "
+                            + "they are returned as null"
+                    );
+                }
+                skipWarnings.add(
+                    "Column ["
+                        + attr.name()
+                        + "] in file ["
+                        + fileLocation
+                        + "] has type ["
+                        + actualInFile
+                        + "] incompatible with planner type ["
+                        + attr.dataType()
+                        + "]; returning nulls for this column"
+                );
                 logger.warn(
                     "Column [{}] in file [{}] has type [{}] incompatible with planner type [{}] after widening; "
                         + "returning nulls for this column",

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -28,6 +28,7 @@ import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LimitedBreaker;
@@ -50,6 +51,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.junit.After;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -80,6 +82,19 @@ public class ParquetFormatReaderTests extends ESTestCase {
         super.setUp();
         ParquetStorageObjectAdapter.clearFooterCacheForTests();
         blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    /**
+     * The schema-vs-planner mismatch fallback in {@code ParquetFormatReader} now emits a response
+     * Warning header alongside the existing {@code logger.warn}. Drop accumulated warnings so the
+     * parent {@code ensureNoWarnings} post-check passes; tests that assert on them call
+     * {@code drainWarnings()} from inside the test method.
+     */
+    @After
+    public void clearWarningHeaders() {
+        if (threadContext != null) {
+            threadContext.stashContext();
+        }
     }
 
     public void testFormatName() {
@@ -1669,6 +1684,56 @@ public class ParquetFormatReaderTests extends ESTestCase {
             Page page = it.next();
             assertTrue(page.getBlock(0).isNull(0));
         }
+    }
+
+    /**
+     * Schema-vs-planner mismatch is a "skip and resume" path: the column is silently null-replaced.
+     * Confirm that, on top of the {@code logger.warn} we keep, the reader emits a response Warning
+     * header so clients see the same information they get for other recoverable ES|QL warnings.
+     */
+    public void testSchemaMismatchEmitsResponseWarningHeader() throws Exception {
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT32).named("x").named("test_schema");
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            Group g = factory.newGroup();
+            g.add("x", 42);
+            return List.of(g);
+        });
+        StorageObject storageObject = createStorageObject(parquetData, "s3://bucket/warn.parquet");
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        List<Attribute> plannerTypes = List.of(new ReferenceAttribute(Source.EMPTY, "x", DataType.KEYWORD));
+        try (
+            CloseableIterator<Page> iterator = reader.readRange(
+                storageObject,
+                List.of("x"),
+                100,
+                0,
+                parquetData.length,
+                plannerTypes,
+                ErrorPolicy.STRICT
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertTrue(page.getBlock(0).isNull(0));
+        }
+
+        List<String> warnings = drainWarnings();
+        // 1 summary + 1 detail
+        assertEquals("Expected summary + 1 detail, got: " + warnings, 2, warnings.size());
+        assertTrue("Summary should mention the file path, got: " + warnings.get(0), warnings.get(0).contains("s3://bucket/warn.parquet"));
+        assertTrue("Detail should mention column [x], got: " + warnings.get(1), warnings.get(1).contains("Column [x]"));
+        assertTrue("Detail should mention the planner type, got: " + warnings.get(1), warnings.get(1).contains("KEYWORD"));
+        assertTrue(
+            "Detail should mention the on-disk type, got: " + warnings.get(1),
+            warnings.get(1).contains("INTEGER") || warnings.get(1).contains("LONG")
+        );
+    }
+
+    private List<String> drainWarnings() {
+        List<String> raw = threadContext.getResponseHeaders().getOrDefault("Warning", List.of());
+        List<String> messages = raw.stream().map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false)).toList();
+        threadContext.stashContext();
+        return messages;
     }
 
     public void testReadRangeSelectsCorrectRowGroups() throws Exception {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -93,6 +93,9 @@ public class ParquetFormatReaderTests extends ESTestCase {
     @After
     public void clearWarningHeaders() {
         if (threadContext != null) {
+            // Swap in a fresh empty context (we deliberately do not restore() - the parent
+            // ESTestCase provides a fresh threadContext for the next test, so the stashed one
+            // can be discarded).
             threadContext.stashContext();
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
@@ -44,6 +44,14 @@ import java.util.Locale;
  *   FROM s3://bucket/data.csv WITH {"error_mode": "null_field"}
  * }
  *
+ * <h2>Client-visible warnings</h2>
+ * Whenever the non-strict modes ({@link Mode#SKIP_ROW} and {@link Mode#NULL_FIELD}) cause a row to be
+ * dropped or a field to be null-filled, format readers emit response {@code Warning} headers via
+ * {@link SkipWarnings}: a one-time summary identifying the file, plus per-event details capped at
+ * {@link SkipWarnings#MAX_ADDED_WARNINGS} entries (further events collapse into a single
+ * "further warnings suppressed" line). This is independent of {@code logErrors}, which still only
+ * controls server-side WARN logging.
+ *
  * @param mode           how to handle rows with parse errors
  * @param maxErrors      maximum number of errors to tolerate before failing
  *                       (only meaningful for {@code SKIP_ROW} and {@code NULL_FIELD})

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
@@ -127,6 +127,15 @@ public record ErrorPolicy(Mode mode, long maxErrors, double maxErrorRatio, boole
     }
 
     /**
+     * Lowercase, locale-insensitive name of {@link #mode()}, suitable for user-facing messages
+     * (e.g. {@code "skip_row"}, {@code "null_field"}). Matches the parser input accepted by
+     * {@link Mode#parse(String)}.
+     */
+    public String modeName() {
+        return mode.name().toLowerCase(Locale.ROOT);
+    }
+
+    /**
      * Checks whether the error budget has been exceeded given the current counts.
      * Always returns {@code false} for {@link Mode#FAIL_FAST} (which never reaches
      * this check — it throws immediately in the caller).

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.common.logging.HeaderWarning;
+
+/**
+ * Collects response {@code Warning} headers for datasource read paths that skip a malformed input
+ * and resume processing (non-strict {@link ErrorPolicy}, or similar best-effort fallbacks).
+ * <p>
+ * The first recorded detail also emits a one-time summary header so clients see a single line
+ * describing the overall situation (e.g. "malformed rows were skipped in file X") followed by per-event
+ * details. Per-event details are capped at {@link #MAX_ADDED_WARNINGS}; on overflow a single
+ * "further warnings suppressed" entry is emitted so clients know more were dropped.
+ * <p>
+ * Writes go through {@link HeaderWarning#addWarning(String, Object...)} which attaches them to the
+ * current thread's response headers; if no thread context is bound (e.g. in unit tests that don't
+ * care), the call is a no-op. Instances are stateful and not thread-safe: create one per reader
+ * iterator or decoder.
+ */
+public final class SkipWarnings {
+
+    /** Maximum number of per-event entries recorded; mirrors {@code compute.operator.Warnings}. */
+    public static final int MAX_ADDED_WARNINGS = 20;
+
+    private final String summary;
+    private int added;
+    private boolean summaryEmitted;
+    private boolean overflowEmitted;
+
+    public SkipWarnings(String summary) {
+        this.summary = summary;
+    }
+
+    /**
+     * Record a single skip/null-fill event. Emits the summary header on the first call, the detail
+     * on this and the next up to {@link #MAX_ADDED_WARNINGS} calls, and a single
+     * "further warnings suppressed" header when the cap is exceeded.
+     */
+    public void add(String detail) {
+        if (summaryEmitted == false) {
+            HeaderWarning.addWarning(summary);
+            summaryEmitted = true;
+        }
+        if (added < MAX_ADDED_WARNINGS) {
+            HeaderWarning.addWarning(detail);
+            added++;
+        } else if (overflowEmitted == false) {
+            HeaderWarning.addWarning("... further warnings suppressed (more than " + MAX_ADDED_WARNINGS + " recorded)");
+            overflowEmitted = true;
+        }
+    }
+
+    /** Number of per-event detail warnings emitted so far (excludes the summary and overflow lines). */
+    public int added() {
+        return added;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarnings.java
@@ -22,13 +22,31 @@ import org.elasticsearch.common.logging.HeaderWarning;
  * current thread's response headers; if no thread context is bound (e.g. in unit tests that don't
  * care), the call is a no-op. Instances are stateful and not thread-safe: create one per reader
  * iterator or decoder.
+ * <p>
+ * Callers working against an {@link ErrorPolicy} should use {@link #of(ErrorPolicy, String)} to
+ * obtain either a live collector or the shared {@link #NOOP} sink, so that call sites never have
+ * to null-guard subsequent {@link #add(String)} invocations.
+ * <p>
+ * This utility lives alongside {@link ErrorPolicy} in the {@code spi} package because datasource
+ * plugins may need to emit the same shape of warnings from outside this module; it is a concrete
+ * utility rather than an SPI interface.
  */
-public final class SkipWarnings {
+public class SkipWarnings {
 
     /** Maximum number of per-event entries recorded; mirrors {@code compute.operator.Warnings}. */
     public static final int MAX_ADDED_WARNINGS = 20;
 
+    /**
+     * Shared sink used when the current {@link ErrorPolicy} never triggers skip/null-fill behavior
+     * (e.g. {@link ErrorPolicy#isStrict()}). All {@link #add(String)} calls are silently dropped.
+     */
+    public static final SkipWarnings NOOP = new SkipWarnings("") {
+        @Override
+        public void add(String detail) {}
+    };
+
     private final String summary;
+    // Mutable state: not thread-safe, one instance per reader iterator/decoder.
     private int added;
     private boolean summaryEmitted;
     private boolean overflowEmitted;
@@ -38,12 +56,23 @@ public final class SkipWarnings {
     }
 
     /**
+     * Returns {@link #NOOP} for strict policies (which never skip/null-fill and therefore never need
+     * to emit a warning), or a fresh live collector seeded with {@code summary} otherwise.
+     */
+    public static SkipWarnings of(ErrorPolicy policy, String summary) {
+        return policy.isStrict() ? NOOP : new SkipWarnings(summary);
+    }
+
+    /**
      * Record a single skip/null-fill event. Emits the summary header on the first call, the detail
      * on this and the next up to {@link #MAX_ADDED_WARNINGS} calls, and a single
      * "further warnings suppressed" header when the cap is exceeded.
      */
     public void add(String detail) {
         if (summaryEmitted == false) {
+            // Use the no-varargs overload so HeaderWarning treats both summary and detail as plain
+            // strings (LoggerMessageFormat#format early-returns when argArray is empty); this keeps
+            // user data containing '{' or '}' from being reinterpreted as a placeholder pattern.
             HeaderWarning.addWarning(summary);
             summaryEmitted = true;
         }
@@ -54,10 +83,5 @@ public final class SkipWarnings {
             HeaderWarning.addWarning("... further warnings suppressed (more than " + MAX_ADDED_WARNINGS + " recorded)");
             overflowEmitted = true;
         }
-    }
-
-    /** Number of per-event detail warnings emitted so far (excludes the summary and overflow lines). */
-    public int added() {
-        return added;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarningsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarningsTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.common.logging.HeaderWarning;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+
+public class SkipWarningsTests extends ESTestCase {
+
+    public void testEmitsSummaryOnFirstAddOnly() {
+        SkipWarnings warnings = new SkipWarnings("the summary");
+        warnings.add("first detail");
+        warnings.add("second detail");
+        assertEquals(2, warnings.added());
+
+        List<String> emitted = drain();
+        assertEquals(3, emitted.size());
+        assertEquals("the summary", emitted.get(0));
+        assertEquals("first detail", emitted.get(1));
+        assertEquals("second detail", emitted.get(2));
+    }
+
+    public void testNoSummaryWhenNothingAdded() {
+        new SkipWarnings("not used");
+        assertNull(threadContext.getResponseHeaders().get("Warning"));
+    }
+
+    public void testCapsAtMaxAddedWarningsAndEmitsOverflow() {
+        SkipWarnings warnings = new SkipWarnings("summary");
+        int total = SkipWarnings.MAX_ADDED_WARNINGS + 5;
+        for (int i = 0; i < total; i++) {
+            warnings.add("detail " + i);
+        }
+        assertEquals(SkipWarnings.MAX_ADDED_WARNINGS, warnings.added());
+
+        List<String> emitted = drain();
+        // 1 summary + MAX_ADDED_WARNINGS details + 1 overflow notice
+        assertEquals(SkipWarnings.MAX_ADDED_WARNINGS + 2, emitted.size());
+        assertEquals("summary", emitted.get(0));
+        assertEquals("detail 0", emitted.get(1));
+        assertEquals("detail " + (SkipWarnings.MAX_ADDED_WARNINGS - 1), emitted.get(SkipWarnings.MAX_ADDED_WARNINGS));
+        String overflow = emitted.get(SkipWarnings.MAX_ADDED_WARNINGS + 1);
+        assertTrue("overflow should mention suppression, got: " + overflow, overflow.contains("further warnings suppressed"));
+    }
+
+    public void testOverflowEmittedOnceEvenWithManyExtraAdds() {
+        SkipWarnings warnings = new SkipWarnings("s");
+        for (int i = 0; i < SkipWarnings.MAX_ADDED_WARNINGS + 50; i++) {
+            warnings.add("d");
+        }
+        // The "d" details dedupe inside HeaderWarning's identical-message cache, so we cannot count
+        // them by emission. What we CAN check is that the overflow message appears exactly once.
+        List<String> emitted = drain();
+        long overflowCount = emitted.stream().filter(s -> s.contains("further warnings suppressed")).count();
+        assertEquals(1, overflowCount);
+    }
+
+    private List<String> drain() {
+        List<String> raw = threadContext.getResponseHeaders().getOrDefault("Warning", List.of());
+        List<String> messages = raw.stream().map(s -> HeaderWarning.extractWarningValueFromWarningHeader(s, false)).toList();
+        threadContext.stashContext();
+        return messages;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarningsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/SkipWarningsTests.java
@@ -18,7 +18,6 @@ public class SkipWarningsTests extends ESTestCase {
         SkipWarnings warnings = new SkipWarnings("the summary");
         warnings.add("first detail");
         warnings.add("second detail");
-        assertEquals(2, warnings.added());
 
         List<String> emitted = drain();
         assertEquals(3, emitted.size());
@@ -38,7 +37,6 @@ public class SkipWarningsTests extends ESTestCase {
         for (int i = 0; i < total; i++) {
             warnings.add("detail " + i);
         }
-        assertEquals(SkipWarnings.MAX_ADDED_WARNINGS, warnings.added());
 
         List<String> emitted = drain();
         // 1 summary + MAX_ADDED_WARNINGS details + 1 overflow notice
@@ -60,6 +58,39 @@ public class SkipWarningsTests extends ESTestCase {
         List<String> emitted = drain();
         long overflowCount = emitted.stream().filter(s -> s.contains("further warnings suppressed")).count();
         assertEquals(1, overflowCount);
+    }
+
+    public void testNoopDropsEverything() {
+        SkipWarnings.NOOP.add("first");
+        SkipWarnings.NOOP.add("second");
+        assertNull(threadContext.getResponseHeaders().get("Warning"));
+    }
+
+    public void testOfStrictPolicyReturnsNoop() {
+        assertSame(SkipWarnings.NOOP, SkipWarnings.of(ErrorPolicy.STRICT, "summary ignored"));
+    }
+
+    public void testOfLenientPolicyReturnsLiveCollector() {
+        SkipWarnings warnings = SkipWarnings.of(ErrorPolicy.LENIENT, "live summary");
+        assertNotSame(SkipWarnings.NOOP, warnings);
+        warnings.add("a detail");
+        List<String> emitted = drain();
+        assertEquals(2, emitted.size());
+        assertEquals("live summary", emitted.get(0));
+        assertEquals("a detail", emitted.get(1));
+    }
+
+    /**
+     * Pin {@link SkipWarnings#MAX_ADDED_WARNINGS} to the same value used by
+     * {@code compute.operator.Warnings#MAX_ADDED_WARNINGS} (package-private, not importable here).
+     * Keep the literal below in sync if the compute-side cap ever changes.
+     */
+    public void testMaxAddedWarningsMatchesComputeOperatorWarningsCap() {
+        assertEquals(
+            "SkipWarnings.MAX_ADDED_WARNINGS must stay in sync with compute.operator.Warnings.MAX_ADDED_WARNINGS",
+            20,
+            SkipWarnings.MAX_ADDED_WARNINGS
+        );
     }
 
     private List<String> drain() {


### PR DESCRIPTION
This adds Warning header emitting when:
- we produce null columnsn on mismatch between data and plan;
- the error policy is non-strict and processing enouters errors.

🤖-assisted development.