### PR TITLE
ESQL: Adaptive S3 prefetch depth and zero-copy strings

### DIFF
--- a/docs/changelog/147936.yaml
+++ b/docs/changelog/147936.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147936
+summary: Adaptive S3 prefetch depth and zero-copy strings
+type: enhancement

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -44,12 +44,12 @@ import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
-import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
@@ -327,15 +327,13 @@ public class OrcFormatReader implements RangeAwareFormatReader {
      * structural (corrupt stripe, schema mismatch) rather than row-level.
      */
     @Override
-    public CloseableIterator<Page> readRange(
-        StorageObject object,
-        List<String> projectedColumns,
-        int batchSize,
-        long rangeStart,
-        long rangeEnd,
-        List<Attribute> resolvedAttributes,
-        ErrorPolicy errorPolicy
-    ) throws IOException {
+    public CloseableIterator<Page> readRange(StorageObject object, RangeReadContext context) throws IOException {
+        long rangeStart = context.rangeStart();
+        long rangeEnd = context.rangeEnd();
+        List<String> projectedColumns = context.projectedColumns();
+        int batchSize = context.batchSize();
+        List<Attribute> resolvedAttributes = context.resolvedAttributes();
+
         if (rangeEnd <= rangeStart) {
             throw new IllegalArgumentException("rangeEnd [" + rangeEnd + "] must be greater than rangeStart [" + rangeStart + "]");
         }

--- a/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-orc/src/test/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReaderTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -1184,12 +1185,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         try (
             CloseableIterator<Page> iter = reader.readRange(
                 object,
-                projection,
-                1024,
-                range.offset(),
-                range.offset() + range.length(),
-                List.of(),
-                null
+                new RangeReadContext(projection, 1024, range.offset(), range.offset() + range.length(), List.of(), null)
             )
         ) {
             assertTrue(iter.hasNext());
@@ -1204,12 +1200,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         try (
             CloseableIterator<Page> iter = reader.readRange(
                 object,
-                null,
-                1024,
-                range.offset(),
-                range.offset() + range.length(),
-                List.of(),
-                null
+                new RangeReadContext(null, 1024, range.offset(), range.offset() + range.length(), List.of(), null)
             )
         ) {
             while (iter.hasNext()) {
@@ -1230,12 +1221,7 @@ public class OrcFormatReaderTests extends ESTestCase {
         try (
             CloseableIterator<Page> iter = reader.readRange(
                 object,
-                null,
-                1024,
-                range.offset(),
-                range.offset() + range.length(),
-                List.of(),
-                null
+                new RangeReadContext(null, 1024, range.offset(), range.offset() + range.length(), List.of(), null)
             )
         ) {
             while (iter.hasNext()) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
@@ -35,6 +35,7 @@ final class DictionaryValueDecoder {
     private final int[] groupValues = new int[8];
     private int groupNext = 8;
     private BytesRef[] cachedDictBytesRefs;
+    private Dictionary cachedDict;
 
     void init(ByteBuffer valueBytes) {
         ByteBuffer dup = valueBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
@@ -80,6 +81,8 @@ final class DictionaryValueDecoder {
     }
 
     void readBinaries(BytesRef[] values, int offset, int count, Dictionary dict) {
+        Check.notNull(dict, "dictionary");
+        assert cachedDict == null || cachedDict == dict;
         if (cachedDictBytesRefs == null) {
             int size = dict.getMaxId() + 1;
             cachedDictBytesRefs = new BytesRef[size];
@@ -87,6 +90,7 @@ final class DictionaryValueDecoder {
                 byte[] bytes = dict.decodeToBinary(i).getBytes();
                 cachedDictBytesRefs[i] = new BytesRef(bytes, 0, bytes.length);
             }
+            cachedDict = dict;
         }
         for (int i = 0; i < count; i++) {
             values[offset + i] = cachedDictBytesRefs[nextIndex()];

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.parquet.column.Dictionary;
-import org.apache.parquet.io.api.Binary;
 import org.elasticsearch.xpack.esql.core.util.Check;
 
 import java.nio.ByteBuffer;
@@ -35,6 +34,7 @@ final class DictionaryValueDecoder {
     private int packedRemaining;
     private final int[] groupValues = new int[8];
     private int groupNext = 8;
+    private BytesRef[] cachedDictBytesRefs;
 
     void init(ByteBuffer valueBytes) {
         ByteBuffer dup = valueBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
@@ -80,10 +80,16 @@ final class DictionaryValueDecoder {
     }
 
     void readBinaries(BytesRef[] values, int offset, int count, Dictionary dict) {
+        if (cachedDictBytesRefs == null) {
+            int size = dict.getMaxId() + 1;
+            cachedDictBytesRefs = new BytesRef[size];
+            for (int i = 0; i < size; i++) {
+                byte[] bytes = dict.decodeToBinary(i).getBytes();
+                cachedDictBytesRefs[i] = new BytesRef(bytes, 0, bytes.length);
+            }
+        }
         for (int i = 0; i < count; i++) {
-            Binary bin = dict.decodeToBinary(nextIndex());
-            byte[] bytes = bin.getBytes();
-            values[offset + i] = new BytesRef(bytes, 0, bytes.length);
+            values[offset + i] = cachedDictBytesRefs[nextIndex()];
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -14,10 +14,12 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.schema.MessageType;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
@@ -30,6 +32,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NavigableMap;
@@ -89,12 +92,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final int[] nextSurvivor;
     private final CompressionCodecFactory codecFactory;
     private int rowBudget;
-    /**
-     * Bytes reserved on the breaker for the pending (in-flight) prefetch. Only mutated from the
-     * iterator thread (the prefetch I/O thread populates the {@link CompletableFuture} but never
-     * touches this field), so a plain {@code long} is sufficient.
-     */
-    private long pendingReservedBytes = 0;
+    private final int prefetchDepth;
+    private final ArrayDeque<PendingPrefetch> pendingPrefetches = new ArrayDeque<>();
     /** Bytes reserved on the breaker for the chunks currently in use by {@link #rowGroup}. */
     private long currentReservedBytes = 0;
 
@@ -105,9 +104,6 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private boolean exhausted = false;
     private int rowGroupOrdinal = -1;
     private int pageBatchIndexInRowGroup = 0;
-    private CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> pendingPrefetch;
-    /** Ordinal of the row group whose chunks are pending prefetch; -1 when no prefetch is in flight. */
-    private int pendingPrefetchOrdinal = -1;
 
     OptimizedParquetColumnIterator(
         ParquetFileReader reader,
@@ -143,8 +139,99 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.codecFactory = codecFactory;
 
         this.projectedColumnPaths = buildProjectedColumnPaths(columnInfos);
+        this.prefetchDepth = computePrefetchDepth(reader.getRowGroups(), this.projectedColumnPaths);
 
         reader.setRequestedSchema(projectedSchema);
+
+        prefetchFirstRowGroup();
+    }
+
+    /**
+     * Seeds the prefetch queue at construction time so that the first {@link #advanceRowGroup()}
+     * call finds ready data instead of falling through to synchronous I/O.
+     */
+    private void prefetchFirstRowGroup() {
+        if (storageObject == null) {
+            return;
+        }
+        int startOrdinal = nextSurvivingRowGroupOrdinal(0);
+        fillPrefetchQueue(startOrdinal);
+    }
+
+    /**
+     * Fills the prefetch queue up to {@link #prefetchDepth} entries, starting from ordinal
+     * {@code fromOrdinal}. Each entry reserves bytes on the circuit breaker before starting
+     * async I/O. Filling stops early if the breaker would trip or if no more surviving row
+     * groups remain.
+     */
+    private void fillPrefetchQueue(int fromOrdinal) {
+        List<BlockMetaData> rowGroups = reader.getRowGroups();
+        int nextOrdinal = fromOrdinal;
+        while (pendingPrefetches.size() < prefetchDepth && nextOrdinal < rowGroups.size()) {
+            BlockMetaData nextBlock = rowGroups.get(nextOrdinal);
+            long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, projectedColumnPaths);
+            if (prefetchBytes <= 0) {
+                nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
+                continue;
+            }
+            try {
+                breaker.addEstimateBytesAndMaybeBreak(prefetchBytes, "esql_parquet_prefetch");
+            } catch (CircuitBreakingException e) {
+                logger.debug(
+                    "Stopping prefetch queue fill at row group [{}] in [{}]: circuit breaker limit reached ({} bytes requested)",
+                    nextOrdinal,
+                    fileLocation,
+                    prefetchBytes
+                );
+                break;
+            }
+            try {
+                RowRanges nextRowRanges = allRowRanges != null && nextOrdinal < allRowRanges.length ? allRowRanges[nextOrdinal] : null;
+                CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future;
+                if (nextRowRanges != null) {
+                    future = ColumnChunkPrefetcher.prefetchAsync(
+                        storageObject,
+                        nextBlock,
+                        projectedColumnPaths,
+                        nextRowRanges,
+                        preloadedMetadata,
+                        nextOrdinal,
+                        nextBlock.getRowCount()
+                    );
+                } else {
+                    future = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, projectedColumnPaths);
+                }
+                pendingPrefetches.addLast(new PendingPrefetch(nextOrdinal, future, prefetchBytes));
+            } catch (Exception e) {
+                logger.debug("Failed to initiate prefetch for row group [{}] in [{}]: {}", nextOrdinal, fileLocation, e.getMessage());
+                breaker.addWithoutBreaking(-prefetchBytes);
+                break;
+            }
+            nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
+        }
+    }
+
+    private static int computePrefetchDepth(List<BlockMetaData> rowGroups, Set<String> projectedColumnPaths) {
+        if (rowGroups.isEmpty()) {
+            return 1;
+        }
+        BlockMetaData block = rowGroups.get(0);
+        long projectedBytes = 0;
+        for (ColumnChunkMetaData col : block.getColumns()) {
+            if (projectedColumnPaths.contains(col.getPath().toDotString())) {
+                projectedBytes += col.getTotalSize();
+            }
+        }
+        // Larger projected sizes need deeper prefetch: an S3 GET for a 20MB string column takes
+        // ~200ms while decode takes ~10ms, so single-ahead can't hide the latency. The circuit
+        // breaker caps actual memory regardless of depth.
+        if (projectedBytes > 32_000_000) {
+            return 3;
+        }
+        if (projectedBytes > 8_000_000) {
+            return 2;
+        }
+        return 1;
     }
 
     private static Set<String> buildProjectedColumnPaths(ColumnInfo[] columnInfos) {
@@ -203,26 +290,31 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
 
         BlockMetaData block = reader.getRowGroups().get(rowGroupOrdinal);
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = takePendingPrefetch(rowGroupOrdinal);
-        RowRanges currentRowRanges = resolveCurrentRowRanges(block);
-        rowGroup = PrefetchedRowGroupBuilder.build(
-            block,
-            rowGroupOrdinal,
-            projectedSchema,
-            projectedColumnPaths,
-            currentRowRanges,
-            preloadedMetadata,
-            chunks,
-            storageObject,
-            codecFactory
-        );
-        // When RowRanges narrow the row group, only the surviving row count is consumed -
-        // mirrors parquet-mr's filtered PageReadStore.getRowCount(). The PageReader's per-page
-        // value count is unchanged; PageColumnReader caps at maxRows on each readBatch call so
-        // columns whose pages span more rows than the filtered count return aligned blocks.
-        rowsRemainingInGroup = currentRowRanges != null ? currentRowRanges.selectedRowCount() : rowGroup.getRowCount();
-        triggerNextRowGroupPrefetch();
-        initColumnReaders(currentRowRanges);
-        return rowsRemainingInGroup > 0;
+        try {
+            RowRanges currentRowRanges = resolveCurrentRowRanges(block);
+            rowGroup = PrefetchedRowGroupBuilder.build(
+                block,
+                rowGroupOrdinal,
+                projectedSchema,
+                projectedColumnPaths,
+                currentRowRanges,
+                preloadedMetadata,
+                chunks,
+                storageObject,
+                codecFactory
+            );
+            // When RowRanges narrow the row group, only the surviving row count is consumed -
+            // mirrors parquet-mr's filtered PageReadStore.getRowCount(). The PageReader's per-page
+            // value count is unchanged; PageColumnReader caps at maxRows on each readBatch call so
+            // columns whose pages span more rows than the filtered count return aligned blocks.
+            rowsRemainingInGroup = currentRowRanges != null ? currentRowRanges.selectedRowCount() : rowGroup.getRowCount();
+            triggerNextRowGroupPrefetch();
+            initColumnReaders(currentRowRanges);
+            return rowsRemainingInGroup > 0;
+        } catch (Exception e) {
+            releaseCurrentReservation();
+            throw e;
+        }
     }
 
     /**
@@ -312,42 +404,43 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     }
 
     /**
-     * Joins the pending prefetch and returns the prefetched chunks for the row group whose ordinal
-     * matches {@code expectedOrdinal}. Returns {@code null} when there is no usable prefetch (no
-     * future scheduled, future failed, future returned empty data, or the prefetched ordinal does
-     * not match the row group we're about to read because stats dropped intermediate row groups).
-     * The breaker reservation is released for any prefetch whose data is not handed back to the
-     * caller.
+     * Dequeues the head of the prefetch queue if it matches {@code expectedOrdinal}, joining its
+     * future and returning the prefetched chunks. Entries whose ordinals don't match (because
+     * the stats filter skipped intermediate row groups) are cancelled and their breaker
+     * reservations released. Returns {@code null} when there is no usable prefetch.
      */
     private NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> takePendingPrefetch(int expectedOrdinal) {
-        // The chunks from the previous row group are no longer referenced by anyone; release
-        // their reservation regardless of whether the new prefetch produces usable data.
         releaseCurrentReservation();
 
-        if (pendingPrefetch == null) {
+        while (pendingPrefetches.isEmpty() == false) {
+            PendingPrefetch head = pendingPrefetches.peekFirst();
+            if (head.ordinal() == expectedOrdinal) {
+                break;
+            }
+            if (head.ordinal() > expectedOrdinal) {
+                return null;
+            }
+            pendingPrefetches.pollFirst();
+            FutureUtils.cancel(head.future());
+            if (head.reservedBytes() > 0) {
+                breaker.addWithoutBreaking(-head.reservedBytes());
+            }
+        }
+
+        if (pendingPrefetches.isEmpty()) {
             return null;
         }
-        if (pendingPrefetchOrdinal != expectedOrdinal) {
-            // Stats filter advanced past the prefetched row group. The bytes we fetched are now
-            // useless; drop them and free the reservation so the next prefetch can run.
-            cancelPendingPrefetch();
-            return null;
-        }
-        long reserved = pendingReservedBytes;
-        pendingReservedBytes = 0;
-        CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future = pendingPrefetch;
-        pendingPrefetch = null;
-        pendingPrefetchOrdinal = -1;
+
+        PendingPrefetch head = pendingPrefetches.pollFirst();
         try {
-            NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> data = future.join();
+            NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> data = head.future().join();
             if (data != null && data.isEmpty() == false) {
                 logger.trace("Took [{}] prefetched column chunks for row group [{}] in [{}]", data.size(), expectedOrdinal, fileLocation);
-                // Hold on to the reservation while these chunks are in use by the row group.
-                currentReservedBytes = reserved;
+                currentReservedBytes = head.reservedBytes();
                 return data;
             }
-            if (reserved > 0) {
-                breaker.addWithoutBreaking(-reserved);
+            if (head.reservedBytes() > 0) {
+                breaker.addWithoutBreaking(-head.reservedBytes());
             }
             return null;
         } catch (Exception e) {
@@ -357,102 +450,42 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 fileLocation,
                 e.getMessage()
             );
-            if (reserved > 0) {
-                breaker.addWithoutBreaking(-reserved);
+            if (head.reservedBytes() > 0) {
+                breaker.addWithoutBreaking(-head.reservedBytes());
             }
             return null;
         }
     }
 
     /**
-     * Triggers an async prefetch of column chunk data for the next surviving row group (skipping
-     * row groups dropped by the statistics filter so we never pay for I/O we won't use). Reserves
-     * the estimated bytes on the circuit breaker before starting I/O; if the breaker would trip,
-     * prefetch is skipped and the query falls back to synchronous I/O for that row group. The
-     * reservation is released when the prefetched data is taken in {@link #advanceRowGroup()} or
-     * on failure/cancel.
+     * Refills the prefetch queue after consuming an entry in {@link #advanceRowGroup()}.
+     * Starts from the ordinal after the last queued entry (or after the current row group
+     * if the queue is empty). Skips row groups dropped by the statistics filter.
      */
     private void triggerNextRowGroupPrefetch() {
         if (storageObject == null) {
             return;
         }
-        List<BlockMetaData> rowGroups = reader.getRowGroups();
-        int nextRgOrdinal = nextSurvivingRowGroupOrdinal(rowGroupOrdinal + 1);
-        if (nextRgOrdinal >= rowGroups.size()) {
-            return;
+        int startOrdinal;
+        if (pendingPrefetches.isEmpty()) {
+            startOrdinal = nextSurvivingRowGroupOrdinal(rowGroupOrdinal + 1);
+        } else {
+            startOrdinal = nextSurvivingRowGroupOrdinal(pendingPrefetches.peekLast().ordinal() + 1);
         }
-        BlockMetaData nextBlock = rowGroups.get(nextRgOrdinal);
-        long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, projectedColumnPaths);
-        if (prefetchBytes <= 0) {
-            // No data to prefetch (empty projection or zero-byte columns). This is safe because
-            // installPendingPrefetch tolerates pendingPrefetch == null — no invariant is broken.
-            return;
-        }
-        try {
-            breaker.addEstimateBytesAndMaybeBreak(prefetchBytes, "esql_parquet_prefetch");
-            pendingReservedBytes = prefetchBytes;
-        } catch (CircuitBreakingException e) {
-            logger.debug(
-                "Skipping prefetch for row group [{}] in [{}]: circuit breaker limit reached ({} bytes requested)",
-                nextRgOrdinal,
-                fileLocation,
-                prefetchBytes
-            );
-            return;
-        }
-        try {
-            // nextRgOrdinal is always a surviving ordinal (nextSurvivingRowGroupOrdinal skips
-            // dropped row groups), so allRowRanges[nextRgOrdinal] is non-null when allRowRanges
-            // itself is non-null. The explicit null guard makes the contract obvious.
-            RowRanges nextRowRanges = allRowRanges != null && nextRgOrdinal < allRowRanges.length ? allRowRanges[nextRgOrdinal] : null;
-            if (nextRowRanges != null) {
-                pendingPrefetch = ColumnChunkPrefetcher.prefetchAsync(
-                    storageObject,
-                    nextBlock,
-                    projectedColumnPaths,
-                    nextRowRanges,
-                    preloadedMetadata,
-                    nextRgOrdinal,
-                    nextBlock.getRowCount()
-                );
-            } else {
-                pendingPrefetch = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, projectedColumnPaths);
-            }
-            pendingPrefetchOrdinal = nextRgOrdinal;
-        } catch (Exception e) {
-            logger.debug("Failed to initiate prefetch for row group [{}] in [{}]: {}", nextRgOrdinal, fileLocation, e.getMessage());
-            pendingPrefetch = null;
-            pendingPrefetchOrdinal = -1;
-            releasePendingReservation();
-        }
+        fillPrefetchQueue(startOrdinal);
     }
 
     /**
-     * Cancels the pending prefetch future and releases the breaker reservation. Note that
-     * {@link org.elasticsearch.common.util.concurrent.FutureUtils#cancel} only flips the
-     * future's cancelled state — it does not interrupt in-flight storage SDK reads. If the
-     * async read is already in progress, the SDK may still allocate a buffer that becomes
-     * untracked by the breaker until GC. Draining the future before releasing would risk
-     * blocking {@link #close()}, so we accept this brief discrepancy.
+     * Cancels all pending prefetches and releases their breaker reservations. Called when the
+     * iterator is exhausted or closed.
      */
     private void cancelPendingPrefetch() {
-        if (pendingPrefetch != null) {
-            org.elasticsearch.common.util.concurrent.FutureUtils.cancel(pendingPrefetch);
-            pendingPrefetch = null;
-        }
-        pendingPrefetchOrdinal = -1;
-        releasePendingReservation();
-    }
-
-    /**
-     * Releases the breaker reservation held for the in-flight (pending) prefetch. Idempotent —
-     * safe to call multiple times (subsequent calls are no-ops when reservation is zero).
-     */
-    private void releasePendingReservation() {
-        long reserved = pendingReservedBytes;
-        pendingReservedBytes = 0;
-        if (reserved > 0) {
-            breaker.addWithoutBreaking(-reserved);
+        while (pendingPrefetches.isEmpty() == false) {
+            PendingPrefetch entry = pendingPrefetches.pollFirst();
+            FutureUtils.cancel(entry.future());
+            if (entry.reservedBytes() > 0) {
+                breaker.addWithoutBreaking(-entry.reservedBytes());
+            }
         }
     }
 
@@ -581,6 +614,16 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         } finally {
             releaseCurrentReservation();
             reader.close();
+        }
+    }
+
+    private record PendingPrefetch(
+        int ordinal,
+        CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future,
+        long reservedBytes
+    ) {
+        PendingPrefetch {
+            assert reservedBytes >= 0 : "reservedBytes must be non-negative: " + reservedBytes;
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -92,6 +92,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final int[] nextSurvivor;
     private final CompressionCodecFactory codecFactory;
     private int rowBudget;
+    /** Async prefetches allowed ahead of the consumed row group (1-3 based on projected column size). */
     private final int prefetchDepth;
     private final ArrayDeque<PendingPrefetch> pendingPrefetches = new ArrayDeque<>();
     /** Bytes reserved on the breaker for the chunks currently in use by {@link #rowGroup}. */
@@ -211,6 +212,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         }
     }
 
+    private static final long DEEPER_PREFETCH_BYTES = 32_000_000L;
+    private static final long SHALLOW_PREFETCH_BYTES = 8_000_000L;
+
     private static int computePrefetchDepth(List<BlockMetaData> rowGroups, Set<String> projectedColumnPaths) {
         if (rowGroups.isEmpty()) {
             return 1;
@@ -225,10 +229,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         // Larger projected sizes need deeper prefetch: an S3 GET for a 20MB string column takes
         // ~200ms while decode takes ~10ms, so single-ahead can't hide the latency. The circuit
         // breaker caps actual memory regardless of depth.
-        if (projectedBytes > 32_000_000) {
+        if (projectedBytes > DEEPER_PREFETCH_BYTES) {
             return 3;
         }
-        if (projectedBytes > 8_000_000) {
+        if (projectedBytes > SHALLOW_PREFETCH_BYTES) {
             return 2;
         }
         return 1;
@@ -417,14 +421,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             if (head.ordinal() == expectedOrdinal) {
                 break;
             }
-            if (head.ordinal() > expectedOrdinal) {
-                return null;
-            }
+            assert head.ordinal() <= expectedOrdinal : "prefetch queue has ordinal " + head.ordinal() + " > expected " + expectedOrdinal;
             pendingPrefetches.pollFirst();
             FutureUtils.cancel(head.future());
-            if (head.reservedBytes() > 0) {
-                breaker.addWithoutBreaking(-head.reservedBytes());
-            }
+            head.release(breaker);
         }
 
         if (pendingPrefetches.isEmpty()) {
@@ -439,9 +439,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 currentReservedBytes = head.reservedBytes();
                 return data;
             }
-            if (head.reservedBytes() > 0) {
-                breaker.addWithoutBreaking(-head.reservedBytes());
-            }
+            head.release(breaker);
             return null;
         } catch (Exception e) {
             logger.debug(
@@ -450,9 +448,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 fileLocation,
                 e.getMessage()
             );
-            if (head.reservedBytes() > 0) {
-                breaker.addWithoutBreaking(-head.reservedBytes());
-            }
+            head.release(breaker);
             return null;
         }
     }
@@ -483,9 +479,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         while (pendingPrefetches.isEmpty() == false) {
             PendingPrefetch entry = pendingPrefetches.pollFirst();
             FutureUtils.cancel(entry.future());
-            if (entry.reservedBytes() > 0) {
-                breaker.addWithoutBreaking(-entry.reservedBytes());
-            }
+            entry.release(breaker);
         }
     }
 
@@ -617,6 +611,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         }
     }
 
+    /** Bundles an in-flight prefetch future with its breaker reservation for paired release. */
     private record PendingPrefetch(
         int ordinal,
         CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future,
@@ -624,6 +619,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     ) {
         PendingPrefetch {
             assert reservedBytes >= 0 : "reservedBytes must be non-negative: " + reservedBytes;
+        }
+
+        void release(CircuitBreaker breaker) {
+            if (reservedBytes > 0) {
+                breaker.addWithoutBreaking(-reservedBytes);
+            }
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -880,7 +880,9 @@ final class PageColumnReader {
                 int fromPage = Math.min(remaining, availableInPage());
                 BytesRef[] vals = readBinaryValues(fromPage);
                 for (int i = 0; i < fromPage; i++) {
-                    allValues[produced + i] = isUuid ? new BytesRef(ParquetColumnDecoding.formatUuid(vals[i].bytes)) : vals[i];
+                    allValues[produced + i] = isUuid
+                        ? new BytesRef(ParquetColumnDecoding.formatUuid(vals[i].bytes, vals[i].offset, vals[i].length))
+                        : vals[i];
                 }
                 advancePosition(fromPage);
                 produced += fromPage;
@@ -911,7 +913,8 @@ final class PageColumnReader {
                 if (pageNulls.get(i)) {
                     allNulls.set(produced + i);
                 } else if (isUuid) {
-                    allValues[produced + i] = new BytesRef(ParquetColumnDecoding.formatUuid(vals[valIdx++].bytes));
+                    BytesRef uuidRef = vals[valIdx++];
+                    allValues[produced + i] = new BytesRef(ParquetColumnDecoding.formatUuid(uuidRef.bytes, uuidRef.offset, uuidRef.length));
                 } else {
                     allValues[produced + i] = vals[valIdx++];
                 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -66,6 +66,9 @@ final class ParquetColumnDecoding {
         if (bytes == null || length != 16) {
             throw new QlIllegalArgumentException("UUID requires exactly 16 bytes, got " + (bytes == null ? "null" : length));
         }
+        if (offset < 0 || offset + 16 > bytes.length) {
+            throw new QlIllegalArgumentException("UUID byte offset out of bounds: offset=" + offset + ", array length=" + bytes.length);
+        }
         StringBuilder sb = new StringBuilder(36);
         for (int i = 0; i < 16; i++) {
             sb.append(HEX[(bytes[offset + i] >> 4) & 0xF]);

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetColumnDecoding.java
@@ -55,13 +55,21 @@ final class ParquetColumnDecoding {
      * Parquet {@code FIXED_LEN_BYTE_ARRAY(16)} is always exactly 16 bytes.
      */
     static String formatUuid(byte[] bytes) {
-        if (bytes == null || bytes.length != 16) {
-            throw new QlIllegalArgumentException("UUID requires exactly 16 bytes, got " + (bytes == null ? "null" : bytes.length));
+        return formatUuid(bytes, 0, bytes == null ? 0 : bytes.length);
+    }
+
+    /**
+     * Formats a 16-byte UUID in big-endian layout as the standard 8-4-4-4-12 hex string.
+     * The UUID bytes start at {@code offset} in the given array.
+     */
+    static String formatUuid(byte[] bytes, int offset, int length) {
+        if (bytes == null || length != 16) {
+            throw new QlIllegalArgumentException("UUID requires exactly 16 bytes, got " + (bytes == null ? "null" : length));
         }
         StringBuilder sb = new StringBuilder(36);
         for (int i = 0; i < 16; i++) {
-            sb.append(HEX[(bytes[i] >> 4) & 0xF]);
-            sb.append(HEX[bytes[i] & 0xF]);
+            sb.append(HEX[(bytes[offset + i] >> 4) & 0xF]);
+            sb.append(HEX[bytes[offset + i] & 0xF]);
             if (i == 3 || i == 5 || i == 7 || i == 9) {
                 sb.append('-');
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -23,6 +23,7 @@ import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.GroupType;
@@ -47,12 +48,12 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
-import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
@@ -212,6 +213,44 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             }
             throw newInvalidParquetFileException(uri, e);
         }
+    }
+
+    private static ParquetFileReader openParquetFile(
+        StorageObject object,
+        InputFile inputFile,
+        ParquetReadOptions options,
+        ParquetMetadata cachedFooter
+    ) throws IOException {
+        String uri = object.path().toString();
+        try {
+            return ParquetFileReader.open(inputFile, cachedFooter, options, inputFile.newStream());
+        } catch (IOException e) {
+            throw newInvalidParquetFileException(uri, e);
+        } catch (RuntimeException e) {
+            if (e instanceof CircuitBreakingException) {
+                throw e;
+            }
+            if (e instanceof ElasticsearchException) {
+                throw e;
+            }
+            throw newInvalidParquetFileException(uri, e);
+        }
+    }
+
+    /**
+     * Filters a cached footer's row groups to only those whose midpoint falls within [rangeStart, rangeEnd).
+     * This mirrors parquet-mr's split assignment logic (see {@code ParquetInputFormat.getRowGroupInfo})
+     * which is applied during footer parsing but skipped when using a pre-parsed {@link ParquetMetadata}.
+     */
+    private static ParquetMetadata filterBlocksByRange(ParquetMetadata metadata, long rangeStart, long rangeEnd) {
+        List<BlockMetaData> filtered = new ArrayList<>();
+        for (BlockMetaData block : metadata.getBlocks()) {
+            long midpoint = block.getStartingPos() + block.getCompressedSize() / 2;
+            if (midpoint >= rangeStart && midpoint < rangeEnd) {
+                filtered.add(block);
+            }
+        }
+        return new ParquetMetadata(metadata.getFileMetaData(), filtered);
     }
 
     private static IOException newInvalidParquetFileException(String uri, Exception e) {
@@ -599,17 +638,34 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
      * structural (corrupt page, schema mismatch) rather than row-level.
      */
     @Override
-    public CloseableIterator<Page> readRange(
-        StorageObject object,
-        List<String> projectedColumns,
-        int batchSize,
-        long rangeStart,
-        long rangeEnd,
-        List<Attribute> resolvedAttributes,
-        ErrorPolicy errorPolicy
-    ) throws IOException {
+    public CloseableIterator<Page> readRange(StorageObject object, RangeReadContext context) throws IOException {
+        long rangeStart = context.rangeStart();
+        long rangeEnd = context.rangeEnd();
+        List<String> projectedColumns = context.projectedColumns();
+        int batchSize = context.batchSize();
+        List<Attribute> resolvedAttributes = context.resolvedAttributes();
+
         InputFile parquetInputFile = ParquetStorageObjectAdapter.forRange(object, rangeEnd - rangeStart);
-        ParquetFileReader reader = openParquetFile(object, parquetInputFile, readOptionsBuilder().withRange(rangeStart, rangeEnd).build());
+        ParquetReadOptions rangeOptions = readOptionsBuilder().withRange(rangeStart, rangeEnd).build();
+        ParquetFileReader reader;
+        if (context.fileContext() instanceof ParquetMetadata cachedFooter) {
+            ParquetMetadata rangeMetadata = filterBlocksByRange(cachedFooter, rangeStart, rangeEnd);
+            reader = openParquetFile(object, parquetInputFile, rangeOptions, rangeMetadata);
+        } else {
+            // Parse the full footer (all row groups) and cache it for subsequent splits.
+            // ParquetFileReader.open with a range only retains blocks whose midpoint falls
+            // in the range, making getFooter() unusable for other splits. readFooter with
+            // options that have no range returns the complete metadata. The underlying
+            // FooterByteCache ensures the footer bytes are fetched from storage only once.
+            ParquetMetadata fullFooter = ParquetFileReader.readFooter(
+                parquetInputFile,
+                readOptionsBuilder().build(),
+                parquetInputFile.newStream()
+            );
+            context.setFileContext(fullFooter);
+            ParquetMetadata rangeMetadata = filterBlocksByRange(fullFooter, rangeStart, rangeEnd);
+            reader = openParquetFile(object, parquetInputFile, rangeOptions, rangeMetadata);
+        }
         try {
             FileMetaData fileMetaData = reader.getFileMetaData();
             MessageType parquetSchema = fileMetaData.getSchema();
@@ -623,11 +679,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             // parquet-mr never sees the filter and the reader does not need to be re-opened.
             if (useOptimized == false && FilterCompat.isFilteringRequired(recordFilter)) {
                 reader.close();
-                reader = openParquetFile(
-                    object,
-                    parquetInputFile,
-                    readOptionsBuilder().withRange(rangeStart, rangeEnd).withRecordFilter(recordFilter).build()
-                );
+                ParquetReadOptions filteredOptions = readOptionsBuilder().withRange(rangeStart, rangeEnd)
+                    .withRecordFilter(recordFilter)
+                    .build();
+                if (context.fileContext() instanceof ParquetMetadata cf) {
+                    reader = openParquetFile(object, parquetInputFile, filteredOptions, filterBlocksByRange(cf, rangeStart, rangeEnd));
+                } else {
+                    reader = openParquetFile(object, parquetInputFile, filteredOptions);
+                }
                 fileMetaData = reader.getFileMetaData();
                 parquetSchema = fileMetaData.getSchema();
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
@@ -60,19 +60,40 @@ final class PlainValueDecoder {
     }
 
     void readBinaries(BytesRef[] values, int offset, int count) {
-        for (int i = 0; i < count; i++) {
-            int length = buffer.getInt();
-            byte[] copy = new byte[length];
-            buffer.get(copy);
-            values[offset + i] = new BytesRef(copy);
+        if (buffer.hasArray()) {
+            byte[] backing = buffer.array();
+            int baseOffset = buffer.arrayOffset();
+            for (int i = 0; i < count; i++) {
+                int length = buffer.getInt();
+                int pos = buffer.position();
+                values[offset + i] = new BytesRef(backing, baseOffset + pos, length);
+                buffer.position(pos + length);
+            }
+        } else {
+            for (int i = 0; i < count; i++) {
+                int length = buffer.getInt();
+                byte[] copy = new byte[length];
+                buffer.get(copy);
+                values[offset + i] = new BytesRef(copy);
+            }
         }
     }
 
     void readFixedBinaries(BytesRef[] values, int offset, int count, int fixedLength) {
-        for (int i = 0; i < count; i++) {
-            byte[] copy = new byte[fixedLength];
-            buffer.get(copy);
-            values[offset + i] = new BytesRef(copy);
+        if (buffer.hasArray()) {
+            byte[] backing = buffer.array();
+            int baseOffset = buffer.arrayOffset();
+            for (int i = 0; i < count; i++) {
+                int pos = buffer.position();
+                values[offset + i] = new BytesRef(backing, baseOffset + pos, fixedLength);
+                buffer.position(pos + fixedLength);
+            }
+        } else {
+            for (int i = 0; i < count; i++) {
+                byte[] copy = new byte[fixedLength];
+                buffer.get(copy);
+                values[offset + i] = new BytesRef(copy);
+            }
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
@@ -59,6 +59,7 @@ final class PlainValueDecoder {
         buffer.position(basePos + (count + 7) / 8);
     }
 
+    /** Returned BytesRef instances share storage with the value buffer and must be copied before the buffer is reused. */
     void readBinaries(BytesRef[] values, int offset, int count) {
         if (buffer.hasArray()) {
             byte[] backing = buffer.array();
@@ -79,6 +80,7 @@ final class PlainValueDecoder {
         }
     }
 
+    /** Returned BytesRef instances share storage with the value buffer and must be copied before the buffer is reused. */
     void readFixedBinaries(BytesRef[] values, int offset, int count, int fixedLength) {
         if (buffer.hasArray()) {
             byte[] backing = buffer.array();

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -48,6 +48,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -1581,12 +1582,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         try (
             CloseableIterator<Page> iterator = reader.readRange(
                 storageObject,
-                List.of("x"),
-                100,
-                0,
-                parquetData.length,
-                plannerTypes,
-                ErrorPolicy.STRICT
+                new RangeReadContext(List.of("x"), 100, 0, parquetData.length, plannerTypes, ErrorPolicy.STRICT)
             )
         ) {
             assertTrue(iterator.hasNext());
@@ -1616,12 +1612,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         try (
             CloseableIterator<Page> it = r.readRange(
                 storageObject,
-                List.of("x"),
-                10,
-                0,
-                parquetData.length,
-                plannerTypes,
-                ErrorPolicy.STRICT
+                new RangeReadContext(List.of("x"), 10, 0, parquetData.length, plannerTypes, ErrorPolicy.STRICT)
             )
         ) {
             Page page = it.next();
@@ -1644,12 +1635,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         try (
             CloseableIterator<Page> iterator = reader.readRange(
                 storageObject,
-                List.of("x"),
-                100,
-                0,
-                parquetData.length,
-                plannerTypes,
-                ErrorPolicy.STRICT
+                new RangeReadContext(List.of("x"), 100, 0, parquetData.length, plannerTypes, ErrorPolicy.STRICT)
             )
         ) {
             assertTrue(iterator.hasNext());
@@ -1676,12 +1662,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         try (
             CloseableIterator<Page> it = r.readRange(
                 storageObject,
-                List.of("x"),
-                10,
-                0,
-                parquetData.length,
-                plannerTypes,
-                ErrorPolicy.STRICT
+                new RangeReadContext(List.of("x"), 10, 0, parquetData.length, plannerTypes, ErrorPolicy.STRICT)
             )
         ) {
             Page page = it.next();
@@ -1702,12 +1683,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         try (
             CloseableIterator<Page> it = r.readRange(
                 storageObject,
-                List.of("x"),
-                10,
-                0,
-                parquetData.length,
-                plannerTypes,
-                ErrorPolicy.STRICT
+                new RangeReadContext(List.of("x"), 10, 0, parquetData.length, plannerTypes, ErrorPolicy.STRICT)
             )
         ) {
             Page page = it.next();
@@ -1733,12 +1709,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         try (
             CloseableIterator<Page> iterator = reader.readRange(
                 storageObject,
-                List.of("x"),
-                100,
-                0,
-                parquetData.length,
-                plannerTypes,
-                ErrorPolicy.STRICT
+                new RangeReadContext(List.of("x"), 100, 0, parquetData.length, plannerTypes, ErrorPolicy.STRICT)
             )
         ) {
             assertTrue(iterator.hasNext());
@@ -1781,12 +1752,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             try (
                 CloseableIterator<Page> iterator = reader.readRange(
                     storageObject,
-                    null,
-                    1000,
-                    rangeStart,
-                    rangeEnd,
-                    List.of(),
-                    ErrorPolicy.STRICT
+                    new RangeReadContext(null, 1000, rangeStart, rangeEnd, List.of(), ErrorPolicy.STRICT)
                 )
             ) {
                 while (iterator.hasNext()) {
@@ -1846,12 +1812,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             try (
                 CloseableIterator<Page> iterator = reader.readRange(
                     storageObject,
-                    null,
-                    1000,
-                    rangeStart,
-                    rangeEnd,
-                    List.of(),
-                    ErrorPolicy.STRICT
+                    new RangeReadContext(null, 1000, rangeStart, rangeEnd, List.of(), ErrorPolicy.STRICT)
                 )
             ) {
                 while (iterator.hasNext()) {
@@ -1861,6 +1822,55 @@ public class ParquetFormatReaderTests extends ESTestCase {
         }
 
         assertEquals("Sum of rows across splits must equal the row count written", numRows, totalRowsFromRanges);
+    }
+
+    /**
+     * Verifies that cross-split footer caching via {@link RangeReadContext#fileContext()} produces
+     * correct results. Simulates the {@code AsyncExternalSourceOperatorFactory} pattern: the first
+     * split parses the footer and caches it; subsequent splits reuse the cached footer. Row counts
+     * and values must match a non-cached full read.
+     */
+    public void testCrossSlitFooterCachingProducesCorrectResults() throws Exception {
+        int numRows = 5_000;
+        byte[] parquetData = createCompressibleMultiRowGroupFile(numRows, CompressionCodecName.SNAPPY);
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        assertTrue("Need multiple ranges to exercise caching", ranges.size() >= 2);
+
+        Object cachedFileContext = null;
+        int cachedTotalRows = 0;
+        Set<Long> cachedIds = new HashSet<>();
+
+        for (RangeAwareFormatReader.SplitRange range : ranges) {
+            RangeReadContext ctx = new RangeReadContext(
+                null,
+                1000,
+                range.offset(),
+                range.offset() + range.length(),
+                List.of(),
+                ErrorPolicy.STRICT
+            );
+            if (cachedFileContext != null) {
+                ctx.setFileContext(cachedFileContext);
+            }
+            try (CloseableIterator<Page> iterator = reader.readRange(storageObject, ctx)) {
+                while (iterator.hasNext()) {
+                    Page page = iterator.next();
+                    LongBlock ids = (LongBlock) page.getBlock(0);
+                    for (int row = 0; row < page.getPositionCount(); row++) {
+                        cachedIds.add(ids.getLong(row));
+                    }
+                    cachedTotalRows += page.getPositionCount();
+                }
+            }
+            assertNotNull("fileContext should be set after readRange", ctx.fileContext());
+            cachedFileContext = ctx.fileContext();
+        }
+
+        assertEquals("Footer-cached row count must match written rows", numRows, cachedTotalRows);
+        assertEquals("Footer-cached ids must cover all rows (no duplicates, no drops)", numRows, cachedIds.size());
     }
 
     /**
@@ -1887,7 +1897,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
 
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
-        List<RangeAwareFormatReader.SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
         assertThat("Test needs multiple row groups to exercise concurrency", ranges.size(), greaterThan(2));
 
         AtomicInteger totalRows = new AtomicInteger();
@@ -1901,12 +1911,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             try (
                 CloseableIterator<Page> iterator = reader.readRange(
                     storageObject,
-                    null,
-                    500,
-                    rangeStart,
-                    rangeEnd,
-                    List.of(),
-                    ErrorPolicy.STRICT
+                    new RangeReadContext(null, 500, rangeStart, rangeEnd, List.of(), ErrorPolicy.STRICT)
                 )
             ) {
                 while (iterator.hasNext()) {
@@ -1967,12 +1972,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             try (
                 CloseableIterator<Page> iterator = reader.readRange(
                     storageObject,
-                    null,
-                    500,
-                    rangeStart,
-                    rangeEnd,
-                    List.of(),
-                    ErrorPolicy.STRICT
+                    new RangeReadContext(null, 500, rangeStart, rangeEnd, List.of(), ErrorPolicy.STRICT)
                 )
             ) {
                 while (iterator.hasNext()) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -1887,7 +1887,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
         StorageObject storageObject = createStorageObject(parquetData);
 
         ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
-        List<RangeAwareFormatReader.SplitRange> ranges = reader.discoverSplitRanges(storageObject);
+        List<RangeAwareFormatReader.SplitRange> ranges = reader.resolveFileLayout(storageObject).splitRanges();
         assertThat("Test needs multiple row groups to exercise concurrency", ranges.size(), greaterThan(2));
 
         AtomicInteger totalRows = new AtomicInteger();
@@ -2335,6 +2335,89 @@ public class ParquetFormatReaderTests extends ESTestCase {
         assertEquals(totalRows, rowOffset);
         assertTrue(
             "expected the queue to grow past the DecodeBuffers slot count to actually exercise the bug, got max depth " + maxObservedDepth,
+            maxObservedDepth >= 3
+        );
+    }
+
+    /**
+     * Regression test for the zero-copy {@link BytesRef} optimisation in {@link PlainValueDecoder}
+     * and the dictionary cache in {@link DictionaryValueDecoder}. Models the producer/consumer
+     * boundary the same way as
+     * {@link #testEmittedPagesAreNotMutatedAcrossProducerConsumerBoundary()}: a queue lookahead
+     * ensures the consumer reads pages that were emitted several decode batches ago.
+     *
+     * <p>Two string columns are tested: {@code v_unique} has unique values per row (triggers PLAIN
+     * encoding once parquet-mr's dictionary threshold is exceeded), and {@code v_dict} has low
+     * cardinality (stays dictionary-encoded). Both exercise the code paths that now return
+     * {@link BytesRef} objects sharing backing arrays with the page buffer or the dictionary cache.
+     */
+    public void testStringColumnsNotCorruptedAcrossProducerConsumerBoundary() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("v_unique")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("v_dict")
+            .named("retention_test_string");
+
+        int batchSize = 32;
+        int totalRows = batchSize * 20;
+        int lookahead = 6;
+        String[] dictValues = { "alpha", "bravo", "charlie", "delta", "echo" };
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>(totalRows);
+            for (int i = 0; i < totalRows; i++) {
+                Group g = factory.newGroup();
+                g.add("v_unique", "row-" + i);
+                g.add("v_dict", dictValues[i % dictValues.length]);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory);
+
+        Deque<Page> queue = new ArrayDeque<>();
+        int rowOffset = 0;
+        int maxObservedDepth = 0;
+        BytesRef scratch = new BytesRef();
+        try (CloseableIterator<Page> iterator = reader.read(storageObject, null, batchSize)) {
+            while (true) {
+                while (queue.size() < lookahead && iterator.hasNext()) {
+                    queue.addLast(iterator.next());
+                }
+                if (queue.isEmpty()) break;
+                maxObservedDepth = Math.max(maxObservedDepth, queue.size());
+                Page page = queue.removeFirst();
+                try {
+                    int rows = page.getPositionCount();
+                    BytesRefBlock uniqueBlock = (BytesRefBlock) page.getBlock(0);
+                    BytesRefBlock dictBlock = (BytesRefBlock) page.getBlock(1);
+                    for (int r = 0; r < rows; r++) {
+                        int absRow = rowOffset + r;
+                        assertEquals(
+                            "unique string corrupted after queue lookahead (row=" + absRow + ")",
+                            new BytesRef("row-" + absRow),
+                            uniqueBlock.getBytesRef(r, scratch)
+                        );
+                        assertEquals(
+                            "dict string corrupted after queue lookahead (row=" + absRow + ")",
+                            new BytesRef(dictValues[absRow % dictValues.length]),
+                            dictBlock.getBytesRef(r, scratch)
+                        );
+                    }
+                    rowOffset += rows;
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        }
+        assertEquals(totalRows, rowOffset);
+        assertTrue(
+            "expected the queue to grow past 3 to exercise the zero-copy BytesRef paths, got max depth " + maxObservedDepth,
             maxObservedDepth >= 3
         );
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
@@ -487,6 +488,10 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         CloseableIterator<Page> pages;
         @Nullable
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo;
+        @Nullable
+        StoragePath lastRangeFilePath;
+        @Nullable
+        Object lastFileContext;
 
         ProducerState(
             @Nullable ExternalSliceQueue queue,
@@ -679,7 +684,14 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     ? storageProvider.newObject(fileSplit.path(), Long.parseLong(fileLengthStr))
                     : storageProvider.newObject(fileSplit.path());
                 long rangeEnd = fileSplit.offset() + fileSplit.length();
-                pages = rangeReader.readRange(fullObj, cols, batchSize, fileSplit.offset(), rangeEnd, attributes, errorPolicy);
+                Object fileContext = fileSplit.path().equals(state.lastRangeFilePath) ? state.lastFileContext : null;
+                RangeReadContext rangeCtx = new RangeReadContext(cols, batchSize, fileSplit.offset(), rangeEnd, attributes, errorPolicy);
+                if (fileContext != null) {
+                    rangeCtx.setFileContext(fileContext);
+                }
+                pages = rangeReader.readRange(fullObj, rangeCtx);
+                state.lastRangeFilePath = fileSplit.path();
+                state.lastFileContext = rangeCtx.fileContext();
             } else {
                 StorageObject obj = FileSplitProvider.storageObjectForSplit(storageProvider, fileSplit);
                 boolean firstSplit = fileSplit.offset() == 0 || "true".equals(fileSplit.config().get(FileSplitProvider.FIRST_SPLIT_KEY));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeAwareFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeAwareFormatReader.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.datasources.spi;
 
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
-import org.elasticsearch.xpack.esql.core.expression.Attribute;
 
 import java.io.IOException;
 import java.util.List;
@@ -70,22 +69,9 @@ public interface RangeAwareFormatReader extends FormatReader {
      * The storage object must represent the full file (not a range-limited view),
      * because columnar formats need access to file-level metadata (e.g. footer).
      *
-     * @param object            the full-file storage object
-     * @param projectedColumns  columns to project
-     * @param batchSize         rows per page
-     * @param rangeStart        start byte offset of the assigned range
-     * @param rangeEnd          end byte offset (exclusive) of the assigned range
-     * @param resolvedAttributes schema attributes resolved from metadata
-     * @param errorPolicy       error handling policy
+     * @param object  the full-file storage object
+     * @param context per-split read parameters and optional cross-split file context
      * @return an iterator that yields pages from the matching row groups
      */
-    CloseableIterator<Page> readRange(
-        StorageObject object,
-        List<String> projectedColumns,
-        int batchSize,
-        long rangeStart,
-        long rangeEnd,
-        List<Attribute> resolvedAttributes,
-        ErrorPolicy errorPolicy
-    ) throws IOException;
+    CloseableIterator<Page> readRange(StorageObject object, RangeReadContext context) throws IOException;
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/RangeReadContext.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+
+import java.util.List;
+
+/**
+ * Context for a single {@link RangeAwareFormatReader#readRange} call. Bundles the per-split
+ * parameters and carries an opaque file-level context for cross-split state (e.g. cached
+ * parsed footer metadata).
+ */
+public final class RangeReadContext {
+    private final List<String> projectedColumns;
+    private final int batchSize;
+    private final long rangeStart;
+    private final long rangeEnd;
+    private final List<Attribute> resolvedAttributes;
+    private final ErrorPolicy errorPolicy;
+    /**
+     * Opaque file-level context, single-writer/single-reader, carried by the owning producer across successive readRange calls.
+     */
+    @Nullable
+    private Object fileContext;
+
+    public RangeReadContext(
+        List<String> projectedColumns,
+        int batchSize,
+        long rangeStart,
+        long rangeEnd,
+        List<Attribute> resolvedAttributes,
+        ErrorPolicy errorPolicy
+    ) {
+        this.projectedColumns = projectedColumns;
+        this.batchSize = batchSize;
+        this.rangeStart = rangeStart;
+        this.rangeEnd = rangeEnd;
+        this.resolvedAttributes = resolvedAttributes;
+        this.errorPolicy = errorPolicy;
+    }
+
+    public List<String> projectedColumns() {
+        return projectedColumns;
+    }
+
+    public int batchSize() {
+        return batchSize;
+    }
+
+    public long rangeStart() {
+        return rangeStart;
+    }
+
+    public long rangeEnd() {
+        return rangeEnd;
+    }
+
+    public List<Attribute> resolvedAttributes() {
+        return resolvedAttributes;
+    }
+
+    public ErrorPolicy errorPolicy() {
+        return errorPolicy;
+    }
+
+    @Nullable
+    public Object fileContext() {
+        return fileContext;
+    }
+
+    public void setFileContext(@Nullable Object fileContext) {
+        this.fileContext = fileContext;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -23,12 +23,12 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
-import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader.SplitRange;
+import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitDiscoveryContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitProvider;
@@ -727,15 +727,7 @@ public class FileSplitProviderTests extends ESTestCase {
             }
 
             @Override
-            public CloseableIterator<Page> readRange(
-                StorageObject object,
-                List<String> projectedColumns,
-                int batchSize,
-                long rangeStart,
-                long rangeEnd,
-                List<Attribute> resolvedAttributes,
-                ErrorPolicy errorPolicy
-            ) {
+            public CloseableIterator<Page> readRange(StorageObject object, RangeReadContext context) {
                 throw new UnsupportedOperationException();
             }
 
@@ -808,15 +800,7 @@ public class FileSplitProviderTests extends ESTestCase {
             }
 
             @Override
-            public CloseableIterator<Page> readRange(
-                StorageObject object,
-                List<String> projectedColumns,
-                int batchSize,
-                long rangeStart,
-                long rangeEnd,
-                List<Attribute> resolvedAttributes,
-                ErrorPolicy errorPolicy
-            ) {
+            public CloseableIterator<Page> readRange(StorageObject object, RangeReadContext context) {
                 throw new UnsupportedOperationException("not called during split discovery");
             }
 


### PR DESCRIPTION
Improve Parquet reader performance for S3-backed queries by
addressing two bottlenecks discovered during profiling:

Prefetch pipeline: the single row-group-ahead prefetch left
the iterator stalling on S3 latency for large column chunks.
Replace with an adaptive-depth prefetch deque (1-3 ahead based
on projected column size) and prefetch row group 0 at
construction time to eliminate the first-RG sync fallback.

String allocation: PlainValueDecoder and DictionaryValueDecoder
allocated a fresh byte[] per value, driving GC pressure on
string-heavy queries. PlainValueDecoder now creates zero-copy
BytesRef views into the page buffer backing array.
DictionaryValueDecoder caches BytesRef per dictionary entry at
first use, turning per-value allocation into per-entry.

Developed with AI-assisted tooling