### PR TITLE
[ESQL] Fix COUNT(*) pushdown for coalesced splits

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -19,6 +19,10 @@ apply plugin: 'elasticsearch.string-templates'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.esql-function'
 
+versions << [
+  'hadoop': '3.4.3',
+]
+
 esplugin {
   name = 'x-pack-esql'
   description = 'The plugin that powers ESQL for Elasticsearch'
@@ -100,6 +104,10 @@ dependencies {
   internalClusterTestImplementation project(path: xpackModule('esql-datasource-compression-libs'))
   internalClusterTestImplementation project(path: xpackModule('esql-datasource-bzip2'))
   internalClusterTestImplementation project(path: xpackModule('esql-datasource-http'))
+  internalClusterTestImplementation project(path: xpackModule('esql-datasource-parquet'))
+  internalClusterTestImplementation "org.apache.parquet:parquet-hadoop-bundle:${versions.parquet}"
+  internalClusterTestImplementation("org.apache.hadoop:hadoop-common:${versions.hadoop}") { transitive = false }
+  internalClusterTestImplementation("org.apache.hadoop:hadoop-mapreduce-client-core:${versions.hadoop}") { transitive = false }
 }
 
 tasks.named('splitPackagesAudit').configure {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetCountPushdownIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetCountPushdownIT.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.elasticsearch.plugins.ExtensiblePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
+import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.EXTERNAL_COMMAND;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Integration test verifying COUNT(*) pushdown for local Parquet files.
+ * When pushdown fires, the data driver uses a LocalSourceExec (no Async operators)
+ * instead of scanning all row groups through AsyncExternalSourceOperatorFactory.
+ */
+public class ExternalParquetCountPushdownIT extends AbstractEsqlIntegTestCase {
+
+    /**
+     * Re-enables extension loading that {@link EsqlPluginWithEnterpriseOrTrialLicense} suppresses.
+     * Without this, DataSourcePlugin implementations (Parquet, HTTP) are not discovered.
+     */
+    public static final class EsqlEnterpriseWithDatasourceExtensions extends EsqlPluginWithEnterpriseOrTrialLicense {
+        @Override
+        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
+            super.loadExtensions(loader);
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.remove(EsqlPluginWithEnterpriseOrTrialLicense.class);
+        plugins.add(EsqlEnterpriseWithDatasourceExtensions.class);
+        plugins.add(HttpDataSourcePlugin.class);
+        plugins.add(ParquetDataSourcePlugin.class);
+        return plugins;
+    }
+
+    @Override
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
+
+    public void testCountStarPushdown() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 300;
+        Path parquetFile = writeParquetFile(totalRows, 100);
+        try {
+            String query = "EXTERNAL \"file://" + parquetFile.toAbsolutePath() + "\" | STATS c = COUNT(*)";
+
+            var request = syncEsqlQueryRequest(query);
+            request.profile(true);
+
+            try (var response = run(request)) {
+                List<? extends ColumnInfo> columns = response.columns();
+                assertThat(columns.size(), equalTo(1));
+                assertThat(columns.get(0).name(), equalTo("c"));
+
+                List<List<Object>> rows = getValuesList(response);
+                assertThat(rows.size(), equalTo(1));
+                assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo((long) totalRows));
+
+                assertNoPushdownBypass(response);
+            }
+        } finally {
+            Files.deleteIfExists(parquetFile);
+        }
+    }
+
+    public void testCountStarPushdownSingleRowGroup() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 50;
+        Path parquetFile = writeParquetFile(totalRows, totalRows + 1);
+        try {
+            String query = "EXTERNAL \"file://" + parquetFile.toAbsolutePath() + "\" | STATS c = COUNT(*)";
+
+            var request = syncEsqlQueryRequest(query);
+            request.profile(true);
+
+            try (var response = run(request)) {
+                List<List<Object>> rows = getValuesList(response);
+                assertThat(((Number) rows.get(0).get(0)).longValue(), equalTo((long) totalRows));
+
+                assertNoPushdownBypass(response);
+            }
+        } finally {
+            Files.deleteIfExists(parquetFile);
+        }
+    }
+
+    public void testCountStarPushdownManyRowGroups() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 1000;
+        // rowGroupSize=50 bytes forces ~20 row groups for 1000 rows
+        Path parquetFile = writeParquetFile(totalRows, 50);
+        try {
+            String query = "EXTERNAL \"file://" + parquetFile.toAbsolutePath() + "\" | STATS c = COUNT(*)";
+
+            var request = syncEsqlQueryRequest(query);
+            request.profile(true);
+
+            try (var response = run(request)) {
+                List<List<Object>> rows = getValuesList(response);
+                long count = ((Number) rows.get(0).get(0)).longValue();
+                assertThat(count, equalTo((long) totalRows));
+
+                assertNoPushdownBypass(response);
+            }
+        } finally {
+            Files.deleteIfExists(parquetFile);
+        }
+    }
+
+    public void testCountStarPushdownCoordinatorOnly() throws Exception {
+        assumeTrue("requires EXTERNAL command capability", EXTERNAL_COMMAND.isEnabled());
+
+        int totalRows = 500;
+        Path parquetFile = writeParquetFile(totalRows, 80);
+        try {
+            String query = "EXTERNAL \"file://"
+                + parquetFile.toAbsolutePath()
+                + "\" WITH { \"external_distribution\": \"coordinator_only\" } | STATS c = COUNT(*)";
+
+            var request = syncEsqlQueryRequest(query);
+            request.profile(true);
+
+            try (var response = run(request)) {
+                List<List<Object>> rows = getValuesList(response);
+                long count = ((Number) rows.get(0).get(0)).longValue();
+                assertThat(count, equalTo((long) totalRows));
+
+                assertNoPushdownBypass(response);
+            }
+        } finally {
+            Files.deleteIfExists(parquetFile);
+        }
+    }
+
+    /**
+     * Asserts that no Async* operator appears in any driver profile.
+     * When pushdown fires, the plan is a LocalSourceExec — there is no
+     * AsyncExternalSourceOperatorFactory executing file reads.
+     */
+    private static void assertNoPushdownBypass(EsqlQueryResponse response) {
+        var profile = response.profile();
+        assertNotNull("profile must be present (request had profile=true)", profile);
+
+        for (var driver : profile.drivers()) {
+            for (var op : driver.operators()) {
+                assertFalse(
+                    "expected no Async* operators (pushdown should have fired) but found: " + op.operator(),
+                    op.operator().startsWith("Async")
+                );
+            }
+        }
+    }
+
+    private Path writeParquetFile(int rowCount, int rowGroupSize) throws IOException {
+        MessageType schema = MessageTypeParser.parseMessageType(
+            "message test { required int64 id; required binary name (UTF8); required int32 value; }"
+        );
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputFile outputFile = createOutputFile(baos);
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withRowGroupSize(rowGroupSize)
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                Group g = factory.newGroup();
+                g.add("id", (long) i);
+                g.add("name", "row_" + i);
+                g.add("value", i * 10);
+                writer.write(g);
+            }
+        }
+
+        Path tempFile = createTempDir().resolve("pushdown_test.parquet");
+        Files.write(tempFile, baos.toByteArray());
+        return tempFile;
+    }
+
+    private static OutputFile createOutputFile(ByteArrayOutputStream baos) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position = 0;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        baos.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        baos.write(b, off, len);
+                        position += len;
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CoalescedSplit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CoalescedSplit.java
@@ -10,9 +10,12 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.SplitStats;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -56,6 +59,7 @@ public class CoalescedSplit implements ExternalSplit {
     private final String sourceType;
     private final List<ExternalSplit> children;
     private final long estimatedSizeInBytes;
+    private final SplitStats cachedStats;
 
     public CoalescedSplit(String sourceType, List<ExternalSplit> children) {
         if (sourceType == null) {
@@ -67,12 +71,14 @@ public class CoalescedSplit implements ExternalSplit {
         this.sourceType = sourceType;
         this.children = List.copyOf(children);
         this.estimatedSizeInBytes = computeEstimatedSize(this.children);
+        this.cachedStats = computeSplitStats();
     }
 
     public CoalescedSplit(StreamInput in) throws IOException {
         this.sourceType = in.readString();
         this.children = in.readNamedWriteableCollectionAsList(ExternalSplit.class);
         this.estimatedSizeInBytes = computeEstimatedSize(this.children);
+        this.cachedStats = computeSplitStats();
     }
 
     private static long computeEstimatedSize(List<ExternalSplit> children) {
@@ -112,6 +118,34 @@ public class CoalescedSplit implements ExternalSplit {
         return estimatedSizeInBytes;
     }
 
+    /**
+     * Returns merged statistics for all children. The result is computed once in the constructor
+     * and cached — CoalescedSplit is immutable so re-computation is unnecessary.
+     * Returns {@code null} if any child has no statistics, since a partial aggregate
+     * would produce incorrect optimizer decisions.
+     */
+    @Override
+    @Nullable
+    public SplitStats splitStats() {
+        return cachedStats;
+    }
+
+    @Nullable
+    private SplitStats computeSplitStats() {
+        if (children.size() == 1) {
+            return children.getFirst().splitStats();
+        }
+        List<SplitStats> childStats = new ArrayList<>(children.size());
+        for (ExternalSplit child : children) {
+            SplitStats cs = child.splitStats();
+            if (cs == null) {
+                return null;
+            }
+            childStats.add(cs);
+        }
+        return new MergedSplitStats(childStats);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -127,6 +161,34 @@ public class CoalescedSplit implements ExternalSplit {
     @Override
     public int hashCode() {
         return Objects.hash(sourceType, children);
+    }
+
+    /**
+     * Flattens a split list by unwrapping any {@link CoalescedSplit} into its children.
+     * Returns the original list unchanged when no coalesced splits are present.
+     */
+    public static List<ExternalSplit> flatten(List<? extends ExternalSplit> splits) {
+        boolean hasCoalesced = false;
+        for (ExternalSplit split : splits) {
+            if (split instanceof CoalescedSplit) {
+                hasCoalesced = true;
+                break;
+            }
+        }
+        if (hasCoalesced == false) {
+            @SuppressWarnings("unchecked")
+            List<ExternalSplit> unchanged = (List<ExternalSplit>) splits;
+            return unchanged;
+        }
+        List<ExternalSplit> flat = new ArrayList<>();
+        for (ExternalSplit split : splits) {
+            if (split instanceof CoalescedSplit cs) {
+                flat.addAll(cs.children());
+            } else {
+                flat.add(split);
+            }
+        }
+        return flat;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplit.java
@@ -284,7 +284,9 @@ public class FileSplit implements ExternalSplit {
 
     /**
      * Returns the compact split stats, or {@code null} if only legacy map stats are available.
+     * Overrides {@link ExternalSplit#splitStats()} with a covariant return type.
      */
+    @Override
     @Nullable
     public SplitStats splitStats() {
         return splitStats;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.datasources.spi.SplitStats;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStats.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.core.Nullable;
+
+import java.util.List;
+
+/**
+ * Lazily merges statistics from a list of child {@link org.elasticsearch.xpack.esql.datasources.spi.SplitStats} instances.
+ * Used by {@link CoalescedSplit#splitStats()} to expose aggregate statistics for
+ * composite splits without eagerly materializing a full {@link SplitStats}.
+ * <p>
+ * Each accessor method computes its result on demand by iterating the children.
+ * This is appropriate because the optimizer calls these methods at most a few times
+ * per planning phase, and the child count is typically small (a few dozen splits).
+ */
+public final class MergedSplitStats implements org.elasticsearch.xpack.esql.datasources.spi.SplitStats {
+
+    private final List<org.elasticsearch.xpack.esql.datasources.spi.SplitStats> children;
+
+    public MergedSplitStats(List<org.elasticsearch.xpack.esql.datasources.spi.SplitStats> children) {
+        if (children == null || children.isEmpty()) {
+            throw new IllegalArgumentException("children cannot be null or empty");
+        }
+        this.children = List.copyOf(children);
+    }
+
+    /** Returns the list of child stats that this instance merges. */
+    public List<org.elasticsearch.xpack.esql.datasources.spi.SplitStats> children() {
+        return children;
+    }
+
+    @Override
+    public long rowCount() {
+        long total = 0;
+        for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
+            total += child.rowCount();
+        }
+        return total;
+    }
+
+    /**
+     * Returns the sum of children's uncompressed sizes, or {@code -1} if any child
+     * reports an unknown size. A single unknown child poisons the aggregate because
+     * we cannot give a meaningful partial sum to the optimizer.
+     */
+    @Override
+    public long sizeInBytes() {
+        long total = 0;
+        for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
+            long s = child.sizeInBytes();
+            if (s < 0) {
+                return -1;
+            }
+            total += s;
+        }
+        return total;
+    }
+
+    /**
+     * Returns the sum of children's compressed sizes, or {@code -1} if any child
+     * reports an unknown compressed size.
+     */
+    @Override
+    public long compressedSizeInBytes() {
+        long total = 0;
+        for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
+            long s = child.compressedSizeInBytes();
+            if (s < 0) {
+                return -1;
+            }
+            total += s;
+        }
+        return total;
+    }
+
+    /**
+     * Returns the sum of null counts across children for the named column.
+     * Returns {@code -1} if any child returns an unknown null count for the column,
+     * or if the column is not present in any child.
+     */
+    @Override
+    public long columnNullCount(String name) {
+        long total = 0;
+        for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
+            long nc = child.columnNullCount(name);
+            if (nc < 0) {
+                return -1;
+            }
+            total += nc;
+        }
+        return total;
+    }
+
+    /**
+     * Returns the minimum of children's min values for the named column.
+     * Returns {@code null} if any child returns null for the column min, or if
+     * the column is not present in any child. Cross-type numeric widening is applied
+     * via {@link SplitStats#mergedMin}.
+     */
+    @Override
+    @Nullable
+    public Object columnMin(String name) {
+        Object result = null;
+        for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
+            Object childMin = child.columnMin(name);
+            if (childMin == null) {
+                // Unknown min in any child poisons the aggregate
+                return null;
+            }
+            result = SplitStats.mergedMin(result, childMin);
+            if (result == null) {
+                // Incompatible types — clear the stat
+                return null;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the maximum of children's max values for the named column.
+     * Returns {@code null} if any child returns null for the column max, or if
+     * the column is not present in any child. Cross-type numeric widening is applied
+     * via {@link SplitStats#mergedMax}.
+     */
+    @Override
+    @Nullable
+    public Object columnMax(String name) {
+        Object result = null;
+        for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
+            Object childMax = child.columnMax(name);
+            if (childMax == null) {
+                // Unknown max in any child poisons the aggregate
+                return null;
+            }
+            result = SplitStats.mergedMax(result, childMax);
+            if (result == null) {
+                // Incompatible types — clear the stat
+                return null;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the sum of per-column sizes across children, or {@code -1} if any child
+     * returns an unknown size for the column.
+     */
+    @Override
+    public long columnSizeBytes(String name) {
+        long total = 0;
+        for (org.elasticsearch.xpack.esql.datasources.spi.SplitStats child : children) {
+            long sz = child.columnSizeBytes(name);
+            if (sz < 0) {
+                return -1;
+            }
+            total += sz;
+        }
+        return total;
+    }
+
+    @Override
+    public String toString() {
+        return "MergedSplitStats[children=" + children.size() + "]";
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SourceStatisticsSerializer.java
@@ -8,10 +8,8 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -178,28 +176,6 @@ public final class SourceStatisticsSerializer {
     @Nullable
     public static Long extractColumnSizeBytes(Map<String, Object> sourceMetadata, String columnName) {
         return sourceMetadata != null ? asBoxedLong(sourceMetadata.get(columnSizeBytesKey(columnName))) : null;
-    }
-
-    /**
-     * Resolves the effective metadata for a set of splits. For single-split queries returns
-     * the given sourceMetadata directly; for multi-split queries merges per-split statistics
-     * from each {@link FileSplit}. Returns {@code null} if any split is not a {@code FileSplit}
-     * or if {@link #mergeStatistics} cannot produce a valid merged result (e.g. missing or
-     * non-numeric row counts).
-     */
-    public static Map<String, Object> resolveEffectiveMetadata(List<? extends ExternalSplit> splits, Map<String, Object> sourceMetadata) {
-        if (splits.size() <= 1) {
-            return sourceMetadata;
-        }
-        List<Map<String, Object>> splitStats = new ArrayList<>(splits.size());
-        for (ExternalSplit split : splits) {
-            if (split instanceof FileSplit fileSplit) {
-                splitStats.add(fileSplit.statistics());
-            } else {
-                return null;
-            }
-        }
-        return mergeStatistics(splitStats);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/SplitStats.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  * Instances are effectively immutable after construction and safe for use within a single
  * request processing thread.
  */
-public final class SplitStats implements Writeable {
+public final class SplitStats implements org.elasticsearch.xpack.esql.datasources.spi.SplitStats, Writeable {
 
     private static final Logger logger = LogManager.getLogger(SplitStats.class);
 
@@ -150,11 +150,13 @@ public final class SplitStats implements Writeable {
         return columnSegmentOrdinals.length;
     }
 
+    @Override
     public long rowCount() {
         return rowCount;
     }
 
     /** Returns size in bytes, or {@code -1} if unknown. */
+    @Override
     public long sizeInBytes() {
         return sizeInBytes;
     }
@@ -254,12 +256,14 @@ public final class SplitStats implements Writeable {
      * Returns the null count for the column with the given name, or {@code -1} if the column
      * is not found or its null count is unknown.
      */
+    @Override
     public long columnNullCount(String name) {
         int col = findColumn(name);
         return col >= 0 ? nullCounts[col] : -1;
     }
 
     /** Returns the min value for the column with the given name, or {@code null} if not found. */
+    @Override
     @Nullable
     public Object columnMin(String name) {
         int col = findColumn(name);
@@ -267,6 +271,7 @@ public final class SplitStats implements Writeable {
     }
 
     /** Returns the max value for the column with the given name, or {@code null} if not found. */
+    @Override
     @Nullable
     public Object columnMax(String name) {
         int col = findColumn(name);
@@ -274,6 +279,7 @@ public final class SplitStats implements Writeable {
     }
 
     /** Returns the size in bytes for the column with the given name, or {@code -1} if not found. */
+    @Override
     public long columnSizeBytes(String name) {
         int col = findColumn(name);
         return col >= 0 ? sizesBytes[col] : -1;
@@ -561,30 +567,39 @@ public final class SplitStats implements Writeable {
     }
 
     /**
-     * Resolves the effective {@link SplitStats} for a set of splits. For single-split queries
-     * the per-split stats (if available) or the sourceMetadata map is used; for multi-split
-     * queries the per-split stats are merged. Returns {@code null} if any split lacks stats.
+     * Resolves the effective {@link org.elasticsearch.xpack.esql.datasources.spi.SplitStats} for
+     * a set of splits. Uses {@link ExternalSplit#splitStats()} on each split, which handles both
+     * {@link FileSplit} and {@link CoalescedSplit} transparently without flattening. For single-split
+     * queries the per-split stats (if available) or the sourceMetadata map is used; for multi-split
+     * queries a {@link MergedSplitStats} over the per-split stats is returned. Returns {@code null}
+     * if any split lacks stats.
      */
     @Nullable
-    public static SplitStats resolveEffectiveStats(List<? extends ExternalSplit> splits, Map<String, Object> sourceMetadata) {
+    public static org.elasticsearch.xpack.esql.datasources.spi.SplitStats resolveEffectiveStats(
+        List<? extends ExternalSplit> splits,
+        Map<String, Object> sourceMetadata
+    ) {
         if (splits.size() <= 1) {
-            if (splits.size() == 1 && splits.getFirst() instanceof FileSplit fs && fs.splitStats() != null) {
-                return fs.splitStats();
+            if (splits.size() == 1) {
+                org.elasticsearch.xpack.esql.datasources.spi.SplitStats perSplit = splits.getFirst().splitStats();
+                if (perSplit != null) {
+                    return perSplit;
+                }
             }
             if (sourceMetadata != null && Boolean.TRUE.equals(sourceMetadata.get(SourceStatisticsSerializer.STATS_PARTIAL))) {
                 return null;
             }
             return of(sourceMetadata);
         }
-        List<SplitStats> perSplit = new ArrayList<>(splits.size());
+        List<org.elasticsearch.xpack.esql.datasources.spi.SplitStats> perSplitStats = new ArrayList<>(splits.size());
         for (ExternalSplit split : splits) {
-            if (split instanceof FileSplit fs && fs.splitStats() != null) {
-                perSplit.add(fs.splitStats());
-            } else {
+            org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats = split.splitStats();
+            if (stats == null) {
                 return null;
             }
+            perSplitStats.add(stats);
         }
-        return merge(perSplit);
+        return new MergedSplitStats(perSplitStats);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalSplit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ExternalSplit.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources.spi;
 
 import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.core.Nullable;
 
 /**
  * A serializable, parallelizable unit of work for an external data source.
@@ -20,5 +21,21 @@ public interface ExternalSplit extends NamedWriteable {
 
     default long estimatedSizeInBytes() {
         return -1;
+    }
+
+    /**
+     * Returns per-split statistics for use by the optimizer (aggregate pushdown, filter pruning).
+     * Returns {@code null} if statistics are unavailable for this split.
+     * <p>
+     * Implementations that carry row-group or stripe metadata should override this method.
+     * {@link org.elasticsearch.xpack.esql.datasources.FileSplit} returns its compact
+     * {@link SplitStats} when present.
+     * {@link org.elasticsearch.xpack.esql.datasources.CoalescedSplit} returns a
+     * {@link org.elasticsearch.xpack.esql.datasources.MergedSplitStats} that lazily
+     * aggregates its children's statistics.
+     */
+    @Nullable
+    default SplitStats splitStats() {
+        return null;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SplitStats.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.spi;
+
+import org.elasticsearch.core.Nullable;
+
+/**
+ * Per-split statistics used by the optimizer for aggregate pushdown and filter pruning.
+ * Implemented by {@link org.elasticsearch.xpack.esql.datasources.SplitStats} for
+ * individual file splits and by {@link org.elasticsearch.xpack.esql.datasources.MergedSplitStats}
+ * for composite splits that aggregate statistics lazily from their children.
+ * <p>
+ * Unknown numeric values are represented as {@code -1}; unknown object values as {@code null}.
+ * This matches the sentinel convention used throughout the datasources layer
+ * (see {@link ExternalSplit#estimatedSizeInBytes()}).
+ */
+public interface SplitStats {
+
+    /** Total row count for this split. Always {@code >= 0}. */
+    long rowCount();
+
+    /**
+     * Uncompressed size of the data in this split, in bytes.
+     * Returns {@code -1} if unknown.
+     */
+    long sizeInBytes();
+
+    /**
+     * On-disk (compressed) size of this split, in bytes.
+     * Returns {@code -1} if unknown.
+     */
+    default long compressedSizeInBytes() {
+        return -1;
+    }
+
+    /**
+     * Number of null values in the named column, or {@code -1} if unknown or the
+     * column is not present in this split's statistics.
+     */
+    long columnNullCount(String name);
+
+    /**
+     * Minimum value for the named column, or {@code null} if unknown or the column
+     * is not present in this split's statistics.
+     */
+    @Nullable
+    Object columnMin(String name);
+
+    /**
+     * Maximum value for the named column, or {@code null} if unknown or the column
+     * is not present in this split's statistics.
+     */
+    @Nullable
+    Object columnMax(String name);
+
+    /**
+     * Uncompressed size in bytes for the named column, or {@code -1} if unknown or the
+     * column is not present in this split's statistics.
+     */
+    default long columnSizeBytes(String name) {
+        return -1;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdown.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdown.java
@@ -10,7 +10,8 @@ package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.CoalescedSplit;
+import org.elasticsearch.xpack.esql.datasources.MergedSplitStats;
 import org.elasticsearch.xpack.esql.datasources.SplitStats;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
@@ -84,14 +85,21 @@ final class ExternalSourceAggregatePushdown {
      * <p>
      * When a single split is present and has its own statistics, those are preferred over
      * file-level metadata to avoid misclassification when split stats differ from the whole.
+     * <p>
+     * Uses {@link ExternalSplit#splitStats()} on each split, which handles both
+     * {@link org.elasticsearch.xpack.esql.datasources.FileSplit} and
+     * {@link org.elasticsearch.xpack.esql.datasources.CoalescedSplit} transparently.
      */
-    static SplitStats resolveFilteredStats(ExternalSourceExec externalExec, Expression filterCondition) {
+    static org.elasticsearch.xpack.esql.datasources.spi.SplitStats resolveFilteredStats(
+        ExternalSourceExec externalExec,
+        Expression filterCondition
+    ) {
         List<? extends ExternalSplit> splits = externalExec.splits();
 
         if (splits.isEmpty() || splits.size() == 1) {
-            SplitStats stats = null;
-            if (splits.size() == 1 && splits.getFirst() instanceof FileSplit fs && fs.splitStats() != null) {
-                stats = fs.splitStats();
+            org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats = null;
+            if (splits.size() == 1) {
+                stats = splits.getFirst().splitStats();
             }
             if (stats == null) {
                 stats = SplitStats.of(externalExec.sourceMetadata());
@@ -107,12 +115,10 @@ final class ExternalSourceAggregatePushdown {
             };
         }
 
-        List<SplitStats> matchedStats = new ArrayList<>();
-        for (ExternalSplit split : splits) {
-            if (split instanceof FileSplit == false) {
-                return null;
-            }
-            SplitStats stats = ((FileSplit) split).splitStats();
+        List<ExternalSplit> flatSplits = CoalescedSplit.flatten(splits);
+        List<org.elasticsearch.xpack.esql.datasources.spi.SplitStats> matchedStats = new ArrayList<>();
+        for (ExternalSplit split : flatSplits) {
+            org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats = split.splitStats();
             if (stats == null) {
                 return null;
             }
@@ -130,6 +136,6 @@ final class ExternalSourceAggregatePushdown {
         if (matchedStats.isEmpty()) {
             return SplitStats.EMPTY;
         }
-        return SplitStats.merge(matchedStats);
+        return new MergedSplitStats(matchedStats);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushAggregatesToExternalSource.java
@@ -93,7 +93,7 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
             return aggregateExec;
         }
 
-        SplitStats stats = SplitStats.resolveEffectiveStats(externalExec.splits(), externalExec.sourceMetadata());
+        var stats = SplitStats.resolveEffectiveStats(externalExec.splits(), externalExec.sourceMetadata());
         if (stats == null) {
             return aggregateExec;
         }
@@ -121,7 +121,7 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
 
     private boolean resolveAggregateValues(
         List<? extends NamedExpression> aggregates,
-        SplitStats stats,
+        org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats,
         List<Object> values,
         List<DataType> dataTypes
     ) {
@@ -141,7 +141,7 @@ public class PushAggregatesToExternalSource extends PhysicalOptimizerRules.Param
         return true;
     }
 
-    private Object resolveFromStats(Expression aggFunction, SplitStats stats) {
+    private Object resolveFromStats(Expression aggFunction, org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats) {
         if (aggFunction instanceof Count count) {
             if (count.hasFilter()) {
                 return null;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushFiltersToSource.java
@@ -257,7 +257,7 @@ public class PushFiltersToSource extends PhysicalOptimizerRules.ParameterizedOpt
 
         // Split filter condition by AND and reorder by estimated selectivity
         List<Expression> filters = splitAnd(filterExec.condition());
-        SplitStats effectiveStats = SplitStats.resolveEffectiveStats(externalExec.splits(), externalExec.sourceMetadata());
+        var effectiveStats = SplitStats.resolveEffectiveStats(externalExec.splits(), externalExec.sourceMetadata());
         filters = FilterEvaluationOrderEstimator.orderByEstimatedCost(filters, effectiveStats);
 
         // Use the SPI to push filters

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushStatsToExternalSource.java
@@ -85,7 +85,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
             filterForClassification = filterCondition.transformDown(ReferenceAttribute.class, r -> aliasReplacedBy.resolve(r, r));
         }
 
-        SplitStats stats;
+        org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats;
         if (filterForClassification != null) {
             stats = ExternalSourceAggregatePushdown.resolveFilteredStats(externalExec, filterForClassification);
         } else {
@@ -132,7 +132,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         return new LocalSourceExec(aggregateExec.source(), outputAttrs, LocalSupplier.of(new Page(blocks)));
     }
 
-    private static Object resolveFromStats(Expression aggFunction, SplitStats stats) {
+    private static Object resolveFromStats(Expression aggFunction, org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats) {
         if (aggFunction instanceof Count count) {
             return resolveCount(count, stats);
         } else if (aggFunction instanceof Min min) {
@@ -143,7 +143,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         return null;
     }
 
-    private static Object resolveCount(Count count, SplitStats stats) {
+    private static Object resolveCount(Count count, org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats) {
         if (count.hasFilter()) {
             return null;
         }
@@ -160,7 +160,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         return null;
     }
 
-    private static Object resolveMin(Min min, SplitStats stats) {
+    private static Object resolveMin(Min min, org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats) {
         if (min.hasFilter()) {
             return null;
         }
@@ -171,7 +171,7 @@ public class PushStatsToExternalSource extends PhysicalOptimizerRules.OptimizerR
         return null;
     }
 
-    private static Object resolveMax(Max max, SplitStats stats) {
+    private static Object resolveMax(Max max, org.elasticsearch.xpack.esql.datasources.spi.SplitStats stats) {
         if (max.hasFilter()) {
             return null;
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SplitFilterClassifier.java
@@ -11,7 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
-import org.elasticsearch.xpack.esql.datasources.SplitStats;
+import org.elasticsearch.xpack.esql.datasources.spi.SplitStats;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
@@ -64,7 +64,7 @@ final class SplitFilterClassifier {
      * Supports AND, OR, NOT, and leaf comparisons (field op literal).
      */
     public static SplitMatch classifyExpression(Expression filter, SplitStats splitStats) {
-        if (filter == null || splitStats == null || splitStats.columnCount() == 0) {
+        if (filter == null || splitStats == null) {
             return SplitMatch.AMBIGUOUS;
         }
         return classifyRecursive(filter, splitStats);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/MergedSplitStatsTests.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+
+public class MergedSplitStatsTests extends ESTestCase {
+
+    // -- rowCount --
+
+    public void testRowCountSumsChildren() {
+        SplitStats a = stats(100, -1);
+        SplitStats b = stats(200, -1);
+        SplitStats c = stats(300, -1);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b, c));
+        assertEquals(600, merged.rowCount());
+    }
+
+    public void testRowCountSingleChild() {
+        MergedSplitStats merged = new MergedSplitStats(List.of(stats(42, -1)));
+        assertEquals(42, merged.rowCount());
+    }
+
+    // -- sizeInBytes --
+
+    public void testSizeInBytesSumsWhenAllKnown() {
+        SplitStats a = stats(100, 1000);
+        SplitStats b = stats(200, 2000);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        assertEquals(3000, merged.sizeInBytes());
+    }
+
+    public void testSizeInBytesReturnsMinusOneWhenAnyUnknown() {
+        SplitStats a = stats(100, 1000);
+        SplitStats b = stats(200, -1);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        assertEquals(-1, merged.sizeInBytes());
+    }
+
+    public void testSizeInBytesAllUnknown() {
+        SplitStats a = stats(100, -1);
+        SplitStats b = stats(200, -1);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        assertEquals(-1, merged.sizeInBytes());
+    }
+
+    // -- columnNullCount --
+
+    public void testColumnNullCountSumsChildren() {
+        SplitStats a = splitStatsWithColumn("age", 5L, 10, 90, 400);
+        SplitStats b = splitStatsWithColumn("age", 3L, 15, 80, 800);
+        SplitStats c = splitStatsWithColumn("age", 2L, 20, 70, 1200);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b, c));
+        assertEquals(10, merged.columnNullCount("age"));
+    }
+
+    public void testColumnNullCountReturnsMinusOneWhenAnyUnknown() {
+        SplitStats a = splitStatsWithColumn("age", -1L, 10, 90, 400);
+        SplitStats b = splitStatsWithColumn("age", 3L, 15, 80, 800);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        assertEquals(-1, merged.columnNullCount("age"));
+    }
+
+    public void testColumnNullCountReturnsMinusOneForMissingColumn() {
+        SplitStats a = splitStatsWithColumn("age", 5L, 10, 90, 400);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a));
+        assertEquals(-1, merged.columnNullCount("name"));
+    }
+
+    // -- columnMin --
+
+    public void testColumnMinTakesMinimumAcrossChildren() {
+        SplitStats a = splitStatsWithColumn("age", 0L, 18, 65, 400);
+        SplitStats b = splitStatsWithColumn("age", 0L, 25, 80, 800);
+        SplitStats c = splitStatsWithColumn("age", 0L, 10, 70, 1200);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b, c));
+        assertEquals(10, merged.columnMin("age"));
+    }
+
+    public void testColumnMinReturnsNullWhenAnyChildHasNullMin() {
+        SplitStats withMin = splitStatsWithColumn("age", 0L, 18, 65, 400);
+        SplitStats withoutMin = splitStatsWithNullMinMax("age");
+        MergedSplitStats merged = new MergedSplitStats(List.of(withMin, withoutMin));
+        assertNull(merged.columnMin("age"));
+    }
+
+    public void testColumnMinReturnsNullForMissingColumn() {
+        SplitStats a = splitStatsWithColumn("age", 0L, 18, 65, 400);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a));
+        assertNull(merged.columnMin("name"));
+    }
+
+    public void testColumnMinCrossTypeIntegerLong() {
+        SplitStats a = splitStatsWithColumn("score", 0L, 18, 65, 400);   // Integer min=18
+        SplitStats b = splitStatsWithLongColumn("score", 10L, 20L, 200L); // Long min=20
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        // Integer 18 vs Long 20 -> min is 18, widened to Long
+        Object min = merged.columnMin("score");
+        assertNotNull(min);
+        assertEquals(18L, ((Number) min).longValue());
+    }
+
+    // -- columnMax --
+
+    public void testColumnMaxTakesMaximumAcrossChildren() {
+        SplitStats a = splitStatsWithColumn("age", 0L, 18, 65, 400);
+        SplitStats b = splitStatsWithColumn("age", 0L, 25, 90, 800);
+        SplitStats c = splitStatsWithColumn("age", 0L, 10, 70, 1200);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b, c));
+        assertEquals(90, merged.columnMax("age"));
+    }
+
+    public void testColumnMaxReturnsNullWhenAnyChildHasNullMax() {
+        SplitStats withMax = splitStatsWithColumn("age", 0L, 18, 65, 400);
+        SplitStats withoutMax = splitStatsWithNullMinMax("age");
+        MergedSplitStats merged = new MergedSplitStats(List.of(withMax, withoutMax));
+        assertNull(merged.columnMax("age"));
+    }
+
+    // -- columnSizeBytes --
+
+    public void testColumnSizeBytesSumsChildren() {
+        SplitStats a = splitStatsWithColumn("age", 0L, 18, 65, 400);
+        SplitStats b = splitStatsWithColumn("age", 0L, 25, 90, 800);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        assertEquals(1200, merged.columnSizeBytes("age"));
+    }
+
+    public void testColumnSizeBytesReturnsMinusOneWhenAnyUnknown() {
+        SplitStats a = splitStatsWithColumn("age", 0L, 18, 65, -1);
+        SplitStats b = splitStatsWithColumn("age", 0L, 25, 90, 800);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        assertEquals(-1, merged.columnSizeBytes("age"));
+    }
+
+    // -- children() --
+
+    public void testChildrenReturnsAllChildren() {
+        SplitStats a = stats(100, -1);
+        SplitStats b = stats(200, -1);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        assertEquals(2, merged.children().size());
+    }
+
+    // -- constructor validation --
+
+    public void testConstructorRejectsNullChildren() {
+        expectThrows(IllegalArgumentException.class, () -> new MergedSplitStats(null));
+    }
+
+    public void testConstructorRejectsEmptyChildren() {
+        expectThrows(IllegalArgumentException.class, () -> new MergedSplitStats(List.of()));
+    }
+
+    // -- toString --
+
+    public void testToStringIncludesChildCount() {
+        SplitStats a = stats(100, -1);
+        SplitStats b = stats(200, -1);
+        MergedSplitStats merged = new MergedSplitStats(List.of(a, b));
+        String str = merged.toString();
+        assertTrue(str.contains("2"));
+    }
+
+    // -- helpers --
+
+    private static SplitStats stats(long rowCount, long sizeInBytes) {
+        SplitStats.Builder b = new SplitStats.Builder().rowCount(rowCount);
+        if (sizeInBytes >= 0) {
+            b.sizeInBytes(sizeInBytes);
+        }
+        return b.build();
+    }
+
+    private static SplitStats splitStatsWithColumn(String name, long nullCount, int min, int max, long sizeBytes) {
+        SplitStats.Builder b = new SplitStats.Builder().rowCount(100);
+        b.addColumn(name, nullCount, min, max, sizeBytes);
+        return b.build();
+    }
+
+    private static SplitStats splitStatsWithLongColumn(String name, long nullCount, long min, long max) {
+        SplitStats.Builder b = new SplitStats.Builder().rowCount(100);
+        b.addColumn(name, nullCount, min, max, -1);
+        return b.build();
+    }
+
+    private static SplitStats splitStatsWithNullMinMax(String name) {
+        SplitStats.Builder b = new SplitStats.Builder().rowCount(100);
+        b.addColumn(name, -1L, null, null, -1L);
+        return b.build();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitStatsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/SplitStatsTests.java
@@ -316,7 +316,7 @@ public class SplitStatsTests extends ESTestCase {
         Map<String, Object> sourceMetadata = new HashMap<>();
         sourceMetadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 1000L);
 
-        SplitStats result = SplitStats.resolveEffectiveStats(List.of(), sourceMetadata);
+        var result = SplitStats.resolveEffectiveStats(List.of(), sourceMetadata);
         assertNotNull(result);
         assertEquals(1000, result.rowCount());
     }
@@ -326,7 +326,7 @@ public class SplitStatsTests extends ESTestCase {
         sourceMetadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 1000L);
         sourceMetadata.put(SourceStatisticsSerializer.STATS_PARTIAL, Boolean.TRUE);
 
-        SplitStats result = SplitStats.resolveEffectiveStats(List.of(), sourceMetadata);
+        var result = SplitStats.resolveEffectiveStats(List.of(), sourceMetadata);
         assertNull("Should return null for partial stats to prevent wrong pushdown", result);
     }
 
@@ -335,7 +335,7 @@ public class SplitStatsTests extends ESTestCase {
         sourceMetadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 1000L);
         sourceMetadata.put(SourceStatisticsSerializer.STATS_PARTIAL, Boolean.FALSE);
 
-        SplitStats result = SplitStats.resolveEffectiveStats(List.of(), sourceMetadata);
+        var result = SplitStats.resolveEffectiveStats(List.of(), sourceMetadata);
         assertNotNull("Non-true partial flag should not block stats", result);
         assertEquals(1000, result.rowCount());
     }
@@ -346,7 +346,7 @@ public class SplitStatsTests extends ESTestCase {
         SplitStats splitStats = b.build();
         FileSplit split = fileSplitWithStats(splitStats);
 
-        SplitStats result = SplitStats.resolveEffectiveStats(List.of(split), Map.of());
+        var result = SplitStats.resolveEffectiveStats(List.of(split), Map.of());
         assertNotNull(result);
         assertEquals(500, result.rowCount());
         assertEquals(0, result.columnNullCount("x"));
@@ -367,7 +367,7 @@ public class SplitStatsTests extends ESTestCase {
 
         List<ExternalSplit> splits = List.of(fileSplitWithStats(s1), fileSplitWithStats(s2), fileSplitWithStats(s3));
 
-        SplitStats result = SplitStats.resolveEffectiveStats(splits, Map.of());
+        var result = SplitStats.resolveEffectiveStats(splits, Map.of());
         assertNotNull(result);
         assertEquals(600, result.rowCount());
         assertEquals(15, result.columnNullCount("age"));
@@ -393,7 +393,7 @@ public class SplitStatsTests extends ESTestCase {
 
         List<ExternalSplit> splits = List.of(splitWithStats, splitWithoutStats);
 
-        SplitStats result = SplitStats.resolveEffectiveStats(splits, Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 9999L));
+        var result = SplitStats.resolveEffectiveStats(splits, Map.of(SourceStatisticsSerializer.STATS_ROW_COUNT, 9999L));
         assertNull("Should return null when any split lacks stats", result);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/CountPushdownWiringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/CountPushdownWiringTests.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.FileSplit;
+import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.SplitCoalescer;
+import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
+import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
+import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
+import org.elasticsearch.xpack.esql.plan.physical.LocalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.planner.mapper.LocalMapper;
+import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
+import org.elasticsearch.xpack.esql.stats.SearchStats;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.alias;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.referenceAttribute;
+
+/**
+ * Wiring tests that verify COUNT(*) pushdown works end-to-end through
+ * {@link PlannerUtils#localPlan} — the same code path used on data nodes.
+ * <p>
+ * Unlike {@link PushAggregatesToExternalSourceTests} which tests the optimizer rule
+ * in isolation, these tests exercise the full chain: FragmentExec containing a logical
+ * Aggregate → ExternalRelation is mapped, splits are injected, and the physical
+ * optimizer runs. This catches regressions where splits lose their statistics during
+ * the wiring between split discovery and the optimizer.
+ */
+public class CountPushdownWiringTests extends ESTestCase {
+
+    private static final ReferenceAttribute AGE = referenceAttribute("age", DataType.INTEGER);
+
+    /**
+     * Core scenario: EXTERNAL "file" | STATS c = COUNT(*) with multiple row-group splits.
+     * Each split carries per-row-group statistics. The optimizer should replace the
+     * AggregateExec → ExternalSourceExec subtree with a LocalSourceExec.
+     */
+    public void testCountStarPushdownThroughLocalPlan() {
+        List<ExternalSplit> splits = createSplitsWithStats(5, 1000L);
+        PhysicalPlan result = runLocalPlanWithSplits(countStarAggregate(), splits);
+
+        LocalSourceExec local = as(result, LocalSourceExec.class);
+        Page page = local.supplier().get();
+        assertEquals(5000L, as(page.getBlock(0), LongBlock.class).getLong(0));
+    }
+
+    /**
+     * Single-split scenario: one row group with stats.
+     */
+    public void testCountStarPushdownSingleSplit() {
+        List<ExternalSplit> splits = createSplitsWithStats(1, 42_000L);
+        PhysicalPlan result = runLocalPlanWithSplits(countStarAggregate(), splits);
+
+        LocalSourceExec local = as(result, LocalSourceExec.class);
+        Page page = local.supplier().get();
+        assertEquals(42_000L, as(page.getBlock(0), LongBlock.class).getLong(0));
+    }
+
+    /**
+     * Regression guard: splits without stats must NOT push down. The optimizer
+     * should preserve the AggregateExec → ExternalSourceExec subtree.
+     */
+    public void testCountStarNotPushedWithoutSplitStats() {
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            splits.add(
+                new FileSplit("file", StoragePath.of("file:///split" + i + ".parquet"), 0, 100, ".parquet", Map.of(), Map.of(), null)
+            );
+        }
+        PhysicalPlan result = runLocalPlanWithSplits(countStarAggregate(), splits);
+
+        as(result, AggregateExec.class);
+    }
+
+    /**
+     * Regression test: CoalescedSplits wrapping FileSplits with stats must still push down.
+     * This is the exact scenario that breaks with large S3 Parquet files (>32 row-group splits
+     * trigger SplitCoalescer, which wraps FileSplits in CoalescedSplit).
+     */
+    public void testCountStarPushdownWithCoalescedSplits() {
+        List<ExternalSplit> fileSplits = createSplitsWithStats(50, 200L);
+        List<ExternalSplit> coalesced = SplitCoalescer.coalesce(fileSplits);
+        assertFalse("coalescing should have fired for 50 splits", coalesced.equals(fileSplits));
+
+        PhysicalPlan result = runLocalPlanWithSplits(countStarAggregate(), coalesced);
+
+        LocalSourceExec local = as(result, LocalSourceExec.class);
+        Page page = local.supplier().get();
+        assertEquals(10_000L, as(page.getBlock(0), LongBlock.class).getLong(0));
+    }
+
+    /**
+     * Mixed splits: some with stats, some without. Must NOT push down.
+     */
+    public void testCountStarNotPushedWithMixedSplitStats() {
+        List<ExternalSplit> splits = new ArrayList<>();
+        splits.add(fileSplitWithStats(0, 1000L));
+        splits.add(new FileSplit("file", StoragePath.of("file:///noStats.parquet"), 0, 100, ".parquet", Map.of(), Map.of(), null));
+        splits.add(fileSplitWithStats(2, 2000L));
+
+        PhysicalPlan result = runLocalPlanWithSplits(countStarAggregate(), splits);
+        as(result, AggregateExec.class);
+    }
+
+    /**
+     * Empty splits list: pushdown should use sourceMetadata from the ExternalRelation
+     * (the pre-fix behavior where the optimizer sees 0 splits).
+     */
+    public void testCountStarPushdownWithEmptySplitsUsesSourceMetadata() {
+        PhysicalPlan result = runLocalPlanWithSplits(countStarAggregate(), List.of());
+
+        LocalSourceExec local = as(result, LocalSourceExec.class);
+        Page page = local.supplier().get();
+        assertEquals(99_000L, as(page.getBlock(0), LongBlock.class).getLong(0));
+    }
+
+    /**
+     * INITIAL mode (data node): intermediate blocks should have (value, seen) pairs.
+     */
+    public void testCountStarInitialModeThroughLocalPlan() {
+        List<ExternalSplit> splits = createSplitsWithStats(3, 500L);
+        Aggregate logicalAgg = countStarAggregate();
+
+        PhysicalPlan mapped = LocalMapper.INSTANCE.map(logicalAgg);
+        AggregateExec aggExec = as(mapped, AggregateExec.class);
+        assertEquals(AggregatorMode.INITIAL, aggExec.getMode());
+
+        FormatReaderRegistry registry = buildParquetRegistry();
+        PhysicalPlan result = runLocalPlanWithSplitsAndRegistry(logicalAgg, splits, registry);
+
+        LocalSourceExec local = as(result, LocalSourceExec.class);
+        Page page = local.supplier().get();
+        assertEquals(2, page.getBlockCount());
+        assertEquals(1500L, as(page.getBlock(0), LongBlock.class).getLong(0));
+    }
+
+    // ---- helpers ----
+
+    private PhysicalPlan runLocalPlanWithSplits(Aggregate logicalAgg, List<ExternalSplit> splits) {
+        return runLocalPlanWithSplitsAndRegistry(logicalAgg, splits, buildParquetRegistry());
+    }
+
+    private PhysicalPlan runLocalPlanWithSplitsAndRegistry(
+        Aggregate logicalAgg,
+        List<ExternalSplit> splits,
+        FormatReaderRegistry registry
+    ) {
+        FragmentExec fragment = new FragmentExec(logicalAgg);
+
+        PhysicalPlan result = PlannerUtils.localPlan(
+            PlannerSettings.DEFAULTS,
+            new EsqlFlags(true),
+            null,
+            FoldContext.small(),
+            fragment,
+            SearchStats.EMPTY,
+            registry,
+            splits,
+            null
+        );
+
+        return result;
+    }
+
+    private static Aggregate countStarAggregate() {
+        List<Attribute> attrs = List.of(referenceAttribute("x", DataType.INTEGER), AGE);
+        Map<String, Object> sourceMetadata = new HashMap<>();
+        sourceMetadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 99_000L);
+
+        SourceMetadata metadata = new SourceMetadata() {
+            @Override
+            public List<Attribute> schema() {
+                return attrs;
+            }
+
+            @Override
+            public String sourceType() {
+                return "parquet";
+            }
+
+            @Override
+            public String location() {
+                return "file:///test.parquet";
+            }
+
+            @Override
+            public Map<String, Object> sourceMetadata() {
+                return sourceMetadata;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                return o instanceof SourceMetadata;
+            }
+
+            @Override
+            public int hashCode() {
+                return 1;
+            }
+        };
+
+        ExternalRelation external = new ExternalRelation(Source.EMPTY, "file:///test.parquet", metadata, attrs);
+        Alias countAlias = alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
+        return new Aggregate(Source.EMPTY, external, List.of(), List.of(countAlias));
+    }
+
+    private static List<ExternalSplit> createSplitsWithStats(int count, long rowsPerSplit) {
+        List<ExternalSplit> splits = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            splits.add(fileSplitWithStats(i, rowsPerSplit));
+        }
+        return splits;
+    }
+
+    private static FileSplit fileSplitWithStats(int index, long rowCount) {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put(SourceStatisticsSerializer.STATS_ROW_COUNT, rowCount);
+        stats.put(SourceStatisticsSerializer.STATS_SIZE_BYTES, rowCount * 100);
+        return new FileSplit(
+            "file",
+            StoragePath.of("file:///split" + index + ".parquet"),
+            index * 1024L,
+            1024,
+            ".parquet",
+            Map.of(),
+            Map.of(),
+            null,
+            stats
+        );
+    }
+
+    private static FormatReaderRegistry buildParquetRegistry() {
+        FormatReaderRegistry registry = new FormatReaderRegistry(null);
+        AggregatePushdownSupport parquetSupport = (aggregates, groupings) -> {
+            if (groupings.isEmpty() == false) {
+                return AggregatePushdownSupport.Pushability.NO;
+            }
+            for (Expression agg : aggregates) {
+                if (agg instanceof Count || agg instanceof Min || agg instanceof Max) {
+                    continue;
+                }
+                return AggregatePushdownSupport.Pushability.NO;
+            }
+            return AggregatePushdownSupport.Pushability.YES;
+        };
+        registry.registerLazy("parquet", (settings, blockFactory) -> new StubFormatReader(parquetSupport), null, null);
+        return registry;
+    }
+
+    private static class StubFormatReader implements FormatReader {
+        private final AggregatePushdownSupport support;
+
+        StubFormatReader(AggregatePushdownSupport support) {
+            this.support = support;
+        }
+
+        @Override
+        public SourceMetadata metadata(org.elasticsearch.xpack.esql.datasources.spi.StorageObject object) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public org.elasticsearch.compute.operator.CloseableIterator<Page> read(
+            org.elasticsearch.xpack.esql.datasources.spi.StorageObject object,
+            org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext context
+        ) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String formatName() {
+            return "parquet";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public AggregatePushdownSupport aggregatePushdownSupport() {
+            return support;
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
SplitCoalescer wraps FileSplits in CoalescedSplit when there are >32
row-group splits. The optimizer only checked `instanceof FileSplit`
for statistics access, silently skipping pushdown for large Parquet
files.

Adds a SplitStats SPI interface on ExternalSplit so CoalescedSplit
exposes merged statistics transparently via MergedSplitStats.
Eliminates all `instanceof FileSplit` checks in the optimizer stats
path.

Developed with AI-assisted tooling