### PR TITLE
[ESQL] Fix Parquet decode-buffer aliasing across pages

### DIFF
--- a/docs/changelog/147738.yaml
+++ b/docs/changelog/147738.yaml
@@ -1,0 +1,5 @@
+pr: 147738
+summary: Stop sharing decode buffers between Parquet pages
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DecodeBuffers.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DecodeBuffers.java
@@ -10,24 +10,24 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 import java.util.BitSet;
 
 /**
- * Reusable decode buffers for {@link PageColumnReader} batch operations. Eliminates per-batch
- * allocation of primitive arrays by keeping warm arrays that are reused across batches.
+ * Reusable scratch buffers for {@link PageColumnReader} batch decoding. Eliminates per-batch
+ * allocation of primitive arrays by keeping warm arrays that are reused across batches within
+ * a single column reader.
  *
- * <p>Each buffer type is lazily allocated and grown as needed. {@code BlockFactory.newXxxArrayVector}
- * wraps arrays by reference (no copy), so each {@link PageColumnReader} must own its own
- * {@code DecodeBuffers} instance. Within a single column, the {@link #takeLongs()} and
- * {@link #takeDoubles()} methods alternate between two slots so the previous batch's array can
- * be handed off to a Block while the next batch decodes into the alternate slot.
+ * <p>Buffers are pure scratch space: {@link PageColumnReader} decodes into them, then copies the
+ * decoded slice into a freshly allocated, tightly sized array before handing it to
+ * {@code BlockFactory}. The Block therefore never aliases anything inside this class, so the
+ * reader is free to overwrite the scratch arrays on the next batch. See the {@code Block
+ * construction helpers} section in {@link PageColumnReader} for the full ownership rationale.
  *
- * <p><b>Important:</b> each {@link PageColumnReader} must own its own {@code DecodeBuffers} instance.
- * Sharing across columns causes block corruption because {@code BlockFactory.newXxxArrayVector()}
- * wraps arrays by reference. When two columns share a buffer, the second column's decode overwrites
- * the first column's live block data. The double-buffering for longs/doubles (slot A/B via
- * {@link #takeLongs()}/{@link #takeDoubles()}) handles at most 2 consumers but fails with 3+.
+ * <p>Each buffer type is lazily allocated and grown as needed. Longs and doubles still rotate
+ * between two slots (see {@link #takeLongs()} / {@link #takeDoubles()}); after the copy-on-emit
+ * fix this is no longer required for correctness - one slot would be sufficient - and is kept
+ * only to avoid changing the buffer-growth profile in the same patch. Collapsing to a single
+ * slot is left as a follow-up.
  *
- * <p>TODO: when {@code ColumnBlockConversions} gains an {@code ownsArray=true} overload (zero-copy
- * handoff), revisit sharing: a single DecodeBuffers per row group would reduce object overhead if
- * blocks take ownership and the buffer is immediately recycled.
+ * <p>Each {@link PageColumnReader} owns its own instance. Sharing across columns is unnecessary
+ * and would only complicate ownership without buying anything.
  */
 final class DecodeBuffers {
 
@@ -65,10 +65,14 @@ final class DecodeBuffers {
     }
 
     /**
-     * Returns the current long buffer and swaps to the alternate slot. The caller takes
-     * exclusive ownership of the returned array (e.g., to hand off to a Block without copying).
-     * The next call to {@link #longs(int)} will use the alternate slot, avoiding reallocation
-     * as long as the previous buffer is released before the one after next is taken.
+     * Returns the current long scratch buffer and swaps to the alternate slot for the next
+     * call to {@link #longs(int)}. The returned array is still owned by this {@code DecodeBuffers}
+     * - callers must not retain it past the next {@code takeLongs()} or {@code longs(int)}
+     * call. {@link PageColumnReader} reads the decoded slice and copies it into a fresh,
+     * Block-owned array before emit, so this is safe by construction.
+     *
+     * <p>The slot flip is a historical artifact: with copy-on-emit a single slot would be
+     * enough. Kept for now to leave allocation behavior unchanged in this patch.
      */
     long[] takeLongs() {
         if (longSlotA) {
@@ -95,10 +99,10 @@ final class DecodeBuffers {
     }
 
     /**
-     * Returns the current double buffer and swaps to the alternate slot. The caller takes
-     * exclusive ownership of the returned array (e.g., to hand off to a Block without copying).
-     * The next call to {@link #doubles(int)} will use the alternate slot, avoiding reallocation
-     * as long as the previous buffer is released before the one after next is taken.
+     * Returns the current double scratch buffer and swaps to the alternate slot. Same ownership
+     * rules as {@link #takeLongs()}: the array stays owned by this {@code DecodeBuffers} and
+     * must not be retained past the next call. {@link PageColumnReader} copies the decoded
+     * slice into a Block-owned array before emit.
      */
     double[] takeDoubles() {
         if (doubleSlotA) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -31,6 +31,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.BitSet;
 
 /**
@@ -1102,9 +1103,7 @@ final class PageColumnReader {
     // for the regression coverage.
 
     private Block takeLongBlock(BlockFactory blockFactory, int rowCount, boolean noNulls, BitSet nullBitSet) {
-        long[] src = buffers.takeLongs();
-        long[] owned = new long[rowCount];
-        System.arraycopy(src, 0, owned, 0, rowCount);
+        long[] owned = Arrays.copyOf(buffers.takeLongs(), rowCount);
         if (noNulls) {
             return blockFactory.newLongArrayVector(owned, rowCount).asBlock();
         }
@@ -1112,9 +1111,7 @@ final class PageColumnReader {
     }
 
     private Block takeDoubleBlock(BlockFactory blockFactory, int rowCount, boolean noNulls, BitSet nullBitSet) {
-        double[] src = buffers.takeDoubles();
-        double[] owned = new double[rowCount];
-        System.arraycopy(src, 0, owned, 0, rowCount);
+        double[] owned = Arrays.copyOf(buffers.takeDoubles(), rowCount);
         if (noNulls) {
             return blockFactory.newDoubleArrayVector(owned, rowCount).asBlock();
         }
@@ -1122,8 +1119,7 @@ final class PageColumnReader {
     }
 
     private Block takeIntBlock(BlockFactory blockFactory, int[] src, int rowCount, boolean noNulls, BitSet nullBitSet) {
-        int[] owned = new int[rowCount];
-        System.arraycopy(src, 0, owned, 0, rowCount);
+        int[] owned = Arrays.copyOf(src, rowCount);
         if (noNulls) {
             return blockFactory.newIntArrayVector(owned, rowCount).asBlock();
         }
@@ -1131,8 +1127,7 @@ final class PageColumnReader {
     }
 
     private Block takeBooleanBlock(BlockFactory blockFactory, boolean[] src, int rowCount, boolean noNulls, BitSet nullBitSet) {
-        boolean[] owned = new boolean[rowCount];
-        System.arraycopy(src, 0, owned, 0, rowCount);
+        boolean[] owned = Arrays.copyOf(src, rowCount);
         if (noNulls) {
             return blockFactory.newBooleanArrayVector(owned, rowCount).asBlock();
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -391,7 +391,7 @@ final class PageColumnReader {
             int produced = readNonNullBooleans(values, 0, maxRows);
             Block constant = ConstantBlockDetection.tryConstantBoolean(values, produced, blockFactory);
             if (constant != null) return constant;
-            return blockFactory.newBooleanArrayVector(values, produced).asBlock();
+            return takeBooleanBlock(blockFactory, values, produced, true, null);
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -407,13 +407,13 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantBoolean(values, produced, blockFactory);
             if (constant != null) return constant;
-            return blockFactory.newBooleanArrayVector(values, produced).asBlock();
+            return takeBooleanBlock(blockFactory, values, produced, true, null);
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return blockFactory.newBooleanArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
+        return takeBooleanBlock(blockFactory, values, produced, false, nulls.toBitSet());
     }
 
     private int readNonNullBooleans(boolean[] values, int offset, int maxRows) {
@@ -450,7 +450,7 @@ final class PageColumnReader {
             int produced = readNonNullInts(values, 0, maxRows);
             Block constant = ConstantBlockDetection.tryConstantInt(values, produced, blockFactory);
             if (constant != null) return constant;
-            return blockFactory.newIntArrayVector(values, produced).asBlock();
+            return takeIntBlock(blockFactory, values, produced, true, null);
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -466,13 +466,13 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantInt(values, produced, blockFactory);
             if (constant != null) return constant;
-            return blockFactory.newIntArrayVector(values, produced).asBlock();
+            return takeIntBlock(blockFactory, values, produced, true, null);
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return blockFactory.newIntArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
+        return takeIntBlock(blockFactory, values, produced, false, nulls.toBitSet());
     }
 
     private int readNonNullInts(int[] values, int offset, int maxRows) {
@@ -1074,9 +1074,37 @@ final class PageColumnReader {
     }
 
     // --- Block construction helpers ---
+    //
+    // These helpers copy the decode buffer into a fresh, tightly sized owned array before
+    // handing it to BlockFactory.
+    //
+    // Why the copy is necessary: BlockFactory#new*ArrayVector(values, positionCount) does NOT
+    // copy. It stores the array reference directly inside the Vector (see e.g.
+    // LongArrayVector#values), and the Vector reads from that array for the entire lifetime of
+    // the Block. Memory accounting on the circuit breaker is computed from the array's full
+    // length too. So whatever array a caller hands in is logically owned by the resulting Block
+    // until the Block is released.
+    //
+    // PageColumnReader's DecodeBuffers, by contrast, are a small per-reader pool that is reused
+    // across successive read*Batch calls: longs and doubles rotate between two slots, while ints
+    // and booleans share a single buffer. When AsyncExternalSourceBuffer keeps several emitted
+    // Pages queued between the producer driver and the consumer driver - the steady-state shape
+    // for parquet reads - more than two Blocks for a given column are alive at once, the
+    // two-slot rotation cannot keep up, and the next decode silently mutates the array still
+    // referenced by an earlier Block. The result is non-deterministic, incorrect numeric
+    // aggregates while COUNT(*) stays correct.
+    //
+    // Defensively copying here transfers a fresh array to the Block on every emit, decoupling
+    // the Block's lifetime from the reader's pool. The copy is sized to positionCount, which
+    // also keeps the breaker accounting tight (vs. the oversized pooled buffer's array.length).
+    //
+    // See {@code ParquetFormatReaderTests#testEmittedPagesAreNotMutatedAcrossProducerConsumerBoundary}
+    // for the regression coverage.
 
     private Block takeLongBlock(BlockFactory blockFactory, int rowCount, boolean noNulls, BitSet nullBitSet) {
-        long[] owned = buffers.takeLongs();
+        long[] src = buffers.takeLongs();
+        long[] owned = new long[rowCount];
+        System.arraycopy(src, 0, owned, 0, rowCount);
         if (noNulls) {
             return blockFactory.newLongArrayVector(owned, rowCount).asBlock();
         }
@@ -1084,11 +1112,31 @@ final class PageColumnReader {
     }
 
     private Block takeDoubleBlock(BlockFactory blockFactory, int rowCount, boolean noNulls, BitSet nullBitSet) {
-        double[] owned = buffers.takeDoubles();
+        double[] src = buffers.takeDoubles();
+        double[] owned = new double[rowCount];
+        System.arraycopy(src, 0, owned, 0, rowCount);
         if (noNulls) {
             return blockFactory.newDoubleArrayVector(owned, rowCount).asBlock();
         }
         return blockFactory.newDoubleArrayBlock(owned, rowCount, null, nullBitSet, Block.MvOrdering.UNORDERED);
+    }
+
+    private Block takeIntBlock(BlockFactory blockFactory, int[] src, int rowCount, boolean noNulls, BitSet nullBitSet) {
+        int[] owned = new int[rowCount];
+        System.arraycopy(src, 0, owned, 0, rowCount);
+        if (noNulls) {
+            return blockFactory.newIntArrayVector(owned, rowCount).asBlock();
+        }
+        return blockFactory.newIntArrayBlock(owned, rowCount, null, nullBitSet, Block.MvOrdering.UNORDERED);
+    }
+
+    private Block takeBooleanBlock(BlockFactory blockFactory, boolean[] src, int rowCount, boolean noNulls, BitSet nullBitSet) {
+        boolean[] owned = new boolean[rowCount];
+        System.arraycopy(src, 0, owned, 0, rowCount);
+        if (noNulls) {
+            return blockFactory.newBooleanArrayVector(owned, rowCount).asBlock();
+        }
+        return blockFactory.newBooleanArrayBlock(owned, rowCount, null, nullBitSet, Block.MvOrdering.UNORDERED);
     }
 
     // --- Scatter utilities ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -60,9 +60,11 @@ import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -2149,6 +2151,114 @@ public class ParquetFormatReaderTests extends ESTestCase {
                 return StoragePath.of(locationUri);
             }
         };
+    }
+
+    /**
+     * Regression test for the buffer-aliasing bug where {@code PageColumnReader} could let a
+     * later batch's decode mutate the values inside an earlier still-referenced {@link Page}.
+     *
+     * <p>The bug: {@code PageColumnReader.take{Long,Double,Int,Boolean}Block} used to hand the
+     * pooled {@code DecodeBuffers} array directly to {@link BlockFactory}. {@link BlockFactory}
+     * does not copy: it stores the reference. {@code DecodeBuffers} reuses its primitive arrays
+     * across batches (longs/doubles via two-slot rotation; ints/booleans single-buffered), so
+     * when more than two pages from the same column reader were alive at once - the normal case
+     * for {@code AsyncExternalSourceBuffer} - the producer's next decode would overwrite values
+     * inside an earlier emitted Block. Symptom: aggregations like SUM and AVG produced
+     * non-deterministic, incorrect results across runs while COUNT(*) stayed correct.
+     *
+     * <p>The shape that triggers the bug in production is {@code AsyncExternalSourceBuffer}: a
+     * producer driver decodes pages and queues them, and a consumer driver pulls them out
+     * later, after the producer has already advanced several pages further. This test models
+     * that boundary deterministically in a single thread - alternating produce and consume
+     * with a fixed lookahead larger than the {@link DecodeBuffers} slot count - so each Page
+     * the consumer reads has been "alive" while the producer kept reusing the underlying
+     * primitive arrays. With the fix every read value equals the row index it was assigned at
+     * write time; without it the consumer sees values from a later batch (e.g.
+     * {@code expected:<0> but was:<180>}).
+     */
+    public void testEmittedPagesAreNotMutatedAcrossProducerConsumerBoundary() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("v_long")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("v_int")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("v_double")
+            .named("retention_test_pc");
+
+        int totalRows = 600;
+        int batchSize = 30;
+        // Lookahead must exceed the DecodeBuffers slot count (2 for long/double, 1 for
+        // int/boolean) so the producer is guaranteed to reuse a buffer the consumer still
+        // references. 6 mirrors the typical AsyncExternalSourceBuffer queue depth.
+        int lookahead = 6;
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>(totalRows);
+            for (int i = 0; i < totalRows; i++) {
+                Group g = factory.newGroup();
+                g.add("v_long", (long) i);
+                g.add("v_int", i);
+                g.add("v_double", (double) i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        Deque<Page> queue = new ArrayDeque<>();
+        int rowOffset = 0;
+        int maxObservedDepth = 0;
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, batchSize)) {
+            while (true) {
+                // Producer: keep the queue full up to `lookahead`, mirroring the async buffer
+                // refilling ahead of the consumer.
+                while (queue.size() < lookahead && iterator.hasNext()) {
+                    queue.addLast(iterator.next());
+                }
+                if (queue.isEmpty()) break;
+                maxObservedDepth = Math.max(maxObservedDepth, queue.size());
+                // Consumer: pull the oldest queued page and verify its values. By construction
+                // the producer has already decoded `lookahead - 1` more pages into the same
+                // PageColumnReader since this page was emitted.
+                Page page = queue.removeFirst();
+                try {
+                    int rows = page.getPositionCount();
+                    LongBlock lb = (LongBlock) page.getBlock(0);
+                    IntBlock ib = (IntBlock) page.getBlock(1);
+                    DoubleBlock db = (DoubleBlock) page.getBlock(2);
+                    for (int r = 0; r < rows; r++) {
+                        long expected = rowOffset + r;
+                        assertEquals(
+                            "long value mutated after queue lookahead (page-rel row=" + r + ", abs=" + expected + ")",
+                            expected,
+                            lb.getLong(r)
+                        );
+                        assertEquals(
+                            "int value mutated after queue lookahead (page-rel row=" + r + ", abs=" + expected + ")",
+                            (int) expected,
+                            ib.getInt(r)
+                        );
+                        assertEquals(
+                            "double value mutated after queue lookahead (page-rel row=" + r + ", abs=" + expected + ")",
+                            (double) expected,
+                            db.getDouble(r),
+                            0.0
+                        );
+                    }
+                    rowOffset += rows;
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        }
+        assertEquals(totalRows, rowOffset);
+        assertTrue(
+            "expected the queue to grow past the DecodeBuffers slot count to actually exercise the bug, got max depth " + maxObservedDepth,
+            maxObservedDepth >= 3
+        );
     }
 
     public void testWithConfigOptimizedReaderTrue() {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -2154,27 +2154,18 @@ public class ParquetFormatReaderTests extends ESTestCase {
     }
 
     /**
-     * Regression test for the buffer-aliasing bug where {@code PageColumnReader} could let a
-     * later batch's decode mutate the values inside an earlier still-referenced {@link Page}.
+     * Regression test for the {@code PageColumnReader} buffer-aliasing bug. Models the producer/
+     * consumer boundary deterministically in a single thread by maintaining a queue lookahead
+     * larger than the {@link DecodeBuffers} slot count, so every {@link Page} the consumer reads
+     * has been alive across several subsequent decodes by the producer - the same shape
+     * {@code AsyncExternalSourceBuffer} produces in production. See the {@code Block construction
+     * helpers} block in {@link PageColumnReader} for the bug mechanism.
      *
-     * <p>The bug: {@code PageColumnReader.take{Long,Double,Int,Boolean}Block} used to hand the
-     * pooled {@code DecodeBuffers} array directly to {@link BlockFactory}. {@link BlockFactory}
-     * does not copy: it stores the reference. {@code DecodeBuffers} reuses its primitive arrays
-     * across batches (longs/doubles via two-slot rotation; ints/booleans single-buffered), so
-     * when more than two pages from the same column reader were alive at once - the normal case
-     * for {@code AsyncExternalSourceBuffer} - the producer's next decode would overwrite values
-     * inside an earlier emitted Block. Symptom: aggregations like SUM and AVG produced
-     * non-deterministic, incorrect results across runs while COUNT(*) stayed correct.
-     *
-     * <p>The shape that triggers the bug in production is {@code AsyncExternalSourceBuffer}: a
-     * producer driver decodes pages and queues them, and a consumer driver pulls them out
-     * later, after the producer has already advanced several pages further. This test models
-     * that boundary deterministically in a single thread - alternating produce and consume
-     * with a fixed lookahead larger than the {@link DecodeBuffers} slot count - so each Page
-     * the consumer reads has been "alive" while the producer kept reusing the underlying
-     * primitive arrays. With the fix every read value equals the row index it was assigned at
-     * write time; without it the consumer sees values from a later batch (e.g.
-     * {@code expected:<0> but was:<180>}).
+     * <p>All four affected primitive types are covered: longs and doubles (two-slot rotation in
+     * {@code DecodeBuffers}), ints and booleans (single slot - aliasing hits at queue depth 2).
+     * Without the fix each batch's decode mutates earlier emitted Blocks (typical failure:
+     * {@code expected:<0> but was:<160>}); with the fix every value equals its write-time row
+     * index.
      */
     public void testEmittedPagesAreNotMutatedAcrossProducerConsumerBoundary() throws Exception {
         MessageType schema = Types.buildMessage()
@@ -2184,10 +2175,15 @@ public class ParquetFormatReaderTests extends ESTestCase {
             .named("v_int")
             .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
             .named("v_double")
+            .required(PrimitiveType.PrimitiveTypeName.BOOLEAN)
+            .named("v_bool")
             .named("retention_test_pc");
 
-        int totalRows = 600;
-        int batchSize = 30;
+        // batchSize must be a multiple of 8 so PlainValueDecoder.readBooleans does not skip
+        // bits across batch boundaries - that is an unrelated decoder issue we do not want to
+        // entangle with this regression.
+        int batchSize = 32;
+        int totalRows = batchSize * 20;
         // Lookahead must exceed the DecodeBuffers slot count (2 for long/double, 1 for
         // int/boolean) so the producer is guaranteed to reuse a buffer the consumer still
         // references. 6 mirrors the typical AsyncExternalSourceBuffer queue depth.
@@ -2200,6 +2196,10 @@ public class ParquetFormatReaderTests extends ESTestCase {
                 g.add("v_long", (long) i);
                 g.add("v_int", i);
                 g.add("v_double", (double) i);
+                // (i % 7) < 3 has period 7, which does not divide batchSize=32, so the
+                // boolean pattern differs between consecutive batches and aliasing actually
+                // shows up as a visible mutation.
+                g.add("v_bool", (i % 7) < 3);
                 groups.add(g);
             }
             return groups;
@@ -2229,6 +2229,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
                     LongBlock lb = (LongBlock) page.getBlock(0);
                     IntBlock ib = (IntBlock) page.getBlock(1);
                     DoubleBlock db = (DoubleBlock) page.getBlock(2);
+                    BooleanBlock bb = (BooleanBlock) page.getBlock(3);
                     for (int r = 0; r < rows; r++) {
                         long expected = rowOffset + r;
                         assertEquals(
@@ -2246,6 +2247,11 @@ public class ParquetFormatReaderTests extends ESTestCase {
                             (double) expected,
                             db.getDouble(r),
                             0.0
+                        );
+                        assertEquals(
+                            "boolean value mutated after queue lookahead (page-rel row=" + r + ", abs=" + expected + ")",
+                            (expected % 7) < 3,
+                            bb.getBoolean(r)
                         );
                     }
                     rowOffset += rows;


### PR DESCRIPTION
`PageColumnReader` handed its pooled `DecodeBuffers` arrays directly to `BlockFactory#new*ArrayVector` / `new*ArrayBlock`. `BlockFactory` does not copy: it stores the array reference for the lifetime of the `Block`. `DecodeBuffers` however reuses its primitive arrays across successive `read*Batch` calls (longs/doubles rotate between two slots, ints and booleans share a single buffer), so once more than two `Page`s from the same column reader were alive at once the next decode silently mutated the array still referenced by an earlier `Block`.

This is the steady-state shape under `AsyncExternalSourceBuffer`: the producer driver decodes `Page`s and queues them while the consumer driver reads them later. Symptom was non-deterministic, incorrect numeric aggregates (`SUM`, `AVG`, `COUNT_DISTINCT`) on Parquet sources while `COUNT(*)` stayed correct.

**Fix:** in `take{Long,Double,Int,Boolean}Block` copy the decode buffer into a fresh, `positionCount`-sized array before handing it to `BlockFactory`. This decouples the `Block`'s lifetime from the reader's pool and also tightens circuit-breaker accounting (no oversized backing array).

Adds a regression test that models the producer/consumer boundary deterministically in a single thread by maintaining a queue lookahead larger than the `DecodeBuffers` slot count. The test fails without the fix (e.g. `expected:<0> but was:<120>`) and passes with it.

Developed with AI-assisted tooling