### PR TITLE
Use textarea for reproduction line in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-failure.yml
+++ b/.github/ISSUE_TEMPLATE/test-failure.yml
@@ -12,11 +12,12 @@ body:
       description: A link to a Gradle buildscan (preferred) or Jenkins job with the failure
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: repro_line
     attributes:
       label: Repro line
       description: The reproduce line from the build output
+      render: text
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
So that the reproduction line is wrapped inside a fenced code block that is both easier to read and convenient to copy with the copy popup. This is also consistent with the issues created by automation and Slack notifications.
