### PR TITLE
[9.4] Add missing node feature for skip store ignored keyword multi fields (#147501)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
@@ -83,8 +83,8 @@ synthetic_source text with multi-field:
 ---
 synthetic_source text with ignored multi-field:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
-      reason: "Source mode configured through index setting"
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.keyword.multi_fields_not_stored_when_ignored"]
+      reason: "Source mode configured through index setting, feature under test must be present"
 
   - do:
       indices.create:
@@ -125,8 +125,8 @@ synthetic_source text with ignored multi-field:
 ---
 synthetic_source text with ignored multi-field and multiple values in the same doc:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
-      reason: "Source mode configured through index setting"
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.keyword.multi_fields_not_stored_when_ignored"]
+      reason: "Source mode configured through index setting, feature under test must be present"
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -88,6 +88,10 @@ public class MapperFeatures implements FeatureSpecification {
     public static final NodeFeature IGNORED_VALUES_STORED_IN_BINARY_DV = new NodeFeature("mapper.doc_values.ignored_values_in_binary_dv");
     static final NodeFeature KEYWORD_NORMALIZER_SKIP_STORE_SETTING = new NodeFeature("mapper.keyword.normalizer_skip_store_setting");
 
+    public static final NodeFeature KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED = new NodeFeature(
+        "mapper.keyword.multi_fields_not_stored_when_ignored"
+    );
+
     @Override
     public Set<NodeFeature> getTestFeatures() {
         return Set.of(
@@ -149,7 +153,8 @@ public class MapperFeatures implements FeatureSpecification {
             ES940_DISK_BBQ,
             FLATTENED_PASSTHROUGH_FEATURE,
             IGNORED_VALUES_STORED_IN_BINARY_DV,
-            KEYWORD_NORMALIZER_SKIP_STORE_SETTING
+            KEYWORD_NORMALIZER_SKIP_STORE_SETTING,
+            KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED
         );
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Add missing node feature for skip store ignored keyword multi fields (#147501)](https://github.com/elastic/elasticsearch/pull/147501)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)