### PR TITLE
Enhance test fixtures to support Range Request

### DIFF
--- a/test/fixtures/azure-fixture/src/main/java/fixture/azure/AzureHttpHandler.java
+++ b/test/fixtures/azure-fixture/src/main/java/fixture/azure/AzureHttpHandler.java
@@ -33,6 +33,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -266,6 +267,8 @@ public class AzureHttpHandler implements HttpHandler {
                 responseHeaders.add(X_MS_BLOB_CONTENT_LENGTH, String.valueOf(blobContents.length()));
                 responseHeaders.add("Content-Length", String.valueOf(blobContents.length()));
                 responseHeaders.add(X_MS_BLOB_TYPE, blob.type());
+                responseHeaders.add("ETag", "\"blockblob\"");
+                responseHeaders.add("Last-Modified", DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now(ZoneOffset.UTC)));
 
                 final MockAzureBlobStore.CopyInfo copyInfo = blob.copyInfo();
                 if (copyInfo != null) {
@@ -284,8 +287,11 @@ public class AzureHttpHandler implements HttpHandler {
 
                 final BytesReference responseContent;
                 final RestStatus successStatus;
-                // see Constants.HeaderConstants.STORAGE_RANGE_HEADER
-                final String rangeHeader = exchange.getRequestHeaders().getFirst("x-ms-range");
+                // Azure SDK uses x-ms-range; fall back to the standard Range header for other clients
+                String rangeHeader = exchange.getRequestHeaders().getFirst("x-ms-range");
+                if (rangeHeader == null) {
+                    rangeHeader = exchange.getRequestHeaders().getFirst("Range");
+                }
                 if (rangeHeader != null) {
                     final HttpHeaderParser.Range range = HttpHeaderParser.parseRangeHeader(rangeHeader);
                     if (range == null) {
@@ -294,21 +300,28 @@ public class AzureHttpHandler implements HttpHandler {
                             "Range header does not match expected format: " + rangeHeader
                         );
                     }
-
-                    final BytesReference blobContents = blob.getContents();
-                    if (blobContents.length() <= range.start()) {
+                    // Azure Blob Storage does not support suffix ranges (bytes=-N): the Get Blob REST API
+                    // documents only "bytes=start-end" and "bytes=start-". Real Azure returns 416 InvalidRange
+                    // for any other form, so the fixture mirrors that to keep tests faithful.
+                    if (range.isSuffixRange()) {
                         exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
                         sendResponseHeadersWithTrace(exchange, RestStatus.REQUESTED_RANGE_NOT_SATISFIED.getStatus(), -1);
                         return;
                     }
 
-                    long start = range.start();
-                    long end = Math.min(range.end(), blobContents.length() - 1);
-                    long sliceLength = end - start + 1;
-                    responseContent = blobContents.slice(Math.toIntExact(start), Math.toIntExact(sliceLength));
+                    final BytesReference blobContents = blob.getContents();
+                    final HttpHeaderParser.ResolvedRange resolved = range.resolveAgainst(blobContents.length());
+                    if (resolved == null) {
+                        exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+                        sendResponseHeadersWithTrace(exchange, RestStatus.REQUESTED_RANGE_NOT_SATISFIED.getStatus(), -1);
+                        return;
+                    }
+
+                    responseContent = blobContents.slice(Math.toIntExact(resolved.start()), Math.toIntExact(resolved.length()));
                     successStatus = RestStatus.PARTIAL_CONTENT;
                     // Azure SDK expects Content-Range for 206 responses (RFC 7233: bytes start-end/total)
-                    exchange.getResponseHeaders().add("Content-Range", "bytes " + start + "-" + end + "/" + blobContents.length());
+                    exchange.getResponseHeaders()
+                        .add("Content-Range", "bytes " + resolved.start() + "-" + resolved.end() + "/" + blobContents.length());
                 } else {
                     responseContent = blob.getContents();
                     successStatus = RestStatus.OK;
@@ -318,6 +331,8 @@ public class AzureHttpHandler implements HttpHandler {
                 exchange.getResponseHeaders().add(X_MS_BLOB_CONTENT_LENGTH, String.valueOf(responseContent.length()));
                 exchange.getResponseHeaders().add(X_MS_BLOB_TYPE, blob.type());
                 exchange.getResponseHeaders().add("ETag", "\"blockblob\"");
+                exchange.getResponseHeaders()
+                    .add("Last-Modified", DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now(ZoneOffset.UTC)));
                 sendResponseHeadersWithTrace(
                     exchange,
                     successStatus.getStatus(),

--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpFixture.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpFixture.java
@@ -11,10 +11,17 @@ package fixture.gcs;
 import com.sun.net.httpserver.HttpServer;
 
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.TestEsExecutors;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.rules.ExternalResource;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public class GoogleCloudStorageHttpFixture extends ExternalResource {
 
@@ -22,6 +29,7 @@ public class GoogleCloudStorageHttpFixture extends ExternalResource {
     private final String bucket;
     private final String token;
     private HttpServer server;
+    private ExecutorService executorService;
     private GoogleCloudStorageHttpHandler handler;
 
     public GoogleCloudStorageHttpFixture(boolean enabled, final String bucket, final String token) {
@@ -52,11 +60,23 @@ public class GoogleCloudStorageHttpFixture extends ExternalResource {
     @Override
     protected void before() throws Throwable {
         if (enabled) {
+            this.executorService = EsExecutors.newScaling(
+                "gcs-http-fixture",
+                1,
+                100,
+                30,
+                TimeUnit.SECONDS,
+                true,
+                TestEsExecutors.testOnlyDaemonThreadFactory("gcs-http-fixture"),
+                new ThreadContext(Settings.EMPTY)
+            );
+
             this.server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
             this.handler = new GoogleCloudStorageHttpHandler(bucket);
             server.createContext("/" + token, new FakeOAuth2HttpHandler());
             server.createContext("/computeMetadata/v1/project/project-id", new FakeProjectIdHttpHandler());
             server.createContext("/", handler);
+            server.setExecutor(executorService);
             server.start();
         }
     }
@@ -65,6 +85,7 @@ public class GoogleCloudStorageHttpFixture extends ExternalResource {
     protected void after() {
         if (enabled) {
             server.stop(0);
+            ThreadPool.terminate(executorService, 10, TimeUnit.SECONDS);
         }
     }
 }

--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
@@ -31,6 +31,9 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URLDecoder;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -152,14 +155,14 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                             throw new AssertionError("Range bytes header does not match expected format: " + rangeHeader);
                         }
 
-                        if (range.start() >= blob.contents().length()) {
+                        final HttpHeaderParser.ResolvedRange resolved = range.resolveAgainst(blob.contents().length());
+                        if (resolved == null) {
                             exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
                             exchange.sendResponseHeaders(RestStatus.REQUESTED_RANGE_NOT_SATISFIED.getStatus(), -1);
                             return;
                         }
 
-                        final long lastIndex = Math.min(range.end(), blob.contents().length() - 1);
-                        response = blob.contents().slice(Math.toIntExact(range.start()), Math.toIntExact(lastIndex - range.start() + 1));
+                        response = blob.contents().slice(Math.toIntExact(resolved.start()), Math.toIntExact(resolved.length()));
                         statusCode = RestStatus.PARTIAL_CONTENT.getStatus();
                     }
                     // I think it's enough to use the generation here, at least until
@@ -314,7 +317,66 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                     responseBytes.writeTo(exchange.getResponseBody());
                 }
             } else {
-                exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
+                // XML API routes — match against the decoded path/request to handle percent-encoded URIs
+                final String decodedRequest = exchange.getRequestMethod()
+                    + " "
+                    + URLDecoder.decode(exchange.getRequestURI().toString(), UTF_8);
+                final String decodedPath = URLDecoder.decode(exchange.getRequestURI().getPath(), UTF_8);
+                if (Regex.simpleMatch("HEAD /" + bucket + "/*", decodedRequest)) {
+                    // XML API: Head Object
+                    final String key = decodedPath.substring(("/" + bucket + "/").length());
+                    final MockGcsBlobStore.BlobVersion blob = mockGcsBlobStore.getBlob(key, null, null);
+                    if (blob != null) {
+                        final String lastModified = DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now(ZoneOffset.UTC));
+                        exchange.getResponseHeaders().add("Content-Length", String.valueOf(blob.contents().length()));
+                        exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+                        exchange.getResponseHeaders().add("ETag", "\"" + blob.generation() + "\"");
+                        exchange.getResponseHeaders().add("Last-Modified", lastModified);
+                        exchange.getResponseHeaders().add("x-goog-generation", String.valueOf(blob.generation()));
+                        exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
+                    } else {
+                        exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
+                    }
+                } else if (Regex.simpleMatch("GET /" + bucket + "/*", decodedRequest)) {
+                    // XML API: Get Object
+                    final String key = decodedPath.substring(("/" + bucket + "/").length());
+                    final MockGcsBlobStore.BlobVersion blob = mockGcsBlobStore.getBlob(key, null, null);
+                    if (blob != null) {
+                        final String rangeHeader = exchange.getRequestHeaders().getFirst("Range");
+                        final BytesReference response;
+                        final int statusCode;
+                        if (rangeHeader == null) {
+                            response = blob.contents();
+                            statusCode = RestStatus.OK.getStatus();
+                        } else {
+                            final HttpHeaderParser.Range range = HttpHeaderParser.parseRangeHeader(rangeHeader);
+                            if (range == null) {
+                                throw new AssertionError("Range header does not match expected format: " + rangeHeader);
+                            }
+                            final HttpHeaderParser.ResolvedRange resolved = range.resolveAgainst(blob.contents().length());
+                            if (resolved == null) {
+                                exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+                                exchange.sendResponseHeaders(RestStatus.REQUESTED_RANGE_NOT_SATISFIED.getStatus(), -1);
+                                return;
+                            }
+                            response = blob.contents().slice(Math.toIntExact(resolved.start()), Math.toIntExact(resolved.length()));
+                            exchange.getResponseHeaders()
+                                .add("Content-Range", "bytes " + resolved.start() + "-" + resolved.end() + "/" + blob.contents().length());
+                            statusCode = RestStatus.PARTIAL_CONTENT.getStatus();
+                        }
+                        final String lastModified = DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now(ZoneOffset.UTC));
+                        exchange.getResponseHeaders().add("ETag", "\"" + blob.generation() + "\"");
+                        exchange.getResponseHeaders().add("Last-Modified", lastModified);
+                        exchange.getResponseHeaders().add("x-goog-generation", String.valueOf(blob.generation()));
+                        exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+                        exchange.sendResponseHeaders(statusCode, response.length());
+                        response.writeTo(exchange.getResponseBody());
+                    } else {
+                        exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
+                    }
+                } else {
+                    exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
+                }
             }
         } catch (MockGcsBlobStore.GcsRestException e) {
             sendError(exchange, e);

--- a/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
+++ b/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
@@ -187,6 +187,18 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
             new TestHttpResponse(RestStatus.PARTIAL_CONTENT, blobBytes.slice(start, length), TestHttpExchange.EMPTY_HEADERS),
             getBlobContents(handler, bucket, blobName, null, new HttpHeaderParser.Range(start, end))
         );
+
+        // Suffix range: last N bytes.
+        var suffixLength = randomIntBetween(1, blobBytes.length() - 1);
+        assertEquals(
+            "Suffix Range: bytes=-" + suffixLength,
+            new TestHttpResponse(
+                RestStatus.PARTIAL_CONTENT,
+                blobBytes.slice(blobBytes.length() - suffixLength, suffixLength),
+                TestHttpExchange.EMPTY_HEADERS
+            ),
+            getBlobContents(handler, bucket, blobName, null, new HttpHeaderParser.Range(-suffixLength, null))
+        );
     }
 
     public void testZeroLengthObjectGets() {
@@ -215,6 +227,100 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
             getBlobContents(handler, bucket, blobName, null, new HttpHeaderParser.Range(randomIntBetween(0, 30), randomIntBetween(31, 100)))
         );
     }
+
+    public void testXmlApiHeadObject() {
+        final var bucket = randomIdentifier();
+        final var handler = new GoogleCloudStorageHttpHandler(bucket);
+        final var blobName = randomIdentifier("blob_name_");
+        final var blobBytes = randomBytesReference(256);
+        assertEquals(RestStatus.OK, executeUpload(handler, bucket, blobName, blobBytes, 0L).restStatus());
+
+        // Existing object: status, content metadata, and ETag/x-goog-generation headers are populated.
+        final var hit = executeXmlApi(handler, "HEAD", bucket, blobName);
+        assertEquals(RestStatus.OK.getStatus(), hit.responseCode);
+        assertEquals(BytesArray.EMPTY, hit.body);
+        assertEquals(String.valueOf(blobBytes.length()), hit.headers.getFirst("Content-length"));
+        assertEquals("application/octet-stream", hit.headers.getFirst("Content-type"));
+        assertEquals("\"1\"", hit.headers.getFirst("Etag"));
+        assertEquals("1", hit.headers.getFirst("X-goog-generation"));
+        assertNotNull("Last-Modified must be set", hit.headers.getFirst("Last-modified"));
+
+        // Missing object: MockGcsBlobStore.getBlob throws BlobNotFoundException, dispatcher catch maps to 404.
+        final var miss = executeXmlApi(handler, "HEAD", bucket, "does-not-exist");
+        assertEquals(RestStatus.NOT_FOUND.getStatus(), miss.responseCode);
+    }
+
+    public void testXmlApiGetObject() {
+        final var bucket = randomIdentifier();
+        final var handler = new GoogleCloudStorageHttpHandler(bucket);
+        final var blobName = randomIdentifier("blob_name_");
+        final var blobBytes = randomBytesReference(256);
+        assertEquals(RestStatus.OK, executeUpload(handler, bucket, blobName, blobBytes, 0L).restStatus());
+
+        // Full body when no Range header is sent.
+        final var full = executeXmlApi(handler, "GET", bucket, blobName);
+        assertEquals(RestStatus.OK.getStatus(), full.responseCode);
+        assertEquals(blobBytes, full.body);
+        assertNull("OK response must not advertise a Content-Range", full.headers.getFirst("Content-range"));
+
+        // Bounded range: 206 + Content-Range.
+        final var boundedStart = randomIntBetween(0, blobBytes.length() - 1);
+        final var boundedLength = randomIntBetween(1, blobBytes.length() - boundedStart);
+        final var boundedEnd = boundedStart + boundedLength - 1;
+        final var bounded = executeXmlApi(handler, "GET", bucket, blobName, "bytes=" + boundedStart + "-" + boundedEnd);
+        assertEquals(RestStatus.PARTIAL_CONTENT.getStatus(), bounded.responseCode);
+        assertEquals(blobBytes.slice(boundedStart, boundedLength), bounded.body);
+        assertEquals("bytes " + boundedStart + "-" + boundedEnd + "/" + blobBytes.length(), bounded.headers.getFirst("Content-range"));
+
+        // Suffix range: real GCS XML API supports bytes=-N (last N bytes).
+        final var suffixLength = randomIntBetween(1, blobBytes.length() - 1);
+        final var suffixStart = blobBytes.length() - suffixLength;
+        final var suffix = executeXmlApi(handler, "GET", bucket, blobName, "bytes=-" + suffixLength);
+        assertEquals(RestStatus.PARTIAL_CONTENT.getStatus(), suffix.responseCode);
+        assertEquals(blobBytes.slice(suffixStart, suffixLength), suffix.body);
+        assertEquals(
+            "bytes " + suffixStart + "-" + (blobBytes.length() - 1) + "/" + blobBytes.length(),
+            suffix.headers.getFirst("Content-range")
+        );
+
+        // Unsatisfiable range (start past EOF): 416.
+        final var pastEofStart = randomIntBetween(blobBytes.length(), Integer.MAX_VALUE - 1);
+        final var pastEofEnd = randomIntBetween(pastEofStart, Integer.MAX_VALUE);
+        final var unsatisfiable = executeXmlApi(handler, "GET", bucket, blobName, "bytes=" + pastEofStart + "-" + pastEofEnd);
+        assertEquals(RestStatus.REQUESTED_RANGE_NOT_SATISFIED.getStatus(), unsatisfiable.responseCode);
+
+        // Missing object: MockGcsBlobStore.getBlob throws BlobNotFoundException, dispatcher catch maps to 404.
+        final var missing = executeXmlApi(handler, "GET", bucket, "does-not-exist");
+        assertEquals(RestStatus.NOT_FOUND.getStatus(), missing.responseCode);
+    }
+
+    private static RawResponse executeXmlApi(GoogleCloudStorageHttpHandler handler, String method, String bucket, String key) {
+        return executeXmlApi(handler, method, bucket, key, null);
+    }
+
+    private static RawResponse executeXmlApi(
+        GoogleCloudStorageHttpHandler handler,
+        String method,
+        String bucket,
+        String key,
+        @Nullable String rangeHeaderValue
+    ) {
+        final var headers = rangeHeaderValue != null ? Headers.of("Range", rangeHeaderValue) : TestHttpExchange.EMPTY_HEADERS;
+        // URLEncoder is form-encoded; for a path segment we have to fix up '+' (space) so the handler's
+        // URLDecoder.decode round-trips correctly. Bucket is constrained to be percent-safe by GCS naming
+        // rules so it is left as-is.
+        final var encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8).replace("+", "%20");
+        final var exchange = new TestHttpExchange(method, "/" + bucket + "/" + encodedKey, BytesArray.EMPTY, headers);
+        try {
+            handler.handle(exchange);
+        } catch (IOException e) {
+            fail(e);
+        }
+        return new RawResponse(exchange.getResponseCode(), exchange.getResponseBodyContents(), exchange.getResponseHeaders());
+    }
+
+    /** Captures the full handler response without the {@link #handleRequest} header allow-list filter. */
+    private record RawResponse(int responseCode, BytesReference body, Headers headers) {}
 
     public void testResumableUpload() {
         final var bucket = randomIdentifier();
@@ -658,7 +764,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
             "GET",
             "/download/storage/v1/b/" + bucket + "/o/" + blobName + generateQueryString("ifGenerationMatch", ifGenerationMatch),
             BytesArray.EMPTY,
-            range != null ? rangeHeader(range.start(), range.end()) : TestHttpExchange.EMPTY_HEADERS
+            range != null ? Headers.of("Range", range.headerString()) : TestHttpExchange.EMPTY_HEADERS
         );
     }
 

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -393,28 +393,31 @@ public class S3HttpHandler implements HttpHandler {
                 }
 
                 // S3 supports https://www.rfc-editor.org/rfc/rfc9110.html#name-range
-                // This handler supports both bounded ranges (bytes=0-100) and open-ended ranges (bytes=100-)
+                // Supports bounded (bytes=0-100), open-ended (bytes=100-), and suffix (bytes=-N) ranges
                 final HttpHeaderParser.Range range = parseRangeHeader(rangeHeader);
                 if (range == null) {
                     throw new AssertionError("Bytes range does not match expected pattern: " + rangeHeader);
                 }
-                long start = range.start();
-                // For open-ended ranges (bytes=N-), end is null, meaning "to end of file"
-                long end = range.end() != null ? range.end() : blob.length() - 1;
-                if (end < start) {
+                // A byte-range with end < start is invalid. Real S3 ignores it and returns the full object
+                // with 200 OK, so the fixture mirrors that behavior. This check must run before
+                // resolveAgainst, otherwise an invalid range whose start is also beyond EOF (e.g.
+                // "bytes=300-50" against a 200-byte object) would be reported as 416 instead of being ignored.
+                if (range.end() != null && range.end() < range.start()) {
                     exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
                     exchange.sendResponseHeaders(RestStatus.OK.getStatus(), blob.length());
                     blob.writeTo(exchange.getResponseBody());
                     return;
-                } else if (blob.length() <= start) {
+                }
+                final HttpHeaderParser.ResolvedRange resolved = range.resolveAgainst(blob.length());
+                if (resolved == null) {
                     exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
                     exchange.sendResponseHeaders(RestStatus.REQUESTED_RANGE_NOT_SATISFIED.getStatus(), -1);
                     return;
                 }
-                var responseBlob = blob.slice(Math.toIntExact(start), Math.toIntExact(Math.min(end - start + 1, blob.length() - start)));
-                end = start + responseBlob.length() - 1;
+                var responseBlob = blob.slice(Math.toIntExact(resolved.start()), Math.toIntExact(resolved.length()));
                 exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
-                exchange.getResponseHeaders().add("Content-Range", String.format(Locale.ROOT, "bytes %d-%d/%d", start, end, blob.length()));
+                exchange.getResponseHeaders()
+                    .add("Content-Range", String.format(Locale.ROOT, "bytes %d-%d/%d", resolved.start(), resolved.end(), blob.length()));
                 exchange.sendResponseHeaders(RestStatus.PARTIAL_CONTENT.getStatus(), responseBlob.length());
                 responseBlob.writeTo(exchange.getResponseBody());
 

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -202,6 +202,30 @@ public class S3HttpHandlerTests extends ESTestCase {
             ),
             handleRequest(handler, "GET", blobPath, BytesArray.EMPTY, bytesRangeHeader(start, end))
         );
+
+        // Suffix range: last N bytes of the blob.
+        var suffixLength = randomIntBetween(1, blobBytes.length() - 1);
+        var suffixStart = blobBytes.length() - suffixLength;
+        assertEquals(
+            "Suffix Range: bytes=-" + suffixLength,
+            new TestHttpResponse(
+                RestStatus.PARTIAL_CONTENT,
+                blobBytes.slice(suffixStart, suffixLength),
+                addETag(expectedEtag, contentRangeHeader(suffixStart, blobBytes.length() - 1, blobBytes.length()))
+            ),
+            handleRequest(handler, "GET", blobPath, BytesArray.EMPTY, bytesSuffixHeader(suffixLength))
+        );
+
+        // Suffix length larger than the blob: returns the entire object (RFC 9110 §14.1.2).
+        assertEquals(
+            "Suffix Range larger than blob: bytes=-" + (blobBytes.length() + 100),
+            new TestHttpResponse(
+                RestStatus.PARTIAL_CONTENT,
+                blobBytes,
+                addETag(expectedEtag, contentRangeHeader(0, blobBytes.length() - 1, blobBytes.length()))
+            ),
+            handleRequest(handler, "GET", blobPath, BytesArray.EMPTY, bytesSuffixHeader(blobBytes.length() + 100))
+        );
     }
 
     public void testSingleMultipartUpload() {
@@ -612,17 +636,21 @@ public class S3HttpHandlerTests extends ESTestCase {
         );
     }
 
-    private static Headers bytesRangeHeader(@Nullable Integer startInclusive, @Nullable Integer endInclusive) {
+    private static Headers bytesRangeHeader(int startInclusive, @Nullable Integer endInclusive) {
         StringBuilder range = new StringBuilder("bytes=");
-        if (startInclusive != null) {
-            range.append(startInclusive);
-        }
-        range.append('-');
+        range.append(startInclusive).append('-');
         if (endInclusive != null) {
             range.append(endInclusive);
         }
         var headers = new Headers();
         headers.put("Range", List.of(range.toString()));
+        return headers;
+    }
+
+    /** Suffix-range header per RFC 7233 §2.1: "bytes=-N" requests the last N bytes. */
+    private static Headers bytesSuffixHeader(int suffixLength) {
+        var headers = new Headers();
+        headers.put("Range", List.of("bytes=-" + suffixLength));
         return headers;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/fixture/HttpHeaderParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/fixture/HttpHeaderParser.java
@@ -15,17 +15,18 @@ import java.util.regex.Pattern;
 public enum HttpHeaderParser {
     ;
 
-    // Pattern supports both bounded ranges (bytes=0-100) and open-ended ranges (bytes=100-)
     private static final Pattern RANGE_HEADER_PATTERN = Pattern.compile("bytes=([0-9]+)-([0-9]*)");
+    private static final Pattern SUFFIX_RANGE_PATTERN = Pattern.compile("bytes=-([0-9]+)");
     private static final Pattern CONTENT_RANGE_HEADER_PATTERN = Pattern.compile("bytes (?:(\\d+)-(\\d+)|\\*)/(?:(\\d+)|\\*)");
 
     /**
-     * Parse a "Range" header
+     * Parse a "Range" header per RFC 7233.
      *
-     * Supports both bounded and open-ended ranges:
+     * Supports bounded, open-ended, and suffix ranges:
      * <ul>
      *   <li>Bounded: <code>Range: bytes={range_start}-{range_end}</code></li>
      *   <li>Open-ended: <code>Range: bytes={range_start}-</code> (end is null, meaning "to end of file")</li>
+     *   <li>Suffix: <code>Range: bytes=-{suffix_length}</code> (last N bytes; start is negative, end is null)</li>
      * </ul>
      *
      * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range">MDN: Range header</a>
@@ -44,14 +45,23 @@ public enum HttpHeaderParser {
                 return null;
             }
         }
+        final Matcher suffixMatcher = SUFFIX_RANGE_PATTERN.matcher(rangeHeaderValue);
+        if (suffixMatcher.matches()) {
+            try {
+                long suffixLength = Long.parseLong(suffixMatcher.group(1));
+                return new Range(-suffixLength, null);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
         return null;
     }
 
     /**
      * A HTTP "Range" from a Range header.
      *
-     * @param start The start of the range (always present)
-     * @param end The end of the range, or null for open-ended ranges (meaning "to end of file")
+     * @param start The start of the range. Negative values indicate a suffix range (last N bytes from end).
+     * @param end The end of the range, or null for open-ended/suffix ranges.
      */
     public record Range(long start, Long end) {
 
@@ -60,14 +70,57 @@ public enum HttpHeaderParser {
         }
 
         /**
-         * Returns true if this is an open-ended range (no end specified).
+         * Returns true if this is a suffix range (bytes=-N, meaning the last N bytes).
+         */
+        public boolean isSuffixRange() {
+            return start < 0;
+        }
+
+        /**
+         * Returns true if this is an open-ended range (no end specified, not a suffix range).
          */
         public boolean isOpenEnded() {
-            return end == null;
+            return end == null && start >= 0;
+        }
+
+        /**
+         * Resolves this (possibly relative) range against a known content length,
+         * producing absolute byte offsets clamped to [0, contentLength).
+         *
+         * @return resolved absolute range, or null if the range is unsatisfiable (start &gt;= contentLength)
+         */
+        public ResolvedRange resolveAgainst(long contentLength) {
+            long resolvedStart;
+            long resolvedEnd;
+            if (isSuffixRange()) {
+                long suffixLength = -start;
+                resolvedStart = Math.max(0, contentLength - suffixLength);
+                resolvedEnd = contentLength - 1;
+            } else {
+                resolvedStart = start;
+                resolvedEnd = end != null ? end : contentLength - 1;
+            }
+            if (resolvedStart >= contentLength) {
+                return null;
+            }
+            resolvedEnd = Math.min(resolvedEnd, contentLength - 1);
+            return new ResolvedRange(resolvedStart, resolvedEnd);
         }
 
         public String headerString() {
+            if (start < 0) {
+                return "bytes=-" + (-start);
+            }
             return end != null ? "bytes=" + start + "-" + end : "bytes=" + start + "-";
+        }
+    }
+
+    /**
+     * An absolute byte range with both start and end resolved against a content length.
+     */
+    public record ResolvedRange(long start, long end) {
+        public long length() {
+            return end - start + 1;
         }
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/http/HttpHeaderParserTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/http/HttpHeaderParserTests.java
@@ -48,14 +48,92 @@ public class HttpHeaderParserTests extends ESTestCase {
         assertEquals(new HttpHeaderParser.Range(bytes, null), HttpHeaderParser.parseRangeHeader(Strings.format("bytes=%d-", bytes)));
     }
 
-    public void testParseRangeHeaderSuffixLengthNotMatched() {
-        assertNull(HttpHeaderParser.parseRangeHeader(Strings.format("bytes=-%d", randomLongBetween(0, Long.MAX_VALUE))));
+    public void testParseRangeHeaderSuffixLength() {
+        var bytes = randomLongBetween(1, Long.MAX_VALUE);
+        assertEquals(new HttpHeaderParser.Range(-bytes, null), HttpHeaderParser.parseRangeHeader(Strings.format("bytes=-%d", bytes)));
+    }
+
+    public void testParseRangeHeaderSuffixLengthInvalidLong() {
+        final BigInteger longOverflow = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE).add(randomBigInteger());
+        assertNull(HttpHeaderParser.parseRangeHeader("bytes=-" + longOverflow));
     }
 
     public void testRangeHeaderString() {
         final long start = randomLongBetween(0, 10_000);
         final long end = randomLongBetween(start, start + 10_000);
         assertEquals("bytes=" + start + "-" + end, new HttpHeaderParser.Range(start, end).headerString());
+    }
+
+    public void testOpenEndedRangeHeaderString() {
+        var start = randomLongBetween(0, 10_000);
+        assertEquals("bytes=" + start + "-", new HttpHeaderParser.Range(start, null).headerString());
+    }
+
+    public void testSuffixRangeHeaderString() {
+        var bytes = randomLongBetween(1, Long.MAX_VALUE);
+        assertEquals("bytes=-" + bytes, new HttpHeaderParser.Range(-bytes, null).headerString());
+    }
+
+    public void testRangeTypeFlags() {
+        // bounded: neither open-ended nor suffix
+        var bounded = new HttpHeaderParser.Range(10, 50L);
+        assertFalse(bounded.isOpenEnded());
+        assertFalse(bounded.isSuffixRange());
+
+        // open-ended: open-ended but not suffix
+        var openEnded = new HttpHeaderParser.Range(10, null);
+        assertTrue(openEnded.isOpenEnded());
+        assertFalse(openEnded.isSuffixRange());
+
+        // suffix: suffix but not open-ended (key behavioral distinction)
+        var suffix = new HttpHeaderParser.Range(-30, null);
+        assertFalse(suffix.isOpenEnded());
+        assertTrue(suffix.isSuffixRange());
+    }
+
+    public void testResolveAgainstBounded() {
+        var resolved = new HttpHeaderParser.Range(10, 50L).resolveAgainst(100);
+        assertNotNull(resolved);
+        assertEquals(10, resolved.start());
+        assertEquals(50, resolved.end());
+        assertEquals(41, resolved.length());
+    }
+
+    public void testResolveAgainstOpenEnded() {
+        var resolved = new HttpHeaderParser.Range(80, null).resolveAgainst(100);
+        assertNotNull(resolved);
+        assertEquals(80, resolved.start());
+        assertEquals(99, resolved.end());
+        assertEquals(20, resolved.length());
+    }
+
+    public void testResolveAgainstSuffix() {
+        var resolved = new HttpHeaderParser.Range(-30, null).resolveAgainst(100);
+        assertNotNull(resolved);
+        assertEquals(70, resolved.start());
+        assertEquals(99, resolved.end());
+        assertEquals(30, resolved.length());
+    }
+
+    public void testResolveAgainstSuffixLargerThanContent() {
+        var resolved = new HttpHeaderParser.Range(-200, null).resolveAgainst(100);
+        assertNotNull(resolved);
+        assertEquals(0, resolved.start());
+        assertEquals(99, resolved.end());
+        assertEquals(100, resolved.length());
+    }
+
+    public void testResolveAgainstUnsatisfiable() {
+        assertNull(new HttpHeaderParser.Range(100, 150L).resolveAgainst(100));
+        assertNull(new HttpHeaderParser.Range(200, null).resolveAgainst(100));
+    }
+
+    public void testResolveAgainstClampsEnd() {
+        var resolved = new HttpHeaderParser.Range(50, 200L).resolveAgainst(100);
+        assertNotNull(resolved);
+        assertEquals(50, resolved.start());
+        assertEquals(99, resolved.end());
+        assertEquals(50, resolved.length());
     }
 
     public void testParseContentRangeHeaderFull() {


### PR DESCRIPTION
## Summary
  Aligns the Azure, GCS, and S3 test fixtures with real cloud-provider behavior for HTTP `Range` requests so tests that exercise range reads (partial reads, suffix ranges) are faithful.
  - **Shared parser** (`HttpHeaderParser`): adds suffix range support (`bytes=-N`), a `ResolvedRange` helper that clamps a relative `Range` to a known content length, and `headerString()` for round-tripping.
  - **Azure** (`AzureHttpHandler`): also accepts the standard `Range` header (in addition to `x-ms-range`), returns `416` for suffix ranges to mirror real Azure, and adds `ETag`/`Last-Modified` to `GetBlob` responses.
  - **S3** (`S3HttpHandler`): supports suffix ranges, and matches real S3 by ignoring invalid ranges (`end < start`) and returning the full object with `200`, even when the start is also past EOF (which previously misreported as `416`).
  - **GCS** (`GoogleCloudStorageHttpHandler`): supports suffix ranges on the JSON download path, adds the XML API `GET`/`HEAD /{bucket}/{key}` routes (with range support, `ETag`, `Last-Modified`, `x-goog-generation`), and the fixture now serves requests on a scaling executor so concurrent range reads don't serialize.
  - Expanded unit tests for `HttpHeaderParser`, `S3HttpHandler`, and `GoogleCloudStorageHttpHandler` cover suffix/open-ended/invalid ranges, EOF clamping, and the new XML routes.
  
  
  Assisted by Cursor/Claude