### PR TITLE
Enforce single values for numeric fields when multi_value=no is configured in the mapping (multi_value=no part 4/5)

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FallbackSyntheticSourceBlockLoader;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -602,6 +603,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
 
     private final IndexSettings indexSettings;
 
+    private final DocValuesFieldFactory dvFactory;
+
     private ScaledFloatFieldMapper(
         String simpleName,
         ScaledFloatFieldType mappedFieldType,
@@ -622,6 +625,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         this.indexSettings = builder.indexSettings;
         this.metricType = builder.metric.getValue();
         this.offsetsFieldName = offsetsFieldName;
+        // in parseCreateField(), we call IndexType.points(), which defaults skippers to false
+        this.dvFactory = new DocValuesFieldFactory(docValuesParameters.multiValue(), false, indexSettings.getIndexVersionCreated());
     }
 
     boolean coerce() {
@@ -640,6 +645,11 @@ public class ScaledFloatFieldMapper extends FieldMapper {
 
     public FieldMapper.DocValuesParameter.Values docValuesParameters() {
         return docValuesParameters;
+    }
+
+    @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue().isSingleValued();
     }
 
     @Override
@@ -722,7 +732,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             fieldType().name(),
             scaledValue,
             IndexType.points(indexed, docValuesParameters.enabled()),
-            stored
+            stored,
+            dvFactory
         );
 
         if (shouldStoreOffsets) {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -12,8 +12,10 @@ package org.elasticsearch.index.mapper.extras;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.DocValueFetcher;
+import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.IndexType;
@@ -152,6 +154,7 @@ public class TokenCountFieldMapper extends FieldMapper {
     private final NamedAnalyzer analyzer;
     private final boolean enablePositionIncrements;
     private final Integer nullValue;
+    private final DocValuesFieldFactory dvFactory;
 
     protected TokenCountFieldMapper(String simpleName, MappedFieldType defaultFieldType, BuilderParams builderParams, Builder builder) {
         super(simpleName, defaultFieldType, builderParams);
@@ -161,6 +164,8 @@ public class TokenCountFieldMapper extends FieldMapper {
         this.index = builder.index.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
         this.store = builder.store.getValue();
+        // in parseCreateField(), we call IndexType.points(), which defaults skippers to false
+        this.dvFactory = new DocValuesFieldFactory(docValuesParameters.multiValue(), false, IndexVersion.current());
     }
 
     @Override
@@ -183,7 +188,8 @@ public class TokenCountFieldMapper extends FieldMapper {
             fieldType().name(),
             tokenCount,
             IndexType.points(index, docValuesParameters.enabled()),
-            store
+            store,
+            dvFactory
         );
     }
 
@@ -226,6 +232,11 @@ public class TokenCountFieldMapper extends FieldMapper {
 
     public FieldMapper.DocValuesParameter.Values docValuesParameters() {
         return docValuesParameters;
+    }
+
+    @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue().isSingleValued();
     }
 
     @Override

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapperTests.java
@@ -13,6 +13,8 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.tests.analysis.CannedTokenStream;
 import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.analysis.Token;
@@ -21,12 +23,14 @@ import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -154,6 +158,53 @@ public class TokenCountFieldMapperTests extends MapperTestCase {
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
         TokenCountFieldMapper mapper = (TokenCountFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED));
+    }
+
+    public void testMultiValueNoAcceptsSingleValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(8))));
+    }
+
+    public void testMultiValueNoRejectsArray() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        String first = randomAlphanumericOfLength(8);
+        String second = randomAlphanumericOfLength(8);
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", first, second)))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    public void testMultiValueNoUsesNumericDocValues() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(8))));
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertFalse("expected at least one indexable field for [field]", fields.isEmpty());
+        boolean hasDocValuesField = false;
+        for (IndexableField f : fields) {
+            DocValuesType dvType = f.fieldType().docValuesType();
+            if (dvType != DocValuesType.NONE) {
+                hasDocValuesField = true;
+                assertEquals("multi_value=no must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
+            }
+        }
+        assertTrue("expected a doc values field for [field]", hasDocValuesField);
     }
 
     private Analyzer createMockAnalyzer() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -564,6 +564,11 @@ public class BooleanFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue().isSingleValued();
+    }
+
+    @Override
     public BooleanFieldType fieldType() {
         return (BooleanFieldType) super.fieldType();
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -1102,6 +1102,7 @@ public final class DateFieldMapper extends FieldMapper {
     private final boolean store;
     private final boolean indexed;
     private final DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final Locale locale;
     private final String format;
     private final boolean ignoreMalformed;
@@ -1130,6 +1131,11 @@ public final class DateFieldMapper extends FieldMapper {
         this.store = builder.store.getValue();
         this.indexed = builder.index.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(
+            docValuesParameters.multiValue(),
+            ((DateFieldType) mappedFieldType).hasDocValuesSkipper(),
+            builder.indexSettings.getIndexVersionCreated()
+        );
         this.locale = builder.locale.getValue();
         this.format = builder.format.getValue();
         this.ignoreMalformed = builder.ignoreMalformed.getValue();
@@ -1173,6 +1179,11 @@ public final class DateFieldMapper extends FieldMapper {
 
     public DocValuesParameter.Values docValuesParameters() {
         return docValuesParameters;
+    }
+
+    @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue().isSingleValued();
     }
 
     @Override
@@ -1272,11 +1283,16 @@ public final class DateFieldMapper extends FieldMapper {
         }
 
         if (fieldType().hasDocValuesSkipper()) {
-            context.doc().add(SortedNumericDocValuesField.indexedField(fieldType().name(), timestamp));
+            dvFactory.addNumericField(context.doc(), fieldType().name(), timestamp);
         } else if (indexed && docValuesParameters.enabled()) {
-            context.doc().add(new LongField(fieldType().name(), timestamp, Field.Store.NO));
+            context.doc()
+                .add(
+                    docValuesParameters.multiValue().isSingleValued()
+                        ? new SingleValuedLongField(fieldType().name(), timestamp)
+                        : new LongField(fieldType().name(), timestamp, Field.Store.NO)
+                );
         } else if (docValuesParameters.enabled()) {
-            context.doc().add(new SortedNumericDocValuesField(fieldType().name(), timestamp));
+            dvFactory.addNumericField(context.doc(), fieldType().name(), timestamp);
         } else if (indexed) {
             context.doc().add(new LongPoint(fieldType().name(), timestamp));
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocValuesFieldFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocValuesFieldFactory.java
@@ -40,6 +40,14 @@ public class DocValuesFieldFactory {
     }
 
     /**
+     * The location of this is not-ideal, but it keeps things simple for now.
+     * TODO: find a better place for this method.
+     */
+    public boolean isSingleValued() {
+        return multiValue.isSingleValued();
+    }
+
+    /**
      * Adds a numeric doc values field. For {@code multi_value=no}, creates a {@link NumericDocValuesField} (single-valued).
      * Otherwise, creates a {@link SortedNumericDocValuesField} (multi-valued).
      */

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -453,17 +453,20 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            public void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored) {
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
                 final float f = value.floatValue();
                 if (indexType.hasPoints()) {
                     document.add(new HalfFloatPoint(name, f));
                 }
                 if (indexType.hasDocValues()) {
-                    if (indexType.hasDocValuesSkipper()) {
-                        document.add(SortedNumericDocValuesField.indexedField(name, HalfFloatPoint.halfFloatToSortableShort(f)));
-                    } else {
-                        document.add(new SortedNumericDocValuesField(name, HalfFloatPoint.halfFloatToSortableShort(f)));
-                    }
+                    dvFactory.addNumericField(document, name, HalfFloatPoint.halfFloatToSortableShort(f));
                 }
                 if (stored) {
                     document.add(new StoredField(name, f));
@@ -666,16 +669,21 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            public void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored) {
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
                 final float f = value.floatValue();
                 if (indexType.hasPoints() && indexType.hasDocValues()) {
-                    document.add(new FloatField(name, f, Field.Store.NO));
+                    document.add(
+                        dvFactory.isSingleValued() ? new SingleValuedFloatField(name, f) : new FloatField(name, f, Field.Store.NO)
+                    );
                 } else if (indexType.hasDocValues()) {
-                    if (indexType.hasDocValuesSkipper()) {
-                        document.add(SortedNumericDocValuesField.indexedField(name, NumericUtils.floatToSortableInt(f)));
-                    } else {
-                        document.add(new SortedNumericDocValuesField(name, NumericUtils.floatToSortableInt(f)));
-                    }
+                    dvFactory.addNumericField(document, name, NumericUtils.floatToSortableInt(f));
                 } else if (indexType.hasPoints()) {
                     document.add(new FloatPoint(name, f));
                 }
@@ -846,16 +854,21 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            public void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored) {
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
                 final double d = value.doubleValue();
                 if (indexType.hasPoints() && indexType.hasDocValues()) {
-                    document.add(new DoubleField(name, d, Field.Store.NO));
+                    document.add(
+                        dvFactory.isSingleValued() ? new SingleValuedDoubleField(name, d) : new DoubleField(name, d, Field.Store.NO)
+                    );
                 } else if (indexType.hasDocValues()) {
-                    if (indexType.hasDocValuesSkipper()) {
-                        document.add(SortedNumericDocValuesField.indexedField(name, NumericUtils.doubleToSortableLong(d)));
-                    } else {
-                        document.add(new SortedNumericDocValuesField(name, NumericUtils.doubleToSortableLong(d)));
-                    }
+                    dvFactory.addNumericField(document, name, NumericUtils.doubleToSortableLong(d));
                 } else if (indexType.hasPoints()) {
                     document.add(new DoublePoint(name, d));
                 }
@@ -1004,8 +1017,15 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            public void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored) {
-                INTEGER.addFields(document, name, value, indexType, stored);
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
+                INTEGER.addFields(document, name, value, indexType, stored, dvFactory);
             }
 
             @Override
@@ -1147,8 +1167,15 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            public void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored) {
-                INTEGER.addFields(document, name, value, indexType, stored);
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
+                INTEGER.addFields(document, name, value, indexType, stored, dvFactory);
             }
 
             @Override
@@ -1360,16 +1387,19 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            public void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored) {
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
                 final int i = value.intValue();
                 if (indexType.hasPoints() && indexType.hasDocValues()) {
-                    document.add(new IntField(name, i, Field.Store.NO));
+                    document.add(dvFactory.isSingleValued() ? new SingleValuedIntField(name, i) : new IntField(name, i, Field.Store.NO));
                 } else if (indexType.hasDocValues()) {
-                    if (indexType.hasDocValuesSkipper()) {
-                        document.add(SortedNumericDocValuesField.indexedField(name, i));
-                    } else {
-                        document.add(new SortedNumericDocValuesField(name, i));
-                    }
+                    dvFactory.addNumericField(document, name, i);
                 } else if (indexType.hasPoints()) {
                     document.add(new IntPoint(name, i));
                 }
@@ -1543,16 +1573,19 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
-            public void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored) {
+            public void addFields(
+                LuceneDocument document,
+                String name,
+                Number value,
+                IndexType indexType,
+                boolean stored,
+                DocValuesFieldFactory dvFactory
+            ) {
                 final long l = value.longValue();
                 if (indexType.hasPoints() && indexType.hasDocValues()) {
-                    document.add(new LongField(name, l, Field.Store.NO));
+                    document.add(dvFactory.isSingleValued() ? new SingleValuedLongField(name, l) : new LongField(name, l, Field.Store.NO));
                 } else if (indexType.hasDocValues()) {
-                    if (indexType.hasDocValuesSkipper()) {
-                        document.add(SortedNumericDocValuesField.indexedField(name, l));
-                    } else {
-                        document.add(new SortedNumericDocValuesField(name, l));
-                    }
+                    dvFactory.addNumericField(document, name, l);
                 } else if (indexType.hasPoints()) {
                     document.add(new LongPoint(name, l));
                 }
@@ -1710,15 +1743,41 @@ public class NumberFieldMapper extends FieldMapper {
 
         /**
          * Maps the given {@code value} to one or more Lucene field values ands them to the given {@code document} under the given
-         * {@code name}.
-         *
+         * {@code name}. Delegates to {@link #addFields(LuceneDocument, String, Number, IndexType, boolean, DocValuesFieldFactory)}
+         * with a {@link DocValuesParameter.Values.MultiValue#SORTED}-configured factory — kept so test callers and other non-mapper
+         * callers don't need to thread a {@code DocValuesFieldFactory} through when they only care about the default multi-valued behavior.
+         */
+        public final void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored) {
+            addFields(
+                document,
+                name,
+                value,
+                indexType,
+                stored,
+                new DocValuesFieldFactory(
+                    DocValuesParameter.Values.MultiValue.SORTED,
+                    indexType.hasDocValuesSkipper(),
+                    IndexVersion.current()
+                )
+            );
+        }
+
+        /**
          * @param document document to add fields to
          * @param name field name
          * @param value value to map
          * @param indexType an IndexType describing the index structures to be added
          * @param stored whether or not the field is stored
+         * @param dvFactory factory responsible for creating doc values fields
          */
-        public abstract void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored);
+        public abstract void addFields(
+            LuceneDocument document,
+            String name,
+            Number value,
+            IndexType indexType,
+            boolean stored,
+            DocValuesFieldFactory dvFactory
+        );
 
         /**
          * For a given {@code Number}, returns the sortable long representation that will be stored in the doc values.
@@ -2365,6 +2424,8 @@ public class NumberFieldMapper extends FieldMapper {
     // cached to avoid lookup overhead
     private final NumberFieldType fieldType;
 
+    private final DocValuesFieldFactory dvFactory;
+
     private NumberFieldMapper(
         String simpleName,
         MappedFieldType mappedFieldType,
@@ -2393,6 +2454,11 @@ public class NumberFieldMapper extends FieldMapper {
 
         // this is basically just an inlined version of `(NumberFieldType) super.fieldType()`
         this.fieldType = (NumberFieldType) mappedFieldType;
+        this.dvFactory = new DocValuesFieldFactory(
+            docValuesParameters.multiValue(),
+            fieldType.indexType.hasDocValuesSkipper(),
+            builder.indexSettings.getIndexVersionCreated()
+        );
     }
 
     boolean coerce() {
@@ -2406,6 +2472,11 @@ public class NumberFieldMapper extends FieldMapper {
 
     public DocValuesParameter.Values docValuesParameters() {
         return docValuesParameters;
+    }
+
+    @Override
+    protected boolean isSingleValueEnforced() {
+        return allowMultipleValues == false || docValuesParameters.multiValue().isSingleValued();
     }
 
     @Override
@@ -2526,7 +2597,7 @@ public class NumberFieldMapper extends FieldMapper {
         switch (type) {
             case BYTE, SHORT, INTEGER -> addIntFields(doc, name, numericValue.intValue());
             case LONG -> addLongFields(doc, name, numericValue.longValue());
-            default -> type.addFields(doc, name, numericValue, fieldType.indexType, stored);
+            default -> type.addFields(doc, name, numericValue, fieldType.indexType, stored, dvFactory);
         }
 
         if (false == allowMultipleValues && (indexed || docValuesParameters.enabled() || stored)) {
@@ -2545,13 +2616,9 @@ public class NumberFieldMapper extends FieldMapper {
     private void addIntFields(LuceneDocument document, String name, int i) {
         final var indexType = fieldType.indexType();
         if (indexType.hasPoints() && indexType.hasDocValues()) {
-            document.add(new IntField(name, i, Field.Store.NO));
+            document.add(dvFactory.isSingleValued() ? new SingleValuedIntField(name, i) : new IntField(name, i, Field.Store.NO));
         } else if (indexType.hasDocValues()) {
-            if (indexType.hasDocValuesSkipper()) {
-                document.add(SortedNumericDocValuesField.indexedField(name, i));
-            } else {
-                document.add(new SortedNumericDocValuesField(name, i));
-            }
+            dvFactory.addNumericField(document, name, i);
         } else if (indexType.hasPoints()) {
             document.add(new IntPoint(name, i));
         }
@@ -2563,13 +2630,9 @@ public class NumberFieldMapper extends FieldMapper {
     private void addLongFields(LuceneDocument document, String name, long l) {
         final var indexType = fieldType.indexType();
         if (indexType.hasPoints() && indexType.hasDocValues()) {
-            document.add(new LongField(name, l, Field.Store.NO));
+            document.add(dvFactory.isSingleValued() ? new SingleValuedLongField(name, l) : new LongField(name, l, Field.Store.NO));
         } else if (indexType.hasDocValues()) {
-            if (indexType.hasDocValuesSkipper()) {
-                document.add(SortedNumericDocValuesField.indexedField(name, l));
-            } else {
-                document.add(new SortedNumericDocValuesField(name, l));
-            }
+            dvFactory.addNumericField(document, name, l);
         } else if (indexType.hasPoints()) {
             document.add(new LongPoint(name, l));
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedDoubleField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedDoubleField.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.DoubleField;
+import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Single-valued counterpart to Lucene's {@link DoubleField}. Bundles a {@link DoublePoint}-compatible point with a
+ * {@link NumericDocValuesField}-compatible doc value into a single indexable field.
+ */
+public final class SingleValuedDoubleField extends Field {
+
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setDimensions(1, Double.BYTES);
+        FIELD_TYPE.setDocValuesType(DocValuesType.NUMERIC);
+        FIELD_TYPE.freeze();
+    }
+
+    public SingleValuedDoubleField(String name, double value) {
+        super(name, FIELD_TYPE);
+        fieldsData = NumericUtils.doubleToSortableLong(value);
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+        byte[] encodedPoint = new byte[Double.BYTES];
+        DoublePoint.encodeDimension(NumericUtils.sortableLongToDouble(numericValue().longValue()), encodedPoint, 0);
+        return new BytesRef(encodedPoint);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " <" + name + ':' + NumericUtils.sortableLongToDouble(numericValue().longValue()) + '>';
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedFloatField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedFloatField.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.FloatField;
+import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Single-valued counterpart to Lucene's {@link FloatField}. Bundles a {@link FloatPoint}-compatible point with a
+ * {@link NumericDocValuesField}-compatible doc value into a single indexable field.
+ */
+public final class SingleValuedFloatField extends Field {
+
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setDimensions(1, Float.BYTES);
+        FIELD_TYPE.setDocValuesType(DocValuesType.NUMERIC);
+        FIELD_TYPE.freeze();
+    }
+
+    public SingleValuedFloatField(String name, float value) {
+        super(name, FIELD_TYPE);
+        fieldsData = (long) NumericUtils.floatToSortableInt(value);
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+        byte[] encodedPoint = new byte[Float.BYTES];
+        FloatPoint.encodeDimension(NumericUtils.sortableIntToFloat(numericValue().intValue()), encodedPoint, 0);
+        return new BytesRef(encodedPoint);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " <" + name + ':' + NumericUtils.sortableIntToFloat(numericValue().intValue()) + '>';
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedIntField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedIntField.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Single-valued counterpart to Lucene's {@link IntField}. Bundles an {@link IntPoint}-compatible point with a
+ * {@link NumericDocValuesField}-compatible doc value into a single indexable field.
+ */
+public final class SingleValuedIntField extends Field {
+
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setDimensions(1, Integer.BYTES);
+        FIELD_TYPE.setDocValuesType(DocValuesType.NUMERIC);
+        FIELD_TYPE.freeze();
+    }
+
+    public SingleValuedIntField(String name, int value) {
+        super(name, FIELD_TYPE);
+        fieldsData = value;
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+        var bytes = new byte[Integer.BYTES];
+        NumericUtils.intToSortableBytes((Integer) fieldsData, bytes, 0);
+        return new BytesRef(bytes);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " <" + name + ':' + fieldsData + '>';
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedLongField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SingleValuedLongField.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
+
+/**
+ * Single-valued counterpart to Lucene's {@link LongField}. Bundles a {@link LongPoint}-compatible point with a
+ * {@link NumericDocValuesField}-compatible doc value into a single indexable field.
+ */
+public final class SingleValuedLongField extends Field {
+
+    private static final FieldType FIELD_TYPE = new FieldType();
+
+    static {
+        FIELD_TYPE.setDimensions(1, Long.BYTES);
+        FIELD_TYPE.setDocValuesType(DocValuesType.NUMERIC);
+        FIELD_TYPE.freeze();
+    }
+
+    public SingleValuedLongField(String name, long value) {
+        super(name, FIELD_TYPE);
+        fieldsData = value;
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+        var bytes = new byte[Long.BYTES];
+        NumericUtils.longToSortableBytes((Long) fieldsData, bytes, 0);
+        return new BytesRef(bytes);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " <" + name + ':' + fieldsData + '>';
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -129,6 +129,51 @@ public class BooleanFieldMapperTests extends MapperTestCase {
         assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED));
     }
 
+    public void testMultiValueNoAcceptsSingleValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        mapper.parse(source(b -> b.field("field", randomBoolean())));
+    }
+
+    public void testMultiValueNoRejectsArray() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", true, false)))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    public void testMultiValueNoUsesNumericDocValues() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", randomBoolean())));
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertFalse("expected at least one indexable field for [field]", fields.isEmpty());
+        boolean hasDocValuesField = false;
+        for (IndexableField f : fields) {
+            DocValuesType dvType = f.fieldType().docValuesType();
+            if (dvType != DocValuesType.NONE) {
+                hasDocValuesField = true;
+                assertEquals("multi_value=no must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
+            }
+        }
+        assertTrue("expected a doc values field for [field]", hasDocValuesField);
+    }
+
     public void testSerialization() throws IOException {
 
         DocumentMapper defaultMapper = createDocumentMapper(fieldMapping(this::minimalMapping));

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -160,6 +160,51 @@ public class DateFieldMapperTests extends MapperTestCase {
         assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED));
     }
 
+    public void testMultiValueNoAcceptsSingleValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        mapper.parse(source(b -> b.field("field", "2016-03-11")));
+    }
+
+    public void testMultiValueNoRejectsArray() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", "2016-03-11", "2016-03-12")))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    public void testMultiValueNoUsesNumericDocValues() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", "2016-03-11")));
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertFalse("expected at least one indexable field for [field]", fields.isEmpty());
+        boolean hasDocValuesField = false;
+        for (IndexableField f : fields) {
+            DocValuesType dvType = f.fieldType().docValuesType();
+            if (dvType != DocValuesType.NONE) {
+                hasDocValuesField = true;
+                assertEquals("multi_value=no must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
+            }
+        }
+        assertTrue("expected a doc values field for [field]", hasDocValuesField);
+    }
+
     public void testNotIndexed() throws Exception {
 
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "date").field("index", false)));

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -370,7 +370,10 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
             DocumentParsingException.class,
             () -> mapperService.documentMapper().parse(source(b -> b.array("field", randomNumber(), randomNumber(), randomNumber())))
         );
-        assertThat(e.getCause().getMessage(), containsString("Only one field can be stored per key"));
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
     }
 
     protected abstract Number randomNumber();
@@ -548,5 +551,113 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
             e.getMessage(),
             containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, arrays]")
         );
+    }
+
+    public void testMultiValueNoAcceptsSingleValue() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        mapper.parse(source(b -> b.field("field", getSampleValueForDocument())));
+    }
+
+    public void testMultiValueNoRejectsArray() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", getSampleValueForDocument(), getSampleValueForDocument())))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * Both values are malformed and would route to the {@code _ignored} fallback. Enforcement still throws on the second
+     * {@link FieldMapper#parse(DocumentParserContext)} call before either is handled.
+     */
+    public void testMultiValueNoRejectsTwoIgnoreMalformedFallbacks() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("ignore_malformed", true);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", "not-a-number", "also-not-a-number")))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * One regular value and one malformed value (routed to {@code _ignored} fallback). Single value enforcement throws on the
+     * second (malformed) value.
+     */
+    public void testMultiValueNoRejectsRegularPlusMalformed() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("ignore_malformed", true);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", getSampleValueForDocument(), "not-a-number")))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    /**
+     * One malformed value (routed to {@code _ignored} fallback) followed by one regular value. Single value enforcement throws on the
+     * second (regular) value.
+     */
+    public void testMultiValueNoRejectsMalformedPlusRegular() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("ignore_malformed", true);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        DocumentParsingException e = expectThrows(
+            DocumentParsingException.class,
+            () -> mapper.parse(source(b -> b.array("field", "not-a-number", getSampleValueForDocument())))
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+        );
+    }
+
+    public void testMultiValueNoUsesNumericDocValues() throws IOException {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.startObject("doc_values").field("multi_value", "no").endObject();
+        }));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", getSampleValueForDocument())));
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertFalse("expected at least one indexable field for [field]", fields.isEmpty());
+        boolean hasDocValuesField = false;
+        for (IndexableField f : fields) {
+            DocValuesType dvType = f.fieldType().docValuesType();
+            if (dvType != DocValuesType.NONE) {
+                hasDocValuesField = true;
+                assertEquals("multi_value=no must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
+            }
+        }
+        assertTrue("expected a doc values field for [field]", hasDocValuesField);
     }
 }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -28,6 +28,7 @@ import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.BlockSourceReader;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
+import org.elasticsearch.index.mapper.DocValuesFieldFactory;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FallbackSyntheticSourceBlockLoader;
 import org.elasticsearch.index.mapper.FieldMapper;
@@ -39,6 +40,7 @@ import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.SimpleMappedFieldType;
+import org.elasticsearch.index.mapper.SingleValuedLongField;
 import org.elasticsearch.index.mapper.SortedNumericDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.SortedNumericWithOffsetsDocValuesSyntheticFieldLoaderLayer;
 import org.elasticsearch.index.mapper.SourceLoader;
@@ -686,6 +688,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
     private final boolean isSourceSynthetic;
     private final boolean indexed;
     private final FieldMapper.DocValuesParameter.Values docValuesParameters;
+    private final DocValuesFieldFactory dvFactory;
     private final boolean stored;
     private final Explicit<Boolean> ignoreMalformed;
     private final String nullValue;
@@ -707,6 +710,11 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         this.isSourceSynthetic = isSourceSynthetic;
         this.indexed = builder.indexed.getValue();
         this.docValuesParameters = builder.docValuesParameters.getValue();
+        this.dvFactory = new DocValuesFieldFactory(
+            docValuesParameters.multiValue(),
+            mappedFieldType.indexType().hasDocValuesSkipper(),
+            builder.indexSettings.getIndexVersionCreated()
+        );
         this.stored = builder.stored.getValue();
         this.ignoreMalformed = builder.ignoreMalformed.getValue();
         this.nullValue = builder.nullValue.getValue();
@@ -729,6 +737,11 @@ public class UnsignedLongFieldMapper extends FieldMapper {
 
     public FieldMapper.DocValuesParameter.Values docValuesParameters() {
         return docValuesParameters;
+    }
+
+    @Override
+    protected boolean isSingleValueEnforced() {
+        return docValuesParameters.multiValue().isSingleValued();
     }
 
     @Override
@@ -787,24 +800,23 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         }
 
         if (numericValue != null) {
-            List<Field> fields = new ArrayList<>();
             if (indexed && docValuesParameters.enabled()) {
-                fields.add(new LongField(fieldType().name(), numericValue, Field.Store.NO));
+                context.doc()
+                    .add(
+                        docValuesParameters.multiValue().isSingleValued()
+                            ? new SingleValuedLongField(fieldType().name(), numericValue)
+                            : new LongField(fieldType().name(), numericValue, Field.Store.NO)
+                    );
             } else if (docValuesParameters.enabled()) {
-                if (fieldType().indexType().hasDocValuesSkipper()) {
-                    fields.add(SortedNumericDocValuesField.indexedField(fieldType().name(), numericValue));
-                } else {
-                    fields.add(new SortedNumericDocValuesField(fieldType().name(), numericValue));
-                }
+                dvFactory.addNumericField(context.doc(), fieldType().name(), numericValue);
             } else if (indexed) {
-                fields.add(new LongPoint(fieldType().name(), numericValue));
+                context.doc().add(new LongPoint(fieldType().name(), numericValue));
             }
             if (stored) {
                 // for stored field, keeping original unsigned_long value in the String form
                 String storedValued = isNullValue ? nullValue : Long.toUnsignedString(unsignedToSortableSignedLong(numericValue));
-                fields.add(new StoredField(fieldType().name(), storedValued));
+                context.doc().add(new StoredField(fieldType().name(), storedValued));
             }
-            context.doc().addAll(fields);
 
             if (docValuesParameters.enabled() == false && (stored || indexed)) {
                 context.addToFieldNames(fieldType().name());


### PR DESCRIPTION
This a continuation of https://github.com/elastic/elasticsearch/pull/147071

The [original PR](https://github.com/elastic/elasticsearch/pull/146417) for enforcing `multi_value=no` was getting quite large, so I've decided to split it up into multiple ones:
1. Changes to `MultiValuedSortedBinaryDocValues` to make it read from a plain `BinaryDocValuesField` whenever `.count` field is missing. Also changes to `BinaryFieldMapper` to decouple it from binary doc values encoding formats.
2. ntroduction of `DocValuesFieldFactory`, which will serve as the one place responsible for creating doc values fields. Its `multi_value` and `skippers` aware and will branch depending on their configurations. For example, if `multi_value=no`, then `SortedNumericDocValuesField` is replaced with `NumericDocValuesField`.
3. Single value enforcement for text-family of fields and ip fields.
4. We are here ->  **Single value enforcement for numeric-family of fields.**
5. Single value enforcement for flattented fields.

Note, as part of this PR, `allowMultipleValues` is now supported by the same single-value enforcement that we introduced earlier.

Note, numeric fields are special in that they sometimes create a single indexable field that combined a point field and a doc values field; ex. `IntField`. The problem with these fields is that they're from Lucene and they hardcode the doc values type to be muti-valued, with no option for an override. As a compromise, I've created single-valued versions of these: `SingleValuedDoubleField`, `SingleValuedIntField`, `SingleValuedLongField`, and `SingleValuedFloatField`. This is not new, `SeqNoFieldMapper` already has an internal `SingleValueLongField`, although its implementation is a bit unique so I decided against replacing it with the standalone variant I created. 