### PR TITLE
[9.2] Move flaky assertion to IT from yamlRestTest (#147834)

### DIFF
--- a/qa/smoke-test-http/src/internalClusterTest/java/org/elasticsearch/http/HttpStatsIT.java
+++ b/qa/smoke-test-http/src/internalClusterTest/java/org/elasticsearch/http/HttpStatsIT.java
@@ -22,10 +22,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -84,6 +86,8 @@ public class HttpStatsIT extends HttpSmokeTestCase {
     }
 
     private void assertHttpStats(XContentTestUtils.JsonMapView jsonMapView) {
+        assertClientStats(jsonMapView);
+
         final List<String> routes = List.of("/", "/_cat/nodes", "/{index}/_search", "/_cluster/state");
 
         for (var route : routes) {
@@ -112,5 +116,47 @@ public class HttpStatsIT extends HttpSmokeTestCase {
                 ltMillis > 1 ? notNullValue() : nullValue()
             );
         }
+    }
+
+    /**
+     * Assert the per-client fields exposed under {@code http.clients}.
+     * We have an internal cluster and a known rest client, so we can deterministically
+     * locate the client(s) that have served at least one request and assert the full shape.
+     */
+    private static void assertClientStats(XContentTestUtils.JsonMapView jsonMapView) {
+        final List<?> clients = jsonMapView.get("http.clients");
+        assertThat(clients, not(empty()));
+
+        // the same lower bound the yaml test used to have.
+        final long minEpochMillis = 1684328268000L;
+
+        // Filter out requests freshly made or inactive by request_count >= 1. Those entries are guaranteed
+        // to have every field populated.
+        int assertedClients = 0;
+        for (int i = 0; i < clients.size(); i++) {
+            final String prefix = "http.clients." + i;
+            final Number requestCount = jsonMapView.get(prefix + ".request_count");
+            if (requestCount == null || requestCount.longValue() < 1) {
+                continue;
+            }
+            assertedClients += 1;
+
+            final Number id = jsonMapView.get(prefix + ".id");
+            final Number openedTimeMillis = jsonMapView.get(prefix + ".opened_time_millis");
+            final Number lastRequestTimeMillis = jsonMapView.get(prefix + ".last_request_time_millis");
+            final Number requestSizeBytes = jsonMapView.get(prefix + ".request_size_bytes");
+
+            assertThat(id.longValue(), greaterThanOrEqualTo(1L));
+
+            assertThat(jsonMapView.get(prefix + ".agent"), notNullValue());
+            assertThat(jsonMapView.get(prefix + ".local_address"), notNullValue());
+            assertThat(jsonMapView.get(prefix + ".remote_address"), notNullValue());
+            assertThat(jsonMapView.get(prefix + ".last_uri"), notNullValue());
+            assertThat(openedTimeMillis.longValue(), greaterThanOrEqualTo(minEpochMillis));
+            assertThat(lastRequestTimeMillis.longValue(), greaterThanOrEqualTo(openedTimeMillis.longValue()));
+            assertThat(requestCount.longValue(), greaterThanOrEqualTo(1L));
+            assertThat(requestSizeBytes.longValue(), greaterThanOrEqualTo(0L));
+        }
+        assertThat("expected at least one client with request_count >= 1, got: " + clients, assertedClients, greaterThanOrEqualTo(1));
     }
 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.info/20_info_http.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.info/20_info_http.yml
@@ -13,13 +13,12 @@
   - gte: { http.total_opened: 1 }
   - is_true: http.clients
   - gte: { http.clients.0.id: 1 }
-  - match: { http.clients.0.agent: "/.*/" }
-  - match: { http.clients.0.local_address: "/.*/" }
-  - match: { http.clients.0.remote_address: "/.*/" }
-  - is_true:  http.clients.0.last_uri
   - gte: { http.clients.0.opened_time_millis: 1684328268000 } # 2023-05-17
-  - gte: { http.clients.0.last_request_time_millis: 1684328268000 }
-  - gte: { http.clients.0.request_count: 1 }
-  - gte: { http.clients.0.request_size_bytes: 0 }
-    # values for clients.0.closed_time_millis, clients.0.x_forwarded_for, and clients.0.x_opaque_id are often
-    # null and cannot be tested here
+    # Other per-client fields (agent, local_address, remote_address, last_uri,
+    # last_request_time_millis, request_count, request_size_bytes,
+    # closed_time_millis, x_forwarded_for, x_opaque_id) are populated lazily
+    # from the first request on the channel and may be unset on a freshly
+    # accepted connection. The clients list ordering is also non-deterministic,
+    # so clients.0 may be any tracked channel. Deeper assertions on these
+    # fields live in HttpStatsIT, where the test client can be located
+    # deterministically.


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Move flaky assertion to IT from yamlRestTest (#147834)