### PR TITLE
[8.19] [Transform] Exclude clusters in license check (#143146) (#147933)

### DIFF
--- a/docs/changelog/143146.yaml
+++ b/docs/changelog/143146.yaml
@@ -1,0 +1,7 @@
+area: Transform
+issues:
+ - 114514
+ - 114509
+pr: 143146
+summary: Exclude clusters in license check
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RemoteClusterLicenseChecker.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RemoteClusterLicenseChecker.java
@@ -23,9 +23,12 @@ import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.xpack.core.action.XPackInfoAction;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -264,20 +267,34 @@ public final class RemoteClusterLicenseChecker {
     /**
      * Extract the list of remote cluster aliases from the list of index names. Remote index names are of the form
      * {@code cluster_alias:index_name} and the cluster_alias is extracted (and expanded if it is a wildcard) for
-     * each index name that represents a remote index.
+     * each index name that represents a remote index. Exclusion patterns of the form {@code -cluster_alias:*} are
+     * handled by removing the corresponding clusters from the result.
+     * Exclusions are applied to the complete set of
+     * included clusters regardless of their position in the list (order-independent).
      *
      * @param remoteClusters the aliases for remote clusters
      * @param indices        the collection of index names
      * @return the remote cluster names
      */
     public static List<String> remoteClusterAliases(final Set<String> remoteClusters, final List<String> indices) {
-        return indices.stream()
+        Set<String> included = new LinkedHashSet<>();
+        Set<String> excluded = new HashSet<>();
+        indices.stream()
             .filter(RemoteClusterLicenseChecker::isRemoteIndex)
             .map(index -> RemoteClusterAware.splitIndexName(index)[0])
             .distinct()
-            .flatMap(clusterExpression -> ClusterNameExpressionResolver.resolveClusterNames(remoteClusters, clusterExpression).stream())
-            .distinct()
-            .collect(Collectors.toList());
+            .forEach(clusterExpression -> {
+                boolean isExclusion = clusterExpression.startsWith("-");
+                String expression = isExclusion ? clusterExpression.substring(1) : clusterExpression;
+                List<String> resolved = ClusterNameExpressionResolver.resolveClusterNames(remoteClusters, expression);
+                if (isExclusion) {
+                    excluded.addAll(resolved);
+                } else {
+                    included.addAll(resolved);
+                }
+            });
+        included.removeAll(excluded);
+        return new ArrayList<>(included);
     }
 
     /**

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
@@ -142,6 +142,24 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
         assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), empty());
     }
 
+    public void testExcludedRemoteClusterAlias() {
+        final Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final List<String> indices = Arrays.asList("*:remote-index1", "-remote-cluster1:*");
+        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), contains("remote-cluster2"));
+    }
+
+    public void testExcludedAllRemoteClusterAliases() {
+        final Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final List<String> indices = Arrays.asList("*:remote-index1", "-remote-cluster1:*", "-remote-cluster2:*");
+        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), empty());
+    }
+
+    public void testExcludedRemoteClusterAliasWithWildcard() {
+        final Set<String> remoteClusters = Sets.newHashSet("remote-cluster1", "remote-cluster2");
+        final List<String> indices = Arrays.asList("*:remote-index1", "-*1:*");
+        assertThat(RemoteClusterLicenseChecker.remoteClusterAliases(remoteClusters, indices), contains("remote-cluster2"));
+    }
+
     public void testCheckRemoteClusterLicensesGivenCompatibleLicenses() {
         final AtomicInteger index = new AtomicInteger();
         final List<XPackInfoResponse> responses = new ArrayList<>();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
@@ -133,6 +133,35 @@ public class DatafeedCcsIT extends AbstractMultiClustersTestCase {
         }
     }
 
+    public void testDatafeedWithCcsExcludedRemoteCluster() throws Exception {
+        String jobId = "ccs-excluded-remote-job";
+        String datafeedId = jobId;
+        long localDocs = randomIntBetween(32, 2048);
+        long remoteDocs = randomIntBetween(32, 2048);
+        indexRemoteDocs(remoteDocs);
+        long endTimeMs = indexLocalDocs(localDocs);
+        setupJobAndDatafeed(
+            jobId,
+            datafeedId,
+            endTimeMs,
+            List.of(DATA_INDEX, REMOTE_CLUSTER + ":" + DATA_INDEX, "-" + REMOTE_CLUSTER + ":*")
+        );
+        try {
+            assertBusy(() -> {
+                JobStats jobStats = getJobStats(jobId);
+                assertThat(jobStats.getState(), is(JobState.CLOSED));
+                assertThat(jobStats.getDataCounts().getProcessedRecordCount(), is(localDocs));
+            }, 3, TimeUnit.MINUTES);
+        } catch (AssertionError ae) {
+            try {
+                client(LOCAL_CLUSTER).execute(CloseJobAction.INSTANCE, new CloseJobAction.Request(jobId).setForce(true)).actionGet();
+            } catch (Exception e) {
+                ae.addSuppressed(e);
+            }
+            throw ae;
+        }
+    }
+
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84268")
     public void testDatafeedWithCcsRemoteUnavailable() throws Exception {
         setSkipUnavailable(randomBoolean());
@@ -178,11 +207,23 @@ public class DatafeedCcsIT extends AbstractMultiClustersTestCase {
      * @return The epoch millisecond timestamp of the most recent document.
      */
     private long indexRemoteDocs(long numDocs) {
-        client(REMOTE_CLUSTER).admin().indices().prepareCreate(DATA_INDEX).setMapping("time", "type=date").get();
+        return indexDocs(REMOTE_CLUSTER, numDocs);
+    }
+
+    /**
+     * Index some datafeed data into the local cluster.
+     * @return The epoch millisecond timestamp of the most recent document.
+     */
+    private long indexLocalDocs(long numDocs) {
+        return indexDocs(LOCAL_CLUSTER, numDocs);
+    }
+
+    private long indexDocs(String clusterAlias, long numDocs) {
+        client(clusterAlias).admin().indices().prepareCreate(DATA_INDEX).setMapping("time", "type=date").get();
         long now = System.currentTimeMillis();
         long weekAgo = now - 604800000;
         long twoWeeksAgo = weekAgo - 604800000;
-        BaseMlIntegTestCase.indexDocs(client(REMOTE_CLUSTER), logger, DATA_INDEX, numDocs, twoWeeksAgo, weekAgo);
+        BaseMlIntegTestCase.indexDocs(client(clusterAlias), logger, DATA_INDEX, numDocs, twoWeeksAgo, weekAgo);
         return weekAgo;
     }
 
@@ -213,15 +254,15 @@ public class DatafeedCcsIT extends AbstractMultiClustersTestCase {
      * Create and start a job and datafeed on the local cluster but searching for data in the remote cluster.
      */
     private void setupJobAndDatafeed(String jobId, String datafeedId, Long endTimeMs) throws Exception {
+        setupJobAndDatafeed(jobId, datafeedId, endTimeMs, List.of(REMOTE_CLUSTER + ":" + DATA_INDEX));
+    }
+
+    private void setupJobAndDatafeed(String jobId, String datafeedId, Long endTimeMs, List<String> indices) throws Exception {
         Job.Builder job = BaseMlIntegTestCase.createScheduledJob(jobId, ByteSizeValue.ofMb(20));
         client(LOCAL_CLUSTER).execute(PutJobAction.INSTANCE, new PutJobAction.Request(job)).actionGet();
 
         // Default frequency is 1 second, which avoids the test sleeping excessively
-        DatafeedConfig.Builder config = BaseMlIntegTestCase.createDatafeedBuilder(
-            datafeedId,
-            job.getId(),
-            List.of(REMOTE_CLUSTER + ":" + DATA_INDEX)
-        );
+        DatafeedConfig.Builder config = BaseMlIntegTestCase.createDatafeedBuilder(datafeedId, job.getId(), indices);
         // Setting a small chunk size increases the number of separate searches the datafeed
         // must make, which maximises the chance of a problem being exposed by the test
         config.setChunkingConfig(ChunkingConfig.newManual(TimeValue.timeValueMinutes(10)));

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCCSCanMatchIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCCSCanMatchIT.java
@@ -352,7 +352,19 @@ public class TransformCCSCanMatchIT extends AbstractMultiClustersTestCase {
         testTransformLifecycle(QueryBuilders.rangeQuery("@timestamp").from(100_000_000), 0);
     }
 
+    public void testTransformLifecycle_WithExcludedRemoteCluster() throws Exception {
+        testTransformLifecycle(
+            new String[] { "local_*", "*:remote_*", "-" + REMOTE_CLUSTER + ":*" },
+            QueryBuilders.matchAllQuery(),
+            localOldDocs + localNewDocs
+        );
+    }
+
     private void testTransformLifecycle(QueryBuilder query, long expectedHitCount) throws Exception {
+        testTransformLifecycle(new String[] { "local_*", "*:remote_*" }, query, expectedHitCount);
+    }
+
+    private void testTransformLifecycle(String[] sourceIndices, QueryBuilder query, long expectedHitCount) throws Exception {
         String transformId = "test-transform-lifecycle";
         {
             QueryConfig queryConfig;
@@ -362,7 +374,7 @@ public class TransformCCSCanMatchIT extends AbstractMultiClustersTestCase {
             }
             TransformConfig transformConfig = TransformConfig.builder()
                 .setId(transformId)
-                .setSource(new SourceConfig(new String[] { "local_*", "*:remote_*" }, queryConfig, Map.of()))
+                .setSource(new SourceConfig(sourceIndices, queryConfig, Map.of()))
                 .setDest(new DestConfig(transformId + "-dest", null, null))
                 .setLatestConfig(new LatestConfig(List.of("position"), "@timestamp"))
                 .build();


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [Transform] Exclude clusters in license check (#143146) (#147933)