### PR TITLE
[9.4] Bump JDK to 26.0.1 (#147424)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 9.4.0
 lucene            = 10.4.0
 
 bundled_jdk_vendor = openjdk
-bundled_jdk = 26+35@c3cc523845074aa0af4f5e1e1ed4151d
+bundled_jdk = 26.0.1+8@458fda22e4c54d5ba572ab8d2b22eb83
 # optional dependencies
 spatial4j         = 0.7
 jts               = 1.20.0


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Bump JDK to 26.0.1 (#147424)