### PR TITLE
Return 400 for malformed OTLP protobuf

### DIFF
--- a/docs/changelog/147797.yaml
+++ b/docs/changelog/147797.yaml
@@ -1,0 +1,5 @@
+area: TSDB
+issues: []
+pr: 147797
+summary: Return 400 for malformed OTLP protobuf
+type: bug

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportAction.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportAction.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.oteldata.otlp;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageLite;
 
 import org.apache.logging.log4j.LogManager;
@@ -77,6 +78,10 @@ public abstract class AbstractOTLPTransportAction extends HandledTransportAction
                 }
             }));
 
+        } catch (InvalidProtocolBufferException e) {
+            listener.onFailure(
+                new ElasticsearchStatusException("Invalid OTLP protobuf payload: " + e.getMessage(), RestStatus.BAD_REQUEST, e)
+            );
         } catch (Exception e) {
             logger.error("failed to execute otlp request", e);
             listener.onFailure(e);

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportActionTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPTransportActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.mockito.ArgumentCaptor;
@@ -85,6 +86,15 @@ public abstract class AbstractOTLPTransportActionTests extends ESTestCase {
         OTLPActionResponse response = executeRequest(createEmptyRequest());
 
         assertThat(parseHasPartialSuccess(response.getResponse().array()), equalTo(false));
+    }
+
+    public void testMalformedProtobufReturnsBadRequest() {
+        OTLPActionRequest malformedRequest = new OTLPActionRequest(new BytesArray(new byte[] { (byte) 0x80 }));
+
+        Exception e = executeRequestExpectingFailure(malformedRequest, new BulkResponse(new BulkItemResponse[] {}, 0));
+
+        assertThat(ExceptionsHelper.status(e), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(e.getMessage(), containsString("Invalid OTLP protobuf payload"));
     }
 
     public void test429() {


### PR DESCRIPTION
## Summary
- Return a 400 Bad Request for malformed OTLP protobuf payloads instead of surfacing them as server errors.
- Add shared OTLP transport action coverage so logs, metrics, and traces all inherit the behavior.

## Test plan
- `./gradlew :x-pack:plugin:otel-data:test --tests org.elasticsearch.xpack.oteldata.otlp.OTLPTracesTransportActionTests --tests org.elasticsearch.xpack.oteldata.otlp.OTLPLogsTransportActionTests --tests org.elasticsearch.xpack.oteldata.otlp.OTLPMetricsTransportActionTests`