### PR TITLE
Unmute HttOptionsNoAuthnIntegTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -523,12 +523,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.StatelessCommitServiceTests
   method: testOldCommitsAreRetainedIfSearchNodesUseThem
   issue: https://github.com/elastic/elasticsearch/issues/147888
-- class: org.elasticsearch.xpack.security.authc.HttOptionsNoAuthnIntegTests
-  method: testNoAuthnForPreFlightRequest
-  issue: https://github.com/elastic/elasticsearch/issues/147898
-- class: org.elasticsearch.xpack.security.authc.HttOptionsNoAuthnIntegTests
-  method: testNoAuthnForResourceOptionsMethod
-  issue: https://github.com/elastic/elasticsearch/issues/147899
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=synonyms/110_synonyms_invalid/Load index with an invalid synonym rule with lenient set to false}
   issue: https://github.com/elastic/elasticsearch/issues/147907


### PR DESCRIPTION
These are fixed by the certificate regeneration in PR  #147819. 
Unfortunately they got muted minutes before the fix got merged.

Resolves #147898
Resolves #147899
