### PR TITLE
Update ResumeInfo Serialisation Tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/RelocationOriginWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/RelocationOriginWireSerializingTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.reindex.resumeinfo;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.index.reindex.ResumeInfo;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+/**
+ * Wire serialization tests for {@link ResumeInfo.RelocationOrigin}.
+ */
+public class RelocationOriginWireSerializingTests extends AbstractWireSerializingTestCase<ResumeInfo.RelocationOrigin> {
+
+    @Override
+    protected Writeable.Reader<ResumeInfo.RelocationOrigin> instanceReader() {
+        return ResumeInfo.RelocationOrigin::new;
+    }
+
+    @Override
+    protected ResumeInfo.RelocationOrigin createTestInstance() {
+        return new ResumeInfo.RelocationOrigin(
+            randomBoolean() ? TaskId.EMPTY_TASK_ID : new TaskId(randomAlphaOfLengthBetween(1, 10), randomNonNegativeLong()),
+            randomLong()
+        );
+    }
+
+    @Override
+    protected ResumeInfo.RelocationOrigin mutateInstance(ResumeInfo.RelocationOrigin instance) throws IOException {
+        // RelocationOrigin is a record so instance based equality doesn't need to be tested
+        return null;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/ResumeInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/ResumeInfoTests.java
@@ -108,11 +108,7 @@ public class ResumeInfoTests extends ESTestCase {
 
     public void testResumeInfoWithSourceTaskResult() throws IOException {
         ResumeInfo.RelocationOrigin origin = randomOrigin();
-        ScrollWorkerResumeInfo worker = scrollWorkerResumeInfo(
-            randomAlphaOfLengthBetween(1, 24),
-            randomNonNegativeLong(),
-            taskStatus()
-        );
+        ScrollWorkerResumeInfo worker = scrollWorkerResumeInfo(randomAlphaOfLengthBetween(1, 24), randomNonNegativeLong(), taskStatus());
         TaskResult source = TaskResultTests.randomTaskResult();
         ResumeInfo info = new ResumeInfo(origin, worker, null, source);
         assertThat(info.sourceTaskResult(), equalTo(source));

--- a/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/ResumeInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/ResumeInfoTests.java
@@ -22,8 +22,11 @@ import org.elasticsearch.index.reindex.ResumeInfo.ScrollWorkerResumeInfo;
 import org.elasticsearch.index.reindex.ResumeInfo.SliceStatus;
 import org.elasticsearch.index.reindex.ResumeInfo.WorkerResult;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskResult;
+import org.elasticsearch.tasks.TaskResultTests;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
@@ -83,6 +86,46 @@ public class ResumeInfoTests extends ESTestCase {
         assertFalse(info.isSliceCompleted(0));
         assertTrue(info.isSliceCompleted(1));
         expectThrows(IllegalArgumentException.class, () -> info.isSliceCompleted(2));
+    }
+
+    /** Sliced resume may carry PIT worker state for an in-progress slice. */
+    public void testResumeInfoWithSlicesIncludingPitWorker() {
+        PitWorkerResumeInfo pitWorker = new PitWorkerResumeInfo(
+            new BytesArray(randomAlphaOfLengthBetween(1, 32).getBytes(StandardCharsets.UTF_8)),
+            randomSearchAfterValues(),
+            randomNonNegativeLong(),
+            taskStatus(),
+            randomBoolean() ? null : (randomBoolean() ? Version.CURRENT : Version.fromId(randomIntBetween(1, 999_999)))
+        );
+        int sliceInProgress = randomIntBetween(0, 50);
+        int sliceDone = randomValueOtherThan(sliceInProgress, () -> randomIntBetween(0, 50));
+        SliceStatus inProgress = new SliceStatus(sliceInProgress, pitWorker, null);
+        SliceStatus completed = sliceStatusWithResult(sliceDone, new ElasticsearchException(randomAlphaOfLengthBetween(1, 40)));
+        ResumeInfo info = new ResumeInfo(randomOrigin(), null, Map.of(sliceInProgress, inProgress, sliceDone, completed));
+        assertThat(info.getSlice(sliceInProgress).get().resumeInfo(), equalTo(pitWorker));
+        assertFalse(info.isSliceCompleted(sliceInProgress));
+    }
+
+    public void testResumeInfoWithSourceTaskResult() throws IOException {
+        ResumeInfo.RelocationOrigin origin = randomOrigin();
+        ScrollWorkerResumeInfo worker = scrollWorkerResumeInfo(
+            randomAlphaOfLengthBetween(1, 24),
+            randomNonNegativeLong(),
+            taskStatus()
+        );
+        TaskResult source = TaskResultTests.randomTaskResult();
+        ResumeInfo info = new ResumeInfo(origin, worker, null, source);
+        assertThat(info.sourceTaskResult(), equalTo(source));
+        assertThat(info.getWorker().get(), equalTo(worker));
+    }
+
+    public void testResumeInfoThreeArgConstructorLeavesSourceTaskResultNull() {
+        ResumeInfo info = new ResumeInfo(
+            randomOrigin(),
+            scrollWorkerResumeInfo(randomAlphaOfLengthBetween(1, 24), randomNonNegativeLong(), taskStatus()),
+            null
+        );
+        assertNull(info.sourceTaskResult());
     }
 
     /** Stored slices map is a copy; later mutations to the input map do not affect the instance. */
@@ -231,6 +274,19 @@ public class ResumeInfoTests extends ESTestCase {
         assertFalse(status.isCompleted());
     }
 
+    public void testSliceStatusWithPitWorkerResumeInfo() {
+        PitWorkerResumeInfo pit = new PitWorkerResumeInfo(
+            new BytesArray(randomAlphaOfLengthBetween(1, 24).getBytes(StandardCharsets.UTF_8)),
+            randomSearchAfterValues(),
+            randomNonNegativeLong(),
+            taskStatus(),
+            randomBoolean() ? null : (randomBoolean() ? Version.CURRENT : Version.fromId(randomIntBetween(1, 999_999)))
+        );
+        SliceStatus status = new SliceStatus(randomIntBetween(0, 100), pit, null);
+        assertThat(status.resumeInfo(), equalTo(pit));
+        assertFalse(status.isCompleted());
+    }
+
     public void testSliceStatusWithResultFailure() {
         WorkerResult result = new WorkerResult(null, new ElasticsearchException("err"));
         SliceStatus status = new SliceStatus(3, null, result);
@@ -248,6 +304,21 @@ public class ResumeInfoTests extends ESTestCase {
         assertNull(status.resumeInfo());
         assertThat(status.result(), equalTo(result));
         assertTrue(status.isCompleted());
+    }
+
+    // ---------- RelocationOrigin ----------
+
+    /** {@link ResumeInfo.RelocationOrigin} rejects a null {@link TaskId}. */
+    public void testRelocationOriginRejectsNullOriginalTaskId() {
+        expectThrows(NullPointerException.class, () -> new ResumeInfo.RelocationOrigin(null, randomNonNegativeLong()));
+    }
+
+    public void testRelocationOriginAccessors() {
+        TaskId taskId = new TaskId(randomAlphaOfLength(5), randomNonNegativeLong());
+        long startMillis = randomNonNegativeLong();
+        ResumeInfo.RelocationOrigin origin = new ResumeInfo.RelocationOrigin(taskId, startMillis);
+        assertThat(origin.originalTaskId(), equalTo(taskId));
+        assertThat(origin.originalStartTimeMillis(), equalTo(startMillis));
     }
 
     private static BulkByScrollTask.Status taskStatus() {
@@ -271,5 +342,18 @@ public class ResumeInfoTests extends ESTestCase {
             randomBoolean() ? TaskId.EMPTY_TASK_ID : new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()),
             randomNonNegativeLong()
         );
+    }
+
+    private static Object[] randomSearchAfterValues() {
+        int length = randomIntBetween(1, 4);
+        Object[] values = new Object[length];
+        for (int i = 0; i < length; i++) {
+            values[i] = switch (randomIntBetween(0, 2)) {
+                case 0 -> randomLong();
+                case 1 -> randomAlphaOfLengthBetween(1, 12);
+                default -> randomInt();
+            };
+        }
+        return values;
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/ResumeInfoWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/ResumeInfoWireSerializingTests.java
@@ -16,8 +16,11 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.ResumeInfo;
 import org.elasticsearch.index.reindex.ResumeInfo.WorkerResumeInfo;
+import org.elasticsearch.tasks.RawTaskStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskResult;
+import org.elasticsearch.tasks.TaskResultTests;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
@@ -25,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.elasticsearch.index.reindex.resumeinfo.PitWorkerResumeInfoWireSerializingTests.randomPitWorkerResumeInfo;
 import static org.elasticsearch.index.reindex.resumeinfo.ScrollWorkerResumeInfoWireSerializingTests.randomScrollWorkerResumeInfo;
@@ -36,18 +40,18 @@ import static org.elasticsearch.index.reindex.resumeinfo.SliceStatusWireSerializ
 
 /**
  * Wire serialization tests for {@link ResumeInfo}.
- * Uses a {@link Wrapper} with content-based equals/hashCode because {@link ResumeInfo} can contain
  */
 public class ResumeInfoWireSerializingTests extends AbstractWireSerializingTestCase<ResumeInfoWireSerializingTests.Wrapper> {
 
     /**
-     * Register {@link ResumeInfo.WorkerResumeInfo} and {@link Task.Status} so that the optional worker
-     * and any nested types inside slices can be deserialized when round-tripping {@link ResumeInfo}.
+     * Register {@link ResumeInfo.WorkerResumeInfo} and {@link Task.Status} implementations so workers, slices, and
+     * optional {@link ResumeInfo#sourceTaskResult()} ({@link org.elasticsearch.tasks.TaskInfo} embedded status) can deserialize.
      */
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
         List<NamedWriteableRegistry.Entry> entries = new ArrayList<>(org.elasticsearch.cluster.ClusterModule.getNamedWriteables());
         entries.add(new NamedWriteableRegistry.Entry(Task.Status.class, BulkByScrollTask.Status.NAME, BulkByScrollTask.Status::new));
+        entries.add(new NamedWriteableRegistry.Entry(Task.Status.class, RawTaskStatus.NAME, RawTaskStatus::new));
         entries.add(
             new NamedWriteableRegistry.Entry(
                 ResumeInfo.WorkerResumeInfo.class,
@@ -76,11 +80,12 @@ public class ResumeInfoWireSerializingTests extends AbstractWireSerializingTestC
             new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()),
             randomNonNegativeLong()
         );
+        final TaskResult sourceTaskResult = randomBoolean() ? randomSourceTaskResult() : null;
         if (randomBoolean()) {
             WorkerResumeInfo worker = randomBoolean() ? randomScrollWorkerResumeInfo() : randomPitWorkerResumeInfo();
-            return new Wrapper(new ResumeInfo(origin, worker, null));
+            return new Wrapper(new ResumeInfo(origin, worker, null, sourceTaskResult));
         } else {
-            return new Wrapper(new ResumeInfo(origin, null, randomSlicesMap()));
+            return new Wrapper(new ResumeInfo(origin, null, randomSlicesMap(), sourceTaskResult));
         }
     }
 
@@ -97,6 +102,14 @@ public class ResumeInfoWireSerializingTests extends AbstractWireSerializingTestC
             map.put(i, randomSliceStatusWithId(i));
         }
         return map;
+    }
+
+    private static TaskResult randomSourceTaskResult() {
+        try {
+            return TaskResultTests.randomTaskResult();
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
     }
 
     /**
@@ -137,18 +150,36 @@ public class ResumeInfoWireSerializingTests extends AbstractWireSerializingTestC
         }
 
         private static boolean resumeInfoContentEquals(ResumeInfo a, ResumeInfo b) {
-            if (workerResumeInfoContentEquals(a.worker(), b.worker()) == false) return false;
-            if (a.slices() == null && b.slices() == null) return true;
-            if (a.slices() == null || b.slices() == null) return false;
-            if (a.slices().keySet().equals(b.slices().keySet()) == false) return false;
+            if (Objects.equals(a.relocationOrigin(), b.relocationOrigin()) == false) {
+                return false;
+            }
+            if (Objects.equals(a.sourceTaskResult(), b.sourceTaskResult()) == false) {
+                return false;
+            }
+            if (workerResumeInfoContentEquals(a.worker(), b.worker()) == false) {
+                return false;
+            }
+            if (a.slices() == null && b.slices() == null) {
+                return true;
+            }
+            if (a.slices() == null || b.slices() == null) {
+                return false;
+            }
+            if (a.slices().keySet().equals(b.slices().keySet()) == false) {
+                return false;
+            }
             for (Integer key : a.slices().keySet()) {
-                if (sliceStatusContentEquals(a.slices().get(key), b.slices().get(key)) == false) return false;
+                if (sliceStatusContentEquals(a.slices().get(key), b.slices().get(key)) == false) {
+                    return false;
+                }
             }
             return true;
         }
 
         private static int resumeInfoContentHashCode(ResumeInfo info) {
-            int result = workerResumeInfoContentHashCode(info.worker());
+            int result = Objects.hashCode(info.relocationOrigin());
+            result = 31 * result + Objects.hashCode(info.sourceTaskResult());
+            result = 31 * result + workerResumeInfoContentHashCode(info.worker());
             if (info.slices() != null) {
                 for (Map.Entry<Integer, ResumeInfo.SliceStatus> entry : info.slices().entrySet()) {
                     result = 31 * result + entry.getKey().hashCode();

--- a/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/SliceStatusWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/SliceStatusWireSerializingTests.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.index.reindex.resumeinfo;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.IndexDocFailureStoreStatus;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -18,6 +20,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.BulkByScrollTaskStatusTests;
+import org.elasticsearch.index.reindex.PaginatedSearchFailure;
 import org.elasticsearch.index.reindex.ResumeInfo.PitWorkerResumeInfo;
 import org.elasticsearch.index.reindex.ResumeInfo.ScrollWorkerResumeInfo;
 import org.elasticsearch.index.reindex.ResumeInfo.SliceStatus;
@@ -31,7 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import static java.util.Collections.emptyList;
 import static org.elasticsearch.index.reindex.resumeinfo.PitWorkerResumeInfoWireSerializingTests.pitWorkerResumeInfoContentEquals;
 import static org.elasticsearch.index.reindex.resumeinfo.PitWorkerResumeInfoWireSerializingTests.pitWorkerResumeInfoContentHashCode;
 import static org.elasticsearch.index.reindex.resumeinfo.PitWorkerResumeInfoWireSerializingTests.randomPitWorkerResumeInfo;
@@ -40,6 +42,7 @@ import static org.elasticsearch.index.reindex.resumeinfo.ScrollWorkerResumeInfoW
 /**
  * Wire serialization tests for {@link SliceStatus}.
  * Uses a {@link Wrapper} with content-based equals/hashCode because {@link SliceStatus}
+ * embeds {@link BulkByScrollResponse} and {@link Exception} without structural {@code equals}.
  */
 public class SliceStatusWireSerializingTests extends AbstractWireSerializingTestCase<SliceStatusWireSerializingTests.Wrapper> {
 
@@ -108,8 +111,7 @@ public class SliceStatusWireSerializingTests extends AbstractWireSerializingTest
         result = 31 * result + workerResumeInfoContentHashCode(status.resumeInfo());
         if (status.result() != null) {
             if (status.result().getResponse().isPresent()) {
-                BulkByScrollResponse response = status.result().getResponse().get();
-                result = 31 * result + Objects.hash(response.getTook(), response.getStatus(), response.isTimedOut());
+                result = 31 * result + bulkByScrollResponseContentHashCode(status.result().getResponse().get());
             } else {
                 result = 31 * result + Objects.hashCode(status.result().getFailure().get().getMessage());
             }
@@ -138,16 +140,111 @@ public class SliceStatusWireSerializingTests extends AbstractWireSerializingTest
         if (a.getStatus().equals(b.getStatus()) == false) {
             return false;
         }
-        if (a.getBulkFailures().size() != b.getBulkFailures().size()) {
-            return false;
-        }
-        if (a.getSearchFailures().size() != b.getSearchFailures().size()) {
-            return false;
-        }
         if (a.isTimedOut() != b.isTimedOut()) {
             return false;
         }
+        if (bulkFailuresContentEquals(a.getBulkFailures(), b.getBulkFailures()) == false) {
+            return false;
+        }
+        return searchFailuresContentEquals(a.getSearchFailures(), b.getSearchFailures());
+    }
+
+    static int bulkByScrollResponseContentHashCode(BulkByScrollResponse response) {
+        int result = Objects.hash(response.getTook(), response.getStatus(), response.isTimedOut());
+        result = 31 * result + bulkFailuresContentHashCode(response.getBulkFailures());
+        result = 31 * result + searchFailuresContentHashCode(response.getSearchFailures());
+        return result;
+    }
+
+    private static boolean bulkFailuresContentEquals(List<BulkItemResponse.Failure> a, List<BulkItemResponse.Failure> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (int i = 0; i < a.size(); i++) {
+            if (bulkFailureContentEquals(a.get(i), b.get(i)) == false) {
+                return false;
+            }
+        }
         return true;
+    }
+
+    private static int bulkFailuresContentHashCode(List<BulkItemResponse.Failure> failures) {
+        int result = 1;
+        for (BulkItemResponse.Failure f : failures) {
+            result = 31 * result + bulkFailureContentHashCode(f);
+        }
+        return result;
+    }
+
+    private static boolean bulkFailureContentEquals(BulkItemResponse.Failure a, BulkItemResponse.Failure b) {
+        return Objects.equals(a.getIndex(), b.getIndex())
+            && Objects.equals(a.getId(), b.getId())
+            && a.getStatus() == b.getStatus()
+            && a.getSeqNo() == b.getSeqNo()
+            && a.getTerm() == b.getTerm()
+            && a.isAborted() == b.isAborted()
+            && a.getFailureStoreStatus() == b.getFailureStoreStatus()
+            && throwablesShallowEquals(a.getCause(), b.getCause());
+    }
+
+    private static int bulkFailureContentHashCode(BulkItemResponse.Failure f) {
+        return Objects.hash(
+            f.getIndex(),
+            f.getId(),
+            f.getStatus(),
+            f.getSeqNo(),
+            f.getTerm(),
+            f.isAborted(),
+            f.getFailureStoreStatus(),
+            f.getCause() == null ? null : f.getCause().getClass().getName(),
+            f.getCause() == null ? null : f.getCause().getMessage()
+        );
+    }
+
+    private static boolean searchFailuresContentEquals(List<PaginatedSearchFailure> a, List<PaginatedSearchFailure> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (int i = 0; i < a.size(); i++) {
+            if (paginatedSearchFailureContentEquals(a.get(i), b.get(i)) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int searchFailuresContentHashCode(List<PaginatedSearchFailure> failures) {
+        int result = 1;
+        for (PaginatedSearchFailure f : failures) {
+            result = 31 * result + paginatedSearchFailureContentHashCode(f);
+        }
+        return result;
+    }
+
+    private static boolean paginatedSearchFailureContentEquals(PaginatedSearchFailure a, PaginatedSearchFailure b) {
+        return a.getStatus() == b.getStatus()
+            && Objects.equals(a.getIndex(), b.getIndex())
+            && Objects.equals(a.getShardId(), b.getShardId())
+            && Objects.equals(a.getNodeId(), b.getNodeId())
+            && throwablesShallowEquals(a.getReason(), b.getReason());
+    }
+
+    private static int paginatedSearchFailureContentHashCode(PaginatedSearchFailure f) {
+        Throwable reason = f.getReason();
+        return Objects.hash(
+            f.getStatus(),
+            f.getIndex(),
+            f.getShardId(),
+            f.getNodeId(),
+            reason == null ? null : reason.getClass().getName(),
+            reason == null ? null : reason.getMessage()
+        );
+    }
+
+    private static boolean throwablesShallowEquals(Throwable a, Throwable b) {
+        if (a == b) return true;
+        if (a == null || b == null) return false;
+        return a.getClass().equals(b.getClass()) && Objects.equals(a.getMessage(), b.getMessage());
     }
 
     /**
@@ -203,13 +300,52 @@ public class SliceStatusWireSerializingTests extends AbstractWireSerializingTest
         }
     }
 
-    private static BulkByScrollResponse randomBulkByScrollResponse() {
+    static BulkByScrollResponse randomBulkByScrollResponse() {
         return new BulkByScrollResponse(
             TimeValue.timeValueMillis(randomNonNegativeLong()),
             BulkByScrollTaskStatusTests.randomStatusWithoutException(),
-            emptyList(),
-            emptyList(),
+            randomBulkFailuresList(),
+            randomSearchFailuresList(),
             randomBoolean()
+        );
+    }
+
+    private static List<BulkItemResponse.Failure> randomBulkFailuresList() {
+        int n = randomIntBetween(0, 2);
+        List<BulkItemResponse.Failure> list = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            list.add(randomBulkFailure());
+        }
+        return list;
+    }
+
+    private static BulkItemResponse.Failure randomBulkFailure() {
+        return new BulkItemResponse.Failure(
+            randomAlphaOfLengthBetween(1, 10),
+            randomBoolean() ? randomAlphaOfLengthBetween(1, 10) : null,
+            new ElasticsearchException(randomAlphaOfLengthBetween(1, 20)),
+            randomLong(),
+            randomNonNegativeLong(),
+            randomBoolean(),
+            randomFrom(IndexDocFailureStoreStatus.values())
+        );
+    }
+
+    private static List<PaginatedSearchFailure> randomSearchFailuresList() {
+        int n = randomIntBetween(0, 2);
+        List<PaginatedSearchFailure> list = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            list.add(randomSearchFailure());
+        }
+        return list;
+    }
+
+    private static PaginatedSearchFailure randomSearchFailure() {
+        return new PaginatedSearchFailure(
+            new ElasticsearchException(randomAlphaOfLengthBetween(1, 20)),
+            randomBoolean() ? randomAlphaOfLengthBetween(1, 10) : null,
+            randomBoolean() ? randomIntBetween(0, 10) : null,
+            randomBoolean() ? randomAlphaOfLengthBetween(1, 10) : null
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/WorkerResultWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/WorkerResultWireSerializingTests.java
@@ -103,9 +103,8 @@ public class WorkerResultWireSerializingTests extends AbstractWireSerializingTes
     }
 
     private static ResumeInfo.WorkerResult randomWorkerResult() {
-        return randomBoolean() ? new ResumeInfo.WorkerResult(randomBulkByScrollResponse(), null) : new ResumeInfo.WorkerResult(
-            null,
-            new ElasticsearchException(randomAlphaOfLengthBetween(1, 20))
-        );
+        return randomBoolean()
+            ? new ResumeInfo.WorkerResult(randomBulkByScrollResponse(), null)
+            : new ResumeInfo.WorkerResult(null, new ElasticsearchException(randomAlphaOfLengthBetween(1, 20)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/WorkerResultWireSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/resumeinfo/WorkerResultWireSerializingTests.java
@@ -13,20 +13,21 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
-import org.elasticsearch.index.reindex.BulkByScrollTaskStatusTests;
 import org.elasticsearch.index.reindex.ResumeInfo;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
 import java.util.Objects;
 
-import static java.util.Collections.emptyList;
+import static org.elasticsearch.index.reindex.resumeinfo.SliceStatusWireSerializingTests.bulkByScrollResponseContentEquals;
+import static org.elasticsearch.index.reindex.resumeinfo.SliceStatusWireSerializingTests.bulkByScrollResponseContentHashCode;
+import static org.elasticsearch.index.reindex.resumeinfo.SliceStatusWireSerializingTests.randomBulkByScrollResponse;
 
 /**
  * Wire serialization tests for {@link ResumeInfo.WorkerResult}.
  * Uses a {@link Wrapper} with content-based equals/hashCode because {@link ResumeInfo.WorkerResult}
+ * holds {@link BulkByScrollResponse} without structural {@code equals}.
  */
 public class WorkerResultWireSerializingTests extends AbstractWireSerializingTestCase<WorkerResultWireSerializingTests.Wrapper> {
 
@@ -42,7 +43,6 @@ public class WorkerResultWireSerializingTests extends AbstractWireSerializingTes
 
     @Override
     protected Wrapper mutateInstance(Wrapper instance) throws IOException {
-        // WorkerResult is a record; no need to verify equality via mutations
         return null;
     }
 
@@ -93,41 +93,19 @@ public class WorkerResultWireSerializingTests extends AbstractWireSerializingTes
             }
         }
 
-        private static boolean bulkByScrollResponseContentEquals(BulkByScrollResponse a, BulkByScrollResponse b) {
-            return Objects.equals(a.getTook(), b.getTook())
-                && a.getStatus().equals(b.getStatus())
-                && a.getBulkFailures().size() == b.getBulkFailures().size()
-                && a.getSearchFailures().size() == b.getSearchFailures().size()
-                && a.isTimedOut() == b.isTimedOut();
-        }
-
         private static int workerResultContentHashCode(ResumeInfo.WorkerResult result) {
             if (result.getResponse().isPresent()) {
-                BulkByScrollResponse response = result.getResponse().get();
-                return Objects.hash(response.getTook(), response.getStatus(), response.isTimedOut());
+                return bulkByScrollResponseContentHashCode(result.getResponse().get());
             } else {
                 return Objects.hashCode(result.getFailure().get().getMessage());
             }
         }
     }
 
-    private ResumeInfo.WorkerResult randomWorkerResult() {
-        return randomBoolean()
-            ? new ResumeInfo.WorkerResult(randomBulkByScrollResponse(), null)
-            : new ResumeInfo.WorkerResult(null, randomException());
-    }
-
-    private BulkByScrollResponse randomBulkByScrollResponse() {
-        return new BulkByScrollResponse(
-            TimeValue.timeValueMillis(randomNonNegativeLong()),
-            BulkByScrollTaskStatusTests.randomStatusWithoutException(),
-            emptyList(),
-            emptyList(),
-            randomBoolean()
+    private static ResumeInfo.WorkerResult randomWorkerResult() {
+        return randomBoolean() ? new ResumeInfo.WorkerResult(randomBulkByScrollResponse(), null) : new ResumeInfo.WorkerResult(
+            null,
+            new ElasticsearchException(randomAlphaOfLengthBetween(1, 20))
         );
-    }
-
-    private Exception randomException() {
-        return new ElasticsearchException(randomAlphaOfLengthBetween(1, 20));
     }
 }

--- a/server/src/test/java/org/elasticsearch/tasks/TaskInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskInfoTests.java
@@ -301,7 +301,7 @@ public class TaskInfoTests extends AbstractXContentSerializingTestCase<TaskInfo>
         }
     }
 
-    static TaskInfo randomTaskInfo() {
+    public static TaskInfo randomTaskInfo() {
         String nodeId = randomAlphaOfLength(5);
         TaskId taskId = randomTaskId(nodeId);
         String type = randomAlphaOfLength(5);

--- a/server/src/test/java/org/elasticsearch/tasks/TaskResultTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskResultTests.java
@@ -112,7 +112,8 @@ public class TaskResultTests extends ESTestCase {
         }
     }
 
-    private static TaskResult randomTaskResult() throws IOException {
+    /** Build a {@link TaskResult} covering completed, error, and response variants */
+    public static TaskResult randomTaskResult() throws IOException {
         return switch (between(0, 2)) {
             case 0 -> new TaskResult(randomBoolean(), randomTaskInfo());
             case 1 -> new TaskResult(randomTaskInfo(), new RuntimeException("error"));


### PR DESCRIPTION
The `ResumeInfo` serialisation tests had diverged from the code. This test updates them to use `RelocationOrigin`
