### PR TITLE
[9.2] Fix readiness edge case on startup (#140791)

### DIFF
--- a/docs/changelog/140791.yaml
+++ b/docs/changelog/140791.yaml
@@ -1,0 +1,6 @@
+pr: 140791
+summary: Fix readiness edge case on startup
+area: Infra/Node Lifecycle
+type: bug
+issues:
+ - 136955

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -443,9 +443,6 @@ tests:
 - class: org.elasticsearch.xpack.logsdb.qa.BulkDynamicMappingChallengeRestIT
   method: testEsqlTermsAggregation
   issue: https://github.com/elastic/elasticsearch/issues/138717
-- class: org.elasticsearch.readiness.ReadinessClusterIT
-  method: testReadinessDuringRestartsNormalOrder
-  issue: https://github.com/elastic/elasticsearch/issues/136955
 - class: org.elasticsearch.index.reindex.ReindexNodeShutdownIT
   method: testReindexWithShutdown
   issue: https://github.com/elastic/elasticsearch/issues/139806

--- a/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
+++ b/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
@@ -24,6 +24,10 @@ import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
 import java.util.Set;
 
+import static org.elasticsearch.test.ESTestCase.assertBusy;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class MockReadinessService extends ReadinessService {
     /**
      * Marker plugin used by {@link MockNode} to enable {@link MockReadinessService}.
@@ -100,25 +104,11 @@ public class MockReadinessService extends ReadinessService {
         return mockedSocket != null && mockedSocket.isOpen();
     }
 
-    public static void tcpReadinessProbeTrue(ReadinessService readinessService) throws InterruptedException {
-        for (int i = 1; i <= RETRIES; ++i) {
-            if (socketIsOpen(readinessService)) {
-                return;
-            }
-            Thread.sleep(RETRY_DELAY_IN_MILLIS * i);
-        }
-
-        throw new AssertionError("Readiness socket should be open");
+    public static void tcpReadinessProbeTrue(ReadinessService readinessService) throws Exception {
+        assertBusy(() -> assertTrue("Readiness socket should be open", socketIsOpen(readinessService)));
     }
 
-    public static void tcpReadinessProbeFalse(ReadinessService readinessService) throws InterruptedException {
-        for (int i = 0; i < RETRIES; ++i) {
-            if (socketIsOpen(readinessService) == false) {
-                return;
-            }
-            Thread.sleep(RETRY_DELAY_IN_MILLIS * i);
-        }
-
-        throw new AssertionError("Readiness socket should be closed");
+    public static void tcpReadinessProbeFalse(ReadinessService readinessService) throws Exception {
+        assertBusy(() -> assertFalse("Readiness socket should be close", socketIsOpen(readinessService)));
     }
 }


### PR DESCRIPTION
The readiness service watches for cluster state updates to determine when the node is ready. It must have a master node elected, and file settings must have been applied. Normally those take a little bit of time. However, the readiness services is setup to not even allow starting the tcp listener until after the service start method is called. This occurs in Node.start(), but _after_ the initial node join. If the initial join occurs before start, and the state already reflects the "ready" state, when start is called the service will be marked active, but nothing will ever start the listener.

This commit adjusts the readiness service to keep track of the last state applied. It also moves adding the cluster state listener to when the service is started. Finally, it adjusts the readiness test helpers to use assertBusy instead of a hand rolled backoff loop.

closes #136955
closes #142440

Backport of #140791.
