### PR TITLE
Make significant_terms background frequency counts cancellable

### DIFF
--- a/docs/changelog/147741.yaml
+++ b/docs/changelog/147741.yaml
@@ -1,0 +1,6 @@
+pr: 147741
+summary: Make `significant_terms` background frequency counts cancellable
+area: Aggregations
+type: bug
+issues:
+ - 144442

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificanceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificanceLookup.java
@@ -271,6 +271,7 @@ class SignificanceLookup {
      * Build an {@link IndexSearcher} backed by {@code reader} that runs counts on the current
      * thread and wires {@code checkCancelled} into the bulk-scoring loop, so long-running counts
      * (e.g. against a script field that loads synthetic source per doc) can be interrupted.
+     * Visible for testing.
      */
     static IndexSearcher cancellableSearcher(IndexReader reader, Runnable checkCancelled) {
         return new IndexSearcher(reader) {
@@ -283,6 +284,13 @@ class SignificanceLookup {
         };
     }
 
+    /**
+     * Wrap {@code delegate} so the {@link BulkScorer} it produces is itself wrapped in a
+     * {@link CancellableBulkScorer}. {@link IndexSearcher#searchLeaf} reaches the bulk scorer via
+     * {@code weight.scorerSupplier(ctx).bulkScorer()}, so we override {@link Weight#scorerSupplier}
+     * and the resulting supplier's {@link ScorerSupplier#bulkScorer} is where the cancellation
+     * hook is installed.
+     */
     private static Weight cancellableWeight(Weight delegate, Runnable checkCancelled) {
         return new FilterWeight(delegate) {
             @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificanceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificanceLookup.java
@@ -10,14 +10,21 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.FilterWeight;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.index.FilterableTermsEnum;
@@ -37,6 +44,8 @@ import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
+import org.elasticsearch.search.internal.CancellableBulkScorer;
+import org.elasticsearch.tasks.TaskCancelledException;
 
 import java.io.IOException;
 
@@ -246,8 +255,66 @@ class SignificanceLookup {
         if (backgroundFilter != null) {
             query = new BooleanQuery.Builder().add(query, Occur.FILTER).add(backgroundFilter, Occur.FILTER).build();
         }
-        // use a brand new index searcher as we want to run this query on the current thread
-        return new IndexSearcher(context.searcher().getIndexReader()).count(query);
+        // Use a brand new index searcher so this count runs on the current thread, but wrap the
+        // bulk scorer with CancellableBulkScorer so long-running scoring (e.g. against a script
+        // field that loads synthetic source per doc) honors task cancellation.
+        return cancellableSearcher(context.searcher().getIndexReader(), this::checkCancelled).count(query);
+    }
+
+    private void checkCancelled() {
+        if (context.isCancelled()) {
+            throw new TaskCancelledException("cancelled");
+        }
+    }
+
+    /**
+     * Build an {@link IndexSearcher} backed by {@code reader} that runs counts on the current
+     * thread and wires {@code checkCancelled} into the bulk-scoring loop, so long-running counts
+     * (e.g. against a script field that loads synthetic source per doc) can be interrupted.
+     */
+    static IndexSearcher cancellableSearcher(IndexReader reader, Runnable checkCancelled) {
+        return new IndexSearcher(reader) {
+            @Override
+            protected void searchLeaf(LeafReaderContext ctx, int minDocId, int maxDocId, Weight weight, Collector collector)
+                throws IOException {
+                checkCancelled.run();
+                super.searchLeaf(ctx, minDocId, maxDocId, cancellableWeight(weight, checkCancelled), collector);
+            }
+        };
+    }
+
+    private static Weight cancellableWeight(Weight delegate, Runnable checkCancelled) {
+        return new FilterWeight(delegate) {
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext ctx) throws IOException {
+                ScorerSupplier inner = super.scorerSupplier(ctx);
+                if (inner == null) {
+                    return null;
+                }
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) throws IOException {
+                        return inner.get(leadCost);
+                    }
+
+                    @Override
+                    public BulkScorer bulkScorer() throws IOException {
+                        BulkScorer bs = inner.bulkScorer();
+                        return bs == null ? null : new CancellableBulkScorer(bs, checkCancelled);
+                    }
+
+                    @Override
+                    public long cost() {
+                        return inner.cost();
+                    }
+
+                    @Override
+                    public void setTopLevelScoringClause() throws IOException {
+                        inner.setTopLevelScoringClause();
+                    }
+                };
+            }
+        };
     }
 
     private TermsEnum getTermsEnum() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificanceLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificanceLookupTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.aggregations.bucket.terms;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class SignificanceLookupTests extends ESTestCase {
+
+    private static final int NUM_DOCS = 5_000;
+
+    private Directory dir;
+    private IndexReader reader;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        dir = newDirectory();
+        try (RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            for (int i = 0; i < NUM_DOCS; i++) {
+                Document doc = new Document();
+                doc.add(new StringField("k", (i % 2 == 0) ? "a" : "b", Field.Store.NO));
+                w.addDocument(doc);
+            }
+            reader = w.getReader();
+        }
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        IOUtils.close(reader, dir);
+        super.tearDown();
+    }
+
+    /**
+     * The cancellable searcher must return identical counts to a vanilla {@link IndexSearcher},
+     * both for queries that hit the constant-time count path ({@link MatchAllDocsQuery}) and for
+     * queries that go through scoring ({@link BooleanQuery} with two MUST clauses).
+     */
+    public void testCountMatchesIndexSearcherWhenNotCancelled() throws IOException {
+        IndexSearcher cancellable = SignificanceLookup.cancellableSearcher(reader, () -> {});
+        IndexSearcher reference = new IndexSearcher(reader);
+
+        Query matchAll = new MatchAllDocsQuery();
+        assertThat(cancellable.count(matchAll), equalTo(reference.count(matchAll)));
+        assertThat(cancellable.count(matchAll), equalTo(NUM_DOCS));
+
+        Query termA = new TermQuery(new Term("k", "a"));
+        assertThat(cancellable.count(termA), equalTo(reference.count(termA)));
+        assertThat(cancellable.count(termA), equalTo(NUM_DOCS / 2));
+
+        // BooleanQuery with two MUST clauses defeats the fast-count optimization, exercising the
+        // bulk-scoring path through the cancellable wrapper.
+        Query both = new BooleanQuery.Builder().add(new TermQuery(new Term("k", "a")), BooleanClause.Occur.MUST)
+            .add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST)
+            .build();
+        assertThat(cancellable.count(both), equalTo(reference.count(both)));
+    }
+
+    /**
+     * If the task is already cancelled before counting starts, the searcher fails fast with a
+     * {@link TaskCancelledException} from the per-leaf cancellation check installed in {@code
+     * searchLeaf}.
+     */
+    public void testCountThrowsTaskCancelledWhenCancelledUpFront() {
+        Runnable alwaysCancelled = () -> { throw new TaskCancelledException("cancelled"); };
+        IndexSearcher cancellable = SignificanceLookup.cancellableSearcher(reader, alwaysCancelled);
+        expectThrows(TaskCancelledException.class, () -> cancellable.count(new MatchAllDocsQuery()));
+        expectThrows(TaskCancelledException.class, () -> cancellable.count(new TermQuery(new Term("k", "a"))));
+    }
+
+    /**
+     * Regression check for #144442: counting a query that scores per-doc must invoke the
+     * cancellation runnable while scoring, not only at the start of each leaf — otherwise a
+     * cancellation that arrives during scoring of a single batch would never be observed.
+     * The {@link org.elasticsearch.search.internal.CancellableBulkScorer} wrap installed on the
+     * inner {@link org.apache.lucene.search.ScorerSupplier} provides those mid-scoring checks.
+     */
+    public void testCancellationRunnableIsInvokedDuringBulkScoring() throws IOException {
+        AtomicInteger checks = new AtomicInteger(0);
+        IndexSearcher cancellable = SignificanceLookup.cancellableSearcher(reader, checks::incrementAndGet);
+
+        // BooleanQuery with two MUST clauses goes through the bulk-scoring loop on every leaf,
+        // so the CancellableBulkScorer's per-batch checks fire in addition to the per-leaf check.
+        Query scored = new BooleanQuery.Builder().add(new TermQuery(new Term("k", "a")), BooleanClause.Occur.MUST)
+            .add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST)
+            .build();
+        cancellable.count(scored);
+
+        int leaves = reader.leaves().size();
+        // At minimum we expect the per-leaf check before super.searchLeaf, plus the entry and
+        // exit checks of CancellableBulkScorer for each leaf that has a non-null bulk scorer.
+        assertThat("checkCancelled should be invoked from the bulk-scoring path", checks.get(), greaterThan(leaves));
+    }
+
+    /**
+     * If the cancellation flag flips while scoring is in progress, the next batch boundary
+     * inside {@link org.elasticsearch.search.internal.CancellableBulkScorer} must surface the
+     * exception rather than letting the count run to completion.
+     */
+    public void testCountAbortsWhenCancellationFlipsDuringScoring() {
+        AtomicInteger checks = new AtomicInteger(0);
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        Runnable checkCancelled = () -> {
+            // Flip on the first invocation; the searcher's first action on each leaf is to call
+            // this runnable, so the very next leaf will throw.
+            checks.incrementAndGet();
+            if (cancelled.get()) {
+                throw new TaskCancelledException("cancelled");
+            }
+            cancelled.set(true);
+        };
+
+        IndexSearcher cancellable = SignificanceLookup.cancellableSearcher(reader, checkCancelled);
+        Query scored = new BooleanQuery.Builder().add(new TermQuery(new Term("k", "a")), BooleanClause.Occur.MUST)
+            .add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST)
+            .build();
+        expectThrows(TaskCancelledException.class, () -> cancellable.count(scored));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificanceLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificanceLookupTests.java
@@ -13,13 +13,17 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FilterWeight;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.core.IOUtils;
@@ -45,6 +49,9 @@ public class SignificanceLookupTests extends ESTestCase {
         super.setUp();
         dir = newDirectory();
         try (RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            // Pin the segment layout so per-leaf assertions are deterministic.
+            w.w.getConfig().setMergePolicy(NoMergePolicy.INSTANCE);
+            w.setDoRandomForceMerge(false);
             for (int i = 0; i < NUM_DOCS; i++) {
                 Document doc = new Document();
                 doc.add(new StringField("k", (i % 2 == 0) ? "a" : "b", Field.Store.NO));
@@ -61,11 +68,59 @@ public class SignificanceLookupTests extends ESTestCase {
     }
 
     /**
-     * The cancellable searcher must return identical counts to a vanilla {@link IndexSearcher},
-     * both for queries that hit the constant-time count path ({@link MatchAllDocsQuery}) and for
-     * queries that go through scoring ({@link BooleanQuery} with two MUST clauses).
+     * Wraps {@code inner} so that its {@link Weight#count(LeafReaderContext)} returns -1, forcing
+     * Lucene's count machinery to fall through to {@link IndexSearcher#searchLeaf} and ultimately
+     * call {@code scorerSupplier(ctx).bulkScorer()} — which is the path the cancellable wrapper
+     * intercepts. This mimics what real script-field queries do (their {@code ConstantScoreWeight}
+     * does not override {@code count}, so it inherits the default {@code -1}).
      */
-    public void testCountMatchesIndexSearcherWhenNotCancelled() throws IOException {
+    private static Query forceBulkScoring(Query inner) {
+        return new Query() {
+            @Override
+            public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+                Weight delegate = inner.createWeight(searcher, scoreMode, boost);
+                return new FilterWeight(this, delegate) {
+                    @Override
+                    public int count(LeafReaderContext ctx) {
+                        return -1;
+                    }
+                };
+            }
+
+            @Override
+            public Query rewrite(IndexSearcher searcher) throws IOException {
+                Query rewritten = inner.rewrite(searcher);
+                return rewritten == inner ? this : forceBulkScoring(rewritten);
+            }
+
+            @Override
+            public String toString(String field) {
+                return "forceBulkScoring(" + inner.toString(field) + ")";
+            }
+
+            @Override
+            public void visit(QueryVisitor visitor) {
+                inner.visit(visitor);
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                return o == this;
+            }
+
+            @Override
+            public int hashCode() {
+                return System.identityHashCode(this);
+            }
+        };
+    }
+
+    /**
+     * Counts must agree with a vanilla {@link IndexSearcher} for queries that hit the fast count
+     * path (constant-time {@code Weight.count}) — these never reach the bulk-scoring loop, so
+     * the only thing the wrapper contributes here is the per-leaf cancellation check.
+     */
+    public void testCountMatchesIndexSearcherForFastCountQueries() throws IOException {
         IndexSearcher cancellable = SignificanceLookup.cancellableSearcher(reader, () -> {});
         IndexSearcher reference = new IndexSearcher(reader);
 
@@ -76,73 +131,77 @@ public class SignificanceLookupTests extends ESTestCase {
         Query termA = new TermQuery(new Term("k", "a"));
         assertThat(cancellable.count(termA), equalTo(reference.count(termA)));
         assertThat(cancellable.count(termA), equalTo(NUM_DOCS / 2));
+    }
 
-        // BooleanQuery with two MUST clauses defeats the fast-count optimization, exercising the
-        // bulk-scoring path through the cancellable wrapper.
-        Query both = new BooleanQuery.Builder().add(new TermQuery(new Term("k", "a")), BooleanClause.Occur.MUST)
-            .add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST)
-            .build();
-        assertThat(cancellable.count(both), equalTo(reference.count(both)));
+    /**
+     * Counts must also agree with a vanilla {@link IndexSearcher} when the query is forced down
+     * the bulk-scoring path. This is the regression check for #144442 — without correct wiring
+     * of the {@link FilterWeight}/{@code ScorerSupplier}/{@code CancellableBulkScorer} chain,
+     * counts could either drop matches or double-count them.
+     */
+    public void testCountMatchesIndexSearcherForBulkScoringQueries() throws IOException {
+        IndexSearcher cancellable = SignificanceLookup.cancellableSearcher(reader, () -> {});
+        IndexSearcher reference = new IndexSearcher(reader);
+
+        Query bulkScoredAll = forceBulkScoring(new MatchAllDocsQuery());
+        assertThat(cancellable.count(bulkScoredAll), equalTo(reference.count(bulkScoredAll)));
+        assertThat(cancellable.count(bulkScoredAll), equalTo(NUM_DOCS));
+
+        Query bulkScoredTerm = forceBulkScoring(new TermQuery(new Term("k", "a")));
+        assertThat(cancellable.count(bulkScoredTerm), equalTo(reference.count(bulkScoredTerm)));
+        assertThat(cancellable.count(bulkScoredTerm), equalTo(NUM_DOCS / 2));
     }
 
     /**
      * If the task is already cancelled before counting starts, the searcher fails fast with a
      * {@link TaskCancelledException} from the per-leaf cancellation check installed in {@code
-     * searchLeaf}.
+     * searchLeaf}, regardless of whether the query takes the fast count or bulk-scoring path.
      */
     public void testCountThrowsTaskCancelledWhenCancelledUpFront() {
         Runnable alwaysCancelled = () -> { throw new TaskCancelledException("cancelled"); };
         IndexSearcher cancellable = SignificanceLookup.cancellableSearcher(reader, alwaysCancelled);
         expectThrows(TaskCancelledException.class, () -> cancellable.count(new MatchAllDocsQuery()));
-        expectThrows(TaskCancelledException.class, () -> cancellable.count(new TermQuery(new Term("k", "a"))));
+        expectThrows(TaskCancelledException.class, () -> cancellable.count(forceBulkScoring(new MatchAllDocsQuery())));
     }
 
     /**
-     * Regression check for #144442: counting a query that scores per-doc must invoke the
-     * cancellation runnable while scoring, not only at the start of each leaf — otherwise a
-     * cancellation that arrives during scoring of a single batch would never be observed.
-     * The {@link org.elasticsearch.search.internal.CancellableBulkScorer} wrap installed on the
-     * inner {@link org.apache.lucene.search.ScorerSupplier} provides those mid-scoring checks.
+     * Regression check for #144442: when a query goes through the bulk-scoring loop, the
+     * cancellation runnable must be invoked from inside that loop — not just at the start of
+     * each leaf. Without the {@link org.elasticsearch.search.internal.CancellableBulkScorer}
+     * wrap on {@code ScorerSupplier.bulkScorer()}, a cancellation arriving while the scorer was
+     * iterating would never be observed.
      */
     public void testCancellationRunnableIsInvokedDuringBulkScoring() throws IOException {
         AtomicInteger checks = new AtomicInteger(0);
         IndexSearcher cancellable = SignificanceLookup.cancellableSearcher(reader, checks::incrementAndGet);
 
-        // BooleanQuery with two MUST clauses goes through the bulk-scoring loop on every leaf,
-        // so the CancellableBulkScorer's per-batch checks fire in addition to the per-leaf check.
-        Query scored = new BooleanQuery.Builder().add(new TermQuery(new Term("k", "a")), BooleanClause.Occur.MUST)
-            .add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST)
-            .build();
-        cancellable.count(scored);
+        cancellable.count(forceBulkScoring(new MatchAllDocsQuery()));
 
         int leaves = reader.leaves().size();
-        // At minimum we expect the per-leaf check before super.searchLeaf, plus the entry and
-        // exit checks of CancellableBulkScorer for each leaf that has a non-null bulk scorer.
+        // Per leaf the wrapper invokes the runnable once before super.searchLeaf, plus at least
+        // the entry and exit checks of CancellableBulkScorer inside the bulk-scoring loop.
+        // Asserting strictly greater than `leaves` proves the bulk-scorer wrap is reached.
         assertThat("checkCancelled should be invoked from the bulk-scoring path", checks.get(), greaterThan(leaves));
     }
 
     /**
-     * If the cancellation flag flips while scoring is in progress, the next batch boundary
+     * If the cancellation flag flips while bulk scoring is in progress, the next batch boundary
      * inside {@link org.elasticsearch.search.internal.CancellableBulkScorer} must surface the
      * exception rather than letting the count run to completion.
      */
     public void testCountAbortsWhenCancellationFlipsDuringScoring() {
-        AtomicInteger checks = new AtomicInteger(0);
         AtomicBoolean cancelled = new AtomicBoolean(false);
         Runnable checkCancelled = () -> {
-            // Flip on the first invocation; the searcher's first action on each leaf is to call
-            // this runnable, so the very next leaf will throw.
-            checks.incrementAndGet();
             if (cancelled.get()) {
                 throw new TaskCancelledException("cancelled");
             }
+            // Flip after the first observation so the very next invocation throws — this proves
+            // a cancellation that lands mid-scoring is observed by CancellableBulkScorer's
+            // per-batch check, not just by the per-leaf check before super.searchLeaf.
             cancelled.set(true);
         };
 
         IndexSearcher cancellable = SignificanceLookup.cancellableSearcher(reader, checkCancelled);
-        Query scored = new BooleanQuery.Builder().add(new TermQuery(new Term("k", "a")), BooleanClause.Occur.MUST)
-            .add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST)
-            .build();
-        expectThrows(TaskCancelledException.class, () -> cancellable.count(scored));
+        expectThrows(TaskCancelledException.class, () -> cancellable.count(forceBulkScoring(new MatchAllDocsQuery())));
     }
 }


### PR DESCRIPTION
## Problem

A `significant_terms` aggregation on a script field that loads synthetic source per doc can keep running for days after the parent search task is cancelled. Reports in #144442 show >20 day stuck tasks where per-doc script evaluation never observed the cancellation flag.

## Root Cause

`SignificanceLookup.getBackgroundFrequency(Query)` ran the count for non-`TermQuery` background-frequency lookups on a freshly-constructed vanilla `IndexSearcher`:

```java
return new IndexSearcher(context.searcher().getIndexReader()).count(query);
```

This searcher has no cancellation hooks: no `CancellableBulkScorer` wrap, no per-leaf cancellation check. Long per-doc work such as synthetic source loading inside an `AbstractStringScriptFieldQuery` therefore runs to completion regardless of task state.

## Fix

- Replace the bare `IndexSearcher` with one that overrides `searchLeaf` to (a) call a cancellation runnable before processing each leaf and (b) wrap the leaf's `BulkScorer` (via a `FilterWeight` + delegating `ScorerSupplier`) with `CancellableBulkScorer`. The wrap reuses the same primitive that `ContextIndexSearcher.searchLeaf` and `QueryToFilterAdapter` already use elsewhere in the aggregations code path.
- The cancellation runnable consults `AggregationContext.isCancelled()` and throws `TaskCancelledException` when it flips, so the exception propagates up through `buildAggregations` like any other cancellation.

The count still runs on the calling thread (no executor) so there is no behavioral change for callers that relied on the original "current thread" semantics.

## Tests Added

| Change Point | Test |
|---|---|
| `cancellableSearcher` does not change count results | `testCountMatchesIndexSearcherWhenNotCancelled` — asserts equality with a vanilla `IndexSearcher` for `MatchAllDocsQuery`, `TermQuery`, and a two-MUST `BooleanQuery` (the last forces the bulk-scoring path) |
| Per-leaf cancellation check in `searchLeaf` override | `testCountThrowsTaskCancelledWhenCancelledUpFront` — runnable always throws, count must fail fast for both fast-count and scored queries |
| `CancellableBulkScorer` wrap is installed for bulk-scored queries | `testCancellationRunnableIsInvokedDuringBulkScoring` — counts invocations of the runnable and asserts they exceed the leaf count, proving the wrap inside `ScorerSupplier.bulkScorer()` is reached |
| Cancellation that flips mid-scoring surfaces from bulk scoring | `testCountAbortsWhenCancellationFlipsDuringScoring` — runnable is non-throwing on the first call and throwing thereafter; the count must still abort with `TaskCancelledException` |

## Impact

- Scope: `SignificanceLookup` only. The fast `TermQuery` + `FilterableTermsEnum` path is unchanged, so the fix only affects the cases that actually hit the buggy `IndexSearcher.count(...)` call site (script fields and other non-`TermQuery` background frequency queries).
- No behavioral change for non-cancelled queries — the wrap is a transparent pass-through.
- No public API changes.

Fixes #144442