### PR TITLE
Rename gettor method in SearchResponse for the search profile shard results

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -582,7 +582,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
                     }
                 }
                 assertResponse(search, resp -> {
-                    final var profileResults = resp.getProfileResults();
+                    final var profileResults = resp.getSearchProfileShardResults();
                     assertThat(profileResults, not(anEmptyMap()));
                     for (final var searchShardProfileKey : profileResults.keySet()) {
                         assertThat(searchShardProfileKeys, hasItem(searchShardProfileKey));
@@ -604,7 +604,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
                 BytesReference pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openRequest).actionGet().getPointInTimeId();
                 try {
                     assertResponse(prepareSearch().setPointInTime(new PointInTimeBuilder(pitId)).setProfile(true), response -> {
-                        var profileResults = response.getProfileResults();
+                        var profileResults = response.getSearchProfileShardResults();
                         assertThat(profileResults, not(anEmptyMap()));
                         for (final var profileKey : profileResults.keySet()) {
                             assertThat(profileKey, in(searchShardProfileKeys));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/profile/SearchProfileCoordinatorRequestMetadataIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/profile/SearchProfileCoordinatorRequestMetadataIT.java
@@ -54,7 +54,7 @@ public class SearchProfileCoordinatorRequestMetadataIT extends ESIntegTestCase {
         assertCheckedResponse(
             prepareSearch(concreteIndex).setProfile(false).setSource(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())),
             response -> {
-                assertThat(response.getProfileResults().size(), equalTo(0));
+                assertThat(response.getSearchProfileShardResults().size(), equalTo(0));
                 BytesReference bytes = XContentHelper.toXContent(response, XContentType.JSON, false);
                 Map<String, Object> map = XContentHelper.convertToMap(bytes, false, XContentType.JSON).v2();
                 assertNull(map.get("profile"));
@@ -64,7 +64,7 @@ public class SearchProfileCoordinatorRequestMetadataIT extends ESIntegTestCase {
 
     private static void assertProfileRequestInXContent(SearchResponse response, String expectedIndexExpression, int expectedSize)
         throws IOException {
-        assertThat(response.getProfileResults().size(), greaterThanOrEqualTo(1));
+        assertThat(response.getSearchProfileShardResults().size(), greaterThanOrEqualTo(1));
         BytesReference bytes = XContentHelper.toXContent(response, XContentType.JSON, false);
         Map<String, Object> map = XContentHelper.convertToMap(bytes, false, XContentType.JSON).v2();
         @SuppressWarnings("unchecked")

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
@@ -124,7 +124,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
         assertNoFailuresAndResponse(
             prepareSearch("idx").setProfile(true).addAggregation(histogram("histo").field(NUMBER_FIELD).interval(1L)),
             response -> {
-                Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
+                Map<String, SearchProfileShardResult> profileResults = response.getSearchProfileShardResults();
                 assertThat(profileResults, notNullValue());
                 assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
                 for (SearchProfileShardResult profileShardResult : profileResults.values()) {
@@ -169,7 +169,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                         )
                 ),
             response -> {
-                Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
+                Map<String, SearchProfileShardResult> profileResults = response.getSearchProfileShardResults();
                 assertThat(profileResults, notNullValue());
                 assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
                 for (SearchProfileShardResult profileShardResult : profileResults.values()) {
@@ -257,7 +257,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                         )
                 ),
             response -> {
-                Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
+                Map<String, SearchProfileShardResult> profileResults = response.getSearchProfileShardResults();
                 assertThat(profileResults, notNullValue());
                 assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
                 for (SearchProfileShardResult profileShardResult : profileResults.values()) {
@@ -329,7 +329,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                         .subAggregation(max("max").field(NUMBER_FIELD))
                 ),
             response -> {
-                Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
+                Map<String, SearchProfileShardResult> profileResults = response.getSearchProfileShardResults();
                 assertThat(profileResults, notNullValue());
                 assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
                 for (SearchProfileShardResult profileShardResult : profileResults.values()) {
@@ -402,7 +402,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                         )
                 ),
             response -> {
-                Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
+                Map<String, SearchProfileShardResult> profileResults = response.getSearchProfileShardResults();
                 assertThat(profileResults, notNullValue());
                 assertThat(profileResults.size(), equalTo(getNumShards("idx").numPrimaries));
                 for (SearchProfileShardResult profileShardResult : profileResults.values()) {
@@ -620,7 +620,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                         )
                 ),
             response -> {
-                Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
+                Map<String, SearchProfileShardResult> profileResults = response.getSearchProfileShardResults();
                 assertThat(profileResults, notNullValue());
                 assertThat(profileResults.size(), equalTo(0));
             }
@@ -653,7 +653,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                         .subAggregation(new MaxAggregationBuilder("m").field("date"))
                 ),
             response -> {
-                Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
+                Map<String, SearchProfileShardResult> profileResults = response.getSearchProfileShardResults();
                 assertThat(profileResults, notNullValue());
                 assertThat(profileResults.size(), equalTo(getNumShards("dateidx").numPrimaries));
                 for (SearchProfileShardResult profileShardResult : profileResults.values()) {
@@ -728,7 +728,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                         new DateHistogramAggregationBuilder("histo").field("date").calendarInterval(DateHistogramInterval.MONTH)
                     ),
                 response -> {
-                    Map<String, SearchProfileShardResult> profileResults = response.getProfileResults();
+                    Map<String, SearchProfileShardResult> profileResults = response.getSearchProfileShardResults();
                     assertThat(profileResults, notNullValue());
                     assertThat(profileResults.size(), equalTo(getNumShards("date_filter_by_filter_disabled").numPrimaries));
                     for (SearchProfileShardResult profileShardResult : profileResults.values()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/profile/dfs/DfsProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/profile/dfs/DfsProfilerIT.java
@@ -87,9 +87,9 @@ public class DfsProfilerIT extends ESIntegTestCase {
                     .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
                     .setKnnSearch(randomList(2, 5, () -> knnSearchBuilder)),
                 response -> {
-                    assertNotNull("Profile response element should not be null", response.getProfileResults());
-                    assertThat("Profile response should not be an empty array", response.getProfileResults().size(), not(0));
-                    for (Map.Entry<String, SearchProfileShardResult> shard : response.getProfileResults().entrySet()) {
+                    assertNotNull("Profile response element should not be null", response.getSearchProfileShardResults());
+                    assertThat("Profile response should not be an empty array", response.getSearchProfileShardResults().size(), not(0));
+                    for (Map.Entry<String, SearchProfileShardResult> shard : response.getSearchProfileShardResults().entrySet()) {
                         for (QueryProfileShardResult searchProfiles : shard.getValue().getQueryProfileResults()) {
                             for (ProfileResult result : searchProfiles.getQueryResults()) {
                                 assertNotNull(result.getQueryName());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/profile/query/QueryProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/profile/query/QueryProfilerIT.java
@@ -67,13 +67,13 @@ public class QueryProfilerIT extends ESIntegTestCase {
             assertResponse(
                 prepareSearch().setQuery(q).setTrackTotalHits(true).setProfile(true).setSearchType(SearchType.QUERY_THEN_FETCH),
                 response -> {
-                    assertNotNull("Profile response element should not be null", response.getProfileResults());
+                    assertNotNull("Profile response element should not be null", response.getSearchProfileShardResults());
                     if (response.getSkippedShards() == response.getSuccessfulShards()) {
-                        assertEquals(0, response.getProfileResults().size());
+                        assertEquals(0, response.getSearchProfileShardResults().size());
                     } else {
-                        assertThat("Profile response should not be an empty array", response.getProfileResults().size(), not(0));
+                        assertThat("Profile response should not be an empty array", response.getSearchProfileShardResults().size(), not(0));
                     }
-                    for (Map.Entry<String, SearchProfileShardResult> shard : response.getProfileResults().entrySet()) {
+                    for (Map.Entry<String, SearchProfileShardResult> shard : response.getSearchProfileShardResults().entrySet()) {
                         for (QueryProfileShardResult searchProfiles : shard.getValue().getQueryProfileResults()) {
                             for (ProfileResult result : searchProfiles.getQueryResults()) {
                                 assertNotNull(result.getQueryName());
@@ -193,11 +193,11 @@ public class QueryProfilerIT extends ESIntegTestCase {
         QueryBuilder q = QueryBuilders.matchQuery("field1", "one");
 
         assertResponse(prepareSearch().setQuery(q).setProfile(true).setSearchType(SearchType.QUERY_THEN_FETCH), response -> {
-            Map<String, SearchProfileShardResult> p = response.getProfileResults();
+            Map<String, SearchProfileShardResult> p = response.getSearchProfileShardResults();
             assertNotNull(p);
-            assertThat("Profile response should not be an empty array", response.getProfileResults().size(), not(0));
+            assertThat("Profile response should not be an empty array", response.getSearchProfileShardResults().size(), not(0));
 
-            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getProfileResults().entrySet()) {
+            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getSearchProfileShardResults().entrySet()) {
                 for (QueryProfileShardResult searchProfiles : shardResult.getValue().getQueryProfileResults()) {
                     for (ProfileResult result : searchProfiles.getQueryResults()) {
                         assertEquals(result.getQueryName(), "TermQuery");
@@ -234,11 +234,11 @@ public class QueryProfilerIT extends ESIntegTestCase {
             .must(QueryBuilders.matchQuery("field1", "two"));
 
         assertResponse(prepareSearch().setQuery(q).setProfile(true).setSearchType(SearchType.QUERY_THEN_FETCH), response -> {
-            Map<String, SearchProfileShardResult> p = response.getProfileResults();
+            Map<String, SearchProfileShardResult> p = response.getSearchProfileShardResults();
             assertNotNull(p);
-            assertThat("Profile response should not be an empty array", response.getProfileResults().size(), not(0));
+            assertThat("Profile response should not be an empty array", response.getSearchProfileShardResults().size(), not(0));
 
-            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getProfileResults().entrySet()) {
+            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getSearchProfileShardResults().entrySet()) {
                 for (QueryProfileShardResult searchProfiles : shardResult.getValue().getQueryProfileResults()) {
                     for (ProfileResult result : searchProfiles.getQueryResults()) {
                         assertEquals(result.getQueryName(), "BooleanQuery");
@@ -294,10 +294,10 @@ public class QueryProfilerIT extends ESIntegTestCase {
         logger.info("Query: {}", q);
 
         assertResponse(prepareSearch().setQuery(q).setProfile(true).setSearchType(SearchType.QUERY_THEN_FETCH), response -> {
-            assertNotNull("Profile response element should not be null", response.getProfileResults());
-            assertThat("Profile response should not be an empty array", response.getProfileResults().size(), not(0));
+            assertNotNull("Profile response element should not be null", response.getSearchProfileShardResults());
+            assertThat("Profile response should not be an empty array", response.getSearchProfileShardResults().size(), not(0));
 
-            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getProfileResults().entrySet()) {
+            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getSearchProfileShardResults().entrySet()) {
                 for (QueryProfileShardResult searchProfiles : shardResult.getValue().getQueryProfileResults()) {
                     for (ProfileResult result : searchProfiles.getQueryResults()) {
                         assertNotNull(result.getQueryName());
@@ -339,10 +339,10 @@ public class QueryProfilerIT extends ESIntegTestCase {
         logger.info("Query: {}", q);
 
         assertResponse(prepareSearch().setQuery(q).setProfile(true).setSearchType(SearchType.QUERY_THEN_FETCH), response -> {
-            assertNotNull("Profile response element should not be null", response.getProfileResults());
-            assertThat("Profile response should not be an empty array", response.getProfileResults().size(), not(0));
+            assertNotNull("Profile response element should not be null", response.getSearchProfileShardResults());
+            assertThat("Profile response should not be an empty array", response.getSearchProfileShardResults().size(), not(0));
 
-            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getProfileResults().entrySet()) {
+            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getSearchProfileShardResults().entrySet()) {
                 for (QueryProfileShardResult searchProfiles : shardResult.getValue().getQueryProfileResults()) {
                     for (ProfileResult result : searchProfiles.getQueryResults()) {
                         assertNotNull(result.getQueryName());
@@ -379,10 +379,10 @@ public class QueryProfilerIT extends ESIntegTestCase {
         logger.info("Query: {}", q);
 
         assertResponse(prepareSearch().setQuery(q).setProfile(true).setSearchType(SearchType.QUERY_THEN_FETCH), response -> {
-            assertNotNull("Profile response element should not be null", response.getProfileResults());
-            assertThat("Profile response should not be an empty array", response.getProfileResults().size(), not(0));
+            assertNotNull("Profile response element should not be null", response.getSearchProfileShardResults());
+            assertThat("Profile response should not be an empty array", response.getSearchProfileShardResults().size(), not(0));
 
-            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getProfileResults().entrySet()) {
+            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getSearchProfileShardResults().entrySet()) {
                 for (QueryProfileShardResult searchProfiles : shardResult.getValue().getQueryProfileResults()) {
                     for (ProfileResult result : searchProfiles.getQueryResults()) {
                         assertNotNull(result.getQueryName());
@@ -419,10 +419,10 @@ public class QueryProfilerIT extends ESIntegTestCase {
         logger.info("Query: {}", q);
 
         assertResponse(prepareSearch().setQuery(q).setProfile(true).setSearchType(SearchType.QUERY_THEN_FETCH), response -> {
-            assertNotNull("Profile response element should not be null", response.getProfileResults());
-            assertThat("Profile response should not be an empty array", response.getProfileResults().size(), not(0));
+            assertNotNull("Profile response element should not be null", response.getSearchProfileShardResults());
+            assertThat("Profile response should not be an empty array", response.getSearchProfileShardResults().size(), not(0));
 
-            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getProfileResults().entrySet()) {
+            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getSearchProfileShardResults().entrySet()) {
                 for (QueryProfileShardResult searchProfiles : shardResult.getValue().getQueryProfileResults()) {
                     for (ProfileResult result : searchProfiles.getQueryResults()) {
                         assertNotNull(result.getQueryName());
@@ -458,10 +458,10 @@ public class QueryProfilerIT extends ESIntegTestCase {
         logger.info("Query: {}", q.toString());
 
         assertResponse(prepareSearch().setQuery(q).setProfile(true).setSearchType(SearchType.QUERY_THEN_FETCH), response -> {
-            assertNotNull("Profile response element should not be null", response.getProfileResults());
-            assertThat("Profile response should not be an empty array", response.getProfileResults().size(), not(0));
+            assertNotNull("Profile response element should not be null", response.getSearchProfileShardResults());
+            assertThat("Profile response should not be an empty array", response.getSearchProfileShardResults().size(), not(0));
 
-            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getProfileResults().entrySet()) {
+            for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getSearchProfileShardResults().entrySet()) {
                 for (QueryProfileShardResult searchProfiles : shardResult.getValue().getQueryProfileResults()) {
                     for (ProfileResult result : searchProfiles.getQueryResults()) {
                         assertNotNull(result.getQueryName());
@@ -507,10 +507,10 @@ public class QueryProfilerIT extends ESIntegTestCase {
                     fail();
                 }
 
-                assertNotNull("Profile response element should not be null", response.getProfileResults());
-                assertThat("Profile response should not be an empty array", response.getProfileResults().size(), not(0));
+                assertNotNull("Profile response element should not be null", response.getSearchProfileShardResults());
+                assertThat("Profile response should not be an empty array", response.getSearchProfileShardResults().size(), not(0));
 
-                for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getProfileResults().entrySet()) {
+                for (Map.Entry<String, SearchProfileShardResult> shardResult : response.getSearchProfileShardResults().entrySet()) {
                     for (QueryProfileShardResult searchProfiles : shardResult.getValue().getQueryProfileResults()) {
                         for (ProfileResult result : searchProfiles.getQueryResults()) {
                             assertNotNull(result.getQueryName());
@@ -549,7 +549,11 @@ public class QueryProfilerIT extends ESIntegTestCase {
 
         assertResponse(
             prepareSearch().setQuery(q).setProfile(false),
-            response -> assertThat("Profile response element should be an empty map", response.getProfileResults().size(), equalTo(0))
+            response -> assertThat(
+                "Profile response element should be an empty map",
+                response.getSearchProfileShardResults().size(),
+                equalTo(0)
+            )
         );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/VectorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/VectorIT.java
@@ -90,7 +90,7 @@ public class VectorIT extends ESIntegTestCase {
         );
         assertResponse(client().prepareSearch(INDEX_NAME).setKnnSearch(List.of(query)).setSize(1).setProfile(true), acornResponse -> {
             assertNotEquals(0, acornResponse.getHits().getHits().length);
-            var profileResults = acornResponse.getProfileResults();
+            var profileResults = acornResponse.getSearchProfileShardResults();
             long vectorOpsSum = profileResults.values()
                 .stream()
                 .mapToLong(
@@ -115,7 +115,7 @@ public class VectorIT extends ESIntegTestCase {
                 .get();
             assertResponse(client().prepareSearch(INDEX_NAME).setKnnSearch(List.of(query)).setSize(1).setProfile(true), fanoutResponse -> {
                 assertNotEquals(0, fanoutResponse.getHits().getHits().length);
-                var fanoutProfileResults = fanoutResponse.getProfileResults();
+                var fanoutProfileResults = fanoutResponse.getSearchProfileShardResults();
                 long fanoutVectorOpsSum = fanoutProfileResults.values()
                     .stream()
                     .mapToLong(
@@ -157,7 +157,7 @@ public class VectorIT extends ESIntegTestCase {
         var query = new KnnSearchBuilder(VECTOR_FIELD, vector, 1, 1, 10f, null, null);
         assertResponse(client().prepareSearch(INDEX_NAME).setKnnSearch(List.of(query)).setSize(1).setProfile(true), response -> {
             assertNotEquals(0, response.getHits().getHits().length);
-            var profileResults = response.getProfileResults();
+            var profileResults = response.getSearchProfileShardResults();
             long vectorOpsSum = profileResults.values()
                 .stream()
                 .mapToLong(
@@ -178,7 +178,7 @@ public class VectorIT extends ESIntegTestCase {
                 client().prepareSearch(INDEX_NAME).setKnnSearch(List.of(query)).setSize(1).setProfile(true),
                 earlyTerminationResponse -> {
                     assertNotEquals(0, earlyTerminationResponse.getHits().getHits().length);
-                    var earlyTerminationResults = earlyTerminationResponse.getProfileResults();
+                    var earlyTerminationResults = earlyTerminationResponse.getSearchProfileShardResults();
                     long earlyTerminationVectorOpsSum = earlyTerminationResults.values()
                         .stream()
                         .mapToLong(

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -431,7 +431,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
      * @return The profile results or an empty map
      */
     @Nullable
-    public Map<String, SearchProfileShardResult> getProfileResults() {
+    public Map<String, SearchProfileShardResult> getSearchProfileShardResults() {
         if (profileResults == null) {
             return Collections.emptyMap();
         }
@@ -443,7 +443,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
      * ({@link SearchProfileResults#getOriginalSource()} / {@link SearchProfileResults#getRequestIndices()}).
      * {@code null} when profiling did not produce a profile object.
      * <p>
-     * For per-shard timings only, {@link #getProfileResults()} returns the shard map (empty when profiling was off).
+     * For per-shard timings only, {@link #getSearchProfileShardResults()} returns the shard map (empty when profiling was off).
      */
     @Nullable
     public SearchProfileResults getSearchProfileResults() {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponseMerger.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponseMerger.java
@@ -149,7 +149,7 @@ public final class SearchResponseMerger implements Releasable {
 
             Collections.addAll(failures, searchResponse.getShardFailures());
 
-            shardProfileResults.putAll(searchResponse.getProfileResults());
+            shardProfileResults.putAll(searchResponse.getSearchProfileShardResults());
 
             if (searchResponse.hasAggregations()) {
                 InternalAggregations internalAggs = searchResponse.getAggregations();

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1055,7 +1055,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     }
 
     static SearchProfileResults getSearchProfileResults(SearchResponse searchResponse, SearchCoordinatorContext searchCoordinatorContext) {
-        Map<String, SearchProfileShardResult> profileResults = searchResponse.getProfileResults();
+        Map<String, SearchProfileShardResult> profileResults = searchResponse.getSearchProfileShardResults();
         SearchProfileResults profile = profileResults == null || profileResults.isEmpty() ? null : new SearchProfileResults(profileResults);
 
         if (profile != null) {

--- a/server/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
@@ -169,11 +169,11 @@ public class FetchSearchPhaseTests extends ESTestCase {
 
     private void assertProfiles(boolean profiled, int totalShards, SearchResponse searchResponse) {
         if (false == profiled) {
-            assertThat(searchResponse.getProfileResults(), equalTo(Map.of()));
+            assertThat(searchResponse.getSearchProfileShardResults(), equalTo(Map.of()));
             return;
         }
-        assertThat(searchResponse.getProfileResults().values().size(), equalTo(totalShards));
-        for (SearchProfileShardResult profileShardResult : searchResponse.getProfileResults().values()) {
+        assertThat(searchResponse.getSearchProfileShardResults().values().size(), equalTo(totalShards));
+        for (SearchProfileShardResult profileShardResult : searchResponse.getSearchProfileShardResults().values()) {
             assertThat(profileShardResult.getFetchPhase().getTime(), equalTo(FETCH_PROFILE_TIME));
         }
     }
@@ -394,14 +394,14 @@ public class FetchSearchPhaseTests extends ESTestCase {
                  * profiling information for the search on both shards but only
                  * for the fetch on the successful shard.
                  */
-                assertThat(searchResponse.getProfileResults().values().size(), equalTo(2));
-                assertThat(searchResponse.getProfileResults().get(shard1Target.toString()).getFetchPhase(), nullValue());
+                assertThat(searchResponse.getSearchProfileShardResults().values().size(), equalTo(2));
+                assertThat(searchResponse.getSearchProfileShardResults().get(shard1Target.toString()).getFetchPhase(), nullValue());
                 assertThat(
-                    searchResponse.getProfileResults().get(shard2Target.toString()).getFetchPhase().getTime(),
+                    searchResponse.getSearchProfileShardResults().get(shard2Target.toString()).getFetchPhase().getTime(),
                     equalTo(FETCH_PROFILE_TIME)
                 );
             } else {
-                assertThat(searchResponse.getProfileResults(), equalTo(Map.of()));
+                assertThat(searchResponse.getSearchProfileShardResults(), equalTo(Map.of()));
             }
             assertTrue(mockSearchPhaseContext.releasedSearchContexts.contains(ctx));
         } finally {
@@ -510,9 +510,9 @@ public class FetchSearchPhaseTests extends ESTestCase {
             assertEquals(0, searchResponse.getFailedShards());
             assertEquals(numHits, searchResponse.getSuccessfulShards());
             if (profiled) {
-                assertThat(searchResponse.getProfileResults().values().size(), equalTo(numHits));
+                assertThat(searchResponse.getSearchProfileShardResults().values().size(), equalTo(numHits));
                 int count = 0;
-                for (SearchProfileShardResult profileShardResult : searchResponse.getProfileResults().values()) {
+                for (SearchProfileShardResult profileShardResult : searchResponse.getSearchProfileShardResults().values()) {
                     if (profileShardResult.getFetchPhase() != null) {
                         count++;
                         assertThat(profileShardResult.getFetchPhase().getTime(), equalTo(FETCH_PROFILE_TIME));
@@ -520,7 +520,7 @@ public class FetchSearchPhaseTests extends ESTestCase {
                 }
                 assertThat(count, equalTo(Math.min(numHits, resultSetSize)));
             } else {
-                assertThat(searchResponse.getProfileResults(), equalTo(Map.of()));
+                assertThat(searchResponse.getSearchProfileShardResults(), equalTo(Map.of()));
             }
             int sizeReleasedContexts = Math.max(0, numHits - resultSetSize); // all non fetched results will be freed
             assertEquals(
@@ -746,10 +746,10 @@ public class FetchSearchPhaseTests extends ESTestCase {
             assertEquals(0, searchResponse.getFailedShards());
             assertEquals(2, searchResponse.getSuccessfulShards());
             if (profiled) {
-                assertThat(searchResponse.getProfileResults().size(), equalTo(2));
-                assertThat(searchResponse.getProfileResults().get(shard1Target.toString()).getFetchPhase(), nullValue());
+                assertThat(searchResponse.getSearchProfileShardResults().size(), equalTo(2));
+                assertThat(searchResponse.getSearchProfileShardResults().get(shard1Target.toString()).getFetchPhase(), nullValue());
                 assertThat(
-                    searchResponse.getProfileResults().get(shard2Target.toString()).getFetchPhase().getTime(),
+                    searchResponse.getSearchProfileShardResults().get(shard2Target.toString()).getFetchPhase().getTime(),
                     equalTo(FETCH_PROFILE_TIME)
                 );
             }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
@@ -375,7 +375,7 @@ public class SearchResponseMergerTests extends ESTestCase {
                 assertEquals(0, mergedResponse.getSkippedShards());
                 assertEquals(0, mergedResponse.getFailedShards());
                 assertEquals(0, mergedResponse.getShardFailures().length);
-                assertEquals(expectedProfile, mergedResponse.getProfileResults());
+                assertEquals(expectedProfile, mergedResponse.getSearchProfileShardResults());
             } finally {
                 mergedResponse.decRef();
             }
@@ -420,7 +420,7 @@ public class SearchResponseMergerTests extends ESTestCase {
             awaitResponsesAdded();
             SearchResponse mergedResponse = merger.getMergedResponse(SearchResponse.Clusters.EMPTY);
             try {
-                assertFalse("profile shards should be present", mergedResponse.getProfileResults().isEmpty());
+                assertFalse("profile shards should be present", mergedResponse.getSearchProfileShardResults().isEmpty());
                 SearchProfileResults mergedProfile = mergedResponse.getSearchProfileResults();
                 assertNotNull(mergedProfile);
                 assertEquals(coordinatorSource, mergedProfile.getOriginalSource());
@@ -469,7 +469,7 @@ public class SearchResponseMergerTests extends ESTestCase {
             awaitResponsesAdded();
             SearchResponse mergedResponse = merger.getMergedResponse(SearchResponse.Clusters.EMPTY);
             try {
-                assertTrue("merged profile shards should be empty", mergedResponse.getProfileResults().isEmpty());
+                assertTrue("merged profile shards should be empty", mergedResponse.getSearchProfileShardResults().isEmpty());
                 assertNull(mergedResponse.getSearchProfileResults());
             } finally {
                 mergedResponse.decRef();
@@ -1069,7 +1069,7 @@ public class SearchResponseMergerTests extends ESTestCase {
                 assertNull(response.getScrollId());
                 assertSame(InternalAggregations.EMPTY, response.getAggregations());
                 assertNull(response.getSuggest());
-                assertEquals(0, response.getProfileResults().size());
+                assertEquals(0, response.getSearchProfileShardResults().size());
                 assertNull(response.isTerminatedEarly());
                 assertEquals(0, response.getShardFailures().length);
             } finally {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
@@ -1631,8 +1631,9 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         assertNoFailuresAndResponse(
             prepareSearch("test").setProfile(true).setQuery(new FuzzyQueryBuilder("other_field", "valeu")),
             response -> {
-                assertThat(response.getProfileResults().size(), equalTo(1));
-                SearchProfileShardResult shardResult = response.getProfileResults().get(response.getProfileResults().keySet().toArray()[0]);
+                assertThat(response.getSearchProfileShardResults().size(), equalTo(1));
+                SearchProfileShardResult shardResult = response.getSearchProfileShardResults()
+                    .get(response.getSearchProfileShardResults().keySet().toArray()[0]);
                 assertThat(shardResult.getQueryProfileResults().size(), equalTo(1));
                 QueryProfileShardResult queryProfileShardResult = shardResult.getQueryProfileResults().get(0);
                 assertThat(queryProfileShardResult.getQueryResults().size(), equalTo(1));

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -47,7 +47,6 @@ import org.elasticsearch.search.aggregations.pipeline.StatsBucketPipelineAggrega
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder.MetricsAggregationBuilder;
 import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
-import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.xpack.vectortile.feature.FeatureFactory;
@@ -174,7 +173,7 @@ public class RestVectorTileAction extends BaseRestHandler {
                         searchResponse.getSuggest(),
                         searchResponse.isTimedOut(),
                         searchResponse.isTerminatedEarly(),
-                        searchResponse.getProfileResults() == null ? null : new SearchProfileResults(searchResponse.getProfileResults()),
+                        searchResponse.getSearchProfileResults(),
                         searchResponse.getNumReducePhases(),
                         searchResponse.getScrollId(),
                         searchResponse.getTotalShards(),

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -47,6 +47,7 @@ import org.elasticsearch.search.aggregations.pipeline.StatsBucketPipelineAggrega
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder.MetricsAggregationBuilder;
 import org.elasticsearch.search.crossproject.CrossProjectModeDecider;
 import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
+import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.xpack.vectortile.feature.FeatureFactory;
@@ -173,7 +174,9 @@ public class RestVectorTileAction extends BaseRestHandler {
                         searchResponse.getSuggest(),
                         searchResponse.isTimedOut(),
                         searchResponse.isTerminatedEarly(),
-                        searchResponse.getSearchProfileResults(),
+                        searchResponse.getSearchProfileShardResults() == null
+                            ? null
+                            : new SearchProfileResults(searchResponse.getSearchProfileShardResults()),
                         searchResponse.getNumReducePhases(),
                         searchResponse.getScrollId(),
                         searchResponse.getTotalShards(),


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/145230, we expanded the search profiling results object in `SearchResponse` to also include the original query and target indices. The original gettor method in `SearchResponse` for `getProfileResults` did not return the `SearchProfileResults` object but rather the map of shard to `SearchProfileShardResult` objects. We added a new method to return the `SearchProfileResults` object but the naming of the gettor methods is a little confusing. The PR changes the name of the original `getProfileResults` gettor to `getSearchProfileShardResults` to reflect what is actually being returned. 

One thought was to remove the `getSearchProfileShardResults` gettor in `SearchResponse` and just use `getSearchProfileResults().getShardResults()` but there is null check functionality in `SearchResponse` that returns an empty map in case of a null `searchProfile` so we will retain both gettors. 
