### PR TITLE
[ESQL] Make Parquet codec factory thread-safe

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactory.java
@@ -15,12 +15,14 @@ import com.github.luben.zstd.Zstd;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.elasticsearch.common.CheckedSupplier;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.xerial.snappy.Snappy;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -41,50 +43,75 @@ import java.util.zip.GZIPOutputStream;
  * is direct and {@code useOffHeapDecryptBuffer} is enabled; the current read path uses
  * {@code HeapByteBufferAllocator} so the {@code BytesInput} path is the hot path today, but the
  * direct path is ready for when we switch to a direct allocator.
+ *
+ * <p>This factory is shared across all driver threads of a query, so {@link #getDecompressor} and
+ * {@link #getCompressor} must be safe under concurrent access. Thread-safety is achieved without
+ * losing laziness by:
+ * <ul>
+ *   <li>Building the per-codec lookup tables once in the constructor as immutable {@link EnumMap}s,
+ *       so the hot path is a plain map read with no synchronization.</li>
+ *   <li>Wrapping each entry in a {@link LazyInitializable} which uses double-checked locking to
+ *       create the underlying (de)compressor on first use, so the JNI library backing each codec
+ *       is loaded exactly once per codec regardless of how many threads race for it.</li>
+ * </ul>
+ *
+ * <p>{@link #release()} is intentionally a no-op: the codec adapters here hold no resources that
+ * can be released (the underlying JNI native libraries cannot be unloaded), so there is nothing
+ * to clear. The method exists only because the {@link CompressionCodecFactory} SPI requires it.
  */
 final class PlainCompressionCodecFactory implements CompressionCodecFactory {
 
-    private final Map<CompressionCodecName, BytesInputDecompressor> decompressors = new HashMap<>();
-    private final Map<CompressionCodecName, BytesInputCompressor> compressors = new HashMap<>();
+    private final Map<CompressionCodecName, LazyInitializable<BytesInputDecompressor, RuntimeException>> decompressors;
+    private final Map<CompressionCodecName, LazyInitializable<BytesInputCompressor, RuntimeException>> compressors;
+
+    PlainCompressionCodecFactory() {
+        Map<CompressionCodecName, LazyInitializable<BytesInputDecompressor, RuntimeException>> dec = new EnumMap<>(
+            CompressionCodecName.class
+        );
+        dec.put(CompressionCodecName.UNCOMPRESSED, lazy(NoopDecompressor::new));
+        dec.put(CompressionCodecName.SNAPPY, lazy(SnappyBytesDecompressor::new));
+        dec.put(CompressionCodecName.GZIP, lazy(GzipBytesDecompressor::new));
+        dec.put(CompressionCodecName.ZSTD, lazy(ZstdBytesDecompressor::new));
+        dec.put(CompressionCodecName.LZ4_RAW, lazy(Lz4RawBytesDecompressor::new));
+        this.decompressors = dec;
+
+        Map<CompressionCodecName, LazyInitializable<BytesInputCompressor, RuntimeException>> com = new EnumMap<>(
+            CompressionCodecName.class
+        );
+        com.put(CompressionCodecName.UNCOMPRESSED, lazy(NoopCompressor::new));
+        com.put(CompressionCodecName.SNAPPY, lazy(SnappyBytesCompressor::new));
+        com.put(CompressionCodecName.GZIP, lazy(GzipBytesCompressor::new));
+        com.put(CompressionCodecName.ZSTD, lazy(ZstdBytesCompressor::new));
+        com.put(CompressionCodecName.LZ4_RAW, lazy(Lz4RawBytesCompressor::new));
+        this.compressors = com;
+    }
+
+    private static <T> LazyInitializable<T, RuntimeException> lazy(CheckedSupplier<T, RuntimeException> supplier) {
+        return new LazyInitializable<>(supplier);
+    }
 
     @Override
     public BytesInputDecompressor getDecompressor(CompressionCodecName codecName) {
-        return decompressors.computeIfAbsent(codecName, PlainCompressionCodecFactory::createDecompressor);
+        LazyInitializable<BytesInputDecompressor, RuntimeException> holder = decompressors.get(codecName);
+        if (holder == null) {
+            throw new UnsupportedOperationException("Unsupported Parquet decompression codec: " + codecName);
+        }
+        return holder.getOrCompute();
     }
 
     @Override
     public BytesInputCompressor getCompressor(CompressionCodecName codecName) {
-        return compressors.computeIfAbsent(codecName, PlainCompressionCodecFactory::createCompressor);
+        LazyInitializable<BytesInputCompressor, RuntimeException> holder = compressors.get(codecName);
+        if (holder == null) {
+            throw new UnsupportedOperationException("Unsupported Parquet compression codec: " + codecName);
+        }
+        return holder.getOrCompute();
     }
 
     @Override
     public void release() {
-        decompressors.values().forEach(BytesInputDecompressor::release);
-        decompressors.clear();
-        compressors.values().forEach(BytesInputCompressor::release);
-        compressors.clear();
-    }
-
-    private static BytesInputDecompressor createDecompressor(CompressionCodecName codec) {
-        return switch (codec) {
-            case UNCOMPRESSED -> new NoopDecompressor();
-            case SNAPPY -> new SnappyBytesDecompressor();
-            case GZIP -> new GzipBytesDecompressor();
-            case ZSTD -> new ZstdBytesDecompressor();
-            case LZ4_RAW -> new Lz4RawBytesDecompressor();
-            default -> throw new UnsupportedOperationException("Unsupported Parquet decompression codec: " + codec);
-        };
-    }
-
-    private static BytesInputCompressor createCompressor(CompressionCodecName codec) {
-        return switch (codec) {
-            case UNCOMPRESSED -> new NoopCompressor();
-            case SNAPPY -> new SnappyBytesCompressor();
-            case GZIP -> new GzipBytesCompressor();
-            case ZSTD -> new ZstdBytesCompressor();
-            case LZ4_RAW -> new Lz4RawBytesCompressor();
-            default -> throw new UnsupportedOperationException("Unsupported Parquet compression codec: " + codec);
-        };
+        // No-op: the codec adapters hold no resources, and the JNI native libraries backing them
+        // cannot be unloaded. Implementing this purely to satisfy the parquet-mr SPI.
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -65,8 +65,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -1859,6 +1861,76 @@ public class ParquetFormatReaderTests extends ESTestCase {
         }
 
         assertEquals("Sum of rows across splits must equal the row count written", numRows, totalRowsFromRanges);
+    }
+
+    /**
+     * Regression test for #147691: concurrent {@code readRange} calls on a single shared
+     * {@link ParquetFormatReader} must not corrupt the codec factory it caches internally.
+     * <p>
+     * In production {@code AsyncExternalSourceOperatorFactory} hands a single {@code ParquetFormatReader}
+     * to multiple driver threads, each reading a distinct row-group split. Every split decodes
+     * column chunks via the reader's shared {@link PlainCompressionCodecFactory}, so
+     * {@link PlainCompressionCodecFactory#getDecompressor} runs concurrently for the same codec.
+     * An earlier implementation backed the lookup with an unsynchronized {@code HashMap}, which
+     * raced under load (typically as {@code ConcurrentModificationException} from
+     * {@code computeIfAbsent}, but the symptom is non-deterministic).
+     * <p>
+     * We additionally collect the {@code id} value of every emitted row into a shared set, so a
+     * silently-corrupted decode (e.g. plausible-looking but wrong INT64s after a torn snappy
+     * block) is caught as a duplicate or missing id rather than only via the row count.
+     */
+    public void testConcurrentReadRangeAcrossRowGroupsDoesNotCorruptCodecFactory() throws Exception {
+        int numRows = 10_000;
+        // 8 KB row-group target with highly-compressible payload reliably produces several
+        // row groups; the assertion below pins the invariant in case writer defaults change.
+        byte[] parquetData = createCompressibleMultiRowGroupFile(numRows, CompressionCodecName.SNAPPY);
+        StorageObject storageObject = createStorageObject(parquetData);
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        assertThat("Test needs multiple row groups to exercise concurrency", ranges.size(), greaterThan(2));
+
+        AtomicInteger totalRows = new AtomicInteger();
+        Set<Long> observedIds = new HashSet<>();
+
+        startInParallel(ranges.size(), i -> {
+            RangeAwareFormatReader.SplitRange range = ranges.get(i);
+            long rangeStart = range.offset();
+            long rangeEnd = rangeStart + range.length();
+            List<Long> idsForSplit = new ArrayList<>();
+            try (
+                CloseableIterator<Page> iterator = reader.readRange(
+                    storageObject,
+                    null,
+                    500,
+                    rangeStart,
+                    rangeEnd,
+                    List.of(),
+                    ErrorPolicy.STRICT
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    Page page = iterator.next();
+                    LongBlock ids = (LongBlock) page.getBlock(0);
+                    for (int row = 0; row < page.getPositionCount(); row++) {
+                        idsForSplit.add(ids.getLong(row));
+                    }
+                    totalRows.addAndGet(page.getPositionCount());
+                    page.releaseBlocks();
+                }
+            } catch (IOException e) {
+                throw new AssertionError("readRange failed for split [" + rangeStart + "," + rangeEnd + ")", e);
+            }
+            // Single bulk synchronization per split rather than per-row contention.
+            synchronized (observedIds) {
+                for (Long id : idsForSplit) {
+                    assertTrue("duplicate id [" + id + "] across splits", observedIds.add(id));
+                }
+            }
+        });
+
+        assertEquals("All splits combined must yield every row exactly once", numRows, totalRows.get());
+        assertEquals("Observed ids must cover the full row range", numRows, observedIds.size());
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactoryTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainCompressionCodecFactoryTests.java
@@ -135,12 +135,49 @@ public class PlainCompressionCodecFactoryTests extends ESTestCase {
         expectThrows(UnsupportedOperationException.class, () -> factory.getCompressor(CompressionCodecName.BROTLI));
     }
 
-    public void testReleaseClears() {
-        factory.getDecompressor(CompressionCodecName.SNAPPY);
-        factory.getCompressor(CompressionCodecName.GZIP);
+    public void testReleaseIsNoop() {
+        BytesInputDecompressor before = factory.getDecompressor(CompressionCodecName.SNAPPY);
+        BytesInputCompressor compressorBefore = factory.getCompressor(CompressionCodecName.GZIP);
         factory.release();
-        BytesInputDecompressor d = factory.getDecompressor(CompressionCodecName.SNAPPY);
-        assertNotNull(d);
+        // The factory holds stateless adapters whose backing JNI libraries cannot be unloaded;
+        // release() is a no-op and the cached instances remain valid for reuse.
+        assertSame(before, factory.getDecompressor(CompressionCodecName.SNAPPY));
+        assertSame(compressorBefore, factory.getCompressor(CompressionCodecName.GZIP));
+    }
+
+    /**
+     * Regression test: the factory is shared across all driver threads of an ESQL query, so
+     * concurrent calls to {@link PlainCompressionCodecFactory#getDecompressor} and
+     * {@link PlainCompressionCodecFactory#getCompressor} must be safe and must return the same
+     * cached instance per codec. An earlier version backed the lookup with a plain {@code HashMap}
+     * + {@code computeIfAbsent}, which raced under load.
+     */
+    public void testConcurrentLookupReturnsSameInstance() {
+        int threads = 16;
+        int iterationsPerThread = 200;
+        CompressionCodecName[] codecs = new CompressionCodecName[] {
+            CompressionCodecName.UNCOMPRESSED,
+            CompressionCodecName.SNAPPY,
+            CompressionCodecName.GZIP,
+            CompressionCodecName.ZSTD,
+            CompressionCodecName.LZ4_RAW };
+
+        startInParallel(threads, t -> {
+            for (int i = 0; i < iterationsPerThread; i++) {
+                CompressionCodecName codec = codecs[i % codecs.length];
+                BytesInputDecompressor d = factory.getDecompressor(codec);
+                BytesInputCompressor c = factory.getCompressor(codec);
+                assertNotNull(d);
+                assertNotNull(c);
+                // Identity must hold even mid-race; the holder must hand out the same instance to all callers.
+                assertSame(d, factory.getDecompressor(codec));
+                assertSame(c, factory.getCompressor(codec));
+            }
+        });
+        for (CompressionCodecName codec : codecs) {
+            assertSame(factory.getDecompressor(codec), factory.getDecompressor(codec));
+            assertSame(factory.getCompressor(codec), factory.getCompressor(codec));
+        }
     }
 
     private void assertRoundTrip(CompressionCodecName codec) throws IOException {


### PR DESCRIPTION
PlainCompressionCodecFactory backed its lazy lookup with two plain
HashMaps and computeIfAbsent. The factory is shared across all driver
threads of a query (held on ParquetFormatReader since #147691), so
concurrent calls from drivers reading row-group splits raced on
HashMap.computeIfAbsent and threw ConcurrentModificationException
mid-decode.

Replace the HashMaps with EnumMaps populated once in the constructor,
each entry wrapping a LazyInitializable. The map structure is now
immutable after construction so the hot path is a lock-free read; the
DCL inside LazyInitializable still loads each codec's JNI library
exactly once on first use.

Also drop the manual release() bookkeeping: every adapter has an empty
release() body and the underlying JNI libraries can't be unloaded, so
nothing is reclaimable. The method is kept as a no-op only to satisfy
the parquet-mr SPI.

Add a unit-level concurrency test on the factory and an integration-
style regression test on ParquetFormatReader that drives
readRange in parallel across all row-group splits of a multi-row-group
Snappy file. Both reproduce the original CME against the previous
HashMap implementation.

Developed with AI-assisted tooling