### PR TITLE
ESQL: SampleProbabilityPlaceHolder to have Nullability.FALSE

### DIFF
--- a/docs/changelog/147912.yaml
+++ b/docs/changelog/147912.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147912
+summary: '`SampleProbabilityPlaceHolder` to have Nullability.FALSE'
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/approximation/ApproximationPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/approximation/ApproximationPlan.java
@@ -147,7 +147,9 @@ public class ApproximationPlan {
 
         @Override
         public Nullability nullable() {
-            return Nullability.TRUE;
+            // This placeholder is always replaced with a concrete non-null double value before execution,
+            // so it must not be treated as nullable by optimizer rules (e.g. FoldNull, PropagateNullable).
+            return Nullability.FALSE;
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationPlanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/approximation/ApproximationPlanTests.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.esql.approximation;
 
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.SampledAggregate;
@@ -25,6 +27,15 @@ public class ApproximationPlanTests extends ApproximationTestCase {
     @Override
     protected List<String> filteredWarnings() {
         return withDefaultLimitWarning(super.filteredWarnings());
+    }
+
+    /**
+     * The placeholder will always be substituted with a concrete non-null double before execution.
+     * It must not be treated as nullable by optimizer rules (e.g. FoldNull, PropagateNullable).
+     */
+    public void testSampleProbabilityPlaceHolderIsNotNullable() {
+        var placeholder = new ApproximationPlan.SampleProbabilityPlaceHolder(Source.EMPTY);
+        assertThat(placeholder.nullable(), equalTo(Nullability.FALSE));
     }
 
     public void testApproximationPlan_createsConfidenceInterval_withoutGrouping() throws Exception {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullableTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateNullableTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.approximation.ApproximationPlan;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
@@ -380,6 +381,37 @@ public class PropagateNullableTests extends ESTestCase {
 
         var and = new And(EMPTY, greaterThanOf(fa, ONE), isNotNull);
 
+        assertEquals(and, propagateNullable(and));
+    }
+
+    // a IS NULL AND b > 1 => unchanged (b is a different field, unrelated to a)
+    // The IsNull constraint must not alter expressions that do not reference the null field.
+    public void testIsNullDoesNotModifyUnrelatedComparison() {
+        FieldAttribute fa = getFieldAttribute();
+        FieldAttribute fb = getFieldAttribute("b");
+        var isNull = new IsNull(EMPTY, fa);
+
+        var and = new And(EMPTY, isNull, greaterThanOf(fb, ONE));
+
+        assertEquals(and, propagateNullable(and));
+    }
+
+    // a IS NULL AND SampleProbabilityPlaceHolder > 1 => unchanged
+    public void testIsNullDoesNotNullifyPlaceholder() {
+        FieldAttribute fa = getFieldAttribute();
+        var isNull = new IsNull(EMPTY, fa);
+        var placeholder = new ApproximationPlan.SampleProbabilityPlaceHolder(EMPTY);
+        var and = new And(EMPTY, isNull, greaterThanOf(placeholder, ONE));
+        assertEquals(and, propagateNullable(and));
+    }
+
+    // a IS NOT NULL AND SampleProbabilityPlaceHolder > 1 => unchanged
+    // IS NOT NULL on 'a' must not alter expressions that do not reference 'a'.
+    public void testIsNotNullDoesNotNullifyPlaceholder() {
+        FieldAttribute fa = getFieldAttribute();
+        var isNotNull = new IsNotNull(EMPTY, fa);
+        var placeholder = new ApproximationPlan.SampleProbabilityPlaceHolder(EMPTY);
+        var and = new And(EMPTY, isNotNull, greaterThanOf(placeholder, ONE));
         assertEquals(and, propagateNullable(and));
     }
 


### PR DESCRIPTION
This is an expression that always has a double value, let's help the optimization rules to treat this one properly.
AI-assisted PR.