### PR TITLE
[ESQL] Parquet decode-in-place: eliminate scratch-to-block copy

### DIFF
--- a/docs/changelog/147829.yaml
+++ b/docs/changelog/147829.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147829
+summary: "Parquet decode-in-place: eliminate scratch-to-block copy"
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DecodeBuffers.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DecodeBuffers.java
@@ -7,12 +7,10 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import java.util.BitSet;
-
 /**
- * Reusable scratch buffers for {@link PageColumnReader} batch decoding. Eliminates per-batch
- * allocation of primitive arrays by keeping warm arrays that are reused across batches within
- * a single column reader.
+ * Reusable scratch buffers for {@link PageColumnReader} batch decoding. Provides a scratch
+ * {@code int[]} for type-widening conversions, plus {@link WordMask} instances for null and
+ * value-selection bit masks.
  *
  * <p>Buffers are pure scratch space: {@link PageColumnReader} decodes into them, then copies the
  * decoded slice into a freshly allocated, tightly sized array before handing it to
@@ -20,11 +18,7 @@ import java.util.BitSet;
  * reader is free to overwrite the scratch arrays on the next batch. See the {@code Block
  * construction helpers} section in {@link PageColumnReader} for the full ownership rationale.
  *
- * <p>Each buffer type is lazily allocated and grown as needed. Longs and doubles still rotate
- * between two slots (see {@link #takeLongs()} / {@link #takeDoubles()}); after the copy-on-emit
- * fix this is no longer required for correctness - one slot would be sufficient - and is kept
- * only to avoid changing the buffer-growth profile in the same patch. Collapsing to a single
- * slot is left as a follow-up.
+ * <p>Each buffer is lazily allocated and grown as needed.
  *
  * <p>Each {@link PageColumnReader} owns its own instance. Sharing across columns is unnecessary
  * and would only complicate ownership without buying anything.
@@ -32,14 +26,6 @@ import java.util.BitSet;
 final class DecodeBuffers {
 
     private int[] intBuf;
-    private long[] longBufA;
-    private long[] longBufB;
-    private boolean longSlotA = true;
-    private double[] doubleBufA;
-    private double[] doubleBufB;
-    private boolean doubleSlotA = true;
-    private boolean[] boolBuf;
-    private BitSet nullsBuf;
 
     DecodeBuffers() {}
 
@@ -48,89 +34,6 @@ final class DecodeBuffers {
             intBuf = new int[minSize];
         }
         return intBuf;
-    }
-
-    long[] longs(int minSize) {
-        if (longSlotA) {
-            if (longBufA == null || longBufA.length < minSize) {
-                longBufA = new long[minSize];
-            }
-            return longBufA;
-        } else {
-            if (longBufB == null || longBufB.length < minSize) {
-                longBufB = new long[minSize];
-            }
-            return longBufB;
-        }
-    }
-
-    /**
-     * Returns the current long scratch buffer and swaps to the alternate slot for the next
-     * call to {@link #longs(int)}. The returned array is still owned by this {@code DecodeBuffers}
-     * - callers must not retain it past the next {@code takeLongs()} or {@code longs(int)}
-     * call. {@link PageColumnReader} reads the decoded slice and copies it into a fresh,
-     * Block-owned array before emit, so this is safe by construction.
-     *
-     * <p>The slot flip is a historical artifact: with copy-on-emit a single slot would be
-     * enough. Kept for now to leave allocation behavior unchanged in this patch.
-     */
-    long[] takeLongs() {
-        if (longSlotA) {
-            longSlotA = false;
-            return longBufA;
-        } else {
-            longSlotA = true;
-            return longBufB;
-        }
-    }
-
-    double[] doubles(int minSize) {
-        if (doubleSlotA) {
-            if (doubleBufA == null || doubleBufA.length < minSize) {
-                doubleBufA = new double[minSize];
-            }
-            return doubleBufA;
-        } else {
-            if (doubleBufB == null || doubleBufB.length < minSize) {
-                doubleBufB = new double[minSize];
-            }
-            return doubleBufB;
-        }
-    }
-
-    /**
-     * Returns the current double scratch buffer and swaps to the alternate slot. Same ownership
-     * rules as {@link #takeLongs()}: the array stays owned by this {@code DecodeBuffers} and
-     * must not be retained past the next call. {@link PageColumnReader} copies the decoded
-     * slice into a Block-owned array before emit.
-     */
-    double[] takeDoubles() {
-        if (doubleSlotA) {
-            doubleSlotA = false;
-            return doubleBufA;
-        } else {
-            doubleSlotA = true;
-            return doubleBufB;
-        }
-    }
-
-    boolean[] booleans(int minSize) {
-        if (boolBuf == null || boolBuf.length < minSize) {
-            boolBuf = new boolean[minSize];
-        }
-        return boolBuf;
-    }
-
-    /**
-     * Returns a reusable {@link BitSet} cleared to all-false.
-     */
-    BitSet nulls(int minSize) {
-        if (nullsBuf == null) {
-            nullsBuf = new BitSet(minSize);
-        } else {
-            nullsBuf.clear();
-        }
-        return nullsBuf;
     }
 
     private WordMask nullsMask;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -387,12 +387,13 @@ final class PageColumnReader {
     // --- Boolean ---
 
     private Block readBooleanBatch(int maxRows, BlockFactory blockFactory) {
-        boolean[] values = buffers.booleans(maxRows);
+        boolean[] values = new boolean[maxRows];
         if (maxDefLevel == 0) {
             int produced = readNonNullBooleans(values, 0, maxRows);
             Block constant = ConstantBlockDetection.tryConstantBoolean(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeBooleanBlock(blockFactory, values, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newBooleanArrayVector(values, produced).asBlock();
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -408,13 +409,15 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantBoolean(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeBooleanBlock(blockFactory, values, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newBooleanArrayVector(values, produced).asBlock();
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return takeBooleanBlock(blockFactory, values, produced, false, nulls.toBitSet());
+        if (produced < maxRows) values = Arrays.copyOf(values, produced);
+        return blockFactory.newBooleanArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
     }
 
     private int readNonNullBooleans(boolean[] values, int offset, int maxRows) {
@@ -446,12 +449,13 @@ final class PageColumnReader {
     // --- Int ---
 
     private Block readIntBatch(int maxRows, BlockFactory blockFactory) {
-        int[] values = buffers.ints(maxRows);
+        int[] values = new int[maxRows];
         if (maxDefLevel == 0) {
             int produced = readNonNullInts(values, 0, maxRows);
             Block constant = ConstantBlockDetection.tryConstantInt(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeIntBlock(blockFactory, values, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newIntArrayVector(values, produced).asBlock();
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -467,13 +471,15 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantInt(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeIntBlock(blockFactory, values, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newIntArrayVector(values, produced).asBlock();
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return takeIntBlock(blockFactory, values, produced, false, nulls.toBitSet());
+        if (produced < maxRows) values = Arrays.copyOf(values, produced);
+        return blockFactory.newIntArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
     }
 
     private int readNonNullInts(int[] values, int offset, int maxRows) {
@@ -505,12 +511,13 @@ final class PageColumnReader {
     // --- Long ---
 
     private Block readLongBatch(int maxRows, BlockFactory blockFactory) {
-        long[] values = buffers.longs(maxRows);
+        long[] values = new long[maxRows];
         if (maxDefLevel == 0) {
             int produced = readNonNullLongs(values, 0, maxRows);
             Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeLongBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newLongArrayVector(values, produced).asBlock();
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -526,13 +533,15 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeLongBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newLongArrayVector(values, produced).asBlock();
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return takeLongBlock(blockFactory, produced, false, nulls.toBitSet());
+        if (produced < maxRows) values = Arrays.copyOf(values, produced);
+        return blockFactory.newLongArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
     }
 
     private int readNonNullLongs(long[] values, int offset, int maxRows) {
@@ -572,12 +581,13 @@ final class PageColumnReader {
     // --- Int32 widened to Long ---
 
     private Block readInt32AsLongBatch(int maxRows, BlockFactory blockFactory) {
-        long[] values = buffers.longs(maxRows);
+        long[] values = new long[maxRows];
         if (maxDefLevel == 0) {
             int produced = readNonNullInt32AsLong(values, 0, maxRows);
             Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeLongBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newLongArrayVector(values, produced).asBlock();
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -593,13 +603,15 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeLongBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newLongArrayVector(values, produced).asBlock();
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return takeLongBlock(blockFactory, produced, false, nulls.toBitSet());
+        if (produced < maxRows) values = Arrays.copyOf(values, produced);
+        return blockFactory.newLongArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
     }
 
     private int readNonNullInt32AsLong(long[] values, int offset, int maxRows) {
@@ -650,12 +662,13 @@ final class PageColumnReader {
             return readFloat16Batch(maxRows, blockFactory);
         }
         boolean isFloat = info.parquetType() == PrimitiveType.PrimitiveTypeName.FLOAT;
-        double[] values = buffers.doubles(maxRows);
+        double[] values = new double[maxRows];
         if (maxDefLevel == 0) {
             int produced = readNonNullDoubles(values, 0, maxRows, isFloat);
             Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeDoubleBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newDoubleArrayVector(values, produced).asBlock();
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -671,13 +684,15 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeDoubleBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newDoubleArrayVector(values, produced).asBlock();
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return takeDoubleBlock(blockFactory, produced, false, nulls.toBitSet());
+        if (produced < maxRows) values = Arrays.copyOf(values, produced);
+        return blockFactory.newDoubleArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
     }
 
     private int readNonNullDoubles(double[] values, int offset, int maxRows, boolean isFloat) {
@@ -719,7 +734,7 @@ final class PageColumnReader {
     }
 
     private Block readDecimalAsDoubleBatch(int maxRows, int scale, BlockFactory blockFactory) {
-        double[] values = buffers.doubles(maxRows);
+        double[] values = new double[maxRows];
         if (maxDefLevel == 0) {
             int produced = 0;
             int remaining = maxRows;
@@ -732,7 +747,8 @@ final class PageColumnReader {
             }
             Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeDoubleBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newDoubleArrayVector(values, produced).asBlock();
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -756,13 +772,15 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeDoubleBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newDoubleArrayVector(values, produced).asBlock();
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return takeDoubleBlock(blockFactory, produced, false, nulls.toBitSet());
+        if (produced < maxRows) values = Arrays.copyOf(values, produced);
+        return blockFactory.newDoubleArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
     }
 
     private void readDecimalValues(double[] values, int offset, int count, int scale) {
@@ -790,7 +808,7 @@ final class PageColumnReader {
     }
 
     private Block readFloat16Batch(int maxRows, BlockFactory blockFactory) {
-        double[] values = buffers.doubles(maxRows);
+        double[] values = new double[maxRows];
         if (maxDefLevel == 0) {
             int produced = 0;
             int remaining = maxRows;
@@ -803,7 +821,8 @@ final class PageColumnReader {
             }
             Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeDoubleBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newDoubleArrayVector(values, produced).asBlock();
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -827,13 +846,15 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantDouble(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeDoubleBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newDoubleArrayVector(values, produced).asBlock();
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return takeDoubleBlock(blockFactory, produced, false, nulls.toBitSet());
+        if (produced < maxRows) values = Arrays.copyOf(values, produced);
+        return blockFactory.newDoubleArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
     }
 
     private void readFloat16Values(double[] values, int offset, int count) {
@@ -930,7 +951,7 @@ final class PageColumnReader {
             return readInt96Batch(maxRows, blockFactory);
         }
         boolean isDate = info.parquetType() == PrimitiveType.PrimitiveTypeName.INT32;
-        long[] values = buffers.longs(maxRows);
+        long[] values = new long[maxRows];
         if (maxDefLevel == 0) {
             int produced = 0;
             int remaining = maxRows;
@@ -943,7 +964,8 @@ final class PageColumnReader {
             }
             Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeLongBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newLongArrayVector(values, produced).asBlock();
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -967,13 +989,15 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeLongBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newLongArrayVector(values, produced).asBlock();
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return takeLongBlock(blockFactory, produced, false, nulls.toBitSet());
+        if (produced < maxRows) values = Arrays.copyOf(values, produced);
+        return blockFactory.newLongArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
     }
 
     private void readDatetimeValues(long[] values, int offset, int count, boolean isDate) {
@@ -1006,7 +1030,7 @@ final class PageColumnReader {
     }
 
     private Block readInt96Batch(int maxRows, BlockFactory blockFactory) {
-        long[] values = buffers.longs(maxRows);
+        long[] values = new long[maxRows];
         if (maxDefLevel == 0) {
             int produced = 0;
             int remaining = maxRows;
@@ -1019,7 +1043,8 @@ final class PageColumnReader {
             }
             Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeLongBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newLongArrayVector(values, produced).asBlock();
         }
         WordMask nulls = buffers.nullsMask(maxRows);
         int produced = 0;
@@ -1043,13 +1068,15 @@ final class PageColumnReader {
         if (nulls.isEmpty()) {
             Block constant = ConstantBlockDetection.tryConstantLong(values, produced, blockFactory);
             if (constant != null) return constant;
-            return takeLongBlock(blockFactory, produced, true, null);
+            if (produced < maxRows) values = Arrays.copyOf(values, produced);
+            return blockFactory.newLongArrayVector(values, produced).asBlock();
         }
         Block allNull = ConstantBlockDetection.tryAllNull(nulls.toBitSet(), produced, blockFactory);
         if (allNull != null) {
             return allNull;
         }
-        return takeLongBlock(blockFactory, produced, false, nulls.toBitSet());
+        if (produced < maxRows) values = Arrays.copyOf(values, produced);
+        return blockFactory.newLongArrayBlock(values, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
     }
 
     private void readInt96Values(long[] values, int offset, int count) {
@@ -1075,64 +1102,11 @@ final class PageColumnReader {
     }
 
     // --- Block construction helpers ---
-    //
-    // These helpers copy the decode buffer into a fresh, tightly sized owned array before
-    // handing it to BlockFactory.
-    //
-    // Why the copy is necessary: BlockFactory#new*ArrayVector(values, positionCount) does NOT
-    // copy. It stores the array reference directly inside the Vector (see e.g.
-    // LongArrayVector#values), and the Vector reads from that array for the entire lifetime of
-    // the Block. Memory accounting on the circuit breaker is computed from the array's full
-    // length too. So whatever array a caller hands in is logically owned by the resulting Block
-    // until the Block is released.
-    //
-    // PageColumnReader's DecodeBuffers, by contrast, are a small per-reader pool that is reused
-    // across successive read*Batch calls: longs and doubles rotate between two slots, while ints
-    // and booleans share a single buffer. When AsyncExternalSourceBuffer keeps several emitted
-    // Pages queued between the producer driver and the consumer driver - the steady-state shape
-    // for parquet reads - more than two Blocks for a given column are alive at once, the
-    // two-slot rotation cannot keep up, and the next decode silently mutates the array still
-    // referenced by an earlier Block. The result is non-deterministic, incorrect numeric
-    // aggregates while COUNT(*) stays correct.
-    //
-    // Defensively copying here transfers a fresh array to the Block on every emit, decoupling
-    // the Block's lifetime from the reader's pool. The copy is sized to positionCount, which
-    // also keeps the breaker accounting tight (vs. the oversized pooled buffer's array.length).
-    //
-    // See {@code ParquetFormatReaderTests#testEmittedPagesAreNotMutatedAcrossProducerConsumerBoundary}
-    // for the regression coverage.
-
-    private Block takeLongBlock(BlockFactory blockFactory, int rowCount, boolean noNulls, BitSet nullBitSet) {
-        long[] owned = Arrays.copyOf(buffers.takeLongs(), rowCount);
-        if (noNulls) {
-            return blockFactory.newLongArrayVector(owned, rowCount).asBlock();
-        }
-        return blockFactory.newLongArrayBlock(owned, rowCount, null, nullBitSet, Block.MvOrdering.UNORDERED);
-    }
-
-    private Block takeDoubleBlock(BlockFactory blockFactory, int rowCount, boolean noNulls, BitSet nullBitSet) {
-        double[] owned = Arrays.copyOf(buffers.takeDoubles(), rowCount);
-        if (noNulls) {
-            return blockFactory.newDoubleArrayVector(owned, rowCount).asBlock();
-        }
-        return blockFactory.newDoubleArrayBlock(owned, rowCount, null, nullBitSet, Block.MvOrdering.UNORDERED);
-    }
-
-    private Block takeIntBlock(BlockFactory blockFactory, int[] src, int rowCount, boolean noNulls, BitSet nullBitSet) {
-        int[] owned = Arrays.copyOf(src, rowCount);
-        if (noNulls) {
-            return blockFactory.newIntArrayVector(owned, rowCount).asBlock();
-        }
-        return blockFactory.newIntArrayBlock(owned, rowCount, null, nullBitSet, Block.MvOrdering.UNORDERED);
-    }
-
-    private Block takeBooleanBlock(BlockFactory blockFactory, boolean[] src, int rowCount, boolean noNulls, BitSet nullBitSet) {
-        boolean[] owned = Arrays.copyOf(src, rowCount);
-        if (noNulls) {
-            return blockFactory.newBooleanArrayVector(owned, rowCount).asBlock();
-        }
-        return blockFactory.newBooleanArrayBlock(owned, rowCount, null, nullBitSet, Block.MvOrdering.UNORDERED);
-    }
+    // Primitive batch methods decode directly into a fresh array that becomes the Block's
+    // backing store. For full batches (produced == maxRows) this is zero-copy; partial
+    // last batches are right-sized via Arrays.copyOf. DecodeBuffers scratch arrays are
+    // used only as intermediaries that are consumed within a single batch (e.g. int-to-long
+    // widening in readInt32AsLongBatch) and never handed to BlockFactory.
 
     // --- Scatter utilities ---
 


### PR DESCRIPTION
Decode directly into a fresh Block-owned array instead of into a
DecodeBuffers scratch buffer followed by Arrays.copyOf. For full
batches this is zero-copy; partial last batches right-size via
Arrays.copyOf when produced < maxRows.

Reduces young-gen GC churn on scan-heavy Parquet queries by
halving the number of short-lived primitive arrays created in
the producer hot path.

Also removes dead DecodeBuffers methods and fields that are no
longer used after eliminating the scratch-to-block copy pattern.

Developed with AI-assisted tooling