### PR TITLE
Fix ordering race in RoleReferenceIntersection

### DIFF
--- a/docs/changelog/147765.yaml
+++ b/docs/changelog/147765.yaml
@@ -1,0 +1,5 @@
+area: Security
+issues: []
+pr: 147765
+summary: Fix ordering race in `RoleReferenceIntersection`
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/support/OrderedGroupedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/OrderedGroupedActionListener.java
@@ -16,7 +16,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 
 /**
  * Static utility for fanning out asynchronous work over a collection and gathering the results in
@@ -44,11 +43,7 @@ public final class OrderedGroupedActionListener {
      *                 {@link ActionListener} when done
      * @param delegate receives the ordered results (or the first failure)
      */
-    public static <T, R> void forEach(
-        Collection<T> items,
-        BiConsumer<T, ActionListener<R>> task,
-        ActionListener<List<R>> delegate
-    ) {
+    public static <T, R> void forEach(Collection<T> items, BiConsumer<T, ActionListener<R>> task, ActionListener<List<R>> delegate) {
         if (items.isEmpty()) {
             delegate.onResponse(List.of());
             return;
@@ -83,11 +78,7 @@ public final class OrderedGroupedActionListener {
         }
     }
 
-    private static <R> void finish(
-        AtomicArray<R> results,
-        AtomicReference<Exception> failure,
-        ActionListener<List<R>> delegate
-    ) {
+    private static <R> void finish(AtomicArray<R> results, AtomicReference<Exception> failure, ActionListener<List<R>> delegate) {
         final Exception e = failure.get();
         if (e != null) {
             delegate.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/action/support/OrderedGroupedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/OrderedGroupedActionListener.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.common.util.concurrent.CountDown;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+/**
+ * Static utility for fanning out asynchronous work over a collection and gathering the results in
+ * iteration order — the order-preserving counterpart to {@link GroupedActionListener}, which collects
+ * results in completion order. Use this when the consumer of the result performs an order-sensitive
+ * reduction (e.g. a non-commutative fold).
+ */
+public final class OrderedGroupedActionListener {
+
+    private OrderedGroupedActionListener() {}
+
+    /**
+     * Asynchronously applies {@code task} to each element of {@code items} and invokes {@code delegate}
+     * exactly once with the results in {@code items}'s iteration order, regardless of the order in which
+     * the per-item tasks complete.
+     *
+     * <p>Failure semantics: the first failure is propagated to {@code delegate} with subsequent failures
+     * attached via {@link Exception#addSuppressed}; the delegate is invoked once, after every per-item
+     * task has completed (success or failure).
+     *
+     * <p>If {@code items} is empty, {@code delegate} is invoked immediately with an empty list.
+     *
+     * @param items    the elements to process; iteration order determines result order
+     * @param task     starts the asynchronous work for one element and completes the supplied
+     *                 {@link ActionListener} when done
+     * @param delegate receives the ordered results (or the first failure)
+     */
+    public static <T, R> void forEach(
+        Collection<T> items,
+        BiConsumer<T, ActionListener<R>> task,
+        ActionListener<List<R>> delegate
+    ) {
+        if (items.isEmpty()) {
+            delegate.onResponse(List.of());
+            return;
+        }
+        final int size = items.size();
+        final AtomicArray<R> results = new AtomicArray<>(size);
+        final CountDown countDown = new CountDown(size);
+        final AtomicReference<Exception> failure = new AtomicReference<>();
+        int idx = 0;
+        for (T item : items) {
+            final int slot = idx++;
+            task.accept(item, new ActionListener<>() {
+                @Override
+                public void onResponse(R value) {
+                    results.setOnce(slot, value);
+                    if (countDown.countDown()) {
+                        finish(results, failure, delegate);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    final Exception previous = failure.compareAndExchange(null, e);
+                    if (previous != null && previous != e) {
+                        previous.addSuppressed(e);
+                    }
+                    if (countDown.countDown()) {
+                        finish(results, failure, delegate);
+                    }
+                }
+            });
+        }
+    }
+
+    private static <R> void finish(
+        AtomicArray<R> results,
+        AtomicReference<Exception> failure,
+        ActionListener<List<R>> delegate
+    ) {
+        final Exception e = failure.get();
+        if (e != null) {
+            delegate.onFailure(e);
+        } else {
+            delegate.onResponse(results.asList());
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/support/OrderedGroupedActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/OrderedGroupedActionListenerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class OrderedGroupedActionListenerTests extends ESTestCase {
+
+    public void testDeliversResultsInIterationOrder() {
+        // Tasks complete synchronously inside the loop in iteration order; baseline ergonomic case.
+        final AtomicReference<List<String>> result = new AtomicReference<>();
+        OrderedGroupedActionListener.<Integer, String>forEach(
+            List.of(1, 2, 3),
+            (value, listener) -> listener.onResponse("item-" + value),
+            ActionTestUtils.assertNoFailureListener(result::set)
+        );
+        assertThat(result.get(), contains("item-1", "item-2", "item-3"));
+    }
+
+    public void testPreservesIterationOrderWhenTasksCompleteOutOfOrder() {
+        // Defer each task's completion via the test-controlled map and fire them out of iteration order.
+        // The delegate must still receive results in the iteration order of the original collection.
+        final Map<Integer, ActionListener<String>> deferred = new HashMap<>();
+        final AtomicReference<List<String>> result = new AtomicReference<>();
+        OrderedGroupedActionListener.<Integer, String>forEach(
+            List.of(1, 2, 3),
+            deferred::put,
+            ActionTestUtils.assertNoFailureListener(result::set)
+        );
+
+        deferred.get(3).onResponse("third");
+        deferred.get(1).onResponse("first");
+        deferred.get(2).onResponse("second");
+
+        assertThat(result.get(), contains("first", "second", "third"));
+    }
+
+    public void testEmptyCollectionFiresDelegateImmediatelyWithEmptyList() {
+        final AtomicReference<List<String>> result = new AtomicReference<>();
+        final AtomicInteger taskInvocations = new AtomicInteger();
+        OrderedGroupedActionListener.<Integer, String>forEach(List.of(), (value, listener) -> {
+            taskInvocations.incrementAndGet();
+            listener.onResponse("unused");
+        }, ActionTestUtils.assertNoFailureListener(result::set));
+        assertThat(result.get(), equalTo(List.of()));
+        assertThat(taskInvocations.get(), equalTo(0));
+    }
+
+    public void testFirstFailureWinsAndSubsequentAreSuppressed() {
+        // Defer all tasks so we can fire failures in a controlled order and assert the suppression chain.
+        final Map<Integer, ActionListener<String>> deferred = new HashMap<>();
+        final AtomicReference<Exception> failure = new AtomicReference<>();
+        OrderedGroupedActionListener.<Integer, String>forEach(List.of(1, 2, 3), deferred::put, ActionListener.wrap(v -> {
+            throw new AssertionError("expected failure, got " + v);
+        }, failure::set));
+
+        final Exception first = new RuntimeException("first");
+        final Exception second = new RuntimeException("second");
+        final Exception third = new RuntimeException("third");
+        deferred.get(1).onFailure(first);
+        deferred.get(2).onFailure(second);
+        deferred.get(3).onFailure(third);
+
+        assertThat(failure.get(), sameInstance(first));
+        assertThat(List.of(failure.get().getSuppressed()), contains(sameInstance(second), sameInstance(third)));
+    }
+
+    public void testMixedSuccessAndFailureStillReportsFailure() {
+        final AtomicReference<Exception> failure = new AtomicReference<>();
+        final Exception boom = new RuntimeException("boom");
+        OrderedGroupedActionListener.<Integer, String>forEach(List.of(1, 2, 3), (value, listener) -> {
+            if (value == 2) {
+                listener.onFailure(boom);
+            } else {
+                listener.onResponse("item-" + value);
+            }
+        }, ActionListener.wrap(v -> { throw new AssertionError("expected failure, got " + v); }, failure::set));
+        assertThat(failure.get(), sameInstance(boom));
+    }
+
+    public void testInvokesDelegateExactlyOnce() {
+        final AtomicInteger delegateInvocations = new AtomicInteger();
+        OrderedGroupedActionListener.<Integer, String>forEach(
+            List.of(1, 2, 3),
+            (value, listener) -> listener.onResponse("item-" + value),
+            ActionListener.wrap(v -> delegateInvocations.incrementAndGet(), e -> delegateInvocations.incrementAndGet())
+        );
+        assertThat(delegateInvocations.get(), equalTo(1));
+    }
+
+    public void testSelfSuppressionGuardWhenSameExceptionRefiredTwice() {
+        // Defensive: if a caller hands the same exception instance back through two child listeners,
+        // we must not call addSuppressed(e, e) — that would throw IllegalArgumentException.
+        final Map<Integer, ActionListener<String>> deferred = new HashMap<>();
+        final AtomicReference<Exception> failure = new AtomicReference<>();
+        OrderedGroupedActionListener.forEach(List.of(1, 2), deferred::put, ActionListener.wrap(v -> {
+            throw new AssertionError("expected failure, got " + v);
+        }, failure::set));
+
+        final Exception shared = new RuntimeException("shared");
+        deferred.get(1).onFailure(shared);
+        deferred.get(2).onFailure(shared);
+
+        assertThat(failure.get(), sameInstance(shared));
+        assertThat(failure.get().getSuppressed().length, equalTo(0));
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/RoleReferenceIntersection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/RoleReferenceIntersection.java
@@ -8,10 +8,9 @@
 package org.elasticsearch.xpack.core.security.authz.store;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.GroupedActionListener;
+import org.elasticsearch.action.support.OrderedGroupedActionListener;
 import org.elasticsearch.xpack.core.security.authz.permission.Role;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -37,19 +36,18 @@ public class RoleReferenceIntersection {
     }
 
     public void buildRole(BiConsumer<RoleReference, ActionListener<Role>> singleRoleBuilder, ActionListener<Role> roleActionListener) {
-        final GroupedActionListener<Role> roleGroupedActionListener = new GroupedActionListener<>(
-            roleReferences.size(),
+        // Role#limitedBy is non-commutative, so the fold must reduce in submission order regardless of
+        // the order in which singleRoleBuilder responses arrive.
+        OrderedGroupedActionListener.forEach(
+            roleReferences,
+            singleRoleBuilder,
             roleActionListener.delegateFailureAndWrap((l, roles) -> {
-                assert false == roles.isEmpty();
-                final Iterator<Role> iterator = roles.stream().iterator();
-                Role finalRole = iterator.next();
-                while (iterator.hasNext()) {
-                    finalRole = finalRole.limitedBy(iterator.next());
+                Role finalRole = roles.getFirst();
+                for (int i = 1; i < roles.size(); i++) {
+                    finalRole = finalRole.limitedBy(roles.get(i));
                 }
                 l.onResponse(finalRole);
             })
         );
-
-        roleReferences.forEach(roleReference -> singleRoleBuilder.accept(roleReference, roleGroupedActionListener));
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/RoleReferenceIntersection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/RoleReferenceIntersection.java
@@ -38,16 +38,12 @@ public class RoleReferenceIntersection {
     public void buildRole(BiConsumer<RoleReference, ActionListener<Role>> singleRoleBuilder, ActionListener<Role> roleActionListener) {
         // Role#limitedBy is non-commutative, so the fold must reduce in submission order regardless of
         // the order in which singleRoleBuilder responses arrive.
-        OrderedGroupedActionListener.forEach(
-            roleReferences,
-            singleRoleBuilder,
-            roleActionListener.delegateFailureAndWrap((l, roles) -> {
-                Role finalRole = roles.getFirst();
-                for (int i = 1; i < roles.size(); i++) {
-                    finalRole = finalRole.limitedBy(roles.get(i));
-                }
-                l.onResponse(finalRole);
-            })
-        );
+        OrderedGroupedActionListener.forEach(roleReferences, singleRoleBuilder, roleActionListener.delegateFailureAndWrap((l, roles) -> {
+            Role finalRole = roles.getFirst();
+            for (int i = 1; i < roles.size(); i++) {
+                finalRole = finalRole.limitedBy(roles.get(i));
+            }
+            l.onResponse(finalRole);
+        }));
     }
 }


### PR DESCRIPTION
`RoleReferenceIntersection.buildRole` collected responses via `GroupedActionListener`, which records by completion order. The subsequent fold calls `Role#limitedBy`, which is non-commutative. `LimitedRole`'s invariant is that workflow restrictions live on the base side only, so the reduce depends on _submission_ order. When two role references resolve asynchronously (e.g. an API key whose ASSIGNED and LIMITED_BY role descriptors each declare application privileges and hit the privilege store), completion order can flip and produce a `LimitedRole` whose base/limitedBy assignment swaps.

This change adds `OrderedGroupedActionListener`, an order-preserving counterpart to `GroupedActionListener` exposed via a single static `forEach(items, task, delegate)` method. `RoleReferenceIntersection` uses it to fold results in iteration order regardless of which listener fires first.  