### PR TITLE
[9.3] Fix nonreproducible mapping generation (#147772)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultObjectGenerationHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultObjectGenerationHandler.java
@@ -13,9 +13,9 @@ import org.elasticsearch.datageneration.FieldType;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.ESTestCase.randomDouble;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
@@ -88,9 +88,9 @@ public class DefaultObjectGenerationHandler implements DataSourceHandler {
     // UNSIGNED_LONG is excluded because it is mapped as long
     // and values larger than long fail to parse.
     private static final Set<FieldType> EXCLUDED_FROM_DYNAMIC_MAPPING = Set.of(FieldType.UNSIGNED_LONG, FieldType.PASSTHROUGH);
-    public static final Set<FieldType> ALLOWED_FIELD_TYPES = Arrays.stream(FieldType.values())
+   public static final List<FieldType> ALLOWED_FIELD_TYPES = Arrays.stream(FieldType.values())
         .filter(fieldType -> EXCLUDED_FROM_DYNAMIC_MAPPING.contains(fieldType) == false)
-        .collect(Collectors.toSet());
+        .toList();
 
     @Override
     public DataSourceResponse.FieldTypeGenerator handle(DataSourceRequest.FieldTypeGenerator request) {

--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultObjectGenerationHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultObjectGenerationHandler.java
@@ -88,7 +88,7 @@ public class DefaultObjectGenerationHandler implements DataSourceHandler {
     // UNSIGNED_LONG is excluded because it is mapped as long
     // and values larger than long fail to parse.
     private static final Set<FieldType> EXCLUDED_FROM_DYNAMIC_MAPPING = Set.of(FieldType.UNSIGNED_LONG, FieldType.PASSTHROUGH);
-   public static final List<FieldType> ALLOWED_FIELD_TYPES = Arrays.stream(FieldType.values())
+    public static final List<FieldType> ALLOWED_FIELD_TYPES = Arrays.stream(FieldType.values())
         .filter(fieldType -> EXCLUDED_FROM_DYNAMIC_MAPPING.contains(fieldType) == false)
         .toList();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix nonreproducible mapping generation (#147772)](https://github.com/elastic/elasticsearch/pull/147772)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)