### PR TITLE
[8.19] Update allowed list in pull-requests.json (#147815)

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -8,7 +8,10 @@
         "admin",
         "write"
       ],
-      "allowed_list": ["github-actions[bot]"],
+      "allowed_list": [
+        "github-actions[bot]",
+        "elastic-vault-github-plugin-prod[bot]"
+      ],
       "set_commit_status": false,
       "build_on_commit": true,
       "build_on_comment": true,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Update allowed list in pull-requests.json (#147815)](https://github.com/elastic/elasticsearch/pull/147815)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)