### PR TITLE
[8.19] Bump JDK to 26.0.1 (#147424)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -11,7 +11,6 @@ steps:
               - debian-12
               - debian-13
               - opensuse-leap-15
-              - oraclelinux-7
               - oraclelinux-8
               - oraclelinux-9
               - oraclelinux-10
@@ -22,7 +21,6 @@ steps:
               - rocky-8
               - rocky-9
               - rocky-10
-              - rhel-7
               - rhel-8
               - rhel-9
               - rhel-10
@@ -35,6 +33,32 @@ steps:
           localSsds: 1
           localSsdInterface: nvme
           machineType: custom-32-98304
+        env: {}
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+            - exit_status: "1"
+              limit: 1
+  - group: platform-support-unix-legacy
+    steps:
+      - label: "{{matrix.image}} / platform-support-unix-legacy"
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true functionalTests
+        timeout_in_minutes: 420
+        matrix:
+          setup:
+            image:
+              - oraclelinux-7
+              - rhel-7
+        agents:
+          provider: gcp
+          image: family/elasticsearch-{{matrix.image}}
+          localSsds: 1
+          localSsdInterface: nvme
+          machineType: n1-standard-32
         env: {}
         retry:
           automatic:

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -14,7 +14,6 @@ steps:
               - debian-12
               - debian-13
               - opensuse-leap-15
-              - oraclelinux-7
               - oraclelinux-8
               - oraclelinux-9
               - sles-12
@@ -25,7 +24,6 @@ steps:
               - rocky-8
               - rocky-9
               - rocky-10
-              - rhel-7
               - rhel-8
               - rhel-9
               - rhel-10
@@ -42,3 +40,23 @@ steps:
           diskSizeGb: 350
           machineType: n4-custom-16-32768
           diskType: hyperdisk-balanced
+  - group: packaging-tests-unix-legacy
+    steps:
+      - label: "{{matrix.image}} / {{matrix.PACKAGING_TASK}} / packaging-tests-unix-legacy"
+        key: "packaging-tests-unix-legacy"
+        command: ./.ci/scripts/packaging-test.sh destructiveDistroTest.{{matrix.PACKAGING_TASK}}
+        timeout_in_minutes: 300
+        matrix:
+          setup:
+            image:
+              - oraclelinux-7
+              - rhel-7
+            PACKAGING_TASK:
+              - docker-cloud-ess
+              - packages
+              - archives
+        agents:
+          provider: gcp
+          image: family/elasticsearch-{{matrix.image}}
+          diskSizeGb: 350
+          machineType: n1-standard-32

--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.19.15
 lucene            = 9.12.2
 
 bundled_jdk_vendor = openjdk
-bundled_jdk = 26+35@c3cc523845074aa0af4f5e1e1ed4151d
+bundled_jdk = 26.0.1+8@458fda22e4c54d5ba572ab8d2b22eb83
 # optional dependencies
 spatial4j         = 0.7
 jts               = 1.15.0


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Bump JDK to 26.0.1 (#147424)