### PR TITLE
ES|QL: Fix text_embedding tests

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/embedding.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/embedding.csv-spec
@@ -91,20 +91,25 @@ required_capability: knn_function_v5
 required_capability: fork_v9
 
 FROM dense_vector_text METADATA _score
-| FORK (EVAL query_embedding = EMBEDDING("be excellent to each other", "test_embedding_inference") | WHERE KNN(text_embedding_field, query_embedding))
-       (EVAL query_embedding = EMBEDDING("live long and prosper", "test_embedding_inference") | WHERE KNN(text_embedding_field, query_embedding))
-| SORT _score DESC, _fork ASC
-| LIMIT 10
-| KEEP text_field, query_embedding, _fork
+| FORK (EVAL query_embedding = EMBEDDING("be excellent to each other", "test_embedding_inference") 
+    | WHERE KNN(text_embedding_field, query_embedding)
+    | SORT _score DESC
+    | LIMIT 10)
+       (EVAL query_embedding = EMBEDDING("live long and prosper", "test_embedding_inference") 
+       | WHERE KNN(text_embedding_field, query_embedding)
+       | SORT _score DESC
+       | LIMIT 10)
+| SORT text_field DESC, _fork ASC
+| KEEP text_field, query_embedding, _fork, _score
 ;
 
-text_field:text                                                       | query_embedding:dense_vector | _fork:keyword
-live long and prosper                                                 | [50.0, 57.0, 56.0]           | fork2
-be excellent to each other                                            | [45.0, 55.0, 54.0]           | fork1
-live long and prosper                                                 | [45.0, 55.0, 54.0]           | fork1
-be excellent to each other                                            | [50.0, 57.0, 56.0]           | fork2
-all we have to decide is what to do with the time that is given to us | [45.0, 55.0, 54.0]           | fork1
-all we have to decide is what to do with the time that is given to us | [50.0, 57.0, 56.0]           | fork2
+text_field:text                                                       | query_embedding:dense_vector | _fork:keyword | _score:double
+live long and prosper                                                 | [45.0, 55.0, 54.0]           | fork1         | 0.02..0.3
+live long and prosper                                                 | [50.0, 57.0, 56.0]           | fork2         | 0.9..1.0
+be excellent to each other                                            | [45.0, 55.0, 54.0]           | fork1         | 0.9..1.0
+be excellent to each other                                            | [50.0, 57.0, 56.0]           | fork2         | 0.02..0.3
+all we have to decide is what to do with the time that is given to us | [45.0, 55.0, 54.0]           | fork1         | 0.02..0.03
+all we have to decide is what to do with the time that is given to us | [50.0, 57.0, 56.0]           | fork2         | 0.01..0.02
 ;
 
 embedding with explicit text type option


### PR DESCRIPTION
Fixes the embedding-with-multiple-knn-queries-in-fork                                                                 test. The failure was caused by non-deterministic row ordering