### PR TITLE
Fix testConfiguredReservedRolesAfterClosingAndOpeningIndex

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -16,9 +16,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/118212
 - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/119983
-- class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
-  method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
-  issue: https://github.com/elastic/elasticsearch/issues/120127
 - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
   method: testChildrenTasksCancelledOnTimeout
   issue: https://github.com/elastic/elasticsearch/issues/123568

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizer.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizer.java
@@ -509,6 +509,10 @@ public final class QueryableBuiltInRolesSynchronizer implements ClusterStateList
             listener.onFailure(new IndexNotFoundException(SECURITY_MAIN_ALIAS));
             return;
         }
+        if (securityIndexMetadata.getState() == IndexMetadata.State.CLOSE) {
+            listener.onFailure(new IndexClosedException(securityIndexMetadata.getIndex()));
+            return;
+        }
         final Index concreteSecurityIndex = securityIndexMetadata.getIndex();
         markRolesAsSyncedTaskQueue.submitTask(
             "mark built-in roles as synced task",
@@ -575,6 +579,13 @@ public final class QueryableBuiltInRolesSynchronizer implements ClusterStateList
             IndexMetadata indexMetadata = project.index(concreteSecurityIndexName);
             if (indexMetadata == null) {
                 throw new IndexNotFoundException(concreteSecurityIndexName);
+            }
+            if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
+                // Index was closed between when the sync started and when this task runs. Do not update the
+                // synced-roles digest in metadata, since the actual role documents could not have been
+                // updated/deleted in a closed index. IndexClosedException is treated as an expected failure
+                // and does not count toward failedSyncAttempts.
+                throw new IndexClosedException(indexMetadata.getIndex());
             }
             Map<String, String> existingRoleDigests = indexMetadata.getCustomData(METADATA_QUERYABLE_BUILT_IN_ROLES_DIGEST_KEY);
             if (Objects.equals(expectedRoleDigests, existingRoleDigests)) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizerTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
@@ -396,6 +397,24 @@ public class QueryableBuiltInRolesSynchronizerTests extends ESTestCase {
         verify(clusterState, times(4)).nodes();
         verify(featureService, times(1)).clusterHasFeature(eq(clusterState), eq(QUERYABLE_BUILT_IN_ROLES_FEATURE));
         verifyNoMoreInteractions(nativeRolesStore, featureService, taskQueue, reservedRolesProvider, threadPool, clusterService);
+    }
+
+    public void testMarkRolesAsSyncedTaskRejectsClosedIndex() {
+        // Guard against a race where the security index becomes closed between when a sync started against an
+        // open index and when the resulting MarkRolesAsSyncedTask runs on the master service queue. The task
+        // must not write a new digest to the metadata of a closed index, since the role documents themselves
+        // could not have been updated.
+        final ClusterState clusterState = markShardsAvailable(createClusterStateWithClosedSecurityIndex()).nodes(localNodeMaster())
+            .blocks(emptyClusterBlocks())
+            .build();
+        final Map<String, String> newRoleDigests = Map.of("superuser", "digest-1", "viewer", "digest-2");
+        final MarkRolesAsSyncedTask task = new MarkRolesAsSyncedTask(
+            ActionListener.noop(),
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7,
+            null,
+            newRoleDigests
+        );
+        expectThrows(IndexClosedException.class, () -> task.execute(clusterState));
     }
 
     public void testUnexpectedSyncFailures() {


### PR DESCRIPTION
Resolves: #120127

The test failure showed that after closing the `.security-7` index, restarting the cluster with a new reserved-roles config, and then reading the metadata digest, the digest contained the new roles(`[editor, superuser, viewer]`) instead of the previous ones — i.e. a sync had updated the digest even though the index was closed.

The race: `MarkRolesAsSyncedTask` (queued via the master service) only checked whether the index existed; it did not check whether the index was closed at the time of execution. If a sync started while the index was open and the close happened before the task ran on the master service queue, the task still wrote the new digest into the closed index's metadata.

Fix `QueryableBuiltInRolesSynchronizer.java`:
  - `markRolesAsSynced`: early bailout — fail with `IndexClosedException` if the index is already closed when this method runs.
  - `MarkRolesAsSyncedTask.execute`: `throw IndexClosedException` if the index is closed at task-execution time. `IndexClosedException` is already in `isExpectedFailure`, so it doesn't count toward failedSyncAttempts.

Added unit test `testMarkRolesAsSyncedTaskRejectsClosedIndex` in `QueryableBuiltInRolesSynchronizerTests.java` that exercises `MarkRolesAsSyncedTask.execute` directly against a closed-index cluster state and asserts it throws `IndexClosedException`.