### PR TITLE
ESQL: Late materialization for Parquet reading

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -639,15 +639,14 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                     if (info == null) {
                         blocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
                     } else {
-                        blocks[col] = readColumnBlock(col, info, rowsToRead);
-                        predicateBlockMap.put(attributes.get(col).name(), blocks[col]);
+                        blocks[col] = readColumnBlockWithAttribution(col, info, rowsToRead, blocks);
                     }
+                    predicateBlockMap.put(attributes.get(col).name(), blocks[col]);
                 }
             }
 
             // Phase 2: evaluate filter
             WordMask mask = pushedExpressions.evaluateFilter(predicateBlockMap, rowsToRead, survivorMask);
-            predicateBlockMap = null; // release references to pre-compacted blocks
 
             int survivorCount = rowsToRead;
             int[] positions = null;
@@ -682,13 +681,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                     }
                     blocks[col] = blockFactory.newConstantNullBlock(0);
                 } else if (positions == null) {
-                    // All rows survive -- normal read
-                    blocks[col] = readColumnBlock(col, info, rowsToRead);
+                    blocks[col] = readColumnBlockWithAttribution(col, info, rowsToRead, blocks);
                 } else if (pageColumnReaders != null && pageColumnReaders[col] != null) {
                     blocks[col] = pageColumnReaders[col].readBatchFiltered(rowsToRead, blockFactory, positions, survivorCount);
                 } else {
-                    // List column or fallback: read full then filter
-                    Block fullBlock = readColumnBlock(col, info, rowsToRead);
+                    Block fullBlock = readColumnBlockWithAttribution(col, info, rowsToRead, blocks);
                     blocks[col] = PageColumnReader.filterBlock(fullBlock, positions, survivorCount, blockFactory);
                 }
             }
@@ -701,13 +698,40 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             }
 
             return new Page(blocks);
-        } catch (CircuitBreakingException e) {
+        } catch (ElasticsearchException e) {
             Releasables.closeExpectNoException(blocks);
             throw e;
         } catch (Exception e) {
             Releasables.closeExpectNoException(blocks);
             throw new ElasticsearchException(
                 "Failed to create late-materialized Page at row group ["
+                    + (rowGroupOrdinal + 1)
+                    + "] page batch ["
+                    + pageBatchIndexInRowGroup
+                    + "] in file ["
+                    + fileLocation
+                    + "]: "
+                    + e.getMessage(),
+                e
+            );
+        }
+    }
+
+    private Block readColumnBlockWithAttribution(int colIndex, ColumnInfo info, int rowsToRead, Block[] blocks) {
+        try {
+            return readColumnBlock(colIndex, info, rowsToRead);
+        } catch (CircuitBreakingException e) {
+            Releasables.closeExpectNoException(blocks);
+            throw e;
+        } catch (Exception e) {
+            Releasables.closeExpectNoException(blocks);
+            Attribute attr = attributes.get(colIndex);
+            throw new ElasticsearchException(
+                "Failed to read Parquet column ["
+                    + attr.name()
+                    + "] (type "
+                    + attr.dataType()
+                    + ") at row group ["
                     + (rowGroupOrdinal + 1)
                     + "] page batch ["
                     + pageBatchIndexInRowGroup

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -33,8 +33,10 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -106,6 +108,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private int rowGroupOrdinal = -1;
     private int pageBatchIndexInRowGroup = 0;
 
+    private final boolean lateMaterialization;
+    private final boolean[] isPredicateColumn;
+    private final ParquetPushedExpressions pushedExpressions;
+    private final WordMask survivorMask;
+    private long rowsEliminatedByLateMaterialization;
+
     OptimizedParquetColumnIterator(
         ParquetFileReader reader,
         MessageType projectedSchema,
@@ -120,7 +128,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         StorageObject storageObject,
         RowRanges[] allRowRanges,
         boolean[] survivingRowGroups,
-        CompressionCodecFactory codecFactory
+        CompressionCodecFactory codecFactory,
+        ParquetPushedExpressions pushedExpressions
     ) {
         this.reader = reader;
         this.projectedSchema = projectedSchema;
@@ -138,6 +147,10 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.survivingRowGroups = survivingRowGroups;
         this.nextSurvivor = buildNextSurvivorLookup(survivingRowGroups);
         this.codecFactory = codecFactory;
+        this.pushedExpressions = pushedExpressions;
+        this.isPredicateColumn = classifyPredicateColumns(attributes, columnInfos, pushedExpressions);
+        this.lateMaterialization = pushedExpressions != null && hasProjectionOnlyColumns(isPredicateColumn, columnInfos);
+        this.survivorMask = lateMaterialization ? new WordMask() : null;
 
         this.projectedColumnPaths = buildProjectedColumnPaths(columnInfos);
         this.prefetchDepth = computePrefetchDepth(reader.getRowGroups(), this.projectedColumnPaths);
@@ -188,6 +201,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             }
             try {
                 RowRanges nextRowRanges = allRowRanges != null && nextOrdinal < allRowRanges.length ? allRowRanges[nextOrdinal] : null;
+                if (lateMaterialization) {
+                    nextRowRanges = null;
+                }
                 CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future;
                 if (nextRowRanges != null) {
                     future = ColumnChunkPrefetcher.prefetchAsync(
@@ -248,6 +264,33 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         return paths;
     }
 
+    private static boolean[] classifyPredicateColumns(
+        List<Attribute> attributes,
+        ColumnInfo[] columnInfos,
+        ParquetPushedExpressions pushed
+    ) {
+        boolean[] predicate = new boolean[columnInfos.length];
+        if (pushed == null) {
+            return predicate;
+        }
+        Set<String> predicateNames = pushed.predicateColumnNames();
+        for (int i = 0; i < columnInfos.length; i++) {
+            if (columnInfos[i] != null && predicateNames.contains(attributes.get(i).name())) {
+                predicate[i] = true;
+            }
+        }
+        return predicate;
+    }
+
+    private static boolean hasProjectionOnlyColumns(boolean[] isPredicateColumn, ColumnInfo[] columnInfos) {
+        for (int i = 0; i < columnInfos.length; i++) {
+            if (columnInfos[i] != null && isPredicateColumn[i] == false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public boolean hasNext() {
         if (exhausted) {
@@ -287,6 +330,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             exhausted = true;
             cancelPendingPrefetch();
             releaseCurrentReservation();
+            if (rowsEliminatedByLateMaterialization > 0) {
+                logger.debug("Late materialization eliminated [{}] rows in [{}]", rowsEliminatedByLateMaterialization, fileLocation);
+            }
             return false;
         }
         rowGroupOrdinal = nextOrdinal;
@@ -296,24 +342,24 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = takePendingPrefetch(rowGroupOrdinal);
         try {
             RowRanges currentRowRanges = resolveCurrentRowRanges(block);
+            // When late materialization is active, skip ColumnIndex page filtering — late-mat handles
+            // row-level filtering itself via the survivor mask. Applying both ColumnIndex RowRanges
+            // AND late-mat evaluation causes double-filtering that drops rows incorrectly.
+            RowRanges buildRowRanges = lateMaterialization ? null : currentRowRanges;
             rowGroup = PrefetchedRowGroupBuilder.build(
                 block,
                 rowGroupOrdinal,
                 projectedSchema,
                 projectedColumnPaths,
-                currentRowRanges,
+                buildRowRanges,
                 preloadedMetadata,
                 chunks,
                 storageObject,
                 codecFactory
             );
-            // When RowRanges narrow the row group, only the surviving row count is consumed -
-            // mirrors parquet-mr's filtered PageReadStore.getRowCount(). The PageReader's per-page
-            // value count is unchanged; PageColumnReader caps at maxRows on each readBatch call so
-            // columns whose pages span more rows than the filtered count return aligned blocks.
-            rowsRemainingInGroup = currentRowRanges != null ? currentRowRanges.selectedRowCount() : rowGroup.getRowCount();
+            rowsRemainingInGroup = buildRowRanges != null ? buildRowRanges.selectedRowCount() : rowGroup.getRowCount();
             triggerNextRowGroupPrefetch();
-            initColumnReaders(currentRowRanges);
+            initColumnReaders(buildRowRanges);
             return rowsRemainingInGroup > 0;
         } catch (Exception e) {
             releaseCurrentReservation();
@@ -505,12 +551,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         }
         int rowsToRead = (int) Math.min(effectiveBatch, rowsRemainingInGroup);
 
-        Page result = nextStandard(rowsToRead);
+        Page result = lateMaterialization ? nextWithLateMaterialization(rowsToRead) : nextStandard(rowsToRead);
 
         pageBatchIndexInRowGroup++;
         rowsRemainingInGroup -= rowsToRead;
         if (rowBudget != FormatReader.NO_LIMIT) {
-            rowBudget -= rowsToRead;
+            rowBudget -= lateMaterialization ? result.getPositionCount() : rowsToRead;
         }
         return result;
     }
@@ -580,6 +626,98 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             );
         }
         return new Page(blocks);
+    }
+
+    private Page nextWithLateMaterialization(int rowsToRead) {
+        Block[] blocks = new Block[attributes.size()];
+        try {
+            // Phase 1: decode predicate columns
+            Map<String, Block> predicateBlockMap = new HashMap<>();
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (isPredicateColumn[col]) {
+                    ColumnInfo info = columnInfos[col];
+                    if (info == null) {
+                        blocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
+                    } else {
+                        blocks[col] = readColumnBlock(col, info, rowsToRead);
+                        predicateBlockMap.put(attributes.get(col).name(), blocks[col]);
+                    }
+                }
+            }
+
+            // Phase 2: evaluate filter
+            WordMask mask = pushedExpressions.evaluateFilter(predicateBlockMap, rowsToRead, survivorMask);
+            predicateBlockMap = null; // release references to pre-compacted blocks
+
+            int survivorCount = rowsToRead;
+            int[] positions = null;
+            if (mask != null) {
+                survivorCount = mask.popCount();
+                rowsEliminatedByLateMaterialization += (rowsToRead - survivorCount);
+                if (survivorCount < rowsToRead) {
+                    positions = mask.survivingPositions();
+                    // Compact predicate blocks
+                    for (int col = 0; col < columnInfos.length; col++) {
+                        if (isPredicateColumn[col] && blocks[col] != null) {
+                            blocks[col] = PageColumnReader.filterBlock(blocks[col], positions, survivorCount, blockFactory);
+                        }
+                    }
+                }
+            }
+
+            // Phase 3: decode projection-only columns
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (isPredicateColumn[col]) {
+                    continue;
+                }
+                ColumnInfo info = columnInfos[col];
+                if (info == null) {
+                    blocks[col] = blockFactory.newConstantNullBlock(survivorCount);
+                } else if (survivorCount == 0) {
+                    // Skip entirely
+                    if (pageColumnReaders != null && pageColumnReaders[col] != null) {
+                        pageColumnReaders[col].skipRows(rowsToRead);
+                    } else if (columnReaders != null && columnReaders[col] != null) {
+                        ParquetColumnDecoding.skipValues(columnReaders[col], rowsToRead);
+                    }
+                    blocks[col] = blockFactory.newConstantNullBlock(0);
+                } else if (positions == null) {
+                    // All rows survive -- normal read
+                    blocks[col] = readColumnBlock(col, info, rowsToRead);
+                } else if (pageColumnReaders != null && pageColumnReaders[col] != null) {
+                    blocks[col] = pageColumnReaders[col].readBatchFiltered(rowsToRead, blockFactory, positions, survivorCount);
+                } else {
+                    // List column or fallback: read full then filter
+                    Block fullBlock = readColumnBlock(col, info, rowsToRead);
+                    blocks[col] = PageColumnReader.filterBlock(fullBlock, positions, survivorCount, blockFactory);
+                }
+            }
+
+            // Fill any remaining null slots
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (blocks[col] == null) {
+                    blocks[col] = blockFactory.newConstantNullBlock(survivorCount);
+                }
+            }
+
+            return new Page(blocks);
+        } catch (CircuitBreakingException e) {
+            Releasables.closeExpectNoException(blocks);
+            throw e;
+        } catch (Exception e) {
+            Releasables.closeExpectNoException(blocks);
+            throw new ElasticsearchException(
+                "Failed to create late-materialized Page at row group ["
+                    + (rowGroupOrdinal + 1)
+                    + "] page batch ["
+                    + pageBatchIndexInRowGroup
+                    + "] in file ["
+                    + fileLocation
+                    + "]: "
+                    + e.getMessage(),
+                e
+            );
+        }
     }
 
     private Block readColumnBlock(int colIndex, ColumnInfo info, int rowsToRead) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -121,6 +121,53 @@ final class PageColumnReader {
         };
     }
 
+    /**
+     * Filters a block to retain only the positions specified by {@code positions}.
+     * Takes ownership of {@code source}: the source block is closed after filtering
+     * and the caller owns the returned block.
+     *
+     * @param source        the block to filter; ownership is transferred to this method
+     * @param positions     the positions to retain (ascending, no duplicates)
+     * @param survivorCount the number of valid entries in {@code positions}
+     * @param blockFactory  the factory used to create replacement blocks
+     * @return a new block containing only the selected positions
+     */
+    static Block filterBlock(Block source, int[] positions, int survivorCount, BlockFactory blockFactory) {
+        if (survivorCount == source.getPositionCount()) {
+            return source;
+        }
+        if (survivorCount == 0) {
+            source.close();
+            return blockFactory.newConstantNullBlock(0);
+        }
+        Block filtered = source.filter(false, Arrays.copyOf(positions, survivorCount));
+        source.close();
+        return filtered;
+    }
+
+    /**
+     * Reads a batch and filters it to retain only the surviving positions.
+     * When all rows survive, delegates directly to {@link #readBatch}. When none
+     * survive, skips the rows and returns an empty constant null block.
+     *
+     * @param maxRows           the total number of rows in the batch
+     * @param blockFactory      the factory used to create blocks
+     * @param survivorPositions the positions that survived filtering (ascending, no duplicates)
+     * @param survivorCount     the number of valid entries in {@code survivorPositions}
+     * @return a block containing only the surviving rows
+     */
+    Block readBatchFiltered(int maxRows, BlockFactory blockFactory, int[] survivorPositions, int survivorCount) {
+        if (survivorCount == maxRows) {
+            return readBatch(maxRows, blockFactory);
+        }
+        if (survivorCount == 0) {
+            skipRows(maxRows);
+            return blockFactory.newConstantNullBlock(0);
+        }
+        Block full = readBatch(maxRows, blockFactory);
+        return filterBlock(full, survivorPositions, survivorCount, blockFactory);
+    }
+
     private void loadDictionaryIfNeeded() {
         if (dictionaryLoaded) {
             return;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -69,11 +69,13 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 
 /**
  * FormatReader implementation for Parquet files.
@@ -98,6 +100,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     private final ParquetPushedExpressions pushedExpressions;
     private final boolean forceBaselinePath;
     private final boolean optimizedReader;
+    private final boolean lateMaterializationEnabled;
     // Shared across all iterators created by this reader: holds lazy decompressor instances and
     // pays the per-codec init cost once. The factory is stateless across files/row groups.
     private final PlainCompressionCodecFactory codecFactory = new PlainCompressionCodecFactory();
@@ -105,13 +108,14 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
     static final long DEFAULT_ROW_GROUP_MACRO_SPLIT_TARGET_BYTES = 32L * 1024 * 1024;
 
     static final String CONFIG_OPTIMIZED_READER = "optimized_reader";
+    static final String CONFIG_LATE_MATERIALIZATION = "late_materialization";
 
     public ParquetFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, FilterCompat.NOOP, null, false, true);
+        this(blockFactory, FilterCompat.NOOP, null, false, true, true);
     }
 
     ParquetFormatReader(BlockFactory blockFactory, boolean optimizedReader) {
-        this(blockFactory, FilterCompat.NOOP, null, false, optimizedReader);
+        this(blockFactory, FilterCompat.NOOP, null, false, optimizedReader, true);
     }
 
     private ParquetFormatReader(
@@ -119,13 +123,15 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         FilterCompat.Filter pushedFilter,
         ParquetPushedExpressions pushedExpressions,
         boolean forceBaselinePath,
-        boolean optimizedReader
+        boolean optimizedReader,
+        boolean lateMaterializationEnabled
     ) {
         this.blockFactory = blockFactory;
         this.pushedFilter = pushedFilter;
         this.pushedExpressions = pushedExpressions;
         this.forceBaselinePath = forceBaselinePath;
         this.optimizedReader = optimizedReader;
+        this.lateMaterializationEnabled = lateMaterializationEnabled;
     }
 
     /**
@@ -134,16 +140,23 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
      * testing against the optimized path.
      */
     ParquetFormatReader withBaselinePath() {
-        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, true, optimizedReader);
+        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, true, optimizedReader, lateMaterializationEnabled);
     }
 
     @Override
     public ParquetFormatReader withPushedFilter(Object pushedFilter) {
         if (pushedFilter instanceof FilterCompat.Filter filter) {
-            return new ParquetFormatReader(blockFactory, filter, null, forceBaselinePath, optimizedReader);
+            return new ParquetFormatReader(blockFactory, filter, null, forceBaselinePath, optimizedReader, lateMaterializationEnabled);
         }
         if (pushedFilter instanceof ParquetPushedExpressions exprs) {
-            return new ParquetFormatReader(blockFactory, FilterCompat.NOOP, exprs, forceBaselinePath, optimizedReader);
+            return new ParquetFormatReader(
+                blockFactory,
+                FilterCompat.NOOP,
+                exprs,
+                forceBaselinePath,
+                optimizedReader,
+                lateMaterializationEnabled
+            );
         }
         return this;
     }
@@ -154,10 +167,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             return this;
         }
         boolean newOptimized = parseBooleanConfig(config, CONFIG_OPTIMIZED_READER, optimizedReader);
-        if (newOptimized == optimizedReader) {
+        boolean newLateMat = parseBooleanConfig(config, CONFIG_LATE_MATERIALIZATION, lateMaterializationEnabled);
+        if (newOptimized == optimizedReader && newLateMat == lateMaterializationEnabled) {
             return this;
         }
-        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, forceBaselinePath, newOptimized);
+        return new ParquetFormatReader(blockFactory, pushedFilter, pushedExpressions, forceBaselinePath, newOptimized, newLateMat);
     }
 
     private static boolean parseBooleanConfig(Map<String, Object> config, String key, boolean defaultValue) {
@@ -783,6 +797,22 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             }
         }
 
+        ParquetPushedExpressions effectivePushed = null;
+        if (lateMaterializationEnabled && pushedExpressions != null) {
+            double predicateRatio = computePredicateColumnByteRatio(blocks, projectedAttributes, pushedExpressions);
+            if (predicateRatio < LATE_MATERIALIZATION_PREDICATE_RATIO_THRESHOLD) {
+                effectivePushed = pushedExpressions;
+            } else {
+                logger.debug(
+                    "Late materialization disabled for [{}]: predicate column ratio [{}/{}] exceeds threshold [{}]",
+                    storageObject.path(),
+                    (long) (predicateRatio * 100),
+                    100,
+                    (long) (LATE_MATERIALIZATION_PREDICATE_RATIO_THRESHOLD * 100)
+                );
+            }
+        }
+
         return new OptimizedParquetColumnIterator(
             reader,
             projectedSchema,
@@ -797,8 +827,45 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             storageObject,
             allRowRanges,
             survivingRowGroups,
-            codecFactory
+            codecFactory,
+            effectivePushed
         );
+    }
+
+    static final double LATE_MATERIALIZATION_PREDICATE_RATIO_THRESHOLD = 0.5;
+
+    /**
+     * Computes the ratio of predicate column bytes to total projected column bytes,
+     * averaged across all row groups. Uses compressed on-disk sizes from Parquet metadata.
+     */
+    private static double computePredicateColumnByteRatio(
+        List<BlockMetaData> blocks,
+        List<Attribute> projectedAttributes,
+        ParquetPushedExpressions pushed
+    ) {
+        Set<String> predicateNames = pushed.predicateColumnNames();
+        if (predicateNames.isEmpty()) {
+            return 0.0;
+        }
+        Set<String> projectedNames = new HashSet<>();
+        for (Attribute attr : projectedAttributes) {
+            projectedNames.add(attr.name());
+        }
+        long predicateBytes = 0;
+        long totalBytes = 0;
+        for (BlockMetaData block : blocks) {
+            for (ColumnChunkMetaData col : block.getColumns()) {
+                String name = col.getPath().toDotString();
+                if (projectedNames.contains(name)) {
+                    long size = col.getTotalSize();
+                    totalBytes += size;
+                    if (predicateNames.contains(name)) {
+                        predicateBytes += size;
+                    }
+                }
+            }
+        }
+        return totalBytes > 0 ? (double) predicateBytes / totalBytes : 0.0;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -15,6 +15,12 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -39,6 +45,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -366,5 +373,407 @@ record ParquetPushedExpressions(List<Expression> expressions) {
             return Binary.fromConstantByteArray(bytesRef.bytes, bytesRef.offset, bytesRef.length);
         }
         return Binary.fromString(value.toString());
+    }
+
+    /**
+     * Returns the set of column names referenced by the pushed filter expressions.
+     * This is useful for identifying which columns participate in predicates so that
+     * they can be read even when not explicitly projected.
+     */
+    Set<String> predicateColumnNames() {
+        Set<String> names = new HashSet<>();
+        for (Expression expr : expressions) {
+            collectColumnNames(expr, names);
+        }
+        return names;
+    }
+
+    private static void collectColumnNames(Expression expr, Set<String> names) {
+        if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof In inExpr && inExpr.value() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof IsNull isNull && isNull.field() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof IsNotNull isNotNull && isNotNull.field() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof Range range && range.value() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        } else if (expr instanceof And and) {
+            collectColumnNames(and.left(), names);
+            collectColumnNames(and.right(), names);
+        } else if (expr instanceof Or or) {
+            collectColumnNames(or.left(), names);
+            collectColumnNames(or.right(), names);
+        } else if (expr instanceof Not not) {
+            collectColumnNames(not.field(), names);
+        } else if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne) {
+            names.add(ne.name());
+        }
+    }
+
+    /**
+     * Evaluates all held filter expressions against the given predicate blocks and returns
+     * a survivor mask indicating which rows pass all predicates. Returns {@code null} if
+     * all rows survive (no filtering needed), signaling that compaction can be skipped.
+     *
+     * @param predicateBlocks map of column name to decoded Block for predicate columns
+     * @param rowCount        the number of rows in the current batch
+     * @param reusable        a reusable WordMask instance to avoid allocation
+     * @return the survivor mask with bits set for passing rows, or null if all rows survive
+     */
+    WordMask evaluateFilter(Map<String, Block> predicateBlocks, int rowCount, WordMask reusable) {
+        reusable.setAll(rowCount);
+        for (Expression expr : expressions) {
+            WordMask exprResult = evaluateExpression(expr, predicateBlocks, rowCount);
+            if (exprResult != null) {
+                reusable.and(exprResult);
+            }
+        }
+        if (reusable.isAll()) {
+            return null;
+        }
+        return reusable;
+    }
+
+    private WordMask evaluateExpression(Expression expr, Map<String, Block> blocks, int rowCount) {
+        if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne && bc.right().foldable()) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            Object literal = literalValueOf(bc.right());
+            if (literal == null) {
+                return null;
+            }
+            return evaluateComparison(bc, block, literal, rowCount);
+        }
+        if (expr instanceof In inExpr && inExpr.value() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            return evaluateIn(inExpr, block, rowCount);
+        }
+        if (expr instanceof IsNull isNull && isNull.field() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            WordMask mask = new WordMask();
+            mask.reset(rowCount);
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    mask.set(i);
+                }
+            }
+            return mask;
+        }
+        if (expr instanceof IsNotNull isNotNull && isNotNull.field() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            WordMask mask = new WordMask();
+            mask.reset(rowCount);
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false) {
+                    mask.set(i);
+                }
+            }
+            return mask;
+        }
+        if (expr instanceof Range range && range.value() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            return evaluateRange(range, block, rowCount);
+        }
+        if (expr instanceof And and) {
+            WordMask left = evaluateExpression(and.left(), blocks, rowCount);
+            WordMask right = evaluateExpression(and.right(), blocks, rowCount);
+            if (left != null && right != null) {
+                left.and(right);
+                return left;
+            }
+            return left != null ? left : right;
+        }
+        if (expr instanceof Or or) {
+            WordMask left = evaluateExpression(or.left(), blocks, rowCount);
+            WordMask right = evaluateExpression(or.right(), blocks, rowCount);
+            if (left != null && right != null) {
+                left.or(right);
+                return left;
+            }
+            // conservative: if either arm is unknown, the whole OR is unknown
+            return null;
+        }
+        if (expr instanceof Not not) {
+            WordMask inner = evaluateExpression(not.field(), blocks, rowCount);
+            if (inner != null) {
+                inner.negate();
+                return inner;
+            }
+            return null;
+        }
+        if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            return evaluateStartsWith(sw, block, rowCount);
+        }
+        return null;
+    }
+
+    private static WordMask evaluateComparison(EsqlBinaryComparison bc, Block block, Object literal, int rowCount) {
+        WordMask mask = new WordMask();
+        mask.reset(rowCount);
+        if (block instanceof IntBlock ib) {
+            int val = ((Number) literal).intValue();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false && compareResult(Integer.compare(ib.getInt(i), val), bc)) {
+                    mask.set(i);
+                }
+            }
+        } else if (block instanceof LongBlock lb) {
+            Long boxed = toLongValue(literal);
+            if (boxed == null) {
+                return null;
+            }
+            long val = boxed;
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false && compareResult(Long.compare(lb.getLong(i), val), bc)) {
+                    mask.set(i);
+                }
+            }
+        } else if (block instanceof DoubleBlock db) {
+            double val = ((Number) literal).doubleValue();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false && compareResult(Double.compare(db.getDouble(i), val), bc)) {
+                    mask.set(i);
+                }
+            }
+        } else if (block instanceof BytesRefBlock bb) {
+            BytesRef val = toByteRef(literal);
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false && compareResult(bb.getBytesRef(i, scratch).compareTo(val), bc)) {
+                    mask.set(i);
+                }
+            }
+        } else if (block instanceof BooleanBlock boolBlock) {
+            boolean val = (Boolean) literal;
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false && compareResult(Boolean.compare(boolBlock.getBoolean(i), val), bc)) {
+                    mask.set(i);
+                }
+            }
+        } else {
+            return null;
+        }
+        return mask;
+    }
+
+    private static boolean compareResult(int cmp, EsqlBinaryComparison bc) {
+        if (bc instanceof Equals) {
+            return cmp == 0;
+        } else if (bc instanceof NotEquals) {
+            return cmp != 0;
+        } else if (bc instanceof LessThan) {
+            return cmp < 0;
+        } else if (bc instanceof LessThanOrEqual) {
+            return cmp <= 0;
+        } else if (bc instanceof GreaterThan) {
+            return cmp > 0;
+        } else if (bc instanceof GreaterThanOrEqual) {
+            return cmp >= 0;
+        }
+        return true;
+    }
+
+    private static Long toLongValue(Object literal) {
+        if (literal instanceof Number n) {
+            return n.longValue();
+        }
+        return null;
+    }
+
+    private static BytesRef toByteRef(Object literal) {
+        if (literal instanceof BytesRef br) {
+            return br;
+        }
+        if (literal instanceof String s) {
+            return new BytesRef(s);
+        }
+        return new BytesRef(literal.toString());
+    }
+
+    private static WordMask evaluateIn(In inExpr, Block block, int rowCount) {
+        List<Object> values = new ArrayList<>();
+        for (Expression item : inExpr.list()) {
+            Object val = literalValueOf(item);
+            if (val != null) {
+                values.add(val);
+            }
+        }
+        if (values.isEmpty()) {
+            return null;
+        }
+        WordMask mask = new WordMask();
+        mask.reset(rowCount);
+        if (block instanceof IntBlock ib) {
+            Set<Integer> intSet = new HashSet<>();
+            for (Object v : values) {
+                intSet.add(((Number) v).intValue());
+            }
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false && intSet.contains(ib.getInt(i))) {
+                    mask.set(i);
+                }
+            }
+        } else if (block instanceof LongBlock lb) {
+            Set<Long> longSet = new HashSet<>();
+            for (Object v : values) {
+                longSet.add(((Number) v).longValue());
+            }
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false && longSet.contains(lb.getLong(i))) {
+                    mask.set(i);
+                }
+            }
+        } else if (block instanceof DoubleBlock db) {
+            Set<Double> doubleSet = new HashSet<>();
+            for (Object v : values) {
+                doubleSet.add(((Number) v).doubleValue());
+            }
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false && doubleSet.contains(db.getDouble(i))) {
+                    mask.set(i);
+                }
+            }
+        } else if (block instanceof BytesRefBlock bb) {
+            Set<BytesRef> refSet = new HashSet<>();
+            for (Object v : values) {
+                refSet.add(toByteRef(v));
+            }
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false && refSet.contains(bb.getBytesRef(i, scratch))) {
+                    mask.set(i);
+                }
+            }
+        } else if (block instanceof BooleanBlock boolBlock) {
+            Set<Boolean> boolSet = new HashSet<>();
+            for (Object v : values) {
+                boolSet.add((Boolean) v);
+            }
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false && boolSet.contains(boolBlock.getBoolean(i))) {
+                    mask.set(i);
+                }
+            }
+        } else {
+            return null;
+        }
+        return mask;
+    }
+
+    private static WordMask evaluateRange(Range range, Block block, int rowCount) {
+        Object lower = literalValueOf(range.lower());
+        Object upper = literalValueOf(range.upper());
+        if (lower == null && upper == null) {
+            return null;
+        }
+        boolean includeLower = range.includeLower();
+        boolean includeUpper = range.includeUpper();
+        WordMask mask = new WordMask();
+        mask.reset(rowCount);
+        if (block instanceof IntBlock ib) {
+            Integer lo = lower != null ? ((Number) lower).intValue() : null;
+            Integer hi = upper != null ? ((Number) upper).intValue() : null;
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false) {
+                    int val = ib.getInt(i);
+                    if (inRange(val, lo, hi, includeLower, includeUpper)) {
+                        mask.set(i);
+                    }
+                }
+            }
+        } else if (block instanceof LongBlock lb) {
+            Long lo = lower != null ? ((Number) lower).longValue() : null;
+            Long hi = upper != null ? ((Number) upper).longValue() : null;
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false) {
+                    long val = lb.getLong(i);
+                    if (inRange(val, lo, hi, includeLower, includeUpper)) {
+                        mask.set(i);
+                    }
+                }
+            }
+        } else if (block instanceof DoubleBlock db) {
+            Double lo = lower != null ? ((Number) lower).doubleValue() : null;
+            Double hi = upper != null ? ((Number) upper).doubleValue() : null;
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false) {
+                    double val = db.getDouble(i);
+                    if (inRange(val, lo, hi, includeLower, includeUpper)) {
+                        mask.set(i);
+                    }
+                }
+            }
+        } else {
+            return null;
+        }
+        return mask;
+    }
+
+    private static <T extends Comparable<T>> boolean inRange(T val, T lower, T upper, boolean includeLower, boolean includeUpper) {
+        if (lower != null) {
+            int cmp = val.compareTo(lower);
+            if (includeLower ? cmp < 0 : cmp <= 0) {
+                return false;
+            }
+        }
+        if (upper != null) {
+            int cmp = val.compareTo(upper);
+            if (includeUpper ? cmp > 0 : cmp >= 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static WordMask evaluateStartsWith(StartsWith sw, Block block, int rowCount) {
+        Object prefixValue = literalValueOf(sw.prefix());
+        if (prefixValue == null) {
+            return null;
+        }
+        BytesRef prefix = toByteRef(prefixValue);
+        if (block instanceof BytesRefBlock bb) {
+            WordMask mask = new WordMask();
+            mask.reset(rowCount);
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false) {
+                    BytesRef val = bb.getBytesRef(i, scratch);
+                    if (val.length >= prefix.length && startsWith(val, prefix)) {
+                        mask.set(i);
+                    }
+                }
+            }
+            return mask;
+        }
+        return null;
+    }
+
+    private static boolean startsWith(BytesRef value, BytesRef prefix) {
+        for (int j = 0; j < prefix.length; j++) {
+            if (value.bytes[value.offset + j] != prefix.bytes[prefix.offset + j]) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -686,41 +686,47 @@ record ParquetPushedExpressions(List<Expression> expressions) {
         if (lower == null && upper == null) {
             return null;
         }
-        boolean includeLower = range.includeLower();
-        boolean includeUpper = range.includeUpper();
+        boolean incLo = range.includeLower();
+        boolean incHi = range.includeUpper();
         WordMask mask = new WordMask();
         mask.reset(rowCount);
         if (block instanceof IntBlock ib) {
-            Integer lo = lower != null ? ((Number) lower).intValue() : null;
-            Integer hi = upper != null ? ((Number) upper).intValue() : null;
+            boolean hasLo = lower != null;
+            boolean hasHi = upper != null;
+            int lo = hasLo ? ((Number) lower).intValue() : 0;
+            int hi = hasHi ? ((Number) upper).intValue() : 0;
             for (int i = 0; i < rowCount; i++) {
                 if (block.isNull(i) == false) {
                     int val = ib.getInt(i);
-                    if (inRange(val, lo, hi, includeLower, includeUpper)) {
-                        mask.set(i);
-                    }
+                    if (hasLo && (incLo ? val < lo : val <= lo)) continue;
+                    if (hasHi && (incHi ? val > hi : val >= hi)) continue;
+                    mask.set(i);
                 }
             }
         } else if (block instanceof LongBlock lb) {
-            Long lo = lower != null ? ((Number) lower).longValue() : null;
-            Long hi = upper != null ? ((Number) upper).longValue() : null;
+            boolean hasLo = lower != null;
+            boolean hasHi = upper != null;
+            long lo = hasLo ? ((Number) lower).longValue() : 0;
+            long hi = hasHi ? ((Number) upper).longValue() : 0;
             for (int i = 0; i < rowCount; i++) {
                 if (block.isNull(i) == false) {
                     long val = lb.getLong(i);
-                    if (inRange(val, lo, hi, includeLower, includeUpper)) {
-                        mask.set(i);
-                    }
+                    if (hasLo && (incLo ? val < lo : val <= lo)) continue;
+                    if (hasHi && (incHi ? val > hi : val >= hi)) continue;
+                    mask.set(i);
                 }
             }
         } else if (block instanceof DoubleBlock db) {
-            Double lo = lower != null ? ((Number) lower).doubleValue() : null;
-            Double hi = upper != null ? ((Number) upper).doubleValue() : null;
+            boolean hasLo = lower != null;
+            boolean hasHi = upper != null;
+            double lo = hasLo ? ((Number) lower).doubleValue() : 0;
+            double hi = hasHi ? ((Number) upper).doubleValue() : 0;
             for (int i = 0; i < rowCount; i++) {
                 if (block.isNull(i) == false) {
                     double val = db.getDouble(i);
-                    if (inRange(val, lo, hi, includeLower, includeUpper)) {
-                        mask.set(i);
-                    }
+                    if (hasLo && (incLo ? val < lo : val <= lo)) continue;
+                    if (hasHi && (incHi ? val > hi : val >= hi)) continue;
+                    mask.set(i);
                 }
             }
         } else {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
@@ -52,6 +52,135 @@ final class WordMask {
         return (numBits + 63) >>> 6;
     }
 
+    void clear(int index) {
+        words[index >>> 6] &= ~(1L << index);
+    }
+
+    /**
+     * Resets the mask to the given size and sets all {@code numBits} bits to 1.
+     * Trailing bits in the last word beyond {@code numBits} are left as 0.
+     */
+    void setAll(int numBits) {
+        reset(numBits);
+        int numWords = wordCount();
+        if (numWords == 0) {
+            return;
+        }
+        // fill all full words with all-ones
+        Arrays.fill(words, 0, numWords, ~0L);
+        // mask off trailing bits in the last word
+        int trailing = numBits & 63;
+        if (trailing != 0) {
+            words[numWords - 1] = (1L << trailing) - 1;
+        }
+    }
+
+    /**
+     * Returns the number of set bits in this mask.
+     */
+    int popCount() {
+        int count = 0;
+        int numWords = wordCount();
+        if (numWords == 0) {
+            return 0;
+        }
+        for (int i = 0; i < numWords - 1; i++) {
+            count += Long.bitCount(words[i]);
+        }
+        // mask the last word to only count bits within numBits
+        int trailing = numBits & 63;
+        long lastWord = words[numWords - 1];
+        if (trailing != 0) {
+            lastWord &= (1L << trailing) - 1;
+        }
+        count += Long.bitCount(lastWord);
+        return count;
+    }
+
+    /**
+     * Returns {@code true} if all {@code numBits} bits are set.
+     */
+    boolean isAll() {
+        int numWords = wordCount();
+        if (numWords == 0) {
+            return true;
+        }
+        // check all full words are all-ones
+        for (int i = 0; i < numWords - 1; i++) {
+            if (words[i] != ~0L) {
+                return false;
+            }
+        }
+        // check the last word has the correct trailing bits
+        int trailing = numBits & 63;
+        long expectedLast = trailing == 0 ? ~0L : (1L << trailing) - 1;
+        return words[numWords - 1] == expectedLast;
+    }
+
+    /**
+     * Bitwise AND with another mask of the same size, mutating this mask.
+     */
+    void and(WordMask other) {
+        if (this.numBits != other.numBits) {
+            throw new IllegalArgumentException("numBits mismatch: " + this.numBits + " vs " + other.numBits);
+        }
+        int numWords = wordCount();
+        for (int i = 0; i < numWords; i++) {
+            words[i] &= other.words[i];
+        }
+    }
+
+    void or(WordMask other) {
+        if (this.numBits != other.numBits) {
+            throw new IllegalArgumentException("numBits mismatch: " + this.numBits + " vs " + other.numBits);
+        }
+        int numWords = wordCount();
+        for (int i = 0; i < numWords; i++) {
+            words[i] |= other.words[i];
+        }
+    }
+
+    /**
+     * Flips all bits in this mask. Trailing bits beyond {@code numBits} are kept as 0.
+     */
+    void negate() {
+        int numWords = wordCount();
+        for (int i = 0; i < numWords; i++) {
+            words[i] = ~words[i];
+        }
+        // mask off trailing bits in the last word
+        int trailing = numBits & 63;
+        if (trailing != 0 && numWords > 0) {
+            words[numWords - 1] &= (1L << trailing) - 1;
+        }
+    }
+
+    /**
+     * Returns an array of the indices of all set bits, in ascending order.
+     * Uses {@link Long#numberOfTrailingZeros} to efficiently iterate set bits.
+     */
+    int[] survivingPositions() {
+        int count = popCount();
+        int[] positions = new int[count];
+        int pos = 0;
+        int numWords = wordCount();
+        for (int w = 0; w < numWords; w++) {
+            long word = words[w];
+            // mask trailing bits on the last word
+            int trailing = numBits & 63;
+            if (w == numWords - 1 && trailing != 0) {
+                word &= (1L << trailing) - 1;
+            }
+            int base = w << 6;
+            while (word != 0) {
+                int bit = Long.numberOfTrailingZeros(word);
+                positions[pos++] = base + bit;
+                word &= word - 1; // clear lowest set bit
+            }
+        }
+        return positions;
+    }
+
     BitSet toBitSet() {
         return BitSet.valueOf(Arrays.copyOf(words, wordCount()));
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
@@ -128,6 +128,7 @@ final class WordMask {
         for (int i = 0; i < numWords; i++) {
             words[i] &= other.words[i];
         }
+        maskTrailingBits();
     }
 
     void or(WordMask other) {
@@ -138,6 +139,7 @@ final class WordMask {
         for (int i = 0; i < numWords; i++) {
             words[i] |= other.words[i];
         }
+        maskTrailingBits();
     }
 
     /**
@@ -148,7 +150,11 @@ final class WordMask {
         for (int i = 0; i < numWords; i++) {
             words[i] = ~words[i];
         }
-        // mask off trailing bits in the last word
+        maskTrailingBits();
+    }
+
+    private void maskTrailingBits() {
+        int numWords = wordCount();
         int trailing = numBits & 63;
         if (trailing != 0 && numWords > 0) {
             words[numWords - 1] &= (1L << trailing) - 1;

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -31,9 +31,16 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -241,6 +248,223 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         }
 
         assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    // --- Late Materialization Tests ---
+
+    public void testLateMaterializationBasicFilter() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 300; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("value", i * 0.5);
+                g.add("label", "item_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        Expression gtExpr = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 200L, DataType.LONG), null);
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushedExprs);
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> pages = readAllPages(reader, storageObject);
+
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+        // id > 200 means ids 201..299 => 99 rows
+        assertThat("total rows after filter", totalRows, equalTo(99));
+
+        // Verify id values are in range 201..299
+        int rowIdx = 0;
+        for (Page page : pages) {
+            LongBlock idBlock = page.getBlock(0);
+            for (int pos = 0; pos < page.getPositionCount(); pos++) {
+                long id = idBlock.getLong(pos);
+                assertTrue("id " + id + " should be > 200", id > 200);
+                assertTrue("id " + id + " should be < 300", id < 300);
+                rowIdx++;
+            }
+        }
+        assertThat("verified row count", rowIdx, equalTo(99));
+    }
+
+    public void testLateMaterializationNoFilter() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("value", i * 1.0);
+                g.add("label", "item_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        // No pushed filter — late materialization should not activate
+        List<Page> baselinePages = readAllPages(new ParquetFormatReader(blockFactory, false), storageObject);
+        List<Page> optimizedPages = readAllPages(new ParquetFormatReader(blockFactory, true), storageObject);
+        assertPagesEqual(baselinePages, optimizedPages);
+    }
+
+    public void testLateMaterializationAllRowsEliminated() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("value", i * 0.5);
+                g.add("label", "item_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        Expression gtExpr = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 99999L, DataType.LONG), null);
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushedExprs);
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> pages = readAllPages(reader, storageObject);
+
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("all rows should be eliminated", totalRows, equalTo(0));
+    }
+
+    public void testLateMaterializationPredicateInProjection() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("value")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("big_col1")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("big_col2")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("big_col3")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                Group g = factory.newGroup();
+                g.add("id", i);
+                g.add("value", i * 2.0);
+                g.add("big_col1", (long) i * 100);
+                g.add("big_col2", (long) i * 200);
+                g.add("big_col3", (long) i * 300);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.INTEGER);
+        Expression ltExpr = new LessThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 10, DataType.INTEGER), null);
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(ltExpr));
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushedExprs);
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> pages = readAllPages(reader, storageObject);
+
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("should have 10 rows (id < 10)", totalRows, equalTo(10));
+
+        int rowIdx = 0;
+        for (Page page : pages) {
+            IntBlock idBlock = page.getBlock(0);
+            DoubleBlock valueBlock = page.getBlock(1);
+            for (int pos = 0; pos < page.getPositionCount(); pos++) {
+                int id = idBlock.getInt(pos);
+                double value = valueBlock.getDouble(pos);
+                assertThat("id at row " + rowIdx, id, equalTo(rowIdx));
+                assertThat("value at row " + rowIdx, value, equalTo(rowIdx * 2.0));
+                rowIdx++;
+            }
+        }
+    }
+
+    public void testLateMaterializationNullableColumns() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .optional(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("filter_col")
+            .optional(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("projection_col")
+            .named("test_schema");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < 200; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                if (i % 5 != 0) {
+                    g.add("filter_col", (long) i);
+                }
+                if (i % 3 != 0) {
+                    g.add("projection_col", i * 1.5);
+                }
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        ReferenceAttribute filterAttr = new ReferenceAttribute(Source.EMPTY, "filter_col", DataType.LONG);
+        Expression gtExpr = new GreaterThan(Source.EMPTY, filterAttr, new Literal(Source.EMPTY, 150L, DataType.LONG), null);
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushedExprs);
+
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> pages = readAllPages(reader, storageObject);
+
+        int totalRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+
+        // Compute expected: rows where filter_col > 150 AND filter_col is not null
+        // filter_col is null when i % 5 == 0, otherwise filter_col == i
+        // So we need i > 150 AND i % 5 != 0
+        int expectedRows = 0;
+        for (int i = 0; i < 200; i++) {
+            if (i % 5 != 0 && i > 150) {
+                expectedRows++;
+            }
+        }
+        assertThat("survivor count for filter_col > 150 with nulls", totalRows, equalTo(expectedRows));
     }
 
     // --- Helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -467,6 +467,194 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         assertThat("survivor count for filter_col > 150 with nulls", totalRows, equalTo(expectedRows));
     }
 
+    public void testLateMaterializationWithRowLimit() throws Exception {
+        // 3 columns: predicate (int), projection-only (string), projection-only (double)
+        // The int predicate column is narrow; the two projection columns are wider.
+        // This guarantees the predicate byte ratio < 0.5, activating late materialization.
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("filter_col")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+            .named("score")
+            .named("test_schema");
+
+        int totalRows = 200;
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < totalRows; i++) {
+                Group g = factory.newGroup();
+                g.add("filter_col", i);
+                // Use a long repeating string to make the string column wide relative to the int column
+                g.add("label", "description_for_item_number_" + i + "_with_extra_padding_to_increase_byte_size");
+                g.add("score", i * 3.14);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        // Highly selective filter: filter_col > 190 matches rows 191..199 = 9 rows (~4.5%)
+        ReferenceAttribute filterAttr = new ReferenceAttribute(Source.EMPTY, "filter_col", DataType.INTEGER);
+        Expression gtExpr = new GreaterThan(Source.EMPTY, filterAttr, new Literal(Source.EMPTY, 190, DataType.INTEGER), null);
+        ParquetPushedExpressions pushedExprs = new ParquetPushedExpressions(List.of(gtExpr));
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushedExprs);
+
+        // Set row limit smaller than the 9 matching rows
+        int rowLimit = 5;
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> pages;
+        try (
+            CloseableIterator<Page> iter = reader.read(
+                storageObject,
+                FormatReadContext.builder().batchSize(1024).rowLimit(rowLimit).build()
+            )
+        ) {
+            pages = collectPages(iter);
+        }
+
+        int outputRows = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("output row count should equal the row limit", outputRows, equalTo(rowLimit));
+
+        // Verify the output values are correct (not corrupted by the filter/compact cycle)
+        int rowIdx = 0;
+        for (Page page : pages) {
+            IntBlock filterBlock = page.getBlock(0);
+            BytesRefBlock labelBlock = page.getBlock(1);
+            DoubleBlock scoreBlock = page.getBlock(2);
+            for (int pos = 0; pos < page.getPositionCount(); pos++) {
+                int filterVal = filterBlock.getInt(pos);
+                assertTrue("filter_col value " + filterVal + " should be > 190", filterVal > 190);
+                assertTrue("filter_col value " + filterVal + " should be < 200", filterVal < 200);
+
+                // Verify the label and score correspond to the filter value
+                String label = labelBlock.getBytesRef(pos, new org.apache.lucene.util.BytesRef()).utf8ToString();
+                String expectedLabel = "description_for_item_number_" + filterVal + "_with_extra_padding_to_increase_byte_size";
+                assertThat("label at row " + rowIdx, label, equalTo(expectedLabel));
+                assertThat("score at row " + rowIdx, scoreBlock.getDouble(pos), equalTo(filterVal * 3.14));
+                rowIdx++;
+            }
+        }
+    }
+
+    public void testLateMaterializationHeuristicThreshold() throws Exception {
+        // Scenario A: Predicate column is a narrow int; projection columns are wide strings.
+        // The predicate byte ratio should be well below 0.5, so late materialization is active.
+        // We verify this by applying a selective filter and confirming rows are eliminated.
+        MessageType schemaA = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("pred_col")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("wide_col1")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("wide_col2")
+            .named("test_schema");
+
+        int totalRows = 100;
+        String padding = "x".repeat(200);
+        byte[] parquetDataA = createParquetFile(schemaA, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < totalRows; i++) {
+                Group g = factory.newGroup();
+                g.add("pred_col", i);
+                g.add("wide_col1", padding + "_col1_" + i);
+                g.add("wide_col2", padding + "_col2_" + i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        // Filter: pred_col > 89 => 10 matching rows
+        ReferenceAttribute predAttrA = new ReferenceAttribute(Source.EMPTY, "pred_col", DataType.INTEGER);
+        Expression filterA = new GreaterThan(Source.EMPTY, predAttrA, new Literal(Source.EMPTY, 89, DataType.INTEGER), null);
+        ParquetPushedExpressions pushedA = new ParquetPushedExpressions(List.of(filterA));
+        ParquetFormatReader readerA = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushedA);
+
+        StorageObject storageObjectA = createStorageObject(parquetDataA);
+        List<Page> pagesA = readAllPages(readerA, storageObjectA);
+
+        int totalRowsA = pagesA.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("scenario A: late-mat active, should have 10 surviving rows", totalRowsA, equalTo(10));
+
+        // Verify data correctness
+        for (Page page : pagesA) {
+            IntBlock predBlock = page.getBlock(0);
+            for (int pos = 0; pos < page.getPositionCount(); pos++) {
+                int val = predBlock.getInt(pos);
+                assertTrue("pred_col " + val + " should be > 89", val > 89);
+            }
+        }
+
+        // Scenario B: Predicate column is a wide string (~200+ bytes/row) that dominates the
+        // byte footprint; the projection-only column is a narrow int (4 bytes/row). The
+        // predicate byte ratio exceeds 0.5, so the heuristic should disable late materialization.
+        // When late-mat is disabled, no row-level filtering occurs in the optimized path (only
+        // row-group/page-level statistics filtering, which cannot eliminate individual rows
+        // within a single row group). This means ALL rows are returned.
+        MessageType schemaB = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("wide_pred")
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("narrow_proj")
+            .named("test_schema");
+
+        byte[] parquetDataB = createParquetFile(schemaB, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < totalRows; i++) {
+                Group g = factory.newGroup();
+                g.add("wide_pred", padding + "_pred_" + i);
+                g.add("narrow_proj", i);
+                groups.add(g);
+            }
+            return groups;
+        });
+
+        // Push a filter on the wide predicate column
+        ReferenceAttribute predAttrB = new ReferenceAttribute(Source.EMPTY, "wide_pred", DataType.KEYWORD);
+        Expression filterB = new GreaterThan(
+            Source.EMPTY,
+            predAttrB,
+            new Literal(Source.EMPTY, new org.apache.lucene.util.BytesRef(padding + "_pred_94"), DataType.KEYWORD),
+            null
+        );
+        ParquetPushedExpressions pushedB = new ParquetPushedExpressions(List.of(filterB));
+
+        // Read with late-mat enabled (default) - the heuristic should disable it internally
+        // because the wide predicate column dominates the byte footprint
+        ParquetFormatReader readerBLateMat = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushedB);
+        StorageObject storageObjectB = createStorageObject(parquetDataB);
+        List<Page> pagesBLateMat = readAllPages(readerBLateMat, storageObjectB);
+        int totalRowsBLateMat = pagesBLateMat.stream().mapToInt(Page::getPositionCount).sum();
+
+        // Read with late-mat explicitly disabled via config - should behave identically
+        ParquetFormatReader readerBNoLateMat = ((ParquetFormatReader) new ParquetFormatReader(blockFactory, true).withConfig(
+            Map.of(ParquetFormatReader.CONFIG_LATE_MATERIALIZATION, false)
+        )).withPushedFilter(pushedB);
+        List<Page> pagesBNoLateMat = readAllPages(readerBNoLateMat, storageObjectB);
+        int totalRowsBNoLateMat = pagesBNoLateMat.stream().mapToInt(Page::getPositionCount).sum();
+
+        // Both paths (heuristic-disabled and explicitly-disabled) should produce the same row count.
+        // Since the optimized path without late-mat does not do row-level filtering (only
+        // statistics-level filtering which cannot prune individual rows in a single row group),
+        // both should return all 100 rows.
+        assertThat(
+            "scenario B: heuristic-disabled late-mat and explicit no-late-mat should produce same row count",
+            totalRowsBLateMat,
+            equalTo(totalRowsBNoLateMat)
+        );
+        assertThat("scenario B: without row-level filtering, all rows should be returned", totalRowsBLateMat, equalTo(totalRows));
+
+        // Contrast with scenario A: late-mat was active there and eliminated rows
+        assertTrue(
+            "scenario A (late-mat active) should return fewer rows than scenario B (late-mat disabled)",
+            totalRowsA < totalRowsBLateMat
+        );
+    }
+
     // --- Helpers ---
 
     private List<Page> readAllPages(ParquetFormatReader reader, StorageObject storageObject) throws IOException {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderCorrectnessTests.java
@@ -150,6 +150,139 @@ public class PageColumnReaderCorrectnessTests extends ESTestCase {
         assertReadersMatch(ParquetProperties.WriterVersion.PARQUET_2_0, CompressionCodecName.LZ4_RAW);
     }
 
+    // --- filterBlock tests ---
+
+    public void testFilterBlockLong() {
+        long[] values = { 10, 20, 30, 40, 50 };
+        Block source = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        int[] positions = { 1, 3 };
+        Block result = PageColumnReader.filterBlock(source, positions, positions.length, blockFactory);
+        try {
+            assertEquals(2, result.getPositionCount());
+            LongBlock lb = (LongBlock) result;
+            assertEquals(20L, lb.getLong(0));
+            assertEquals(40L, lb.getLong(1));
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testFilterBlockInt() {
+        int[] values = { 1, 2, 3, 4 };
+        Block source = blockFactory.newIntArrayVector(values, values.length).asBlock();
+        int[] positions = { 0, 2, 3 };
+        Block result = PageColumnReader.filterBlock(source, positions, positions.length, blockFactory);
+        try {
+            assertEquals(3, result.getPositionCount());
+            IntBlock ib = (IntBlock) result;
+            assertEquals(1, ib.getInt(0));
+            assertEquals(3, ib.getInt(1));
+            assertEquals(4, ib.getInt(2));
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testFilterBlockDouble() {
+        double[] values = { 1.1, 2.2, 3.3, 4.4 };
+        Block source = blockFactory.newDoubleArrayVector(values, values.length).asBlock();
+        int[] positions = { 0, 3 };
+        Block result = PageColumnReader.filterBlock(source, positions, positions.length, blockFactory);
+        try {
+            assertEquals(2, result.getPositionCount());
+            DoubleBlock db = (DoubleBlock) result;
+            assertEquals(1.1, db.getDouble(0), 0.0);
+            assertEquals(4.4, db.getDouble(1), 0.0);
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testFilterBlockBoolean() {
+        boolean[] values = { true, false, true, false, true };
+        Block source = blockFactory.newBooleanArrayVector(values, values.length).asBlock();
+        int[] positions = { 1, 2, 4 };
+        Block result = PageColumnReader.filterBlock(source, positions, positions.length, blockFactory);
+        try {
+            assertEquals(3, result.getPositionCount());
+            BooleanBlock bb = (BooleanBlock) result;
+            assertFalse(bb.getBoolean(0));
+            assertTrue(bb.getBoolean(1));
+            assertTrue(bb.getBoolean(2));
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testFilterBlockBytesRef() {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("alpha"));
+            builder.appendBytesRef(new BytesRef("beta"));
+            builder.appendBytesRef(new BytesRef("gamma"));
+            builder.appendBytesRef(new BytesRef("delta"));
+            Block source = builder.build();
+            int[] positions = { 1, 3 };
+            Block result = PageColumnReader.filterBlock(source, positions, positions.length, blockFactory);
+            try {
+                assertEquals(2, result.getPositionCount());
+                BytesRefBlock brb = (BytesRefBlock) result;
+                assertEquals(new BytesRef("beta"), brb.getBytesRef(0, new BytesRef()));
+                assertEquals(new BytesRef("delta"), brb.getBytesRef(1, new BytesRef()));
+            } finally {
+                result.close();
+            }
+        }
+    }
+
+    public void testFilterBlockWithNulls() {
+        try (var builder = blockFactory.newLongBlockBuilder(5)) {
+            builder.appendLong(10);
+            builder.appendNull();
+            builder.appendLong(30);
+            builder.appendNull();
+            builder.appendLong(50);
+            Block source = builder.build();
+            int[] positions = { 0, 1, 3 };
+            Block result = PageColumnReader.filterBlock(source, positions, positions.length, blockFactory);
+            try {
+                assertEquals(3, result.getPositionCount());
+                assertFalse(result.isNull(0));
+                assertTrue(result.isNull(1));
+                assertTrue(result.isNull(2));
+                LongBlock lb = (LongBlock) result;
+                assertEquals(10L, lb.getLong(0));
+            } finally {
+                result.close();
+            }
+        }
+    }
+
+    public void testFilterBlockAllPositions() {
+        long[] values = { 10, 20, 30 };
+        Block source = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        int[] positions = { 0, 1, 2 };
+        Block result = PageColumnReader.filterBlock(source, positions, positions.length, blockFactory);
+        try {
+            // when all positions are selected, filterBlock returns the source directly
+            assertSame(source, result);
+            assertEquals(3, result.getPositionCount());
+        } finally {
+            result.close();
+        }
+    }
+
+    public void testFilterBlockNoPositions() {
+        long[] values = { 10, 20, 30 };
+        Block source = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        int[] positions = {};
+        Block result = PageColumnReader.filterBlock(source, positions, 0, blockFactory);
+        try {
+            assertEquals(0, result.getPositionCount());
+        } finally {
+            result.close();
+        }
+    }
+
     private void assertReadersMatch(ParquetProperties.WriterVersion version, CompressionCodecName codec) throws IOException {
         byte[] data = writeTestFile(version, codec, SCHEMA, NUM_ROWS, PageColumnReaderCorrectnessTests::populateFixedRow);
         assertOptimizedMatchesBaseline(data, COLUMNS);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
@@ -1,0 +1,562 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
+import org.elasticsearch.xpack.esql.expression.predicate.Range;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
+
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for the evaluateFilter path in {@link ParquetPushedExpressions}, which evaluates
+ * pushed filter expressions against decoded block values to produce a row-survivor mask.
+ */
+public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    // ---- Test 1: All 6 comparison ops with LongBlock ----
+
+    public void testComparisonOpsWithLongBlock() {
+        // Block with values [10, 20, 30, 40, 50]
+        long[] values = { 10L, 20L, 30L, 40L, 50L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        int rowCount = 5;
+        WordMask reusable = new WordMask();
+
+        // Equals: x == 30 -> positions [2]
+        assertSurvivors(
+            new ParquetPushedExpressions(List.of(new Equals(Source.EMPTY, attr("x", DataType.LONG), lit(30L, DataType.LONG), null))),
+            blocks,
+            rowCount,
+            reusable,
+            new int[] { 2 }
+        );
+
+        // NotEquals: x != 30 -> positions [0, 1, 3, 4]
+        assertSurvivors(
+            new ParquetPushedExpressions(List.of(new NotEquals(Source.EMPTY, attr("x", DataType.LONG), lit(30L, DataType.LONG), null))),
+            blocks,
+            rowCount,
+            reusable,
+            new int[] { 0, 1, 3, 4 }
+        );
+
+        // GreaterThan: x > 30 -> positions [3, 4]
+        assertSurvivors(
+            new ParquetPushedExpressions(List.of(new GreaterThan(Source.EMPTY, attr("x", DataType.LONG), lit(30L, DataType.LONG), null))),
+            blocks,
+            rowCount,
+            reusable,
+            new int[] { 3, 4 }
+        );
+
+        // GreaterThanOrEqual: x >= 30 -> positions [2, 3, 4]
+        assertSurvivors(
+            new ParquetPushedExpressions(
+                List.of(new GreaterThanOrEqual(Source.EMPTY, attr("x", DataType.LONG), lit(30L, DataType.LONG), null))
+            ),
+            blocks,
+            rowCount,
+            reusable,
+            new int[] { 2, 3, 4 }
+        );
+
+        // LessThan: x < 30 -> positions [0, 1]
+        assertSurvivors(
+            new ParquetPushedExpressions(List.of(new LessThan(Source.EMPTY, attr("x", DataType.LONG), lit(30L, DataType.LONG), null))),
+            blocks,
+            rowCount,
+            reusable,
+            new int[] { 0, 1 }
+        );
+
+        // LessThanOrEqual: x <= 30 -> positions [0, 1, 2]
+        assertSurvivors(
+            new ParquetPushedExpressions(
+                List.of(new LessThanOrEqual(Source.EMPTY, attr("x", DataType.LONG), lit(30L, DataType.LONG), null))
+            ),
+            blocks,
+            rowCount,
+            reusable,
+            new int[] { 0, 1, 2 }
+        );
+    }
+
+    // ---- Test 2: Equals across all 5 block types ----
+
+    public void testEqualsWithIntBlock() {
+        int[] values = { 1, 2, 3, 4 };
+        Block block = blockFactory.newIntArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("i", block);
+        WordMask reusable = new WordMask();
+
+        assertSurvivors(
+            new ParquetPushedExpressions(List.of(new Equals(Source.EMPTY, attr("i", DataType.INTEGER), lit(3, DataType.INTEGER), null))),
+            blocks,
+            4,
+            reusable,
+            new int[] { 2 }
+        );
+    }
+
+    public void testEqualsWithLongBlock() {
+        long[] values = { 100L, 200L, 300L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("l", block);
+        WordMask reusable = new WordMask();
+
+        assertSurvivors(
+            new ParquetPushedExpressions(List.of(new Equals(Source.EMPTY, attr("l", DataType.LONG), lit(200L, DataType.LONG), null))),
+            blocks,
+            3,
+            reusable,
+            new int[] { 1 }
+        );
+    }
+
+    public void testEqualsWithDoubleBlock() {
+        double[] values = { 1.1, 2.2, 3.3 };
+        Block block = blockFactory.newDoubleArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("d", block);
+        WordMask reusable = new WordMask();
+
+        assertSurvivors(
+            new ParquetPushedExpressions(List.of(new Equals(Source.EMPTY, attr("d", DataType.DOUBLE), lit(2.2, DataType.DOUBLE), null))),
+            blocks,
+            3,
+            reusable,
+            new int[] { 1 }
+        );
+    }
+
+    public void testEqualsWithBytesRefBlock() {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("foo"));
+            builder.appendBytesRef(new BytesRef("bar"));
+            builder.appendBytesRef(new BytesRef("baz"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            assertSurvivors(
+                new ParquetPushedExpressions(
+                    List.of(new Equals(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("bar"), DataType.KEYWORD), null))
+                ),
+                blocks,
+                3,
+                reusable,
+                new int[] { 1 }
+            );
+        }
+    }
+
+    public void testEqualsWithBooleanBlock() {
+        boolean[] values = { true, false, true, false };
+        Block block = blockFactory.newBooleanArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("b", block);
+        WordMask reusable = new WordMask();
+
+        assertSurvivors(
+            new ParquetPushedExpressions(
+                List.of(new Equals(Source.EMPTY, attr("b", DataType.BOOLEAN), lit(false, DataType.BOOLEAN), null))
+            ),
+            blocks,
+            4,
+            reusable,
+            new int[] { 1, 3 }
+        );
+    }
+
+    // ---- Test 3: IsNull / IsNotNull ----
+
+    public void testIsNullAndIsNotNull() {
+        // Block: [10, null, 30, null, 50]
+        try (var builder = blockFactory.newLongBlockBuilder(5)) {
+            builder.appendLong(10L);
+            builder.appendNull();
+            builder.appendLong(30L);
+            builder.appendNull();
+            builder.appendLong(50L);
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("x", block);
+            WordMask reusable = new WordMask();
+            int rowCount = 5;
+
+            // IS NULL -> positions [1, 3]
+            assertSurvivors(
+                new ParquetPushedExpressions(List.of(new IsNull(Source.EMPTY, attr("x", DataType.LONG)))),
+                blocks,
+                rowCount,
+                reusable,
+                new int[] { 1, 3 }
+            );
+
+            // IS NOT NULL -> positions [0, 2, 4]
+            assertSurvivors(
+                new ParquetPushedExpressions(List.of(new IsNotNull(Source.EMPTY, attr("x", DataType.LONG)))),
+                blocks,
+                rowCount,
+                reusable,
+                new int[] { 0, 2, 4 }
+            );
+        }
+    }
+
+    // ---- Test 4: In expression ----
+
+    public void testInExpression() {
+        // Block: [1, 2, 3, 4, 5]
+        long[] values = { 1L, 2L, 3L, 4L, 5L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        // IN(2, 4) -> positions [1, 3]
+        Expression inExpr = new In(Source.EMPTY, attr("x", DataType.LONG), List.of(lit(2L, DataType.LONG), lit(4L, DataType.LONG)));
+        assertSurvivors(new ParquetPushedExpressions(List.of(inExpr)), blocks, 5, reusable, new int[] { 1, 3 });
+    }
+
+    public void testInExpressionWithNonFoldableItemsReturnsNull() {
+        // When all items are non-foldable (no literal values), evaluateIn returns null
+        // meaning all rows survive (conservative). We simulate this by using a Literal with null value.
+        long[] values = { 1L, 2L, 3L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        // IN with null literal values -> all null foldables -> empty values -> returns null -> all survive
+        Expression inExpr = new In(Source.EMPTY, attr("x", DataType.LONG), List.of(lit(null, DataType.LONG), lit(null, DataType.LONG)));
+        WordMask result = new ParquetPushedExpressions(List.of(inExpr)).evaluateFilter(blocks, 3, reusable);
+        // null return means all rows survive
+        assertNull(result);
+    }
+
+    // ---- Test 5: Range expression ----
+
+    public void testRangeClosedInclusive() {
+        // Block: [5, 10, 15, 20, 25, 30, 35]
+        long[] values = { 5L, 10L, 15L, 20L, 25L, 30L, 35L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        // 10 <= x <= 30 -> positions [1, 2, 3, 4, 5]
+        Expression range = new Range(
+            Source.EMPTY,
+            attr("x", DataType.LONG),
+            lit(10L, DataType.LONG),
+            true,
+            lit(30L, DataType.LONG),
+            true,
+            ZoneOffset.UTC
+        );
+        assertSurvivors(new ParquetPushedExpressions(List.of(range)), blocks, 7, reusable, new int[] { 1, 2, 3, 4, 5 });
+    }
+
+    public void testRangeExclusiveBounds() {
+        // Block: [5, 10, 15, 20, 25, 30, 35]
+        long[] values = { 5L, 10L, 15L, 20L, 25L, 30L, 35L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        // 10 < x < 30 -> positions [2, 3, 4]
+        Expression range = new Range(
+            Source.EMPTY,
+            attr("x", DataType.LONG),
+            lit(10L, DataType.LONG),
+            false,
+            lit(30L, DataType.LONG),
+            false,
+            ZoneOffset.UTC
+        );
+        assertSurvivors(new ParquetPushedExpressions(List.of(range)), blocks, 7, reusable, new int[] { 2, 3, 4 });
+    }
+
+    public void testRangeLowerOnly() {
+        // Block: [5, 10, 15, 20, 25]
+        long[] values = { 5L, 10L, 15L, 20L, 25L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        // x >= 15 (no upper bound) -> the Range needs both bounds for evaluateRange to produce a result.
+        // Range with null upper literal: evaluateRange checks both and returns null if both are null.
+        // With lower=15 inclusive and upper=null, the code returns null since upperBound will be null from buildPredicate.
+        // However, evaluateRange returns null only when BOTH lower and upper are null.
+        // With lower=15 and upper=null: lower is non-null, upper is null, so hasHi=false, which means no upper check.
+        // -> positions [2, 3, 4]
+        Expression range = new Range(
+            Source.EMPTY,
+            attr("x", DataType.LONG),
+            lit(15L, DataType.LONG),
+            true,
+            lit(null, DataType.LONG),
+            true,
+            ZoneOffset.UTC
+        );
+        assertSurvivors(new ParquetPushedExpressions(List.of(range)), blocks, 5, reusable, new int[] { 2, 3, 4 });
+    }
+
+    public void testRangeUpperOnly() {
+        // Block: [5, 10, 15, 20, 25]
+        long[] values = { 5L, 10L, 15L, 20L, 25L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        // x <= 15 -> positions [0, 1, 2]
+        Expression range = new Range(
+            Source.EMPTY,
+            attr("x", DataType.LONG),
+            lit(null, DataType.LONG),
+            true,
+            lit(15L, DataType.LONG),
+            true,
+            ZoneOffset.UTC
+        );
+        assertSurvivors(new ParquetPushedExpressions(List.of(range)), blocks, 5, reusable, new int[] { 0, 1, 2 });
+    }
+
+    // ---- Test 6: And / Or / Not composition ----
+
+    public void testAndComposition() {
+        // Block: [10, 20, 30, 40, 50]
+        long[] values = { 10L, 20L, 30L, 40L, 50L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        // x > 15 AND x < 45 -> positions [1, 2, 3]
+        Expression left = new GreaterThan(Source.EMPTY, attr("x", DataType.LONG), lit(15L, DataType.LONG), null);
+        Expression right = new LessThan(Source.EMPTY, attr("x", DataType.LONG), lit(45L, DataType.LONG), null);
+        Expression and = new And(Source.EMPTY, left, right);
+        assertSurvivors(new ParquetPushedExpressions(List.of(and)), blocks, 5, reusable, new int[] { 1, 2, 3 });
+    }
+
+    public void testOrWithBothArmsEvaluable() {
+        // Block: [10, 20, 30, 40, 50]
+        long[] values = { 10L, 20L, 30L, 40L, 50L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        // x == 10 OR x == 50 -> positions [0, 4]
+        Expression left = new Equals(Source.EMPTY, attr("x", DataType.LONG), lit(10L, DataType.LONG), null);
+        Expression right = new Equals(Source.EMPTY, attr("x", DataType.LONG), lit(50L, DataType.LONG), null);
+        Expression or = new Or(Source.EMPTY, left, right);
+        assertSurvivors(new ParquetPushedExpressions(List.of(or)), blocks, 5, reusable, new int[] { 0, 4 });
+    }
+
+    public void testOrWithOneArmUnevaluableReturnsNull() {
+        // When one arm of OR references a missing column, evaluateExpression returns null for that arm.
+        // The OR then returns null (conservative: all rows survive).
+        long[] values = { 10L, 20L, 30L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        // Only "x" is in blocks, "y" is missing
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        Expression left = new Equals(Source.EMPTY, attr("x", DataType.LONG), lit(10L, DataType.LONG), null);
+        Expression right = new Equals(Source.EMPTY, attr("y", DataType.LONG), lit(99L, DataType.LONG), null);
+        Expression or = new Or(Source.EMPTY, left, right);
+
+        WordMask result = new ParquetPushedExpressions(List.of(or)).evaluateFilter(blocks, 3, reusable);
+        // null return = all rows survive
+        assertNull(result);
+    }
+
+    public void testNotInvertsMask() {
+        // Block: [10, 20, 30, 40, 50]
+        long[] values = { 10L, 20L, 30L, 40L, 50L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        // NOT(x == 30) -> positions [0, 1, 3, 4]
+        Expression inner = new Equals(Source.EMPTY, attr("x", DataType.LONG), lit(30L, DataType.LONG), null);
+        Expression not = new Not(Source.EMPTY, inner);
+        assertSurvivors(new ParquetPushedExpressions(List.of(not)), blocks, 5, reusable, new int[] { 0, 1, 3, 4 });
+    }
+
+    // ---- Test 7: StartsWith ----
+
+    public void testStartsWithBasic() {
+        // Block: ["apple", "application", "banana"]
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendBytesRef(new BytesRef("application"));
+            builder.appendBytesRef(new BytesRef("banana"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            // STARTS_WITH(s, "app") -> positions [0, 1]
+            Expression sw = new StartsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("app"), DataType.KEYWORD));
+            assertSurvivors(new ParquetPushedExpressions(List.of(sw)), blocks, 3, reusable, new int[] { 0, 1 });
+        }
+    }
+
+    public void testStartsWithExactMatch() {
+        // Block: ["hello", "world"]
+        try (var builder = blockFactory.newBytesRefBlockBuilder(2)) {
+            builder.appendBytesRef(new BytesRef("hello"));
+            builder.appendBytesRef(new BytesRef("world"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            // STARTS_WITH(s, "hello") -> position [0]
+            Expression sw = new StartsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("hello"), DataType.KEYWORD));
+            assertSurvivors(new ParquetPushedExpressions(List.of(sw)), blocks, 2, reusable, new int[] { 0 });
+        }
+    }
+
+    public void testStartsWithPrefixLongerThanValue() {
+        // Block: ["hi", "hey"]
+        try (var builder = blockFactory.newBytesRefBlockBuilder(2)) {
+            builder.appendBytesRef(new BytesRef("hi"));
+            builder.appendBytesRef(new BytesRef("hey"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            // STARTS_WITH(s, "hello_world") -> no matches (prefix longer than values)
+            Expression sw = new StartsWith(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("hello_world"), DataType.KEYWORD));
+            assertSurvivors(new ParquetPushedExpressions(List.of(sw)), blocks, 2, reusable, new int[] {});
+        }
+    }
+
+    // ---- Test 8: Missing predicate column (null-constant block) ----
+
+    public void testMissingPredicateColumnWithConstantNullBlock() {
+        // When a predicate column is missing from the file, the reader inserts a constant-null block.
+        // For a comparison like col > 5, all nulls should yield no matches.
+        Block nullBlock = blockFactory.newConstantNullBlock(5);
+        Map<String, Block> blocks = Map.of("col", nullBlock);
+        WordMask reusable = new WordMask();
+
+        // col > 5 on all-null block -> no survivors
+        Expression expr = new GreaterThan(Source.EMPTY, attr("col", DataType.LONG), lit(5L, DataType.LONG), null);
+        assertSurvivors(new ParquetPushedExpressions(List.of(expr)), blocks, 5, reusable, new int[] {});
+    }
+
+    public void testMissingPredicateColumnIsNullWithConstantNullBlock() {
+        // IS NULL on all-null block -> all rows survive
+        Block nullBlock = blockFactory.newConstantNullBlock(4);
+        Map<String, Block> blocks = Map.of("col", nullBlock);
+        WordMask reusable = new WordMask();
+
+        Expression expr = new IsNull(Source.EMPTY, attr("col", DataType.LONG));
+        assertSurvivors(new ParquetPushedExpressions(List.of(expr)), blocks, 4, reusable, new int[] { 0, 1, 2, 3 });
+    }
+
+    public void testMissingPredicateColumnIsNotNullWithConstantNullBlock() {
+        // IS NOT NULL on all-null block -> no rows survive
+        Block nullBlock = blockFactory.newConstantNullBlock(4);
+        Map<String, Block> blocks = Map.of("col", nullBlock);
+        WordMask reusable = new WordMask();
+
+        Expression expr = new IsNotNull(Source.EMPTY, attr("col", DataType.LONG));
+        assertSurvivors(new ParquetPushedExpressions(List.of(expr)), blocks, 4, reusable, new int[] {});
+    }
+
+    public void testMissingPredicateColumnNotInBlockMap() {
+        // When the block is completely absent from the map (null lookup), the evaluator
+        // returns null for that expression, meaning all rows survive (conservative).
+        Map<String, Block> blocks = new HashMap<>();
+        WordMask reusable = new WordMask();
+
+        Expression expr = new GreaterThan(Source.EMPTY, attr("missing", DataType.LONG), lit(5L, DataType.LONG), null);
+        WordMask result = new ParquetPushedExpressions(List.of(expr)).evaluateFilter(blocks, 3, reusable);
+        // null return means all rows survive
+        assertNull(result);
+    }
+
+    // ---- Test: evaluateFilter returns null when all rows survive ----
+
+    public void testEvaluateFilterReturnsNullWhenAllRowsSurvive() {
+        long[] values = { 10L, 20L, 30L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        // x > 0 -> all rows survive
+        Expression expr = new GreaterThan(Source.EMPTY, attr("x", DataType.LONG), lit(0L, DataType.LONG), null);
+        WordMask result = new ParquetPushedExpressions(List.of(expr)).evaluateFilter(blocks, 3, reusable);
+        assertNull(result);
+    }
+
+    // ---- helpers ----
+
+    private static void assertSurvivors(
+        ParquetPushedExpressions pushed,
+        Map<String, Block> blocks,
+        int rowCount,
+        WordMask reusable,
+        int[] expectedPositions
+    ) {
+        WordMask result = pushed.evaluateFilter(blocks, rowCount, reusable);
+        if (expectedPositions.length == rowCount) {
+            // All rows survive: evaluateFilter may return null (optimization)
+            if (result == null) {
+                return;
+            }
+        }
+        if (expectedPositions.length == 0) {
+            assertNotNull("Expected zero survivors but got null (all survive)", result);
+            assertTrue("Expected empty mask but got non-empty", result.isEmpty());
+            return;
+        }
+        assertNotNull("Expected specific survivors but got null (all survive)", result);
+        assertArrayEquals(expectedPositions, result.survivingPositions());
+    }
+
+    private static Attribute attr(String name, DataType type) {
+        return new ReferenceAttribute(Source.EMPTY, name, type);
+    }
+
+    private static Literal lit(Object value, DataType type) {
+        return new Literal(Source.EMPTY, value, type);
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
@@ -11,6 +11,9 @@ import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -19,13 +22,18 @@ import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
 
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Set;
 
 import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
@@ -39,6 +47,14 @@ import static org.hamcrest.Matchers.containsString;
  * schema-aware translation of DATETIME columns across different Parquet physical types.
  */
 public class ParquetPushedExpressionsTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
 
     // --- TIMESTAMP_MILLIS (INT64) ---
 
@@ -277,6 +293,45 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
 
     public void testConvertMillisToPhysicalNoAnnotation() {
         assertEquals(5678L, ParquetPushedExpressions.convertMillisToPhysical(5678L, null));
+    }
+
+    // --- predicateColumnNames tests ---
+
+    public void testPredicateColumnNamesSingleComparison() {
+        Expression expr = new GreaterThan(Source.EMPTY, attr("status", DataType.LONG), lit(200L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+        assertEquals(Set.of("status"), pushed.predicateColumnNames());
+    }
+
+    public void testPredicateColumnNamesAndTwoColumns() {
+        Expression left = new GreaterThan(Source.EMPTY, attr("age", DataType.LONG), lit(18L, DataType.LONG), null);
+        Expression right = new LessThan(Source.EMPTY, attr("score", DataType.LONG), lit(100L, DataType.LONG), null);
+        Expression and = new And(Source.EMPTY, left, right);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(and));
+        assertEquals(Set.of("age", "score"), pushed.predicateColumnNames());
+    }
+
+    public void testPredicateColumnNamesDeduplicated() {
+        Expression expr1 = new GreaterThan(Source.EMPTY, attr("x", DataType.LONG), lit(1L, DataType.LONG), null);
+        Expression expr2 = new LessThan(Source.EMPTY, attr("x", DataType.LONG), lit(10L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr1, expr2));
+        assertEquals(Set.of("x"), pushed.predicateColumnNames());
+    }
+
+    public void testPredicateColumnNamesNestedAndOrNot() {
+        Expression a = new GreaterThan(Source.EMPTY, attr("col_a", DataType.LONG), lit(1L, DataType.LONG), null);
+        Expression b = new LessThan(Source.EMPTY, attr("col_b", DataType.LONG), lit(5L, DataType.LONG), null);
+        Expression c = new Equals(Source.EMPTY, attr("col_c", DataType.LONG), lit(0L, DataType.LONG), null);
+        Expression and = new And(Source.EMPTY, a, b);
+        Expression not = new Not(Source.EMPTY, c);
+        Expression or = new Or(Source.EMPTY, and, not);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(or));
+        assertEquals(Set.of("col_a", "col_b", "col_c"), pushed.predicateColumnNames());
+    }
+
+    public void testPredicateColumnNamesEmpty() {
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of());
+        assertEquals(Set.of(), pushed.predicateColumnNames());
     }
 
     // --- helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskTests.java
@@ -204,4 +204,270 @@ public class WordMaskTests extends ESTestCase {
         assertThat(positions.length, equalTo(65));
         assertThat(positions[64], equalTo(64));
     }
+
+    /**
+     * AND of two full masks with non-aligned numBits must not leak trailing bits.
+     * If maskTrailingBits() were missing from and(), the trailing bits in the last word
+     * could survive the operation and corrupt popCount/isAll/survivingPositions.
+     */
+    public void testAndMasksTrailingBits() {
+        int numBits = 70; // 1 full word (64) + 6 bits in the second word
+
+        // Both masks fully set: AND should produce a full mask of exactly 70 bits
+        WordMask a = new WordMask();
+        a.setAll(numBits);
+        WordMask b = new WordMask();
+        b.setAll(numBits);
+
+        a.and(b);
+
+        assertThat("popCount must equal numBits after AND of two full masks", a.popCount(), equalTo(70));
+        assertTrue("isAll must be true after AND of two full masks", a.isAll());
+        assertThat("survivingPositions length must equal numBits", a.survivingPositions().length, equalTo(70));
+
+        // Negate then negate: produces a full mask through two negations.
+        // If AND did not mask trailing bits, the double-negate path could expose the issue.
+        WordMask c = new WordMask();
+        c.setAll(numBits);
+        c.negate(); // all zeros within numBits
+        c.negate(); // back to all ones within numBits
+
+        WordMask d = new WordMask();
+        d.setAll(numBits);
+
+        c.and(d);
+        assertThat("popCount after double-negate then AND", c.popCount(), equalTo(70));
+        assertTrue("isAll after double-negate then AND", c.isAll());
+    }
+
+    /**
+     * OR of two masks with non-aligned numBits must not propagate trailing bits.
+     */
+    public void testOrMasksTrailingBits() {
+        int numBits = 70;
+
+        // OR of a full mask with an empty mask should produce exactly numBits set bits
+        WordMask a = new WordMask();
+        a.setAll(numBits);
+        WordMask b = new WordMask();
+        b.reset(numBits);
+
+        a.or(b);
+        assertThat("popCount must equal numBits after OR with empty mask", a.popCount(), equalTo(70));
+        assertTrue("isAll must be true after OR full with empty", a.isAll());
+
+        // OR of two partial masks: set different bits, verify no trailing bit leakage
+        WordMask c = new WordMask();
+        c.reset(numBits);
+        c.set(0);
+        c.set(69); // last valid bit
+
+        WordMask d = new WordMask();
+        d.reset(numBits);
+        d.set(63);
+        d.set(64);
+
+        c.or(d);
+        assertThat("popCount after OR of two sparse masks", c.popCount(), equalTo(4));
+        assertThat(c.survivingPositions(), equalTo(new int[] { 0, 63, 64, 69 }));
+
+        // OR of two negated masks: negate introduces risk of trailing bits
+        WordMask e = new WordMask();
+        e.reset(numBits);
+        e.set(0);
+        e.negate(); // bits 1..69 set
+        WordMask f = new WordMask();
+        f.reset(numBits);
+        f.set(1);
+        f.negate(); // bits 0, 2..69 set
+
+        e.or(f); // should be all 70 bits set
+        assertThat("popCount after OR of two negated masks", e.popCount(), equalTo(70));
+        assertTrue("isAll after OR of two negated masks", e.isAll());
+    }
+
+    /**
+     * Negate with non-aligned numBits must keep trailing bits clean.
+     */
+    public void testNegateMasksTrailingBits() {
+        int numBits = 70;
+
+        // Negate an empty mask: should produce exactly numBits set bits
+        WordMask mask = new WordMask();
+        mask.reset(numBits);
+        mask.negate();
+        assertThat("popCount after negating empty mask", mask.popCount(), equalTo(70));
+        assertTrue("isAll after negating empty mask", mask.isAll());
+        assertThat("survivingPositions length after negating empty mask", mask.survivingPositions().length, equalTo(70));
+
+        // Negate a full mask: should produce zero set bits
+        WordMask full = new WordMask();
+        full.setAll(numBits);
+        full.negate();
+        assertThat("popCount after negating full mask", full.popCount(), equalTo(0));
+        assertTrue("isEmpty after negating full mask", full.isEmpty());
+        assertThat("survivingPositions after negating full mask", full.survivingPositions().length, equalTo(0));
+
+        // Double negate should restore the original mask
+        WordMask orig = new WordMask();
+        orig.reset(numBits);
+        orig.set(5);
+        orig.set(65);
+        orig.negate();
+        orig.negate();
+        assertTrue(orig.get(5));
+        assertTrue(orig.get(65));
+        assertThat(orig.popCount(), equalTo(2));
+    }
+
+    /**
+     * Verify popCount accuracy across word boundaries with known bit patterns.
+     */
+    public void testPopCountAccuracy() {
+        // 200 bits = 3 full words + 8 bits in the 4th word
+        int numBits = 200;
+        WordMask mask = new WordMask();
+        mask.reset(numBits);
+
+        // Set one bit per word boundary region
+        mask.set(0);    // first bit of word 0
+        mask.set(63);   // last bit of word 0
+        mask.set(64);   // first bit of word 1
+        mask.set(127);  // last bit of word 1
+        mask.set(128);  // first bit of word 2
+        mask.set(191);  // last bit of word 2
+        mask.set(192);  // first bit of word 3
+        mask.set(199);  // last valid bit
+        assertThat(mask.popCount(), equalTo(8));
+
+        // Set all bits and verify
+        mask.setAll(numBits);
+        assertThat(mask.popCount(), equalTo(200));
+
+        // Non-aligned: 100 bits = 1 full word + 36 bits
+        WordMask mask2 = new WordMask();
+        mask2.reset(100);
+        for (int i = 0; i < 100; i += 2) {
+            mask2.set(i); // set even bits
+        }
+        assertThat("50 even bits in range [0,100)", mask2.popCount(), equalTo(50));
+    }
+
+    /**
+     * Verify survivingPositions returns correct indices in ascending order for specific bit patterns.
+     */
+    public void testSurvivingPositionsSpecificBits() {
+        int numBits = 130; // 2 full words + 2 bits
+        WordMask mask = new WordMask();
+        mask.reset(numBits);
+
+        // Set bits at word boundaries and in the trailing partial word
+        mask.set(0);
+        mask.set(1);
+        mask.set(62);
+        mask.set(63);
+        mask.set(64);
+        mask.set(65);
+        mask.set(126);
+        mask.set(127);
+        mask.set(128);
+        mask.set(129);
+
+        int[] positions = mask.survivingPositions();
+        assertThat(positions, equalTo(new int[] { 0, 1, 62, 63, 64, 65, 126, 127, 128, 129 }));
+
+        // Negate and verify surviving positions are the complement
+        mask.negate();
+        int[] negPositions = mask.survivingPositions();
+        assertThat("negated mask should have numBits - original count bits", negPositions.length, equalTo(130 - 10));
+        // First few positions after negate: 2, 3, 4, ...
+        assertThat(negPositions[0], equalTo(2));
+        assertThat(negPositions[1], equalTo(3));
+    }
+
+    /**
+     * isAll must return true only when exactly all numBits bits are set,
+     * and must not be fooled by trailing bits beyond numBits.
+     */
+    public void testIsAllWithNonAlignedBits() {
+        int numBits = 70;
+
+        // A mask with all 70 bits set
+        WordMask full = new WordMask();
+        full.setAll(numBits);
+        assertTrue("setAll(70) must produce isAll=true", full.isAll());
+
+        // Clear one bit: isAll must be false
+        full.clear(69);
+        assertFalse("clearing last valid bit must make isAll false", full.isAll());
+
+        // Reset and set only bits 0..68 (missing bit 69): isAll must be false
+        WordMask partial = new WordMask();
+        partial.reset(numBits);
+        for (int i = 0; i < 69; i++) {
+            partial.set(i);
+        }
+        assertFalse("missing bit 69 means isAll must be false", partial.isAll());
+
+        // Zero-bit mask: isAll is vacuously true
+        WordMask zero = new WordMask();
+        zero.reset(0);
+        assertTrue("zero-bit mask is vacuously all-set", zero.isAll());
+    }
+
+    /**
+     * setAll sets exactly n bits and reset clears all bits.
+     */
+    public void testSetAllAndReset() {
+        WordMask mask = new WordMask();
+
+        // setAll with non-aligned size
+        mask.setAll(70);
+        assertThat(mask.popCount(), equalTo(70));
+        assertTrue(mask.isAll());
+        for (int i = 0; i < 70; i++) {
+            assertTrue("bit " + i + " should be set", mask.get(i));
+        }
+
+        // reset should clear everything
+        mask.reset(70);
+        assertThat(mask.popCount(), equalTo(0));
+        assertTrue(mask.isEmpty());
+        for (int i = 0; i < 70; i++) {
+            assertFalse("bit " + i + " should be clear after reset", mask.get(i));
+        }
+
+        // setAll with word-aligned size
+        mask.setAll(128);
+        assertThat(mask.popCount(), equalTo(128));
+        assertTrue(mask.isAll());
+
+        // setAll with small non-aligned size
+        mask.setAll(1);
+        assertThat(mask.popCount(), equalTo(1));
+        assertTrue(mask.isAll());
+        assertTrue(mask.get(0));
+
+        // setAll with zero
+        mask.setAll(0);
+        assertThat(mask.popCount(), equalTo(0));
+        assertTrue(mask.isAll());
+        assertTrue(mask.isEmpty());
+    }
+
+    /**
+     * and() and or() must throw IllegalArgumentException when mask sizes differ.
+     */
+    public void testAndOrWithMismatchedSizes() {
+        WordMask a = new WordMask();
+        a.reset(64);
+        WordMask b = new WordMask();
+        b.reset(128);
+
+        IllegalArgumentException andEx = expectThrows(IllegalArgumentException.class, () -> a.and(b));
+        assertTrue(andEx.getMessage().contains("numBits mismatch"));
+
+        IllegalArgumentException orEx = expectThrows(IllegalArgumentException.class, () -> a.or(b));
+        assertTrue(orEx.getMessage().contains("numBits mismatch"));
+    }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskTests.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class WordMaskTests extends ESTestCase {
+
+    public void testClearBit() {
+        WordMask mask = new WordMask();
+        mask.reset(128);
+        mask.set(10);
+        mask.set(42);
+        mask.set(100);
+        assertTrue(mask.get(42));
+
+        mask.clear(42);
+        assertFalse(mask.get(42));
+        // other bits remain unchanged
+        assertTrue(mask.get(10));
+        assertTrue(mask.get(100));
+    }
+
+    public void testSetAll() {
+        WordMask mask = new WordMask();
+        mask.setAll(128);
+        for (int i = 0; i < 128; i++) {
+            assertTrue("bit " + i + " should be set", mask.get(i));
+        }
+        assertThat(mask.popCount(), equalTo(128));
+    }
+
+    public void testPopCount() {
+        WordMask mask = new WordMask();
+        mask.reset(256);
+        assertThat(mask.popCount(), equalTo(0));
+
+        mask.set(0);
+        mask.set(63);
+        mask.set(64);
+        mask.set(127);
+        mask.set(200);
+        assertThat(mask.popCount(), equalTo(5));
+
+        // full mask
+        WordMask full = new WordMask();
+        full.setAll(256);
+        assertThat(full.popCount(), equalTo(256));
+    }
+
+    public void testIsAll() {
+        WordMask mask = new WordMask();
+        mask.setAll(128);
+        assertTrue(mask.isAll());
+
+        mask.clear(64);
+        assertFalse(mask.isAll());
+
+        // empty mask (all zeros)
+        WordMask empty = new WordMask();
+        empty.reset(128);
+        assertFalse(empty.isAll());
+    }
+
+    public void testAnd() {
+        WordMask a = new WordMask();
+        a.reset(128);
+        a.set(1);
+        a.set(2);
+        a.set(3);
+        a.set(100);
+
+        WordMask b = new WordMask();
+        b.reset(128);
+        b.set(2);
+        b.set(3);
+        b.set(4);
+        b.set(100);
+
+        a.and(b);
+
+        assertFalse(a.get(1));
+        assertTrue(a.get(2));
+        assertTrue(a.get(3));
+        assertFalse(a.get(4));
+        assertTrue(a.get(100));
+        assertThat(a.popCount(), equalTo(3));
+    }
+
+    public void testOr() {
+        WordMask a = new WordMask();
+        a.reset(128);
+        a.set(1);
+        a.set(2);
+
+        WordMask b = new WordMask();
+        b.reset(128);
+        b.set(2);
+        b.set(3);
+        b.set(100);
+
+        a.or(b);
+
+        assertTrue(a.get(1));
+        assertTrue(a.get(2));
+        assertTrue(a.get(3));
+        assertTrue(a.get(100));
+        assertThat(a.popCount(), equalTo(4));
+    }
+
+    public void testNegate() {
+        WordMask mask = new WordMask();
+        mask.reset(128);
+        mask.set(0);
+        mask.set(10);
+        mask.set(127);
+
+        mask.negate();
+
+        assertFalse(mask.get(0));
+        assertFalse(mask.get(10));
+        assertFalse(mask.get(127));
+        assertTrue(mask.get(1));
+        assertTrue(mask.get(50));
+        assertTrue(mask.get(126));
+        assertThat(mask.popCount(), equalTo(128 - 3));
+    }
+
+    public void testSurvivingPositions() {
+        WordMask mask = new WordMask();
+        mask.reset(256);
+        mask.set(0);
+        mask.set(5);
+        mask.set(63);
+        mask.set(64);
+        mask.set(200);
+
+        int[] positions = mask.survivingPositions();
+        assertThat(positions, equalTo(new int[] { 0, 5, 63, 64, 200 }));
+    }
+
+    public void testSurvivingPositionsEmpty() {
+        WordMask mask = new WordMask();
+        mask.reset(128);
+
+        int[] positions = mask.survivingPositions();
+        assertThat(positions.length, equalTo(0));
+    }
+
+    public void testSurvivingPositionsFull() {
+        WordMask mask = new WordMask();
+        int n = 130;
+        mask.setAll(n);
+
+        int[] positions = mask.survivingPositions();
+        assertThat(positions.length, equalTo(n));
+        for (int i = 0; i < n; i++) {
+            assertThat("position at index " + i, positions[i], equalTo(i));
+        }
+    }
+
+    public void testTrailingBits() {
+        // numBits=65 is not word-aligned: 1 full word (64 bits) + 1 bit in second word
+        int numBits = 65;
+
+        // setAll should set exactly 65 bits
+        WordMask mask = new WordMask();
+        mask.setAll(numBits);
+        assertThat(mask.popCount(), equalTo(65));
+        assertTrue(mask.isAll());
+
+        // verify bit 64 (the lone bit in the second word) is set
+        assertTrue(mask.get(64));
+
+        // clear the trailing bit and verify isAll becomes false
+        mask.clear(64);
+        assertFalse(mask.isAll());
+        assertThat(mask.popCount(), equalTo(64));
+
+        // negate on a non-word-aligned mask
+        WordMask negMask = new WordMask();
+        negMask.reset(numBits);
+        negMask.set(0);
+        negMask.set(64);
+        negMask.negate();
+        // after negate, bits 0 and 64 should be clear, all others set
+        assertFalse(negMask.get(0));
+        assertFalse(negMask.get(64));
+        assertTrue(negMask.get(1));
+        assertTrue(negMask.get(63));
+        assertThat(negMask.popCount(), equalTo(63));
+
+        // survivingPositions on non-word-aligned full mask
+        WordMask fullMask = new WordMask();
+        fullMask.setAll(numBits);
+        int[] positions = fullMask.survivingPositions();
+        assertThat(positions.length, equalTo(65));
+        assertThat(positions[64], equalTo(64));
+    }
+}


### PR DESCRIPTION
## Summary

Three-phase decode pipeline in `OptimizedParquetColumnIterator`: decode predicate columns first, evaluate pushed filter to produce a survivor mask (`WordMask`), then decode projection-only columns for surviving rows only. When zero rows survive a batch, projection columns are skipped entirely (no decompress, no decode).

Enabled by default. Auto-disables when predicate columns are ≥50% of total projected bytes. Can be toggled per-query: `WITH { "late_materialization": false }`.

### Changes

- **WordMask** — extended with `popCount`, `and`/`or`/`negate`, `survivingPositions()` for reusable batch-level bitmask operations
- **ParquetPushedExpressions** — `predicateColumnNames()` for column classification, `evaluateFilter()` for block-level predicate evaluation producing a `WordMask` survivor mask
- **PageColumnReader** — `filterBlock()` (static, delegates to `Block.filter()`) and `readBatchFiltered()` for conditional decode-or-skip
- **OptimizedParquetColumnIterator** — three-phase `nextWithLateMaterialization()` pipeline with predicate byte ratio heuristic
- **ParquetFormatReader** — `computePredicateColumnByteRatio()` cost heuristic, `late_materialization` config flag

Developed with AI-assisted tooling