### PR TITLE
[Native] i8 bulk AVX-512 shared-b

### DIFF
--- a/docs/changelog/147865.yaml
+++ b/docs/changelog/147865.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 147865
+summary: "[Native] i8 bulk AVX-512 shared-b"
+type: enhancement

--- a/libs/native/libraries/build.gradle
+++ b/libs/native/libraries/build.gradle
@@ -19,7 +19,7 @@ configurations {
 }
 
 var zstdVersion = "1.5.7"
-var vecVersion = "1.0.109"
+var vecVersion = "1.0.111"
 var pqrsVersion = "0.2.0"
 
 repositories {

--- a/libs/simdvec/native/publish_vec_binaries.sh
+++ b/libs/simdvec/native/publish_vec_binaries.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.109"
+VERSION="1.0.111"
 
 LOCAL=false
 FORCE_UPLOAD=false

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
@@ -187,174 +187,6 @@ static inline int32_t doti8_inner_bulk(const int8_t* a, const int8_t* b, const i
     return (int32_t)(_mm512_reduce_add_epi32(total_ab) - b_correction);
 }
 
-// Bulk dot i8 with shared query loads.
-//
-// Iterates over `batches` document vectors in parallel per dimension step,
-// loading the query once per step (XORed into u8 form for vpdpbusd) and
-// reusing it across all batched documents to amortise b-side L1D bandwidth
-// across the batch.
-//
-// Two independent unroll axes:
-//   batches    - number of distinct document vectors scored in parallel;
-//                amortises the query load and adds independent vpdpbusd chains
-//                across documents.
-//   unroll_dim - number of consecutive 64-byte blocks of the same document
-//                processed per inner-loop iteration, each into its own
-//                accumulator. Hides vpdpbusd latency (Sapphire Rapids:
-//                ~4-cyc latency, ~0.5-cyc throughput on ports 0/5).
-//
-// The single-pair scorer `doti8_inner_bulk` above uses the same dim-axis
-// pattern under its local `batches` constant.
-//
-// Prefetch strategy (head + spread):
-//   - At each batch boundary, software-prefetches the first `unroll_dim`
-//     cache lines of every next-batch vector so the very first inner-loop
-//     iter never waits on a demand miss.
-//   - At each inner iter, software-prefetches the next `unroll_dim` lines
-//     (the lines that the *next* outer iter will consume) of every
-//     next-batch vector. Spreading the issues across the inner loop keeps
-//     the L1d fill buffer occupancy below the per-core ceiling and lets the
-//     prefetched lines arrive ~1 outer iter before they are used.
-template <
-    typename TData,
-    const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
-    int batches = 4,
-    int unroll_dim = 1
->
-static inline void doti8_bulk(
-    const TData* a, const int8_t* b, const int32_t dims, const int32_t pitch,
-    const int32_t* offsets, const int32_t count, f32_t* results
-) {
-    constexpr int stride = sizeof(__m512i);
-    constexpr int dimStride = stride * unroll_dim;
-    const int blk = dims & ~(stride - 1);
-    const __m512i xor_mask = _mm512_set1_epi8((char)0x80);
-    const int lines_to_fetch = dims / CACHE_LINE_SIZE + 1;
-    const int64_t b_correction = precompute_b_correction(b, dims);
-    int c = 0;
-
-    const int8_t* current_vecs[batches];
-    init_pointers<batches, TData, int8_t, mapper>(current_vecs, a, pitch, offsets, 0, count);
-
-    for (; c + batches - 1 < count; c += batches) {
-        const int8_t* next_vecs[batches];
-        const bool has_next = c + 2 * batches - 1 < count;
-        if (has_next) {
-            apply_indexed<batches>([&](auto I) {
-                next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
-                const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
-                apply_indexed<unroll_dim>([&](auto K) {
-                    _mm_prefetch((const void*)(base + K * CACHE_LINE_SIZE), _MM_HINT_T0);
-                });
-            });
-        }
-
-        // Row-major layout: acc[I * unroll_dim + U] keeps the unroll_dim
-        // accumulators for batch member I contiguous, so tree_reduce can fold
-        // them in one call.
-        __m512i acc[batches * unroll_dim];
-        apply_indexed<batches * unroll_dim>([&](auto I) {
-            acc[I] = _mm512_setzero_si512();
-        });
-
-        int i = 0;
-        for (; i + dimStride <= blk; i += dimStride) {
-            if (has_next) {
-                const int next_line_start = i / CACHE_LINE_SIZE + unroll_dim;
-                apply_indexed<unroll_dim>([&](auto U) {
-                    const int line = next_line_start + U;
-                    if (line < lines_to_fetch) {
-                        apply_indexed<batches>([&](auto I) {
-                            const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
-                            _mm_prefetch((const void*)(base + line * CACHE_LINE_SIZE), _MM_HINT_T0);
-                        });
-                    }
-                });
-            }
-            apply_indexed<unroll_dim>([&](auto U) {
-                __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i + U * stride));
-                apply_indexed<batches>([&](auto I) {
-                    __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i + U * stride));
-                    acc[I * unroll_dim + U] = _mm512_dpbusd_epi32(
-                        acc[I * unroll_dim + U], _mm512_xor_si512(av, xor_mask), bv);
-                });
-            });
-        }
-
-        // Fold the unroll_dim accumulators per batch back into acc[I] before
-        // the unroll_dim=1 tail and the masked tail. Skipped at unroll_dim=1,
-        // where the main loop already wrote into acc[I*1+0] = acc[I].
-        if constexpr (unroll_dim > 1) {
-            apply_indexed<batches>([&](auto I) {
-                acc[I] = tree_reduce<unroll_dim, __m512i, _mm512_add_epi32>(&acc[I * unroll_dim]);
-            });
-            for (; i + stride <= blk; i += stride) {
-                if (has_next) {
-                    const int line = i / CACHE_LINE_SIZE + 1;
-                    if (line < lines_to_fetch) {
-                        apply_indexed<batches>([&](auto I) {
-                            const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
-                            _mm_prefetch((const void*)(base + line * CACHE_LINE_SIZE), _MM_HINT_T0);
-                        });
-                    }
-                }
-                __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
-                apply_indexed<batches>([&](auto I) {
-                    __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));
-                    acc[I] = _mm512_dpbusd_epi32(acc[I], _mm512_xor_si512(av, xor_mask), bv);
-                });
-            }
-        }
-
-        const int rem = dims - i;
-        if (rem > 0) {
-            __mmask64 mask = (__mmask64)_bzhi_u64(0xFFFFFFFFFFFFFFFFULL, rem);
-            __m512i bv = _mm512_maskz_loadu_epi8(mask, b + i);
-            apply_indexed<batches>([&](auto I) {
-                __m512i av = _mm512_maskz_loadu_epi8(mask, current_vecs[I] + i);
-                acc[I] = _mm512_dpbusd_epi32(acc[I], _mm512_xor_si512(av, xor_mask), bv);
-            });
-        }
-
-        apply_indexed<batches>([&](auto I) {
-            results[c + I] = (f32_t)(_mm512_reduce_add_epi32(acc[I]) - b_correction);
-        });
-
-        if (has_next) {
-            std::copy_n(next_vecs, batches, current_vecs);
-        }
-    }
-
-    for (; c < count; c++) {
-        const int8_t* a0 = mapper(a, c, offsets, pitch);
-        results[c] = (f32_t)doti8_inner_bulk(a0, b, dims, b_correction);
-    }
-}
-
-EXPORT void vec_doti8_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
-    doti8_bulk<int8_t, sequential_mapper, 4, 2>(a, b, dims, dims, NULL, count, results);
-}
-
-EXPORT void vec_doti8_bulk_offsets_2(
-    const int8_t* a,
-    const int8_t* b,
-    const int32_t dims,
-    const int32_t pitch,
-    const int32_t* offsets,
-    const int32_t count,
-    f32_t* results) {
-    doti8_bulk<int8_t, offsets_mapper, 4, 1>(a, b, dims, pitch, offsets, count, results);
-}
-
-EXPORT void vec_doti8_bulk_sparse_2(
-    const void* const* addresses,
-    const int8_t* b,
-    const int32_t dims,
-    const int32_t count,
-    f32_t* results) {
-    doti8_bulk<const int8_t*, sparse_mapper, 4, 2>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
-}
-
 // Accumulates acc += sqr_distance(pa, pb) for signed int8. Sign-extends to 16-bit,
 // subtracts, then madd for squared accumulation.
 template<int offsetRegs>
@@ -428,31 +260,187 @@ EXPORT f32_t vec_sqri8_2(const int8_t* a, const int8_t* b, const int32_t dims) {
     return (f32_t)sqri8_inner(a, b, dims);
 }
 
-// Bulk squared distance for signed int8 with shared query loads.
+// Step policy structs that capture the per-kernel work for the unified
+// `i8_bulk` template below. Each Step owns:
+//   - `step`               outer dim cursor advance per iter, in bytes
+//   - `BSide`              precomputed query-side scalar (e.g. b_correction)
+//   - `precompute_b`       returns the BSide given the query
+//   - `inner<U,B>(...)`    issues U * B FMA-equivalents into `acc`
+//   - `masked_tail<B>(...)` finalises a sub-step-sized tail with a mask
+//   - `finalize(acc, bs)`  reduces one batch member's accumulator to f32
+//   - `scalar_tail(...)`   single-vector fallback for the per-batch tail
 //
-// The query is sign-extended to 16-bit once per chunk and reused across all
-// batches; this keeps `vpmovsxbw` off the critical path on the b stream
-// (Sapphire Rapids: vpmovsxbw is port-5-only, so one b cvt per outer step
-// instead of one per batched document removes a port-5 bottleneck).
+// The same scaffold (batch loop, prefetch, accumulator lifecycle, tail
+// dispatch) is shared by the Step instantiations.
+
+// DotI8Step: AVX-512 i8 dot via DPBUSD on the (a XOR 0x80) shifted form.
 //
-// The single-vector scorer `sqri8_inner` above uses the multi-accumulator
-// trick on the dim axis; bulk-side parallelism here comes from the batch axis.
+// `vpdpbusd` is unsigned*signed; we XOR the signed `a` lanes with 0x80 so
+// they become unsigned, then subtract a precomputed `b_correction`
+// (= 128 * sum(b)) at the end. Inner step is 64 B (one __m512i per side),
+// so unroll_dim>1 is meaningful here to fill the multi-cycle vpdpbusd
+// latency window with extra independent accumulators.
+struct DotI8Step {
+    static constexpr int step = sizeof(__m512i);  // 64 bytes per inner iter
+    using BSide = int64_t;
+
+    static inline BSide precompute_b(const int8_t* b, const int32_t dims) {
+        return precompute_b_correction(b, dims);
+    }
+
+    // `acc` is __m512i* (not a sized reference) so the same method serves
+    // both the unrolled main loop (size = batches * unroll_dim) and the
+    // unroll_dim>1 tail (size = batches, after the per-batch fold).
+    template <int unroll_dim, int batches>
+    static inline void inner(
+        __m512i* acc,
+        const int8_t* const (&current_vecs)[batches],
+        const int8_t* b, int i
+    ) {
+        const __m512i xor_mask = _mm512_set1_epi8((char)0x80);
+        apply_indexed<unroll_dim>([&](auto U) {
+            __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i + U * step));
+            apply_indexed<batches>([&](auto I) {
+                __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i + U * step));
+                acc[I * unroll_dim + U] = _mm512_dpbusd_epi32(
+                    acc[I * unroll_dim + U], _mm512_xor_si512(av, xor_mask), bv);
+            });
+        });
+    }
+
+    template <int batches>
+    static inline void masked_tail(
+        __m512i* acc,
+        const int8_t* const (&current_vecs)[batches],
+        const int8_t* b, int i, int rem
+    ) {
+        const __m512i xor_mask = _mm512_set1_epi8((char)0x80);
+        __mmask64 mask = (__mmask64)_bzhi_u64(0xFFFFFFFFFFFFFFFFULL, rem);
+        __m512i bv = _mm512_maskz_loadu_epi8(mask, b + i);
+        apply_indexed<batches>([&](auto I) {
+            __m512i av = _mm512_maskz_loadu_epi8(mask, current_vecs[I] + i);
+            acc[I] = _mm512_dpbusd_epi32(acc[I], _mm512_xor_si512(av, xor_mask), bv);
+        });
+    }
+
+    static inline f32_t finalize(__m512i acc, BSide b_correction) {
+        return (f32_t)(_mm512_reduce_add_epi32(acc) - b_correction);
+    }
+
+    static inline f32_t scalar_tail(const int8_t* a, const int8_t* b, int32_t dims, BSide b_correction) {
+        return (f32_t)doti8_inner_bulk(a, b, dims, b_correction);
+    }
+};
+
+// SqrI8Step: AVX-512 squared-distance for signed i8 via cvtepi8_epi16 +
+// sub + madd_epi16. Inner step is 32 B (one __m256i per side, widened to a
+// __m512i of 16-bit lanes). `vpmovsxbw` is port-5-only on Sapphire Rapids,
+// so unroll_dim>1 cannot help here — the b cvt itself is already the
+// bottleneck — and is statically rejected.
+struct SqrI8Step {
+    static constexpr int step = sizeof(__m256i);  // 32 bytes per inner iter
+    // No precomputed query-side scalar is needed; placeholder type to share
+    // the same template signature as DotI8Step.
+    using BSide = int;
+
+    static inline BSide precompute_b(const int8_t*, const int32_t) {
+        return 0;
+    }
+
+    template <int unroll_dim, int batches>
+    static inline void inner(
+        __m512i* acc,
+        const int8_t* const (&current_vecs)[batches],
+        const int8_t* b, int i
+    ) {
+        static_assert(unroll_dim == 1, "SqrI8Step does not support unroll_dim > 1 (port-5 bound)");
+        __m512i b16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(b + i)));
+        apply_indexed<batches>([&](auto I) {
+            __m512i a16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(current_vecs[I] + i)));
+            __m512i dist = _mm512_sub_epi16(a16, b16);
+            acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(dist, dist));
+        });
+    }
+
+    template <int batches>
+    static inline void masked_tail(
+        __m512i* acc,
+        const int8_t* const (&current_vecs)[batches],
+        const int8_t* b, int i, int rem
+    ) {
+        __mmask32 mask = (__mmask32)((1ULL << rem) - 1);
+        __m512i b16 = _mm512_cvtepi8_epi16(_mm256_maskz_loadu_epi8(mask, b + i));
+        apply_indexed<batches>([&](auto I) {
+            __m512i a16 = _mm512_cvtepi8_epi16(_mm256_maskz_loadu_epi8(mask, current_vecs[I] + i));
+            __m512i dist = _mm512_sub_epi16(a16, b16);
+            acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(dist, dist));
+        });
+    }
+
+    static inline f32_t finalize(__m512i acc, BSide /*unused*/) {
+        return (f32_t)_mm512_reduce_add_epi32(acc);
+    }
+
+    static inline f32_t scalar_tail(const int8_t* a, const int8_t* b, int32_t dims, BSide /*unused*/) {
+        return (f32_t)sqri8_inner(a, b, dims);
+    }
+};
+
+// Unified bulk i8 scoring template, parameterised by a Step policy.
 //
-// Prefetch strategy: head=1 + 1-line spread per cache-line boundary. Inner
-// step is half a cache line (32 bytes) so the spread prefetch is gated to
-// fire only on the iter that crosses into a new cache line.
+// Iterates over `batches` document vectors in parallel per dimension step,
+// loading the query once per step and reusing it across all batched
+// documents to amortise b-side L1D bandwidth across the batch.
+//
+// Two independent unroll axes:
+//   batches    - number of distinct document vectors scored in parallel;
+//                amortises the query load and adds independent FMA chains
+//                across documents.
+//   unroll_dim - number of consecutive `step`-byte blocks of the same
+//                document processed per inner-loop iteration, each into its
+//                own accumulator. Hides FMA latency on Steps where the FMA
+//                throughput is not yet saturated by the `batches` chains
+//                alone (true for `DotI8Step`; explicitly unsupported on
+//                `SqrI8Step` whose port-5 cvt is the actual bottleneck).
+//
+// Prefetch strategy (head + spread):
+//   - At each batch boundary, prefetch the first `lines_per_iter` cache
+//     lines of every next-batch vector so the very first inner-loop iter
+//     never waits on a demand miss.
+//   - At each inner iter, prefetch `lines_per_iter` more cache lines per
+//     next-batch vector. The L1d fill-buffer never holds more than
+//     `batches * lines_per_iter` outstanding entries, vs the
+//     `batches * lines_to_fetch` peak of a boundary burst (which would
+//     overflow the per-core ~16-entry LFB on Sapphire Rapids).
+//   - For Steps whose `step` is < CACHE_LINE_SIZE (e.g. SqrI8Step at 32 B
+//     half a cache line), the spread is gated to fire only on the iter
+//     that crosses a cache-line boundary; per-iter `lines_per_iter` falls
+//     back to 1.
 template <
     typename TData,
     const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
-    int batches = 4
+    typename Step,
+    int batches = 4,
+    int unroll_dim = 1
 >
-static inline void sqri8_bulk(
+static inline void i8_bulk(
     const TData* a, const int8_t* b, const int32_t dims, const int32_t pitch,
     const int32_t* offsets, const int32_t count, f32_t* results
 ) {
-    constexpr int chunk = sizeof(__m256i);  // 32 bytes -> 32 i8 -> __m512i of 16-bit
-    const int blk = dims & ~(chunk - 1);
+    constexpr int step = Step::step;
+    constexpr int dimStride = step * unroll_dim;
+    // unroll_dim > 1 only makes sense when each iter consumes >= 1 cache
+    // line; otherwise the prefetch math collapses to lines_per_iter=1 and
+    // the extra accumulators provide no benefit. Steps that are bounded by
+    // a non-FMA port (e.g. SqrI8Step / port 5) reject unroll_dim>1
+    // separately via their own static_assert in `inner`.
+    static_assert(unroll_dim == 1 || dimStride >= CACHE_LINE_SIZE,
+        "unroll_dim>1 only supported when step * unroll_dim >= cache line size");
+    constexpr int lines_per_iter = (dimStride >= CACHE_LINE_SIZE) ? unroll_dim : 1;
+
+    const int blk = dims & ~(step - 1);
     const int lines_to_fetch = dims / CACHE_LINE_SIZE + 1;
+    const auto b_side = Step::precompute_b(b, dims);
     int c = 0;
 
     const int8_t* current_vecs[batches];
@@ -464,48 +452,54 @@ static inline void sqri8_bulk(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
-                const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
-                _mm_prefetch((const void*)base, _MM_HINT_T0);
             });
+            head_prefetch<batches, lines_per_iter>(next_vecs);
         }
 
-        __m512i acc[batches];
-        apply_indexed<batches>([&](auto I) {
+        // Row-major layout: acc[I * unroll_dim + U] keeps the unroll_dim
+        // accumulators for batch member I contiguous, so tree_reduce can fold
+        // them in one call.
+        __m512i acc[batches * unroll_dim];
+        apply_indexed<batches * unroll_dim>([&](auto I) {
             acc[I] = _mm512_setzero_si512();
         });
 
         int i = 0;
-        for (; i + chunk <= blk; i += chunk) {
-            if (has_next && (i & (CACHE_LINE_SIZE - 1)) == 0) {
-                const int line = i / CACHE_LINE_SIZE + 1;
-                if (line < lines_to_fetch) {
-                    apply_indexed<batches>([&](auto I) {
-                        const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
-                        _mm_prefetch((const void*)(base + line * CACHE_LINE_SIZE), _MM_HINT_T0);
-                    });
+        for (; i + dimStride <= blk; i += dimStride) {
+            if (has_next) {
+                if constexpr (dimStride >= CACHE_LINE_SIZE) {
+                    spread_prefetch<batches, lines_per_iter>(next_vecs, i, lines_to_fetch);
+                } else if ((i & (CACHE_LINE_SIZE - 1)) == 0) {
+                    // step < cache line: prefetch one line, but only on the
+                    // iter that crosses a new cache-line boundary.
+                    spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
                 }
             }
-            __m512i b16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(b + i)));
+            Step::template inner<unroll_dim, batches>(acc, current_vecs, b, i);
+        }
+
+        // Fold the unroll_dim accumulators per batch into acc[I] before the
+        // unroll_dim=1 tail and the masked tail. Skipped at unroll_dim=1,
+        // where the main loop already wrote into acc[I*1+0] = acc[I].
+        if constexpr (unroll_dim > 1) {
             apply_indexed<batches>([&](auto I) {
-                __m512i a16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(current_vecs[I] + i)));
-                __m512i dist = _mm512_sub_epi16(a16, b16);
-                acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(dist, dist));
+                acc[I] = tree_reduce<unroll_dim, __m512i, _mm512_add_epi32>(&acc[I * unroll_dim]);
             });
+            for (; i + step <= blk; i += step) {
+                if (has_next) {
+                    spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
+                }
+                Step::template inner<1, batches>(acc, current_vecs, b, i);
+            }
         }
 
         const int rem = dims - i;
         if (rem > 0) {
-            __mmask32 mask = (__mmask32)((1ULL << rem) - 1);
-            __m512i b16 = _mm512_cvtepi8_epi16(_mm256_maskz_loadu_epi8(mask, b + i));
-            apply_indexed<batches>([&](auto I) {
-                __m512i a16 = _mm512_cvtepi8_epi16(_mm256_maskz_loadu_epi8(mask, current_vecs[I] + i));
-                __m512i dist = _mm512_sub_epi16(a16, b16);
-                acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(dist, dist));
-            });
+            Step::template masked_tail<batches>(acc, current_vecs, b, i, rem);
         }
 
         apply_indexed<batches>([&](auto I) {
-            results[c + I] = (f32_t)_mm512_reduce_add_epi32(acc[I]);
+            results[c + I] = Step::finalize(acc[I], b_side);
         });
 
         if (has_next) {
@@ -515,12 +509,36 @@ static inline void sqri8_bulk(
 
     for (; c < count; c++) {
         const int8_t* a0 = mapper(a, c, offsets, pitch);
-        results[c] = (f32_t)sqri8_inner(a0, b, dims);
+        results[c] = Step::scalar_tail(a0, b, dims, b_side);
     }
 }
 
+EXPORT void vec_doti8_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
+    i8_bulk<int8_t, sequential_mapper, DotI8Step, 4, 2>(a, b, dims, dims, NULL, count, results);
+}
+
+EXPORT void vec_doti8_bulk_offsets_2(
+    const int8_t* a,
+    const int8_t* b,
+    const int32_t dims,
+    const int32_t pitch,
+    const int32_t* offsets,
+    const int32_t count,
+    f32_t* results) {
+    i8_bulk<int8_t, offsets_mapper, DotI8Step, 4, 1>(a, b, dims, pitch, offsets, count, results);
+}
+
+EXPORT void vec_doti8_bulk_sparse_2(
+    const void* const* addresses,
+    const int8_t* b,
+    const int32_t dims,
+    const int32_t count,
+    f32_t* results) {
+    i8_bulk<const int8_t*, sparse_mapper, DotI8Step, 4, 2>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
+}
+
 EXPORT void vec_sqri8_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
-    sqri8_bulk<int8_t, sequential_mapper>(a, b, dims, dims, NULL, count, results);
+    i8_bulk<int8_t, sequential_mapper, SqrI8Step, 4, 1>(a, b, dims, dims, NULL, count, results);
 }
 
 EXPORT void vec_sqri8_bulk_offsets_2(
@@ -531,7 +549,7 @@ EXPORT void vec_sqri8_bulk_offsets_2(
     const int32_t* offsets,
     const int32_t count,
     f32_t* results) {
-    sqri8_bulk<int8_t, offsets_mapper>(a, b, dims, pitch, offsets, count, results);
+    i8_bulk<int8_t, offsets_mapper, SqrI8Step, 4, 1>(a, b, dims, pitch, offsets, count, results);
 }
 
 EXPORT void vec_sqri8_bulk_sparse_2(
@@ -540,7 +558,7 @@ EXPORT void vec_sqri8_bulk_sparse_2(
     const int32_t dims,
     const int32_t count,
     f32_t* results) {
-    sqri8_bulk<const int8_t*, sparse_mapper>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
+    i8_bulk<const int8_t*, sparse_mapper, SqrI8Step, 4, 1>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
 }
 
 // --- Cosine i8 (signed) AVX-512 ---

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
@@ -205,6 +205,16 @@ static inline int32_t doti8_inner_bulk(const int8_t* a, const int8_t* b, const i
 //
 // The single-pair scorer `doti8_inner_bulk` above uses the same dim-axis
 // pattern under its local `batches` constant.
+//
+// Prefetch strategy (head + spread):
+//   - At each batch boundary, software-prefetches the first `unroll_dim`
+//     cache lines of every next-batch vector so the very first inner-loop
+//     iter never waits on a demand miss.
+//   - At each inner iter, software-prefetches the next `unroll_dim` lines
+//     (the lines that the *next* outer iter will consume) of every
+//     next-batch vector. Spreading the issues across the inner loop keeps
+//     the L1d fill buffer occupancy below the per-core ceiling and lets the
+//     prefetched lines arrive ~1 outer iter before they are used.
 template <
     typename TData,
     const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
@@ -232,7 +242,10 @@ static inline void doti8_bulk(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
-                prefetch(next_vecs[I], lines_to_fetch);
+                const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
+                apply_indexed<unroll_dim>([&](auto K) {
+                    _mm_prefetch((const void*)(base + K * CACHE_LINE_SIZE), _MM_HINT_T0);
+                });
             });
         }
 
@@ -246,6 +259,18 @@ static inline void doti8_bulk(
 
         int i = 0;
         for (; i + dimStride <= blk; i += dimStride) {
+            if (has_next) {
+                const int next_line_start = i / CACHE_LINE_SIZE + unroll_dim;
+                apply_indexed<unroll_dim>([&](auto U) {
+                    const int line = next_line_start + U;
+                    if (line < lines_to_fetch) {
+                        apply_indexed<batches>([&](auto I) {
+                            const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
+                            _mm_prefetch((const void*)(base + line * CACHE_LINE_SIZE), _MM_HINT_T0);
+                        });
+                    }
+                });
+            }
             apply_indexed<unroll_dim>([&](auto U) {
                 __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i + U * stride));
                 apply_indexed<batches>([&](auto I) {
@@ -264,6 +289,15 @@ static inline void doti8_bulk(
                 acc[I] = tree_reduce<unroll_dim, __m512i, _mm512_add_epi32>(&acc[I * unroll_dim]);
             });
             for (; i + stride <= blk; i += stride) {
+                if (has_next) {
+                    const int line = i / CACHE_LINE_SIZE + 1;
+                    if (line < lines_to_fetch) {
+                        apply_indexed<batches>([&](auto I) {
+                            const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
+                            _mm_prefetch((const void*)(base + line * CACHE_LINE_SIZE), _MM_HINT_T0);
+                        });
+                    }
+                }
                 __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
                 apply_indexed<batches>([&](auto I) {
                     __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));
@@ -403,6 +437,10 @@ EXPORT f32_t vec_sqri8_2(const int8_t* a, const int8_t* b, const int32_t dims) {
 //
 // The single-vector scorer `sqri8_inner` above uses the multi-accumulator
 // trick on the dim axis; bulk-side parallelism here comes from the batch axis.
+//
+// Prefetch strategy: head=1 + 1-line spread per cache-line boundary. Inner
+// step is half a cache line (32 bytes) so the spread prefetch is gated to
+// fire only on the iter that crosses into a new cache line.
 template <
     typename TData,
     const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
@@ -426,7 +464,8 @@ static inline void sqri8_bulk(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
-                prefetch(next_vecs[I], lines_to_fetch);
+                const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
+                _mm_prefetch((const void*)base, _MM_HINT_T0);
             });
         }
 
@@ -437,6 +476,15 @@ static inline void sqri8_bulk(
 
         int i = 0;
         for (; i + chunk <= blk; i += chunk) {
+            if (has_next && (i & (CACHE_LINE_SIZE - 1)) == 0) {
+                const int line = i / CACHE_LINE_SIZE + 1;
+                if (line < lines_to_fetch) {
+                    apply_indexed<batches>([&](auto I) {
+                        const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
+                        _mm_prefetch((const void*)(base + line * CACHE_LINE_SIZE), _MM_HINT_T0);
+                    });
+                }
+            }
             __m512i b16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(b + i)));
             apply_indexed<batches>([&](auto I) {
                 __m512i a16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(current_vecs[I] + i)));

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
@@ -194,19 +194,29 @@ static inline int32_t doti8_inner_bulk(const int8_t* a, const int8_t* b, const i
 // reusing it across all batched documents to amortise b-side L1D bandwidth
 // across the batch.
 //
-// The single-pair scorer `doti8_inner_bulk` above uses a multi-accumulator
-// pattern on the dim axis under its local `batches` constant; that pattern
-// is independent of the cross-document `batches` parallelism here.
+// Two independent unroll axes:
+//   batches    - number of distinct document vectors scored in parallel;
+//                amortises the query load and adds independent vpdpbusd chains
+//                across documents.
+//   unroll_dim - number of consecutive 64-byte blocks of the same document
+//                processed per inner-loop iteration, each into its own
+//                accumulator. Hides vpdpbusd latency (Sapphire Rapids:
+//                ~4-cyc latency, ~0.5-cyc throughput on ports 0/5).
+//
+// The single-pair scorer `doti8_inner_bulk` above uses the same dim-axis
+// pattern under its local `batches` constant.
 template <
     typename TData,
     const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
-    int batches = 4
+    int batches = 4,
+    int unroll_dim = 1
 >
 static inline void doti8_bulk(
     const TData* a, const int8_t* b, const int32_t dims, const int32_t pitch,
     const int32_t* offsets, const int32_t count, f32_t* results
 ) {
     constexpr int stride = sizeof(__m512i);
+    constexpr int dimStride = stride * unroll_dim;
     const int blk = dims & ~(stride - 1);
     const __m512i xor_mask = _mm512_set1_epi8((char)0x80);
     const int lines_to_fetch = dims / CACHE_LINE_SIZE + 1;
@@ -226,18 +236,40 @@ static inline void doti8_bulk(
             });
         }
 
-        __m512i acc[batches];
-        apply_indexed<batches>([&](auto I) {
+        // Row-major layout: acc[I * unroll_dim + U] keeps the unroll_dim
+        // accumulators for batch member I contiguous, so tree_reduce can fold
+        // them in one call.
+        __m512i acc[batches * unroll_dim];
+        apply_indexed<batches * unroll_dim>([&](auto I) {
             acc[I] = _mm512_setzero_si512();
         });
 
         int i = 0;
-        for (; i + stride <= blk; i += stride) {
-            __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
-            apply_indexed<batches>([&](auto I) {
-                __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));
-                acc[I] = _mm512_dpbusd_epi32(acc[I], _mm512_xor_si512(av, xor_mask), bv);
+        for (; i + dimStride <= blk; i += dimStride) {
+            apply_indexed<unroll_dim>([&](auto U) {
+                __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i + U * stride));
+                apply_indexed<batches>([&](auto I) {
+                    __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i + U * stride));
+                    acc[I * unroll_dim + U] = _mm512_dpbusd_epi32(
+                        acc[I * unroll_dim + U], _mm512_xor_si512(av, xor_mask), bv);
+                });
             });
+        }
+
+        // Fold the unroll_dim accumulators per batch back into acc[I] before
+        // the unroll_dim=1 tail and the masked tail. Skipped at unroll_dim=1,
+        // where the main loop already wrote into acc[I*1+0] = acc[I].
+        if constexpr (unroll_dim > 1) {
+            apply_indexed<batches>([&](auto I) {
+                acc[I] = tree_reduce<unroll_dim, __m512i, _mm512_add_epi32>(&acc[I * unroll_dim]);
+            });
+            for (; i + stride <= blk; i += stride) {
+                __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
+                apply_indexed<batches>([&](auto I) {
+                    __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));
+                    acc[I] = _mm512_dpbusd_epi32(acc[I], _mm512_xor_si512(av, xor_mask), bv);
+                });
+            }
         }
 
         const int rem = dims - i;
@@ -266,7 +298,7 @@ static inline void doti8_bulk(
 }
 
 EXPORT void vec_doti8_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
-    doti8_bulk<int8_t, sequential_mapper>(a, b, dims, dims, NULL, count, results);
+    doti8_bulk<int8_t, sequential_mapper, 4, 2>(a, b, dims, dims, NULL, count, results);
 }
 
 EXPORT void vec_doti8_bulk_offsets_2(
@@ -277,7 +309,7 @@ EXPORT void vec_doti8_bulk_offsets_2(
     const int32_t* offsets,
     const int32_t count,
     f32_t* results) {
-    doti8_bulk<int8_t, offsets_mapper>(a, b, dims, pitch, offsets, count, results);
+    doti8_bulk<int8_t, offsets_mapper, 4, 1>(a, b, dims, pitch, offsets, count, results);
 }
 
 EXPORT void vec_doti8_bulk_sparse_2(
@@ -286,7 +318,7 @@ EXPORT void vec_doti8_bulk_sparse_2(
     const int32_t dims,
     const int32_t count,
     f32_t* results) {
-    doti8_bulk<const int8_t*, sparse_mapper>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
+    doti8_bulk<const int8_t*, sparse_mapper, 4, 2>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
 }
 
 // Accumulates acc += sqr_distance(pa, pb) for signed int8. Sign-extends to 16-bit,

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
@@ -187,6 +187,156 @@ static inline int32_t doti8_inner_bulk(const int8_t* a, const int8_t* b, const i
     return (int32_t)(_mm512_reduce_add_epi32(total_ab) - b_correction);
 }
 
+// Bulk dot i8 with shared query loads.
+//
+// Iterates over `batches` document vectors in parallel per dimension step,
+// loading the query once per step (XORed into u8 form for vpdpbusd) and
+// reusing it across all batched documents to amortise b-side L1D bandwidth
+// across the batch.
+//
+// Two independent unroll axes:
+//   batches    - number of distinct document vectors scored in parallel;
+//                amortises the query load and adds independent vpdpbusd chains
+//                across documents.
+//   unroll_dim - number of consecutive 64-byte blocks of the same document
+//                processed per inner-loop iteration, each into its own
+//                accumulator. Hides vpdpbusd latency (Sapphire Rapids:
+//                ~4-cyc latency, ~0.5-cyc throughput on ports 0/5).
+//
+// The single-pair scorer `doti8_inner_bulk` above uses the same dim-axis
+// pattern under its local `batches` constant.
+//
+// Prefetch strategy (head + spread):
+//   - At each batch boundary, software-prefetches the first `unroll_dim`
+//     cache lines of every next-batch vector so the very first inner-loop
+//     iter never waits on a demand miss.
+//   - At each inner iter, software-prefetches the next `unroll_dim` lines
+//     (the lines that the *next* outer iter will consume) of every
+//     next-batch vector. Spreading the issues across the inner loop keeps
+//     the L1d fill buffer occupancy below the per-core ceiling and lets the
+//     prefetched lines arrive ~1 outer iter before they are used.
+template <
+    typename TData,
+    const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
+    int batches = 4,
+    int unroll_dim = 1
+>
+static inline void doti8_bulk(
+    const TData* a, const int8_t* b, const int32_t dims, const int32_t pitch,
+    const int32_t* offsets, const int32_t count, f32_t* results
+) {
+    constexpr int stride = sizeof(__m512i);
+    constexpr int dimStride = stride * unroll_dim;
+    const int blk = dims & ~(stride - 1);
+    const __m512i xor_mask = _mm512_set1_epi8((char)0x80);
+    const int lines_to_fetch = dims / CACHE_LINE_SIZE + 1;
+    const int64_t b_correction = precompute_b_correction(b, dims);
+    int c = 0;
+
+    const int8_t* current_vecs[batches];
+    init_pointers<batches, TData, int8_t, mapper>(current_vecs, a, pitch, offsets, 0, count);
+
+    for (; c + batches - 1 < count; c += batches) {
+        const int8_t* next_vecs[batches];
+        const bool has_next = c + 2 * batches - 1 < count;
+        if (has_next) {
+            apply_indexed<batches>([&](auto I) {
+                next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
+            });
+            head_prefetch<batches, unroll_dim>(next_vecs);
+        }
+
+        // Row-major layout: acc[I * unroll_dim + U] keeps the unroll_dim
+        // accumulators for batch member I contiguous, so tree_reduce can fold
+        // them in one call.
+        __m512i acc[batches * unroll_dim];
+        apply_indexed<batches * unroll_dim>([&](auto I) {
+            acc[I] = _mm512_setzero_si512();
+        });
+
+        int i = 0;
+        for (; i + dimStride <= blk; i += dimStride) {
+            if (has_next) {
+                spread_prefetch<batches, unroll_dim>(next_vecs, i, lines_to_fetch);
+            }
+            apply_indexed<unroll_dim>([&](auto U) {
+                __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i + U * stride));
+                apply_indexed<batches>([&](auto I) {
+                    __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i + U * stride));
+                    acc[I * unroll_dim + U] = _mm512_dpbusd_epi32(
+                        acc[I * unroll_dim + U], _mm512_xor_si512(av, xor_mask), bv);
+                });
+            });
+        }
+
+        // Fold the unroll_dim accumulators per batch back into acc[I] before
+        // the unroll_dim=1 tail and the masked tail. Skipped at unroll_dim=1,
+        // where the main loop already wrote into acc[I*1+0] = acc[I].
+        if constexpr (unroll_dim > 1) {
+            apply_indexed<batches>([&](auto I) {
+                acc[I] = tree_reduce<unroll_dim, __m512i, _mm512_add_epi32>(&acc[I * unroll_dim]);
+            });
+            for (; i + stride <= blk; i += stride) {
+                if (has_next) {
+                    spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
+                }
+                __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
+                apply_indexed<batches>([&](auto I) {
+                    __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));
+                    acc[I] = _mm512_dpbusd_epi32(acc[I], _mm512_xor_si512(av, xor_mask), bv);
+                });
+            }
+        }
+
+        const int rem = dims - i;
+        if (rem > 0) {
+            __mmask64 mask = (__mmask64)_bzhi_u64(0xFFFFFFFFFFFFFFFFULL, rem);
+            __m512i bv = _mm512_maskz_loadu_epi8(mask, b + i);
+            apply_indexed<batches>([&](auto I) {
+                __m512i av = _mm512_maskz_loadu_epi8(mask, current_vecs[I] + i);
+                acc[I] = _mm512_dpbusd_epi32(acc[I], _mm512_xor_si512(av, xor_mask), bv);
+            });
+        }
+
+        apply_indexed<batches>([&](auto I) {
+            results[c + I] = (f32_t)(_mm512_reduce_add_epi32(acc[I]) - b_correction);
+        });
+
+        if (has_next) {
+            std::copy_n(next_vecs, batches, current_vecs);
+        }
+    }
+
+    for (; c < count; c++) {
+        const int8_t* a0 = mapper(a, c, offsets, pitch);
+        results[c] = (f32_t)doti8_inner_bulk(a0, b, dims, b_correction);
+    }
+}
+
+EXPORT void vec_doti8_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
+    doti8_bulk<int8_t, sequential_mapper, 4, 2>(a, b, dims, dims, NULL, count, results);
+}
+
+EXPORT void vec_doti8_bulk_offsets_2(
+    const int8_t* a,
+    const int8_t* b,
+    const int32_t dims,
+    const int32_t pitch,
+    const int32_t* offsets,
+    const int32_t count,
+    f32_t* results) {
+    doti8_bulk<int8_t, offsets_mapper, 4, 1>(a, b, dims, pitch, offsets, count, results);
+}
+
+EXPORT void vec_doti8_bulk_sparse_2(
+    const void* const* addresses,
+    const int8_t* b,
+    const int32_t dims,
+    const int32_t count,
+    f32_t* results) {
+    doti8_bulk<const int8_t*, sparse_mapper, 4, 2>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
+}
+
 // Accumulates acc += sqr_distance(pa, pb) for signed int8. Sign-extends to 16-bit,
 // subtracts, then madd for squared accumulation.
 template<int offsetRegs>
@@ -260,187 +410,31 @@ EXPORT f32_t vec_sqri8_2(const int8_t* a, const int8_t* b, const int32_t dims) {
     return (f32_t)sqri8_inner(a, b, dims);
 }
 
-// Step policy structs that capture the per-kernel work for the unified
-// `i8_bulk` template below. Each Step owns:
-//   - `step`               outer dim cursor advance per iter, in bytes
-//   - `BSide`              precomputed query-side scalar (e.g. b_correction)
-//   - `precompute_b`       returns the BSide given the query
-//   - `inner<U,B>(...)`    issues U * B FMA-equivalents into `acc`
-//   - `masked_tail<B>(...)` finalises a sub-step-sized tail with a mask
-//   - `finalize(acc, bs)`  reduces one batch member's accumulator to f32
-//   - `scalar_tail(...)`   single-vector fallback for the per-batch tail
+// Bulk squared distance for signed int8 with shared query loads.
 //
-// The same scaffold (batch loop, prefetch, accumulator lifecycle, tail
-// dispatch) is shared by the Step instantiations.
-
-// DotI8Step: AVX-512 i8 dot via DPBUSD on the (a XOR 0x80) shifted form.
+// The query is sign-extended to 16-bit once per chunk and reused across all
+// batches; this keeps `vpmovsxbw` off the critical path on the b stream
+// (Sapphire Rapids: vpmovsxbw is port-5-only, so one b cvt per outer step
+// instead of one per batched document removes a port-5 bottleneck).
 //
-// `vpdpbusd` is unsigned*signed; we XOR the signed `a` lanes with 0x80 so
-// they become unsigned, then subtract a precomputed `b_correction`
-// (= 128 * sum(b)) at the end. Inner step is 64 B (one __m512i per side),
-// so unroll_dim>1 is meaningful here to fill the multi-cycle vpdpbusd
-// latency window with extra independent accumulators.
-struct DotI8Step {
-    static constexpr int step = sizeof(__m512i);  // 64 bytes per inner iter
-    using BSide = int64_t;
-
-    static inline BSide precompute_b(const int8_t* b, const int32_t dims) {
-        return precompute_b_correction(b, dims);
-    }
-
-    // `acc` is __m512i* (not a sized reference) so the same method serves
-    // both the unrolled main loop (size = batches * unroll_dim) and the
-    // unroll_dim>1 tail (size = batches, after the per-batch fold).
-    template <int unroll_dim, int batches>
-    static inline void inner(
-        __m512i* acc,
-        const int8_t* const (&current_vecs)[batches],
-        const int8_t* b, int i
-    ) {
-        const __m512i xor_mask = _mm512_set1_epi8((char)0x80);
-        apply_indexed<unroll_dim>([&](auto U) {
-            __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i + U * step));
-            apply_indexed<batches>([&](auto I) {
-                __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i + U * step));
-                acc[I * unroll_dim + U] = _mm512_dpbusd_epi32(
-                    acc[I * unroll_dim + U], _mm512_xor_si512(av, xor_mask), bv);
-            });
-        });
-    }
-
-    template <int batches>
-    static inline void masked_tail(
-        __m512i* acc,
-        const int8_t* const (&current_vecs)[batches],
-        const int8_t* b, int i, int rem
-    ) {
-        const __m512i xor_mask = _mm512_set1_epi8((char)0x80);
-        __mmask64 mask = (__mmask64)_bzhi_u64(0xFFFFFFFFFFFFFFFFULL, rem);
-        __m512i bv = _mm512_maskz_loadu_epi8(mask, b + i);
-        apply_indexed<batches>([&](auto I) {
-            __m512i av = _mm512_maskz_loadu_epi8(mask, current_vecs[I] + i);
-            acc[I] = _mm512_dpbusd_epi32(acc[I], _mm512_xor_si512(av, xor_mask), bv);
-        });
-    }
-
-    static inline f32_t finalize(__m512i acc, BSide b_correction) {
-        return (f32_t)(_mm512_reduce_add_epi32(acc) - b_correction);
-    }
-
-    static inline f32_t scalar_tail(const int8_t* a, const int8_t* b, int32_t dims, BSide b_correction) {
-        return (f32_t)doti8_inner_bulk(a, b, dims, b_correction);
-    }
-};
-
-// SqrI8Step: AVX-512 squared-distance for signed i8 via cvtepi8_epi16 +
-// sub + madd_epi16. Inner step is 32 B (one __m256i per side, widened to a
-// __m512i of 16-bit lanes). `vpmovsxbw` is port-5-only on Sapphire Rapids,
-// so unroll_dim>1 cannot help here — the b cvt itself is already the
-// bottleneck — and is statically rejected.
-struct SqrI8Step {
-    static constexpr int step = sizeof(__m256i);  // 32 bytes per inner iter
-    // No precomputed query-side scalar is needed; placeholder type to share
-    // the same template signature as DotI8Step.
-    using BSide = int;
-
-    static inline BSide precompute_b(const int8_t*, const int32_t) {
-        return 0;
-    }
-
-    template <int unroll_dim, int batches>
-    static inline void inner(
-        __m512i* acc,
-        const int8_t* const (&current_vecs)[batches],
-        const int8_t* b, int i
-    ) {
-        static_assert(unroll_dim == 1, "SqrI8Step does not support unroll_dim > 1 (port-5 bound)");
-        __m512i b16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(b + i)));
-        apply_indexed<batches>([&](auto I) {
-            __m512i a16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(current_vecs[I] + i)));
-            __m512i dist = _mm512_sub_epi16(a16, b16);
-            acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(dist, dist));
-        });
-    }
-
-    template <int batches>
-    static inline void masked_tail(
-        __m512i* acc,
-        const int8_t* const (&current_vecs)[batches],
-        const int8_t* b, int i, int rem
-    ) {
-        __mmask32 mask = (__mmask32)((1ULL << rem) - 1);
-        __m512i b16 = _mm512_cvtepi8_epi16(_mm256_maskz_loadu_epi8(mask, b + i));
-        apply_indexed<batches>([&](auto I) {
-            __m512i a16 = _mm512_cvtepi8_epi16(_mm256_maskz_loadu_epi8(mask, current_vecs[I] + i));
-            __m512i dist = _mm512_sub_epi16(a16, b16);
-            acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(dist, dist));
-        });
-    }
-
-    static inline f32_t finalize(__m512i acc, BSide /*unused*/) {
-        return (f32_t)_mm512_reduce_add_epi32(acc);
-    }
-
-    static inline f32_t scalar_tail(const int8_t* a, const int8_t* b, int32_t dims, BSide /*unused*/) {
-        return (f32_t)sqri8_inner(a, b, dims);
-    }
-};
-
-// Unified bulk i8 scoring template, parameterised by a Step policy.
+// The single-vector scorer `sqri8_inner` above uses the multi-accumulator
+// trick on the dim axis; bulk-side parallelism here comes from the batch axis.
 //
-// Iterates over `batches` document vectors in parallel per dimension step,
-// loading the query once per step and reusing it across all batched
-// documents to amortise b-side L1D bandwidth across the batch.
-//
-// Two independent unroll axes:
-//   batches    - number of distinct document vectors scored in parallel;
-//                amortises the query load and adds independent FMA chains
-//                across documents.
-//   unroll_dim - number of consecutive `step`-byte blocks of the same
-//                document processed per inner-loop iteration, each into its
-//                own accumulator. Hides FMA latency on Steps where the FMA
-//                throughput is not yet saturated by the `batches` chains
-//                alone (true for `DotI8Step`; explicitly unsupported on
-//                `SqrI8Step` whose port-5 cvt is the actual bottleneck).
-//
-// Prefetch strategy (head + spread):
-//   - At each batch boundary, prefetch the first `lines_per_iter` cache
-//     lines of every next-batch vector so the very first inner-loop iter
-//     never waits on a demand miss.
-//   - At each inner iter, prefetch `lines_per_iter` more cache lines per
-//     next-batch vector. The L1d fill-buffer never holds more than
-//     `batches * lines_per_iter` outstanding entries, vs the
-//     `batches * lines_to_fetch` peak of a boundary burst (which would
-//     overflow the per-core ~16-entry LFB on Sapphire Rapids).
-//   - For Steps whose `step` is < CACHE_LINE_SIZE (e.g. SqrI8Step at 32 B
-//     half a cache line), the spread is gated to fire only on the iter
-//     that crosses a cache-line boundary; per-iter `lines_per_iter` falls
-//     back to 1.
+// Prefetch strategy: head=1 + 1-line spread per cache-line boundary. Inner
+// step is half a cache line (32 bytes) so the spread prefetch is gated to
+// fire only on the iter that crosses into a new cache line.
 template <
     typename TData,
     const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
-    typename Step,
-    int batches = 4,
-    int unroll_dim = 1
+    int batches = 4
 >
-static inline void i8_bulk(
+static inline void sqri8_bulk(
     const TData* a, const int8_t* b, const int32_t dims, const int32_t pitch,
     const int32_t* offsets, const int32_t count, f32_t* results
 ) {
-    constexpr int step = Step::step;
-    constexpr int dimStride = step * unroll_dim;
-    // unroll_dim > 1 only makes sense when each iter consumes >= 1 cache
-    // line; otherwise the prefetch math collapses to lines_per_iter=1 and
-    // the extra accumulators provide no benefit. Steps that are bounded by
-    // a non-FMA port (e.g. SqrI8Step / port 5) reject unroll_dim>1
-    // separately via their own static_assert in `inner`.
-    static_assert(unroll_dim == 1 || dimStride >= CACHE_LINE_SIZE,
-        "unroll_dim>1 only supported when step * unroll_dim >= cache line size");
-    constexpr int lines_per_iter = (dimStride >= CACHE_LINE_SIZE) ? unroll_dim : 1;
-
-    const int blk = dims & ~(step - 1);
+    constexpr int chunk = sizeof(__m256i);  // 32 bytes -> 32 i8 -> __m512i of 16-bit
+    const int blk = dims & ~(chunk - 1);
     const int lines_to_fetch = dims / CACHE_LINE_SIZE + 1;
-    const auto b_side = Step::precompute_b(b, dims);
     int c = 0;
 
     const int8_t* current_vecs[batches];
@@ -453,53 +447,40 @@ static inline void i8_bulk(
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
             });
-            head_prefetch<batches, lines_per_iter>(next_vecs);
+            head_prefetch<batches, 1>(next_vecs);
         }
 
-        // Row-major layout: acc[I * unroll_dim + U] keeps the unroll_dim
-        // accumulators for batch member I contiguous, so tree_reduce can fold
-        // them in one call.
-        __m512i acc[batches * unroll_dim];
-        apply_indexed<batches * unroll_dim>([&](auto I) {
+        __m512i acc[batches];
+        apply_indexed<batches>([&](auto I) {
             acc[I] = _mm512_setzero_si512();
         });
 
         int i = 0;
-        for (; i + dimStride <= blk; i += dimStride) {
-            if (has_next) {
-                if constexpr (dimStride >= CACHE_LINE_SIZE) {
-                    spread_prefetch<batches, lines_per_iter>(next_vecs, i, lines_to_fetch);
-                } else if ((i & (CACHE_LINE_SIZE - 1)) == 0) {
-                    // step < cache line: prefetch one line, but only on the
-                    // iter that crosses a new cache-line boundary.
-                    spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
-                }
+        for (; i + chunk <= blk; i += chunk) {
+            if (has_next && (i & (CACHE_LINE_SIZE - 1)) == 0) {
+                spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
             }
-            Step::template inner<unroll_dim, batches>(acc, current_vecs, b, i);
-        }
-
-        // Fold the unroll_dim accumulators per batch into acc[I] before the
-        // unroll_dim=1 tail and the masked tail. Skipped at unroll_dim=1,
-        // where the main loop already wrote into acc[I*1+0] = acc[I].
-        if constexpr (unroll_dim > 1) {
+            __m512i b16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(b + i)));
             apply_indexed<batches>([&](auto I) {
-                acc[I] = tree_reduce<unroll_dim, __m512i, _mm512_add_epi32>(&acc[I * unroll_dim]);
+                __m512i a16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(current_vecs[I] + i)));
+                __m512i dist = _mm512_sub_epi16(a16, b16);
+                acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(dist, dist));
             });
-            for (; i + step <= blk; i += step) {
-                if (has_next) {
-                    spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
-                }
-                Step::template inner<1, batches>(acc, current_vecs, b, i);
-            }
         }
 
         const int rem = dims - i;
         if (rem > 0) {
-            Step::template masked_tail<batches>(acc, current_vecs, b, i, rem);
+            __mmask32 mask = (__mmask32)((1ULL << rem) - 1);
+            __m512i b16 = _mm512_cvtepi8_epi16(_mm256_maskz_loadu_epi8(mask, b + i));
+            apply_indexed<batches>([&](auto I) {
+                __m512i a16 = _mm512_cvtepi8_epi16(_mm256_maskz_loadu_epi8(mask, current_vecs[I] + i));
+                __m512i dist = _mm512_sub_epi16(a16, b16);
+                acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(dist, dist));
+            });
         }
 
         apply_indexed<batches>([&](auto I) {
-            results[c + I] = Step::finalize(acc[I], b_side);
+            results[c + I] = (f32_t)_mm512_reduce_add_epi32(acc[I]);
         });
 
         if (has_next) {
@@ -509,36 +490,12 @@ static inline void i8_bulk(
 
     for (; c < count; c++) {
         const int8_t* a0 = mapper(a, c, offsets, pitch);
-        results[c] = Step::scalar_tail(a0, b, dims, b_side);
+        results[c] = (f32_t)sqri8_inner(a0, b, dims);
     }
 }
 
-EXPORT void vec_doti8_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
-    i8_bulk<int8_t, sequential_mapper, DotI8Step, 4, 2>(a, b, dims, dims, NULL, count, results);
-}
-
-EXPORT void vec_doti8_bulk_offsets_2(
-    const int8_t* a,
-    const int8_t* b,
-    const int32_t dims,
-    const int32_t pitch,
-    const int32_t* offsets,
-    const int32_t count,
-    f32_t* results) {
-    i8_bulk<int8_t, offsets_mapper, DotI8Step, 4, 1>(a, b, dims, pitch, offsets, count, results);
-}
-
-EXPORT void vec_doti8_bulk_sparse_2(
-    const void* const* addresses,
-    const int8_t* b,
-    const int32_t dims,
-    const int32_t count,
-    f32_t* results) {
-    i8_bulk<const int8_t*, sparse_mapper, DotI8Step, 4, 2>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
-}
-
 EXPORT void vec_sqri8_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
-    i8_bulk<int8_t, sequential_mapper, SqrI8Step, 4, 1>(a, b, dims, dims, NULL, count, results);
+    sqri8_bulk<int8_t, sequential_mapper>(a, b, dims, dims, NULL, count, results);
 }
 
 EXPORT void vec_sqri8_bulk_offsets_2(
@@ -549,7 +506,7 @@ EXPORT void vec_sqri8_bulk_offsets_2(
     const int32_t* offsets,
     const int32_t count,
     f32_t* results) {
-    i8_bulk<int8_t, offsets_mapper, SqrI8Step, 4, 1>(a, b, dims, pitch, offsets, count, results);
+    sqri8_bulk<int8_t, offsets_mapper>(a, b, dims, pitch, offsets, count, results);
 }
 
 EXPORT void vec_sqri8_bulk_sparse_2(
@@ -558,7 +515,7 @@ EXPORT void vec_sqri8_bulk_sparse_2(
     const int32_t dims,
     const int32_t count,
     f32_t* results) {
-    i8_bulk<const int8_t*, sparse_mapper, SqrI8Step, 4, 1>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
+    sqri8_bulk<const int8_t*, sparse_mapper>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
 }
 
 // --- Cosine i8 (signed) AVX-512 ---

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
@@ -187,14 +187,28 @@ static inline int32_t doti8_inner_bulk(const int8_t* a, const int8_t* b, const i
     return (int32_t)(_mm512_reduce_add_epi32(total_ab) - b_correction);
 }
 
-// Bulk dot i8 with prefetch. Precomputes query correction once, then scores
-// each document with the lean DPBUSD-only inner loop.
-template <typename TData, const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t)>
+// Bulk dot i8 with shared query loads.
+//
+// Iterates over `batches` document vectors in parallel per dimension step,
+// loading the query once per step (XORed into u8 form for vpdpbusd) and
+// reusing it across all batched documents to amortise b-side L1D bandwidth
+// across the batch.
+//
+// The single-pair scorer `doti8_inner_bulk` above uses a multi-accumulator
+// pattern on the dim axis under its local `batches` constant; that pattern
+// is independent of the cross-document `batches` parallelism here.
+template <
+    typename TData,
+    const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
+    int batches = 4
+>
 static inline void doti8_bulk(
     const TData* a, const int8_t* b, const int32_t dims, const int32_t pitch,
     const int32_t* offsets, const int32_t count, f32_t* results
 ) {
-    constexpr int batches = 4;
+    constexpr int stride = sizeof(__m512i);
+    const int blk = dims & ~(stride - 1);
+    const __m512i xor_mask = _mm512_set1_epi8((char)0x80);
     const int lines_to_fetch = dims / CACHE_LINE_SIZE + 1;
     const int64_t b_correction = precompute_b_correction(b, dims);
     int c = 0;
@@ -212,8 +226,32 @@ static inline void doti8_bulk(
             });
         }
 
+        __m512i acc[batches];
         apply_indexed<batches>([&](auto I) {
-            results[c + I] = (f32_t)doti8_inner_bulk(current_vecs[I], b, dims, b_correction);
+            acc[I] = _mm512_setzero_si512();
+        });
+
+        int i = 0;
+        for (; i + stride <= blk; i += stride) {
+            __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
+            apply_indexed<batches>([&](auto I) {
+                __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));
+                acc[I] = _mm512_dpbusd_epi32(acc[I], _mm512_xor_si512(av, xor_mask), bv);
+            });
+        }
+
+        const int rem = dims - i;
+        if (rem > 0) {
+            __mmask64 mask = (__mmask64)_bzhi_u64(0xFFFFFFFFFFFFFFFFULL, rem);
+            __m512i bv = _mm512_maskz_loadu_epi8(mask, b + i);
+            apply_indexed<batches>([&](auto I) {
+                __m512i av = _mm512_maskz_loadu_epi8(mask, current_vecs[I] + i);
+                acc[I] = _mm512_dpbusd_epi32(acc[I], _mm512_xor_si512(av, xor_mask), bv);
+            });
+        }
+
+        apply_indexed<batches>([&](auto I) {
+            results[c + I] = (f32_t)(_mm512_reduce_add_epi32(acc[I]) - b_correction);
         });
 
         if (has_next) {
@@ -324,8 +362,85 @@ EXPORT f32_t vec_sqri8_2(const int8_t* a, const int8_t* b, const int32_t dims) {
     return (f32_t)sqri8_inner(a, b, dims);
 }
 
+// Bulk squared distance for signed int8 with shared query loads.
+//
+// The query is sign-extended to 16-bit once per chunk and reused across all
+// batches; this keeps `vpmovsxbw` off the critical path on the b stream
+// (Sapphire Rapids: vpmovsxbw is port-5-only, so one b cvt per outer step
+// instead of one per batched document removes a port-5 bottleneck).
+//
+// The single-vector scorer `sqri8_inner` above uses the multi-accumulator
+// trick on the dim axis; bulk-side parallelism here comes from the batch axis.
+template <
+    typename TData,
+    const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
+    int batches = 4
+>
+static inline void sqri8_bulk(
+    const TData* a, const int8_t* b, const int32_t dims, const int32_t pitch,
+    const int32_t* offsets, const int32_t count, f32_t* results
+) {
+    constexpr int chunk = sizeof(__m256i);  // 32 bytes -> 32 i8 -> __m512i of 16-bit
+    const int blk = dims & ~(chunk - 1);
+    const int lines_to_fetch = dims / CACHE_LINE_SIZE + 1;
+    int c = 0;
+
+    const int8_t* current_vecs[batches];
+    init_pointers<batches, TData, int8_t, mapper>(current_vecs, a, pitch, offsets, 0, count);
+
+    for (; c + batches - 1 < count; c += batches) {
+        const int8_t* next_vecs[batches];
+        const bool has_next = c + 2 * batches - 1 < count;
+        if (has_next) {
+            apply_indexed<batches>([&](auto I) {
+                next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
+                prefetch(next_vecs[I], lines_to_fetch);
+            });
+        }
+
+        __m512i acc[batches];
+        apply_indexed<batches>([&](auto I) {
+            acc[I] = _mm512_setzero_si512();
+        });
+
+        int i = 0;
+        for (; i + chunk <= blk; i += chunk) {
+            __m512i b16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(b + i)));
+            apply_indexed<batches>([&](auto I) {
+                __m512i a16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(current_vecs[I] + i)));
+                __m512i dist = _mm512_sub_epi16(a16, b16);
+                acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(dist, dist));
+            });
+        }
+
+        const int rem = dims - i;
+        if (rem > 0) {
+            __mmask32 mask = (__mmask32)((1ULL << rem) - 1);
+            __m512i b16 = _mm512_cvtepi8_epi16(_mm256_maskz_loadu_epi8(mask, b + i));
+            apply_indexed<batches>([&](auto I) {
+                __m512i a16 = _mm512_cvtepi8_epi16(_mm256_maskz_loadu_epi8(mask, current_vecs[I] + i));
+                __m512i dist = _mm512_sub_epi16(a16, b16);
+                acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(dist, dist));
+            });
+        }
+
+        apply_indexed<batches>([&](auto I) {
+            results[c + I] = (f32_t)_mm512_reduce_add_epi32(acc[I]);
+        });
+
+        if (has_next) {
+            std::copy_n(next_vecs, batches, current_vecs);
+        }
+    }
+
+    for (; c < count; c++) {
+        const int8_t* a0 = mapper(a, c, offsets, pitch);
+        results[c] = (f32_t)sqri8_inner(a0, b, dims);
+    }
+}
+
 EXPORT void vec_sqri8_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
-    call_i8_bulk<int8_t, sequential_mapper, sqri8_inner, 4>(a, b, dims, dims, NULL, count, results);
+    sqri8_bulk<int8_t, sequential_mapper>(a, b, dims, dims, NULL, count, results);
 }
 
 EXPORT void vec_sqri8_bulk_offsets_2(
@@ -336,7 +451,7 @@ EXPORT void vec_sqri8_bulk_offsets_2(
     const int32_t* offsets,
     const int32_t count,
     f32_t* results) {
-    call_i8_bulk<int8_t, offsets_mapper, sqri8_inner, 4>(a, b, dims, pitch, offsets, count, results);
+    sqri8_bulk<int8_t, offsets_mapper>(a, b, dims, pitch, offsets, count, results);
 }
 
 EXPORT void vec_sqri8_bulk_sparse_2(
@@ -345,7 +460,7 @@ EXPORT void vec_sqri8_bulk_sparse_2(
     const int32_t dims,
     const int32_t count,
     f32_t* results) {
-    call_i8_bulk<const int8_t*, sparse_mapper, sqri8_inner, 4>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
+    sqri8_bulk<const int8_t*, sparse_mapper>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
 }
 
 // --- Cosine i8 (signed) AVX-512 ---

--- a/libs/simdvec/native/src/vec/headers/amd64/amd64_vec_common.h
+++ b/libs/simdvec/native/src/vec/headers/amd64/amd64_vec_common.h
@@ -15,6 +15,45 @@ static inline void prefetch(const void* ptr, int lines) {
     }
 }
 
+// Head prefetch: at the batch boundary, fetch the first `lines` cache lines
+// of every next-batch vector so the very first inner-loop iter never waits
+// on a demand miss. Counterpart to `spread_prefetch` below.
+template <int batches, int lines, typename T>
+static inline void head_prefetch(const T* const (&next_vecs)[batches]) {
+    apply_indexed<batches>([&](auto I) {
+        const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
+        apply_indexed<lines>([&](auto K) {
+            _mm_prefetch((const void*)(base + K * CACHE_LINE_SIZE), _MM_HINT_T0);
+        });
+    });
+}
+
+// Spread prefetch: at outer-iter byte cursor `i` (relative to the document
+// start), fetch `lines_per_iter` cache lines starting `lines_per_iter` lines
+// ahead. Used together with `head_prefetch` to keep the per-core L1d
+// fill-buffer occupancy bounded (callers issue `batches * lines_per_iter`
+// prefetches per iter instead of `batches * lines_to_fetch` at the boundary).
+//
+// For callers whose outer step is < CACHE_LINE_SIZE the call site must gate
+// on `(i & (CACHE_LINE_SIZE - 1)) == 0` so the spread fires only on the iter
+// that crosses a cache-line boundary (otherwise we'd re-prefetch the same
+// line on consecutive iters).
+template <int batches, int lines_per_iter, typename T>
+static inline void spread_prefetch(
+    const T* const (&next_vecs)[batches], int i, int lines_to_fetch
+) {
+    const int next_line_start = i / CACHE_LINE_SIZE + lines_per_iter;
+    apply_indexed<lines_per_iter>([&](auto U) {
+        const int line = next_line_start + U;
+        if (line < lines_to_fetch) {
+            apply_indexed<batches>([&](auto I) {
+                const uintptr_t base = align_downwards<CACHE_LINE_SIZE>(next_vecs[I]);
+                _mm_prefetch((const void*)(base + line * CACHE_LINE_SIZE), _MM_HINT_T0);
+            });
+        }
+    });
+}
+
 /* Utility functions to perform reduce operations (horizontal ops) over a vector
  * It works by narrowing in half until you're down to 1 element.
  * Schematically, this works as depicted: from a starting vector whose elements


### PR DESCRIPTION
## Summary

Three-commit PR adding shared-b loads, an optional dim-axis unroll on the dot kernel, and a head + spread prefetch schedule for the AVX-512 Tier-2 i8 bulk kernels (`vec_doti8_bulk_*`, `vec_sqri8_bulk_*`).

## Commit layout

| commit | subject | contribution |
|---|---|---|
| `ca1c681` | `[Native] i8 bulk AVX-512 shared-b` | shared-b for `doti8_bulk` and `sqri8_bulk`. |
| `abeef4c` | `[Native] i8 bulk dot unroll_dim axis` | optional dim-axis unroll on `doti8_bulk`; `vec_doti8_bulk_2` / `_sparse_2` activated at `unroll_dim=2`. |
| `b690f91` | `[Native] i8 bulk head + spread prefetch` | replaces the burst prefetch with a head + per-iter spread schedule. |

## Why shared-b

The previous `call_i8_bulk<inner_op>` pattern (in [`amd64_vec_common.h`](libs/simdvec/native/src/vec/headers/amd64/amd64_vec_common.h)) called the single-pair scorer per document, redoing the `vpmovsxbw` sign-extension on `b` four times per outer step (sqri8) or reloading `b` four times per outer step (doti8). Hoisting `b` to the inner loop:

- Cuts L1D bandwidth on `b` 4×.
- For sqri8, removes 3 of the 4 port-5 `vpmovsxbw` instructions per outer step on Sapphire Rapids (`vpmovsxbw` is port-5-only → ~30% port-5 cut).
- Masks `b` once per chunk in the tail instead of once per doc.

## Why `unroll_dim` for `doti8`

`vpdpbusd` on Sapphire Rapids has ~4-cycle latency / ~0.5-cycle throughput on ports 0/5; with shared-b the loop becomes dependency-bound at one accumulator per batch. `unroll_dim=2` adds independent FMA chains along the dim axis to fill the latency window. The squared-distance kernel (`sqri8`) has a higher per-step op count and stays at the implicit `unroll_dim=1` (no template parameter).

## Why head + spread prefetch

Burst prefetch at the batch boundary issues `lines_to_fetch * batches` (~28–100) software prefetches back-to-back; on Intel server cores the per-core line-fill buffer (16 entries) saturates and most of those prefetches are silently dropped, leaving the inner loop to take demand misses.

The head + spread schedule:

- At the batch boundary, issues only `unroll_dim` prefetches per next-batch vector — covering the first cache lines the inner loop will consume.
- At each inner-loop iter, issues `unroll_dim` more prefetches per next-batch vector, targeting the lines the *next* outer iter will consume.

The total prefetch count per batch is unchanged; the LFB occupancy peak drops from `lines_to_fetch * batches` to `batches * unroll_dim` (4–8). Prefetched lines arrive ~1 outer iter before they are demand-loaded, hiding the L2 → L1 transfer latency. The L2 stream prefetcher coordinates better with the steady stride than with the boundary burst.

## Performance — `VectorScorerInt8BulkBenchmark` JMH (162 cells)

Hardware: Intel Xeon Platinum 8573C (Emerald Rapids), shared-tenant cloud VM. JMH params: `-wi 2 -w 2s -i 3 -r 3s -f 1`. `libvec.so` swapped between runs; Java code identical.

Grid: `function ∈ {DOT_PRODUCT, EUCLIDEAN} × dims ∈ {384, 1024, 1536} × bulkSize ∈ {32, 256, 1024} × numVectors ∈ {128, 1500, 130000} × method ∈ {scoreMultipleSequentialBulk, scoreMultipleRandomBulk, scoreQueryMultipleRandomBulk}`.

Aggregate **branch vs main** (mean / median, n=27 per row):

| function    | method                        |    mean |  median |
| ----------- | ----------------------------- | ------: | ------: |
| DOT_PRODUCT | scoreMultipleSequentialBulk   | +19.42% | +22.10% |
| DOT_PRODUCT | scoreMultipleRandomBulk       | +20.86% | +17.51% |
| DOT_PRODUCT | scoreQueryMultipleRandomBulk  | +22.62% | +27.02% |
| EUCLIDEAN   | scoreMultipleSequentialBulk   | +44.63% | +46.32% |
| EUCLIDEAN   | scoreMultipleRandomBulk       | +51.09% | +50.55% |
| EUCLIDEAN   | scoreQueryMultipleRandomBulk  | +45.55% | +46.14% |

- **All 81 EUCLIDEAN cells positive vs main**, single-cell range +9.4% to +104.2%.
- DOT_PRODUCT has a small residual at DRAM-bound corners: 9 of 81 cells in the −0.2% to −6.8% range, almost all clustered at `nv=130000` (one outlier at `dims=1024, bs=32, nv=1500, scoreMultipleRandomBulk`: −4.2%). Aggregate is still strongly positive.
- Top single-cell wins (all EUCLIDEAN, all `dims=1536, nv=1500` — L2-resident corner):
  - `bs=1024, scoreMultipleRandomBulk`: **+104.2%** (10,510 → 21,458 ops/s)
  - `bs=256,  scoreMultipleRandomBulk`: +98.9% (10,539 → 20,958)
  - `bs=1024, scoreQueryMultipleRandomBulk`: +86.5% (11,602 → 21,640)
  - `bs=256,  scoreMultipleSequentialBulk`: +80.1% (11,539 → 20,778)
  - `bs=32,   scoreMultipleRandomBulk`: +78.3% (10,585 → 18,869)

**Per-export coverage** — all 6 i8 exports JMH-covered:

| native export                    | JMH covers via                                    |
| -------------------------------- | ------------------------------------------------- |
| `vec_doti8_bulk_2`               | i8 sequential method, DOT_PRODUCT                 |
| `vec_doti8_bulk_offsets_2`       | i8 random method, DOT_PRODUCT                     |
| `vec_doti8_bulk_sparse_2`        | i8 query-random method, DOT_PRODUCT               |
| `vec_sqri8_bulk_2`               | i8 sequential method, EUCLIDEAN                   |
| `vec_sqri8_bulk_offsets_2`       | i8 random method, EUCLIDEAN                       |
| `vec_sqri8_bulk_sparse_2`        | i8 query-random method, EUCLIDEAN                 |

## Correctness

Validated locally with `bench/i8_i7u_bulk_correctness.cpp` (not in the tree — same convention as #147672) against an i32-exact reference for `doti8` and `sqri8` on sequential / offsets / sparse layouts across `dims ∈ {64, 65, 96, 128, 256, 257, 768, 1024, 1536, 4096}` × `count ∈ {1, 8, 16, 17, 32, 100, 1000}`. All sub-checks pass on the current branch state.

## Caveats

- DOT_PRODUCT has 9 of 81 i8 cells with branch vs main between −0.2% and −6.8%, all clustered at `nv=130000` (DRAM-bound). The aggregate is still strongly positive (means +19% to +23% across the 3 methods); flagged here for reviewer awareness.
- JMH only on Sapphire Rapids / Emerald Rapids (Xeon Platinum 8573C). AMD Turin and Cooper Lake remain TBD.
- libvec version not bumped in this PR. Coordinated bump + Artifactory upload needed for the wins to take effect, ideally batched with #147672.

## Out-of-scope follow-ups

- Extract the per-iter prefetch block into a helper in [`amd64_vec_common.h`](libs/simdvec/native/src/vec/headers/amd64/amd64_vec_common.h) if reviewers prefer that to ~20 lines of inline duplication across the 2 templates (see the first comment on this PR for context).
- Address the residual `dims=384, nv=130000` DRAM-bound DOT_PRODUCT cells if they prove material on production fleet hardware.
- libvec version bump + Artifactory upload coordination with #147672.
