### PR TITLE
test(SemanticTextFieldMapperTests): use same version indexSettings 

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -249,13 +249,7 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_forceTrue_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/146955
-- class: org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapperTests
-  method: testMinimalToMaximal {p0=true p1=ENTERPRISE}
-  issue: https://github.com/elastic/elasticsearch/issues/146966
-- class: org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapperTests
-  method: testMinimalToMaximal {p0=true p1=BASIC}
-  issue: https://github.com/elastic/elasticsearch/issues/146967
-- class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
+- - class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
   method: test {yaml=reindex/10_basic/Response format for created}
   issue: https://github.com/elastic/elasticsearch/issues/147005
 - class: org.elasticsearch.reindex.management.ReindexManagementClientYamlTestSuiteIT

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -249,7 +249,7 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_forceTrue_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/146955
-- - class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
+- class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
   method: test {yaml=reindex/10_basic/Response format for created}
   issue: https://github.com/elastic/elasticsearch/issues/147005
 - class: org.elasticsearch.reindex.management.ReindexManagementClientYamlTestSuiteIT

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -178,11 +178,16 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
 
     private final License.OperationMode operationMode;
 
+    private final IndexVersion testIndexVersion;
+
     private TestThreadPool threadPool;
 
     public SemanticTextFieldMapperTests(boolean useLegacyFormat, License.OperationMode operationMode) {
         this.useLegacyFormat = useLegacyFormat;
         this.operationMode = operationMode;
+        this.testIndexVersion = useLegacyFormat
+            ? SemanticInferenceMetadataFieldsMapperTests.getRandomCompatibleIndexVersion(true)
+            : super.getVersion();
     }
 
     ModelRegistry globalModelRegistry;
@@ -296,16 +301,16 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
 
     @Override
     protected IndexVersion getVersion() {
-        if (useLegacyFormat) {
-            return SemanticInferenceMetadataFieldsMapperTests.getRandomCompatibleIndexVersion(true);
-        }
-        return super.getVersion();
+        return testIndexVersion;
     }
 
     @Override
     protected Settings getIndexSettings() {
         if (useLegacyFormat) {
-            return SemanticInferenceMetadataFieldsMapperTests.randomIndexSettings(true);
+            return Settings.builder()
+                .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), testIndexVersion)
+                .put(InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT.getKey(), true)
+                .build();
         }
         return super.getIndexSettings();
     }


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
<!--
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
-->

fixes https://github.com/elastic/elasticsearch/issues/146966, fixes https://github.com/elastic/elasticsearch/issues/146967

This might have been introduced in https://github.com/elastic/elasticsearch/pull/146211. 

We were using two different index versions, one from `getVersion` and another in `randomIndexSettings`. The test failure happened when the mapper was created with an older index version and the settings included the `rescore_vector` parameter (while both being legacy). 

This caused `testMinimalToMaximal` to fail 
https://github.com/elastic/elasticsearch/blob/843aeddace6f248cd33760e8ce31f5812e9c1440/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java#L528-L537

In this PR we keep the IndexVersion the same across these calls. 