### PR TITLE
[8.19] Fix OOME happening on `SearchResponse#toString()` (part 1) (#147267)

### DIFF
--- a/docs/changelog/147267.yaml
+++ b/docs/changelog/147267.yaml
@@ -1,0 +1,5 @@
+area: Infra/Core
+issues: []
+pr: 147267
+summary: Fix potential OOME on `SearchResponse#toString()` for extemely large responses
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -468,7 +468,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
 
     @Override
     public String toString() {
-        return hasReferences() == false ? "SearchResponse[released]" : Strings.toString(this);
+        return hasReferences() == false ? "SearchResponse[released]" : Strings.toTruncatedString(this);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -750,6 +750,95 @@ public class Strings {
     }
 
     /**
+     * Returns a {@link String} containing the JSON representation of the provided {@link ChunkedToXContent}. The content will be truncated
+     * up to 1 mebibyte; if the limit happens to be in the middle of a UTF-8 character, {@code \uFFFD} will be printed out
+     * instead. The returned content is neither pretty-printed (see {@link XContentBuilder#prettyPrint()}), nor are the values printed in a
+     * human-readable way (see {@link XContentBuilder#humanReadable()}).
+     * <p>
+     * This method is intended to be used for logging/debugging purposes, since it might return an invalid JSON value if the limit happens
+     * to be enforced.
+     *
+     * @param chunkedToXContent A {@link ChunkedToXContent} instance to be serialized to JSON.
+     */
+    public static String toTruncatedString(ChunkedToXContent chunkedToXContent) {
+        return toTruncatedString(chunkedToXContent, 1024 * 1024 /* 1 MiB */).appendIfTruncated("[...]");
+    }
+
+    /**
+     * Returns a {@link TruncatedString} containing the JSON representation of the provided {@link ChunkedToXContent}. The content will
+     * be truncated up to {@code maxBytes} bytes; if the limit happens to be in the middle of a UTF-8 character, {@code \uFFFD} will be
+     * printed out instead. The returned content is neither pretty-printed (see {@link XContentBuilder#prettyPrint()}), nor are the values
+     * printed in a human-readable way (see {@link XContentBuilder#humanReadable()}).
+     * <p>
+     * This method is intended to be used for logging/debugging purposes, since it might return an invalid JSON value if the limit happens
+     * to be enforced.
+     *
+     * @param chunkedToXContent A {@link ChunkedToXContent} instance to be serialized to JSON.
+     * @param maxBytes The maximum number of bytes after which the serialization will stop.
+     */
+    public static TruncatedString toTruncatedString(ChunkedToXContent chunkedToXContent, int maxBytes) {
+        return toTruncatedString(chunkedToXContent, maxBytes, false, false);
+    }
+
+    /**
+     * Returns a {@link TruncatedString} containing the JSON representation of the provided {@link ChunkedToXContent}. The content will
+     * be truncated up to {@code maxBytes} bytes; if the limit happens to be in the middle of a UTF-8 character, {@code \uFFFD} will be
+     * printed out instead.
+     * <p>
+     * This method is intended to be used for logging/debugging purposes, since it might return an invalid JSON value if the limit happens
+     * to be enforced.
+     *
+     * @param chunkedToXContent A {@link ChunkedToXContent} instance to be serialized to JSON.
+     * @param maxBytes The maximum number of bytes after which the serialization will stop.
+     * @param pretty True if the content should be pretty-printed. Also see {@link XContentBuilder#prettyPrint()}.
+     * @param human True if the values should be printed in a human-readable way. Also see {@link XContentBuilder#humanReadable()}}.
+     */
+    public static TruncatedString toTruncatedString(ChunkedToXContent chunkedToXContent, int maxBytes, boolean pretty, boolean human) {
+        try {
+            final var truncatedStream = new TruncatedByteArrayOutputStream(maxBytes);
+            final var builder = createBuilder(pretty, human, truncatedStream);
+
+            if (chunkedToXContent.isFragment()) {
+                builder.startObject();
+            }
+            final var chunks = chunkedToXContent.toXContentChunked(ToXContent.EMPTY_PARAMS);
+            while (chunks.hasNext()) {
+                chunks.next().toXContent(builder, ToXContent.EMPTY_PARAMS);
+                builder.flush();
+                if (truncatedStream.isTruncated()) {
+                    break;
+                }
+            }
+            if (chunkedToXContent.isFragment()) {
+                builder.endObject();
+            }
+
+            return new TruncatedString(toString(builder), truncatedStream.isTruncated());
+        } catch (IOException e) {
+            return new TruncatedString(exceptionToJsonString(e, pretty, human), false);
+        }
+    }
+
+    /**
+     * A small value class that represents a {@link String} that might be truncated.
+     *
+     * @param string The string value.
+     * @param truncated {@code true} if the string was truncated, {@code false} otherwise.
+     */
+    public record TruncatedString(String string, boolean truncated) {
+
+        /**
+         * Appends a given {@code suffix} and returns the result if the value if {@link #string} was truncated; or the unchanged
+         * {@link #string} otherwise.
+         *
+         * @param suffix Suffix to append.
+         */
+        public String appendIfTruncated(String suffix) {
+            return truncated ? string + suffix : string;
+        }
+    }
+
+    /**
      * Return a {@link String} that is the json representation of the provided {@link ToXContent}.
      * Wraps the output into an anonymous object if needed. The content is not pretty-printed
      * nor human readable.
@@ -760,7 +849,8 @@ public class Strings {
 
     /**
      * Return a {@link String} that is the json representation of the provided {@link ChunkedToXContent}.
-     * @deprecated don't add usages of this method, it will be removed eventually
+     * @deprecated don't add usages of this method, it will be removed eventually. Use {@link #toTruncatedString(ChunkedToXContent, int)}
+     *             instead.
      * TODO: remove this method, it makes no sense to turn potentially very large chunked xcontent instances into a string
      */
     @Deprecated
@@ -805,7 +895,8 @@ public class Strings {
     /**
      * Return a {@link String} that is the json representation of the provided {@link ChunkedToXContent}.
      * Allows to control whether the outputted json needs to be pretty printed and human readable.
-     * @deprecated don't add usages of this method, it will be removed eventually
+     * @deprecated don't add usages of this method, it will be removed eventually. Use
+     *             {@link #toTruncatedString(ChunkedToXContent, int, boolean, boolean)} instead.
      * TODO: remove this method, it makes no sense to turn potentially very large chunked xcontent instances into a string
      */
     @Deprecated
@@ -821,7 +912,7 @@ public class Strings {
      */
     public static String toString(ToXContent toXContent, ToXContent.Params params, boolean pretty, boolean human) {
         try {
-            XContentBuilder builder = createBuilder(pretty, human);
+            XContentBuilder builder = createBuilder(pretty, human, null);
             if (toXContent.isFragment()) {
                 builder.startObject();
             }
@@ -831,21 +922,25 @@ public class Strings {
             }
             return toString(builder);
         } catch (IOException e) {
-            try {
-                XContentBuilder builder = createBuilder(pretty, human);
-                builder.startObject();
-                builder.field("error", "error building toString out of XContent: " + e.getMessage());
-                builder.field("stack_trace", ExceptionsHelper.stackTrace(e));
-                builder.endObject();
-                return toString(builder);
-            } catch (IOException e2) {
-                throw new ElasticsearchException("cannot generate error message for deserialization", e);
-            }
+            return exceptionToJsonString(e, pretty, human);
         }
     }
 
-    private static XContentBuilder createBuilder(boolean pretty, boolean human) throws IOException {
-        XContentBuilder builder = JsonXContent.contentBuilder();
+    private static String exceptionToJsonString(Exception exception, boolean pretty, boolean human) {
+        try {
+            XContentBuilder builder = createBuilder(pretty, human, null);
+            builder.startObject();
+            builder.field("error", "error building toString out of XContent: " + exception.getMessage());
+            builder.field("stack_trace", ExceptionsHelper.stackTrace(exception));
+            builder.endObject();
+            return toString(builder);
+        } catch (IOException e) {
+            throw new ElasticsearchException("cannot generate error message for deserialization", exception);
+        }
+    }
+
+    private static XContentBuilder createBuilder(boolean pretty, boolean human, @Nullable OutputStream out) throws IOException {
+        XContentBuilder builder = out == null ? JsonXContent.contentBuilder() : new XContentBuilder(JsonXContent.jsonXContent, out);
         if (pretty) {
             builder.prettyPrint();
         }

--- a/server/src/main/java/org/elasticsearch/common/TruncatedByteArrayOutputStream.java
+++ b/server/src/main/java/org/elasticsearch/common/TruncatedByteArrayOutputStream.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common;
+
+import java.io.ByteArrayOutputStream;
+
+final class TruncatedByteArrayOutputStream extends ByteArrayOutputStream {
+
+    private final int maxBytes;
+    boolean truncated = false;
+
+    TruncatedByteArrayOutputStream(int maxBytes) {
+        this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public void write(int b) {
+        if (isOverCapacity()) {
+            truncated = true;
+            return;
+        }
+        super.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) {
+        if (isOverCapacity()) {
+            truncated = true;
+            return;
+        }
+
+        int remainingSpace = maxBytes - count;
+        if (remainingSpace < len) {
+            truncated = true;
+            len = remainingSpace;
+        }
+
+        super.write(b, off, len);
+    }
+
+    private boolean isOverCapacity() {
+        return count >= maxBytes;
+    }
+
+    /**
+     * Returns {@code true} if this stream has actually truncated its contents.
+     */
+    boolean isTruncated() {
+        return truncated;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -10,12 +10,17 @@
 package org.elasticsearch.common;
 
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -38,6 +43,7 @@ import static org.elasticsearch.common.Strings.trimLeadingCharacter;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
@@ -266,6 +272,83 @@ public class StringsTests extends ESTestCase {
         assertThat(Strings.format1Decimals(100.0 / 3, "%"), equalTo("33.3%"));
     }
 
+    public void testToTruncatedStringWithChunkedXContentUnderLimit() {
+        ChunkedToXContent chunkedToXContent = __ -> List.of(new TestToXContent(1, false), new TestToXContent(2, false)).iterator();
+
+        var result = Strings.toTruncatedString(chunkedToXContent, 1024);
+
+        assertFalse(result.truncated());
+        assertEquals("""
+            {"field1":"value1","field2":"value2"}""", result.string());
+    }
+
+    public void testToTruncatedStringWithChunkedXContentOverLimit() {
+        ChunkedToXContent chunkedToXContent = __ -> IntStream.range(1, 1_000_000).mapToObj(i -> new TestToXContent(i, false)).iterator();
+
+        var result = Strings.toTruncatedString(chunkedToXContent, 100);
+
+        assertTrue(result.truncated());
+        assertEquals("""
+            {"field1":"value1","field2":"value2","field3":"value3","field4":"value4","field5":"value5","field6":""", result.string());
+    }
+
+    public void testToTruncatedStringWithChunkedXContentObjectUnderLimit() {
+        ChunkedToXContentObject chunkedToXContentObject = __ -> List.of(new TestToXContent(1, true), new TestToXContent(2, true))
+            .iterator();
+
+        var result = Strings.toTruncatedString(chunkedToXContentObject, 1024);
+
+        assertFalse(result.truncated());
+        assertEquals("""
+            {"field1":"value1"} {"field2":"value2"}""", result.string());
+    }
+
+    public void testToTruncatedStringWithChunkedXContentObjectOverLimit() {
+        ChunkedToXContentObject chunkedToXContentObject = __ -> IntStream.range(1, 1_000_000)
+            .mapToObj(i -> new TestToXContent(i, true))
+            .iterator();
+
+        var result = Strings.toTruncatedString(chunkedToXContentObject, 100);
+
+        assertTrue(result.truncated());
+        assertEquals(
+            "{\"field1\":\"value1\"} {\"field2\":\"value2\"} {\"field3\":\"value3\"} {\"field4\":\"value4\"} {\"field5\":\"value5\"} ",
+            result.string()
+        );
+    }
+
+    public void testToTruncatedStringPrettyHumanReadableOutput() {
+        ChunkedToXContent chunkedToXContent = __ -> List.of(new TestToXContent(1, false), new TestToXContent(2, false)).iterator();
+
+        var result = Strings.toTruncatedString(chunkedToXContent, 1024, true, true);
+
+        assertFalse(result.truncated());
+        assertEquals("""
+            {
+              "field1" : "this is a value number 1",
+              "field2" : "this is a value number 2"
+            }""", result.string());
+    }
+
+    public void testToTruncatedStringEndsWithEllipsis() {
+        ChunkedToXContent chunkedToXContent = __ -> IntStream.range(1, 1_000_000).mapToObj(i -> new TestToXContent(i, false)).iterator();
+
+        var result = Strings.toTruncatedString(chunkedToXContent);
+
+        assertThat(result, endsWith("[...]"));
+        assertEquals(1024 * 1024 + "[...]".length(), result.length());
+    }
+
+    public void testToTruncatedStringException() {
+        ToXContent chunk = (b, p) -> { throw new IOException("boom!"); };
+        ChunkedToXContent chunkedToXContent = __ -> List.of(chunk).iterator();
+
+        var result = Strings.toTruncatedString(chunkedToXContent, 1024, true, true);
+
+        assertFalse(result.truncated());
+        assertThat(result.string(), containsString("error building toString out of XContent:"));
+    }
+
     private static String lowercaseAsciiOnly(String s) {
         // explicitly lowercase just ascii characters
         StringBuilder sb = new StringBuilder(s);
@@ -276,5 +359,24 @@ public class StringsTests extends ESTestCase {
             }
         }
         return sb.toString();
+    }
+
+    private record TestToXContent(int counter, boolean isObject) implements ToXContent {
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            if (isObject) {
+                builder.startObject();
+            }
+            if (builder.humanReadable()) {
+                builder.field("field" + counter, "this is a value number " + counter);
+            } else {
+                builder.field("field" + counter, "value" + counter);
+            }
+            if (isObject) {
+                builder.endObject();
+            }
+            return builder;
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/TruncatedByteArrayOutputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/TruncatedByteArrayOutputStreamTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+public class TruncatedByteArrayOutputStreamTests extends ESTestCase {
+
+    public void testLimitZero() {
+        var out = new TruncatedByteArrayOutputStream(0);
+
+        out.write('a');
+
+        assertTrue(out.isTruncated());
+        assertEquals("", out.toString(StandardCharsets.UTF_8));
+    }
+
+    public void testUnderLimit() throws IOException {
+        var out = new TruncatedByteArrayOutputStream(1024);
+
+        out.write('a');
+        out.write(new byte[] { 'b', 'c', 'd' });
+        out.write(new byte[] { 'd', 'e', 'f', 'g', 'h' }, 1, 3);
+
+        assertFalse(out.isTruncated());
+        assertEquals("abcdefg", out.toString(StandardCharsets.UTF_8));
+    }
+
+    public void testExactlyLimitBytesNotTruncatedWritingIndividualBytes() {
+        var out = new TruncatedByteArrayOutputStream(10);
+
+        IntStream.range(0, 10).forEach(i -> out.write('a' + i));
+
+        assertFalse(out.isTruncated());
+        assertEquals("abcdefghij", out.toString(StandardCharsets.UTF_8));
+    }
+
+    public void testExactlyLimitBytesNotTruncatedWritingByteArray() throws IOException {
+        var out = new TruncatedByteArrayOutputStream(10);
+
+        var bytes = new byte[10];
+        Arrays.fill(bytes, (byte) 'a');
+
+        out.write(bytes);
+
+        assertFalse(out.isTruncated());
+        assertEquals("aaaaaaaaaa", out.toString(StandardCharsets.UTF_8));
+    }
+
+    public void testOverLimit() throws IOException {
+        var out = new TruncatedByteArrayOutputStream(10);
+        out.write("1234567890".getBytes(StandardCharsets.UTF_8));
+
+        out.write('a');
+        out.write(new byte[] { 'b', 'c', 'd' });
+        out.write(new byte[] { 'd', 'e', 'f', 'g', 'h' }, 1, 3);
+
+        assertTrue(out.isTruncated());
+        assertEquals("1234567890", out.toString(StandardCharsets.UTF_8));
+    }
+
+    public void testOverLimitOneHugeWrite() throws IOException {
+        var out = new TruncatedByteArrayOutputStream(10);
+
+        out.write("1234567890abcdefghijklmnopqrstuvwxyz".getBytes(StandardCharsets.UTF_8));
+
+        assertTrue(out.isTruncated());
+        assertEquals("1234567890", out.toString(StandardCharsets.UTF_8));
+    }
+
+    public void testBreaksInTheMiddleOf4ByteUtf8Character() throws IOException {
+        var out = new TruncatedByteArrayOutputStream(3);
+
+        out.write("\uD83C\uDF4E".getBytes(StandardCharsets.UTF_8)); // red apple emoji🍎
+
+        assertTrue(out.isTruncated());
+        // UTF-8 CharsetDecoder replaces invalid UTF-8 codepoints with \uFFFD
+        assertEquals("\uFFFD", out.toString(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix OOME happening on `SearchResponse#toString()` (part 1) (#147267)