### PR TITLE
Link Buildkite mention in CI README

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,6 +1,6 @@
 # Elasticsearch CI Pipelines
 
-This directory contains pipeline definitions and scripts for running Elasticsearch CI on Buildkite.
+This directory contains pipeline definitions and scripts for running Elasticsearch CI on [Buildkite](https://buildkite.com/elastic).
 
 ## Directory Structure
 


### PR DESCRIPTION
Trivial docs tweak: makes the "Buildkite" mention in `.buildkite/README.md` a link to the Elastic Buildkite org.

Made with [Cursor](https://cursor.com)