### PR TITLE
[9.3] Add missing node feature for skip store ignored keyword multi fields (#147501)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/20_synthetic_source.yml
@@ -83,8 +83,8 @@ synthetic_source text with multi-field:
 ---
 synthetic_source text with ignored multi-field:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
-      reason: "Source mode configured through index setting"
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.keyword.multi_fields_not_stored_when_ignored"]
+      reason: "Source mode configured through index setting, feature under test must be present"
 
   - do:
       indices.create:
@@ -125,8 +125,8 @@ synthetic_source text with ignored multi-field:
 ---
 synthetic_source text with ignored multi-field and multiple values in the same doc:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
-      reason: "Source mode configured through index setting"
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.keyword.multi_fields_not_stored_when_ignored"]
+      reason: "Source mode configured through index setting, feature under test must be present"
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -77,6 +77,10 @@ public class MapperFeatures implements FeatureSpecification {
     );
     static final NodeFeature KEYWORD_NORMALIZER_SKIP_STORE_SETTING = new NodeFeature("mapper.keyword.normalizer_skip_store_setting");
 
+    public static final NodeFeature KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED = new NodeFeature(
+        "mapper.keyword.multi_fields_not_stored_when_ignored"
+    );
+
     @Override
     public Set<NodeFeature> getTestFeatures() {
         return Set.of(
@@ -129,7 +133,8 @@ public class MapperFeatures implements FeatureSpecification {
             TDIGEST_TYPE,
             DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX,
             DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX,
-            KEYWORD_NORMALIZER_SKIP_STORE_SETTING
+            KEYWORD_NORMALIZER_SKIP_STORE_SETTING,
+            KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED
         );
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Add missing node feature for skip store ignored keyword multi fields (#147501)](https://github.com/elastic/elasticsearch/pull/147501)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)