### PR TITLE
ESQL: Eliminate redundant S3 HEAD calls via suffix range and object reuse

### DIFF
--- a/docs/changelog/147962.yaml
+++ b/docs/changelog/147962.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147962
+summary: Eliminate redundant S3 HEAD calls via suffix range and object reuse
+type: enhancement

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -29,12 +29,14 @@ import org.elasticsearch.logging.Logger;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.fixture.HttpHeaderParser;
+import org.elasticsearch.test.fixture.RequestEntry;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -47,6 +49,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -77,6 +80,7 @@ public class S3HttpHandler implements HttpHandler {
     private final ConcurrentMap<String, BytesReference> blobs = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, MultipartUpload> uploads = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, AtomicInteger> completingUploads = new ConcurrentHashMap<>();
+    private final List<RequestEntry> requestLog = new CopyOnWriteArrayList<>();
 
     public S3HttpHandler(final String bucket, S3ConsistencyModel consistencyModel) {
         this(bucket, null, consistencyModel);
@@ -107,11 +111,18 @@ public class S3HttpHandler implements HttpHandler {
      */
     public static final String DEFAULT_LIST_OBJECT_LAST_MODIFIED = "1970-01-01T00:00:00.000Z";
 
+    public List<RequestEntry> requestLog() {
+        return Collections.unmodifiableList(requestLog);
+    }
+
     @Override
     public void handle(final HttpExchange exchange) throws IOException {
         // Remove custom query parameters before processing the request. This simulates how S3 ignores them.
         // https://docs.aws.amazon.com/AmazonS3/latest/userguide/LogFormat.html#LogFormatCustom
         final S3Request request = parseRequest(exchange);
+        requestLog.add(
+            new RequestEntry(System.nanoTime(), request.method(), request.path(), exchange.getRequestHeaders().getFirst("Range"))
+        );
 
         if (METHODS_HAVING_NO_REQUEST_BODY.contains(request.method())) {
             int read = exchange.getRequestBody().read();

--- a/test/framework/src/main/java/org/elasticsearch/test/fixture/RequestCapture.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/fixture/RequestCapture.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.fixture;
+
+import org.elasticsearch.core.Nullable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Snapshot-based capture over a fixture's request log. Create before an action, inspect after.
+ * Path-based filtering isolates concurrent test traffic naturally.
+ */
+public final class RequestCapture {
+    private final List<RequestEntry> log;
+    private final int startIndex;
+    @Nullable
+    private final String pathContains;
+
+    private RequestCapture(List<RequestEntry> log, int startIndex, @Nullable String pathContains) {
+        this.log = log;
+        this.startIndex = startIndex;
+        this.pathContains = pathContains;
+    }
+
+    public static RequestCapture start(List<RequestEntry> log, @Nullable String pathContains) {
+        return new RequestCapture(log, log.size(), pathContains);
+    }
+
+    public static RequestCapture start(List<RequestEntry> log) {
+        return start(log, null);
+    }
+
+    public List<RequestEntry> captured() {
+        int end = log.size();
+        if (end <= startIndex) {
+            return List.of();
+        }
+        return log.subList(startIndex, end).stream().filter(e -> pathContains == null || e.path().contains(pathContains)).toList();
+    }
+
+    public long count(String method) {
+        return captured().stream().filter(e -> e.method().equals(method)).count();
+    }
+
+    public long countHeads() {
+        return count("HEAD");
+    }
+
+    public long countGets() {
+        return count("GET");
+    }
+
+    public long countSuffixRangeGets() {
+        return captured().stream().filter(e -> "GET".equals(e.method()) && e.range() != null && e.range().startsWith("bytes=-")).count();
+    }
+
+    public String dump() {
+        return captured().stream()
+            .map(e -> e.method() + " " + e.path() + (e.range() != null ? " [" + e.range() + "]" : ""))
+            .collect(Collectors.joining("\n"));
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/fixture/RequestEntry.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/fixture/RequestEntry.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.fixture;
+
+import org.elasticsearch.core.Nullable;
+
+/**
+ * A recorded HTTP request from a test fixture handler, for verifying I/O patterns.
+ */
+public record RequestEntry(long timestampNanos, String method, String path, @Nullable String range) {}

--- a/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
+++ b/x-pack/plugin/esql-datasource-s3/src/main/java/org/elasticsearch/xpack/esql/datasource/s3/S3StorageObject.java
@@ -188,6 +188,44 @@ public final class S3StorageObject implements StorageObject {
 
     private void fetchMetadata() throws IOException {
         try {
+            // Suffix range: bytes=-1 returns the last byte + Content-Range with total size.
+            // Avoids a separate HEAD request for file size discovery.
+            GetObjectRequest request = GetObjectRequest.builder().bucket(bucket).key(key).range("bytes=-1").build();
+            try (var response = s3Client.getObject(request)) {
+                // Drain the 1-byte body so the HTTP connection returns to the pool
+                // instead of being aborted on close.
+                response.readAllBytes();
+                GetObjectResponse metadata = response.response();
+                cachedExists = true;
+                cachedLastModified = metadata.lastModified();
+                Long total = ContentRangeParser.parseTotalLength(metadata.contentRange());
+                if (total != null) {
+                    cachedLength = total;
+                    return;
+                }
+            }
+            // Content-Range missing (unexpected for S3) — fall back to HEAD for length
+            fetchMetadataViaHead();
+        } catch (NoSuchKeyException e) {
+            setNotFound();
+        } catch (S3Exception e) {
+            if (e.statusCode() == 416) {
+                // 416 Range Not Satisfiable: object exists but is empty (0 bytes)
+                cachedExists = true;
+                cachedLength = 0L;
+            } else if (e.statusCode() == 403) {
+                // GET denied — try the existing bytes=0-0 fallback which extracts
+                // size from Content-Range; HEAD uses the same s3:GetObject permission
+                // so would also be denied.
+                fetchMetadataViaRangeGet();
+            } else {
+                fetchMetadataViaHead();
+            }
+        }
+    }
+
+    private void fetchMetadataViaHead() throws IOException {
+        try {
             HeadObjectRequest request = HeadObjectRequest.builder().bucket(bucket).key(key).build();
             HeadObjectResponse response = s3Client.headObject(request);
 

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3AnonymousAccessTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3AnonymousAccessTests.java
@@ -13,7 +13,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
@@ -89,10 +88,13 @@ public class S3AnonymousAccessTests extends ESTestCase {
     }
 
     /**
-     * When HeadObject returns a non-403 error, it should propagate as IOException
-     * without attempting the range GET fallback.
+     * When the suffix-range GET fails with a non-403 S3 error, falls back to HEAD.
+     * If HEAD also fails, the error propagates as IOException.
      */
     public void testHeadNon403ErrorPropagates() {
+        when(mockS3Client.getObject(any(GetObjectRequest.class))).thenThrow(
+            S3Exception.builder().statusCode(500).message("Internal Server Error").build()
+        );
         when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenThrow(
             S3Exception.builder().statusCode(500).message("Internal Server Error").build()
         );
@@ -104,14 +106,17 @@ public class S3AnonymousAccessTests extends ESTestCase {
     }
 
     /**
-     * When HeadObject succeeds normally, no fallback is needed.
+     * When the suffix-range GET succeeds, metadata is resolved without HEAD.
      */
     public void testHeadSucceedsNormally() throws IOException {
-        HeadObjectResponse headResponse = HeadObjectResponse.builder()
-            .contentLength(OBJECT_SIZE)
+        GetObjectResponse resp = GetObjectResponse.builder()
+            .contentRange("bytes " + (OBJECT_SIZE - 1) + "-" + (OBJECT_SIZE - 1) + "/" + OBJECT_SIZE)
+            .contentLength(1L)
             .lastModified(Instant.parse("2026-03-18T12:00:00Z"))
             .build();
-        when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenReturn(headResponse);
+        when(mockS3Client.getObject(any(GetObjectRequest.class))).thenReturn(
+            new ResponseInputStream<>(resp, AbortableInputStream.create(new ByteArrayInputStream(new byte[] { 0 })))
+        );
 
         S3StorageObject obj = new S3StorageObject(mockS3Client, BUCKET, KEY, PATH);
 

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3RequestCountingTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3RequestCountingTests.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.s3;
+
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validates the exact number of S3 HEAD and GET requests made for metadata discovery.
+ * Establishes baseline call counts, then verifies improvements after optimization.
+ */
+public class S3RequestCountingTests extends ESTestCase {
+
+    private static final String BUCKET = "test-bucket";
+    private static final String KEY = "data/file.parquet";
+    private static final long FILE_SIZE = 100_000L;
+    private static final StoragePath PATH = StoragePath.of("s3://" + BUCKET + "/" + KEY);
+    private static final Instant LAST_MODIFIED = Instant.parse("2026-01-01T00:00:00Z");
+
+    private final S3Client mockS3 = mock(S3Client.class);
+
+    private void stubHeadResponse() {
+        when(mockS3.headObject(any(HeadObjectRequest.class))).thenReturn(
+            HeadObjectResponse.builder().contentLength(FILE_SIZE).lastModified(LAST_MODIFIED).build()
+        );
+    }
+
+    private void stubSuffixRangeResponse() {
+        GetObjectResponse resp = GetObjectResponse.builder()
+            .contentRange("bytes " + (FILE_SIZE - 1) + "-" + (FILE_SIZE - 1) + "/" + FILE_SIZE)
+            .contentLength(1L)
+            .lastModified(LAST_MODIFIED)
+            .build();
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenReturn(
+            new ResponseInputStream<>(resp, AbortableInputStream.create(new ByteArrayInputStream(new byte[] { 0 })))
+        );
+    }
+
+    /**
+     * After optimization: length() uses suffix-range GET instead of HEAD.
+     */
+    public void testLengthTriggersOneSuffixRangeGet() throws IOException {
+        stubSuffixRangeResponse();
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+
+        long length = obj.length();
+
+        assertEquals(FILE_SIZE, length);
+        verify(mockS3, never()).headObject(any(HeadObjectRequest.class));
+        verify(mockS3, times(1)).getObject(any(GetObjectRequest.class));
+    }
+
+    /**
+     * Calling length() twice should use the cached value (no second request).
+     */
+    public void testLengthCachesAfterFirstCall() throws IOException {
+        stubSuffixRangeResponse();
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+
+        obj.length();
+        obj.length();
+
+        verify(mockS3, times(1)).getObject(any(GetObjectRequest.class));
+    }
+
+    /**
+     * Creating S3StorageObject with pre-known length should make ZERO requests.
+     */
+    public void testPreKnownLengthSkipsHead() throws IOException {
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH, FILE_SIZE);
+
+        long length = obj.length();
+
+        assertEquals(FILE_SIZE, length);
+        verify(mockS3, never()).headObject(any(HeadObjectRequest.class));
+        verify(mockS3, never()).getObject(any(GetObjectRequest.class));
+    }
+
+    /**
+     * The fix: using the SAME object for exists() and length() needs only ONE suffix-range GET.
+     */
+    public void testSameObjectExistsThenLengthCausesOneRequest() throws IOException {
+        stubSuffixRangeResponse();
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        assertTrue(obj.exists());
+        long length = obj.length();
+
+        assertEquals(FILE_SIZE, length);
+        verify(mockS3, never()).headObject(any(HeadObjectRequest.class));
+        verify(mockS3, times(1)).getObject(any(GetObjectRequest.class));
+    }
+
+    /**
+     * Documents the anti-pattern fixed by the GlobExpander collapse: using two separate
+     * S3StorageObject instances for exists() and length() wastes a request because
+     * metadata is not shared across objects. See GlobExpander change in this PR.
+     */
+    public void testExistsThenNewObjectCausesTwoRequests() throws IOException {
+        stubSuffixRangeResponse();
+
+        S3StorageObject existsObj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        assertTrue(existsObj.exists());
+
+        S3StorageObject readObj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        long length = readObj.length();
+
+        assertEquals(FILE_SIZE, length);
+        verify(mockS3, times(2)).getObject(any(GetObjectRequest.class));
+    }
+
+    /**
+     * When the suffix-range GET fails with a non-403 error, fetchMetadata falls back to HEAD.
+     */
+    public void testSuffixRangeFailureFallsBackToHead() throws IOException {
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenThrow(
+            S3Exception.builder().statusCode(500).message("Internal Server Error").build()
+        );
+        stubHeadResponse();
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        long length = obj.length();
+
+        assertEquals(FILE_SIZE, length);
+        verify(mockS3, times(1)).getObject(any(GetObjectRequest.class));
+        verify(mockS3, times(1)).headObject(any(HeadObjectRequest.class));
+    }
+
+    /**
+     * When the suffix-range GET returns 404 (NoSuchKeyException), the object is marked as not found.
+     */
+    public void testSuffixRangeNotFoundSetsNotFound() throws IOException {
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenThrow(NoSuchKeyException.builder().message("Not Found").build());
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        assertFalse(obj.exists());
+        verify(mockS3, never()).headObject(any(HeadObjectRequest.class));
+    }
+
+    /**
+     * When suffix-range GET returns 403, falls back to bytes=0-0 range GET (not HEAD,
+     * since s3:GetObject covers both GET-range and HEAD — HEAD would also be denied).
+     */
+    public void testSuffixRange403FallsBackToRangeGet() throws IOException {
+        // First call (suffix range) → 403; second call (bytes=0-0) → succeeds with Content-Range
+        GetObjectResponse rangeResp = GetObjectResponse.builder()
+            .contentRange("bytes 0-0/" + FILE_SIZE)
+            .contentLength(1L)
+            .lastModified(LAST_MODIFIED)
+            .build();
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenThrow(
+            S3Exception.builder().statusCode(403).message("Access Denied").build()
+        ).thenReturn(new ResponseInputStream<>(rangeResp, AbortableInputStream.create(new ByteArrayInputStream(new byte[] { 0 }))));
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        long length = obj.length();
+
+        assertEquals(FILE_SIZE, length);
+        verify(mockS3, times(2)).getObject(any(GetObjectRequest.class));
+        verify(mockS3, never()).headObject(any(HeadObjectRequest.class));
+    }
+
+    /**
+     * When suffix-range GET returns 416 (Range Not Satisfiable), the object is empty (0 bytes).
+     * No second request needed — 416 confirms existence with zero length.
+     */
+    public void testSuffixRange416MeansEmptyObject() throws IOException {
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenThrow(
+            S3Exception.builder().statusCode(416).message("Range Not Satisfiable").build()
+        );
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        assertTrue(obj.exists());
+        assertEquals(0L, obj.length());
+        verify(mockS3, times(1)).getObject(any(GetObjectRequest.class));
+        verify(mockS3, never()).headObject(any(HeadObjectRequest.class));
+    }
+
+    /**
+     * When suffix-range GET succeeds but Content-Range is absent (unexpected for S3),
+     * falls back to HEAD for the full metadata.
+     */
+    public void testMissingContentRangeFallsBackToHead() throws IOException {
+        GetObjectResponse noContentRange = GetObjectResponse.builder().contentLength(1L).lastModified(LAST_MODIFIED).build();
+        when(mockS3.getObject(any(GetObjectRequest.class))).thenReturn(
+            new ResponseInputStream<>(noContentRange, AbortableInputStream.create(new ByteArrayInputStream(new byte[] { 0 })))
+        );
+        stubHeadResponse();
+
+        S3StorageObject obj = new S3StorageObject(mockS3, BUCKET, KEY, PATH);
+        long length = obj.length();
+
+        assertEquals(FILE_SIZE, length);
+        assertTrue(obj.exists());
+        verify(mockS3, times(1)).getObject(any(GetObjectRequest.class));
+        verify(mockS3, times(1)).headObject(any(HeadObjectRequest.class));
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/glob/GlobExpander.java
@@ -215,8 +215,8 @@ public final class GlobExpander {
                 return FileList.UNRESOLVED;
             }
             // Hints resolved all wildcards to a concrete path — resolve via exists()
-            if (provider.exists(storagePath)) {
-                var obj = provider.newObject(storagePath);
+            var obj = provider.newObject(storagePath);
+            if (obj.exists()) {
                 StorageEntry entry = new StorageEntry(storagePath, obj.length(), obj.lastModified());
                 PartitionMetadata partitionMetadata = detectPartitions(List.of(entry), hivePartitioning, partitionConfig, config);
                 return new GenericFileList(List.of(entry), pattern, partitionMetadata);
@@ -235,8 +235,8 @@ public final class GlobExpander {
                 String prefixStr = prefix.toString();
                 for (String candidate : candidates) {
                     StoragePath fullPath = StoragePath.of(prefixStr + candidate);
-                    if (provider.exists(fullPath)) {
-                        var obj = provider.newObject(fullPath);
+                    var obj = provider.newObject(fullPath);
+                    if (obj.exists()) {
                         matched.add(new StorageEntry(fullPath, obj.length(), obj.lastModified()));
                     }
                     checkDiscoveredFilesLimit(matched.size(), maxDiscoveredFiles);
@@ -389,8 +389,8 @@ public final class GlobExpander {
                     allEntries.addAll(g.files());
                 }
             } else {
-                if (provider.exists(segmentPath)) {
-                    var obj = provider.newObject(segmentPath);
+                var obj = provider.newObject(segmentPath);
+                if (obj.exists()) {
                     allEntries.add(new StorageEntry(segmentPath, obj.length(), obj.lastModified()));
                     checkDiscoveredFilesLimit(allEntries.size(), maxDiscoveredFiles);
                 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/GlobExpanderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/GlobExpanderTests.java
@@ -504,17 +504,17 @@ public class GlobExpanderTests extends ESTestCase {
 
         @Override
         public StorageObject newObject(StoragePath path) {
-            return new StubStorageObject(path);
+            return new StubStorageObject(path, 0, existingPaths.contains(path.toString()));
         }
 
         @Override
         public StorageObject newObject(StoragePath path, long length) {
-            return new StubStorageObject(path, length);
+            return new StubStorageObject(path, length, true);
         }
 
         @Override
         public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
-            return new StubStorageObject(path, length);
+            return new StubStorageObject(path, length, true);
         }
 
         @Override
@@ -557,14 +557,12 @@ public class GlobExpanderTests extends ESTestCase {
     private static class StubStorageObject implements StorageObject {
         private final StoragePath path;
         private final long length;
+        private final boolean exists;
 
-        StubStorageObject(StoragePath path) {
-            this(path, 0);
-        }
-
-        StubStorageObject(StoragePath path, long length) {
+        StubStorageObject(StoragePath path, long length, boolean exists) {
             this.path = path;
             this.length = length;
+            this.exists = exists;
         }
 
         @Override
@@ -589,7 +587,7 @@ public class GlobExpanderTests extends ESTestCase {
 
         @Override
         public boolean exists() {
-            return true;
+            return exists;
         }
 
         @Override


### PR DESCRIPTION
Eliminate redundant S3 HEAD requests during metadata discovery:

S3StorageObject.fetchMetadata() now uses a suffix-range GET
(bytes=-1) instead of HeadObject, extracting the total file
size from the Content-Range response header. This avoids a
dedicated metadata round-trip since the GET also confirms
existence and returns lastModified. Fallback chain: suffix
GET -> HEAD (on non-403 S3 errors) -> bytes=0-0 range GET
(on 403, since s3:GetObject covers both GET and HEAD).
Empty objects (416 on suffix range) are handled without a
second request. The response body is fully drained to
preserve HTTP connection pooling.

GlobExpander collapsed provider.exists(path) + newObject(path)
into newObject(path) + obj.exists() at all three call sites.
The old pattern created two separate S3StorageObject instances
so metadata from the exists check was discarded, causing a
second request when length() was called on the new object.

Also adds request logging infrastructure to the S3 test
fixture (RequestEntry, RequestCapture) for verifiable I/O
assertions. Builds on the suffix-range fixture support from
#147935.

Developed with AI-assisted tooling