### PR TITLE
fix: correctly serialise sparse field pruning options in mixed cluster scenarios

### DIFF
--- a/docs/changelog/147823.yaml
+++ b/docs/changelog/147823.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 147823
+summary: "Fix: correctly serialise sparse field pruning options in mixed cluster scenarios"
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilder.java
@@ -178,8 +178,8 @@ public class SparseVectorQueryBuilder extends LeafQueryBuilder<SparseVectorQuery
         if (out.getTransportVersion().supports(SPARSE_VECTOR_FIELD_PRUNING_OPTIONS)) {
             out.writeOptionalBoolean(shouldPruneTokens);
         } else {
-            // Older nodes carry shouldPruneTokens as a primitive boolean; coerce null to the default to avoid an NPE on auto-unboxing.
-            out.writeBoolean(shouldPruneTokens != null ? shouldPruneTokens : DEFAULT_PRUNE);
+            // Older nodes carry shouldPruneTokens as a primitive boolean; coerce null to the false to avoid an NPE on auto-unboxing.
+            out.writeBoolean(shouldPruneTokens != null ? shouldPruneTokens : false);
         }
 
         out.writeOptionalCollection(queryVectors);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilder.java
@@ -178,7 +178,8 @@ public class SparseVectorQueryBuilder extends LeafQueryBuilder<SparseVectorQuery
         if (out.getTransportVersion().supports(SPARSE_VECTOR_FIELD_PRUNING_OPTIONS)) {
             out.writeOptionalBoolean(shouldPruneTokens);
         } else {
-            out.writeBoolean(shouldPruneTokens);
+            // Older nodes carry shouldPruneTokens as a primitive boolean; coerce null to the default to avoid an NPE on auto-unboxing.
+            out.writeBoolean(shouldPruneTokens != null ? shouldPruneTokens : DEFAULT_PRUNE);
         }
 
         out.writeOptionalCollection(queryVectors);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilder.java
@@ -50,8 +50,10 @@ public class SparseVectorQueryBuilder extends LeafQueryBuilder<SparseVectorQuery
 
     private static final boolean DEFAULT_PRUNE = false;
 
-    private static final TransportVersion SPARSE_VECTOR_FIELD_PRUNING_OPTIONS = TransportVersion.fromName(
-        "sparse_vector_field_pruning_options"
+    public static final String SPARSE_VECTOR_FIELD_PRUNING_OPTIONS = "sparse_vector_field_pruning_options";
+
+    private static final TransportVersion SPARSE_VECTOR_FIELD_PRUNING_OPTIONS_TV = TransportVersion.fromName(
+        SPARSE_VECTOR_FIELD_PRUNING_OPTIONS
     );
 
     private final String fieldName;
@@ -120,7 +122,7 @@ public class SparseVectorQueryBuilder extends LeafQueryBuilder<SparseVectorQuery
         super(in);
         this.fieldName = in.readString();
 
-        if (in.getTransportVersion().supports(SPARSE_VECTOR_FIELD_PRUNING_OPTIONS)) {
+        if (in.getTransportVersion().supports(SPARSE_VECTOR_FIELD_PRUNING_OPTIONS_TV)) {
             this.shouldPruneTokens = in.readOptionalBoolean();
         } else {
             this.shouldPruneTokens = in.readBoolean();
@@ -175,7 +177,7 @@ public class SparseVectorQueryBuilder extends LeafQueryBuilder<SparseVectorQuery
 
         out.writeString(fieldName);
 
-        if (out.getTransportVersion().supports(SPARSE_VECTOR_FIELD_PRUNING_OPTIONS)) {
+        if (out.getTransportVersion().supports(SPARSE_VECTOR_FIELD_PRUNING_OPTIONS_TV)) {
             out.writeOptionalBoolean(shouldPruneTokens);
         } else {
             // Older nodes carry shouldPruneTokens as a primitive boolean; coerce null to the false to avoid an NPE on auto-unboxing.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilderTests.java
@@ -17,6 +17,7 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionType;
@@ -25,6 +26,8 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexVersion;
@@ -38,6 +41,7 @@ import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.vectors.SparseVectorQueryWrapper;
 import org.elasticsearch.test.AbstractQueryTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xpack.core.XPackClientPlugin;
 import org.elasticsearch.xpack.core.ml.action.CoordinatedInferenceAction;
@@ -341,5 +345,24 @@ public class SparseVectorQueryBuilderTests extends AbstractQueryTestCase<SparseV
         assertTrue(rewrittenQueryBuilder instanceof SparseVectorQueryBuilder);
         assertEquals(queryBuilder.shouldPruneTokens(), ((SparseVectorQueryBuilder) rewrittenQueryBuilder).shouldPruneTokens());
         assertNotNull(((SparseVectorQueryBuilder) rewrittenQueryBuilder).getQueryVectors());
+    }
+
+    public void testNullShouldPruneTokensSerializesToOlderTransportVersion() throws IOException {
+        // Older nodes carry shouldPruneTokens as a primitive boolean. Sending a query with a null shouldPruneTokens to such a node must not
+        // NPE during auto-unboxing: it should be coerced to the default (false).
+        SparseVectorQueryBuilder queryBuilder = new SparseVectorQueryBuilder(SPARSE_VECTOR_FIELD, WEIGHTED_TOKENS, null, null, null, null);
+
+        TransportVersion olderVersion = TransportVersionUtils.randomVersionNotSupporting(
+            TransportVersion.fromName("sparse_vector_field_pruning_options")
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(olderVersion);
+        queryBuilder.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        in.setTransportVersion(olderVersion);
+        SparseVectorQueryBuilder roundTripped = new SparseVectorQueryBuilder(in);
+        assertEquals(Boolean.FALSE, roundTripped.shouldPruneTokens());
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilderTests.java
@@ -56,6 +56,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.xpack.core.ml.search.SparseVectorQueryBuilder.QUERY_VECTOR_FIELD;
+import static org.elasticsearch.xpack.core.ml.search.SparseVectorQueryBuilder.SPARSE_VECTOR_FIELD_PRUNING_OPTIONS;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.hasSize;
@@ -353,7 +354,7 @@ public class SparseVectorQueryBuilderTests extends AbstractQueryTestCase<SparseV
         SparseVectorQueryBuilder queryBuilder = new SparseVectorQueryBuilder(SPARSE_VECTOR_FIELD, WEIGHTED_TOKENS, null, null, null, null);
 
         TransportVersion olderVersion = TransportVersionUtils.randomVersionNotSupporting(
-            TransportVersion.fromName("sparse_vector_field_pruning_options")
+            TransportVersion.fromName(SPARSE_VECTOR_FIELD_PRUNING_OPTIONS)
         );
 
         BytesStreamOutput out = new BytesStreamOutput();


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
<!--
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
-->

Reference Issue: https://github.com/elastic/elasticsearch/issues/147776

This PR fixes a potential NPE that can appear in a mixed version cluster. 
In older versions `SparseVectorQueryBuilder::shouldPruneTokens` was a boolean primitive instead of a boxed one. Transmitting a null value would result in an NPE during auto-unboxing. This can happen in a mixed version cluster.

Here we update to always send the boolean value instead. 
