### PR TITLE
Precompute dimension routing flag at mapper build

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -428,6 +428,15 @@ public abstract class IndexRouting {
 
         protected abstract int hashSource(IndexRequest indexRequest);
 
+        /**
+         * Returns true if dimension fields on this index should write to {@link org.elasticsearch.index.mapper.RoutingFields}
+         * during document mapping. Returns false for {@link ForIndexDimensions}, which builds the tsid during routing
+         * on the coordinating node and attaches it to the index request, so the data node does not need to re-extract dimensions.
+         */
+        public boolean extractDimensionsWhileMapping() {
+            return true;
+        }
+
         private static int defaultOnEmpty() {
             throw new IllegalArgumentException("Error extracting routing: source didn't contain any routing fields");
         }
@@ -587,6 +596,11 @@ public abstract class IndexRouting {
                     indexRequest.tsid(tsid);
                 }
                 return hash(tsid);
+            }
+
+            @Override
+            public boolean extractDimensionsWhileMapping() {
+                return false;
             }
 
             public BytesRef buildTsid(XContentType sourceType, BytesReference source) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -20,6 +20,7 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -523,6 +524,7 @@ public class BooleanFieldMapper extends FieldMapper {
     private final ScriptCompiler scriptCompiler;
     private final Explicit<Boolean> ignoreMalformed;
     private final IndexSettings indexSettings;
+    private final boolean writeDimensionRouting;
     private final boolean storeMalformedFields;
 
     private final String offsetsFieldName;
@@ -549,6 +551,9 @@ public class BooleanFieldMapper extends FieldMapper {
         this.scriptValues = builder.scriptValues();
         this.scriptCompiler = builder.scriptCompiler;
         this.indexSettings = builder.indexSettings;
+        this.writeDimensionRouting = builder.dimension.getValue()
+            && builder.indexSettings.getIndexRouting() instanceof IndexRouting.ExtractFromSource efs
+            && efs.extractDimensionsWhileMapping();
         this.ignoreMalformed = builder.ignoreMalformed.getValue();
         this.storeMalformedFields = storeMalformedFields;
         this.offsetsFieldName = offsetsFieldName;
@@ -621,7 +626,7 @@ public class BooleanFieldMapper extends FieldMapper {
             return;
         }
 
-        if (fieldType().isDimension()) {
+        if (writeDimensionRouting) {
             context.getRoutingFields().addBoolean(fieldType().name(), value);
         }
         if (indexed) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -21,6 +21,7 @@ import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
+import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -637,6 +638,7 @@ public class IpFieldMapper extends FieldMapper {
     private final boolean ignoreMalformed;
     private final boolean storeIgnored;
     private final boolean dimension;
+    private final boolean writeDimensionRouting;
 
     private final InetAddress nullValue;
     private final String nullValueAsString;
@@ -672,6 +674,9 @@ public class IpFieldMapper extends FieldMapper {
         this.scriptValues = builder.scriptValues();
         this.scriptCompiler = builder.scriptCompiler;
         this.dimension = builder.dimension.getValue();
+        this.writeDimensionRouting = this.dimension
+            && builder.indexSettings.getIndexRouting() instanceof IndexRouting.ExtractFromSource efs
+            && efs.extractDimensionsWhileMapping();
         this.storeIgnored = storeIgnored;
         this.offsetsFieldName = offsetsFieldName;
         this.indexSettings = builder.indexSettings;
@@ -735,7 +740,7 @@ public class IpFieldMapper extends FieldMapper {
     }
 
     private void indexValue(DocumentParserContext context, ESInetAddressPoint address) {
-        if (dimension && context.getRoutingFields().isNoop() == false) {
+        if (writeDimensionRouting) {
             context.getRoutingFields().addIp(fieldType().name(), address.getInetAddress());
         }
         LuceneDocument doc = context.doc();

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -42,6 +42,7 @@ import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton.AUTOMATON_TYPE;
 import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
@@ -1318,6 +1319,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     private final IndexAnalyzers indexAnalyzers;
     private final IndexSettings indexSettings;
+    private final boolean writeDimensionRouting;
     private final boolean forceDocValuesSkipper;
     private final boolean storeIgnoredFieldsInBinaryDocValues;
     private final String offsetsFieldName;
@@ -1350,6 +1352,9 @@ public final class KeywordFieldMapper extends FieldMapper {
         this.indexAnalyzers = builder.indexAnalyzers;
         this.scriptCompiler = builder.scriptCompiler;
         this.indexSettings = builder.indexSettings;
+        this.writeDimensionRouting = builder.dimension.getValue()
+            && builder.indexSettings.getIndexRouting() instanceof IndexRouting.ExtractFromSource efs
+            && efs.extractDimensionsWhileMapping();
         this.forceDocValuesSkipper = builder.forceDocValuesSkipper;
         this.storeIgnoredFieldsInBinaryDocValues = builder.storeIgnoredFieldsInBinaryDocValues;
         this.offsetsFieldName = offsetsFieldName;
@@ -1479,7 +1484,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         var utfBytes = value.bytes();
         var binaryValue = new BytesRef(utfBytes.bytes(), utfBytes.offset(), utfBytes.length());
-        if (fieldType().isDimension()) {
+        if (writeDimensionRouting) {
             context.getRoutingFields().addString(fieldType().name(), binaryValue);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -2412,6 +2413,7 @@ public class NumberFieldMapper extends FieldMapper {
     private final Number nullValue;
     private final FieldValues<Number> scriptValues;
     private final boolean dimension;
+    private final boolean writeDimensionRouting;
     private final ScriptCompiler scriptCompiler;
     private final Script script;
     private final MetricType metricType;
@@ -2444,6 +2446,9 @@ public class NumberFieldMapper extends FieldMapper {
         this.nullValue = builder.nullValue.getValue();
         this.scriptValues = builder.scriptValues();
         this.dimension = builder.dimension.getValue();
+        this.writeDimensionRouting = this.dimension
+            && builder.indexSettings.getIndexRouting() instanceof IndexRouting.ExtractFromSource efs
+            && efs.extractDimensionsWhileMapping();
         this.scriptCompiler = builder.scriptCompiler;
         this.script = builder.script.getValue();
         this.metricType = builder.metric.getValue();
@@ -2589,7 +2594,7 @@ public class NumberFieldMapper extends FieldMapper {
         final String name = fieldType.name();
         final LuceneDocument doc = context.doc();
 
-        if (dimension) {
+        if (writeDimensionRouting) {
             context.getRoutingFields().addLong(name, numericValue.longValue());
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -34,6 +34,7 @@ import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.lucene.Lucene;
@@ -1455,7 +1456,10 @@ public final class FlattenedFieldMapper extends FieldMapper implements PassThrou
             mappedSubFields,
             builder.storeIgnoredFieldsInBinaryDocValues,
             builder.preserveLeafArrays.get(),
-            builder.indexSettings.getIndexVersionCreated()
+            builder.indexSettings.getIndexVersionCreated(),
+            builder.dimensions.getValue().isEmpty() == false
+                && builder.indexSettings.getIndexRouting() instanceof IndexRouting.ExtractFromSource efs
+                && efs.extractDimensionsWhileMapping()
         );
         this.preserveLeafArrays = builder.preserveLeafArrays.get();
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParser.java
@@ -53,6 +53,8 @@ class FlattenedFieldParser {
 
     private final FlattenedFieldMapper.PreserveLeafArrays preserveLeafArrays;
 
+    private final boolean writeDimensionRouting;
+
     FlattenedFieldParser(
         String rootFieldFullPath,
         String keyedFieldFullPath,
@@ -66,7 +68,8 @@ class FlattenedFieldParser {
         Map<String, FieldMapper> mappedSubFields,
         boolean storeIgnoredFieldsInBinaryDocValues,
         FlattenedFieldMapper.PreserveLeafArrays preserveLeafArrays,
-        IndexVersion indexVersion
+        IndexVersion indexVersion,
+        boolean writeDimensionRouting
     ) {
         this.rootFieldFullPath = rootFieldFullPath;
         this.keyedFieldFullPath = keyedFieldFullPath;
@@ -81,6 +84,7 @@ class FlattenedFieldParser {
         this.storeIgnoredFieldsInBinaryDocValues = storeIgnoredFieldsInBinaryDocValues;
         this.preserveLeafArrays = preserveLeafArrays;
         this.indexVersion = indexVersion;
+        this.writeDimensionRouting = writeDimensionRouting;
     }
 
     public void parse(final DocumentParserContext documentParserContext, FlattenedFieldArrayContext arrayContext) throws IOException {
@@ -245,12 +249,12 @@ class FlattenedFieldParser {
                 context.arrayContext.recordOffset(key, bytesValue);
             }
 
-            if (fieldType.isDimension() == false || context.documentParserContext().getRoutingFields().isNoop()) {
+            if (writeDimensionRouting == false) {
                 return;
             }
 
             final String keyedFieldName = FlattenedFieldParser.extractKey(bytesKeyedValue).utf8ToString();
-            if (fieldType.isDimension() && fieldType.dimensions().contains(keyedFieldName)) {
+            if (fieldType.dimensions().contains(keyedFieldName)) {
                 final BytesRef keyedFieldValue = FlattenedFieldParser.extractValue(bytesKeyedValue);
                 context.documentParserContext().getRoutingFields().addString(rootFieldFullPath + "." + keyedFieldName, keyedFieldValue);
             }

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldParserTests.java
@@ -48,7 +48,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             Map.of(),
             true,
             FlattenedFieldMapper.PreserveLeafArrays.LOSSY,
-            IndexVersion.current()
+            IndexVersion.current(),
+            false
         );
     }
 
@@ -317,7 +318,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             Map.of(),
             true,
             FlattenedFieldMapper.PreserveLeafArrays.LOSSY,
-            IndexVersion.current()
+            IndexVersion.current(),
+            false
         );
 
         TestDocumentParserContext context = new TestDocumentParserContext(xContentParser);
@@ -347,7 +349,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             Map.of(),
             true,
             FlattenedFieldMapper.PreserveLeafArrays.LOSSY,
-            IndexVersion.current()
+            IndexVersion.current(),
+            false
         );
 
         TestDocumentParserContext context = new TestDocumentParserContext(xContentParser);
@@ -372,7 +375,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             Map.of(),
             true,
             FlattenedFieldMapper.PreserveLeafArrays.LOSSY,
-            IndexVersion.current()
+            IndexVersion.current(),
+            false
         );
 
         TestDocumentParserContext context = new TestDocumentParserContext(xContentParser);
@@ -397,7 +401,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             Map.of(),
             false,
             FlattenedFieldMapper.PreserveLeafArrays.LOSSY,
-            IndexVersion.current()
+            IndexVersion.current(),
+            false
         );
 
         TestDocumentParserContext context = new TestDocumentParserContext(xContentParser);
@@ -428,7 +433,8 @@ public class FlattenedFieldParserTests extends ESTestCase {
             Map.of(),
             true,
             FlattenedFieldMapper.PreserveLeafArrays.LOSSY,
-            IndexVersion.current()
+            IndexVersion.current(),
+            false
         );
 
         TestDocumentParserContext configuredContext = new TestDocumentParserContext(createXContentParser(input));


### PR DESCRIPTION
Dimension-capable mappers (keyword, boolean, ip, number, flattened)
previously checked isDimension() on every document parse, and some
also called RoutingFields.isNoop() at parse time to decide whether
to write to RoutingFields. Since both conditions derive entirely from
static index settings, they can be collapsed into a single boolean
computed once in the mapper constructor.

Add extractDimensionsWhileMapping() to IndexRouting.ExtractFromSource
(true by default, false for ForIndexDimensions) to make the intent
explicit and guard against future ExtractFromSource subtypes needing
the same behaviour. Each mapper now stores writeDimensionRouting and
uses it directly in the parse path, removing all isNoop() calls from
the mapper package.