### PR TITLE
perf: lazy allocation of `DocValuesForUtil` scratch buffer

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/DocValuesForUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/DocValuesForUtil.java
@@ -23,13 +23,20 @@ public final class DocValuesForUtil {
     private static final int BITS_IN_SEVEN_BYTES = 7 * Byte.SIZE;
 
     private final int blockSize;
-    private final byte[] encoded;
+
+    // Single threaded use; lazy init in ensureBuffer() needs no synchronization.
+    private byte[] encoded;
 
     public DocValuesForUtil(int numericBlockSize) {
         assert numericBlockSize >= ForUtil.BLOCK_SIZE && (numericBlockSize & (ForUtil.BLOCK_SIZE - 1)) == 0
             : "expected to get a block size that a multiple of " + ForUtil.BLOCK_SIZE + ", got " + numericBlockSize;
         this.blockSize = numericBlockSize;
-        this.encoded = new byte[numericBlockSize * Long.BYTES];
+    }
+
+    private void ensureBuffer() {
+        if (this.encoded == null) {
+            this.encoded = new byte[blockSize * Long.BYTES];
+        }
     }
 
     public static int roundBits(int bitsPerValue) {
@@ -68,7 +75,8 @@ public final class DocValuesForUtil {
     }
 
     private void encodeFiveSixOrSevenBytesPerValue(long[] in, int bitsPerValue, final DataOutput out) throws IOException {
-        int bytesPerValue = bitsPerValue / Byte.SIZE;
+        ensureBuffer();
+        final int bytesPerValue = bitsPerValue / Byte.SIZE;
         for (int i = 0; i < in.length; ++i) {
             ByteUtils.writeLongLE(in[i], this.encoded, i * bytesPerValue);
         }
@@ -93,8 +101,9 @@ public final class DocValuesForUtil {
 
     private void decodeFiveSixOrSevenBytesPerValue(int bitsPerValue, final DataInput in, long[] out) throws IOException {
         // NOTE: we expect multibyte values to be written "least significant byte" first
-        int bytesPerValue = bitsPerValue / Byte.SIZE;
-        long mask = (1L << bitsPerValue) - 1;
+        ensureBuffer();
+        final int bytesPerValue = bitsPerValue / Byte.SIZE;
+        final long mask = (1L << bitsPerValue) - 1;
         in.readBytes(this.encoded, 0, bytesPerValue * blockSize);
         for (int i = 0; i < blockSize; ++i) {
             out[i] = ByteUtils.readLongLE(this.encoded, i * bytesPerValue) & mask;


### PR DESCRIPTION
**TL;DR**: most numeric fields never use the `DocValuesForUtil` scratch buffer. Defer its allocation to reclaim hundreds of MB of pinned heap on busy nodes.

## Issue

`DocValuesForUtil` eagerly allocates a `byte[blockSize * 8]` scratch buffer in its constructor (1 KB at the standard block size, 4 KB at the large block size). The buffer is used by exactly two methods, `encodeFiveSixOrSevenBytesPerValue` and `decodeFiveSixOrSevenBytesPerValue`. Every other bit width (`≤24` via `ForUtil`, `32`, `>56`) bypasses it.

In typical TSDB workloads the dominant paths (counters, gauges, IDs, delta compressed timestamps) likely fit in `≤24` bits per value, so most `DocValuesForUtil` instances pay the up front allocation cost without ever using the buffer.

## Change

Defer the allocation to first use. The `encoded` field becomes nullable; a small `ensureBuffer()` helper allocates it on demand, and the two wide bit width methods call it before touching `encoded`. The allocation fires at most once per `DocValuesForUtil` instance.

## Performance impact

Each `DocValuesForUtil` instance pins a 1 KB or 4 KB scratch buffer for its full lifetime, regardless of whether it ever needs it. The savings scale as `N × (1 - f) × buffer_size`. Concrete sizings at the standard 1 KB block size:

| `N`       | Memory before | Memory after, `f = 10%` | Memory after, `f = 1%` | Savings at `f = 1%` |
|-----------|---------------|--------------------------|------------------------|---------------------|
| 10,000    | 10 MB         | 1.0 MB                   | 0.1 MB                 | ~9.9 MB             |
| 100,000   | 100 MB        | 10 MB                    | 1.0 MB                 | ~99 MB              |
| 1,000,000 | 1.0 GB        | 100 MB                   | 10 MB                  | ~990 MB             |

Where:

* `N` is the number of `DocValuesForUtil` objects currently in memory on the node. After #147920 these are short lived: active query iterators on the read side and active flushes or merges on the write side, growing with concurrent queries and concurrent merges. Busy nodes easily hold tens or hundreds of thousands at once.
* `f` is the share of those `N` objects that ever execute the 5, 6, or 7 byte per value path during their lifetime, typically because the field had values requiring those widths. The remaining `N * (1 - f)` objects never touch the scratch buffer at all.

For TSDB workloads `f` is likely low, probably well under 10%, often closer to 1%. Every entry in the table quadruples at the large block size.

This is a steady state heap usage fix, not a hot loop optimization. Other than saving memory it will also spare a lot of GC work. No wire format change; round trip tests across formats produce identical output. Buffer lifetime tracks the owning iterator, so no static state and no thread locality concerns.

## Tests

This change has no behavioral surface: it only defers an internal allocation. Correctness is already covered by `DocValuesForUtilTests.testEncodeDecode`, which exercises encode and decode round trips across every bit width tier, and by the dependent codec tests for both block sizes.

```bash
./gradlew :server:test \
  --tests "*DocValuesForUtilTests*" \
  --tests "*ES87TSDBDocValuesFormatTests*" \
  --tests "*ES819TSDBDocValuesFormatTests*" \
  --tests "*TsdbDocValueBwcTests*"
```
