### PR TITLE
[9.4] Share the same doc values producer for IdBloomFilterSupplier and TSDBSyntheticIdFieldsProducer (#147910)

### DIFF
--- a/docs/changelog/147910.yaml
+++ b/docs/changelog/147910.yaml
@@ -1,0 +1,5 @@
+area: Codec
+issues: []
+pr: 147910
+summary: Share the same doc values producer for `IdBloomFilterSupplier` and TSDBSyntheticIdFieldsProducer
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/IdBloomFilterSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/IdBloomFilterSupplier.java
@@ -36,10 +36,7 @@ public class IdBloomFilterSupplier implements Closeable {
     private final DocValuesProducer docValuesProducer;
     private final FieldInfo idFieldInfo;
 
-    public IdBloomFilterSupplier(SegmentReadState state) throws IOException {
-        var codec = state.segmentInfo.getCodec();
-        // Erase the segment suffix (used only for reading postings)
-        SegmentReadState segmentReadState = new SegmentReadState(state, "");
+    public IdBloomFilterSupplier(SegmentReadState state, DocValuesProducer docValuesProducer) {
         var idFieldInfo = state.fieldInfos.fieldInfo(IdFieldMapper.NAME);
         if (idFieldInfo == null) {
             throw new IllegalStateException(IdFieldMapper.NAME + " field not found");
@@ -49,7 +46,7 @@ public class IdBloomFilterSupplier implements Closeable {
         }
 
         this.idFieldInfo = idFieldInfo;
-        this.docValuesProducer = codec.docValuesFormat().fieldsProducer(segmentReadState);
+        this.docValuesProducer = docValuesProducer;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormat.java
@@ -53,7 +53,7 @@ public class TSDBSyntheticIdPostingsFormat extends PostingsFormat {
 
             docValuesProducer = codec.docValuesFormat().fieldsProducer(segmentReadState);
             var fieldsProducer = new TSDBSyntheticIdFieldsProducer(state, docValuesProducer);
-            idBloomFilterSupplier = new IdBloomFilterSupplier(state);
+            idBloomFilterSupplier = new IdBloomFilterSupplier(state, docValuesProducer);
             success = true;
             return new DelegatingBloomFilterFieldsProducer(fieldsProducer, idBloomFilterSupplier);
         } finally {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Share the same doc values producer for IdBloomFilterSupplier and TSDBSyntheticIdFieldsProducer (#147910)