### PR TITLE
ESQL: Add `Block#valueMaxByteSize`

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -150,6 +150,18 @@ public final class BytesRefArray extends AbstractRefCounted implements Accountab
         return bytes.get(startOffset, length, scratch);
     }
 
+    /**
+     * {@return the maximum byte length of any entry in this array, or {@code 0} if empty}
+     */
+    public int valueMaxByteSize() {
+        int max = 0;
+        for (long i = 0; i < size; i++) {
+            int length = (int) (startOffsets.get(i + 1) - startOffsets.get(i));
+            max = Math.max(max, length);
+        }
+        return max;
+    }
+
     public long size() {
         return size;
     }

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -155,9 +155,12 @@ public final class BytesRefArray extends AbstractRefCounted implements Accountab
      */
     public int valueMaxByteSize() {
         int max = 0;
-        for (long i = 0; i < size; i++) {
-            int length = (int) (startOffsets.get(i + 1) - startOffsets.get(i));
+        long prev = startOffsets.get(0);
+        for (long i = 1; i <= size; i++) {
+            long curr = startOffsets.get(i);
+            int length = (int) (curr - prev);
             max = Math.max(max, length);
+            prev = curr;
         }
         return max;
     }

--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefArrayTests.java
@@ -182,6 +182,19 @@ public class BytesRefArrayTests extends ESTestCase {
         }
     }
 
+    public void testValueMaxByteSize() {
+        int size = randomIntBetween(0, 100);
+        try (BytesRefArray array = new BytesRefArray(size, mockBigArrays())) {
+            int expectedMax = 0;
+            for (int i = 0; i < size; i++) {
+                BytesRef value = new BytesRef(randomByteArrayOfLength(between(0, 20)));
+                array.append(value);
+                expectedMax = Math.max(expectedMax, value.length);
+            }
+            assertThat(array.valueMaxByteSize(), equalTo(expectedMax));
+        }
+    }
+
     public void testAppendPagedBytesCursorSinglePage() {
         try (BytesRefArray array = new BytesRefArray(0, mockBigArrays())) {
             byte[] data = randomByteArrayOfLength(between(1, 100));

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -89,6 +89,11 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public ToMask toMask() {
         if (getPositionCount() == 0) {
             return new ToMask(blockFactory().newConstantBooleanVector(false, 0), false);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
@@ -84,6 +84,11 @@ final class BooleanArrayVector extends AbstractVector implements BooleanVector {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Byte.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.BOOLEAN;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -87,6 +87,11 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public ToMask toMask() {
         if (getPositionCount() == 0) {
             return new ToMask(blockFactory().newConstantBooleanVector(false, 0), false);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayVector.java
@@ -103,6 +103,11 @@ public final class BooleanBigArrayVector extends AbstractVector implements Boole
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Byte.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.BOOLEAN;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -102,6 +102,12 @@ public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, Bo
     @Override
     BooleanBlock expand();
 
+    /**
+     * The maximum size in bytes of any single value stored in this block, or {@code 0} if there are no values.
+     * Always {@code Byte.BYTES} since all boolean values encode to the same number of bytes.
+     */
+    int valueMaxByteSize();
+
     static BooleanBlock readFrom(BlockStreamInput in) throws IOException {
         final byte serializationType = in.readByte();
         return switch (serializationType) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
@@ -78,6 +78,12 @@ public sealed interface BooleanVector extends Vector permits ConstantBooleanVect
     boolean allFalse();
 
     /**
+     * The maximum size in bytes of any single value stored in this vector, or {@code 0} if there are no values.
+     * Always {@code Byte.BYTES} since all boolean values encode to the same number of bytes.
+     */
+    int valueMaxByteSize();
+
+    /**
      * Compares the given object with this vector for equality. Returns {@code true} if and only if the
      * given object is a BooleanVector, and both vectors are {@link #equals(BooleanVector, BooleanVector) equal}.
      */

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -45,6 +45,11 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public int getPositionCount() {
         return vector.getPositionCount();
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -92,6 +92,11 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public OrdinalBytesRefBlock asOrdinals() {
         return null;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
@@ -83,6 +83,11 @@ final class BytesRefArrayVector extends AbstractVector implements BytesRefVector
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return values.valueMaxByteSize();
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.BYTES_REF;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -143,6 +143,12 @@ public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, 
     @Override
     BytesRefBlock expand();
 
+    /**
+     * The maximum size in bytes of any single value stored in this block, or {@code 0} if there are no values.
+     * Scans all value indices to find the maximum.
+     */
+    int valueMaxByteSize();
+
     static BytesRefBlock readFrom(BlockStreamInput in) throws IOException {
         final byte serializationType = in.readByte();
         return switch (serializationType) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -94,6 +94,12 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
     BytesRefVector slice(int beginInclusive, int endExclusive);
 
     /**
+     * The maximum size in bytes of any single value stored in this vector, or {@code 0} if there are no values.
+     * Scans all positions to find the maximum.
+     */
+    int valueMaxByteSize();
+
+    /**
      * Compares the given object with this vector for equality. Returns {@code true} if and only if the
      * given object is a BytesRefVector, and both vectors are {@link #equals(BytesRefVector, BytesRefVector) equal}.
      */

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -56,6 +56,11 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public int getPositionCount() {
         return vector.getPositionCount();
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
@@ -48,6 +48,11 @@ final class ConstantBooleanVector extends AbstractVector implements BooleanVecto
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Byte.BYTES;
+    }
+
+    @Override
     public BooleanVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantBooleanVector(value, positions.length);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
@@ -59,6 +59,11 @@ final class ConstantBytesRefVector extends AbstractVector implements BytesRefVec
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return getPositionCount() == 0 ? 0 : value.length;
+    }
+
+    @Override
     public BytesRefVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantBytesRefVector(value, positions.length);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
@@ -48,6 +48,11 @@ final class ConstantDoubleVector extends AbstractVector implements DoubleVector 
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Double.BYTES;
+    }
+
+    @Override
     public DoubleVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantDoubleVector(value, positions.length);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantFloatVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantFloatVector.java
@@ -48,6 +48,11 @@ final class ConstantFloatVector extends AbstractVector implements FloatVector {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Float.BYTES;
+    }
+
+    @Override
     public FloatVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantFloatVector(value, positions.length);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
@@ -48,6 +48,11 @@ final class ConstantIntVector extends AbstractVector implements IntVector {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public IntVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantIntVector(value, positions.length);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
@@ -48,6 +48,11 @@ final class ConstantLongVector extends AbstractVector implements LongVector {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     public LongVector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstantLongVector(value, positions.length);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -89,6 +89,11 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public double getDouble(int valueIndex) {
         return vector.getDouble(valueIndex);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
@@ -83,6 +83,11 @@ final class DoubleArrayVector extends AbstractVector implements DoubleVector {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Double.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.DOUBLE;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -87,6 +87,11 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public double getDouble(int valueIndex) {
         return vector.getDouble(valueIndex);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayVector.java
@@ -78,6 +78,11 @@ public final class DoubleBigArrayVector extends AbstractVector implements Double
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Double.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.DOUBLE;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -124,6 +124,12 @@ public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, Doub
     @Override
     DoubleBlock expand();
 
+    /**
+     * The maximum size in bytes of any single value stored in this block, or {@code 0} if there are no values.
+     * Always {@code Double.BYTES} since all double values encode to the same number of bytes.
+     */
+    int valueMaxByteSize();
+
     static DoubleBlock readFrom(BlockStreamInput in) throws IOException {
         final byte serializationType = in.readByte();
         return switch (serializationType) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
@@ -69,6 +69,12 @@ public sealed interface DoubleVector extends Vector permits ConstantDoubleVector
     DoubleVector slice(int beginInclusive, int endExclusive);
 
     /**
+     * The maximum size in bytes of any single value stored in this vector, or {@code 0} if there are no values.
+     * Always {@code Double.BYTES} since all double values encode to the same number of bytes.
+     */
+    int valueMaxByteSize();
+
+    /**
      * Compares the given object with this vector for equality. Returns {@code true} if and only if the
      * given object is a DoubleVector, and both vectors are {@link #equals(DoubleVector, DoubleVector) equal}.
      */

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -39,6 +39,11 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public int getPositionCount() {
         return vector.getPositionCount();
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayBlock.java
@@ -89,6 +89,11 @@ public final class FloatArrayBlock extends AbstractArrayBlock implements FloatBl
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public float getFloat(int valueIndex) {
         return vector.getFloat(valueIndex);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatArrayVector.java
@@ -83,6 +83,11 @@ final class FloatArrayVector extends AbstractVector implements FloatVector {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Float.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.FLOAT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBigArrayBlock.java
@@ -87,6 +87,11 @@ public final class FloatBigArrayBlock extends AbstractArrayBlock implements Floa
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public float getFloat(int valueIndex) {
         return vector.getFloat(valueIndex);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBigArrayVector.java
@@ -66,6 +66,11 @@ public final class FloatBigArrayVector extends AbstractVector implements FloatVe
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Float.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.FLOAT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatBlock.java
@@ -124,6 +124,12 @@ public sealed interface FloatBlock extends Block permits FloatArrayBlock, FloatV
     @Override
     FloatBlock expand();
 
+    /**
+     * The maximum size in bytes of any single value stored in this block, or {@code 0} if there are no values.
+     * Always {@code Float.BYTES} since all float values encode to the same number of bytes.
+     */
+    int valueMaxByteSize();
+
     static FloatBlock readFrom(BlockStreamInput in) throws IOException {
         final byte serializationType = in.readByte();
         return switch (serializationType) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVector.java
@@ -69,6 +69,12 @@ public sealed interface FloatVector extends Vector permits ConstantFloatVector, 
     FloatVector slice(int beginInclusive, int endExclusive);
 
     /**
+     * The maximum size in bytes of any single value stored in this vector, or {@code 0} if there are no values.
+     * Always {@code Float.BYTES} since all float values encode to the same number of bytes.
+     */
+    int valueMaxByteSize();
+
+    /**
      * Compares the given object with this vector for equality. Returns {@code true} if and only if the
      * given object is a FloatVector, and both vectors are {@link #equals(FloatVector, FloatVector) equal}.
      */

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FloatVectorBlock.java
@@ -39,6 +39,11 @@ public final class FloatVectorBlock extends AbstractVectorBlock implements Float
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public int getPositionCount() {
         return vector.getPositionCount();
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -89,6 +89,11 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public int getInt(int valueIndex) {
         return vector.getInt(valueIndex);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
@@ -93,6 +93,11 @@ final class IntArrayVector extends AbstractVector implements IntVector {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.INT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -87,6 +87,11 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public int getInt(int valueIndex) {
         return vector.getInt(valueIndex);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
@@ -118,6 +118,11 @@ public final class IntBigArrayVector extends AbstractVector implements IntVector
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.INT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -126,6 +126,12 @@ public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorB
     @Override
     IntBlock expand();
 
+    /**
+     * The maximum size in bytes of any single value stored in this block, or {@code 0} if there are no values.
+     * Always {@code Integer.BYTES} since all int values encode to the same number of bytes.
+     */
+    int valueMaxByteSize();
+
     static IntBlock readFrom(BlockStreamInput in) throws IOException {
         final byte serializationType = in.readByte();
         return switch (serializationType) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
@@ -80,6 +80,12 @@ public sealed interface IntVector extends Vector permits ConstantIntVector, IntA
     int max();
 
     /**
+     * The maximum size in bytes of any single value stored in this vector, or {@code 0} if there are no values.
+     * Always {@code Integer.BYTES} since all int values encode to the same number of bytes.
+     */
+    int valueMaxByteSize();
+
+    /**
      * Compares the given object with this vector for equality. Returns {@code true} if and only if the
      * given object is a IntVector, and both vectors are {@link #equals(IntVector, IntVector) equal}.
      */

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -39,6 +39,11 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public int getPositionCount() {
         return vector.getPositionCount();
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -89,6 +89,11 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public long getLong(int valueIndex) {
         return vector.getLong(valueIndex);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
@@ -83,6 +83,11 @@ final class LongArrayVector extends AbstractVector implements LongVector {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.LONG;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -87,6 +87,11 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public long getLong(int valueIndex) {
         return vector.getLong(valueIndex);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayVector.java
@@ -78,6 +78,11 @@ public final class LongBigArrayVector extends AbstractVector implements LongVect
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.LONG;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -125,6 +125,12 @@ public sealed interface LongBlock extends Block permits LongArrayBlock, LongVect
     @Override
     LongBlock expand();
 
+    /**
+     * The maximum size in bytes of any single value stored in this block, or {@code 0} if there are no values.
+     * Always {@code Long.BYTES} since all long values encode to the same number of bytes.
+     */
+    int valueMaxByteSize();
+
     static LongBlock readFrom(BlockStreamInput in) throws IOException {
         final byte serializationType = in.readByte();
         return switch (serializationType) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
@@ -70,6 +70,12 @@ public sealed interface LongVector extends Vector permits ConstantLongVector, Lo
     LongVector slice(int beginInclusive, int endExclusive);
 
     /**
+     * The maximum size in bytes of any single value stored in this vector, or {@code 0} if there are no values.
+     * Always {@code Long.BYTES} since all long values encode to the same number of bytes.
+     */
+    int valueMaxByteSize();
+
+    /**
      * Compares the given object with this vector for equality. Returns {@code true} if and only if the
      * given object is a LongVector, and both vectors are {@link #equals(LongVector, LongVector) equal}.
      */

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -39,6 +39,11 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public int getPositionCount() {
         return vector.getPositionCount();
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/DoubleArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/DoubleArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class DoubleArrowBufBlock extends AbstractArrowBufBlock<DoubleVecto
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Double.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<DoubleVector> vectorConstructor() {
         return DoubleArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/DoubleArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/DoubleArrowBufVector.java
@@ -67,6 +67,11 @@ public final class DoubleArrowBufVector extends AbstractArrowBufVector<DoubleVec
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Double.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.DOUBLE;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Float16ArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Float16ArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class Float16ArrowBufBlock extends AbstractArrowBufBlock<DoubleVect
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Double.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<DoubleVector> vectorConstructor() {
         return Float16ArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Float16ArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Float16ArrowBufVector.java
@@ -67,6 +67,11 @@ public final class Float16ArrowBufVector extends AbstractArrowBufVector<DoubleVe
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Double.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.DOUBLE;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/FloatArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/FloatArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class FloatArrowBufBlock extends AbstractArrowBufBlock<FloatVector,
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Float.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<FloatVector> vectorConstructor() {
         return FloatArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/FloatArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/FloatArrowBufVector.java
@@ -67,6 +67,11 @@ public final class FloatArrowBufVector extends AbstractArrowBufVector<FloatVecto
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Float.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.FLOAT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Int16ArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Int16ArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class Int16ArrowBufBlock extends AbstractArrowBufBlock<IntVector, I
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<IntVector> vectorConstructor() {
         return Int16ArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Int16ArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Int16ArrowBufVector.java
@@ -67,6 +67,11 @@ public final class Int16ArrowBufVector extends AbstractArrowBufVector<IntVector,
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.INT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Int8ArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Int8ArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class Int8ArrowBufBlock extends AbstractArrowBufBlock<IntVector, In
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<IntVector> vectorConstructor() {
         return Int8ArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Int8ArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/Int8ArrowBufVector.java
@@ -67,6 +67,11 @@ public final class Int8ArrowBufVector extends AbstractArrowBufVector<IntVector, 
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.INT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/IntArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/IntArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class IntArrowBufBlock extends AbstractArrowBufBlock<IntVector, Int
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<IntVector> vectorConstructor() {
         return IntArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/IntArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/IntArrowBufVector.java
@@ -67,6 +67,11 @@ public final class IntArrowBufVector extends AbstractArrowBufVector<IntVector, I
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.INT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/LongArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/LongArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class LongArrowBufBlock extends AbstractArrowBufBlock<LongVector, L
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<LongVector> vectorConstructor() {
         return LongArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/LongArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/LongArrowBufVector.java
@@ -67,6 +67,11 @@ public final class LongArrowBufVector extends AbstractArrowBufVector<LongVector,
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.LONG;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/LongMul1kArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/LongMul1kArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class LongMul1kArrowBufBlock extends AbstractArrowBufBlock<LongVect
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<LongVector> vectorConstructor() {
         return LongMul1kArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/LongMul1kArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/LongMul1kArrowBufVector.java
@@ -67,6 +67,11 @@ public final class LongMul1kArrowBufVector extends AbstractArrowBufVector<LongVe
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.LONG;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt16ArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt16ArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class UInt16ArrowBufBlock extends AbstractArrowBufBlock<IntVector, 
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<IntVector> vectorConstructor() {
         return UInt16ArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt16ArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt16ArrowBufVector.java
@@ -67,6 +67,11 @@ public final class UInt16ArrowBufVector extends AbstractArrowBufVector<IntVector
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.INT;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt32ArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt32ArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class UInt32ArrowBufBlock extends AbstractArrowBufBlock<LongVector,
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<LongVector> vectorConstructor() {
         return UInt32ArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt32ArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt32ArrowBufVector.java
@@ -67,6 +67,11 @@ public final class UInt32ArrowBufVector extends AbstractArrowBufVector<LongVecto
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.LONG;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt8ArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt8ArrowBufBlock.java
@@ -53,6 +53,11 @@ public final class UInt8ArrowBufBlock extends AbstractArrowBufBlock<IntVector, I
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<IntVector> vectorConstructor() {
         return UInt8ArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt8ArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/arrow/UInt8ArrowBufVector.java
@@ -67,6 +67,11 @@ public final class UInt8ArrowBufVector extends AbstractArrowBufVector<IntVector,
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.INT;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractDelegatingCompoundBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractDelegatingCompoundBlock.java
@@ -72,6 +72,11 @@ public abstract class AbstractDelegatingCompoundBlock<T extends Block> extends A
     }
 
     @Override
+    public int valueMaxByteSize() {
+        throw new UnsupportedOperationException(getClass().getSimpleName() + " does not have a single value byte size");
+    }
+
+    @Override
     public long ramBytesUsed() {
         long bytes = 0;
         for (Block b : getSubBlocks()) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleArrayBlock.java
@@ -70,6 +70,12 @@ public final class AggregateMetricDoubleArrayBlock extends AbstractDelegatingCom
     }
 
     @Override
+    public int valueMaxByteSize() {
+        // Three dense-double sub-blocks (min, max, sum) plus one dense-int sub-block (count).
+        return 3 * Double.BYTES + Integer.BYTES;
+    }
+
+    @Override
     public Vector asVector() {
         return null;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -218,6 +218,13 @@ public interface Block extends Accountable, BlockLoader.Block, Writeable, RefCou
      */
     ElementType elementType();
 
+    /**
+     * {@return the maximum byte size of any single value in this block}
+     * For fixed-width types this is a constant. For {@code BytesRef} this
+     * scans all values.
+     */
+    int valueMaxByteSize();
+
     /** The block factory associated with this block. */
     BlockFactory blockFactory();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -220,8 +220,8 @@ public interface Block extends Accountable, BlockLoader.Block, Writeable, RefCou
 
     /**
      * {@return the maximum byte size of any single value in this block}
-     * For fixed-width types this is a constant. For {@code BytesRef} this
-     * scans all values.
+     * For fixed-width types this is a constant. For {@code BytesRef}, this
+     * scans all values quickly.
      */
     int valueMaxByteSize();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/CompositeBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/CompositeBlock.java
@@ -116,6 +116,11 @@ public final class CompositeBlock extends AbstractNonThreadSafeRefCounted implem
     }
 
     @Override
+    public int valueMaxByteSize() {
+        throw new UnsupportedOperationException("composite blocks do not have a single value byte size");
+    }
+
+    @Override
     public BlockFactory blockFactory() {
         return blocks[0].blockFactory();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -88,6 +88,11 @@ public final class ConstantNullBlock extends AbstractNonThreadSafeRefCounted
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return 0;
+    }
+
+    @Override
     public ConstantNullBlock filter(boolean mayContainDuplicates, int... positions) {
         return (ConstantNullBlock) blockFactory().newConstantNullBlock(positions.length);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
@@ -181,6 +181,11 @@ public final class ConstantNullVector extends AbstractVector
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return 0;
+    }
+
+    @Override
     public boolean isConstant() {
         return true;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -44,6 +44,11 @@ public class DocBlock extends AbstractVectorBlock implements Block, RefCounted {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public Block slice(int beginInclusive, int endExclusive) {
         return vector.slice(beginInclusive, endExclusive).asBlock();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -45,7 +45,7 @@ public class DocBlock extends AbstractVectorBlock implements Block, RefCounted {
 
     @Override
     public int valueMaxByteSize() {
-        return Integer.BYTES;
+        return 3 * Integer.BYTES;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -413,6 +413,11 @@ public final class DocVector extends AbstractVector implements Vector {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public boolean isConstant() {
         return shards.isConstant() && segments.isConstant() && docs.isConstant();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -414,7 +414,7 @@ public final class DocVector extends AbstractVector implements Vector {
 
     @Override
     public int valueMaxByteSize() {
-        return Integer.BYTES;
+        return 3 * Integer.BYTES;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramArrayBlock.java
@@ -21,7 +21,7 @@ import org.elasticsearch.exponentialhistogram.ZeroBucket;
 import java.io.IOException;
 import java.util.List;
 
-final class ExponentialHistogramArrayBlock extends AbstractDelegatingCompoundBlock<ExponentialHistogramBlock>
+public final class ExponentialHistogramArrayBlock extends AbstractDelegatingCompoundBlock<ExponentialHistogramBlock>
     implements
         ExponentialHistogramBlock {
 
@@ -270,6 +270,13 @@ final class ExponentialHistogramArrayBlock extends AbstractDelegatingCompoundBlo
     }
 
     @Override
+    public int valueMaxByteSize() {
+        // Five sub-blocks of doubles (dense arrays, 8 bytes per slot regardless of null)
+        // plus the variable-length encoded histogram bytes.
+        return 5 * Double.BYTES + encodedHistograms.valueMaxByteSize();
+    }
+
+    @Override
     public Vector asVector() {
         return null;
     }
@@ -413,5 +420,5 @@ final class ExponentialHistogramArrayBlock extends AbstractDelegatingCompoundBlo
         return encodedHistograms.hashCode();
     }
 
-    record EncodedHistogramData(double count, double sum, double min, double max, double zeroThreshold, BytesRef encodedHistogram) {}
+    public record EncodedHistogramData(double count, double sum, double min, double max, double zeroThreshold, BytesRef encodedHistogram) {}
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/IntRangeVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/IntRangeVector.java
@@ -119,6 +119,11 @@ final class IntRangeVector extends AbstractVector implements IntVector {
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Integer.BYTES;
+    }
+
+    @Override
     public boolean isConstant() {
         return getPositionCount() == 1;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LongRangeArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LongRangeArrayBlock.java
@@ -70,6 +70,11 @@ public final class LongRangeArrayBlock extends AbstractNonThreadSafeRefCounted i
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Long.BYTES * 2;
+    }
+
+    @Override
     public BlockFactory blockFactory() {
         return fromBlock.blockFactory();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -216,6 +216,11 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return bytes.valueMaxByteSize();
+    }
+
+    @Override
     public BlockFactory blockFactory() {
         return ordinals.blockFactory();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -163,6 +163,11 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return bytes.valueMaxByteSize();
+    }
+
+    @Override
     public boolean isConstant() {
         return bytes.isConstant() || ordinals.isConstant();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/TDigestArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/TDigestArrayBlock.java
@@ -67,6 +67,13 @@ public final class TDigestArrayBlock extends AbstractDelegatingCompoundBlock<TDi
     }
 
     @Override
+    public int valueMaxByteSize() {
+        // Three dense-double sub-blocks (min, max, sum) plus one dense-long sub-block (valueCount)
+        // plus the variable-length encoded digest bytes.
+        return 3 * Double.BYTES + Long.BYTES + encodedDigests.valueMaxByteSize();
+    }
+
+    @Override
     protected List<Block> getSubBlocks() {
         return List.of(encodedDigests, minima, maxima, sums, valueCounts);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
@@ -90,8 +90,8 @@ public interface Vector extends Accountable, RefCounted, Releasable {
 
     /**
      * {@return the maximum byte size of any single value in this vector}
-     * For fixed-width types this is a constant. For {@code BytesRef} this
-     * scans all values.
+     * For fixed-width types this is a constant. For {@code BytesRef}, this
+     * scans all values quickly.
      */
     int valueMaxByteSize();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
@@ -89,6 +89,13 @@ public interface Vector extends Accountable, RefCounted, Releasable {
     ElementType elementType();
 
     /**
+     * {@return the maximum byte size of any single value in this vector}
+     * For fixed-width types this is a constant. For {@code BytesRef} this
+     * scans all values.
+     */
+    int valueMaxByteSize();
+
+    /**
      * {@return true iff this vector is a constant vector - returns the same constant value for every position}
      */
     boolean isConstant();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -97,6 +97,11 @@ public final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$
         return null;
     }
 
+    @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
 $if(BytesRef)$
     @Override
     public OrdinalBytesRefBlock asOrdinals() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -150,6 +150,15 @@ $else$
 $endif$
 
     @Override
+    public int valueMaxByteSize() {
+$if(BytesRef)$
+        return values.valueMaxByteSize();
+$else$
+        return $BYTES$;
+$endif$
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.$TYPE$;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -86,6 +86,11 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
         return null;
     }
 
+    @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
 $if(boolean)$
     @Override
     public ToMask toMask() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
@@ -173,6 +173,11 @@ $endif$
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return $BYTES$;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.$TYPE$;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -223,6 +223,16 @@ $endif$
     @Override
     $Type$Block expand();
 
+    /**
+     * The maximum size in bytes of any single value stored in this block, or {@code 0} if there are no values.
+$if(BytesRef)$
+     * Scans all value indices to find the maximum.
+$else$
+     * Always {@code $BYTES$} since all $type$ values encode to the same number of bytes.
+$endif$
+     */
+    int valueMaxByteSize();
+
     static $Type$Block readFrom(BlockStreamInput in) throws IOException {
         final byte serializationType = in.readByte();
         return switch (serializationType) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -81,6 +81,15 @@ $if(BytesRef)$
 $endif$
 
     @Override
+    public int valueMaxByteSize() {
+$if(BytesRef)$
+        return getPositionCount() == 0 ? 0 : value.length;
+$else$
+        return $BYTES$;
+$endif$
+    }
+
+    @Override
     public $Type$Vector filter(boolean mayContainDuplicates, int... positions) {
         return blockFactory().newConstant$Type$Vector(value, positions.length);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -150,6 +150,16 @@ $elseif(boolean)$
 $endif$
 
     /**
+     * The maximum size in bytes of any single value stored in this vector, or {@code 0} if there are no values.
+$if(BytesRef)$
+     * Scans all positions to find the maximum.
+$else$
+     * Always {@code $BYTES$} since all $type$ values encode to the same number of bytes.
+$endif$
+     */
+    int valueMaxByteSize();
+
+    /**
      * Compares the given object with this vector for equality. Returns {@code true} if and only if the
      * given object is a $Type$Vector, and both vectors are {@link #equals($Type$Vector, $Type$Vector) equal}.
      */

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -72,6 +72,11 @@ $endif$
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return vector.valueMaxByteSize();
+    }
+
+    @Override
     public int getPositionCount() {
         return vector.getPositionCount();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BooleanArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BooleanArrowBufBlock.java
@@ -80,6 +80,11 @@ public final class BooleanArrowBufBlock extends AbstractArrowBufBlock<BooleanVec
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Byte.BYTES;
+    }
+
+    @Override
     public ToMask toMask() {
         if (getPositionCount() == 0) {
             return new ToMask(blockFactory().newConstantBooleanVector(false, 0), false);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BooleanArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BooleanArrowBufVector.java
@@ -66,6 +66,11 @@ public final class BooleanArrowBufVector extends AbstractArrowBufVector<BooleanV
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return Byte.BYTES;
+    }
+
+    @Override
     public boolean allTrue() {
         for (int i = 0; i < positionCount; i++) {
             if (getBoolean(i) == false) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufBlock.java
@@ -158,6 +158,17 @@ public final class BytesRefArrowBufBlock extends AbstractArrowBufBlock<BytesRefV
     }
 
     @Override
+    public int valueMaxByteSize() {
+        int max = 0;
+        for (int i = 0; i < getTotalValueCount(); i++) {
+            int start = valueOffsetsBuffer.getInt((long) i * Integer.BYTES);
+            int end = valueOffsetsBuffer.getInt((long) (i + 1) * Integer.BYTES);
+            max = Math.max(max, end - start);
+        }
+        return max;
+    }
+
+    @Override
     public OrdinalBytesRefBlock asOrdinals() {
         return null;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufBlock.java
@@ -160,10 +160,11 @@ public final class BytesRefArrowBufBlock extends AbstractArrowBufBlock<BytesRefV
     @Override
     public int valueMaxByteSize() {
         int max = 0;
-        for (int i = 0; i < getTotalValueCount(); i++) {
-            int start = valueOffsetsBuffer.getInt((long) i * Integer.BYTES);
-            int end = valueOffsetsBuffer.getInt((long) (i + 1) * Integer.BYTES);
-            max = Math.max(max, end - start);
+        int prev = valueOffsetsBuffer.getInt(0);
+        for (int i = 1; i <= getTotalValueCount(); i++) {
+            int curr = valueOffsetsBuffer.getInt((long) i * Integer.BYTES);
+            max = Math.max(max, curr - prev);
+            prev = curr;
         }
         return max;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufVector.java
@@ -113,10 +113,11 @@ public final class BytesRefArrowBufVector extends AbstractArrowBufVector<BytesRe
     @Override
     public int valueMaxByteSize() {
         int max = 0;
-        for (int i = 0; i < getPositionCount(); i++) {
-            int start = valueOffsetsBuffer.getInt((long) i * Integer.BYTES);
-            int end = valueOffsetsBuffer.getInt((long) (i + 1) * Integer.BYTES);
-            max = Math.max(max, end - start);
+        int prev = valueOffsetsBuffer.getInt(0);
+        for (int i = 1; i <= getPositionCount(); i++) {
+            int curr = valueOffsetsBuffer.getInt((long) i * Integer.BYTES);
+            max = Math.max(max, curr - prev);
+            prev = curr;
         }
         return max;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/BytesRefArrowBufVector.java
@@ -111,6 +111,17 @@ public final class BytesRefArrowBufVector extends AbstractArrowBufVector<BytesRe
     }
 
     @Override
+    public int valueMaxByteSize() {
+        int max = 0;
+        for (int i = 0; i < getPositionCount(); i++) {
+            int start = valueOffsetsBuffer.getInt((long) i * Integer.BYTES);
+            int end = valueOffsetsBuffer.getInt((long) (i + 1) * Integer.BYTES);
+            max = Math.max(max, end - start);
+        }
+        return max;
+    }
+
+    @Override
     public OrdinalBytesRefVector asOrdinals() {
         return null;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/X-ArrowBufBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/X-ArrowBufBlock.java.st
@@ -53,6 +53,11 @@ public final class $Name$ArrowBufBlock extends AbstractArrowBufBlock<$Type$Vecto
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return $BYTES$;
+    }
+
+    @Override
     protected ArrowBufVectorConstructor<$Type$Vector> vectorConstructor() {
         return $Name$ArrowBufVector::new;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/X-ArrowBufVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/arrow/X-ArrowBufVector.java.st
@@ -67,6 +67,11 @@ public final class $Name$ArrowBufVector extends AbstractArrowBufVector<$Type$Vec
     }
 
     @Override
+    public int valueMaxByteSize() {
+        return $BYTES$;
+    }
+
+    @Override
     public ElementType elementType() {
         return ElementType.$TYPE$;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultSortableAscTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultSortableAscTopNEncoder.java
@@ -8,10 +8,16 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class DefaultSortableAscTopNEncoder extends SortableAscTopNEncoder {
     private final DefaultSortableDescTopNEncoder descEncoder = new DefaultSortableDescTopNEncoder(this);
+
+    @Override
+    protected int maxBytesRefValueSize(Block b) {
+        throw new IllegalStateException("Cannot find encoder for BytesRef value");
+    }
 
     @Override
     public void encodeBytesRef(BytesRef value, BreakingBytesRefBuilder bytesRefBuilder) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultSortableDescTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultSortableDescTopNEncoder.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class DefaultSortableDescTopNEncoder extends SortableDescTopNEncoder {
@@ -15,6 +16,11 @@ class DefaultSortableDescTopNEncoder extends SortableDescTopNEncoder {
 
     DefaultSortableDescTopNEncoder(DefaultSortableAscTopNEncoder ascEncoder) {
         this.ascEncoder = ascEncoder;
+    }
+
+    @Override
+    protected int maxBytesRefValueSize(Block b) {
+        throw new IllegalStateException("Cannot find encoder for BytesRef value");
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoder.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 import java.lang.invoke.MethodHandles;
@@ -23,6 +24,39 @@ public class DefaultUnsortableTopNEncoder implements TopNEncoder {
     public static final VarHandle INT = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.nativeOrder());
     public static final VarHandle FLOAT = MethodHandles.byteArrayViewVarHandle(float[].class, ByteOrder.nativeOrder());
     public static final VarHandle DOUBLE = MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.nativeOrder());
+
+    @Override
+    public int maxValueSize(Block b) {
+        return switch (b.elementType()) {
+            case BOOLEAN -> Byte.BYTES;
+            case INT -> Integer.BYTES;
+            case LONG -> Long.BYTES;
+            case FLOAT -> Float.BYTES;
+            case DOUBLE -> Double.BYTES;
+            case BYTES_REF -> {
+                int maxLen = b.valueMaxByteSize();
+                yield vIntSize(maxLen) + maxLen;
+            }
+            case NULL -> 0;
+            default -> throw new IllegalArgumentException("No encoder for [" + b.elementType() + "]");
+        };
+    }
+
+    private static int vIntSize(int value) {
+        if (value < 0x80) {
+            return 1;
+        }
+        if (value < 0x4000) {
+            return 2;
+        }
+        if (value < 0x200000) {
+            return 3;
+        }
+        if (value < 0x10000000) {
+            return 4;
+        }
+        return 5;
+    }
 
     @Override
     public void encodeLong(long value, BreakingBytesRefBuilder bytesRefBuilder) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/FixedLengthAscTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/FixedLengthAscTopNEncoder.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class FixedLengthAscTopNEncoder extends SortableAscTopNEncoder {
@@ -17,6 +18,12 @@ class FixedLengthAscTopNEncoder extends SortableAscTopNEncoder {
     FixedLengthAscTopNEncoder(int length) {
         this.length = length;
         this.descEncoder = new FixedLengthDescTopNEncoder(length, this);
+    }
+
+    @Override
+    protected int maxBytesRefValueSize(Block b) {
+        assert length == b.valueMaxByteSize();
+        return length;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/FixedLengthDescTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/FixedLengthDescTopNEncoder.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class FixedLengthDescTopNEncoder extends SortableDescTopNEncoder {
@@ -17,6 +18,12 @@ class FixedLengthDescTopNEncoder extends SortableDescTopNEncoder {
     FixedLengthDescTopNEncoder(int length, FixedLengthAscTopNEncoder ascEncoder) {
         this.length = length;
         this.ascEncoder = ascEncoder;
+    }
+
+    @Override
+    protected int maxBytesRefValueSize(Block b) {
+        assert length == b.valueMaxByteSize();
+        return length;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SortableAscTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SortableAscTopNEncoder.java
@@ -9,12 +9,30 @@ package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
  * A {@link TopNEncoder} that encodes values to byte arrays that may be sorted directly.
  */
 public abstract class SortableAscTopNEncoder implements TopNEncoder {
+    @Override
+    public final int maxValueSize(Block b) {
+        return switch (b.elementType()) {
+            case BOOLEAN -> Byte.BYTES;
+            case INT, FLOAT -> Integer.BYTES;
+            case LONG, DOUBLE -> Long.BYTES;
+            case BYTES_REF -> maxBytesRefValueSize(b);
+            case NULL -> 0;
+            default -> throw new IllegalArgumentException("No encoder for [" + b.elementType() + "]");
+        };
+    }
+
+    /**
+     * Maximum encoded byte size for a single {@code BYTES_REF} value from the block.
+     */
+    protected abstract int maxBytesRefValueSize(Block b);
+
     @Override
     public final void encodeLong(long value, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.grow(bytesRefBuilder.length() + Long.BYTES);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SortableDescTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SortableDescTopNEncoder.java
@@ -9,12 +9,30 @@ package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
  * A {@link TopNEncoder} that encodes values to byte arrays that may be sorted directly.
  */
 public abstract class SortableDescTopNEncoder implements TopNEncoder {
+    @Override
+    public final int maxValueSize(Block b) {
+        return switch (b.elementType()) {
+            case BOOLEAN -> Byte.BYTES;
+            case INT, FLOAT -> Integer.BYTES;
+            case LONG, DOUBLE -> Long.BYTES;
+            case BYTES_REF -> maxBytesRefValueSize(b);
+            case NULL -> 0;
+            default -> throw new IllegalArgumentException("No encoder for [" + b.elementType() + "]");
+        };
+    }
+
+    /**
+     * Maximum encoded byte size for a single {@code BYTES_REF} value from the block.
+     */
+    protected abstract int maxBytesRefValueSize(Block b);
+
     @Override
     public final void encodeLong(long value, BreakingBytesRefBuilder bytesRefBuilder) {
         TopNEncoder.DEFAULT_SORTABLE.encodeLong(~value, bytesRefBuilder);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNEncoder.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
@@ -49,6 +50,12 @@ public interface TopNEncoder {
      * Placeholder encoder for unsupported data types.
      */
     UnsupportedTypesTopNEncoder UNSUPPORTED = new UnsupportedTypesTopNEncoder();
+
+    /**
+     * Maximum size of any individual element in the {@link Block} when encoded
+     * by this encoder.
+     */
+    int maxValueSize(Block b);
 
     void encodeLong(long value, BreakingBytesRefBuilder bytesRefBuilder);
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/UnsupportedTypesTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/UnsupportedTypesTopNEncoder.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
@@ -18,6 +19,11 @@ import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
  * unsupported data types fields values (which should always be "null" by convention) using value extractors.
  */
 class UnsupportedTypesTopNEncoder extends SortableAscTopNEncoder {
+    @Override
+    protected int maxBytesRefValueSize(Block b) {
+        throw new UnsupportedOperationException("Encountered a bug; trying to size an unsupported data type value for TopN");
+    }
+
     @Override
     public void encodeBytesRef(BytesRef value, BreakingBytesRefBuilder bytesRefBuilder) {
         throw new UnsupportedOperationException("Encountered a bug; trying to encode an unsupported data type value for TopN");

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/Utf8AscTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/Utf8AscTopNEncoder.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 import java.util.Arrays;
@@ -27,6 +28,11 @@ final class Utf8AscTopNEncoder extends SortableAscTopNEncoder {
     static final byte TERMINATOR = 0x00;
 
     private final Utf8DescTopNEncoder descEncoder = new Utf8DescTopNEncoder(this);
+
+    @Override
+    protected int maxBytesRefValueSize(Block b) {
+        return b.valueMaxByteSize() + 1; // + 1 for NUL terminator
+    }
 
     @Override
     public void encodeBytesRef(BytesRef value, BreakingBytesRefBuilder bytesRefBuilder) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/Utf8DescTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/Utf8DescTopNEncoder.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 import static org.elasticsearch.compute.operator.topn.Utf8AscTopNEncoder.CONTINUATION_BYTE;
@@ -22,6 +23,11 @@ final class Utf8DescTopNEncoder extends SortableDescTopNEncoder {
 
     Utf8DescTopNEncoder(Utf8AscTopNEncoder ascEncoder) {
         this.ascEncoder = ascEncoder;
+    }
+
+    @Override
+    protected int maxBytesRefValueSize(Block b) {
+        return b.valueMaxByteSize() + 1; // + 1 for NUL terminator
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/VersionAscTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/VersionAscTopNEncoder.java
@@ -8,10 +8,16 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 class VersionAscTopNEncoder extends SortableAscTopNEncoder {
     private final VersionDescTopNEncoder descEncoder = new VersionDescTopNEncoder(this);
+
+    @Override
+    protected int maxBytesRefValueSize(Block b) {
+        return b.valueMaxByteSize() + 1; // + 1 for NUL terminator
+    }
 
     @Override
     public void encodeBytesRef(BytesRef value, BreakingBytesRefBuilder bytesRefBuilder) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/VersionDescTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/VersionDescTopNEncoder.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 import static org.elasticsearch.compute.operator.topn.VersionAscTopNEncoder.refuseNul;
@@ -17,6 +18,11 @@ class VersionDescTopNEncoder extends SortableDescTopNEncoder {
 
     VersionDescTopNEncoder(VersionAscTopNEncoder ascEncoder) {
         this.ascEncoder = ascEncoder;
+    }
+
+    @Override
+    protected int maxBytesRefValueSize(Block b) {
+        return b.valueMaxByteSize() + 1; // + 1 for NUL terminator
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
@@ -471,6 +471,7 @@ public class BlockHashRandomizedTests extends ComputeTestCase {
                     .newIntBlockBuilder(positionCount * maxValuesPerPosition);
                 BytesRefVector.Builder bytes = TestBlockFactory.getNonBreakingInstance().newBytesRefVectorBuilder(maxValuesPerPosition);
             ) {
+                int valueMaxByteSize = 0;
                 for (int p = 0; p < positionCount; p++) {
                     int valueCount = between(1, maxValuesPerPosition);
                     int dupCount = between(0, dups);
@@ -487,7 +488,9 @@ public class BlockHashRandomizedTests extends ComputeTestCase {
                             bytes.appendBytesRef(new BytesRef(k));
                             return dictionary.size();
                         });
-                        valuesAtPosition.add(new BytesRef(key));
+                        BytesRef keyBytes = new BytesRef(key);
+                        valueMaxByteSize = Math.max(valueMaxByteSize, keyBytes.length);
+                        valuesAtPosition.add(keyBytes);
                         ordinals.appendInt(ordinal);
                         ordsAtPosition.add(ordinal);
                     }
@@ -498,7 +501,7 @@ public class BlockHashRandomizedTests extends ComputeTestCase {
                         ordinals.endPositionEntry();
                     }
                 }
-                return new RandomBlock(values, new OrdinalBytesRefBlock(ordinals.build(), bytes.build()));
+                return new RandomBlock(values, new OrdinalBytesRefBlock(ordinals.build(), bytes.build()), valueMaxByteSize);
             }
         }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
@@ -466,12 +466,12 @@ public class BlockHashRandomizedTests extends ComputeTestCase {
             Map<String, Integer> dictionary = new HashMap<>();
             Set<String> keys = dictionary(maxValuesPerPosition);
             List<List<Object>> values = new ArrayList<>(positionCount);
+            int valueMaxByteSize = 0;
             try (
                 IntBlock.Builder ordinals = TestBlockFactory.getNonBreakingInstance()
                     .newIntBlockBuilder(positionCount * maxValuesPerPosition);
                 BytesRefVector.Builder bytes = TestBlockFactory.getNonBreakingInstance().newBytesRefVectorBuilder(maxValuesPerPosition);
             ) {
-                int valueMaxByteSize = 0;
                 for (int p = 0; p < positionCount; p++) {
                     int valueCount = between(1, maxValuesPerPosition);
                     int dupCount = between(0, dups);
@@ -488,9 +488,9 @@ public class BlockHashRandomizedTests extends ComputeTestCase {
                             bytes.appendBytesRef(new BytesRef(k));
                             return dictionary.size();
                         });
-                        BytesRef keyBytes = new BytesRef(key);
-                        valueMaxByteSize = Math.max(valueMaxByteSize, keyBytes.length);
-                        valuesAtPosition.add(keyBytes);
+                        BytesRef keyBytesRef = new BytesRef(key);
+                        valuesAtPosition.add(keyBytesRef);
+                        valueMaxByteSize = Math.max(valueMaxByteSize, keyBytesRef.length);
                         ordinals.appendInt(ordinal);
                         ordsAtPosition.add(ordinal);
                     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -267,6 +267,7 @@ public class BasicBlockTests extends ESTestCase {
             assertEmptyLookup(blockFactory, block);
             assertThat(block.asVector().min(), equalTo(0));
             assertThat(block.asVector().max(), equalTo(positionCount - 1));
+            assertThat(block.valueMaxByteSize(), equalTo(Integer.BYTES));
             assertDeepCopy(block);
 
             try (IntBlock.Builder blockBuilder = blockFactory.newIntBlockBuilder(1)) {
@@ -299,6 +300,7 @@ public class BasicBlockTests extends ESTestCase {
                 assertSingleValueDenseBlock(vector.asBlock());
                 assertThat(vector.min(), equalTo(0));
                 assertThat(vector.max(), equalTo(positionCount - 1));
+                assertThat(vector.valueMaxByteSize(), equalTo(Integer.BYTES));
                 assertInsertNulls(vector.asBlock());
                 assertDeepCopy(vector.asBlock());
                 releaseAndAssertBreaker(vector.asBlock());
@@ -328,6 +330,7 @@ public class BasicBlockTests extends ESTestCase {
             assertEmptyLookup(blockFactory, vector.asBlock());
             assertThat(vector.min(), equalTo(start));
             assertThat(vector.max(), equalTo(start + positionCount - 1));
+            assertThat(vector.valueMaxByteSize(), equalTo(Integer.BYTES));
             assertDeepCopy(vector.asBlock());
             assertSingleValueDenseBlock(vector.asBlock());
 
@@ -357,6 +360,7 @@ public class BasicBlockTests extends ESTestCase {
             assertEmptyLookup(blockFactory, block);
             assertThat(block.asVector().min(), equalTo(Integer.MAX_VALUE));
             assertThat(block.asVector().max(), equalTo(Integer.MIN_VALUE));
+            assertThat(block.valueMaxByteSize(), equalTo(Integer.BYTES));
             assertInsertNulls(block);
             assertDeepCopy(block);
             releaseAndAssertBreaker(block);
@@ -365,6 +369,7 @@ public class BasicBlockTests extends ESTestCase {
                 IntVector vector = vectorBuilder.build();
                 assertThat(vector.min(), equalTo(Integer.MAX_VALUE));
                 assertThat(vector.max(), equalTo(Integer.MIN_VALUE));
+                assertThat(vector.valueMaxByteSize(), equalTo(Integer.BYTES));
                 assertInsertNulls(vector.asBlock());
                 assertDeepCopy(vector.asBlock());
                 releaseAndAssertBreaker(vector.asBlock());
@@ -406,6 +411,7 @@ public class BasicBlockTests extends ESTestCase {
             assertEmptyLookup(blockFactory, block);
             assertThat(block.asVector().min(), equalTo(value));
             assertThat(block.asVector().max(), equalTo(value));
+            assertThat(block.valueMaxByteSize(), equalTo(Integer.BYTES));
             assertInsertNulls(block);
             assertDeepCopy(block);
             releaseAndAssertBreaker(block);
@@ -437,6 +443,7 @@ public class BasicBlockTests extends ESTestCase {
             }
             assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
             assertEmptyLookup(blockFactory, block);
+            assertThat(block.valueMaxByteSize(), equalTo(Long.BYTES));
 
             try (LongBlock.Builder blockBuilder = blockFactory.newLongBlockBuilder(1)) {
                 LongBlock copy = blockBuilder.copyFrom(block, 0, block.getPositionCount()).build();
@@ -465,6 +472,7 @@ public class BasicBlockTests extends ESTestCase {
             LongStream.range(0, positionCount).forEach(vectorBuilder::appendLong);
             LongVector vector = vectorBuilder.build();
             assertSingleValueDenseBlock(vector.asBlock());
+            assertThat(vector.valueMaxByteSize(), equalTo(Long.BYTES));
             assertInsertNulls(vector.asBlock());
             assertDeepCopy(vector.asBlock());
             releaseAndAssertBreaker(vector.asBlock());
@@ -503,6 +511,7 @@ public class BasicBlockTests extends ESTestCase {
                 b -> assertThat(b, instanceOf(ConstantNullBlock.class))
             );
             assertEmptyLookup(blockFactory, block);
+            assertThat(block.valueMaxByteSize(), equalTo(Long.BYTES));
             assertInsertNulls(block);
             assertDeepCopy(block);
             releaseAndAssertBreaker(block);
@@ -535,6 +544,7 @@ public class BasicBlockTests extends ESTestCase {
             }
             assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
             assertEmptyLookup(blockFactory, block);
+            assertThat(block.valueMaxByteSize(), equalTo(Double.BYTES));
 
             try (DoubleBlock.Builder blockBuilder = blockFactory.newDoubleBlockBuilder(1)) {
                 DoubleBlock copy = blockBuilder.copyFrom(block, 0, block.getPositionCount()).build();
@@ -565,6 +575,7 @@ public class BasicBlockTests extends ESTestCase {
                 IntStream.range(0, positionCount).mapToDouble(ii -> 1.0 / ii).forEach(vectorBuilder::appendDouble);
                 DoubleVector vector = vectorBuilder.build();
                 assertSingleValueDenseBlock(vector.asBlock());
+                assertThat(vector.valueMaxByteSize(), equalTo(Double.BYTES));
                 assertInsertNulls(vector.asBlock());
                 assertDeepCopy(vector.asBlock());
                 releaseAndAssertBreaker(vector.asBlock());
@@ -602,6 +613,7 @@ public class BasicBlockTests extends ESTestCase {
                 b -> assertThat(b, instanceOf(ConstantNullBlock.class))
             );
             assertEmptyLookup(blockFactory, block);
+            assertThat(block.valueMaxByteSize(), equalTo(Double.BYTES));
             assertInsertNulls(block);
             assertDeepCopy(block);
             releaseAndAssertBreaker(block);
@@ -635,6 +647,7 @@ public class BasicBlockTests extends ESTestCase {
             }
             assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
             assertEmptyLookup(blockFactory, block);
+            assertThat(block.valueMaxByteSize(), equalTo(Float.BYTES));
 
             try (FloatBlock.Builder blockBuilder = blockFactory.newFloatBlockBuilder(1)) {
                 FloatBlock copy = blockBuilder.copyFrom(block, 0, block.getPositionCount()).build();
@@ -665,6 +678,7 @@ public class BasicBlockTests extends ESTestCase {
                 IntStream.range(0, positionCount).mapToDouble(ii -> 1.0 / ii).forEach(vectorBuilder::appendDouble);
                 DoubleVector vector = vectorBuilder.build();
                 assertSingleValueDenseBlock(vector.asBlock());
+                assertThat(vector.valueMaxByteSize(), equalTo(Double.BYTES));
                 assertInsertNulls(vector.asBlock());
                 assertDeepCopy(vector.asBlock());
                 releaseAndAssertBreaker(vector.asBlock());
@@ -702,6 +716,7 @@ public class BasicBlockTests extends ESTestCase {
                 b -> assertThat(b, instanceOf(ConstantNullBlock.class))
             );
             assertEmptyLookup(blockFactory, block);
+            assertThat(block.valueMaxByteSize(), equalTo(Float.BYTES));
             assertInsertNulls(block);
             assertDeepCopy(block);
             releaseAndAssertBreaker(block);
@@ -751,6 +766,7 @@ public class BasicBlockTests extends ESTestCase {
         }
         assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
         assertEmptyLookup(blockFactory, block);
+        assertThat(block.valueMaxByteSize(), equalTo(Arrays.stream(values).mapToInt(v -> v.length).max().orElse(0)));
 
         try (BytesRefBlock.Builder blockBuilder = blockFactory.newBytesRefBlockBuilder(1)) {
             BytesRefBlock copy = blockBuilder.copyFrom(block, 0, block.getPositionCount()).build();
@@ -782,6 +798,7 @@ public class BasicBlockTests extends ESTestCase {
             IntStream.range(0, positionCount).mapToObj(ii -> new BytesRef(randomAlphaOfLength(5))).forEach(vectorBuilder::appendBytesRef);
             BytesRefVector vector = vectorBuilder.build();
             assertSingleValueDenseBlock(vector.asBlock());
+            assertThat(vector.valueMaxByteSize(), equalTo(5));
             assertInsertNulls(vector.asBlock());
             assertDeepCopy(vector.asBlock());
             releaseAndAssertBreaker(vector.asBlock());
@@ -929,6 +946,7 @@ public class BasicBlockTests extends ESTestCase {
                 b -> assertThat(b, instanceOf(ConstantNullBlock.class))
             );
             assertEmptyLookup(blockFactory, block);
+            assertThat(block.valueMaxByteSize(), equalTo(originalValue.length));
             assertInsertNulls(block);
             assertDeepCopy(block);
             releaseAndAssertBreaker(block);
@@ -979,6 +997,7 @@ public class BasicBlockTests extends ESTestCase {
                 }
             }
 
+            assertThat(block.valueMaxByteSize(), equalTo(Byte.BYTES));
             try (BooleanBlock.Builder blockBuilder = blockFactory.newBooleanBlockBuilder(1)) {
                 BooleanBlock copy = blockBuilder.copyFrom(block, 0, block.getPositionCount()).build();
                 assertThat(copy, equalTo(block));
@@ -1013,6 +1032,7 @@ public class BasicBlockTests extends ESTestCase {
             Arrays.stream(bools).forEach(vectorBuilder::appendBoolean);
             BooleanVector vector = vectorBuilder.build();
             assertSingleValueDenseBlock(vector.asBlock());
+            assertThat(vector.valueMaxByteSize(), equalTo(Byte.BYTES));
             assertToMask(vector);
             if (value == null) {
                 assertThat(vector.allTrue(), equalTo(Arrays.stream(bools).allMatch(v -> v)));
@@ -1069,6 +1089,7 @@ public class BasicBlockTests extends ESTestCase {
                 assertFalse(block.asVector().allTrue());
                 assertTrue(block.asVector().allFalse());
             }
+            assertThat(block.valueMaxByteSize(), equalTo(Byte.BYTES));
             assertInsertNulls(block);
             assertDeepCopy(block);
             releaseAndAssertBreaker(block);
@@ -1113,6 +1134,7 @@ public class BasicBlockTests extends ESTestCase {
                 singletonList(null),
                 b -> assertThat(b, instanceOf(ConstantNullBlock.class))
             );
+            assertThat(((IntBlock) block).valueMaxByteSize(), equalTo(0));
             assertInsertNulls(block);
             assertDeepCopy(block);
             releaseAndAssertBreaker(block);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
@@ -82,6 +82,7 @@ public class BlockMultiValuedTests extends ESTestCase {
 
             assertThat(b.block().mayHaveMultivaluedFields(), equalTo(b.values().stream().anyMatch(l -> l != null && l.size() > 1)));
             assertThat(b.block().doesHaveMultivaluedFields(), equalTo(b.values().stream().anyMatch(l -> l != null && l.size() > 1)));
+            assertThat(b.block().valueMaxByteSize(), equalTo(b.valueMaxByteSize()));
             assertInsertNulls(b.block());
         } finally {
             b.block().close();

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/RandomBlock.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/RandomBlock.java
@@ -32,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.time.DateUtils.MAX_MILLIS_BEFORE_9999;
@@ -42,8 +43,9 @@ import static org.elasticsearch.test.ESTestCase.randomMillisUpToYear9999;
  * A block of random values.
  * @param values the values as java object
  * @param block randomly built block
+ * @param valueMaxByteSize the maximum byte size of any single value in the block
  */
-public record RandomBlock(List<List<Object>> values, Block block) {
+public record RandomBlock(List<List<Object>> values, Block block, int valueMaxByteSize) {
     /**
      * A random {@link ElementType} for which we can build a {@link RandomBlock}.
      */
@@ -218,8 +220,26 @@ public record RandomBlock(List<List<Object>> values, Block block) {
             if (ESTestCase.randomBoolean()) {
                 builder.mvOrdering(mvOrdering);
             }
-            return new RandomBlock(values, builder.build());
+            Block builtBlock = builder.build();
+            return new RandomBlock(values, builtBlock, computeValueMaxByteSize(elementType, values));
         }
+    }
+
+    private static int computeValueMaxByteSize(ElementType elementType, List<List<Object>> values) {
+        return switch (elementType) {
+            case BOOLEAN -> Byte.BYTES;
+            case INT -> Integer.BYTES;
+            case LONG -> Long.BYTES;
+            case FLOAT -> Float.BYTES;
+            case DOUBLE -> Double.BYTES;
+            case BYTES_REF -> values.stream()
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .mapToInt(v -> ((BytesRef) v).length)
+                .max()
+                .orElse(0);
+            default -> throw new IllegalArgumentException("valueMaxByteSize not supported for element type [" + elementType + "]");
+        };
     }
 
     public int valueCount() {
@@ -256,7 +276,8 @@ public record RandomBlock(List<List<Object>> values, Block block) {
                 mergedBlock.copyFrom(rhs.block, r, r + 1);
                 r++;
             }
-            return new RandomBlock(mergedValues, mergedBlock.build());
+            Block builtBlock = mergedBlock.build();
+            return new RandomBlock(mergedValues, builtBlock, computeValueMaxByteSize(builtBlock.elementType(), mergedValues));
         }
     }
 }

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/RandomBlock.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/RandomBlock.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.ExponentialHistogramArrayBlock;
 import org.elasticsearch.compute.data.ExponentialHistogramBlockBuilder;
 import org.elasticsearch.compute.data.FloatBlock;
 import org.elasticsearch.compute.data.IntBlock;
@@ -32,7 +33,6 @@ import org.elasticsearch.test.ESTestCase;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.time.DateUtils.MAX_MILLIS_BEFORE_9999;
@@ -43,7 +43,7 @@ import static org.elasticsearch.test.ESTestCase.randomMillisUpToYear9999;
  * A block of random values.
  * @param values the values as java object
  * @param block randomly built block
- * @param valueMaxByteSize the maximum byte size of any single value in the block
+ * @param valueMaxByteSize the maximum byte size of any single value
  */
 public record RandomBlock(List<List<Object>> values, Block block, int valueMaxByteSize) {
     /**
@@ -112,6 +112,20 @@ public record RandomBlock(List<List<Object>> values, Block block, int valueMaxBy
         try (var builder = elementType.newBlockBuilder(positionCount, blockFactory)) {
             boolean bytesRefFromPoints = ESTestCase.randomBoolean();
             Supplier<Point> pointSupplier = ESTestCase.randomBoolean() ? GeometryTestUtils::randomPoint : ShapeTestUtils::randomPoint;
+            int valueMaxByteSize = switch (elementType) {
+                case BOOLEAN -> Byte.BYTES;
+                case INT -> Integer.BYTES;
+                case LONG -> Long.BYTES;
+                case FLOAT -> Float.BYTES;
+                case DOUBLE -> Double.BYTES;
+                case NULL -> 0;
+                case DOC -> 3 * Integer.BYTES;
+                case LONG_RANGE -> 2 * Long.BYTES;
+                case BYTES_REF, EXPONENTIAL_HISTOGRAM -> 0; // Updated per value below
+                case AGGREGATE_METRIC_DOUBLE -> 3 * Double.BYTES + Integer.BYTES;
+                case TDIGEST -> 0; // TDIGEST has no well-defined single-value byte size
+                case COMPOSITE, UNKNOWN -> throw new IllegalArgumentException("can't build a random " + elementType + " block");
+            };
             for (int p = 0; p < positionCount; p++) {
                 if (elementType == ElementType.NULL) {
                     assert nullAllowed;
@@ -159,6 +173,7 @@ public record RandomBlock(List<List<Object>> values, Block block, int valueMaxBy
                                 : new BytesRef(ESTestCase.randomRealisticUnicodeOfLength(4));
                             valuesAtPosition.add(b);
                             ((BytesRefBlock.Builder) builder).appendBytesRef(b);
+                            valueMaxByteSize = Math.max(valueMaxByteSize, b.length);
                         }
                         case BOOLEAN -> {
                             boolean b = ESTestCase.randomBoolean();
@@ -182,12 +197,17 @@ public record RandomBlock(List<List<Object>> values, Block block, int valueMaxBy
                             ExponentialHistogram histogram = BlockTestUtils.randomExponentialHistogram();
                             b.append(histogram);
                             valuesAtPosition.add(histogram);
+                            valueMaxByteSize = Math.max(
+                                valueMaxByteSize,
+                                5 * Double.BYTES + ExponentialHistogramArrayBlock.encode(histogram).encodedHistogram().length
+                            );
                         }
                         case TDIGEST -> {
                             TDigestBlockBuilder b = (TDigestBlockBuilder) builder;
                             TDigestHolder digest = BlockTestUtils.randomTDigest();
                             b.appendTDigest(digest);
                             valuesAtPosition.add(digest);
+                            valueMaxByteSize = Math.max(valueMaxByteSize, 3 * Double.BYTES + Long.BYTES + digest.getEncodedDigest().length);
                         }
                         case LONG_RANGE -> {
                             var b = (LongRangeBlockBuilder) builder;
@@ -221,25 +241,8 @@ public record RandomBlock(List<List<Object>> values, Block block, int valueMaxBy
                 builder.mvOrdering(mvOrdering);
             }
             Block builtBlock = builder.build();
-            return new RandomBlock(values, builtBlock, computeValueMaxByteSize(elementType, values));
+            return new RandomBlock(values, builtBlock, valueMaxByteSize);
         }
-    }
-
-    private static int computeValueMaxByteSize(ElementType elementType, List<List<Object>> values) {
-        return switch (elementType) {
-            case BOOLEAN -> Byte.BYTES;
-            case INT -> Integer.BYTES;
-            case LONG -> Long.BYTES;
-            case FLOAT -> Float.BYTES;
-            case DOUBLE -> Double.BYTES;
-            case BYTES_REF -> values.stream()
-                .filter(Objects::nonNull)
-                .flatMap(List::stream)
-                .mapToInt(v -> ((BytesRef) v).length)
-                .max()
-                .orElse(0);
-            default -> throw new IllegalArgumentException("valueMaxByteSize not supported for element type [" + elementType + "]");
-        };
     }
 
     public int valueCount() {
@@ -277,7 +280,8 @@ public record RandomBlock(List<List<Object>> values, Block block, int valueMaxBy
                 r++;
             }
             Block builtBlock = mergedBlock.build();
-            return new RandomBlock(mergedValues, builtBlock, computeValueMaxByteSize(builtBlock.elementType(), mergedValues));
+            return new RandomBlock(mergedValues, builtBlock, Math.max(valueMaxByteSize, rhs.valueMaxByteSize));
         }
     }
+
 }


### PR DESCRIPTION
Adds a method to `Block`/`Vector`/`TopNEncoder` to tell you the maximum length of any individual value. We'll use this to decide to use `PackedBytesBuilder` or a dense representation for TopN. These should run quite quickly, even for the few cases where we have to calculate them on the fly and don't know at plan time.
