### PR TITLE
[8.19] Fix readiness edge case on startup (#140791)

### DIFF
--- a/docs/changelog/140791.yaml
+++ b/docs/changelog/140791.yaml
@@ -1,0 +1,6 @@
+pr: 140791
+summary: Fix readiness edge case on startup
+area: Infra/Node Lifecycle
+type: bug
+issues:
+ - 136955

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -331,9 +331,6 @@ tests:
 - class: org.elasticsearch.search.aggregations.metrics.TopHitsIT
   method: testMixedSortFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/142077
-- class: org.elasticsearch.readiness.ReadinessClusterIT
-  method: testReadinessDuringRestartsNormalOrder
-  issue: https://github.com/elastic/elasticsearch/issues/142440
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {stats.StatsByMvFieldAggExpr}
   issue: https://github.com/elastic/elasticsearch/issues/141835

--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.metadata.ReservedStateMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.transport.BoundTransportAddress;
@@ -44,9 +45,11 @@ import java.util.function.Function;
 public class ReadinessService extends AbstractLifecycleComponent implements ClusterStateListener {
     private static final Logger logger = LogManager.getLogger(ReadinessService.class);
 
+    private final ClusterService clusterService;
     private final Environment environment;
     private final CheckedSupplier<ServerSocketChannel, IOException> socketChannelFactory;
 
+    private volatile ClusterState lastClusterState = null;
     private volatile boolean active; // false;
     private volatile ServerSocketChannel serverChannel;
     // package private for testing
@@ -67,9 +70,9 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
         CheckedSupplier<ServerSocketChannel, IOException> socketChannelFactory
     ) {
         this.serverChannel = null;
+        this.clusterService = clusterService;
         this.environment = environment;
         this.socketChannelFactory = socketChannelFactory;
-        clusterService.addListener(this);
     }
 
     // package private for testing
@@ -156,8 +159,13 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
 
     @Override
     protected void doStart() {
-        // Mark the service as active, we'll start the listener when ES is ready
+        // Mark the service as active, we'll start the tcp listener when ES is ready
         this.active = true;
+        if (clusterService.lifecycleState() == Lifecycle.State.STARTED) {
+            this.lastClusterState = clusterService.state();
+            checkReadyState(null, lastClusterState);
+        }
+        clusterService.addListener(this);
     }
 
     // package private for testing
@@ -227,9 +235,14 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        ClusterState clusterState = event.state();
+        checkReadyState(lastClusterState, event.state());
+        this.lastClusterState = event.state();
+    }
+
+    private void checkReadyState(ClusterState previousState, ClusterState clusterState) {
         Set<String> shutdownNodeIds = PluginShutdownService.shutdownNodes(clusterState);
-        boolean shuttingDown = shutdownNodeIds.contains(clusterState.nodes().getLocalNodeId());
+        String localNodeId = clusterState.nodes().getLocalNodeId();
+        boolean shuttingDown = localNodeId != null && shutdownNodeIds.contains(localNodeId);
 
         if (shuttingDown) {
             // only disable the probe and log if the probe is running
@@ -238,10 +251,10 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
                 logger.info("marking node as not ready because it's shutting down");
             }
         } else {
-            boolean masterElected = getReadinessState(clusterState, event.previousState(), this::isMasterElected, "masterElected");
+            boolean masterElected = getReadinessState(clusterState, previousState, this::isMasterElected, "masterElected");
             boolean fileSettingsApplied = getReadinessState(
                 clusterState,
-                event.previousState(),
+                previousState,
                 this::areFileSettingsApplied,
                 "fileSettingsApplied"
             );
@@ -256,7 +269,7 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
         String description
     ) {
         boolean newStateValue = accessor.apply(clusterState);
-        boolean oldStateValue = accessor.apply(previousState);
+        boolean oldStateValue = previousState != null && accessor.apply(previousState);
         if (oldStateValue != newStateValue) {
             logger.info("readiness change: {}={}", description, newStateValue);
         }

--- a/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
-import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -53,6 +53,9 @@ import java.util.Set;
 
 import static org.elasticsearch.cluster.metadata.ReservedStateErrorMetadata.ErrorKind.TRANSIENT;
 import static org.elasticsearch.cluster.metadata.ReservedStateMetadata.EMPTY_VERSION;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ReadinessServiceTests extends ESTestCase implements ReadinessClientProbe {
     private ClusterService clusterService;
@@ -104,12 +107,9 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
     public void setUp() throws Exception {
         super.setUp();
         threadpool = new TestThreadPool("readiness_service_tests");
-        clusterService = new ClusterService(
-            Settings.EMPTY,
-            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-            threadpool,
-            null
-        );
+        clusterService = mock(ClusterService.class);
+        when(clusterService.lifecycleState()).thenReturn(Lifecycle.State.STARTED);
+        when(clusterService.state()).thenReturn(emptyState());
         env = newEnvironment(Settings.builder().put(ReadinessService.PORT.getKey(), 0).build());
 
         httpTransport = new FakeHttpTransport();
@@ -118,6 +118,14 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
 
     @After
     public void tearDown() throws Exception {
+        // make sure readiness service is shut down
+        if (readinessService.lifecycleState() == Lifecycle.State.STARTED) {
+            readinessService.stop();
+        }
+        if (readinessService.lifecycleState() == Lifecycle.State.STOPPED) {
+            readinessService.close();
+        }
+
         super.tearDown();
         threadpool.shutdownNow();
     }
@@ -198,9 +206,6 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
 
         // test that we cannot connect to the socket anymore
         tcpReadinessProbeFalse(readinessService);
-
-        readinessService.stop();
-        readinessService.close();
     }
 
     public void testStatusChange() throws Exception {
@@ -283,9 +288,6 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
         }
         assertFalse(readinessService.ready());
         tcpReadinessProbeFalse(readinessService);
-
-        readinessService.stop();
-        readinessService.close();
     }
 
     public void testFileSettingsUpdateError() throws Exception {
@@ -305,9 +307,13 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
         ClusterChangedEvent event = new ClusterChangedEvent("test", state, ClusterState.EMPTY_STATE);
         readinessService.clusterChanged(event);
         assertTrue(readinessService.ready());
+    }
 
-        readinessService.stop();
-        readinessService.close();
+    public void testAlreadyReadyWhenStarted() throws Exception {
+        ClusterState readyState = ClusterState.builder(noFileSettingsState()).metadata(emptyReservedStateMetadata).build();
+        when(clusterService.state()).thenReturn(readyState);
+        readinessService.start();
+        assertTrue(readinessService.ready());
     }
 
     public void testFileSettingsMixedCluster() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
+++ b/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
@@ -24,6 +24,10 @@ import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
 import java.util.Set;
 
+import static org.elasticsearch.test.ESTestCase.assertBusy;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class MockReadinessService extends ReadinessService {
     /**
      * Marker plugin used by {@link MockNode} to enable {@link MockReadinessService}.
@@ -100,25 +104,11 @@ public class MockReadinessService extends ReadinessService {
         return mockedSocket != null && mockedSocket.isOpen();
     }
 
-    public static void tcpReadinessProbeTrue(ReadinessService readinessService) throws InterruptedException {
-        for (int i = 1; i <= RETRIES; ++i) {
-            if (socketIsOpen(readinessService)) {
-                return;
-            }
-            Thread.sleep(RETRY_DELAY_IN_MILLIS * i);
-        }
-
-        throw new AssertionError("Readiness socket should be open");
+    public static void tcpReadinessProbeTrue(ReadinessService readinessService) throws Exception {
+        assertBusy(() -> assertTrue("Readiness socket should be open", socketIsOpen(readinessService)));
     }
 
-    public static void tcpReadinessProbeFalse(ReadinessService readinessService) throws InterruptedException {
-        for (int i = 0; i < RETRIES; ++i) {
-            if (socketIsOpen(readinessService) == false) {
-                return;
-            }
-            Thread.sleep(RETRY_DELAY_IN_MILLIS * i);
-        }
-
-        throw new AssertionError("Readiness socket should be closed");
+    public static void tcpReadinessProbeFalse(ReadinessService readinessService) throws Exception {
+        assertBusy(() -> assertFalse("Readiness socket should be close", socketIsOpen(readinessService)));
     }
 }


### PR DESCRIPTION
The readiness service watches for cluster state updates to determine when the node is ready. It must have a master node elected, and file settings must have been applied. Normally those take a little bit of time. However, the readiness services is setup to not even allow starting the tcp listener until after the service start method is called. This occurs in Node.start(), but _after_ the initial node join. If the initial join occurs before start, and the state already reflects the "ready" state, when start is called the service will be marked active, but nothing will ever start the listener.

This commit adjusts the readiness service to keep track of the last state applied. It also moves adding the cluster state listener to when the service is started. Finally, it adjusts the readiness test helpers to use assertBusy instead of a hand rolled backoff loop.

closes #136955
closes #142440

Backport of #140791.
