### PR TITLE
Bump CCS YAML suite timeouts on encryption-at-rest

### DIFF
--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/CcsCommonYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/CcsCommonYamlTestSuiteIT.java
@@ -72,7 +72,7 @@ import static java.util.Collections.unmodifiableList;
  * by subclassing this class then add an entry to {@link TestSuiteApiCheck} mapping the API
  * name(s) to the new class.
  */
-@TimeoutSuite(millis = 20 * TimeUnits.MINUTE) // to account for slow as hell VMs
+@TimeoutSuite(millis = 25 * TimeUnits.MINUTE) // to account for slow as hell VMs
 public class CcsCommonYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     private static final Logger logger = LogManager.getLogger(CcsCommonYamlTestSuiteIT.class);

--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
@@ -68,7 +68,7 @@ import static org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT.rewrite;
  * by subclassing this class then add an entry to {@link TestSuiteApiCheck} mapping the API
  * name(s) to the new class.
  */
-@TimeoutSuite(millis = 25 * TimeUnits.MINUTE) // to account for slow as hell VMs
+@TimeoutSuite(millis = 30 * TimeUnits.MINUTE) // to account for slow as hell VMs
 public class RcsCcsCommonYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     private static final Logger logger = LogManager.getLogger(RcsCcsCommonYamlTestSuiteIT.class);


### PR DESCRIPTION
Same pattern as #133528 (which closed #133409 in Sep 2025): the two Common suites are again hitting their @TimeoutSuite budgets on the encryption-at-rest periodic step. Bump CcsCommon 20->25 min and RcsCcsCommon 25->30 min, mirroring the previous +5 minute bump.

RcsCcsSearchYamlTestSuiteIT inherits its budget from the RCS Common parent, so this also restores symmetry with CssSearchYamlTestSuiteIT (explicit 30 min), addressing #146756 and #145956 in passing.

Closes #146755, #146756, #145956
Relates to #133409