### PR TITLE
Address memory issue in AbstractTSDBDocValuesProducer.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -2014,13 +2014,13 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     }
 
     private void readNumericField(IndexInput meta, NumericEntry entry, int numericBlockShift) throws IOException {
-        entry.numericFieldReader = numericCodec.createReader(readContext);
-        entry.numericFieldReader.readFieldEntry(meta, entry, numericBlockShift);
+        var numericFieldReader = numericCodec.createReader(readContext);
+        numericFieldReader.readFieldEntry(meta, entry, numericBlockShift);
     }
 
     private void readOrdinalField(IndexInput meta, NumericEntry entry, int numericBlockShift) throws IOException {
-        entry.ordinalFieldReader = ordinalCodec.createReader(readContext);
-        entry.ordinalFieldReader.readFieldEntry(meta, entry, numericBlockShift);
+        var ordinalFieldReader = ordinalCodec.createReader(readContext);
+        ordinalFieldReader.readFieldEntry(meta, entry, numericBlockShift);
     }
 
     private BinaryEntry readBinary(IndexInput meta, int version) throws IOException {
@@ -2179,10 +2179,12 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
     private BlockDecoder blockDecoder(NumericEntry entry, long maxOrd) {
         if (maxOrd != AbstractTSDBDocValuesConsumer.NO_MAX_ORD) {
             final int bitsPerOrd = PackedInts.bitsRequired(maxOrd - 1);
-            final OrdinalFieldReader.Decoder decoder = entry.ordinalFieldReader.decoder();
+            var ordinalFieldReader = ordinalCodec.createReader(readContext);
+            final OrdinalFieldReader.Decoder decoder = ordinalFieldReader.decoder();
             return (input, values) -> decoder.decodeOrdinals(input, values, bitsPerOrd);
         } else {
-            final NumericFieldReader.Decoder decoder = entry.numericFieldReader.decoder();
+            var numericFieldReader = numericCodec.createReader(readContext);
+            final NumericFieldReader.Decoder decoder = numericFieldReader.decoder();
             return (input, values) -> decoder.decodeBlock(input, values, numericBlockSize);
         }
     }
@@ -2743,8 +2745,6 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         public long valuesOffset;
         public long valuesLength;
         public DirectMonotonicReader.Meta sortedOrdinals;
-        public NumericFieldReader numericFieldReader;
-        public OrdinalFieldReader ordinalFieldReader;
     }
 
     static class BinaryEntry {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -48,6 +48,7 @@ import org.apache.lucene.util.packed.PackedInts;
 import org.elasticsearch.core.Assertions;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.blockloader.docvalues.CustomBinaryDocValuesReader;
@@ -2184,7 +2185,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
             return (input, values) -> decoder.decodeOrdinals(input, values, bitsPerOrd);
         } else {
             var numericFieldReader = numericCodec.createReader(readContext);
-            final NumericFieldReader.Decoder decoder = numericFieldReader.decoder();
+            final NumericFieldReader.Decoder decoder = numericFieldReader.decoder(entry.pipelineDescriptor);
             return (input, values) -> decoder.decodeBlock(input, values, numericBlockSize);
         }
     }
@@ -2745,6 +2746,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
         public long valuesOffset;
         public long valuesLength;
         public DirectMonotonicReader.Meta sortedOrdinals;
+        public PipelineDescriptor pipelineDescriptor;
     }
 
     static class BinaryEntry {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/NumericFieldReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/NumericFieldReader.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.codec.tsdb;
 
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 
 import java.io.IOException;
 
@@ -19,7 +20,7 @@ import java.io.IOException;
  *
  * <p>{@link #readFieldEntry} runs once per field at segment-open time and parses the field metadata
  * (value counts, offsets, codec-specific header, DISI metadata) into a
- * {@link AbstractTSDBDocValuesProducer.NumericEntry}. {@link #decoder()} returns the per-block
+ * {@link AbstractTSDBDocValuesProducer.NumericEntry}. {@link #decoder(PipelineDescriptor)} returns the per-block
  * {@link Decoder} that the iteration code drives during value access; the same decoder may be
  * used for many blocks of the same field.
  */
@@ -39,7 +40,7 @@ public interface NumericFieldReader {
      *
      * @return the block decoder
      */
-    Decoder decoder();
+    Decoder decoder(PipelineDescriptor pipelineDescriptor);
 
     /**
      * Decodes one block of numeric values.

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBNumericFieldReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBNumericFieldReader.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.index.codec.tsdb;
 
 import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.index.codec.tsdb.pipeline.PipelineDescriptor;
 
 import java.io.IOException;
 
@@ -18,7 +19,7 @@ import java.io.IOException;
  * from the TSDB block layout.
  *
  * <p>{@link #readFieldEntry} delegates to the shared metadata parsing in
- * {@link TSDBDocValuesBlockReader}. {@link #decoder()} returns the {@link Decoder} supplied at
+ * {@link TSDBDocValuesBlockReader}. {@link NumericFieldReader#decoder(PipelineDescriptor)} returns the {@link Decoder} supplied at
  * construction time, which the iteration code drives during value access.
  */
 public final class TSDBNumericFieldReader implements NumericFieldReader {
@@ -41,7 +42,7 @@ public final class TSDBNumericFieldReader implements NumericFieldReader {
     }
 
     @Override
-    public Decoder decoder() {
+    public Decoder decoder(PipelineDescriptor pipelineDescriptor) {
         return decoder;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95NumericFieldReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es95/ES95NumericFieldReader.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * reads the {@link FieldDescriptor} from the field's metadata header so the correct
  * pipeline decoder can be reconstructed at read time.
  *
- * <p>{@link #decoder()} returns a {@link Decoder} backed by the pipeline identified by the
+ * <p>{@link NumericFieldReader#decoder(PipelineDescriptor)} returns a {@link Decoder} backed by the pipeline identified by the
  * {@link FieldDescriptor}, falling back to the provided fallback decoder for ordinal-range
  * and single-ordinal fields that bypass pipeline encoding.
  */
@@ -39,7 +39,6 @@ final class ES95NumericFieldReader implements NumericFieldReader {
 
     private final NumericCodecFactory numericCodecFactory;
     private final Decoder fallbackDecoder;
-    private PipelineDescriptor pipelineDescriptor;
 
     ES95NumericFieldReader(final NumericCodecFactory numericCodecFactory, final Decoder fallbackDecoder) {
         this.numericCodecFactory = numericCodecFactory;
@@ -48,11 +47,11 @@ final class ES95NumericFieldReader implements NumericFieldReader {
 
     @Override
     public void readFieldEntry(final IndexInput meta, final NumericEntry entry, int numericBlockShift) throws IOException {
-        BLOCK_READER.readFieldEntry(meta, entry, numericBlockShift, m -> pipelineDescriptor = FieldDescriptor.read(m));
+        BLOCK_READER.readFieldEntry(meta, entry, numericBlockShift, m -> entry.pipelineDescriptor = FieldDescriptor.read(m));
     }
 
     @Override
-    public Decoder decoder() {
+    public Decoder decoder(PipelineDescriptor pipelineDescriptor) {
         if (pipelineDescriptor != null) {
             final NumericDecoder decoder = numericCodecFactory.createDecoder(pipelineDescriptor);
             final NumericBlockDecoder blockDecoder = decoder.newBlockDecoder();


### PR DESCRIPTION
The memory usage can really grow in case there are many fields and segments. The issue is that indirectly there are many `DocValuesForUtil` instances and each hold a 4kb byte array here. And the `DocValuesForUtil` are always hold in memory for each numeric (set) or sorted (set) doc values field.

The change addresses this by removing `numericFieldReader` and `ordinalFieldReader` fields from `NumericEntry`.

Note that this is a bug, but didn't get released in a stateful version.