### PR TITLE
Use bulk vector scoring for rescoring kNN queries

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnSearcher.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnSearcher.java
@@ -727,14 +727,7 @@ public class KnnSearcher {
         }
         if (searchParameters.overSamplingFactor() > 1f) {
             // oversample the topK results to get more candidates for the final result
-            knnQuery = RescoreKnnVectorQuery.fromInnerQuery(
-                VECTOR_FIELD,
-                vector,
-                similarityFunction,
-                searchParameters.topK(),
-                overSampledTopK,
-                knnQuery
-            );
+            knnQuery = RescoreKnnVectorQuery.fromInnerQuery(VECTOR_FIELD, vector, searchParameters.topK(), overSampledTopK, knnQuery);
         }
         QueryProfiler profiler = new QueryProfiler();
         TopDocs docs = searcher.search(knnQuery, searchParameters.topK());

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -3223,14 +3223,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     : new ESKnnFloatVectorQuery(name(), queryVector, adjustedK, numCands, filter, knnSearchStrategy, hnswEarlyTermination);
             }
             if (rescore) {
-                knnQuery = RescoreKnnVectorQuery.fromInnerQuery(
-                    name(),
-                    queryVector,
-                    similarity.vectorSimilarityFunction(indexVersionCreated, ElementType.FLOAT),
-                    k,
-                    adjustedK,
-                    knnQuery
-                );
+                knnQuery = RescoreKnnVectorQuery.fromInnerQuery(name(), queryVector, k, adjustedK, knnQuery);
             }
             if (similarityThreshold != null) {
                 knnQuery = new VectorSimilarityQuery(

--- a/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
@@ -287,36 +287,47 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             DocIdSetIterator conjunction = ConjunctionUtils.intersectIterators(List.of(vectorIter, filterIterator));
 
             VectorScorer scorer = knnVectorValues.rescorer(floatTarget);
-            int[] docs = new int[PREFETCH_BUFFER_SIZE];
             DocAndFloatFeatureBuffer scoreBuffer = new DocAndFloatFeatureBuffer();
             scoreBuffer.growNoCopy(PREFETCH_BUFFER_SIZE);
 
-            // sequentially copy the doc ids into the docs array for bulk rescoring in batches
-            int nextDocIdx = 0;
-            while ((docs[nextDocIdx++] = conjunction.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+            if (input != null) {
+                int[] docs = new int[PREFETCH_BUFFER_SIZE];
 
-                if (nextDocIdx == PREFETCH_BUFFER_SIZE) {
-                    // do the bulk rescore
-                    var bulk = scorer.bulk(new ArrayDocIdSetIterator(docs));
-                    bulk.nextDocsAndScores(docs[PREFETCH_BUFFER_SIZE - 1], null, scoreBuffer);
+                // sequentially copy the doc ids into the docs array for bulk rescoring in batches
+                int nextDocIdx = 0;
+                while ((docs[nextDocIdx++] = conjunction.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+
+                    if (nextDocIdx == PREFETCH_BUFFER_SIZE) {
+                        // do the bulk rescore
+                        var bulk = scorer.bulk(new ArrayDocIdSetIterator(docs, PREFETCH_BUFFER_SIZE));
+                        bulk.nextDocsAndScores(docs[PREFETCH_BUFFER_SIZE - 1], null, scoreBuffer);
+
+                        for (int s = 0; s < scoreBuffer.size; s++) {
+                            if (!Float.isNaN(scoreBuffer.features[s])) {
+                                queue.add(new ScoreDoc(scoreBuffer.docs[s] + docBase, scoreBuffer.features[s]));
+                            }
+                        }
+                        nextDocIdx = 0; // don't need to explicitly clear the arrays, they just get overwritten
+                    }
+
+                    input.prefetch((long) vectorIter.index() * vectorByteSize, vectorByteSize);
+                }
+
+                if (nextDocIdx > 0) {
+                    // rescore the remaining docs
+                    var bulk = scorer.bulk(new ArrayDocIdSetIterator(docs, nextDocIdx));
+                    bulk.nextDocsAndScores(docs[nextDocIdx - 1], null, scoreBuffer);
 
                     for (int s = 0; s < scoreBuffer.size; s++) {
                         if (!Float.isNaN(scoreBuffer.features[s])) {
                             queue.add(new ScoreDoc(scoreBuffer.docs[s] + docBase, scoreBuffer.features[s]));
                         }
                     }
-                    nextDocIdx = 0; // don't need to explicitly clear the arrays, they just get overwritten
                 }
-
-                if (input != null) {
-                    input.prefetch((long) vectorIter.index() * vectorByteSize, vectorByteSize);
-                }
-            }
-
-            if (nextDocIdx > 0) {
-                // rescore the remaining docs
-                var bulk = scorer.bulk(new ArrayDocIdSetIterator(Arrays.copyOf(docs, nextDocIdx)));
-                bulk.nextDocsAndScores(docs[nextDocIdx - 1], null, scoreBuffer);
+            } else {
+                // just use the bulk scorer over the whole lot, nothing to prefetch
+                var bulk = scorer.bulk(conjunction);
+                bulk.nextDocsAndScores(DocIdSetIterator.NO_MORE_DOCS, null, scoreBuffer);
 
                 for (int s = 0; s < scoreBuffer.size; s++) {
                     if (!Float.isNaN(scoreBuffer.features[s])) {
@@ -329,10 +340,12 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
         private static class ArrayDocIdSetIterator extends DocIdSetIterator {
 
             private final int[] ids;
+            private final int size;
             private int idx = -1;
 
-            private ArrayDocIdSetIterator(int[] ids) {
+            private ArrayDocIdSetIterator(int[] ids, int size) {
                 this.ids = ids;
+                this.size = size;
             }
 
             @Override
@@ -340,12 +353,12 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
                 if (idx == -1) {
                     return -1;
                 }
-                return idx < ids.length ? ids[idx] : NO_MORE_DOCS;
+                return idx < size ? ids[idx] : NO_MORE_DOCS;
             }
 
             @Override
             public int nextDoc() {
-                if (++idx >= ids.length) {
+                if (++idx >= size) {
                     return NO_MORE_DOCS;
                 } else {
                     return ids[idx];
@@ -354,11 +367,11 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
 
             @Override
             public int advance(int target) {
-                if (idx >= ids.length) {
+                if (idx >= size) {
                     return NO_MORE_DOCS;
                 }
 
-                int pos = Arrays.binarySearch(ids, idx + 1, ids.length, target);
+                int pos = Arrays.binarySearch(ids, idx + 1, size, target);
                 if (pos < 0) {
                     pos = -pos - 1;
                 }
@@ -369,7 +382,7 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
 
             @Override
             public long cost() {
-                return ids.length;
+                return size;
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
@@ -12,7 +12,6 @@ package org.elasticsearch.search.vectors;
 import org.apache.lucene.codecs.lucene95.HasIndexSlice;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.KnnVectorValues;
-import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.queries.function.FunctionScoreQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.ConjunctionUtils;
@@ -57,21 +56,13 @@ import java.util.Objects;
 public abstract class RescoreKnnVectorQuery extends Query implements QueryProfilerProvider {
     protected final String fieldName;
     protected final float[] floatTarget;
-    protected final VectorSimilarityFunction vectorSimilarityFunction;
     protected final int k;
     protected final Query innerQuery;
     protected long vectorOperations = 0;
 
-    private RescoreKnnVectorQuery(
-        String fieldName,
-        float[] floatTarget,
-        VectorSimilarityFunction vectorSimilarityFunction,
-        int k,
-        Query innerQuery
-    ) {
+    private RescoreKnnVectorQuery(String fieldName, float[] floatTarget, int k, Query innerQuery) {
         this.fieldName = fieldName;
         this.floatTarget = floatTarget;
-        this.vectorSimilarityFunction = vectorSimilarityFunction;
         this.k = k;
         this.innerQuery = innerQuery;
     }
@@ -81,26 +72,18 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
      *
      * @param fieldName                the name of the field containing the vector
      * @param floatTarget              the target vector to compare against
-     * @param vectorSimilarityFunction the similarity function to apply
      * @param k                        the number of top documents to return after rescoring
      * @param rescoreK                 the number of top documents to consider for rescoring
      * @param innerQuery               the original Lucene query to rescore
      */
-    public static RescoreKnnVectorQuery fromInnerQuery(
-        String fieldName,
-        float[] floatTarget,
-        VectorSimilarityFunction vectorSimilarityFunction,
-        int k,
-        int rescoreK,
-        Query innerQuery
-    ) {
+    public static RescoreKnnVectorQuery fromInnerQuery(String fieldName, float[] floatTarget, int k, int rescoreK, Query innerQuery) {
         if ((innerQuery instanceof KnnFloatVectorQuery fQuery && fQuery.getK() == rescoreK)
             || (innerQuery instanceof KnnByteVectorQuery bQuery && bQuery.getK() == rescoreK)
             || (innerQuery instanceof AbstractIVFKnnVectorQuery ivfQuery && ivfQuery.k == rescoreK)) {
             // Queries that return only the top `k` results and do not require reduction before re-scoring.
-            return new InlineRescoreQuery(fieldName, floatTarget, vectorSimilarityFunction, k, innerQuery);
+            return new InlineRescoreQuery(fieldName, floatTarget, k, innerQuery);
         }
-        return new LateRescoreQuery(fieldName, floatTarget, vectorSimilarityFunction, k, rescoreK, innerQuery);
+        return new LateRescoreQuery(fieldName, floatTarget, k, rescoreK, innerQuery);
     }
 
     public Query innerQuery() {
@@ -132,14 +115,13 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
         RescoreKnnVectorQuery that = (RescoreKnnVectorQuery) o;
         return Objects.equals(fieldName, that.fieldName)
             && Arrays.equals(floatTarget, that.floatTarget)
-            && vectorSimilarityFunction == that.vectorSimilarityFunction
             && Objects.equals(k, that.k)
             && Objects.equals(innerQuery, that.innerQuery);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fieldName, Arrays.hashCode(floatTarget), vectorSimilarityFunction, k, innerQuery);
+        return Objects.hash(fieldName, Arrays.hashCode(floatTarget), k, innerQuery);
     }
 
     @Override
@@ -152,8 +134,6 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             + ", floatTarget="
             + floatTarget[0]
             + "..."
-            + ", vectorSimilarityFunction="
-            + vectorSimilarityFunction
             + ", k="
             + k
             + ", vectorQuery="
@@ -162,14 +142,8 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
     }
 
     private static class InlineRescoreQuery extends RescoreKnnVectorQuery {
-        private InlineRescoreQuery(
-            String fieldName,
-            float[] floatTarget,
-            VectorSimilarityFunction vectorSimilarityFunction,
-            int k,
-            Query innerQuery
-        ) {
-            super(fieldName, floatTarget, vectorSimilarityFunction, k, innerQuery);
+        private InlineRescoreQuery(String fieldName, float[] floatTarget, int k, Query innerQuery) {
+            super(fieldName, floatTarget, k, innerQuery);
         }
 
         @Override
@@ -196,15 +170,8 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
     private static class LateRescoreQuery extends RescoreKnnVectorQuery {
         final int rescoreK;
 
-        private LateRescoreQuery(
-            String fieldName,
-            float[] floatTarget,
-            VectorSimilarityFunction vectorSimilarityFunction,
-            int k,
-            int rescoreK,
-            Query innerQuery
-        ) {
-            super(fieldName, floatTarget, vectorSimilarityFunction, k, innerQuery);
+        private LateRescoreQuery(String fieldName, float[] floatTarget, int k, int rescoreK, Query innerQuery) {
+            super(fieldName, floatTarget, k, innerQuery);
             this.rescoreK = rescoreK;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
@@ -16,6 +16,7 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.queries.function.FunctionScoreQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.ConjunctionUtils;
+import org.apache.lucene.search.DocAndFloatFeatureBuffer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnByteVectorQuery;
@@ -27,6 +28,8 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.VectorScorer;
+import org.apache.lucene.store.IndexInput;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.search.profile.query.QueryProfiler;
@@ -34,7 +37,6 @@ import org.elasticsearch.search.profile.query.QueryProfiler;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
@@ -261,7 +263,6 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             assert innerRewritten.getClass() != MatchAllDocsQuery.class;
 
             List<ScoreDoc> results = new ArrayList<>(10);
-            List<CheckedRunnable<IOException>> buffer = new LinkedList<>();
             for (var leaf : indexSearcher.getIndexReader().leaves()) {
                 var knnVectorValues = leaf.reader().getFloatVectorValues(fieldName);
                 if (knnVectorValues == null) {
@@ -278,20 +279,9 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
                     continue;
                 }
                 var filterIterator = scorer.iterator();
-                rescoreIndividually(
-                    leaf.docBase,
-                    knnVectorValues,
-                    leaf.reader().getFieldInfos().fieldInfo(fieldName).getVectorSimilarityFunction(),
-                    buffer,
-                    results,
-                    filterIterator
-                );
+                bulkRescore(leaf.docBase, knnVectorValues, results, filterIterator);
             }
 
-            for (var runnable : buffer) {
-                runnable.run();
-            }
-            buffer.clear();
             // Remove any remaining sentinel values
             ScoreDoc[] arrayResults = results.toArray(new ScoreDoc[0]);
             return new KnnScoreDocQuery(arrayResults, indexSearcher.getIndexReader());
@@ -321,43 +311,98 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
          * Adds rescoring work to {@code buffer}. If {@code buffer} is non-empty after this call,
          * the caller must run the queued {@link CheckedRunnable}s to materialize results into {@code queue}.
          */
-        private void rescoreIndividually(
-            int docBase,
-            FloatVectorValues knnVectorValues,
-            VectorSimilarityFunction function,
-            List<CheckedRunnable<IOException>> buffer,
-            List<ScoreDoc> queue,
-            DocIdSetIterator filterIterator
-        ) throws IOException {
-            final int vectorByteSize = knnVectorValues.getVectorByteLength();
-            final HasIndexSlice sliceable = (knnVectorValues instanceof HasIndexSlice h) ? h : null;
-            final var input = sliceable != null ? sliceable.getSlice() : null;
+        private void bulkRescore(int docBase, FloatVectorValues knnVectorValues, List<ScoreDoc> queue, DocIdSetIterator filterIterator)
+            throws IOException {
+            int vectorByteSize = knnVectorValues.getVectorByteLength();
+            IndexInput input = (knnVectorValues instanceof HasIndexSlice h) ? h.getSlice() : null;
 
             KnnVectorValues.DocIndexIterator vectorIter = knnVectorValues.iterator();
             DocIdSetIterator conjunction = ConjunctionUtils.intersectIterators(List.of(vectorIter, filterIterator));
-            int doc;
-            while ((doc = conjunction.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-                assert doc == vectorIter.docID();
-                final int docID = doc;
-                final int ord = vectorIter.index();
 
-                if (buffer.size() == PREFETCH_BUFFER_SIZE) {
-                    for (var runnable : buffer) {
-                        runnable.run();
+            VectorScorer scorer = knnVectorValues.rescorer(floatTarget);
+            int[] docs = new int[PREFETCH_BUFFER_SIZE];
+            DocAndFloatFeatureBuffer scoreBuffer = new DocAndFloatFeatureBuffer();
+            scoreBuffer.growNoCopy(PREFETCH_BUFFER_SIZE);
+
+            // sequentially copy the doc ids into the docs array for bulk rescoring in batches
+            int nextDocIdx = 0;
+            while ((docs[nextDocIdx++] = conjunction.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+
+                if (nextDocIdx == PREFETCH_BUFFER_SIZE) {
+                    // do the bulk rescore
+                    var bulk = scorer.bulk(new ArrayDocIdSetIterator(docs));
+                    bulk.nextDocsAndScores(docs[PREFETCH_BUFFER_SIZE - 1], null, scoreBuffer);
+
+                    for (int s = 0; s < scoreBuffer.size; s++) {
+                        if (!Float.isNaN(scoreBuffer.features[s])) {
+                            queue.add(new ScoreDoc(scoreBuffer.docs[s] + docBase, scoreBuffer.features[s]));
+                        }
                     }
-                    buffer.clear();
+                    nextDocIdx = 0; // don't need to explicitly clear the arrays, they just get overwritten
                 }
 
                 if (input != null) {
-                    input.prefetch((long) ord * vectorByteSize, vectorByteSize);
+                    input.prefetch((long) vectorIter.index() * vectorByteSize, vectorByteSize);
                 }
-                buffer.add(() -> {
-                    float[] vector = knnVectorValues.vectorValue(ord);
-                    float score = function.compare(floatTarget, vector);
-                    if (Float.isNaN(score) == false) {
-                        queue.add(new ScoreDoc(docID + docBase, score));
+            }
+
+            if (nextDocIdx > 0) {
+                // rescore the remaining docs
+                var bulk = scorer.bulk(new ArrayDocIdSetIterator(Arrays.copyOf(docs, nextDocIdx)));
+                bulk.nextDocsAndScores(docs[nextDocIdx - 1], null, scoreBuffer);
+
+                for (int s = 0; s < scoreBuffer.size; s++) {
+                    if (!Float.isNaN(scoreBuffer.features[s])) {
+                        queue.add(new ScoreDoc(scoreBuffer.docs[s] + docBase, scoreBuffer.features[s]));
                     }
-                });
+                }
+            }
+        }
+
+        private static class ArrayDocIdSetIterator extends DocIdSetIterator {
+
+            private final int[] ids;
+            private int idx = -1;
+
+            private ArrayDocIdSetIterator(int[] ids) {
+                this.ids = ids;
+            }
+
+            @Override
+            public int docID() {
+                if (idx == -1) {
+                    return -1;
+                }
+                return idx < ids.length ? ids[idx] : NO_MORE_DOCS;
+            }
+
+            @Override
+            public int nextDoc() {
+                if (++idx >= ids.length) {
+                    return NO_MORE_DOCS;
+                } else {
+                    return ids[idx];
+                }
+            }
+
+            @Override
+            public int advance(int target) {
+                if (idx >= ids.length) {
+                    return NO_MORE_DOCS;
+                }
+
+                int pos = Arrays.binarySearch(ids, idx + 1, ids.length, target);
+                if (pos < 0) {
+                    pos = -pos - 1;
+                }
+                idx = pos;
+
+                return docID();
+            }
+
+            @Override
+            public long cost() {
+                return ids.length;
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/vectors/RescoreKnnVectorQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/RescoreKnnVectorQueryTests.java
@@ -100,7 +100,6 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
                     RescoreKnnVectorQuery rescoreKnnVectorQuery = RescoreKnnVectorQuery.fromInnerQuery(
                         FIELD_NAME,
                         queryVector,
-                        VectorSimilarityFunction.COSINE,
                         k,
                         k,
                         innerQuery
@@ -182,7 +181,6 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
                     RescoreKnnVectorQuery rescoreKnnVectorQuery = RescoreKnnVectorQuery.fromInnerQuery(
                         FIELD_NAME,
                         queryVector,
-                        VectorSimilarityFunction.COSINE,
                         k,
                         k,
                         innerQuery
@@ -193,14 +191,7 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
                     assertThat(rescoredDocs.scoreDocs, arrayWithSize(k));
 
                     searcher = newSearcher(new SingleVectorQueryIndexReader(reader), true, false);
-                    rescoreKnnVectorQuery = RescoreKnnVectorQuery.fromInnerQuery(
-                        FIELD_NAME,
-                        queryVector,
-                        VectorSimilarityFunction.COSINE,
-                        k,
-                        k,
-                        innerQuery
-                    );
+                    rescoreKnnVectorQuery = RescoreKnnVectorQuery.fromInnerQuery(FIELD_NAME, queryVector, k, k, innerQuery);
                     TopDocs singleRescored = searcher.search(rescoreKnnVectorQuery, numDocs);
                     assertThat(singleRescored.scoreDocs, arrayWithSize(k));
 
@@ -235,14 +226,7 @@ public class RescoreKnnVectorQueryTests extends ESTestCase {
     }
 
     private void checkProfiling(int k, int numDocs, float[] queryVector, IndexReader reader, Query innerQuery) throws IOException {
-        var rescoreKnnVectorQuery = RescoreKnnVectorQuery.fromInnerQuery(
-            FIELD_NAME,
-            queryVector,
-            VectorSimilarityFunction.COSINE,
-            k,
-            k,
-            innerQuery
-        );
+        var rescoreKnnVectorQuery = RescoreKnnVectorQuery.fromInnerQuery(FIELD_NAME, queryVector, k, k, innerQuery);
         IndexSearcher searcher = newSearcher(reader, true, false);
         searcher.search(rescoreKnnVectorQuery, numDocs);
 


### PR DESCRIPTION
Use the bulk path as part of the format's vector scorer, rather than explicitly reading each value separately.

This gets rid of the shared buffer that consolidated rescores across leaves, but that's necessary due to different KnnVectorValues potentially having different rescorer implementations, and the previous implementation was single-scoring anyway. It also uses the native scoring paths that are available.