### PR TITLE
ESQL:DS: CSV: support headless files

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatOptions.java
@@ -24,6 +24,12 @@ import java.time.format.DateTimeFormatter;
  * @param maxFieldSize       maximum size in bytes for a single field value; 0 means no limit
  *                           (default: 10MB). Provides OOM protection against malformed files.
  * @param multiValueSyntax   syntax for multi-value fields: BRACKETS (default, [a,b,c]) or NONE
+ * @param headerRow          when {@code true} (default), the first non-comment line is read as the
+ *                           schema header; when {@code false}, no header is read and column names
+ *                           are synthesized from {@link #columnPrefix}.
+ * @param columnPrefix       prefix used to synthesize column names when {@link #headerRow} is
+ *                           {@code false}. Counters are appended starting at 0 (e.g.
+ *                           {@code col0, col1, col2, ...}). Default: {@code "col"}.
  */
 public record CsvFormatOptions(
     char delimiter,
@@ -34,7 +40,9 @@ public record CsvFormatOptions(
     Charset encoding,
     DateTimeFormatter datetimeFormatter,
     int maxFieldSize,
-    MultiValueSyntax multiValueSyntax
+    MultiValueSyntax multiValueSyntax,
+    boolean headerRow,
+    String columnPrefix
 ) {
 
     public enum MultiValueSyntax {
@@ -45,6 +53,9 @@ public record CsvFormatOptions(
     /** 10 MB default field size limit — generous for real-world data, prevents OOM on corrupt files. */
     static final int DEFAULT_MAX_FIELD_SIZE = 10 * 1024 * 1024;
 
+    /** Default prefix for synthesized column names when {@link #headerRow} is {@code false}. */
+    public static final String DEFAULT_COLUMN_PREFIX = "col";
+
     public static final CsvFormatOptions DEFAULT = new CsvFormatOptions(
         ',',
         '"',
@@ -54,7 +65,9 @@ public record CsvFormatOptions(
         StandardCharsets.UTF_8,
         null,
         DEFAULT_MAX_FIELD_SIZE,
-        MultiValueSyntax.BRACKETS
+        MultiValueSyntax.BRACKETS,
+        true,
+        DEFAULT_COLUMN_PREFIX
     );
 
     public static final CsvFormatOptions TSV = new CsvFormatOptions(
@@ -66,7 +79,9 @@ public record CsvFormatOptions(
         StandardCharsets.UTF_8,
         null,
         DEFAULT_MAX_FIELD_SIZE,
-        MultiValueSyntax.BRACKETS
+        MultiValueSyntax.BRACKETS,
+        true,
+        DEFAULT_COLUMN_PREFIX
     );
 
     public CsvFormatOptions {
@@ -84,6 +99,9 @@ public record CsvFormatOptions(
         }
         if (multiValueSyntax == null) {
             throw new IllegalArgumentException("multiValueSyntax must not be null");
+        }
+        if (columnPrefix == null) {
+            throw new IllegalArgumentException("columnPrefix must not be null");
         }
     }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -58,11 +58,14 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -99,6 +102,12 @@ import java.util.regex.Pattern;
  *   <tr><td>{@code max_field_size}</td><td>10 MB</td><td>OOM protection; max bytes per field</td></tr>
  *   <tr><td>{@code multi_value_syntax}</td><td>{@code brackets}</td><td>Multi-value field syntax</td></tr>
  *   <tr><td>{@code schema_sample_size}</td><td>20,000</td><td>Number of rows to sample for type inference</td></tr>
+ *   <tr><td>{@code header_row}</td><td>{@code true}</td>
+ *       <td>When {@code false}, no header row is read; column names are synthesized from
+ *           {@code column_prefix} and types are inferred from the sample.</td></tr>
+ *   <tr><td>{@code column_prefix}</td><td>{@code col}</td>
+ *       <td>Prefix for synthesized column names when {@code header_row} is {@code false};
+ *           a 0-based counter is appended (e.g. {@code col0, col1, col2, ...}).</td></tr>
  * </table>
  *
  * <h2>Bracket multi-value syntax</h2>
@@ -130,6 +139,9 @@ import java.util.regex.Pattern;
  * }
  * {@snippet lang="esql" :
  *   EXTERNAL "s3://bucket/data.csv" WITH {"multi_value_syntax": "brackets", "error_mode": "skip_row"}
+ * }
+ * {@snippet lang="esql" :
+ *   EXTERNAL "https://datasets.example.com/headerless.csv.gz" WITH {"header_row": false}
  * }
  *
  * <p>Works with any {@link org.elasticsearch.xpack.esql.datasources.spi.StorageProvider}
@@ -199,6 +211,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
         DateTimeFormatter datetimeFormatter = parseDatetimeFormat(config.get("datetime_format"));
         int maxFieldSize = parseInt(config.get("max_field_size"), CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE);
         CsvFormatOptions.MultiValueSyntax multiValueSyntax = parseMultiValueSyntax(config.get("multi_value_syntax"));
+        boolean headerRow = parseBoolean(config.get("header_row"), true);
+        String columnPrefix = parseString(config.get("column_prefix"), CsvFormatOptions.DEFAULT_COLUMN_PREFIX);
 
         if (delimiter == ','
             && quoteChar == '"'
@@ -208,7 +222,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
             && StandardCharsets.UTF_8.equals(encoding)
             && datetimeFormatter == null
             && maxFieldSize == CsvFormatOptions.DEFAULT_MAX_FIELD_SIZE
-            && multiValueSyntax == CsvFormatOptions.MultiValueSyntax.BRACKETS) {
+            && multiValueSyntax == CsvFormatOptions.MultiValueSyntax.BRACKETS
+            && headerRow
+            && CsvFormatOptions.DEFAULT_COLUMN_PREFIX.equals(columnPrefix)) {
             return null;
         }
         return new CsvFormatOptions(
@@ -220,7 +236,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
             encoding,
             datetimeFormatter,
             maxFieldSize,
-            multiValueSyntax
+            multiValueSyntax,
+            headerRow,
+            columnPrefix
         );
     }
 
@@ -280,6 +298,26 @@ public class CsvFormatReader implements SegmentableFormatReader {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid integer value [" + value + "]", e);
         }
+    }
+
+    private static boolean parseBoolean(Object value, boolean defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Boolean b) {
+            return b;
+        }
+        String s = value.toString().trim();
+        if (s.isEmpty()) {
+            return defaultValue;
+        }
+        if ("true".equalsIgnoreCase(s)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(s)) {
+            return false;
+        }
+        throw new IllegalArgumentException("Invalid boolean value [" + value + "]");
     }
 
     private static Charset parseEncoding(Object value) {
@@ -347,6 +385,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
             InputStream stream = object.newStream();
             BufferedReader reader = new BufferedReader(new InputStreamReader(stream, options.encoding()), READER_BUFFER_SIZE)
         ) {
+            if (options.headerRow() == false) {
+                return inferSchemaWithSyntheticNames(reader);
+            }
             String headerLine = null;
             while ((headerLine = reader.readLine()) != null) {
                 headerLine = headerLine.trim();
@@ -361,9 +402,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
             }
             List<Attribute> typedSchema = parseSchema(headerLine);
             if (typedSchema != null) {
+                checkUniqueAttributeNames(typedSchema);
                 return typedSchema;
             }
-            return inferSchemaFromSample(headerLine, reader);
+            List<Attribute> inferred = inferSchemaFromSample(headerLine, reader);
+            checkUniqueAttributeNames(inferred);
+            return inferred;
         }
     }
 
@@ -376,6 +420,60 @@ public class CsvFormatReader implements SegmentableFormatReader {
             return CsvSchemaInferrer.inferSchema(columnNames, sample.rows());
         } finally {
             breaker.addWithoutBreaking(-sample.reservedBytes());
+        }
+    }
+
+    private List<Attribute> inferSchemaWithSyntheticNames(BufferedReader reader) throws IOException {
+        Iterator<List<?>> csvIterator = newCsvIterator(reader);
+        CircuitBreaker breaker = blockFactory.breaker();
+        SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, breaker);
+        try {
+            if (sample.rows().isEmpty()) {
+                throw new IOException("CSV file has no data rows");
+            }
+            int columnCount = 0;
+            for (String[] row : sample.rows()) {
+                if (row.length > columnCount) {
+                    columnCount = row.length;
+                }
+            }
+            String[] columnNames = synthesizeColumnNames(columnCount, options.columnPrefix());
+            return CsvSchemaInferrer.inferSchema(columnNames, sample.rows());
+        } finally {
+            breaker.addWithoutBreaking(-sample.reservedBytes());
+        }
+    }
+
+    static String[] synthesizeColumnNames(int count, String prefix) {
+        String[] names = new String[count];
+        for (int i = 0; i < count; i++) {
+            names[i] = prefix + i;
+        }
+        return names;
+    }
+
+    /**
+     * Throws a {@link ParsingException} when the inferred or typed header has duplicate column names.
+     * Without this guard the optimizer's {@code PlanConsistencyChecker} would later 500 with a
+     * "duplicate output attribute" error that is hard to map back to the CSV input.
+     */
+    private static void checkUniqueAttributeNames(List<Attribute> attributes) {
+        Set<String> seen = new HashSet<>(attributes.size());
+        LinkedHashSet<String> duplicates = null;
+        for (Attribute a : attributes) {
+            if (seen.add(a.name()) == false) {
+                if (duplicates == null) {
+                    duplicates = new LinkedHashSet<>();
+                }
+                duplicates.add(a.name());
+            }
+        }
+        if (duplicates != null) {
+            throw new ParsingException(
+                "CSV header has duplicate column names {}; if the file has no header row, "
+                    + "set [\"header_row\": false] in the WITH options",
+                duplicates
+            );
         }
     }
 
@@ -708,6 +806,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
             if (schema == null) {
                 if (preResolvedSchema != null) {
                     schema = preResolvedSchema;
+                } else if (options.headerRow() == false) {
+                    schema = inferSchemaHeaderlessFromBatchReader();
+                    if (schema == null) {
+                        return null;
+                    }
                 } else {
                     String headerLine = null;
                     String line;
@@ -912,6 +1015,25 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 blockFactory.breaker().addWithoutBreaking(-sample.reservedBytes());
                 return null;
             }
+            prefetchedRows = sample.rows();
+            prefetchedRowsBytes = sample.reservedBytes();
+            return CsvSchemaInferrer.inferSchema(columnNames, sample.rows());
+        }
+
+        private List<Attribute> inferSchemaHeaderlessFromBatchReader() throws IOException {
+            csvIterator = newCsvIterator(reader);
+            SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, blockFactory.breaker());
+            if (sample.rows().isEmpty()) {
+                blockFactory.breaker().addWithoutBreaking(-sample.reservedBytes());
+                return null;
+            }
+            int columnCount = 0;
+            for (String[] row : sample.rows()) {
+                if (row.length > columnCount) {
+                    columnCount = row.length;
+                }
+            }
+            String[] columnNames = synthesizeColumnNames(columnCount, options.columnPrefix());
             prefetchedRows = sample.rows();
             prefetchedRowsBytes = sample.reservedBytes();
             return CsvSchemaInferrer.inferSchema(columnNames, sample.rows());

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 import org.junit.After;
 
@@ -493,7 +494,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1100,7 +1103,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1126,7 +1131,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1168,7 +1175,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(schema.append(data).toString());
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1200,7 +1209,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1225,7 +1236,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1250,7 +1263,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1284,7 +1299,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1316,7 +1333,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1343,7 +1362,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1368,7 +1389,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1521,7 +1544,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             formatter,
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1657,7 +1682,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1688,7 +1715,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1716,7 +1745,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1745,7 +1776,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1772,7 +1805,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1799,7 +1834,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1825,7 +1862,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1851,7 +1890,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1915,7 +1956,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -1959,7 +2002,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
 
@@ -2113,7 +2158,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -2144,7 +2191,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -2176,7 +2225,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.BRACKETS
+            CsvFormatOptions.MultiValueSyntax.BRACKETS,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -2225,7 +2276,9 @@ public class CsvFormatReaderTests extends ESTestCase {
             CsvFormatOptions.DEFAULT.encoding(),
             CsvFormatOptions.DEFAULT.datetimeFormatter(),
             CsvFormatOptions.DEFAULT.maxFieldSize(),
-            CsvFormatOptions.MultiValueSyntax.NONE
+            CsvFormatOptions.MultiValueSyntax.NONE,
+            true,
+            CsvFormatOptions.DEFAULT_COLUMN_PREFIX
         );
         StorageObject object = createStorageObject(schema.append(data).toString());
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
@@ -2863,6 +2916,117 @@ public class CsvFormatReaderTests extends ESTestCase {
 
         List<Attribute> schema = reader.schema(object);
         assertEquals(DataType.BOOLEAN, schema.get(0).dataType());
+    }
+
+    // --- Headerless CSV (header_row=false) ---
+
+    public void testHeaderlessSchemaUsesDefaultPrefix() throws IOException {
+        // No header line; first non-comment row is data with values that would otherwise collide as names.
+        String csv = "9110818468285196899,0,\"\",1,2013-07-14T20:38:47Z,42.5,true\n"
+            + "9110818468285196900,0,\"\",0,2013-07-14T20:38:48Z,17.0,false\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+
+        List<Attribute> schema = reader.schema(object);
+
+        assertEquals(7, schema.size());
+        for (int i = 0; i < schema.size(); i++) {
+            assertEquals("col" + i, schema.get(i).name());
+        }
+        // Per-column inference: long, integer, keyword (empty), integer, datetime, double, boolean.
+        assertEquals(DataType.LONG, schema.get(0).dataType());
+        assertEquals(DataType.INTEGER, schema.get(1).dataType());
+        assertEquals(DataType.KEYWORD, schema.get(2).dataType());
+        assertEquals(DataType.INTEGER, schema.get(3).dataType());
+        assertEquals(DataType.DATETIME, schema.get(4).dataType());
+        assertEquals(DataType.DOUBLE, schema.get(5).dataType());
+        assertEquals(DataType.BOOLEAN, schema.get(6).dataType());
+    }
+
+    public void testHeaderlessSchemaUsesCustomPrefix() throws IOException {
+        String csv = "1,2\n3,4\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(
+            Map.of("header_row", false, "column_prefix", "f_")
+        );
+
+        List<Attribute> schema = reader.schema(object);
+
+        assertEquals(2, schema.size());
+        assertEquals("f_0", schema.get(0).name());
+        assertEquals("f_1", schema.get(1).name());
+    }
+
+    public void testHeaderlessReadConsumesRow0AsData() throws IOException {
+        // Without header_row=false this would have lost row 0 to the header.
+        String csv = "10,20\n30,40\n50,60\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+            IntBlock col0 = (IntBlock) page.getBlock(0);
+            IntBlock col1 = (IntBlock) page.getBlock(1);
+            assertEquals(10, col0.getInt(0));
+            assertEquals(30, col0.getInt(1));
+            assertEquals(50, col0.getInt(2));
+            assertEquals(20, col1.getInt(0));
+            assertEquals(40, col1.getInt(1));
+            assertEquals(60, col1.getInt(2));
+        }
+    }
+
+    public void testHeaderlessSkipsCommentLines() throws IOException {
+        String csv = "// a comment header\n1,2\n3,4\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+
+        List<Attribute> schema = reader.schema(object);
+        assertEquals(2, schema.size());
+        assertEquals("col0", schema.get(0).name());
+        assertEquals(DataType.INTEGER, schema.get(0).dataType());
+    }
+
+    public void testHeaderlessEmptyInputThrows() {
+        StorageObject object = createStorageObject("");
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+
+        IOException ex = expectThrows(IOException.class, () -> reader.schema(object));
+        assertTrue(ex.getMessage().toLowerCase(Locale.ROOT).contains("no data rows"));
+    }
+
+    public void testInvalidHeaderRowOptionThrows() {
+        // Bad value rejected at config parse time, not deferred to read.
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", "not_a_bool"))
+        );
+        assertTrue(ex.getMessage().contains("Invalid boolean value"));
+    }
+
+    // --- Duplicate-name guard (header_row=true) ---
+
+    public void testDuplicateInferredHeaderNamesThrowParsingException() {
+        // Two columns both literally named "x" in the header row — would otherwise produce duplicate
+        // ReferenceAttributes that the post-optimizer verifier rejects with a 500.
+        String csv = "x,x,y\n1,2,3\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        ParsingException ex = expectThrows(ParsingException.class, () -> reader.schema(object));
+        assertTrue(ex.getMessage().contains("duplicate column names"));
+        assertTrue(ex.getMessage().contains("header_row"));
+    }
+
+    public void testDuplicateTypedHeaderNamesThrowParsingException() {
+        String csv = "id:long,id:long\n1,2\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        ParsingException ex = expectThrows(ParsingException.class, () -> reader.schema(object));
+        assertTrue(ex.getMessage().contains("duplicate column names"));
     }
 
     private StorageObject createStorageObject(String csvContent) {

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvSchemaInferrerTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvSchemaInferrerTests.java
@@ -197,4 +197,15 @@ public class CsvSchemaInferrerTests extends ESTestCase {
         assertEquals("name", schema.get(0).name());
         assertEquals("age", schema.get(1).name());
     }
+
+    public void testSynthesizeColumnNames() {
+        String[] names = CsvFormatReader.synthesizeColumnNames(4, "col");
+        assertArrayEquals(new String[] { "col0", "col1", "col2", "col3" }, names);
+
+        String[] custom = CsvFormatReader.synthesizeColumnNames(3, "f_");
+        assertArrayEquals(new String[] { "f_0", "f_1", "f_2" }, custom);
+
+        String[] zero = CsvFormatReader.synthesizeColumnNames(0, "col");
+        assertEquals(0, zero.length);
+    }
 }


### PR DESCRIPTION
Adds `header_row` and `column_prefix` options to the CSV plugin.

Before the change, we always read the first non-comment line as a header. For headerless files where row 0 has duplicate cell values, this produced an `ExternalRelation` whose output had multiple `ReferenceAttribute`s with identical names but distinct `NameId`s; `PlanConsistencyChecker` later rejected the plan with a 500.

Row 0 was also silently consumed as a header even when it shouldn't have been.

* `header_row`, default `true`: When `false`, the first non-comment line is not consumed as a header; the sample starts at row 0 and column names are synthesized:
* `column_prefix`, default `"col"`: prefix for synthesized column names; a 0-based counter is appended (`col0`, `col1`, …). Only used when `header_row=false`.
