### PR TITLE
[9.4] Fix nonreproducible mapping generation (#147772)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultObjectGenerationHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultObjectGenerationHandler.java
@@ -13,9 +13,9 @@ import org.elasticsearch.datageneration.FieldType;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.ESTestCase.randomDouble;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
@@ -104,9 +104,9 @@ public class DefaultObjectGenerationHandler implements DataSourceHandler {
         FieldType.PASSTHROUGH,
         FieldType.FLATTENED
     );
-    public static final Set<FieldType> ALLOWED_FIELD_TYPES = Arrays.stream(FieldType.values())
+    public static final List<FieldType> ALLOWED_FIELD_TYPES = Arrays.stream(FieldType.values())
         .filter(fieldType -> EXCLUDED_FROM_DYNAMIC_MAPPING.contains(fieldType) == false)
-        .collect(Collectors.toSet());
+        .toList();
 
     @Override
     public DataSourceResponse.FieldTypeGenerator handle(DataSourceRequest.FieldTypeGenerator request) {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix nonreproducible mapping generation (#147772)