### PR TITLE
[ESQL] Add index-based range accessors to FileList

### DIFF
--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -45,6 +45,7 @@ import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FileLayout;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
@@ -74,9 +75,9 @@ import java.util.OptionalLong;
  * ESQL's columnar {@link Block}/{@link Page} model. Each ORC {@link ColumnVector} is
  * converted directly to the corresponding ESQL Block type.
  *
- * <p>Supports stripe-level split parallelism: {@link #discoverSplitRanges} exposes
- * per-stripe byte ranges, and {@link #readRange} restricts reading to stripes within
- * a given byte range via ORC's {@code Reader.Options.range()}.
+ * <p>Supports stripe-level split parallelism: {@link #resolveFileLayout} exposes
+ * per-stripe byte ranges (alongside file metadata), and {@link #readRange} restricts
+ * reading to stripes within a given byte range via ORC's {@code Reader.Options.range()}.
  *
  * <p>Key features:
  * <ul>
@@ -115,17 +116,51 @@ public class OrcFormatReader implements RangeAwareFormatReader {
         return this;
     }
 
+    /**
+     * Resolves both schema/statistics and split ranges in a single pass over the ORC file's
+     * footer. This is the single primitive of the {@link RangeAwareFormatReader} SPI; the
+     * inherited {@code metadata} default discards the split ranges for metadata-only callers
+     * and still pays exactly one footer read per call.
+     */
     @Override
-    public SourceMetadata metadata(StorageObject object) throws IOException {
+    public FileLayout resolveFileLayout(StorageObject object) throws IOException {
         OrcStorageObjectAdapter fs = new OrcStorageObjectAdapter(object);
         Path path = new Path(object.path().toString());
-        OrcFile.ReaderOptions options = orcReaderOptions(fs);
-        try (Reader reader = OrcFile.createReader(path, options)) {
-            TypeDescription schema = reader.getSchema();
-            List<Attribute> attributes = convertOrcSchemaToAttributes(schema);
-            SourceStatistics statistics = extractStatistics(reader, schema);
-            return new SimpleSourceMetadata(attributes, formatName(), object.path().toString(), statistics, null);
+        try (Reader reader = OrcFile.createReader(path, orcReaderOptions(fs))) {
+            SourceMetadata metadata = buildMetadata(reader, object);
+            List<SplitRange> ranges = buildSplitRangesFromStripes(reader);
+            return new FileLayout(metadata, ranges);
         }
+    }
+
+    private SourceMetadata buildMetadata(Reader reader, StorageObject object) {
+        TypeDescription schema = reader.getSchema();
+        List<Attribute> attributes = convertOrcSchemaToAttributes(schema);
+        SourceStatistics statistics = extractStatistics(reader, schema);
+        return new SimpleSourceMetadata(attributes, formatName(), object.path().toString(), statistics, null);
+    }
+
+    private static List<SplitRange> buildSplitRangesFromStripes(Reader reader) throws IOException {
+        List<StripeInformation> stripes = reader.getStripes();
+        if (stripes.isEmpty()) {
+            return List.of();
+        }
+        List<StripeStatistics> stripeStats = reader.getStripeStatistics();
+        TypeDescription schema = reader.getSchema();
+        if (stripes.size() == 1) {
+            StripeInformation stripe = stripes.getFirst();
+            Map<String, Object> stats = stripeStats.isEmpty() == false
+                ? buildStripeStats(stripe, stripeStats.getFirst(), schema)
+                : Map.of();
+            return List.of(new SplitRange(stripe.getOffset(), stripe.getLength(), stats));
+        }
+        List<SplitRange> ranges = new ArrayList<>(stripes.size());
+        for (int i = 0; i < stripes.size(); i++) {
+            StripeInformation stripe = stripes.get(i);
+            Map<String, Object> stats = (i < stripeStats.size()) ? buildStripeStats(stripe, stripeStats.get(i), schema) : Map.of();
+            ranges.add(new SplitRange(stripe.getOffset(), stripe.getLength(), stats));
+        }
+        return ranges;
     }
 
     /**
@@ -256,34 +291,6 @@ public class OrcFormatReader implements RangeAwareFormatReader {
 
         CloseableIterator<Page> iter = new OrcPageIterator(reader, rows, schema, projectedAttributes, batchSize, blockFactory);
         return rowLimit != NO_LIMIT ? new RowLimitingIterator(iter, rowLimit) : iter;
-    }
-
-    @Override
-    public List<SplitRange> discoverSplitRanges(StorageObject object) throws IOException {
-        OrcStorageObjectAdapter fs = new OrcStorageObjectAdapter(object);
-        Path path = new Path(object.path().toString());
-        try (Reader reader = OrcFile.createReader(path, orcReaderOptions(fs))) {
-            List<StripeInformation> stripes = reader.getStripes();
-            if (stripes.isEmpty()) {
-                return List.of();
-            }
-            List<StripeStatistics> stripeStats = reader.getStripeStatistics();
-            TypeDescription schema = reader.getSchema();
-            if (stripes.size() == 1) {
-                StripeInformation stripe = stripes.getFirst();
-                Map<String, Object> stats = stripeStats.isEmpty() == false
-                    ? buildStripeStats(stripe, stripeStats.getFirst(), schema)
-                    : Map.of();
-                return List.of(new SplitRange(stripe.getOffset(), stripe.getLength(), stats));
-            }
-            List<SplitRange> ranges = new ArrayList<>(stripes.size());
-            for (int i = 0; i < stripes.size(); i++) {
-                StripeInformation stripe = stripes.get(i);
-                Map<String, Object> stats = (i < stripeStats.size()) ? buildStripeStats(stripe, stripeStats.get(i), schema) : Map.of();
-                ranges.add(new SplitRange(stripe.getOffset(), stripe.getLength(), stats));
-            }
-            return ranges;
-        }
     }
 
     private static Map<String, Object> buildStripeStats(StripeInformation stripe, StripeStatistics stats, TypeDescription schema) {

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.FileLayout;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
@@ -105,7 +106,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         List<Attribute> attributes = metadata.schema();
 
         assertEquals(4, attributes.size());
@@ -344,7 +345,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals("orc", metadata.sourceType());
     }
 
@@ -458,7 +459,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.DATETIME, metadata.schema().get(1).dataType());
 
         readFirstPage(reader, storageObject, null, page -> {
@@ -564,7 +565,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.KEYWORD, metadata.schema().get(1).dataType());
 
         readFirstPage(reader, storageObject, null, page -> {
@@ -751,7 +752,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.DATETIME, metadata.schema().get(1).dataType());
 
         readFirstPage(reader, storageObject, null, page -> {
@@ -797,7 +798,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.DATETIME, metadata.schema().get(1).dataType());
 
         readFirstPage(reader, storageObject, null, page -> {
@@ -827,7 +828,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.UNSUPPORTED, metadata.schema().get(1).dataType());
 
         readFirstPage(reader, storageObject, null, page -> {
@@ -860,7 +861,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.DOUBLE, metadata.schema().get(1).dataType());
 
         readFirstPage(reader, storageObject, null, page -> {
@@ -946,7 +947,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.DOUBLE, metadata.schema().get(1).dataType());
 
         readFirstPage(reader, storageObject, null, page -> {
@@ -974,7 +975,7 @@ public class OrcFormatReaderTests extends ESTestCase {
 
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
-        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertEquals("Single-stripe file should return one range with stats", 1, ranges.size());
         SplitRange range = ranges.getFirst();
         assertTrue("Range offset must be non-negative", range.offset() >= 0);
@@ -992,8 +993,72 @@ public class OrcFormatReaderTests extends ESTestCase {
 
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
-        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertTrue("Empty file (no stripes) should return empty ranges", ranges.isEmpty());
+    }
+
+    /**
+     * Sanity check that two consecutive {@code resolveFileLayout} calls on the same file
+     * produce equivalent metadata and split ranges. Previously this test compared
+     * {@code resolveFileLayout} against the now-removed {@code metadata} +
+     * {@code discoverSplitRanges} primitives; with the SPI collapsed to a single primitive,
+     * it remains useful as an idempotence check across calls.
+     */
+    public void testResolveFileLayoutIsStableAcrossCalls() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct()
+            .addField("id", TypeDescription.createLong())
+            .addField("name", TypeDescription.createString());
+        byte[] orcData = createMultiStripeOrcFile(schema, 3, batchIndex -> {
+            VectorizedRowBatch batch = schema.createRowBatch();
+            batch.size = 50;
+            LongColumnVector idCol = (LongColumnVector) batch.cols[0];
+            BytesColumnVector nameCol = (BytesColumnVector) batch.cols[1];
+            for (int i = 0; i < 50; i++) {
+                idCol.vector[i] = batchIndex * 50L + i;
+                nameCol.setVal(i, ("n_" + (batchIndex * 50 + i)).getBytes(StandardCharsets.UTF_8));
+            }
+            return batch;
+        });
+
+        StorageObject storageObject = createStorageObject(orcData);
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+
+        FileLayout firstLayout = reader.resolveFileLayout(storageObject);
+        SourceMetadata expectedMetadata = firstLayout.metadata();
+        List<SplitRange> expectedRanges = firstLayout.splitRanges();
+
+        FileLayout layout = reader.resolveFileLayout(storageObject);
+
+        assertNotNull(layout.metadata());
+        assertEquals("Schema size should match", expectedMetadata.schema().size(), layout.metadata().schema().size());
+        for (int i = 0; i < expectedMetadata.schema().size(); i++) {
+            Attribute expected = expectedMetadata.schema().get(i);
+            Attribute actual = layout.metadata().schema().get(i);
+            assertEquals("attribute name at " + i, expected.name(), actual.name());
+            assertEquals("attribute type at " + i, expected.dataType(), actual.dataType());
+        }
+        assertEquals("Source types should match", expectedMetadata.sourceType(), layout.metadata().sourceType());
+
+        assertEquals("Number of split ranges should match", expectedRanges.size(), layout.splitRanges().size());
+        for (int i = 0; i < expectedRanges.size(); i++) {
+            SplitRange expected = expectedRanges.get(i);
+            SplitRange actual = layout.splitRanges().get(i);
+            assertEquals("Range offset should match at index " + i, expected.offset(), actual.offset());
+            assertEquals("Range length should match at index " + i, expected.length(), actual.length());
+            assertEquals("Range stats should match at index " + i, expected.statistics(), actual.statistics());
+        }
+    }
+
+    public void testResolveFileLayoutEmptyFile() throws Exception {
+        TypeDescription schema = TypeDescription.createStruct().addField("id", TypeDescription.createLong());
+        byte[] orcData = createOrcFile(schema, batch -> batch.size = 0);
+
+        StorageObject storageObject = createStorageObject(orcData);
+        OrcFormatReader reader = new OrcFormatReader(blockFactory);
+
+        FileLayout layout = reader.resolveFileLayout(storageObject);
+        assertNotNull(layout.metadata());
+        assertTrue(layout.splitRanges().isEmpty());
     }
 
     public void testDiscoverSplitRanges_multiStripeFile() throws Exception {
@@ -1015,7 +1080,7 @@ public class OrcFormatReaderTests extends ESTestCase {
 
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
-        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
 
         assertTrue("Multi-stripe file should return non-empty ranges", ranges.size() >= 2);
         for (SplitRange range : ranges) {
@@ -1054,7 +1119,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertTrue("Should have multiple stripes", ranges.size() >= 2);
 
         // First stripe: all values should be 0
@@ -1107,7 +1172,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(orcData);
         OrcFormatReader reader = new OrcFormatReader(blockFactory);
 
-        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertTrue("Should have multiple stripes", ranges.size() >= 2);
 
         readFirstRangePage(reader, storageObject, ranges.get(0), List.of("name", "score"), page -> {
@@ -1142,7 +1207,7 @@ public class OrcFormatReaderTests extends ESTestCase {
             .build();
         OrcFormatReader reader = (OrcFormatReader) new OrcFormatReader(blockFactory).withPushedFilter(sarg);
 
-        List<SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertTrue("Should have multiple stripes", ranges.size() >= 2);
 
         assertEquals("Filter should exclude all rows in this stripe", 0, countRangeRows(reader, storageObject, ranges.get(0)));

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -48,6 +48,7 @@ import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FileLayout;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
@@ -222,18 +223,29 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         return new IOException("Could not read [" + uri + "] as a Parquet file: " + detail, e);
     }
 
+    /**
+     * Resolves both schema/statistics and split ranges in a single pass over the Parquet file's
+     * footer. This avoids the double footer read that would otherwise happen when {@code metadata}
+     * and split discovery are invoked separately during planning.
+     */
     @Override
-    public SourceMetadata metadata(StorageObject object) throws IOException {
+    public FileLayout resolveFileLayout(StorageObject object) throws IOException {
         InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
         ParquetReadOptions options = readOptionsBuilder().build();
 
         try (ParquetFileReader reader = openParquetFile(object, parquetInputFile, options)) {
             FileMetaData fileMetaData = reader.getFileMetaData();
             MessageType parquetSchema = fileMetaData.getSchema();
-            List<Attribute> schema = convertParquetSchemaToAttributes(parquetSchema);
-            SourceStatistics statistics = extractStatistics(reader, parquetSchema);
-            return new SimpleSourceMetadata(schema, formatName(), object.path().toString(), statistics, null);
+            SourceMetadata metadata = buildSourceMetadata(reader, parquetSchema, object);
+            List<SplitRange> ranges = buildSplitRangesFromRowGroups(reader);
+            return new FileLayout(metadata, ranges);
         }
+    }
+
+    private SourceMetadata buildSourceMetadata(ParquetFileReader reader, MessageType parquetSchema, StorageObject object) {
+        List<Attribute> schema = convertParquetSchemaToAttributes(parquetSchema);
+        SourceStatistics statistics = extractStatistics(reader, parquetSchema);
+        return new SimpleSourceMetadata(schema, formatName(), object.path().toString(), statistics, null);
     }
 
     @SuppressWarnings("rawtypes")
@@ -473,36 +485,31 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         // No resources to close at the reader level
     }
 
-    @Override
-    public List<SplitRange> discoverSplitRanges(StorageObject object) throws IOException {
-        InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
-        ParquetReadOptions options = readOptionsBuilder().build();
-        try (ParquetFileReader reader = openParquetFile(object, parquetInputFile, options)) {
-            List<BlockMetaData> rowGroups = reader.getRowGroups();
-            if (rowGroups.isEmpty()) {
-                return List.of();
-            }
-            if (rowGroups.size() == 1) {
-                BlockMetaData block = rowGroups.getFirst();
-                Map<String, Object> stats = buildRowGroupStats(block);
-                return List.of(new SplitRange(block.getStartingPos(), block.getCompressedSize(), stats));
-            }
-            List<SplitRange> ranges = new ArrayList<>(rowGroups.size());
-            for (BlockMetaData block : rowGroups) {
-                Map<String, Object> stats = buildRowGroupStats(block);
-                // Use the compressed on-disk size for the SplitRange length: this value is fed to
-                // readRange() which builds a byte range end = startingPos + length for Parquet's
-                // withRange(rangeStart, rangeEnd) filter. That filter includes a row group when its
-                // starting position lies in the range, so the end must land at or before the next
-                // row group's starting position. getTotalByteSize() returns the uncompressed size
-                // (much larger than what is actually on disk), which would make adjacent ranges
-                // overlap in byte space and cause Parquet to select each row group from multiple
-                // splits, producing duplicate rows.
-                ranges.add(new SplitRange(block.getStartingPos(), block.getCompressedSize(), stats));
-            }
-            List<SplitRange> coalesced = coalesceRowGroupRanges(ranges, DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES);
-            return coalesced.size() < 2 ? ranges : coalesced;
+    private static List<SplitRange> buildSplitRangesFromRowGroups(ParquetFileReader reader) {
+        List<BlockMetaData> rowGroups = reader.getRowGroups();
+        if (rowGroups.isEmpty()) {
+            return List.of();
         }
+        if (rowGroups.size() == 1) {
+            BlockMetaData block = rowGroups.getFirst();
+            Map<String, Object> stats = buildRowGroupStats(block);
+            return List.of(new SplitRange(block.getStartingPos(), block.getCompressedSize(), stats));
+        }
+        List<SplitRange> ranges = new ArrayList<>(rowGroups.size());
+        for (BlockMetaData block : rowGroups) {
+            Map<String, Object> stats = buildRowGroupStats(block);
+            // Use the compressed on-disk size for the SplitRange length: this value is fed to
+            // readRange() which builds a byte range end = startingPos + length for Parquet's
+            // withRange(rangeStart, rangeEnd) filter. That filter includes a row group when its
+            // starting position lies in the range, so the end must land at or before the next
+            // row group's starting position. getTotalByteSize() returns the uncompressed size
+            // (much larger than what is actually on disk), which would make adjacent ranges
+            // overlap in byte space and cause Parquet to select each row group from multiple
+            // splits, producing duplicate rows.
+            ranges.add(new SplitRange(block.getStartingPos(), block.getCompressedSize(), stats));
+        }
+        List<SplitRange> coalesced = coalesceRowGroupRanges(ranges, DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES);
+        return coalesced.size() < 2 ? ranges : coalesced;
     }
 
     @SuppressWarnings("rawtypes")

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -141,7 +141,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         List<Attribute> attributes = metadata.schema();
 
         assertEquals(4, attributes.size());
@@ -349,7 +349,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             var reader = new ParquetFormatReader(limitedFactory);
 
             // Read the schema without creating any ESQL block. This is enough to trip the breaker.
-            assertThrows(CircuitBreakingException.class, () -> reader.metadata(storageObject));
+            assertThrows(CircuitBreakingException.class, () -> reader.resolveFileLayout(storageObject));
 
             // Sanity check
             assertEquals(0, limitedFactory.breaker().getUsed());
@@ -360,7 +360,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             var reader = new ParquetFormatReader(limitedFactory);
 
             // Read the schema is now ok
-            var metadata = reader.metadata(storageObject);
+            var metadata = reader.resolveFileLayout(storageObject).metadata();
             assertEquals(0, limitedFactory.breaker().getUsed());
 
             // Reading a page trips the breaker
@@ -871,7 +871,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.DOUBLE, metadata.schema().get(0).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
@@ -904,7 +904,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.DOUBLE, metadata.schema().get(0).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
@@ -995,7 +995,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.DATETIME, metadata.schema().get(0).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
@@ -1080,7 +1080,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.DATETIME, metadata.schema().get(0).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
@@ -1118,7 +1118,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.DOUBLE, metadata.schema().get(0).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
@@ -1156,7 +1156,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.KEYWORD, metadata.schema().get(0).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
@@ -1194,7 +1194,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.INTEGER, metadata.schema().get(0).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
@@ -1239,7 +1239,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals(DataType.KEYWORD, metadata.schema().get(0).dataType());
 
         try (CloseableIterator<Page> iterator = reader.read(storageObject, null, 10)) {
@@ -1329,7 +1329,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals("parquet", metadata.sourceType());
     }
 
@@ -1355,7 +1355,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertTrue("statistics() should be present", metadata.statistics().isPresent());
 
         var stats = metadata.statistics().get();
@@ -1398,7 +1398,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
 
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
 
         var stats = metadata.statistics().orElseThrow();
         var enriched = org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer.embedStatistics(
@@ -1416,7 +1416,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertEquals("delta", maxCity);
 
         // Also verify per-split stats if we can force multi-row-group
-        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         for (RangeAwareFormatReader.SplitRange range : ranges) {
             for (Map.Entry<String, Object> entry : range.statistics().entrySet()) {
                 assertFalse("Split stat value must not be a Parquet Binary: " + entry.getKey(), entry.getValue() instanceof Binary);
@@ -1430,7 +1430,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertTrue("Expected multiple ranges for multi-row-group file, got " + ranges.size(), ranges.size() > 1);
 
         for (RangeAwareFormatReader.SplitRange range : ranges) {
@@ -1453,7 +1453,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertEquals("Single row group file should return one range with stats", 1, ranges.size());
         RangeAwareFormatReader.SplitRange range = ranges.getFirst();
         assertTrue("Range offset must be non-negative", range.offset() >= 0);
@@ -1470,7 +1470,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertTrue("Empty file (no row groups) should return empty ranges", ranges.isEmpty());
     }
 
@@ -1496,7 +1496,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertEquals(1, ranges.size());
         Map<String, Object> stats = ranges.getFirst().statistics();
         assertEquals(100L, stats.get("_stats.row_count"));
@@ -1516,7 +1516,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         Arrays.fill(garbage, (byte) 0x5a);
         StorageObject storageObject = createStorageObject(garbage, "s3://bucket/path/file.parquet");
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
-        IOException ex = expectThrows(IOException.class, () -> reader.metadata(storageObject));
+        IOException ex = expectThrows(IOException.class, () -> reader.resolveFileLayout(storageObject));
         assertThat(
             ex.getMessage(),
             allOf(
@@ -1529,7 +1529,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
     public void testInvalidParquetOpenEmptyFile() throws Exception {
         StorageObject storageObject = createStorageObject(new byte[0], "memory://empty.parquet");
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
-        IOException ex = expectThrows(IOException.class, () -> reader.metadata(storageObject));
+        IOException ex = expectThrows(IOException.class, () -> reader.resolveFileLayout(storageObject));
         assertThat(
             ex.getMessage(),
             allOf(
@@ -1549,7 +1549,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         byte[] truncated = Arrays.copyOf(full, Math.max(1, full.length / 8));
         StorageObject storageObject = createStorageObject(truncated, "https://host/obj.parquet");
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
-        IOException ex = expectThrows(IOException.class, () -> reader.metadata(storageObject));
+        IOException ex = expectThrows(IOException.class, () -> reader.resolveFileLayout(storageObject));
         assertTrue(ex.getMessage(), ex.getMessage().contains("https://host/obj.parquet"));
     }
 
@@ -1558,7 +1558,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         byte[] parquetData = createParquetFile(schema, factory -> List.of());
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
-        SourceMetadata metadata = reader.metadata(storageObject);
+        SourceMetadata metadata = reader.resolveFileLayout(storageObject).metadata();
         assertEquals("id", metadata.schema().get(0).name());
     }
 
@@ -1769,7 +1769,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertTrue("Need at least 2 ranges for this test, got " + ranges.size(), ranges.size() >= 2);
 
         int totalRowsFromRanges = 0;
@@ -1822,7 +1822,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
 
-        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertTrue("Need at least 3 ranges for this regression test, got " + ranges.size(), ranges.size() >= 3);
 
         // Byte ranges must be sorted and non-overlapping (end_i <= start_{i+1}).
@@ -1885,7 +1885,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             }
         }
 
-        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertTrue("Need at least 2 ranges for this test, got " + ranges.size(), ranges.size() >= 2);
 
         List<String> rangeRows = new ArrayList<>();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -309,6 +309,8 @@ public class ExternalSourceResolver {
             extMetadata = enrichSchemaWithPartitionColumns(extMetadata, partitionMetadata);
         }
 
+        // Only anchor file ranges are captured here (FIRST_FILE_WINS opens only the anchor for schema);
+        // non-anchor files fall back to the slow path during split discovery.
         if (anchorRanges != null && anchorRanges.isEmpty() == false) {
             listing = GlobExpander.withFileSplitRanges(listing, Map.of(anchorPath, anchorRanges));
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -28,8 +28,10 @@ import org.elasticsearch.xpack.esql.datasources.cache.SchemaCacheEntry;
 import org.elasticsearch.xpack.esql.datasources.cache.SchemaCacheKey;
 import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FileLayout;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -49,6 +51,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Resolver for external data sources (Iceberg tables, Parquet files, etc.).
@@ -176,6 +179,10 @@ public class ExternalSourceResolver {
 
         ExternalSourceMetadata extMetadata;
         StorageObject object;
+        // Captures split ranges produced by single-pass file layout resolution (e.g. Parquet/ORC).
+        // On a schema cache hit the file is not re-opened during resolution, so no ranges are
+        // captured here -- split discovery falls back to opening the file (status quo).
+        List<RangeAwareFormatReader.SplitRange> capturedRanges = null;
         if (isCacheable(provider)) {
             // Stat the file first (cheap HEAD/stat) to get mtime for the cache key.
             // Null mtime (e.g. gRPC/Flight, GCS/Azure fixtures) falls back to EPOCH so the
@@ -186,18 +193,24 @@ public class ExternalSourceResolver {
             long mtime = lastMod != null ? lastMod.toEpochMilli() : Instant.EPOCH.toEpochMilli();
             String formatType = detectFormatType(storagePath);
             SchemaCacheKey schemaKey = SchemaCacheKey.build(storagePath.toString(), mtime, formatType, config);
+            // Captures split ranges only when the loader runs (cache miss); stays null on cache hit.
+            AtomicReference<List<RangeAwareFormatReader.SplitRange>> rangesHolder = new AtomicReference<>();
             SchemaCacheEntry schemaEntry = cacheService.getOrComputeSchema(schemaKey, k -> {
-                SourceMetadata meta = resolveSingleSource(path, config);
+                FileLayout layout = resolveSingleFileLayout(path, config);
+                SourceMetadata meta = layout.metadata();
+                rangesHolder.set(layout.splitRanges());
                 Map<String, Object> enrichedMeta = meta.statistics()
                     .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
                     .orElse(meta.sourceMetadata());
                 return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta, meta.config());
             });
+            capturedRanges = rangesHolder.get();
             List<Attribute> schema = schemaEntry.toAttributes();
             extMetadata = buildMetadataFromCache(schemaEntry, schema, config);
         } else {
-            SourceMetadata metadata = resolveSingleSource(path, config);
-            extMetadata = wrapAsExternalSourceMetadata(metadata, config);
+            FileLayout layout = resolveSingleFileLayout(path, config);
+            extMetadata = wrapAsExternalSourceMetadata(layout.metadata(), config);
+            capturedRanges = layout.splitRanges();
             object = provider.newObject(storagePath);
         }
 
@@ -205,6 +218,9 @@ public class ExternalSourceResolver {
             List.of(new StorageEntry(storagePath, object.length(), object.lastModified())),
             path
         );
+        if (capturedRanges != null && capturedRanges.isEmpty() == false) {
+            singletonList = GlobExpander.withFileSplitRanges(singletonList, Map.of(storagePath, capturedRanges));
+        }
         return new ExternalSourceResolution.ResolvedSource(extMetadata, singletonList);
     }
 
@@ -259,21 +275,28 @@ public class ExternalSourceResolver {
         long anchorMtime = listing.lastModifiedMillis(anchor);
 
         ExternalSourceMetadata extMetadata;
+        // Capture anchor-file split ranges from single-pass resolution (cache miss only).
+        List<RangeAwareFormatReader.SplitRange> anchorRanges = null;
         if (cacheable) {
             String formatType = detectFormatType(anchorPath);
             SchemaCacheKey schemaKey = SchemaCacheKey.build(anchorPath.toString(), anchorMtime, formatType, config);
+            AtomicReference<List<RangeAwareFormatReader.SplitRange>> rangesHolder = new AtomicReference<>();
             SchemaCacheEntry schemaEntry = cacheService.getOrComputeSchema(schemaKey, k -> {
-                SourceMetadata meta = resolveSingleSource(anchorPath.toString(), config);
+                FileLayout layout = resolveSingleFileLayout(anchorPath.toString(), config);
+                SourceMetadata meta = layout.metadata();
+                rangesHolder.set(layout.splitRanges());
                 Map<String, Object> enrichedMeta = meta.statistics()
                     .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
                     .orElse(meta.sourceMetadata());
                 return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta, meta.config());
             });
+            anchorRanges = rangesHolder.get();
             List<Attribute> schema = schemaEntry.toAttributes();
             extMetadata = buildMetadataFromCache(schemaEntry, schema, config);
         } else {
-            SourceMetadata metadata = resolveSingleSource(anchorPath.toString(), config);
-            extMetadata = wrapAsExternalSourceMetadata(metadata, config);
+            FileLayout layout = resolveSingleFileLayout(anchorPath.toString(), config);
+            extMetadata = wrapAsExternalSourceMetadata(layout.metadata(), config);
+            anchorRanges = layout.splitRanges();
         }
 
         extMetadata = enrichWithFileCount(extMetadata, listing.fileCount());
@@ -284,6 +307,10 @@ public class ExternalSourceResolver {
         PartitionMetadata partitionMetadata = listing.partitionMetadata();
         if (partitionMetadata != null && partitionMetadata.isEmpty() == false) {
             extMetadata = enrichSchemaWithPartitionColumns(extMetadata, partitionMetadata);
+        }
+
+        if (anchorRanges != null && anchorRanges.isEmpty() == false) {
+            listing = GlobExpander.withFileSplitRanges(listing, Map.of(anchorPath, anchorRanges));
         }
 
         return new ExternalSourceResolution.ResolvedSource(extMetadata, listing);
@@ -379,7 +406,8 @@ public class ExternalSourceResolver {
         FormatReader.SchemaResolution schemaResolution
     ) throws Exception {
         long startNanos = System.nanoTime();
-        Map<StoragePath, SourceMetadata> allMetadata = readAllFileMetadata(fileList, config);
+        AllFileLayouts layouts = readAllFileLayouts(fileList, config);
+        Map<StoragePath, SourceMetadata> allMetadata = layouts.metadata();
         long durationMs = (System.nanoTime() - startNanos) / 1_000_000;
 
         LOGGER.debug("Schema reconciliation [{}]: scanned {} files in {}ms", schemaResolution, allMetadata.size(), durationMs);
@@ -402,27 +430,42 @@ public class ExternalSourceResolver {
         }
 
         FileList enriched = GlobExpander.withSchemaInfo(fileList, result.perFileInfo());
+        if (layouts.splitRanges().isEmpty() == false) {
+            enriched = GlobExpander.withFileSplitRanges(enriched, layouts.splitRanges());
+        }
         return new ExternalSourceResolution.ResolvedSource(extMetadata, enriched);
     }
 
     /**
-     * Reads metadata from all files in parallel with bounded concurrency.
-     * Uses a semaphore to cap the number of concurrent metadata reads.
+     * Aggregate result of reading all files' layouts in parallel: the per-file metadata used for
+     * schema reconciliation, plus per-file split ranges captured for free during the same open.
      */
-    private Map<StoragePath, SourceMetadata> readAllFileMetadata(FileList fileList, Map<String, Object> config) throws Exception {
+    private record AllFileLayouts(
+        Map<StoragePath, SourceMetadata> metadata,
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> splitRanges
+    ) {}
+
+    /**
+     * Reads layouts (metadata + optional split ranges) from all files in parallel with bounded
+     * concurrency. Uses a semaphore to cap the number of concurrent reads.
+     */
+    private AllFileLayouts readAllFileLayouts(FileList fileList, Map<String, Object> config) throws Exception {
         int fileCount = fileList.fileCount();
 
         if (fileCount == 1) {
             StoragePath filePath = fileList.path(0);
-            SourceMetadata meta = resolveSingleSource(filePath.toString(), config);
-            return Map.of(filePath, meta);
+            FileLayout layout = resolveSingleFileLayout(filePath.toString(), config);
+            Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> ranges = layout.splitRanges().isEmpty()
+                ? Map.of()
+                : Map.of(filePath, layout.splitRanges());
+            return new AllFileLayouts(Map.of(filePath, layout.metadata()), ranges);
         }
 
         Semaphore semaphore = new Semaphore(Math.min(fileCount, MAX_PARALLEL_METADATA_READS));
         AtomicBoolean failed = new AtomicBoolean(false);
 
         @SuppressWarnings("unchecked")
-        CompletableFuture<Map.Entry<StoragePath, SourceMetadata>>[] futures = new CompletableFuture[fileCount];
+        CompletableFuture<Map.Entry<StoragePath, FileLayout>>[] futures = new CompletableFuture[fileCount];
 
         for (int i = 0; i < fileCount; i++) {
             StoragePath filePath = fileList.path(i);
@@ -433,8 +476,8 @@ public class ExternalSourceResolver {
                 try {
                     semaphore.acquire();
                     try {
-                        SourceMetadata meta = resolveSingleSource(filePath.toString(), config);
-                        return Map.entry(filePath, meta);
+                        FileLayout layout = resolveSingleFileLayout(filePath.toString(), config);
+                        return Map.entry(filePath, layout);
                     } finally {
                         semaphore.release();
                     }
@@ -458,14 +501,19 @@ public class ExternalSourceResolver {
             throw new RuntimeException("Failed to read file metadata in parallel", cause != null ? cause : e);
         }
 
-        Map<StoragePath, SourceMetadata> result = new LinkedHashMap<>();
-        for (CompletableFuture<Map.Entry<StoragePath, SourceMetadata>> future : futures) {
-            Map.Entry<StoragePath, SourceMetadata> entry = future.get();
+        Map<StoragePath, SourceMetadata> metadata = new LinkedHashMap<>();
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> splitRanges = new LinkedHashMap<>();
+        for (CompletableFuture<Map.Entry<StoragePath, FileLayout>> future : futures) {
+            Map.Entry<StoragePath, FileLayout> entry = future.get();
             if (entry != null) {
-                result.put(entry.getKey(), entry.getValue());
+                FileLayout layout = entry.getValue();
+                metadata.put(entry.getKey(), layout.metadata());
+                if (layout.splitRanges().isEmpty() == false) {
+                    splitRanges.put(entry.getKey(), layout.splitRanges());
+                }
             }
         }
-        return result;
+        return new AllFileLayouts(metadata, splitRanges);
     }
 
     private ExternalSourceMetadata buildUnifiedMetadata(
@@ -550,7 +598,13 @@ public class ExternalSourceResolver {
         return "false".equalsIgnoreCase(value.toString()) == false;
     }
 
-    private SourceMetadata resolveSingleSource(String path, Map<String, Object> config) {
+    /**
+     * Resolves the {@link FileLayout} (metadata + optional pre-computed split ranges) for a single
+     * path by iterating the registered {@link ExternalSourceFactory factories}. For range-aware
+     * file factories this captures schema and split ranges in a single open; other factories
+     * yield an empty range list.
+     */
+    private FileLayout resolveSingleFileLayout(String path, Map<String, Object> config) {
         // Early scheme validation: reject unsupported schemes without loading any plugin factories
         try {
             StoragePath parsed = StoragePath.of(path);
@@ -570,7 +624,7 @@ public class ExternalSourceResolver {
         for (ExternalSourceFactory factory : dataSourceModule.sourceFactories().values()) {
             if (factory.canHandle(path)) {
                 try {
-                    return factory.resolveMetadata(path, config);
+                    return factory.resolveFileLayout(path, config);
                 } catch (Exception e) {
                     LOGGER.debug("Factory [{}] claimed path [{}] but failed: {}", factory.type(), path, e.getMessage());
                     lastFailure = e;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -12,8 +12,10 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSourceFactory;
+import org.elasticsearch.xpack.esql.datasources.spi.FileLayout;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceOperatorFactoryProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
@@ -97,6 +99,11 @@ final class FileSourceFactory implements ExternalSourceFactory {
 
     @Override
     public SourceMetadata resolveMetadata(String location, Map<String, Object> config) {
+        return resolveFileLayout(location, config).metadata();
+    }
+
+    @Override
+    public FileLayout resolveFileLayout(String location, Map<String, Object> config) {
         try {
             StoragePath storagePath = StoragePath.of(location);
             String scheme = storagePath.scheme();
@@ -113,7 +120,12 @@ final class FileSourceFactory implements ExternalSourceFactory {
                 throw new IOException("File does not exist: " + location);
             }
             FormatReader reader = resolveFormatReader(storagePath.objectName(), config).withConfig(config);
-            return reader.metadata(storageObject);
+            // For range-aware (columnar) formats, read schema and split ranges in a single pass.
+            // Other formats only have schema; split discovery is a no-op for them.
+            if (reader instanceof RangeAwareFormatReader rangeReader) {
+                return rangeReader.resolveFileLayout(storageObject);
+            }
+            return FileLayout.ofMetadata(reader.metadata(storageObject));
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to resolve metadata for [" + location + "]", e);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -195,7 +195,7 @@ public class FileSplitProvider implements SplitProvider {
                 continue;
             }
 
-            if (tryRangeAwareSplits(fileList, filePath, fileLength, format, config, partitionValues, columnMapping, splits)) {
+            if (tryRangeAwareSplits(fileList, i, filePath, fileLength, format, config, partitionValues, columnMapping, splits)) {
                 continue;
             }
 
@@ -362,6 +362,7 @@ public class FileSplitProvider implements SplitProvider {
      */
     private boolean tryRangeAwareSplits(
         FileList fileList,
+        int fileIndex,
         StoragePath filePath,
         long fileLength,
         String format,
@@ -372,13 +373,27 @@ public class FileSplitProvider implements SplitProvider {
     ) {
         // Fast path: pre-resolved ranges captured during metadata resolution. This avoids a
         // second open of the file (e.g. Parquet footer read) on remote storage.
-        Map<StoragePath, List<SplitRange>> preResolved = fileList != null ? fileList.fileSplitRanges() : null;
-        if (preResolved != null) {
-            List<SplitRange> cached = preResolved.get(filePath);
-            if (cached != null && cached.isEmpty() == false) {
-                LOGGER.trace("Using {} pre-resolved split ranges for [{}]", cached.size(), filePath);
-                buildSplitsFromRanges(cached, filePath, fileLength, format, config, partitionValues, columnMapping, splits);
+        if (fileList != null) {
+            int rc = fileList.rangeCount(fileIndex);
+            if (rc > 0) {
+                LOGGER.trace("Using {} pre-resolved split ranges for [{}]", rc, filePath);
+                buildSplitsFromIndexedRanges(
+                    fileList,
+                    fileIndex,
+                    rc,
+                    filePath,
+                    fileLength,
+                    format,
+                    config,
+                    partitionValues,
+                    columnMapping,
+                    splits
+                );
                 return true;
+            }
+            // rc == 0: resolution ran but produced no ranges — skip range-aware, fall through to single-split
+            if (rc == 0) {
+                return false;
             }
         }
 
@@ -417,6 +432,40 @@ public class FileSplitProvider implements SplitProvider {
         } catch (IOException e) {
             LOGGER.warn("Failed to discover split ranges for [{}], falling back to single split", filePath, e);
             return false;
+        }
+    }
+
+    private static void buildSplitsFromIndexedRanges(
+        FileList fileList,
+        int fileIndex,
+        int rangeCount,
+        StoragePath filePath,
+        long fileLength,
+        String format,
+        Map<String, Object> config,
+        Map<String, Object> partitionValues,
+        @Nullable SchemaReconciliation.ColumnMapping columnMapping,
+        List<ExternalSplit> splits
+    ) {
+        Map<String, Object> splitConfig = new HashMap<>(config);
+        splitConfig.put(RANGE_SPLIT_KEY, "true");
+        splitConfig.put(FILE_LENGTH_KEY, Long.toString(fileLength));
+
+        for (int r = 0; r < rangeCount; r++) {
+            SplitStats stats = fileList.rangeStats(fileIndex, r);
+            splits.add(
+                FileSplit.withSplitStats(
+                    "file",
+                    filePath,
+                    fileList.rangeOffset(fileIndex, r),
+                    fileList.rangeLength(fileIndex, r),
+                    format,
+                    splitConfig,
+                    partitionValues,
+                    columnMapping,
+                    stats
+                )
+            );
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -195,7 +195,7 @@ public class FileSplitProvider implements SplitProvider {
                 continue;
             }
 
-            if (tryRangeAwareSplits(filePath, fileLength, format, config, partitionValues, columnMapping, splits)) {
+            if (tryRangeAwareSplits(fileList, filePath, fileLength, format, config, partitionValues, columnMapping, splits)) {
                 continue;
             }
 
@@ -351,10 +351,17 @@ public class FileSplitProvider implements SplitProvider {
 
     /**
      * Attempts to create range-aware splits for columnar formats (e.g. Parquet row groups).
-     * The format reader reads file metadata (e.g. Parquet footer) to discover independently
-     * readable byte ranges. Returns true if range-aware splits were created.
+     * <p>
+     * Fast path: when the {@link FileList} carries pre-resolved ranges from single-pass file
+     * layout resolution (see {@link RangeAwareFormatReader#resolveFileLayout}), the file is not
+     * re-opened here -- splits are built directly from the cached ranges.
+     * <p>
+     * Slow path: when no pre-resolved ranges are available, the format reader reads file metadata
+     * (e.g. Parquet footer) to discover independently readable byte ranges. Returns true if
+     * range-aware splits were created.
      */
     private boolean tryRangeAwareSplits(
+        FileList fileList,
         StoragePath filePath,
         long fileLength,
         String format,
@@ -363,6 +370,18 @@ public class FileSplitProvider implements SplitProvider {
         @Nullable SchemaReconciliation.ColumnMapping columnMapping,
         List<ExternalSplit> splits
     ) {
+        // Fast path: pre-resolved ranges captured during metadata resolution. This avoids a
+        // second open of the file (e.g. Parquet footer read) on remote storage.
+        Map<StoragePath, List<SplitRange>> preResolved = fileList != null ? fileList.fileSplitRanges() : null;
+        if (preResolved != null) {
+            List<SplitRange> cached = preResolved.get(filePath);
+            if (cached != null && cached.isEmpty() == false) {
+                LOGGER.trace("Using {} pre-resolved split ranges for [{}]", cached.size(), filePath);
+                buildSplitsFromRanges(cached, filePath, fileLength, format, config, partitionValues, columnMapping, splits);
+                return true;
+            }
+        }
+
         if (formatRegistry == null || storageRegistry == null || format == null) {
             return false;
         }
@@ -388,35 +407,48 @@ public class FileSplitProvider implements SplitProvider {
             }
             StorageObject object = provider.newObject(filePath, fileLength);
 
-            List<SplitRange> ranges = rangeReader.discoverSplitRanges(object);
+            List<SplitRange> ranges = rangeReader.resolveFileLayout(object).splitRanges();
             if (ranges.isEmpty()) {
                 return false;
             }
 
-            Map<String, Object> splitConfig = new HashMap<>(config);
-            splitConfig.put(RANGE_SPLIT_KEY, "true");
-            splitConfig.put(FILE_LENGTH_KEY, Long.toString(fileLength));
-
-            for (SplitRange range : ranges) {
-                Map<String, Object> rangeStats = range.statistics().isEmpty() ? null : range.statistics();
-                splits.add(
-                    new FileSplit(
-                        "file",
-                        filePath,
-                        range.offset(),
-                        range.length(),
-                        format,
-                        splitConfig,
-                        partitionValues,
-                        columnMapping,
-                        rangeStats
-                    )
-                );
-            }
+            buildSplitsFromRanges(ranges, filePath, fileLength, format, config, partitionValues, columnMapping, splits);
             return true;
         } catch (IOException e) {
             LOGGER.warn("Failed to discover split ranges for [{}], falling back to single split", filePath, e);
             return false;
+        }
+    }
+
+    private static void buildSplitsFromRanges(
+        List<SplitRange> ranges,
+        StoragePath filePath,
+        long fileLength,
+        String format,
+        Map<String, Object> config,
+        Map<String, Object> partitionValues,
+        @Nullable SchemaReconciliation.ColumnMapping columnMapping,
+        List<ExternalSplit> splits
+    ) {
+        Map<String, Object> splitConfig = new HashMap<>(config);
+        splitConfig.put(RANGE_SPLIT_KEY, "true");
+        splitConfig.put(FILE_LENGTH_KEY, Long.toString(fileLength));
+
+        for (SplitRange range : ranges) {
+            Map<String, Object> rangeStats = range.statistics().isEmpty() ? null : range.statistics();
+            splits.add(
+                new FileSplit(
+                    "file",
+                    filePath,
+                    range.offset(),
+                    range.length(),
+                    format,
+                    splitConfig,
+                    partitionValues,
+                    columnMapping,
+                    rangeStats
+                )
+            );
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/CompactRangeStore.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/CompactRangeStore.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.glob;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xpack.esql.datasources.SplitStats;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.IntFunction;
+
+/**
+ * Compact storage of per-file byte ranges using CSR (Compressed Sparse Row) indexing
+ * and dictionary encoding for length templates and split statistics.
+ * <p>
+ * Per-range offsets are stored explicitly (ranges need not be contiguous within a file).
+ * Per-range lengths are stored via a length template dictionary: files with identical
+ * range-length sequences share the same {@code long[]} instance, reducing memory when
+ * many files have the same row-group geometry (common for Parquet files written by the
+ * same job).
+ * <p>
+ * Per-range {@link SplitStats} are deduplicated via a dictionary so that ranges with
+ * identical statistics share a single object reference.
+ * <p>
+ * Returns {@code null} from {@link #build} when ranges contain invalid data (negative
+ * offsets, non-positive lengths) — callers fall back to the slow path.
+ */
+final class CompactRangeStore {
+
+    private static final Logger LOGGER = LogManager.getLogger(CompactRangeStore.class);
+
+    private final int[] fileRangeStarts;         // CSR, length = fileCount + 1
+    private final long[][] lengthTemplates;      // unique length sequences
+    private final short[] fileLengthTemplateId;  // per-file -> template index
+    private final long[] rangeOffsets;            // per-range offset, length = totalRanges
+    private final SplitStats[] statsDictionary;  // unique SplitStats objects
+    private final short[] rangeStatsId;          // per-range -> stats dict index, length = totalRanges
+
+    private CompactRangeStore(
+        int[] fileRangeStarts,
+        long[][] lengthTemplates,
+        short[] fileLengthTemplateId,
+        long[] rangeOffsets,
+        SplitStats[] statsDictionary,
+        short[] rangeStatsId
+    ) {
+        this.fileRangeStarts = fileRangeStarts;
+        this.lengthTemplates = lengthTemplates;
+        this.fileLengthTemplateId = fileLengthTemplateId;
+        this.rangeOffsets = rangeOffsets;
+        this.statsDictionary = statsDictionary;
+        this.rangeStatsId = rangeStatsId;
+    }
+
+    int rangeCount(int fileIndex) {
+        return fileRangeStarts[fileIndex + 1] - fileRangeStarts[fileIndex];
+    }
+
+    long rangeOffset(int fileIndex, int rangeIndex) {
+        return rangeOffsets[fileRangeStarts[fileIndex] + rangeIndex];
+    }
+
+    long rangeLength(int fileIndex, int rangeIndex) {
+        return lengthTemplates[Short.toUnsignedInt(fileLengthTemplateId[fileIndex])][rangeIndex];
+    }
+
+    @Nullable
+    SplitStats rangeStats(int fileIndex, int rangeIndex) {
+        int globalIndex = fileRangeStarts[fileIndex] + rangeIndex;
+        short id = rangeStatsId[globalIndex];
+        return id < 0 ? null : statsDictionary[id];
+    }
+
+    long estimatedBytes() {
+        // object header
+        long bytes = 64;
+        // fileRangeStarts
+        bytes += (long) fileRangeStarts.length * Integer.BYTES;
+        // lengthTemplates: array of arrays
+        bytes += (long) lengthTemplates.length * 16; // array references + headers
+        for (long[] template : lengthTemplates) {
+            bytes += (long) template.length * Long.BYTES;
+        }
+        // fileLengthTemplateId
+        bytes += (long) fileLengthTemplateId.length * Short.BYTES;
+        // rangeOffsets
+        bytes += (long) rangeOffsets.length * Long.BYTES;
+        // statsDictionary: array of references
+        bytes += (long) statsDictionary.length * 8;
+        // rangeStatsId
+        bytes += (long) rangeStatsId.length * Short.BYTES;
+        return bytes;
+    }
+
+    /**
+     * Builds a compact range store from the given file-to-range mapping.
+     * Returns {@code null} if the map is null, empty, or no file has any ranges.
+     *
+     * @param fileCount    the number of files
+     * @param pathAt       function returning the {@link StoragePath} for a file index
+     * @param rangesByPath mapping from storage path to split ranges
+     * @return the compact store, or {@code null} if there are no ranges
+     */
+    @Nullable
+    static CompactRangeStore build(
+        int fileCount,
+        IntFunction<StoragePath> pathAt,
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath
+    ) {
+        if (rangesByPath == null || rangesByPath.isEmpty()) {
+            return null;
+        }
+
+        // Materialize paths once — pathAt.apply() may reconstruct paths from dictionaries
+        StoragePath[] paths = new StoragePath[fileCount];
+        for (int f = 0; f < fileCount; f++) {
+            paths[f] = pathAt.apply(f);
+        }
+
+        int[] fileRangeStarts = new int[fileCount + 1];
+        short[] fileLengthTemplateId = new short[fileCount];
+
+        Map<LongArrayKey, Short> templateDict = new HashMap<>();
+        int templateCount = 0;
+        long[][] tempTemplates = new long[16][];
+
+        Map<SplitStats, Short> statsDict = new HashMap<>();
+        int statsCount = 0;
+        SplitStats[] tempStats = new SplitStats[16];
+
+        int totalRanges = 0;
+        boolean hasAnyRange = false;
+
+        for (int f = 0; f < fileCount; f++) {
+            List<RangeAwareFormatReader.SplitRange> ranges = rangesByPath.get(paths[f]);
+            int count = (ranges != null) ? ranges.size() : 0;
+            fileRangeStarts[f] = totalRanges;
+            totalRanges += count;
+            if (count > 0) {
+                hasAnyRange = true;
+            }
+        }
+        fileRangeStarts[fileCount] = totalRanges;
+
+        if (hasAnyRange == false) {
+            return null;
+        }
+
+        long[] rangeOffsets = new long[totalRanges];
+        short[] rangeStatsId = new short[totalRanges];
+        Arrays.fill(rangeStatsId, (short) -1);
+
+        for (int f = 0; f < fileCount; f++) {
+            StoragePath path = paths[f];
+            List<RangeAwareFormatReader.SplitRange> ranges = rangesByPath.get(path);
+            int count = (ranges != null) ? ranges.size() : 0;
+
+            if (count == 0) {
+                long[] emptyLengths = new long[0];
+                LongArrayKey key = new LongArrayKey(emptyLengths);
+                Short existingEmpty = templateDict.get(key);
+                if (existingEmpty != null) {
+                    fileLengthTemplateId[f] = existingEmpty;
+                } else {
+                    if (templateCount >= 65535) {
+                        LOGGER.debug("Template dictionary overflow ({} templates); falling back to slow path", templateCount);
+                        return null;
+                    }
+                    short id = (short) templateCount;
+                    if (templateCount >= tempTemplates.length) {
+                        tempTemplates = Arrays.copyOf(tempTemplates, tempTemplates.length * 2);
+                    }
+                    tempTemplates[templateCount++] = emptyLengths;
+                    templateDict.put(key, id);
+                    fileLengthTemplateId[f] = id;
+                }
+                continue;
+            }
+
+            int globalStart = fileRangeStarts[f];
+            long[] lengths = new long[count];
+            for (int r = 0; r < count; r++) {
+                RangeAwareFormatReader.SplitRange range = ranges.get(r);
+                if (range.offset() < 0 || range.length() <= 0) {
+                    LOGGER.warn(
+                        "Aborting compact range store build: invalid range for [{}] (offset={}, length={}); falling back to slow path",
+                        path,
+                        range.offset(),
+                        range.length()
+                    );
+                    return null;
+                }
+                rangeOffsets[globalStart + r] = range.offset();
+                lengths[r] = range.length();
+            }
+
+            LongArrayKey key = new LongArrayKey(lengths);
+            Short existingId = templateDict.get(key);
+            if (existingId != null) {
+                fileLengthTemplateId[f] = existingId;
+            } else {
+                if (templateCount > Short.MAX_VALUE) {
+                    return null;
+                }
+                short id = (short) templateCount;
+                if (templateCount >= tempTemplates.length) {
+                    tempTemplates = Arrays.copyOf(tempTemplates, tempTemplates.length * 2);
+                }
+                tempTemplates[templateCount++] = lengths;
+                templateDict.put(key, id);
+                fileLengthTemplateId[f] = id;
+            }
+
+            for (int r = 0; r < count; r++) {
+                Map<String, Object> statsMap = ranges.get(r).statistics();
+                SplitStats stats = SplitStats.of(statsMap);
+                if (stats != null) {
+                    Short sid = statsDict.get(stats);
+                    if (sid != null) {
+                        rangeStatsId[globalStart + r] = sid;
+                    } else {
+                        if (statsCount > Short.MAX_VALUE) {
+                            LOGGER.debug("Stats dictionary overflow ({} entries); falling back to slow path", statsCount);
+                            return null;
+                        }
+                        if (statsCount >= tempStats.length) {
+                            tempStats = Arrays.copyOf(tempStats, tempStats.length * 2);
+                        }
+                        tempStats[statsCount] = stats;
+                        statsDict.put(stats, (short) statsCount);
+                        rangeStatsId[globalStart + r] = (short) statsCount;
+                        statsCount++;
+                    }
+                }
+            }
+        }
+
+        long[][] lengthTemplates = Arrays.copyOf(tempTemplates, templateCount);
+        SplitStats[] statsDictionary = Arrays.copyOf(tempStats, statsCount);
+
+        return new CompactRangeStore(fileRangeStarts, lengthTemplates, fileLengthTemplateId, rangeOffsets, statsDictionary, rangeStatsId);
+    }
+
+    /**
+     * Wrapper for {@code long[]} that provides value-based {@code equals} and {@code hashCode}
+     * using {@link Arrays#equals(long[], long[])} and {@link Arrays#hashCode(long[])}.
+     */
+    private record LongArrayKey(long[] values) {
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof LongArrayKey that) {
+                return Arrays.equals(values, that.values);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(values);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/DictionaryFileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/DictionaryFileList.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources.glob;
 
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
+import org.elasticsearch.xpack.esql.datasources.SplitStats;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
@@ -34,6 +35,8 @@ final class DictionaryFileList implements FileList {
     @Nullable
     private final PartitionMetadata partitionMetadata;
     private final int fileCount;
+    @Nullable
+    private final CompactRangeStore ranges;
 
     DictionaryFileList(
         String basePath,
@@ -45,7 +48,8 @@ final class DictionaryFileList implements FileList {
         @Nullable String sharedExtension,
         @Nullable String originalPattern,
         @Nullable PartitionMetadata partitionMetadata,
-        int fileCount
+        int fileCount,
+        @Nullable CompactRangeStore ranges
     ) {
         this.basePath = basePath;
         this.tokens = tokens;
@@ -57,6 +61,23 @@ final class DictionaryFileList implements FileList {
         this.originalPattern = originalPattern;
         this.partitionMetadata = partitionMetadata;
         this.fileCount = fileCount;
+        this.ranges = ranges;
+    }
+
+    DictionaryFileList withRanges(CompactRangeStore ranges) {
+        return new DictionaryFileList(
+            basePath,
+            tokens,
+            pathTokens,
+            pathStarts,
+            sizes,
+            mtimesMillis,
+            sharedExtension,
+            originalPattern,
+            partitionMetadata,
+            fileCount,
+            ranges
+        );
     }
 
     @Override
@@ -114,6 +135,27 @@ final class DictionaryFileList implements FileList {
     }
 
     @Override
+    public int rangeCount(int i) {
+        return ranges != null ? ranges.rangeCount(i) : -1;
+    }
+
+    @Override
+    public long rangeOffset(int i, int r) {
+        return ranges != null ? ranges.rangeOffset(i, r) : 0L;
+    }
+
+    @Override
+    public long rangeLength(int i, int r) {
+        return ranges != null ? ranges.rangeLength(i, r) : size(i);
+    }
+
+    @Override
+    @Nullable
+    public SplitStats rangeStats(int i, int r) {
+        return ranges != null ? ranges.rangeStats(i, r) : null;
+    }
+
+    @Override
     public long estimatedBytes() {
         // object header + reference fields
         long bytes = 64;
@@ -130,7 +172,7 @@ final class DictionaryFileList implements FileList {
         if (sharedExtension != null) {
             bytes += 40 + sharedExtension.length() * (long) Character.BYTES;
         }
-        return bytes;
+        return bytes + (ranges != null ? ranges.estimatedBytes() : 0);
     }
 
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/FileListCompactor.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources.glob;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.util.ArrayList;
@@ -43,14 +44,15 @@ final class FileListCompactor {
             return raw;
         }
         String normalizedBase = normalizeBase(basePath);
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath = raw.fileSplitRanges();
         PartitionMetadata pm = raw.partitionMetadata();
         if (pm != null && pm.isEmpty() == false) {
-            FileList hive = tryHive(normalizedBase, raw, pm);
+            FileList hive = tryHive(normalizedBase, raw, pm, rangesByPath);
             if (hive != null) {
                 return hive;
             }
         }
-        FileList dict = tryDictionary(normalizedBase, raw);
+        FileList dict = tryDictionary(normalizedBase, raw, rangesByPath);
         if (dict != null) {
             return dict;
         }
@@ -70,7 +72,12 @@ final class FileListCompactor {
     // ------------------------------------------------------------------
 
     @SuppressWarnings("unchecked")
-    private static FileList tryHive(String normalizedBase, GenericFileList raw, PartitionMetadata pm) {
+    private static FileList tryHive(
+        String normalizedBase,
+        GenericFileList raw,
+        PartitionMetadata pm,
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath
+    ) {
         List<StorageEntry> files = raw.files();
         int count = files.size();
         String[] colNames = pm.partitionColumns().keySet().toArray(new String[0]);
@@ -116,6 +123,7 @@ final class FileListCompactor {
         long[] orderedSizes = new long[count];
         String[] orderedLeafNames = new String[count];
         long[] orderedMtimes = new long[count];
+        StoragePath[] orderedPaths = new StoragePath[count];
 
         String sharedExt = null;
         boolean extChecked = false;
@@ -136,6 +144,7 @@ final class FileListCompactor {
 
             for (int fi : fileIndices) {
                 StorageEntry entry = files.get(fi);
+                orderedPaths[filePos] = entry.path();
                 orderedSizes[filePos] = entry.length();
                 orderedMtimes[filePos] = entry.lastModified().toEpochMilli();
 
@@ -193,6 +202,8 @@ final class FileListCompactor {
             colValDicts[c] = colValLists[c].toArray(new String[0]);
         }
 
+        CompactRangeStore rangeStore = CompactRangeStore.build(count, i -> orderedPaths[i], rangesByPath);
+
         return new HiveFileList(
             normalizedBase,
             colNames,
@@ -206,7 +217,8 @@ final class FileListCompactor {
             sharedExt,
             raw.originalPattern(),
             raw.partitionMetadata(),
-            count
+            count,
+            rangeStore
         );
     }
 
@@ -214,7 +226,11 @@ final class FileListCompactor {
     // Dictionary-encoded encoding
     // ------------------------------------------------------------------
 
-    private static FileList tryDictionary(String normalizedBase, GenericFileList raw) {
+    private static FileList tryDictionary(
+        String normalizedBase,
+        GenericFileList raw,
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath
+    ) {
         List<StorageEntry> files = raw.files();
         int count = files.size();
         long[] sizes = new long[count];
@@ -321,6 +337,8 @@ final class FileListCompactor {
 
         String[] tokenArray = tokenList.toArray(new String[0]);
 
+        CompactRangeStore rangeStore = CompactRangeStore.build(count, i -> files.get(i).path(), rangesByPath);
+
         return new DictionaryFileList(
             normalizedBase,
             tokenArray,
@@ -331,7 +349,8 @@ final class FileListCompactor {
             sharedExt,
             raw.originalPattern(),
             raw.partitionMetadata(),
-            count
+            count,
+            rangeStore
         );
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GenericFileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GenericFileList.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources.glob;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.SchemaReconciliation;
+import org.elasticsearch.xpack.esql.datasources.SplitStats;
 import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
@@ -86,10 +87,36 @@ final class GenericFileList implements FileList {
         return fileSchemaInfo;
     }
 
+    @Nullable
+    Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> fileSplitRanges() {
+        return fileSplitRanges;
+    }
+
+    @Override
+    public int rangeCount(int i) {
+        if (fileSplitRanges == null) {
+            return -1;
+        }
+        StoragePath p = path(i);
+        List<RangeAwareFormatReader.SplitRange> ranges = fileSplitRanges.get(p);
+        return ranges != null ? ranges.size() : 0;
+    }
+
+    @Override
+    public long rangeOffset(int i, int r) {
+        return fileSplitRanges.get(path(i)).get(r).offset();
+    }
+
+    @Override
+    public long rangeLength(int i, int r) {
+        return fileSplitRanges.get(path(i)).get(r).length();
+    }
+
     @Override
     @Nullable
-    public Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> fileSplitRanges() {
-        return fileSplitRanges;
+    public SplitStats rangeStats(int i, int r) {
+        Map<String, Object> stats = fileSplitRanges.get(path(i)).get(r).statistics();
+        return (stats == null || stats.isEmpty()) ? null : SplitStats.of(stats);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GenericFileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GenericFileList.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.SchemaReconciliation;
 import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.util.List;
@@ -28,13 +29,14 @@ final class GenericFileList implements FileList {
     private final String originalPattern;
     private final PartitionMetadata partitionMetadata;
     private final Map<StoragePath, SchemaReconciliation.FileSchemaInfo> fileSchemaInfo;
+    private final Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> fileSplitRanges;
 
     GenericFileList(List<StorageEntry> files, String originalPattern) {
-        this(files, originalPattern, null, null);
+        this(files, originalPattern, null, null, null);
     }
 
     GenericFileList(List<StorageEntry> files, String originalPattern, @Nullable PartitionMetadata partitionMetadata) {
-        this(files, originalPattern, partitionMetadata, null);
+        this(files, originalPattern, partitionMetadata, null, null);
     }
 
     GenericFileList(
@@ -43,6 +45,16 @@ final class GenericFileList implements FileList {
         @Nullable PartitionMetadata partitionMetadata,
         @Nullable Map<StoragePath, SchemaReconciliation.FileSchemaInfo> fileSchemaInfo
     ) {
+        this(files, originalPattern, partitionMetadata, fileSchemaInfo, null);
+    }
+
+    GenericFileList(
+        List<StorageEntry> files,
+        String originalPattern,
+        @Nullable PartitionMetadata partitionMetadata,
+        @Nullable Map<StoragePath, SchemaReconciliation.FileSchemaInfo> fileSchemaInfo,
+        @Nullable Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> fileSplitRanges
+    ) {
         if (files == null) {
             throw new IllegalArgumentException("files cannot be null");
         }
@@ -50,6 +62,7 @@ final class GenericFileList implements FileList {
         this.originalPattern = originalPattern;
         this.partitionMetadata = partitionMetadata;
         this.fileSchemaInfo = fileSchemaInfo;
+        this.fileSplitRanges = fileSplitRanges;
     }
 
     List<StorageEntry> files() {
@@ -73,12 +86,27 @@ final class GenericFileList implements FileList {
         return fileSchemaInfo;
     }
 
+    @Override
+    @Nullable
+    public Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> fileSplitRanges() {
+        return fileSplitRanges;
+    }
+
     /**
      * Returns a new GenericFileList with per-file schema info attached.
      * Used by schema reconciliation to pass column mappings from planning to split discovery.
      */
     GenericFileList withSchemaInfo(Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo) {
-        return new GenericFileList(files, originalPattern, partitionMetadata, schemaInfo);
+        return new GenericFileList(files, originalPattern, partitionMetadata, schemaInfo, fileSplitRanges);
+    }
+
+    /**
+     * Returns a new GenericFileList with pre-resolved per-file split ranges attached.
+     * Captured during single-pass file layout resolution (Parquet/ORC) and consumed by
+     * split discovery to avoid re-reading file footers.
+     */
+    GenericFileList withFileSplitRanges(Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> splitRanges) {
+        return new GenericFileList(files, originalPattern, partitionMetadata, fileSchemaInfo, splitRanges);
     }
 
     int size() {
@@ -132,12 +160,14 @@ final class GenericFileList implements FileList {
         GenericFileList other = (GenericFileList) o;
         return Objects.equals(files, other.files)
             && Objects.equals(originalPattern, other.originalPattern)
-            && Objects.equals(partitionMetadata, other.partitionMetadata);
+            && Objects.equals(partitionMetadata, other.partitionMetadata)
+            && Objects.equals(fileSchemaInfo, other.fileSchemaInfo)
+            && Objects.equals(fileSplitRanges, other.fileSplitRanges);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(files, originalPattern, partitionMetadata);
+        return Objects.hash(files, originalPattern, partitionMetadata, fileSchemaInfo, fileSplitRanges);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
@@ -73,10 +73,9 @@ public final class GlobExpander {
      * Captured during single-pass file layout resolution and consumed by split discovery to
      * avoid re-reading file footers.
      * <p>
-     * Returns the input unchanged when {@code splitRanges} is null/empty, or when the file list
-     * is a compact representation (e.g. {@code DictionaryFileList}, {@code HiveFileList}) that
-     * does not currently carry per-file ranges. In that case split discovery falls back to
-     * re-opening each file -- a follow-up may extend compact lists to carry ranges as well.
+     * For compact representations ({@code DictionaryFileList}, {@code HiveFileList}), the ranges
+     * are stored in a {@link CompactRangeStore} that uses CSR indexing and dictionary encoding.
+     * Returns the input unchanged when {@code splitRanges} is null/empty.
      */
     public static FileList withFileSplitRanges(FileList fileList, Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> splitRanges) {
         if (splitRanges == null || splitRanges.isEmpty()) {
@@ -84,6 +83,14 @@ public final class GlobExpander {
         }
         if (fileList instanceof GenericFileList generic) {
             return generic.withFileSplitRanges(splitRanges);
+        }
+        if (fileList instanceof DictionaryFileList dict) {
+            CompactRangeStore store = CompactRangeStore.build(dict.fileCount(), dict::path, splitRanges);
+            return store != null ? dict.withRanges(store) : fileList;
+        }
+        if (fileList instanceof HiveFileList hive) {
+            CompactRangeStore store = CompactRangeStore.build(hive.fileCount(), hive::path, splitRanges);
+            return store != null ? hive.withRanges(store) : fileList;
         }
         return fileList;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.StorageIterator;
 import org.elasticsearch.xpack.esql.datasources.TemplatePartitionDetector;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
@@ -63,6 +64,26 @@ public final class GlobExpander {
     public static FileList withSchemaInfo(FileList fileList, Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo) {
         if (fileList instanceof GenericFileList generic) {
             return generic.withSchemaInfo(schemaInfo);
+        }
+        return fileList;
+    }
+
+    /**
+     * Returns a copy of the file list with pre-resolved per-file split ranges attached.
+     * Captured during single-pass file layout resolution and consumed by split discovery to
+     * avoid re-reading file footers.
+     * <p>
+     * Returns the input unchanged when {@code splitRanges} is null/empty, or when the file list
+     * is a compact representation (e.g. {@code DictionaryFileList}, {@code HiveFileList}) that
+     * does not currently carry per-file ranges. In that case split discovery falls back to
+     * re-opening each file -- a follow-up may extend compact lists to carry ranges as well.
+     */
+    public static FileList withFileSplitRanges(FileList fileList, Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> splitRanges) {
+        if (splitRanges == null || splitRanges.isEmpty()) {
+            return fileList;
+        }
+        if (fileList instanceof GenericFileList generic) {
+            return generic.withFileSplitRanges(splitRanges);
         }
         return fileList;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/HiveFileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/HiveFileList.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.datasources.glob;
 
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
+import org.elasticsearch.xpack.esql.datasources.SplitStats;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
@@ -37,6 +38,8 @@ final class HiveFileList implements FileList {
     @Nullable
     private final PartitionMetadata partitionMetadata;
     private final int fileCount;
+    @Nullable
+    private final CompactRangeStore ranges;
 
     HiveFileList(
         String basePath,
@@ -51,7 +54,8 @@ final class HiveFileList implements FileList {
         @Nullable String sharedExtension,
         @Nullable String originalPattern,
         @Nullable PartitionMetadata partitionMetadata,
-        int fileCount
+        int fileCount,
+        @Nullable CompactRangeStore ranges
     ) {
         this.basePath = basePath;
         this.partitionColumnNames = partitionColumnNames;
@@ -66,6 +70,26 @@ final class HiveFileList implements FileList {
         this.originalPattern = originalPattern;
         this.partitionMetadata = partitionMetadata;
         this.fileCount = fileCount;
+        this.ranges = ranges;
+    }
+
+    HiveFileList withRanges(CompactRangeStore ranges) {
+        return new HiveFileList(
+            basePath,
+            partitionColumnNames,
+            columnValueDicts,
+            groupValueIndices,
+            groupFileStarts,
+            sizes,
+            mtimesMillis,
+            groupMtimes,
+            leafNames,
+            sharedExtension,
+            originalPattern,
+            partitionMetadata,
+            fileCount,
+            ranges
+        );
     }
 
     private int findGroup(int fileIndex) {
@@ -139,6 +163,27 @@ final class HiveFileList implements FileList {
     }
 
     @Override
+    public int rangeCount(int i) {
+        return ranges != null ? ranges.rangeCount(i) : -1;
+    }
+
+    @Override
+    public long rangeOffset(int i, int r) {
+        return ranges != null ? ranges.rangeOffset(i, r) : 0L;
+    }
+
+    @Override
+    public long rangeLength(int i, int r) {
+        return ranges != null ? ranges.rangeLength(i, r) : size(i);
+    }
+
+    @Override
+    @Nullable
+    public SplitStats rangeStats(int i, int r) {
+        return ranges != null ? ranges.rangeStats(i, r) : null;
+    }
+
+    @Override
     public long estimatedBytes() {
         // object header + reference fields
         long bytes = 64;
@@ -166,6 +211,6 @@ final class HiveFileList implements FileList {
         if (sharedExtension != null) {
             bytes += 40 + sharedExtension.length() * (long) Character.BYTES;
         }
-        return bytes;
+        return bytes + (ranges != null ? ranges.estimatedBytes() : 0);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalSourceFactory.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources.spi;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -24,6 +25,20 @@ public interface ExternalSourceFactory {
     boolean canHandle(String location);
 
     SourceMetadata resolveMetadata(String location, Map<String, Object> config);
+
+    /**
+     * Resolves the full file layout (metadata + split ranges) for a single file in one pass.
+     * The default implementation defers to {@link #resolveMetadata} and returns no split ranges,
+     * preserving backward compatibility for non-file factories (connectors, table catalogs).
+     * <p>
+     * File-based factories that work with range-aware (columnar) formats should override this
+     * to read the file's footer once and emit both schema/statistics and split ranges, avoiding
+     * the double-read that would otherwise happen across {@code resolveMetadata} and
+     * {@link RangeAwareFormatReader#resolveFileLayout}.
+     */
+    default FileLayout resolveFileLayout(String location, Map<String, Object> config) {
+        return new FileLayout(resolveMetadata(location, config), List.of());
+    }
 
     default FilterPushdownSupport filterPushdownSupport() {
         return null;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileLayout.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileLayout.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import java.util.List;
+
+/**
+ * Aggregate result of a single-pass file layout resolution: the file's
+ * {@link SourceMetadata} (schema + statistics) plus its
+ * {@link RangeAwareFormatReader.SplitRange split ranges} (e.g. Parquet row groups
+ * or ORC stripes), captured in one pass over the file's footer/metadata.
+ * <p>
+ * For columnar formats this avoids reading the footer twice (once for metadata
+ * resolution, once for split discovery). For non-columnar or non-range-aware
+ * sources, {@code splitRanges} is an empty list.
+ */
+public record FileLayout(SourceMetadata metadata, List<RangeAwareFormatReader.SplitRange> splitRanges) {
+
+    public FileLayout {
+        if (metadata == null) {
+            throw new IllegalArgumentException("metadata must not be null");
+        }
+        splitRanges = splitRanges != null ? List.copyOf(splitRanges) : List.of();
+    }
+
+    /**
+     * Convenience factory for callers that have only metadata (no pre-resolved ranges).
+     */
+    public static FileLayout ofMetadata(SourceMetadata metadata) {
+        return new FileLayout(metadata, List.of());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileList.java
@@ -10,8 +10,8 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.SchemaReconciliation;
+import org.elasticsearch.xpack.esql.datasources.SplitStats;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -163,18 +163,36 @@ public interface FileList {
     }
 
     /**
-     * Per-file split ranges captured during single-pass file layout resolution
-     * (see {@link RangeAwareFormatReader#resolveFileLayout(StorageObject)}). Split discovery
-     * uses the ranges associated with a file to skip re-opening it to read row group/stripe
-     * metadata.
-     * <p>
-     * Returns {@code null} when no pre-resolved ranges are available for any file (e.g. cache
-     * hit, non-range-aware format, or compact {@code FileList} implementations that do not
-     * carry ranges). When the returned map is non-null but does not contain an entry for a
-     * given {@link StoragePath}, split discovery falls back to opening that file.
+     * Number of pre-resolved split ranges for file {@code i}.
+     * Returns {@code -1} if ranges were not resolved (caller should use slow path),
+     * {@code 0} if resolved but the file has no independently-readable ranges,
+     * or a positive count of available ranges.
+     */
+    default int rangeCount(int i) {
+        return -1;
+    }
+
+    /**
+     * Byte offset of range {@code r} within file {@code i}.
+     * Only valid when {@code rangeCount(i) > 0} and {@code 0 <= r < rangeCount(i)}.
+     */
+    default long rangeOffset(int i, int r) {
+        return 0L;
+    }
+
+    /**
+     * Byte length of range {@code r} within file {@code i}.
+     * Only valid when {@code rangeCount(i) > 0} and {@code 0 <= r < rangeCount(i)}.
+     */
+    default long rangeLength(int i, int r) {
+        return size(i);
+    }
+
+    /**
+     * Compact statistics for range {@code r} within file {@code i}, or {@code null} if unavailable.
      */
     @Nullable
-    default Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> fileSplitRanges() {
+    default SplitStats rangeStats(int i, int r) {
         return null;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FileList.java
@@ -11,6 +11,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.SchemaReconciliation;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -158,6 +159,22 @@ public interface FileList {
      */
     @Nullable
     default Map<StoragePath, SchemaReconciliation.FileSchemaInfo> fileSchemaInfo() {
+        return null;
+    }
+
+    /**
+     * Per-file split ranges captured during single-pass file layout resolution
+     * (see {@link RangeAwareFormatReader#resolveFileLayout(StorageObject)}). Split discovery
+     * uses the ranges associated with a file to skip re-opening it to read row group/stripe
+     * metadata.
+     * <p>
+     * Returns {@code null} when no pre-resolved ranges are available for any file (e.g. cache
+     * hit, non-range-aware format, or compact {@code FileList} implementations that do not
+     * carry ranges). When the returned map is non-null but does not contain an entry for a
+     * given {@link StoragePath}, split discovery falls back to opening that file.
+     */
+    @Nullable
+    default Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> fileSplitRanges() {
         return null;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeAwareFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeAwareFormatReader.java
@@ -27,12 +27,21 @@ import java.util.Map;
  * <p>
  * The split discovery flow:
  * <ol>
- *   <li>{@link #discoverSplitRanges} reads file metadata (e.g. Parquet footer) and
- *       returns byte ranges for each independently readable unit (e.g. row group).</li>
+ *   <li>{@link #resolveFileLayout} opens the file's footer/metadata once and returns both
+ *       schema/statistics and byte ranges for each independently readable unit
+ *       (e.g. row group / stripe).</li>
  *   <li>The framework creates one split per range, distributed across drivers/nodes.</li>
  *   <li>At read time, {@link #readRange} receives the full-file object and the assigned
  *       byte range, reading only the relevant row groups.</li>
  * </ol>
+ * <p>
+ * {@link #resolveFileLayout} is the single primitive for this SPI: implementations must
+ * perform exactly one format reader open (i.e. one footer/metadata read) per invocation
+ * and emit both pieces of information together. {@link #metadata(StorageObject)} is a
+ * derived view that delegates to {@code resolveFileLayout} and discards the split ranges;
+ * metadata-only callers therefore still pay exactly one footer read per call. The CPU cost
+ * of building the discarded {@link FileLayout} is negligible compared to the remote I/O
+ * the contract avoids.
  */
 public interface RangeAwareFormatReader extends FormatReader {
 
@@ -54,16 +63,27 @@ public interface RangeAwareFormatReader extends FormatReader {
     }
 
     /**
-     * Discovers independently readable byte ranges within a file by reading its metadata.
-     * Each range typically corresponds to one row group (Parquet) or stripe (ORC).
-     * <p>
-     * Returns a list of {@link SplitRange} objects. An empty list means the
-     * file cannot be split (e.g. single row group) and should be read as a whole.
+     * Resolves both schema/statistics and split ranges from a single open of the file's
+     * footer/metadata. This is the single SPI primitive for columnar formats: callers that
+     * only need metadata go through {@link #metadata(StorageObject)}, which is a derived
+     * view over this same method. Implementations must perform exactly one format reader
+     * open (one footer/metadata read) per invocation; multiple internal CPU passes over
+     * the already-loaded footer are allowed.
      *
      * @param object the storage object representing the full file
-     * @return list of split ranges with optional per-range statistics
+     * @return the file's {@link FileLayout}: metadata and split ranges
      */
-    List<SplitRange> discoverSplitRanges(StorageObject object) throws IOException;
+    FileLayout resolveFileLayout(StorageObject object) throws IOException;
+
+    /**
+     * Returns the metadata for the given file. Derived from {@link #resolveFileLayout};
+     * range information from that single footer read is discarded for metadata-only
+     * callers, preserving the "exactly one footer read per call" guarantee.
+     */
+    @Override
+    default SourceMetadata metadata(StorageObject object) throws IOException {
+        return resolveFileLayout(object).metadata();
+    }
 
     /**
      * Reads only the row groups / stripes that fall within the given byte range.

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -27,11 +27,15 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheService;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FileLayout;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -267,6 +271,68 @@ public class ExternalSourceResolverTests extends ESTestCase {
         assertEquals(1, fileList.fileCount());
         assertEquals("s3://bucket/data/single.parquet", fileList.path(0).toString());
         assertEquals(0L, fileList.size(0));
+    }
+
+    // ===== Pre-resolved split ranges threading =====
+
+    public void testSingleFileResolutionThreadsSplitRangesWhenRangeAware() throws Exception {
+        String location = "s3://bucket/data/single.parquet";
+        StoragePath storagePath = StoragePath.of(location);
+        List<Attribute> schema = List.of(attr("id", DataType.LONG));
+
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put(location, schema);
+
+        Map<StoragePath, List<SplitRange>> rangesByPath = new HashMap<>();
+        SplitRange r1 = new SplitRange(4, 100, Map.of("_stats.row_count", 50L));
+        SplitRange r2 = new SplitRange(104, 100, Map.of("_stats.row_count", 50L));
+        rangesByPath.put(storagePath, List.of(r1, r2));
+
+        ExternalSourceResolution resolution = resolveSingleFileWithRangeReader(location, schemasByPath, rangesByPath);
+
+        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource(location);
+        assertNotNull(resolved);
+        FileList fileList = resolved.fileList();
+        assertNotNull("single-file resolution should attach pre-resolved ranges", fileList.fileSplitRanges());
+        assertEquals(1, fileList.fileSplitRanges().size());
+        assertEquals(List.of(r1, r2), fileList.fileSplitRanges().get(storagePath));
+    }
+
+    public void testMultiFileResolutionThreadsSplitRangesForUnionByName() throws Exception {
+        String f1 = "s3://bucket/data/file1.parquet";
+        String f2 = "s3://bucket/data/file2.parquet";
+        StoragePath p1 = StoragePath.of(f1);
+        StoragePath p2 = StoragePath.of(f2);
+
+        List<Attribute> schema1 = List.of(attr("id", DataType.LONG), attr("a", DataType.KEYWORD));
+        List<Attribute> schema2 = List.of(attr("id", DataType.LONG), attr("b", DataType.KEYWORD));
+
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put(f1, schema1);
+        schemasByPath.put(f2, schema2);
+
+        Map<StoragePath, List<SplitRange>> rangesByPath = new HashMap<>();
+        SplitRange r1 = new SplitRange(4, 100, Map.of("_stats.row_count", 50L));
+        SplitRange r2 = new SplitRange(8, 200, Map.of("_stats.row_count", 100L));
+        rangesByPath.put(p1, List.of(r1));
+        rangesByPath.put(p2, List.of(r2));
+
+        ExternalSourceResolution resolution = resolveMultiFileWithRangeReader(
+            "s3://bucket/data/*.parquet",
+            schemasByPath,
+            rangesByPath,
+            List.of(entry(f1, 200), entry(f2, 400)),
+            // Use UNION_BY_NAME so all files are opened during resolution.
+            FormatReader.SchemaResolution.UNION_BY_NAME
+        );
+
+        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
+        assertNotNull(resolved);
+        FileList fileList = resolved.fileList();
+        assertNotNull("multi-file UNION_BY_NAME should attach pre-resolved ranges", fileList.fileSplitRanges());
+        assertEquals(2, fileList.fileSplitRanges().size());
+        assertEquals(List.of(r1), fileList.fileSplitRanges().get(p1));
+        assertEquals(List.of(r2), fileList.fileSplitRanges().get(p2));
     }
 
     // ===== Schema type preservation =====
@@ -834,6 +900,88 @@ public class ExternalSourceResolverTests extends ESTestCase {
         return new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module);
     }
 
+    private ExternalSourceResolution resolveSingleFileWithRangeReader(
+        String path,
+        Map<String, List<Attribute>> schemasByPath,
+        Map<StoragePath, List<SplitRange>> rangesByPath
+    ) throws Exception {
+        ExternalSourceResolver resolver = createResolverWithRangeReader(schemasByPath, Map.of(), rangesByPath);
+        PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+        resolver.resolve(List.of(path), Map.of(), future);
+        return future.actionGet();
+    }
+
+    private ExternalSourceResolution resolveMultiFileWithRangeReader(
+        String globPattern,
+        Map<String, List<Attribute>> schemasByPath,
+        Map<StoragePath, List<SplitRange>> rangesByPath,
+        List<StorageEntry> listing,
+        FormatReader.SchemaResolution schemaResolution
+    ) throws Exception {
+        Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+        StoragePath sp = StoragePath.of(globPattern);
+        listingsByPrefix.put(sp.patternPrefix().toString(), listing);
+
+        ExternalSourceResolver resolver = createResolverWithRangeReader(schemasByPath, listingsByPrefix, rangesByPath);
+        PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+
+        Map<String, Map<String, Expression>> pathParams = new HashMap<>();
+        if (schemaResolution != FormatReader.SchemaResolution.FIRST_FILE_WINS) {
+            Map<String, Expression> exprParams = new HashMap<>();
+            exprParams.put(
+                ExternalSourceResolver.CONFIG_SCHEMA_RESOLUTION,
+                new Literal(Source.EMPTY, new BytesRef(schemaResolution.name().toLowerCase(java.util.Locale.ROOT)), DataType.KEYWORD)
+            );
+            pathParams.put(globPattern, exprParams);
+        }
+
+        resolver.resolve(List.of(globPattern), pathParams, future);
+        return future.actionGet();
+    }
+
+    private ExternalSourceResolver createResolverWithRangeReader(
+        Map<String, List<Attribute>> schemasByPath,
+        Map<String, List<StorageEntry>> listingsByPrefix,
+        Map<StoragePath, List<SplitRange>> rangesByPath
+    ) {
+        StubRangeAwareFormatReader formatReader = new StubRangeAwareFormatReader(schemasByPath, rangesByPath);
+        StubStorageProvider storageProvider = new StubStorageProvider(listingsByPrefix, schemasByPath);
+
+        DataSourcePlugin plugin = new DataSourcePlugin() {
+            @Override
+            public Set<String> supportedSchemes() {
+                return Set.of("s3");
+            }
+
+            @Override
+            public Set<FormatSpec> formatSpecs() {
+                return Set.of(FormatSpec.of("parquet", ".parquet"));
+            }
+
+            @Override
+            public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+                return Map.of("s3", s -> storageProvider);
+            }
+
+            @Override
+            public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+                return Map.of("parquet", (s, bf) -> formatReader);
+            }
+        };
+
+        List<DataSourcePlugin> plugins = List.of(plugin);
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        return new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module);
+    }
+
     private ExternalSourceResolver createResolverWithCache(
         StorageProvider storageProvider,
         Map<String, List<Attribute>> schemasByPath,
@@ -893,6 +1041,58 @@ public class ExternalSourceResolverTests extends ESTestCase {
                 throw new IllegalArgumentException("No schema configured for path: " + path);
             }
             return new StubSourceMetadata(path, schema);
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String formatName() {
+            return "parquet";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class StubRangeAwareFormatReader implements RangeAwareFormatReader {
+        private final Map<String, List<Attribute>> schemasByPath;
+        private final Map<StoragePath, List<SplitRange>> rangesByPath;
+
+        StubRangeAwareFormatReader(Map<String, List<Attribute>> schemasByPath, Map<StoragePath, List<SplitRange>> rangesByPath) {
+            this.schemasByPath = schemasByPath;
+            this.rangesByPath = rangesByPath;
+        }
+
+        @Override
+        public FileLayout resolveFileLayout(StorageObject object) {
+            String path = object.path().toString();
+            List<Attribute> schema = schemasByPath.get(path);
+            if (schema == null) {
+                throw new IllegalArgumentException("No schema configured for path: " + path);
+            }
+            List<SplitRange> ranges = rangesByPath.getOrDefault(object.path(), List.of());
+            return new FileLayout(new StubSourceMetadata(path, schema), ranges);
+        }
+
+        @Override
+        public CloseableIterator<Page> readRange(
+            StorageObject object,
+            List<String> projectedColumns,
+            int batchSize,
+            long rangeStart,
+            long rangeEnd,
+            List<Attribute> resolvedAttributes,
+            ErrorPolicy errorPolicy
+        ) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.cache.ExternalSourceCacheService;
+import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
 import org.elasticsearch.xpack.esql.datasources.spi.DataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FileLayout;
@@ -293,9 +294,20 @@ public class ExternalSourceResolverTests extends ESTestCase {
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource(location);
         assertNotNull(resolved);
         FileList fileList = resolved.fileList();
-        assertNotNull("single-file resolution should attach pre-resolved ranges", fileList.fileSplitRanges());
-        assertEquals(1, fileList.fileSplitRanges().size());
-        assertEquals(List.of(r1, r2), fileList.fileSplitRanges().get(storagePath));
+        // Verify pre-resolved ranges via the indexed range API
+        assertEquals(1, fileList.fileCount());
+        assertEquals(2, fileList.rangeCount(0));
+        assertEquals(r1.offset(), fileList.rangeOffset(0, 0));
+        assertEquals(r1.length(), fileList.rangeLength(0, 0));
+        assertEquals(r2.offset(), fileList.rangeOffset(0, 1));
+        assertEquals(r2.length(), fileList.rangeLength(0, 1));
+        // Verify rangeStats returns non-null SplitStats with correct row counts
+        SplitStats stats0 = fileList.rangeStats(0, 0);
+        assertNotNull("rangeStats should be non-null for range with statistics", stats0);
+        assertEquals(50L, stats0.rowCount());
+        SplitStats stats1 = fileList.rangeStats(0, 1);
+        assertNotNull("rangeStats should be non-null for range with statistics", stats1);
+        assertEquals(50L, stats1.rowCount());
     }
 
     public void testMultiFileResolutionThreadsSplitRangesForUnionByName() throws Exception {
@@ -329,10 +341,87 @@ public class ExternalSourceResolverTests extends ESTestCase {
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
         assertNotNull(resolved);
         FileList fileList = resolved.fileList();
-        assertNotNull("multi-file UNION_BY_NAME should attach pre-resolved ranges", fileList.fileSplitRanges());
-        assertEquals(2, fileList.fileSplitRanges().size());
-        assertEquals(List.of(r1), fileList.fileSplitRanges().get(p1));
-        assertEquals(List.of(r2), fileList.fileSplitRanges().get(p2));
+        // Verify pre-resolved ranges via the indexed range API
+        assertEquals(2, fileList.fileCount());
+        // File order in the file list depends on the listing order; find each file's index
+        int idx1 = -1, idx2 = -1;
+        for (int i = 0; i < fileList.fileCount(); i++) {
+            if (fileList.path(i).equals(p1)) idx1 = i;
+            if (fileList.path(i).equals(p2)) idx2 = i;
+        }
+        assertTrue("p1 should be in the file list", idx1 >= 0);
+        assertTrue("p2 should be in the file list", idx2 >= 0);
+        assertEquals(1, fileList.rangeCount(idx1));
+        assertEquals(r1.offset(), fileList.rangeOffset(idx1, 0));
+        assertEquals(r1.length(), fileList.rangeLength(idx1, 0));
+        assertEquals(1, fileList.rangeCount(idx2));
+        assertEquals(r2.offset(), fileList.rangeOffset(idx2, 0));
+        assertEquals(r2.length(), fileList.rangeLength(idx2, 0));
+        // Verify rangeStats returns non-null SplitStats with correct row counts
+        SplitStats statsF1 = fileList.rangeStats(idx1, 0);
+        assertNotNull("rangeStats should be non-null for range with statistics", statsF1);
+        assertEquals(50L, statsF1.rowCount());
+        SplitStats statsF2 = fileList.rangeStats(idx2, 0);
+        assertNotNull("rangeStats should be non-null for range with statistics", statsF2);
+        assertEquals(100L, statsF2.rowCount());
+    }
+
+    // ===== Compact round-trip preserves ranges =====
+
+    public void testCompactRoundTripPreservesRanges() {
+        StoragePath p1 = StoragePath.of("s3://bucket/data/file1.parquet");
+        StoragePath p2 = StoragePath.of("s3://bucket/data/file2.parquet");
+
+        SplitRange r1 = new SplitRange(4, 100, Map.of("_stats.row_count", 50L));
+        SplitRange r2 = new SplitRange(104, 200, Map.of("_stats.row_count", 75L));
+        SplitRange r3 = new SplitRange(8, 150, Map.of("_stats.row_count", 60L));
+
+        Map<StoragePath, List<SplitRange>> rangesByPath = new HashMap<>();
+        rangesByPath.put(p1, List.of(r1, r2));
+        rangesByPath.put(p2, List.of(r3));
+
+        List<StorageEntry> entries = List.of(entry("s3://bucket/data/file1.parquet", 300), entry("s3://bucket/data/file2.parquet", 150));
+
+        // Create a GenericFileList with ranges attached
+        FileList raw = GlobExpander.fileListOf(entries, "s3://bucket/data/*.parquet");
+        FileList withRanges = GlobExpander.withFileSplitRanges(raw, rangesByPath);
+
+        // Compact the list (should produce a DictionaryFileList with CompactRangeStore)
+        FileList compact = GlobExpander.compact(withRanges, "s3://bucket/data/");
+
+        // Verify the compact list preserves file count and paths
+        assertEquals(2, compact.fileCount());
+
+        // Find indices in the compact list (order may differ from raw)
+        int idx1 = -1, idx2 = -1;
+        for (int i = 0; i < compact.fileCount(); i++) {
+            if (compact.path(i).equals(p1)) idx1 = i;
+            if (compact.path(i).equals(p2)) idx2 = i;
+        }
+        assertTrue("p1 should be in the compact file list", idx1 >= 0);
+        assertTrue("p2 should be in the compact file list", idx2 >= 0);
+
+        // Verify ranges survived compaction
+        assertEquals(2, compact.rangeCount(idx1));
+        assertEquals(r1.offset(), compact.rangeOffset(idx1, 0));
+        assertEquals(r1.length(), compact.rangeLength(idx1, 0));
+        assertEquals(r2.offset(), compact.rangeOffset(idx1, 1));
+        assertEquals(r2.length(), compact.rangeLength(idx1, 1));
+
+        assertEquals(1, compact.rangeCount(idx2));
+        assertEquals(r3.offset(), compact.rangeOffset(idx2, 0));
+        assertEquals(r3.length(), compact.rangeLength(idx2, 0));
+
+        // Verify stats survived compaction
+        SplitStats s1r0 = compact.rangeStats(idx1, 0);
+        assertNotNull("rangeStats should survive compaction", s1r0);
+        assertEquals(50L, s1r0.rowCount());
+        SplitStats s1r1 = compact.rangeStats(idx1, 1);
+        assertNotNull("rangeStats should survive compaction", s1r1);
+        assertEquals(75L, s1r1.rowCount());
+        SplitStats s2r0 = compact.rangeStats(idx2, 0);
+        assertNotNull("rangeStats should survive compaction", s2r0);
+        assertEquals(60L, s2r0.rowCount());
     }
 
     // ===== Schema type preservation =====

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -25,11 +25,12 @@ import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.FileLayout;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
-import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.SplittableDecompressionCodec;
@@ -648,6 +649,143 @@ public class FileSplitProviderTests extends ESTestCase {
         }
     }
 
+    public void testPreResolvedRangesAreUsedWithoutCallingReader() {
+        SplitRange[] preResolved = {
+            new SplitRange(50, 250, Map.of("_stats.row_count", 100L)),
+            new SplitRange(300, 500, Map.of("_stats.row_count", 200L)) };
+
+        // Reader that fails the test if its resolveFileLayout is invoked: we should be using the cached ranges.
+        RangeAwareFormatReader strictReader = new RangeAwareFormatReader() {
+            @Override
+            public FileLayout resolveFileLayout(StorageObject object) {
+                throw new AssertionError("resolveFileLayout must not be called when pre-resolved ranges are present");
+            }
+
+            @Override
+            public CloseableIterator<Page> readRange(
+                StorageObject object,
+                List<String> projectedColumns,
+                int batchSize,
+                long rangeStart,
+                long rangeEnd,
+                List<Attribute> resolvedAttributes,
+                ErrorPolicy errorPolicy
+            ) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String formatName() {
+                return "parquet";
+            }
+
+            @Override
+            public List<String> fileExtensions() {
+                return List.of(".parquet");
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        FormatReaderRegistry formatRegistry = new FormatReaderRegistry(new DecompressionCodecRegistry());
+        formatRegistry.registerLazy("parquet", (s, bf) -> strictReader, Settings.EMPTY, null);
+        formatRegistry.byName("parquet");
+
+        // The fast path should not need any storage provider lookups either.
+        StorageProviderRegistry storageRegistry = mock(StorageProviderRegistry.class);
+
+        FileSplitProvider splitter = new FileSplitProvider(
+            FileSplitProvider.DEFAULT_TARGET_SPLIT_SIZE,
+            new DecompressionCodecRegistry(),
+            storageRegistry,
+            formatRegistry,
+            Settings.EMPTY
+        );
+
+        StoragePath path = StoragePath.of("s3://b/data.parquet");
+        StorageEntry entry = new StorageEntry(path, 1000, Instant.EPOCH);
+        FileList base = GlobExpander.fileListOf(List.of(entry), "s3://b/*.parquet");
+        FileList fileList = GlobExpander.withFileSplitRanges(base, Map.of(path, List.of(preResolved[0], preResolved[1])));
+
+        SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), PartitionMetadata.EMPTY, List.of());
+        List<ExternalSplit> splits = splitter.discoverSplits(ctx);
+
+        assertEquals(2, splits.size());
+        for (int i = 0; i < splits.size(); i++) {
+            FileSplit fs = (FileSplit) splits.get(i);
+            assertEquals(preResolved[i].offset(), fs.offset());
+            assertEquals(preResolved[i].length(), fs.length());
+            assertEquals("true", fs.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
+            assertEquals("1000", fs.config().get(FileSplitProvider.FILE_LENGTH_KEY));
+            assertEquals(preResolved[i].statistics().get("_stats.row_count"), fs.statistics().get("_stats.row_count"));
+        }
+    }
+
+    public void testPreResolvedRangesProduceSameSplitsAsReader() {
+        SplitRange[] ranges = {
+            new SplitRange(100, 500, Map.of("_stats.row_count", 100L)),
+            new SplitRange(700, 600, Map.of("_stats.row_count", 200L)),
+            new SplitRange(1400, 400, Map.of("_stats.row_count", 300L)) };
+
+        StoragePath path = StoragePath.of("s3://b/data.parquet");
+
+        // Path A: ranges discovered via reader.
+        RangeAwareFormatReader readerA = createMockRangeReader(List.of(ranges));
+        FormatReaderRegistry registryA = new FormatReaderRegistry(new DecompressionCodecRegistry());
+        registryA.registerLazy("parquet", (s, bf) -> readerA, Settings.EMPTY, null);
+        registryA.byName("parquet");
+        FileSplitProvider providerA = new FileSplitProvider(
+            FileSplitProvider.DEFAULT_TARGET_SPLIT_SIZE,
+            new DecompressionCodecRegistry(),
+            createMockStorageRegistry(),
+            registryA,
+            Settings.EMPTY
+        );
+        StorageEntry entry = new StorageEntry(path, 2000, Instant.EPOCH);
+        FileList fileListA = GlobExpander.fileListOf(List.of(entry), "s3://b/*.parquet");
+        List<ExternalSplit> splitsA = providerA.discoverSplits(
+            new SplitDiscoveryContext(null, fileListA, Map.of(), PartitionMetadata.EMPTY, List.of())
+        );
+
+        // Path B: ranges supplied via FileList (fast path).
+        RangeAwareFormatReader readerB = createMockRangeReader(List.of()); // intentionally empty: must be unused
+        FormatReaderRegistry registryB = new FormatReaderRegistry(new DecompressionCodecRegistry());
+        registryB.registerLazy("parquet", (s, bf) -> readerB, Settings.EMPTY, null);
+        registryB.byName("parquet");
+        FileSplitProvider providerB = new FileSplitProvider(
+            FileSplitProvider.DEFAULT_TARGET_SPLIT_SIZE,
+            new DecompressionCodecRegistry(),
+            createMockStorageRegistry(),
+            registryB,
+            Settings.EMPTY
+        );
+        FileList fileListB = GlobExpander.withFileSplitRanges(
+            GlobExpander.fileListOf(List.of(entry), "s3://b/*.parquet"),
+            Map.of(path, List.of(ranges))
+        );
+        List<ExternalSplit> splitsB = providerB.discoverSplits(
+            new SplitDiscoveryContext(null, fileListB, Map.of(), PartitionMetadata.EMPTY, List.of())
+        );
+
+        assertEquals(splitsA.size(), splitsB.size());
+        for (int i = 0; i < splitsA.size(); i++) {
+            FileSplit a = (FileSplit) splitsA.get(i);
+            FileSplit b = (FileSplit) splitsB.get(i);
+            assertEquals(a.offset(), b.offset());
+            assertEquals(a.length(), b.length());
+            assertEquals(a.path(), b.path());
+            assertEquals(a.statistics(), b.statistics());
+            assertEquals(a.config().get(FileSplitProvider.RANGE_SPLIT_KEY), b.config().get(FileSplitProvider.RANGE_SPLIT_KEY));
+            assertEquals(a.config().get(FileSplitProvider.FILE_LENGTH_KEY), b.config().get(FileSplitProvider.FILE_LENGTH_KEY));
+        }
+    }
+
     public void testRangeAwareFallbackForEmptyRanges() {
         RangeAwareFormatReader mockReader = createMockRangeReader(List.<SplitRange>of());
 
@@ -722,8 +860,10 @@ public class FileSplitProviderTests extends ESTestCase {
             private final List<List<SplitRange>> perFileRanges = List.of(List.of(range1), List.of(range2), List.of(range3));
 
             @Override
-            public List<SplitRange> discoverSplitRanges(StorageObject object) {
-                return perFileRanges.get(callCount++);
+            public FileLayout resolveFileLayout(StorageObject object) {
+                List<SplitRange> ranges = perFileRanges.get(callCount++);
+                // Schema is stubbed empty: split discovery only consumes the splitRanges() of the layout.
+                return new FileLayout(new SimpleSourceMetadata(List.of(), formatName(), object.path().toString(), null, null), ranges);
             }
 
             @Override
@@ -736,11 +876,6 @@ public class FileSplitProviderTests extends ESTestCase {
                 List<Attribute> resolvedAttributes,
                 ErrorPolicy errorPolicy
             ) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public SourceMetadata metadata(StorageObject object) {
                 throw new UnsupportedOperationException();
             }
 
@@ -803,8 +938,10 @@ public class FileSplitProviderTests extends ESTestCase {
     private static RangeAwareFormatReader createMockRangeReader(List<SplitRange> ranges) {
         return new RangeAwareFormatReader() {
             @Override
-            public List<SplitRange> discoverSplitRanges(StorageObject object) {
-                return ranges;
+            public FileLayout resolveFileLayout(StorageObject object) {
+                // Schema is stubbed empty: split discovery only consumes the splitRanges() of the layout,
+                // so metadata content is irrelevant here.
+                return new FileLayout(new SimpleSourceMetadata(List.of(), formatName(), object.path().toString(), null, null), ranges);
             }
 
             @Override
@@ -818,11 +955,6 @@ public class FileSplitProviderTests extends ESTestCase {
                 ErrorPolicy errorPolicy
             ) {
                 throw new UnsupportedOperationException("not called during split discovery");
-            }
-
-            @Override
-            public SourceMetadata metadata(StorageObject object) {
-                return null;
             }
 
             @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/CompactRangeStoreTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/CompactRangeStoreTests.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.glob;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.util.List;
+import java.util.Map;
+
+public class CompactRangeStoreTests extends ESTestCase {
+
+    public void testBuildReturnsNullForNullRanges() {
+        CompactRangeStore store = CompactRangeStore.build(3, i -> StoragePath.of("s3://bucket/file_" + i + ".parquet"), null);
+        assertNull(store);
+    }
+
+    public void testBuildReturnsNullForEmptyRanges() {
+        CompactRangeStore store = CompactRangeStore.build(3, i -> StoragePath.of("s3://bucket/file_" + i + ".parquet"), Map.of());
+        assertNull(store);
+    }
+
+    public void testSingleFileSingleRange() {
+        StoragePath path = StoragePath.of("s3://bucket/file_0.parquet");
+        long offset = 4;
+        long length = 128 * 1024 * 1024L; // 128 MB
+        RangeAwareFormatReader.SplitRange range = new RangeAwareFormatReader.SplitRange(offset, length, Map.of("_stats.row_count", 100L));
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath = Map.of(path, List.of(range));
+
+        CompactRangeStore store = CompactRangeStore.build(1, i -> path, rangesByPath);
+        assertNotNull(store);
+        assertEquals(1, store.rangeCount(0));
+        assertEquals(offset, store.rangeOffset(0, 0));
+        assertEquals(length, store.rangeLength(0, 0));
+        assertNotNull(store.rangeStats(0, 0));
+        assertEquals(100L, store.rangeStats(0, 0).rowCount());
+    }
+
+    public void testSingleFileMultipleRanges() {
+        StoragePath path = StoragePath.of("s3://bucket/file_0.parquet");
+        long len1 = 128 * 1024 * 1024L;
+        long len2 = 128 * 1024 * 1024L;
+        long len3 = 64 * 1024 * 1024L;
+        long baseOffset = 4;
+
+        RangeAwareFormatReader.SplitRange r0 = new RangeAwareFormatReader.SplitRange(baseOffset, len1, Map.of("_stats.row_count", 50L));
+        RangeAwareFormatReader.SplitRange r1 = new RangeAwareFormatReader.SplitRange(
+            baseOffset + len1,
+            len2,
+            Map.of("_stats.row_count", 50L)
+        );
+        RangeAwareFormatReader.SplitRange r2 = new RangeAwareFormatReader.SplitRange(
+            baseOffset + len1 + len2,
+            len3,
+            Map.of("_stats.row_count", 25L)
+        );
+
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath = Map.of(path, List.of(r0, r1, r2));
+        CompactRangeStore store = CompactRangeStore.build(1, i -> path, rangesByPath);
+        assertNotNull(store);
+
+        assertEquals(3, store.rangeCount(0));
+        // Verify cumulative offset derivation
+        assertEquals(baseOffset, store.rangeOffset(0, 0));
+        assertEquals(baseOffset + len1, store.rangeOffset(0, 1));
+        assertEquals(baseOffset + len1 + len2, store.rangeOffset(0, 2));
+        // Verify lengths
+        assertEquals(len1, store.rangeLength(0, 0));
+        assertEquals(len2, store.rangeLength(0, 1));
+        assertEquals(len3, store.rangeLength(0, 2));
+    }
+
+    public void testMultiFileIdenticalGeometry() {
+        long len1 = 128 * 1024 * 1024L;
+        long len2 = 128 * 1024 * 1024L;
+        long len3 = 64 * 1024 * 1024L;
+
+        StoragePath[] paths = new StoragePath[3];
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath = new java.util.HashMap<>();
+        for (int f = 0; f < 3; f++) {
+            paths[f] = StoragePath.of("s3://bucket/file_" + f + ".parquet");
+            long base = f * 1000L;
+            rangesByPath.put(
+                paths[f],
+                List.of(
+                    new RangeAwareFormatReader.SplitRange(base, len1, Map.of("_stats.row_count", 10L)),
+                    new RangeAwareFormatReader.SplitRange(base + len1, len2, Map.of("_stats.row_count", 10L)),
+                    new RangeAwareFormatReader.SplitRange(base + len1 + len2, len3, Map.of("_stats.row_count", 5L))
+                )
+            );
+        }
+
+        CompactRangeStore store = CompactRangeStore.build(3, i -> paths[i], rangesByPath);
+        assertNotNull(store);
+
+        // All files should have identical range lengths (same template)
+        for (int f = 0; f < 3; f++) {
+            assertEquals(3, store.rangeCount(f));
+            assertEquals(len1, store.rangeLength(f, 0));
+            assertEquals(len2, store.rangeLength(f, 1));
+            assertEquals(len3, store.rangeLength(f, 2));
+        }
+        // Verify template sharing: all files return the same lengths, confirming template dedup
+        assertEquals(store.rangeLength(0, 0), store.rangeLength(1, 0));
+        assertEquals(store.rangeLength(0, 1), store.rangeLength(2, 1));
+        assertEquals(store.rangeLength(0, 2), store.rangeLength(2, 2));
+    }
+
+    public void testMultiFileDifferentGeometry() {
+        StoragePath path0 = StoragePath.of("s3://bucket/file_0.parquet");
+        StoragePath path1 = StoragePath.of("s3://bucket/file_1.parquet");
+
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath = new java.util.HashMap<>();
+        // File 0: 2 ranges of 128MB each
+        rangesByPath.put(
+            path0,
+            List.of(
+                new RangeAwareFormatReader.SplitRange(0, 128 * 1024 * 1024L, Map.of("_stats.row_count", 10L)),
+                new RangeAwareFormatReader.SplitRange(128 * 1024 * 1024L, 128 * 1024 * 1024L, Map.of("_stats.row_count", 10L))
+            )
+        );
+        // File 1: 1 range of 64MB
+        rangesByPath.put(path1, List.of(new RangeAwareFormatReader.SplitRange(0, 64 * 1024 * 1024L, Map.of("_stats.row_count", 5L))));
+
+        StoragePath[] paths = { path0, path1 };
+        CompactRangeStore store = CompactRangeStore.build(2, i -> paths[i], rangesByPath);
+        assertNotNull(store);
+
+        assertEquals(2, store.rangeCount(0));
+        assertEquals(1, store.rangeCount(1));
+        assertEquals(128 * 1024 * 1024L, store.rangeLength(0, 0));
+        assertEquals(128 * 1024 * 1024L, store.rangeLength(0, 1));
+        assertEquals(64 * 1024 * 1024L, store.rangeLength(1, 0));
+    }
+
+    public void testNullStats() {
+        StoragePath path = StoragePath.of("s3://bucket/file_0.parquet");
+        // Empty statistics map -> SplitStats.of returns null
+        RangeAwareFormatReader.SplitRange range = new RangeAwareFormatReader.SplitRange(0, 1024);
+
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath = Map.of(path, List.of(range));
+        CompactRangeStore store = CompactRangeStore.build(1, i -> path, rangesByPath);
+        assertNotNull(store);
+        assertNull(store.rangeStats(0, 0));
+    }
+
+    public void testStatsDedup() {
+        Map<String, Object> statsMap = Map.of("_stats.row_count", 100L);
+        StoragePath path0 = StoragePath.of("s3://bucket/file_0.parquet");
+        StoragePath path1 = StoragePath.of("s3://bucket/file_1.parquet");
+        StoragePath path2 = StoragePath.of("s3://bucket/file_2.parquet");
+
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath = new java.util.HashMap<>();
+        rangesByPath.put(path0, List.of(new RangeAwareFormatReader.SplitRange(0, 1024, statsMap)));
+        rangesByPath.put(path1, List.of(new RangeAwareFormatReader.SplitRange(0, 1024, statsMap)));
+        rangesByPath.put(path2, List.of(new RangeAwareFormatReader.SplitRange(0, 1024, statsMap)));
+
+        StoragePath[] paths = { path0, path1, path2 };
+        CompactRangeStore store = CompactRangeStore.build(3, i -> paths[i], rangesByPath);
+        assertNotNull(store);
+
+        // All three ranges should share the same SplitStats instance (reference equality)
+        assertSame(store.rangeStats(0, 0), store.rangeStats(1, 0));
+        assertSame(store.rangeStats(1, 0), store.rangeStats(2, 0));
+    }
+
+    public void testEstimatedBytesPositive() {
+        StoragePath path = StoragePath.of("s3://bucket/file_0.parquet");
+        RangeAwareFormatReader.SplitRange range = new RangeAwareFormatReader.SplitRange(0, 1024, Map.of("_stats.row_count", 10L));
+
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath = Map.of(path, List.of(range));
+        CompactRangeStore store = CompactRangeStore.build(1, i -> path, rangesByPath);
+        assertNotNull(store);
+        assertTrue(store.estimatedBytes() > 0);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/GenericFileListTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/GenericFileListTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.PartitionMetadata;
 import org.elasticsearch.xpack.esql.datasources.StorageEntry;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.time.Instant;
@@ -89,6 +90,41 @@ public class GenericFileListTests extends ESTestCase {
     public void testSentinelsHaveNullPartitionMetadata() {
         assertNull(FileList.UNRESOLVED.partitionMetadata());
         assertNull(FileList.EMPTY.partitionMetadata());
+    }
+
+    public void testFileSplitRangesNullByDefault() {
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://bucket/file.parquet"), 100, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://bucket/*.parquet");
+        assertNull(fileList.fileSplitRanges());
+    }
+
+    public void testWithFileSplitRangesAttachesAndPreservesFiles() {
+        StoragePath path = StoragePath.of("s3://bucket/file.parquet");
+        StorageEntry entry = new StorageEntry(path, 100, Instant.EPOCH);
+        GenericFileList fileList = (GenericFileList) GlobExpander.fileListOf(List.of(entry), "s3://bucket/*.parquet");
+
+        RangeAwareFormatReader.SplitRange r = new RangeAwareFormatReader.SplitRange(0, 100, Map.of("_stats.row_count", 10L));
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> ranges = Map.of(path, List.of(r));
+
+        GenericFileList withRanges = fileList.withFileSplitRanges(ranges);
+        assertNotNull(withRanges.fileSplitRanges());
+        assertEquals(1, withRanges.fileSplitRanges().size());
+        assertEquals(List.of(r), withRanges.fileSplitRanges().get(path));
+        assertEquals(fileList.files(), withRanges.files());
+        assertEquals(fileList.originalPattern(), withRanges.originalPattern());
+        assertNull(withRanges.partitionMetadata());
+    }
+
+    public void testEqualityDistinguishesFileSplitRanges() {
+        StoragePath path = StoragePath.of("s3://bucket/file.parquet");
+        StorageEntry entry = new StorageEntry(path, 100, Instant.EPOCH);
+        GenericFileList base = (GenericFileList) GlobExpander.fileListOf(List.of(entry), "s3://bucket/*.parquet");
+
+        RangeAwareFormatReader.SplitRange r = new RangeAwareFormatReader.SplitRange(0, 100, Map.of("_stats.row_count", 10L));
+        GenericFileList withRanges = base.withFileSplitRanges(Map.of(path, List.of(r)));
+
+        assertNotEquals(base, withRanges);
+        assertNotEquals(base.hashCode(), withRanges.hashCode());
     }
 
     public void testEqualityWithPartitionMetadata() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/GenericFileListTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/glob/GenericFileListTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -94,7 +95,7 @@ public class GenericFileListTests extends ESTestCase {
 
     public void testFileSplitRangesNullByDefault() {
         StorageEntry entry = new StorageEntry(StoragePath.of("s3://bucket/file.parquet"), 100, Instant.EPOCH);
-        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://bucket/*.parquet");
+        GenericFileList fileList = (GenericFileList) GlobExpander.fileListOf(List.of(entry), "s3://bucket/*.parquet");
         assertNull(fileList.fileSplitRanges());
     }
 
@@ -137,5 +138,49 @@ public class GenericFileListTests extends ESTestCase {
 
         assertEquals(a, b);
         assertNotEquals(a, c);
+    }
+
+    public void testCompactRoundTripPreservesRanges() {
+        StoragePath p1 = StoragePath.of("s3://bucket/data/file1.parquet");
+        StoragePath p2 = StoragePath.of("s3://bucket/data/file2.parquet");
+
+        RangeAwareFormatReader.SplitRange r1 = new RangeAwareFormatReader.SplitRange(4, 100, Map.of("_stats.row_count", 50L));
+        RangeAwareFormatReader.SplitRange r2 = new RangeAwareFormatReader.SplitRange(104, 200, Map.of("_stats.row_count", 75L));
+        RangeAwareFormatReader.SplitRange r3 = new RangeAwareFormatReader.SplitRange(8, 150, Map.of("_stats.row_count", 60L));
+
+        Map<StoragePath, List<RangeAwareFormatReader.SplitRange>> rangesByPath = new HashMap<>();
+        rangesByPath.put(p1, List.of(r1, r2));
+        rangesByPath.put(p2, List.of(r3));
+
+        List<StorageEntry> entries = List.of(new StorageEntry(p1, 300, Instant.EPOCH), new StorageEntry(p2, 150, Instant.EPOCH));
+
+        FileList raw = GlobExpander.fileListOf(entries, "s3://bucket/data/*.parquet");
+        FileList withRanges = GlobExpander.withFileSplitRanges(raw, rangesByPath);
+        FileList compact = GlobExpander.compact(withRanges, "s3://bucket/data/");
+
+        assertEquals(2, compact.fileCount());
+
+        int idx1 = -1, idx2 = -1;
+        for (int i = 0; i < compact.fileCount(); i++) {
+            if (compact.path(i).equals(p1)) idx1 = i;
+            if (compact.path(i).equals(p2)) idx2 = i;
+        }
+        assertTrue(idx1 >= 0);
+        assertTrue(idx2 >= 0);
+
+        assertEquals(2, compact.rangeCount(idx1));
+        assertEquals(r1.offset(), compact.rangeOffset(idx1, 0));
+        assertEquals(r1.length(), compact.rangeLength(idx1, 0));
+        assertEquals(r2.offset(), compact.rangeOffset(idx1, 1));
+        assertEquals(r2.length(), compact.rangeLength(idx1, 1));
+
+        assertEquals(1, compact.rangeCount(idx2));
+        assertEquals(r3.offset(), compact.rangeOffset(idx2, 0));
+        assertEquals(r3.length(), compact.rangeLength(idx2, 0));
+
+        assertNotNull(compact.rangeStats(idx1, 0));
+        assertEquals(50L, compact.rangeStats(idx1, 0).rowCount());
+        assertNotNull(compact.rangeStats(idx2, 0));
+        assertEquals(60L, compact.rangeStats(idx2, 0).rowCount());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/FileLayoutTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/FileLayoutTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+
+import java.util.List;
+import java.util.Map;
+
+public class FileLayoutTests extends ESTestCase {
+
+    private static SourceMetadata sampleMetadata() {
+        return new SimpleSourceMetadata(List.<Attribute>of(), "parquet", "s3://b/f.parquet");
+    }
+
+    public void testRequiresMetadata() {
+        expectThrows(IllegalArgumentException.class, () -> new FileLayout(null, List.of()));
+    }
+
+    public void testNullSplitRangesBecomesEmpty() {
+        FileLayout layout = new FileLayout(sampleMetadata(), null);
+        assertNotNull(layout.splitRanges());
+        assertTrue(layout.splitRanges().isEmpty());
+    }
+
+    public void testSplitRangesAreDefensivelyCopied() {
+        RangeAwareFormatReader.SplitRange r = new RangeAwareFormatReader.SplitRange(0, 10, Map.of("k", 1L));
+        java.util.ArrayList<RangeAwareFormatReader.SplitRange> mutable = new java.util.ArrayList<>();
+        mutable.add(r);
+        FileLayout layout = new FileLayout(sampleMetadata(), mutable);
+
+        mutable.clear();
+        assertEquals(1, layout.splitRanges().size());
+        assertSame(r, layout.splitRanges().get(0));
+
+        // Returned list should be unmodifiable.
+        expectThrows(UnsupportedOperationException.class, () -> layout.splitRanges().add(r));
+    }
+
+    public void testOfMetadataReturnsEmptyRanges() {
+        FileLayout layout = FileLayout.ofMetadata(sampleMetadata());
+        assertNotNull(layout.metadata());
+        assertTrue(layout.splitRanges().isEmpty());
+    }
+
+    public void testCarriesProvidedRanges() {
+        RangeAwareFormatReader.SplitRange r1 = new RangeAwareFormatReader.SplitRange(0, 10, Map.of("a", 1L));
+        RangeAwareFormatReader.SplitRange r2 = new RangeAwareFormatReader.SplitRange(10, 20, Map.of("b", 2L));
+        FileLayout layout = new FileLayout(sampleMetadata(), List.of(r1, r2));
+        assertEquals(2, layout.splitRanges().size());
+        assertEquals(r1, layout.splitRanges().get(0));
+        assertEquals(r2, layout.splitRanges().get(1));
+    }
+}


### PR DESCRIPTION
Replace `Map`-based `fileSplitRanges()` with index-keyed accessors
(`rangeCount`, `rangeOffset`, `rangeLength`, `rangeStats`) on `FileList`.
Introduce `CompactRangeStore` with CSR indexing and dictionary encoding
for length templates and `SplitStats`, embedded by `DictionaryFileList`
and `HiveFileList` so pre-resolved ranges survive compaction and avoid
redundant footer reads in `FileSplitProvider`.

## Changes

**SPI** (`FileList.java`): Remove `fileSplitRanges()`, add four default
methods with tri-state `rangeCount` (`-1` = not resolved, `0` = empty,
`>0` = ranges available).

**CompactRangeStore** (new): CSR-indexed range storage with
dictionary-encoded length templates, explicit per-range offsets, and
deduplicated `SplitStats`. Validates range sanity (negative offset,
zero length) and guards against `short` overflow.

**Compact lists**: `DictionaryFileList` and `HiveFileList` embed an
optional `CompactRangeStore`, delegating range accessors to it.

**Wiring**: `FileListCompactor` builds the store during compaction.
`GlobExpander.withFileSplitRanges` attaches ranges post-compaction
via `withRanges()`. `FileSplitProvider` uses the index-based API.

Developed with AI-assisted tooling