### PR TITLE
use supplier pattern for license state in dlm shard allocation check …

### DIFF
--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenCloneIndexTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenCloneIndexTests.java
@@ -237,7 +237,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
         timedOut.setTimedOut(true);
         mockHealthResponse.set(timedOut);
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, convert::maybeCloneIndex);
         assertThat(exception.getMessage(), containsString("timed out"));

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenForceMergeTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenForceMergeTests.java
@@ -282,7 +282,7 @@ public class DLMConvertToFrozenForceMergeTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenMarkReadOnlyTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenMarkReadOnlyTests.java
@@ -474,7 +474,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 


### PR DESCRIPTION
…tests

https://github.com/elastic/elasticsearch/pull/147515 & https://github.com/elastic/elasticsearch/pull/147645 were merged at the same time causing tests in the latter to fail since they don't use the supplier pattern enforced by the former.

This PR updates those tests to use the supplier pattern for the license state