### PR TITLE
Ignore openspec directory created by openspec tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ server/src/main/resources/transport/definitions/manifest.txt
 
 # Vector data files
 qa/vector/.data
+
+# Ignore directory created by the openspec tool
+# Prefix slash ensures these are only ignored at the same level as this file
+/openspec/

--- a/.gitignore
+++ b/.gitignore
@@ -95,5 +95,5 @@ server/src/main/resources/transport/definitions/manifest.txt
 qa/vector/.data
 
 # Ignore directory created by the openspec tool
-# Prefix slash ensures these are only ignored at the same level as this file
+# Prefix slash ensures the directory is only ignored at the same level as this file
 /openspec/


### PR DESCRIPTION
This PR adds `openspec` to the `.gitignore` file. It only ignores the directory at the same level as the git ignore file.

Openspec tool: https://github.com/Fission-AI/OpenSpec/tree/main