### PR TITLE
Skip synthetic field mappers in indices.get_field_mapping

### DIFF
--- a/docs/changelog/147905.yaml
+++ b/docs/changelog/147905.yaml
@@ -1,0 +1,6 @@
+pr: 147905
+summary: Skip synthetic field mappers in indices.get_field_mapping
+area: Mapping
+type: bug
+issues:
+ - 118636

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/50_field_wildcards.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_field_mapping/50_field_wildcards.yml
@@ -129,3 +129,45 @@ setup:
   - match:  {test_index_2.mappings.t2.full_name: t2 }
   - length: {test_index_2.mappings: 2}
 
+
+---
+"Get field mapping with wildcard for search_as_you_type field":
+  - requires:
+      cluster_features: ["gte_v8.16.0"]
+      reason: search_as_you_type wildcard fix landed after 8.16
+
+  - do:
+      indices.create:
+        index: search_as_you_type_index
+        body:
+          mappings:
+            properties:
+              field1a:
+                type: search_as_you_type
+              field1b:
+                type: text
+              field2a:
+                type: text
+
+  # Wildcard that matches a search_as_you_type root field must return that field
+  # and must not return its synthetic prefix/shingle subfields (gh-118636).
+  - do:
+      indices.get_field_mapping:
+        index: search_as_you_type_index
+        fields: "field1*"
+
+  - match:    { search_as_you_type_index.mappings.field1a.full_name: field1a }
+  - match:    { search_as_you_type_index.mappings.field1b.full_name: field1b }
+  - length:   { search_as_you_type_index.mappings: 2 }
+
+  # Match-all wildcard must include the search_as_you_type root field but exclude
+  # its synthetic subfields.
+  - do:
+      indices.get_field_mapping:
+        index: search_as_you_type_index
+        fields: "*"
+
+  - match:    { search_as_you_type_index.mappings.field1a.full_name: field1a }
+  - is_false: search_as_you_type_index.mappings.field1a\\._index_prefix
+  - is_false: search_as_you_type_index.mappings.field1a\\._2gram
+  - is_false: search_as_you_type_index.mappings.field1a\\._3gram

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.shard.ShardId;
@@ -162,10 +163,16 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
         for (String field : request.fields()) {
             if (Regex.isMatchAllPattern(field)) {
                 for (Mapper fieldMapper : mappingLookup.fieldMappers()) {
+                    if (isInternalFieldMapper(fieldMapper)) {
+                        continue;
+                    }
                     addFieldMapper(fieldPredicate, fieldMapper.fullPath(), fieldMapper, fieldMappings, request.includeDefaults());
                 }
             } else if (Regex.isSimpleMatchPattern(field)) {
                 for (Mapper fieldMapper : mappingLookup.fieldMappers()) {
+                    if (isInternalFieldMapper(fieldMapper)) {
+                        continue;
+                    }
                     if (Regex.simpleMatch(field, fieldMapper.fullPath())) {
                         addFieldMapper(fieldPredicate, fieldMapper.fullPath(), fieldMapper, fieldMappings, request.includeDefaults());
                     }
@@ -173,12 +180,22 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
             } else {
                 // not a pattern
                 Mapper fieldMapper = mappingLookup.getMapper(field);
-                if (fieldMapper != null) {
+                if (fieldMapper != null && isInternalFieldMapper(fieldMapper) == false) {
                     addFieldMapper(fieldPredicate, field, fieldMapper, fieldMappings, request.includeDefaults());
                 }
             }
         }
         return Collections.unmodifiableMap(fieldMappings);
+    }
+
+    /**
+     * Returns {@code true} for synthetic {@link FieldMapper} instances that are managed internally by their parent mapper
+     * (e.g. {@code search_as_you_type} prefix and shingle subfields, or the {@code _id} subfields backing {@code join}).
+     * Such mappers have no public {@link FieldMapper.Builder} and cannot be serialized on their own, so they should not be
+     * exposed through the get field mapping API.
+     */
+    private static boolean isInternalFieldMapper(Mapper mapper) {
+        return mapper instanceof FieldMapper fieldMapper && fieldMapper.getMergeBuilder() == null;
     }
 
     private static void addFieldMapper(


### PR DESCRIPTION
## Problem

`indices.get_field_mapping` returns an empty response when a wildcard (or even an exact name) selects a field whose type ships with synthetic internal subfield mappers — `search_as_you_type` is the canonical reproducer (gh-118636), but the same pattern affects every `FieldMapper` subclass that returns `null` from `getMergeBuilder()`.

```
PUT my-index
{ "mappings": { "properties": { "field1a": { "type": "search_as_you_type" }, "field1b": { "type": "text" } } } }

GET my-index/_mapping/field/field1*
{}        # expected: field1a, field1b
```

## Root Cause

`TransportGetFieldMappingsIndexAction#findFieldMappingsByType` iterates `mappingLookup.fieldMappers()` and calls `addFieldMapper` for every mapper that matches the requested name. Internal subfield mappers — for instance the prefix/shingle mappers that back `search_as_you_type`, or the synthetic `_id` mapper that backs `join` — have no public `FieldMapper.Builder`, so they cannot serialize their own configuration. When the API tries to render them, the response collapses.

## Fix

`FieldMapper#getMergeBuilder()` already returns `null` for those internal mappers (it is the project-wide signal that a mapper is managed by its parent). Skip mappers that match this condition before adding them to the response.

`TransportGetFieldMappingsIndexAction.java`:
- Add `isInternalFieldMapper(Mapper)` returning true when the mapper is a `FieldMapper` whose `getMergeBuilder()` is null.
- Apply the filter in all three matching branches: `Regex.isMatchAllPattern`, `Regex.isSimpleMatchPattern`, and the exact-name path.

## Tests Added

| Change point | Test |
|--------------|------|
| Wildcard match returns `search_as_you_type` root field but no synthetic subfields | `rest-api-spec/.../indices.get_field_mapping/50_field_wildcards.yml` — `Get field mapping with wildcard for search_as_you_type field` (the `field1*` wildcard returns `field1a` + `field1b` with `length: 2`) |
| `*` match-all returns the root field and excludes its synthetic subfields | same yaml test, second assertion block — asserts `field1a` is present and the `_index_prefix`, `_2gram`, `_3gram` subfields are not |

## Impact

- Restores `indices.get_field_mapping` for indices that contain `search_as_you_type`, `join`, or any other field type whose internal mappers return `null` from `getMergeBuilder`.
- No changes to mapping storage, no changes to query/aggregation behaviour.
- Backwards compatible: clients that previously received empty responses will now see the public field entries; clients that already received correct responses on simpler mappings see no change.

Closes #118636