### PR TITLE
ES|QL irate: Emit warning for invalid or unsupported temporality

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/IrateDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/IrateDoubleAggregator.java
@@ -27,6 +27,7 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 // end generated imports
@@ -40,9 +41,13 @@ import org.elasticsearch.core.Releasables;
     processNulls = true
 )
 public class IrateDoubleAggregator {
-    public static DoubleIrateGroupingState initGrouping(DriverContext driverContext, boolean isDateNanos) {
+
+    public static final String DELTA_UNSUPPORTED_WARNING =
+        "Some nodes in your cluster don't support delta temporality yet, delta temporality series will be ignored. Upgrade your cluster to fix this.";
+
+    public static DoubleIrateGroupingState initGrouping(DriverContext driverContext, boolean isDateNanos, Warnings warnings) {
         final int dateFactor = isDateNanos ? 1_000_000_000 : 1000;
-        return new DoubleIrateGroupingState(driverContext.bigArrays(), driverContext.breaker(), dateFactor);
+        return new DoubleIrateGroupingState(driverContext.bigArrays(), driverContext.breaker(), dateFactor, warnings);
     }
 
     public static void combine(
@@ -62,10 +67,12 @@ public class IrateDoubleAggregator {
                 current.ensureCapacity(groupId);
                 current.append(groupId, timestamp, value);
             } else {
-                // TODO: emit warning that delta is unsupported on this cluster version
+                current.warnings.registerException(IllegalArgumentException.class, DELTA_UNSUPPORTED_WARNING);
             }
         } catch (InvalidTemporalityException e) {
-            // TODO: emit a warning
+            // We can't use @GroupingAggregator(warnExceptions=..) here because that would require a breaking change to the
+            // intermediate state
+            current.warnings.registerException(e);
         }
     }
 
@@ -109,16 +116,18 @@ public class IrateDoubleAggregator {
     public static final class DoubleIrateGroupingState implements Releasable, Accountable, GroupingAggregatorState {
         private TemporalityAccessor cachedTemporalityAccessor;
         private ObjectArray<DoubleIrateState> states;
+        private final Warnings warnings;
         private final BigArrays bigArrays;
         private final CircuitBreaker breaker;
         private long stateBytes; // for individual states
         private final int dateFactor;
 
-        DoubleIrateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, int dateFactor) {
+        DoubleIrateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, int dateFactor, Warnings warnings) {
             this.bigArrays = bigArrays;
             this.breaker = breaker;
             this.states = bigArrays.newObjectArray(1);
             this.dateFactor = dateFactor;
+            this.warnings = warnings;
         }
 
         void ensureCapacity(int groupId) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/IrateIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/IrateIntAggregator.java
@@ -27,6 +27,7 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 // end generated imports
@@ -40,9 +41,13 @@ import org.elasticsearch.core.Releasables;
     processNulls = true
 )
 public class IrateIntAggregator {
-    public static IntIrateGroupingState initGrouping(DriverContext driverContext, boolean isDateNanos) {
+
+    public static final String DELTA_UNSUPPORTED_WARNING =
+        "Some nodes in your cluster don't support delta temporality yet, delta temporality series will be ignored. Upgrade your cluster to fix this.";
+
+    public static IntIrateGroupingState initGrouping(DriverContext driverContext, boolean isDateNanos, Warnings warnings) {
         final int dateFactor = isDateNanos ? 1_000_000_000 : 1000;
-        return new IntIrateGroupingState(driverContext.bigArrays(), driverContext.breaker(), dateFactor);
+        return new IntIrateGroupingState(driverContext.bigArrays(), driverContext.breaker(), dateFactor, warnings);
     }
 
     public static void combine(
@@ -62,10 +67,12 @@ public class IrateIntAggregator {
                 current.ensureCapacity(groupId);
                 current.append(groupId, timestamp, value);
             } else {
-                // TODO: emit warning that delta is unsupported on this cluster version
+                current.warnings.registerException(IllegalArgumentException.class, DELTA_UNSUPPORTED_WARNING);
             }
         } catch (InvalidTemporalityException e) {
-            // TODO: emit a warning
+            // We can't use @GroupingAggregator(warnExceptions=..) here because that would require a breaking change to the
+            // intermediate state
+            current.warnings.registerException(e);
         }
     }
 
@@ -109,16 +116,18 @@ public class IrateIntAggregator {
     public static final class IntIrateGroupingState implements Releasable, Accountable, GroupingAggregatorState {
         private TemporalityAccessor cachedTemporalityAccessor;
         private ObjectArray<IntIrateState> states;
+        private final Warnings warnings;
         private final BigArrays bigArrays;
         private final CircuitBreaker breaker;
         private long stateBytes; // for individual states
         private final int dateFactor;
 
-        IntIrateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, int dateFactor) {
+        IntIrateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, int dateFactor, Warnings warnings) {
             this.bigArrays = bigArrays;
             this.breaker = breaker;
             this.states = bigArrays.newObjectArray(1);
             this.dateFactor = dateFactor;
+            this.warnings = warnings;
         }
 
         void ensureCapacity(int groupId) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/IrateLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/IrateLongAggregator.java
@@ -27,6 +27,7 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 // end generated imports
@@ -40,9 +41,13 @@ import org.elasticsearch.core.Releasables;
     processNulls = true
 )
 public class IrateLongAggregator {
-    public static LongIrateGroupingState initGrouping(DriverContext driverContext, boolean isDateNanos) {
+
+    public static final String DELTA_UNSUPPORTED_WARNING =
+        "Some nodes in your cluster don't support delta temporality yet, delta temporality series will be ignored. Upgrade your cluster to fix this.";
+
+    public static LongIrateGroupingState initGrouping(DriverContext driverContext, boolean isDateNanos, Warnings warnings) {
         final int dateFactor = isDateNanos ? 1_000_000_000 : 1000;
-        return new LongIrateGroupingState(driverContext.bigArrays(), driverContext.breaker(), dateFactor);
+        return new LongIrateGroupingState(driverContext.bigArrays(), driverContext.breaker(), dateFactor, warnings);
     }
 
     public static void combine(
@@ -62,10 +67,12 @@ public class IrateLongAggregator {
                 current.ensureCapacity(groupId);
                 current.append(groupId, timestamp, value);
             } else {
-                // TODO: emit warning that delta is unsupported on this cluster version
+                current.warnings.registerException(IllegalArgumentException.class, DELTA_UNSUPPORTED_WARNING);
             }
         } catch (InvalidTemporalityException e) {
-            // TODO: emit a warning
+            // We can't use @GroupingAggregator(warnExceptions=..) here because that would require a breaking change to the
+            // intermediate state
+            current.warnings.registerException(e);
         }
     }
 
@@ -109,16 +116,18 @@ public class IrateLongAggregator {
     public static final class LongIrateGroupingState implements Releasable, Accountable, GroupingAggregatorState {
         private TemporalityAccessor cachedTemporalityAccessor;
         private ObjectArray<LongIrateState> states;
+        private final Warnings warnings;
         private final BigArrays bigArrays;
         private final CircuitBreaker breaker;
         private long stateBytes; // for individual states
         private final int dateFactor;
 
-        LongIrateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, int dateFactor) {
+        LongIrateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, int dateFactor, Warnings warnings) {
             this.bigArrays = bigArrays;
             this.breaker = breaker;
             this.states = bigArrays.newObjectArray(1);
             this.dateFactor = dateFactor;
+            this.warnings = warnings;
         }
 
         void ensureCapacity(int groupId) {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateDoubleAggregatorFunctionSupplier.java
@@ -9,15 +9,21 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.WarningSourceLocation;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link IrateDoubleAggregator}.
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class IrateDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  WarningSourceLocation warningsSource;
+
   private final boolean isDateNanos;
 
-  public IrateDoubleAggregatorFunctionSupplier(boolean isDateNanos) {
+  public IrateDoubleAggregatorFunctionSupplier(WarningSourceLocation warningsSource,
+      boolean isDateNanos) {
+    this.warningsSource = warningsSource;
     this.isDateNanos = isDateNanos;
   }
 
@@ -39,7 +45,8 @@ public final class IrateDoubleAggregatorFunctionSupplier implements AggregatorFu
   @Override
   public IrateDoubleGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return new IrateDoubleGroupingAggregatorFunction(channels, driverContext, isDateNanos);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new IrateDoubleGroupingAggregatorFunction(warnings, channels, driverContext, isDateNanos);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateDoubleGroupingAggregatorFunction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link IrateDoubleAggregator}.
@@ -33,17 +34,20 @@ public final class IrateDoubleGroupingAggregatorFunction implements GroupingAggr
 
   private final IrateDoubleAggregator.DoubleIrateGroupingState state;
 
+  private final Warnings warnings;
+
   private final List<Integer> channels;
 
   private final DriverContext driverContext;
 
   private final boolean isDateNanos;
 
-  IrateDoubleGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
-      boolean isDateNanos) {
+  IrateDoubleGroupingAggregatorFunction(Warnings warnings, List<Integer> channels,
+      DriverContext driverContext, boolean isDateNanos) {
     this.isDateNanos = isDateNanos;
+    this.warnings = warnings;
     this.channels = channels;
-    this.state = IrateDoubleAggregator.initGrouping(driverContext, isDateNanos);
+    this.state = IrateDoubleAggregator.initGrouping(driverContext, isDateNanos, warnings);
     this.driverContext = driverContext;
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateIntAggregatorFunctionSupplier.java
@@ -9,15 +9,21 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.WarningSourceLocation;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link IrateIntAggregator}.
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class IrateIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  WarningSourceLocation warningsSource;
+
   private final boolean isDateNanos;
 
-  public IrateIntAggregatorFunctionSupplier(boolean isDateNanos) {
+  public IrateIntAggregatorFunctionSupplier(WarningSourceLocation warningsSource,
+      boolean isDateNanos) {
+    this.warningsSource = warningsSource;
     this.isDateNanos = isDateNanos;
   }
 
@@ -39,7 +45,8 @@ public final class IrateIntAggregatorFunctionSupplier implements AggregatorFunct
   @Override
   public IrateIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return new IrateIntGroupingAggregatorFunction(channels, driverContext, isDateNanos);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new IrateIntGroupingAggregatorFunction(warnings, channels, driverContext, isDateNanos);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateIntGroupingAggregatorFunction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link IrateIntAggregator}.
@@ -32,17 +33,20 @@ public final class IrateIntGroupingAggregatorFunction implements GroupingAggrega
 
   private final IrateIntAggregator.IntIrateGroupingState state;
 
+  private final Warnings warnings;
+
   private final List<Integer> channels;
 
   private final DriverContext driverContext;
 
   private final boolean isDateNanos;
 
-  IrateIntGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
-      boolean isDateNanos) {
+  IrateIntGroupingAggregatorFunction(Warnings warnings, List<Integer> channels,
+      DriverContext driverContext, boolean isDateNanos) {
     this.isDateNanos = isDateNanos;
+    this.warnings = warnings;
     this.channels = channels;
-    this.state = IrateIntAggregator.initGrouping(driverContext, isDateNanos);
+    this.state = IrateIntAggregator.initGrouping(driverContext, isDateNanos, warnings);
     this.driverContext = driverContext;
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateLongAggregatorFunctionSupplier.java
@@ -9,15 +9,21 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.WarningSourceLocation;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link AggregatorFunctionSupplier} implementation for {@link IrateLongAggregator}.
  * This class is generated. Edit {@code AggregatorFunctionSupplierImplementer} instead.
  */
 public final class IrateLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+  WarningSourceLocation warningsSource;
+
   private final boolean isDateNanos;
 
-  public IrateLongAggregatorFunctionSupplier(boolean isDateNanos) {
+  public IrateLongAggregatorFunctionSupplier(WarningSourceLocation warningsSource,
+      boolean isDateNanos) {
+    this.warningsSource = warningsSource;
     this.isDateNanos = isDateNanos;
   }
 
@@ -39,7 +45,8 @@ public final class IrateLongAggregatorFunctionSupplier implements AggregatorFunc
   @Override
   public IrateLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext,
       List<Integer> channels) {
-    return new IrateLongGroupingAggregatorFunction(channels, driverContext, isDateNanos);
+    var warnings = Warnings.createWarnings(driverContext.warningsMode(), warningsSource);
+    return new IrateLongGroupingAggregatorFunction(warnings, channels, driverContext, isDateNanos);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/IrateLongGroupingAggregatorFunction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 
 /**
  * {@link GroupingAggregatorFunction} implementation for {@link IrateLongAggregator}.
@@ -31,17 +32,20 @@ public final class IrateLongGroupingAggregatorFunction implements GroupingAggreg
 
   private final IrateLongAggregator.LongIrateGroupingState state;
 
+  private final Warnings warnings;
+
   private final List<Integer> channels;
 
   private final DriverContext driverContext;
 
   private final boolean isDateNanos;
 
-  IrateLongGroupingAggregatorFunction(List<Integer> channels, DriverContext driverContext,
-      boolean isDateNanos) {
+  IrateLongGroupingAggregatorFunction(Warnings warnings, List<Integer> channels,
+      DriverContext driverContext, boolean isDateNanos) {
     this.isDateNanos = isDateNanos;
+    this.warnings = warnings;
     this.channels = channels;
-    this.state = IrateLongAggregator.initGrouping(driverContext, isDateNanos);
+    this.state = IrateLongAggregator.initGrouping(driverContext, isDateNanos, warnings);
     this.driverContext = driverContext;
   }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-IrateAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-IrateAggregator.java.st
@@ -27,6 +27,7 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 // end generated imports
@@ -40,9 +41,13 @@ import org.elasticsearch.core.Releasables;
     processNulls = true
 )
 public class Irate$Type$Aggregator {
-    public static $Type$IrateGroupingState initGrouping(DriverContext driverContext, boolean isDateNanos) {
+
+    public static final String DELTA_UNSUPPORTED_WARNING =
+        "Some nodes in your cluster don't support delta temporality yet, delta temporality series will be ignored. Upgrade your cluster to fix this.";
+
+    public static $Type$IrateGroupingState initGrouping(DriverContext driverContext, boolean isDateNanos, Warnings warnings) {
         final int dateFactor = isDateNanos ? 1_000_000_000 : 1000;
-        return new $Type$IrateGroupingState(driverContext.bigArrays(), driverContext.breaker(), dateFactor);
+        return new $Type$IrateGroupingState(driverContext.bigArrays(), driverContext.breaker(), dateFactor, warnings);
     }
 
     public static void combine(
@@ -62,10 +67,12 @@ public class Irate$Type$Aggregator {
                 current.ensureCapacity(groupId);
                 current.append(groupId, timestamp, value);
             } else {
-                // TODO: emit warning that delta is unsupported on this cluster version
+                current.warnings.registerException(IllegalArgumentException.class, DELTA_UNSUPPORTED_WARNING);
             }
         } catch (InvalidTemporalityException e) {
-            // TODO: emit a warning
+            // We can't use @GroupingAggregator(warnExceptions=..) here because that would require a breaking change to the
+            // intermediate state
+            current.warnings.registerException(e);
         }
     }
 
@@ -109,16 +116,18 @@ public class Irate$Type$Aggregator {
     public static final class $Type$IrateGroupingState implements Releasable, Accountable, GroupingAggregatorState {
         private TemporalityAccessor cachedTemporalityAccessor;
         private ObjectArray<$Type$IrateState> states;
+        private final Warnings warnings;
         private final BigArrays bigArrays;
         private final CircuitBreaker breaker;
         private long stateBytes; // for individual states
         private final int dateFactor;
 
-        $Type$IrateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, int dateFactor) {
+        $Type$IrateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, int dateFactor, Warnings warnings) {
             this.bigArrays = bigArrays;
             this.breaker = breaker;
             this.states = bigArrays.newObjectArray(1);
             this.dateFactor = dateFactor;
+            this.warnings = warnings;
         }
 
         void ensureCapacity(int groupId) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -252,7 +252,7 @@ public class CsvTestsDataLoader {
             "metric_temporality-mappings.json",
             "metric_temporality.csv",
             "metric_temporality-settings.json"
-        ).withRequiredCapabilities(EsqlCapabilities.Cap.TSDB_TEMPORALITY_SUPPORT_V3),
+        ).withRequiredCapabilities(EsqlCapabilities.Cap.TSDB_TEMPORALITY_SUPPORT_V4),
         new TestDataset("ts_window", "ts_window-mappings.json", "ts_window.csv", "ts_window-settings.json")
     ).collect(toMap(TestDataset::indexName, Function.identity()));
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metric_temporality.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metric_temporality.csv-spec
@@ -81,6 +81,8 @@ TS metric_temporality
  | KEEP cluster, irate_bytes
  | SORT cluster
 ;
+warning:Line 2:27: evaluation of [irate(network.total_bytes_in)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:27: java.lang.IllegalArgumentException: Some nodes in your cluster don't support delta temporality yet, delta temporality series will be ignored. Upgrade your cluster to fix this.
 
 cluster:keyword | irate_bytes:double
 prod-cumulative | 0.5786293
@@ -101,6 +103,8 @@ TS metric_temporality
  | KEEP my_temporality, irate_bytes
  | SORT my_temporality
 ;
+warning:Line 2:27: evaluation of [irate(network.total_bytes_in)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:27: java.lang.IllegalArgumentException: Some nodes in your cluster don't support delta temporality yet, delta temporality series will be ignored. Upgrade your cluster to fix this.
 
 my_temporality:keyword | irate_bytes:double
 cumulative             | 0.5786293
@@ -121,6 +125,8 @@ TS metric_temporality
  | KEEP bucket, cluster, irate_bytes
  | SORT bucket, cluster
 ;
+warning:Line 2:27: evaluation of [irate(network.total_bytes_in)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:27: java.lang.IllegalArgumentException: Some nodes in your cluster don't support delta temporality yet, delta temporality series will be ignored. Upgrade your cluster to fix this.
 
 bucket:datetime          | cluster:keyword | irate_bytes:double
 2024-05-10T00:00:00.000Z | prod-cumulative | 0.5703784

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metric_temporality.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metric_temporality.csv-spec
@@ -4,7 +4,7 @@
 
 multipleAggsWithoutTBucket
 required_capability: ts_command_v0
-required_capability: tsdb_temporality_support_v3
+required_capability: tsdb_temporality_support_v4
 
 TS metric_temporality
  | STATS bytes_per_second = SUM(rate(network.total_bytes_in)), bytes = SUM(increase(network.total_bytes_in)) BY cluster
@@ -24,7 +24,7 @@ prod-null       | 0.2928479               | 264.0
 
 rateGroupedByTemporality
 required_capability: ts_command_v0
-required_capability: tsdb_temporality_support_v3
+required_capability: tsdb_temporality_support_v4
 
 TS metric_temporality
  | STATS bytes_per_second = SUM(rate(network.total_bytes_in)) BY my_temporality
@@ -44,7 +44,7 @@ null                   | 0.2928479
 
 multipleAggsByTBucket
 required_capability: ts_command_v0
-required_capability: tsdb_temporality_support_v3
+required_capability: tsdb_temporality_support_v4
 
 TS metric_temporality
  | STATS bytes_per_second = SUM(rate(network.total_bytes_in)), bytes = SUM(increase(network.total_bytes_in)) BY cluster, bucket = TBUCKET(300s)
@@ -73,7 +73,7 @@ bucket:datetime          | cluster:keyword | bytes_per_second:double | bytes:dou
 
 irateWithoutTBucket
 required_capability: ts_command_v0
-required_capability: tsdb_temporality_support_v3
+required_capability: tsdb_temporality_support_v4
 
 TS metric_temporality
  | STATS irate_bytes = SUM(irate(network.total_bytes_in)) BY cluster
@@ -95,7 +95,7 @@ prod-null       | 0.5786293
 
 irateGroupedByTemporality
 required_capability: ts_command_v0
-required_capability: tsdb_temporality_support_v3
+required_capability: tsdb_temporality_support_v4
 
 TS metric_temporality
  | STATS irate_bytes = SUM(irate(network.total_bytes_in)) BY my_temporality
@@ -117,7 +117,7 @@ null                   | 0.5786293
 
 irateByTBucket
 required_capability: ts_command_v0
-required_capability: tsdb_temporality_support_v3
+required_capability: tsdb_temporality_support_v4
 
 TS metric_temporality
  | STATS irate_bytes = SUM(irate(network.total_bytes_in)) BY cluster, bucket = TBUCKET(300s)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2488,7 +2488,7 @@ public class EsqlCapabilities {
         /**
          * TSDB Temporality support which is guarded by a feature flag.
          */
-        TSDB_TEMPORALITY_SUPPORT_V3(IndexSettings.TIME_SERIES_TEMPORALITY_FEATURE_FLAG),
+        TSDB_TEMPORALITY_SUPPORT_V4(IndexSettings.TIME_SERIES_TEMPORALITY_FEATURE_FLAG),
 
         /**
          * Support the null column type for the CHANGE_POINT command

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Irate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Irate.java
@@ -165,9 +165,9 @@ public class Irate extends TimeSeriesAggregateFunction implements OptionalArgume
         final DataType tsType = timestamp().dataType();
         final boolean isDateNanos = tsType == DataType.DATE_NANOS;
         return switch (type) {
-            case COUNTER_LONG -> new IrateLongAggregatorFunctionSupplier(isDateNanos);
-            case COUNTER_INTEGER -> new IrateIntAggregatorFunctionSupplier(isDateNanos);
-            case COUNTER_DOUBLE -> new IrateDoubleAggregatorFunctionSupplier(isDateNanos);
+            case COUNTER_LONG -> new IrateLongAggregatorFunctionSupplier(source(), isDateNanos);
+            case COUNTER_INTEGER -> new IrateIntAggregatorFunctionSupplier(source(), isDateNanos);
+            case COUNTER_DOUBLE -> new IrateDoubleAggregatorFunctionSupplier(source(), isDateNanos);
             default -> throw EsqlIllegalArgumentException.illegalDataType(type);
         };
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/IrateTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/IrateTests.java
@@ -145,7 +145,24 @@ public class IrateTests extends AbstractAggregationTestCase {
                     DataType.DOUBLE,
                     matcher
                 );
-                // TODO: once warnings are emitted for invalid temporality, add withWarning assertions here like RateTests
+                if (temporality == RateTests.TemporalityParameter.INVALID && nonNullDataRows.isEmpty() == false) {
+                    return result.withWarning(
+                        "Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded."
+                    )
+                        .withWarning(
+                            "Line 1:1: org.elasticsearch.compute.aggregation.InvalidTemporalityException: "
+                                + "Invalid temporality value: [gotcha], expected [cumulative] or [delta]"
+                        );
+                }
+                if (temporality == RateTests.TemporalityParameter.DELTA && nonNullDataRows.isEmpty() == false) {
+                    return result.withWarning(
+                        "Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded."
+                    )
+                        .withWarning(
+                            "Line 1:1: java.lang.IllegalArgumentException: Some nodes in your cluster don't support delta temporality yet,"
+                                + " delta temporality series will be ignored. Upgrade your cluster to fix this."
+                        );
+                }
                 return result;
             }
         );
@@ -156,7 +173,6 @@ public class IrateTests extends AbstractAggregationTestCase {
         List<Long> timestamps,
         RateTests.TemporalityParameter temporality
     ) {
-        // TODO: implement delta temporality support for irate; for now it returns null
         if (nonNullDataRows.size() < 2
             || temporality == RateTests.TemporalityParameter.DELTA
             || temporality == RateTests.TemporalityParameter.INVALID) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/IrateTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/IrateTests.java
@@ -173,6 +173,7 @@ public class IrateTests extends AbstractAggregationTestCase {
         List<Long> timestamps,
         RateTests.TemporalityParameter temporality
     ) {
+        // TODO: implement delta temporality support for irate; for now it returns null
         if (nonNullDataRows.size() < 2
             || temporality == RateTests.TemporalityParameter.DELTA
             || temporality == RateTests.TemporalityParameter.INVALID) {


### PR DESCRIPTION
Part of https://github.com/elastic/elasticsearch/issues/139189.

Now that https://github.com/elastic/elasticsearch/pull/147252 is merged, we can fix the remaining todo from https://github.com/elastic/elasticsearch/pull/147150: This PR ensures that we print a warning for data points which have an invalid or delta temporality for irate.

We have to ignore delta temporality for irate, because supporting it required a breaking change to the intermediate state of the aggregator. In a follow up PR I'll add a new aggregator with delta temporality support, which will be used if all nodes involved in the query are on a minimum transport version.