### PR TITLE
Update LIMIT syntax version info in ESQL documentation

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/limit.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/limit.md
@@ -9,15 +9,15 @@ The `LIMIT` processing command limits the number of rows returned.
 
 ::::{applies-switch}
 
-:::{applies-item} { stack: ga, "serverless": "ga"}
-```esql
-LIMIT max_number_of_rows
-```
-:::
-
 :::{applies-item} { "stack": "preview 9.4+", "serverless": "preview" }
 ```esql
 LIMIT max_number_of_rows [BY grouping_expr1[, ..., grouping_exprN]]
+```
+:::
+
+:::{applies-item} { stack: ga 9.0+}
+```esql
+LIMIT max_number_of_rows
 ```
 :::
 ::::


### PR DESCRIPTION
put the serverless/9.4 first

add 9.0+ to existing LIMIT syntax to signify this is preexisting

(9.0 because this docs set starts at 9.0 and a bare "ga" implictly means ga in 9.0 because we don't use applies_to for features that existed in 8.x and below)
