### PR TITLE
Update allowed list in pull-requests.json

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -8,7 +8,11 @@
         "admin",
         "write"
       ],
-      "allowed_list": ["elastic-renovate-prod[bot]", "github-actions[bot]"],
+      "allowed_list": [
+        "elastic-renovate-prod[bot]",
+        "github-actions[bot]",
+        "elastic-vault-github-plugin-prod[bot]"
+      ],
       "set_commit_status": false,
       "build_on_commit": true,
       "build_on_comment": true,


### PR DESCRIPTION
After the migration of Buildkite jobs to ephemeral tokens, pushes made by CI (e.g. spotless auto-commits) authenticate as the GitHub App's bot user `elastic-vault-github-plugin-prod[bot]` rather than as `elasticsearchmachine`.

`buildkite-pr-bot` decides whether to trigger a build based on `context.sender.login` — the push-time identity. Its three allow paths are:

1. `allowed_list` membership
2. `admin`/`write` permission on the base repo
3. `allow_org_users: true` + Elastic org membership

App bot users (logins ending in `[bot]`) cannot be org members, so path 3 never matches them. With the bot also missing from `allowed_list`, the pr-bot logs:

> HttpError: User does not exist or is not a member of the organization … 404
> Ignoring pull request from user 'elastic-vault-github-plugin-prod[bot]'

…and silently drops the `pull_request.synchronize` event. The PR's head commit ends up with no Buildkite check attached, even though earlier commits on the PR have one. This is the same shape of problem that `github-actions[bot]` solves with its existing entry.

Observed on #147724: a spotless auto-commit became the PR head and no `elasticsearch-pull-request` build was triggered until a human pushed a follow-up merge commit.