### PR TITLE
Flatten blockloader output for flattened field root values

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedDocValuesSyntheticFieldLoader.java
@@ -249,7 +249,7 @@ class FlattenedDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFi
         b.startObject(leafName);
         if (hasFlattenedValues) {
             var writer = getWriter();
-            writer.write(b);
+            writer.write(b, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED);
         }
         for (SourceLoader.SyntheticFieldLoader loader : mappedSubFieldLoaders) {
             if (loader.hasValue()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSyntheticWriterHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSyntheticWriterHelper.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -265,6 +266,25 @@ public class FlattenedFieldSyntheticWriterHelper {
         }
     }
 
+    private interface FlattenedPathXContentWriter {
+        void writeValue(XContentBuilder b, KeyValueWithOffset value, KeyValueWithOffset next) throws IOException;
+    }
+
+    public enum OutputStructure {
+        FLATTENED(FlatFlattenedPathXContentWriter::new),
+        NESTED(NestedFlattenedPathXContentWriter::new);
+
+        private final Supplier<FlattenedPathXContentWriter> writerSupplier;
+
+        OutputStructure(Supplier<FlattenedPathXContentWriter> writerSupplier) {
+            this.writerSupplier = writerSupplier;
+        }
+
+        private FlattenedPathXContentWriter getWriter() {
+            return writerSupplier.get();
+        }
+    }
+
     /**
      * Stateful writer that turns a sorted stream of flattened key paths into nested {@link XContentBuilder} output.
      * <p>
@@ -272,11 +292,12 @@ public class FlattenedFieldSyntheticWriterHelper {
      * path prefix (e.g. {@code foo} then {@code foo.bar}), emits a single dotted field name instead of nesting so the
      * reconstructed document matches flattened-field semantics.
      */
-    private static class FlattenedPathXContentWriter {
+    private static class NestedFlattenedPathXContentWriter implements FlattenedPathXContentWriter {
         Prefix openObjects = new Prefix();
         String lastScalarSingleLeaf = null;
 
-        public void write(XContentBuilder b, KeyValueWithOffset value, KeyValueWithOffset next) throws IOException {
+        @Override
+        public void writeValue(XContentBuilder b, KeyValueWithOffset value, KeyValueWithOffset next) throws IOException {
             // startPrefix is the suffix of the path that is within the currently open object, not including the leaf.
             // For example, if the path is foo.bar.baz.qux, and openObjects is [foo], then startPrefix is bar.baz, and leaf is qux.
             var startPrefix = value.key.prefix.diff(openObjects);
@@ -301,6 +322,13 @@ public class FlattenedFieldSyntheticWriterHelper {
 
             int numObjectsToEnd = Prefix.numObjectsToEnd(openObjects.parts, next == null ? List.of() : next.key.prefix.parts);
             endObject(b, numObjectsToEnd, openObjects.parts);
+        }
+    }
+
+    private static class FlatFlattenedPathXContentWriter implements FlattenedPathXContentWriter {
+        @Override
+        public void writeValue(XContentBuilder b, KeyValueWithOffset value, KeyValueWithOffset next) throws IOException {
+            writeField(b, value.values, value.key.fullPath(), value.offsets);
         }
     }
 
@@ -333,14 +361,14 @@ public class FlattenedFieldSyntheticWriterHelper {
         return builder.toString();
     }
 
-    public void write(final XContentBuilder b) throws IOException {
+    public void write(final XContentBuilder b, OutputStructure output) throws IOException {
         var producer = new KeyValueProducer(sortedKeyedValues, sortedOffsetValues);
-        var writer = new FlattenedPathXContentWriter();
+        var writer = output.getWriter();
 
         var curr = producer.next();
         var next = producer.next();
         while (curr != null) {
-            writer.write(b, curr, next);
+            writer.writeValue(b, curr, next);
             curr = next;
             next = producer.next();
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSyntheticWriterHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSyntheticWriterHelper.java
@@ -271,7 +271,9 @@ public class FlattenedFieldSyntheticWriterHelper {
     }
 
     public enum OutputStructure {
+        /** Writes each key using its full dotted path as a single field name with no nested objects. */
         FLATTENED(FlatFlattenedPathXContentWriter::new),
+        /** Reconstructs nested objects by splitting keys on {@code .} and tracking open object scopes. */
         NESTED(NestedFlattenedPathXContentWriter::new);
 
         private final Supplier<FlattenedPathXContentWriter> writerSupplier;
@@ -286,11 +288,15 @@ public class FlattenedFieldSyntheticWriterHelper {
     }
 
     /**
-     * Stateful writer that turns a sorted stream of flattened key paths into nested {@link XContentBuilder} output.
+     * {@link FlattenedPathXContentWriter} implementation for {@link OutputStructure#NESTED} that splits each key on
+     * {@code .} and opens {@link XContentBuilder} object scopes to reconstruct nested structure from sorted path segments.
      * <p>
-     * It tracks which object scopes are currently open and, when a leaf key collides with a prior scalar at the same
-     * path prefix (e.g. {@code foo} then {@code foo.bar}), emits a single dotted field name instead of nesting so the
-     * reconstructed document matches flattened-field semantics.
+     * It keeps track of which object levels are open and how far into the current path each field belongs, and uses
+     * {@code next} to close the right number of objects when the prefix of the following key changes.
+     * <p>
+     * When a leaf already had a scalar value and a later key extends that path (e.g. {@code foo} then {@code foo.bar}),
+     * a nested object under {@code foo} would collide with the scalar. The writer then emits a single dotted field
+     * name in the current object (for example {@code foo.bar}) instead of opening another object under {@code foo}.
      */
     private static class NestedFlattenedPathXContentWriter implements FlattenedPathXContentWriter {
         Prefix openObjects = new Prefix();
@@ -325,6 +331,13 @@ public class FlattenedFieldSyntheticWriterHelper {
         }
     }
 
+    /**
+     * {@link FlattenedPathXContentWriter} implementation for {@link OutputStructure#FLATTENED} that writes each
+     * key with its full dotted path as a single top-level field name, without opening nested objects.
+     * <p>
+     * Unlike {@link NestedFlattenedPathXContentWriter}, it does not split paths on {@code .} or track open object
+     * scopes; {@code next} is ignored because flattening is stateless.
+     */
     private static class FlatFlattenedPathXContentWriter implements FlattenedPathXContentWriter {
         @Override
         public void writeValue(XContentBuilder b, KeyValueWithOffset value, KeyValueWithOffset next) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/RootFlattenedDocValuesBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/RootFlattenedDocValuesBlockLoader.java
@@ -213,7 +213,7 @@ final class RootFlattenedDocValuesBlockLoader implements BlockLoader {
             XContentBuilder jsonBuilder = XContentFactory.jsonBuilder();
             jsonBuilder.startObject();
             if (hasFlattenedValues()) {
-                getWriter().write(jsonBuilder);
+                getWriter().write(jsonBuilder, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED);
             }
             for (SourceLoader.SyntheticFieldLoader loader : getMappedSubFieldLoaders()) {
                 if (loader.hasValue()) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/FlattenedFieldRootBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/FlattenedFieldRootBlockLoaderTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.datageneration.matchers.source.FlattenedFieldMatcher;
 import org.elasticsearch.index.mapper.BinaryDVBlockLoaderTestCase;
 import org.elasticsearch.index.mapper.BlockLoaderTestRunner;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
@@ -133,6 +134,23 @@ public class FlattenedFieldRootBlockLoaderTests extends BinaryDVBlockLoaderTestC
             case List<?> list -> list.stream().map(v -> applyFlattenedNullValue(v, nullValue)).toList();
             default -> value;
         };
+    }
+
+    public void testBlockLoaderOutputFlatStructure() throws IOException {
+        runner.breaker(newLimitedBreaker(TEST_BREAKER_SIZE));
+        runner.document(Map.of("field", Map.of("a", Map.of("x", "10"), "b", Map.of("y", "20"))));
+        runner.fieldName("field");
+
+        Mapping mapping = new Mapping(
+            Map.of("_doc", Map.of("properties", Map.of("field", Map.of("type", "flattened")))),
+            Map.of("field", Map.of("type", "flattened"))
+        );
+
+        String expected = "{\"a.x\":\"10\",\"b.y\":\"20\"}";
+
+        var settings = getSettingsForParams();
+        runner.mapperService(createMapperService(settings.build(), XContentFactory.jsonBuilder().map(mapping.raw())));
+        runner.run(new BytesRef(expected));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSyntheticWriterHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSyntheticWriterHelperTests.java
@@ -28,70 +28,79 @@ import static org.mockito.Mockito.when;
 
 public class FlattenedFieldSyntheticWriterHelperTests extends ESTestCase {
 
+    private String write(FlattenedFieldSyntheticWriterHelper writer, FlattenedFieldSyntheticWriterHelper.OutputStructure outputStructure)
+        throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        XContentBuilder b = new XContentBuilder(XContentType.JSON.xContent(), baos);
+
+        // WHEN
+        b.startObject();
+        writer.write(b, outputStructure);
+        b.endObject();
+        b.flush();
+
+        return baos.toString(StandardCharsets.UTF_8);
+    }
+
     public void testSingleField() throws IOException {
         // GIVEN
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
         when(dv.getValueCount()).thenReturn(1L);
         when(dv.docValueCount()).thenReturn(1);
         byte[] bytes = ("test" + '\0' + "one").getBytes(StandardCharsets.UTF_8);
-        when(dv.nextOrd()).thenReturn(0L);
+        when(dv.nextOrd()).thenReturn(0L).thenReturn(0L);
         when(dv.lookupOrd(0L)).thenReturn(new BytesRef(bytes, 0, bytes.length));
+        var values = new SortedSetSortedKeyedValues(dv);
         FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
+            values,
             FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE
         );
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        XContentBuilder b = new XContentBuilder(XContentType.JSON.xContent(), baos);
-
-        // WHEN
-        b.startObject();
-        writer.write(b);
-        b.endObject();
-        b.flush();
 
         // THEN
-        assertEquals("{\"test\":\"one\"}", baos.toString(StandardCharsets.UTF_8));
+        assertEquals("{\"test\":\"one\"}", write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED));
+        values.reset();
+        assertEquals("{\"test\":\"one\"}", write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED));
     }
 
     public void testFlatObject() throws IOException {
         // GIVEN
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
+        var values = new SortedSetSortedKeyedValues(dv);
         final FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
+            values,
             FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE
         );
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), baos);
         final List<byte[]> bytes = List.of("a" + '\0' + "value_a", "b" + '\0' + "value_b", "c" + '\0' + "value_c", "d" + '\0' + "value_d")
             .stream()
             .map(x -> x.getBytes(StandardCharsets.UTF_8))
             .collect(Collectors.toList());
         when(dv.getValueCount()).thenReturn(Long.valueOf(bytes.size()));
         when(dv.docValueCount()).thenReturn(bytes.size());
-        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L);
+        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L).thenReturn(0L, 1L, 2L, 3L);
         for (int i = 0; i < bytes.size(); i++) {
             when(dv.lookupOrd(ArgumentMatchers.eq((long) i))).thenReturn(new BytesRef(bytes.get(i), 0, bytes.get(i).length));
         }
 
-        // WHEN
-        builder.startObject();
-        writer.write(builder);
-        builder.endObject();
-        builder.flush();
-
         // THEN
-        assertEquals("{\"a\":\"value_a\",\"b\":\"value_b\",\"c\":\"value_c\",\"d\":\"value_d\"}", baos.toString(StandardCharsets.UTF_8));
+        assertEquals(
+            "{\"a\":\"value_a\",\"b\":\"value_b\",\"c\":\"value_c\",\"d\":\"value_d\"}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED)
+        );
+        values.reset();
+        assertEquals(
+            "{\"a\":\"value_a\",\"b\":\"value_b\",\"c\":\"value_c\",\"d\":\"value_d\"}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED)
+        );
     }
 
     public void testSingleObject() throws IOException {
         // GIVEN
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
+        var values = new SortedSetSortedKeyedValues(dv);
         final FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
+            values,
             FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE
         );
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), baos);
         final List<byte[]> bytes = List.of(
             "a" + '\0' + "value_a",
             "a.b" + '\0' + "value_b",
@@ -100,93 +109,92 @@ public class FlattenedFieldSyntheticWriterHelperTests extends ESTestCase {
         ).stream().map(x -> x.getBytes(StandardCharsets.UTF_8)).collect(Collectors.toList());
         when(dv.getValueCount()).thenReturn(Long.valueOf(bytes.size()));
         when(dv.docValueCount()).thenReturn(bytes.size());
-        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L);
+        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L).thenReturn(0L, 1L, 2L, 3L);
         for (int i = 0; i < bytes.size(); i++) {
             when(dv.lookupOrd(ArgumentMatchers.eq((long) i))).thenReturn(new BytesRef(bytes.get(i), 0, bytes.get(i).length));
         }
 
-        // WHEN
-        builder.startObject();
-        writer.write(builder);
-        builder.endObject();
-        builder.flush();
-
         // THEN
         assertEquals(
             "{\"a\":\"value_a\",\"a.b\":\"value_b\",\"a.b.c\":\"value_c\",\"a.d\":\"value_d\"}",
-            baos.toString(StandardCharsets.UTF_8)
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED)
+        );
+        values.reset();
+        assertEquals(
+            "{\"a\":\"value_a\",\"a.b\":\"value_b\",\"a.b.c\":\"value_c\",\"a.d\":\"value_d\"}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED)
         );
     }
 
     public void testMultipleObjects() throws IOException {
         // GIVEN
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
+        var values = new SortedSetSortedKeyedValues(dv);
         final FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
+            values,
             FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE
         );
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), baos);
         final List<byte[]> bytes = List.of("a.x" + '\0' + "10", "a.y" + '\0' + "20", "b.a" + '\0' + "30", "b.c" + '\0' + "40")
             .stream()
             .map(x -> x.getBytes(StandardCharsets.UTF_8))
             .collect(Collectors.toList());
         when(dv.getValueCount()).thenReturn(Long.valueOf(bytes.size()));
         when(dv.docValueCount()).thenReturn(bytes.size());
-        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L);
+        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L).thenReturn(0L, 1L, 2L, 3L);
         for (int i = 0; i < bytes.size(); i++) {
             when(dv.lookupOrd(ArgumentMatchers.eq((long) i))).thenReturn(new BytesRef(bytes.get(i), 0, bytes.get(i).length));
         }
 
-        // WHEN
-        builder.startObject();
-        writer.write(builder);
-        builder.endObject();
-        builder.flush();
-
         // THEN
-        assertEquals("{\"a\":{\"x\":\"10\",\"y\":\"20\"},\"b\":{\"a\":\"30\",\"c\":\"40\"}}", baos.toString(StandardCharsets.UTF_8));
+        assertEquals(
+            "{\"a\":{\"x\":\"10\",\"y\":\"20\"},\"b\":{\"a\":\"30\",\"c\":\"40\"}}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED)
+        );
+        values.reset();
+        assertEquals(
+            "{\"a.x\":\"10\",\"a.y\":\"20\",\"b.a\":\"30\",\"b.c\":\"40\"}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED)
+        );
     }
 
     public void testSingleArray() throws IOException {
         // GIVEN
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
+        var values = new SortedSetSortedKeyedValues(dv);
         final FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
+            values,
             FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE
         );
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), baos);
         final List<byte[]> bytes = List.of("a.x" + '\0' + "10", "a.x" + '\0' + "20", "a.x" + '\0' + "30", "a.x" + '\0' + "40")
             .stream()
             .map(x -> x.getBytes(StandardCharsets.UTF_8))
             .collect(Collectors.toList());
         when(dv.getValueCount()).thenReturn(Long.valueOf(bytes.size()));
         when(dv.docValueCount()).thenReturn(bytes.size());
-        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L);
+        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L).thenReturn(0L, 1L, 2L, 3L);
         for (int i = 0; i < bytes.size(); i++) {
             when(dv.lookupOrd(ArgumentMatchers.eq((long) i))).thenReturn(new BytesRef(bytes.get(i), 0, bytes.get(i).length));
         }
-
-        // WHEN
-        builder.startObject();
-        writer.write(builder);
-        builder.endObject();
-        builder.flush();
-
         // THEN
-        assertEquals("{\"a\":{\"x\":[\"10\",\"20\",\"30\",\"40\"]}}", baos.toString(StandardCharsets.UTF_8));
+        assertEquals(
+            "{\"a\":{\"x\":[\"10\",\"20\",\"30\",\"40\"]}}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED)
+        );
+        values.reset();
+        assertEquals(
+            "{\"a.x\":[\"10\",\"20\",\"30\",\"40\"]}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED)
+        );
     }
 
     public void testMultipleArrays() throws IOException {
         // GIVEN
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
+        var values = new SortedSetSortedKeyedValues(dv);
         final FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
+            values,
             FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE
         );
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), baos);
         final List<byte[]> bytes = List.of(
             "a.x" + '\0' + "10",
             "a.x" + '\0' + "20",
@@ -196,19 +204,21 @@ public class FlattenedFieldSyntheticWriterHelperTests extends ESTestCase {
         ).stream().map(x -> x.getBytes(StandardCharsets.UTF_8)).collect(Collectors.toList());
         when(dv.getValueCount()).thenReturn(Long.valueOf(bytes.size()));
         when(dv.docValueCount()).thenReturn(bytes.size());
-        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L, 4L);
+        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L, 4L).thenReturn(0L, 1L, 2L, 3L, 4L);
         for (int i = 0; i < bytes.size(); i++) {
             when(dv.lookupOrd(ArgumentMatchers.eq((long) i))).thenReturn(new BytesRef(bytes.get(i), 0, bytes.get(i).length));
         }
 
-        // WHEN
-        builder.startObject();
-        writer.write(builder);
-        builder.endObject();
-        builder.flush();
-
         // THEN
-        assertEquals("{\"a\":{\"x\":[\"10\",\"20\"]},\"b\":{\"y\":[\"30\",\"40\",\"50\"]}}", baos.toString(StandardCharsets.UTF_8));
+        assertEquals(
+            "{\"a\":{\"x\":[\"10\",\"20\"]},\"b\":{\"y\":[\"30\",\"40\",\"50\"]}}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED)
+        );
+        values.reset();
+        assertEquals(
+            "{\"a.x\":[\"10\",\"20\"],\"b.y\":[\"30\",\"40\",\"50\"]}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED)
+        );
     }
 
     public void testSingleArrayWithOffsets() throws IOException {
@@ -216,147 +226,135 @@ public class FlattenedFieldSyntheticWriterHelperTests extends ESTestCase {
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
 
         final var offsets = List.of(new FlattenedFieldArrayContext.KeyedOffsetField("a.x", new int[] { 1, 0, -1, 1, 3, 3, 2, -1 }));
-        final var offsetsIterator = offsets.iterator();
+        int[] offsetsIdx = { 0 };
 
+        var values = new SortedSetSortedKeyedValues(dv);
         final FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
-            () -> offsetsIterator.hasNext() ? offsetsIterator.next() : null
+            values,
+            () -> offsetsIdx[0] >= offsets.size() ? null : offsets.get(offsetsIdx[0]++)
         );
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), baos);
         final List<byte[]> bytes = List.of("a.x" + '\0' + "10", "a.x" + '\0' + "20", "a.x" + '\0' + "30", "a.x" + '\0' + "40")
             .stream()
             .map(x -> x.getBytes(StandardCharsets.UTF_8))
             .collect(Collectors.toList());
         when(dv.getValueCount()).thenReturn(Long.valueOf(bytes.size()));
         when(dv.docValueCount()).thenReturn(bytes.size());
-        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L);
+        when(dv.nextOrd()).thenReturn(0L, 1L, 2L, 3L).thenReturn(0L, 1L, 2L, 3L);
         for (int i = 0; i < bytes.size(); i++) {
             when(dv.lookupOrd(ArgumentMatchers.eq((long) i))).thenReturn(new BytesRef(bytes.get(i), 0, bytes.get(i).length));
         }
 
-        // WHEN
-        builder.startObject();
-        writer.write(builder);
-        builder.endObject();
-        builder.flush();
-
         // THEN
-        assertEquals("{\"a\":{\"x\":[\"20\",\"10\",null,\"20\",\"40\",\"40\",\"30\",null]}}", baos.toString(StandardCharsets.UTF_8));
+        assertEquals(
+            "{\"a\":{\"x\":[\"20\",\"10\",null,\"20\",\"40\",\"40\",\"30\",null]}}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED)
+        );
+        values.reset();
+        offsetsIdx[0] = 0;
+        assertEquals(
+            "{\"a.x\":[\"20\",\"10\",null,\"20\",\"40\",\"40\",\"30\",null]}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED)
+        );
     }
 
     public void testSameLeafDifferentPrefix() throws IOException {
         // GIVEN
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
+        var values = new SortedSetSortedKeyedValues(dv);
         final FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
+            values,
             FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE
         );
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), baos);
         final List<byte[]> bytes = List.of("a.x" + '\0' + "10", "b.x" + '\0' + "20")
             .stream()
             .map(x -> x.getBytes(StandardCharsets.UTF_8))
             .collect(Collectors.toList());
         when(dv.getValueCount()).thenReturn(Long.valueOf(bytes.size()));
         when(dv.docValueCount()).thenReturn(bytes.size());
-        when(dv.nextOrd()).thenReturn(0L, 1L);
+        when(dv.nextOrd()).thenReturn(0L, 1L).thenReturn(0L, 1L);
         for (int i = 0; i < bytes.size(); i++) {
             when(dv.lookupOrd(ArgumentMatchers.eq((long) i))).thenReturn(new BytesRef(bytes.get(i), 0, bytes.get(i).length));
         }
 
-        // WHEN
-        builder.startObject();
-        writer.write(builder);
-        builder.endObject();
-        builder.flush();
-
         // THEN
-        assertEquals("{\"a\":{\"x\":\"10\"},\"b\":{\"x\":\"20\"}}", baos.toString(StandardCharsets.UTF_8));
+        assertEquals(
+            "{\"a\":{\"x\":\"10\"},\"b\":{\"x\":\"20\"}}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED)
+        );
+        values.reset();
+        assertEquals("{\"a.x\":\"10\",\"b.x\":\"20\"}", write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED));
     }
 
     public void testScalarObjectMismatchInNestedObject() throws IOException {
         // GIVEN
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
+        var values = new SortedSetSortedKeyedValues(dv);
         final FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
+            values,
             FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE
         );
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), baos);
         final List<byte[]> bytes = List.of("a.b.c" + '\0' + "10", "a.b.c.d" + '\0' + "20")
             .stream()
             .map(x -> x.getBytes(StandardCharsets.UTF_8))
             .collect(Collectors.toList());
         when(dv.getValueCount()).thenReturn(Long.valueOf(bytes.size()));
         when(dv.docValueCount()).thenReturn(bytes.size());
-        when(dv.nextOrd()).thenReturn(0L, 1L);
+        when(dv.nextOrd()).thenReturn(0L, 1L).thenReturn(0L, 1L);
         for (int i = 0; i < bytes.size(); i++) {
             when(dv.lookupOrd(ArgumentMatchers.eq((long) i))).thenReturn(new BytesRef(bytes.get(i), 0, bytes.get(i).length));
         }
 
-        // WHEN
-        builder.startObject();
-        writer.write(builder);
-        builder.endObject();
-        builder.flush();
-
         // THEN
-        assertEquals("{\"a\":{\"b\":{\"c\":\"10\",\"c.d\":\"20\"}}}", baos.toString(StandardCharsets.UTF_8));
+        assertEquals(
+            "{\"a\":{\"b\":{\"c\":\"10\",\"c.d\":\"20\"}}}",
+            write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED)
+        );
+        values.reset();
+        assertEquals("{\"a.b.c\":\"10\",\"a.b.c.d\":\"20\"}", write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED));
     }
 
     public void testSingleDotPath() throws IOException {
         // GIVEN
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
+        var values = new SortedSetSortedKeyedValues(dv);
         final FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
+            values,
             FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE
         );
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), baos);
         final List<byte[]> bytes = Stream.of("." + '\0' + "10").map(x -> x.getBytes(StandardCharsets.UTF_8)).toList();
         when(dv.getValueCount()).thenReturn(Long.valueOf(bytes.size()));
         when(dv.docValueCount()).thenReturn(bytes.size());
+        when(dv.nextOrd()).thenReturn(0L).thenReturn(0L);
         for (int i = 0; i < bytes.size(); i++) {
-            when(dv.nextOrd()).thenReturn((long) i);
             when(dv.lookupOrd(ArgumentMatchers.eq((long) i))).thenReturn(new BytesRef(bytes.get(i), 0, bytes.get(i).length));
         }
 
-        // WHEN
-        builder.startObject();
-        writer.write(builder);
-        builder.endObject();
-        builder.flush();
-
         // THEN
-        assertEquals("{\"\":{\"\":\"10\"}}", baos.toString(StandardCharsets.UTF_8));
+        assertEquals("{\"\":{\"\":\"10\"}}", write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED));
+        values.reset();
+        assertEquals("{\".\":\"10\"}", write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED));
     }
 
     public void testTrailingDotsPath() throws IOException {
         // GIVEN
         final SortedSetDocValues dv = mock(SortedSetDocValues.class);
+        var values = new SortedSetSortedKeyedValues(dv);
         final FlattenedFieldSyntheticWriterHelper writer = new FlattenedFieldSyntheticWriterHelper(
-            new SortedSetSortedKeyedValues(dv),
+            values,
             FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE
         );
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), baos);
         final List<byte[]> bytes = Stream.of("cat.." + '\0' + "10").map(x -> x.getBytes(StandardCharsets.UTF_8)).toList();
         when(dv.getValueCount()).thenReturn(Long.valueOf(bytes.size()));
         when(dv.docValueCount()).thenReturn(bytes.size());
+        when(dv.nextOrd()).thenReturn(0L).thenReturn(0L);
         for (int i = 0; i < bytes.size(); i++) {
-            when(dv.nextOrd()).thenReturn((long) i);
             when(dv.lookupOrd(ArgumentMatchers.eq((long) i))).thenReturn(new BytesRef(bytes.get(i), 0, bytes.get(i).length));
         }
 
-        // WHEN
-        builder.startObject();
-        writer.write(builder);
-        builder.endObject();
-        builder.flush();
-
         // THEN
-        assertEquals("{\"cat\":{\"\":{\"\":\"10\"}}}", baos.toString(StandardCharsets.UTF_8));
+        assertEquals("{\"cat\":{\"\":{\"\":\"10\"}}}", write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED));
+        values.reset();
+        assertEquals("{\"cat..\":\"10\"}", write(writer, FlattenedFieldSyntheticWriterHelper.OutputStructure.FLATTENED));
     }
 
     private class SortedSetSortedKeyedValues implements FlattenedFieldSyntheticWriterHelper.SortedKeyedValues {
@@ -375,6 +373,10 @@ public class FlattenedFieldSyntheticWriterHelperTests extends ESTestCase {
             }
 
             return null;
+        }
+
+        public void reset() {
+            seen = 0;
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
@@ -73,7 +73,7 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
     private final String fieldType;
     protected final Params params;
     private final Collection<DataSourceHandler> customDataSourceHandlers;
-    private final BlockLoaderTestRunner runner;
+    protected final BlockLoaderTestRunner runner;
 
     protected final String fieldName;
 

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/LastValueFieldDownsampler.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/LastValueFieldDownsampler.java
@@ -143,7 +143,7 @@ class LastValueFieldDownsampler extends AbstractFieldDownsampler<FormattedDocVal
                         return null;
                     }
                 }, FlattenedFieldSyntheticWriterHelper.SortedOffsetValues.NONE);
-                helper.write(builder);
+                helper.write(builder, FlattenedFieldSyntheticWriterHelper.OutputStructure.NESTED);
                 builder.endObject();
             }
         }


### PR DESCRIPTION
Currently the output of the RootFlattenedDocValuesBlockLoader is a nested structure with intermediate objects.

```json
{"a":{"x":"10"},"b":{"y":"20"}}
```

This PR updates the output to instead follow a flattened structure of only leaf values.

```json
{"a.x":"10","b.y":"20"}
```