### PR TITLE
[9.2] Fix race in FsBlobContainer.moveBlobAtomic by replacing move op with hard link

### DIFF
--- a/docs/changelog/147405.yaml
+++ b/docs/changelog/147405.yaml
@@ -1,0 +1,6 @@
+area: Distributed
+issues:
+ - 147171
+pr: 147405
+summary: Fix race in FsBlobContainer.moveBlobAtomic by replacing move op with hard link
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -403,20 +404,49 @@ public class FsBlobContainer extends AbstractBlobContainer {
     ) throws IOException {
         final Path sourceBlobPath = path.resolve(sourceBlobName);
         final Path targetBlobPath = path.resolve(targetBlobName);
-        try {
-            if (failIfAlreadyExists && Files.exists(targetBlobPath)) {
-                throw new FileAlreadyExistsException("blob [" + targetBlobPath + "] already exists, cannot overwrite");
+        if (failIfAlreadyExists) {
+            moveAtomicallyUsingHardLink(targetBlobPath, sourceBlobPath, FsBlobContainer::fallbackMoveFileWithNoHardLinkSupported);
+        } else {
+            try {
+                Files.move(sourceBlobPath, targetBlobPath, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException e) {
+                // If the target file exists then Files.move() behaviour is implementation-specific
+                // the existing file might be replaced or this method fails by throwing an IOException so we retry in a non-atomic
+                // way by deleting and then writing.
+                moveBlobNonAtomic(purpose, targetBlobName, sourceBlobPath, targetBlobPath, e);
             }
-            Files.move(sourceBlobPath, targetBlobPath, StandardCopyOption.ATOMIC_MOVE);
-        } catch (IOException e) {
-            // If the target file exists then Files.move() behaviour is implementation specific
-            // the existing file might be replaced or this method fails by throwing an IOException so we retry in a non-atomic
-            // way by deleting and then writing.
-            if (failIfAlreadyExists) {
-                throw e;
-            }
-            moveBlobNonAtomic(purpose, targetBlobName, sourceBlobPath, targetBlobPath, e);
         }
+    }
+
+    /// Use a hard link to atomically fail if the target already exists. A plain Files.move with ATOMIC_MOVE uses rename(2) on
+    /// POSIX which silently replaces an existing target, so a separate Files.exists check beforehand is racy under concurrent
+    /// writers. Files.createLink uses link(2) which atomically fails with FileAlreadyExistsException when the target exists.
+    private static void moveAtomicallyUsingHardLink(
+        Path targetBlobPath,
+        Path sourceBlobPath,
+        CheckedBiConsumer<Path, Path, IOException> fallbackMoveAtomically
+    ) throws IOException {
+        try {
+            Files.createLink(targetBlobPath, sourceBlobPath);
+        } catch (UnsupportedOperationException e) {
+            fallbackMoveAtomically.accept(targetBlobPath, sourceBlobPath);
+            return;
+        }
+        try {
+            Files.delete(sourceBlobPath);
+        } catch (IOException e) {
+            // The link succeeded, so the data is at the target path; the temp file is orphaned but not harmful.
+            logger.warn("failed to delete temporary blob [{}] after hard-linking to [{}]", sourceBlobPath, targetBlobPath);
+        }
+    }
+
+    /// Fall back for filesystems that do not support hard links (e.g., some network mounts).
+    /// This operation is not concurrency safe.
+    private static void fallbackMoveFileWithNoHardLinkSupported(Path targetBlobPath, Path sourceBlobPath) throws IOException {
+        if (Files.exists(targetBlobPath)) {
+            throw new FileAlreadyExistsException("blob [" + targetBlobPath + "] already exists, cannot overwrite");
+        }
+        Files.move(sourceBlobPath, targetBlobPath, StandardCopyOption.ATOMIC_MOVE);
     }
 
     private void moveBlobNonAtomic(OperationPurpose purpose, String targetBlobName, Path sourceBlobPath, Path targetBlobPath, IOException e)

--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -381,6 +381,32 @@ public class FsBlobContainerTests extends ESTestCase {
         }
     }
 
+    public void testConcurrentAtomicWriteOverwriteProtection() throws Exception {
+        restoreFileSystem();
+        final var blobName = randomAlphaOfLengthBetween(1, 20).toLowerCase(Locale.ROOT);
+        final var path = createTempDir();
+        final var container = new FsBlobContainer(new FsBlobStore(randomIntBetween(1, 8) * 1024, path, false), BlobPath.EMPTY, path);
+        final var threadCount = between(2, 8);
+        final var success = new AtomicBoolean();
+
+        startInParallel(threadCount, ignored -> {
+            final var data = new BytesArray(randomByteArrayOfLength(randomIntBetween(1, 512)));
+            try {
+                container.writeBlobAtomic(randomNonDataPurpose(), blobName, data, true);
+                assertTrue("there should be exactly one successful writer", success.compareAndSet(false, true));
+            } catch (FileAlreadyExistsException e) {
+                // expected for all but one thread
+            } catch (Exception e) {
+                fail(e, "unexpected exception");
+            }
+        });
+
+        assertTrue("there should be exactly one successful writer", success.get());
+        for (final String blob : container.listBlobs(randomPurpose()).keySet()) {
+            assertFalse("unexpected temp blob [" + blob + "]", FsBlobContainer.isTempBlobName(blob));
+        }
+    }
+
     public void testCopy() throws Exception {
         // without this, on CI the test sometimes fails with
         // java.nio.file.ProviderMismatchException: mismatch, expected: class org.elasticsearch.common.blobstore.fs.FsBlobContainerTests$1,


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix race in FsBlobContainer.moveBlobAtomic by replacing move op with hard link (#147405) (#147830)