### PR TITLE
OTLP mapping mode follow-ups

### DIFF
--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/MappingMode.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/MappingMode.java
@@ -19,7 +19,16 @@ import org.elasticsearch.core.Nullable;
  * instrumentation scope attribute (which takes precedence).
  */
 public enum MappingMode {
+    /**
+     * Maps OTLP fields into Elasticsearch's standard OTel document structure, preserving resource, scope, and record metadata.
+     * Documents are routed to data streams backed by the built-in OTel templates, using the
+     * {@code <type>-<dataset>.otel-<namespace>} naming pattern.
+     */
     OTEL("otel"),
+
+    /**
+     * Uses a log record's body map as the complete document, without copying the surrounding OTLP metadata.
+     */
     BODYMAP("bodymap");
 
     public static final String HEADER = "X-Elastic-Mapping-Mode";
@@ -49,6 +58,17 @@ public enum MappingMode {
                 return mode;
             }
         }
-        throw new IllegalArgumentException("Unsupported mapping mode [" + value + "], expected one of [otel, bodymap]");
+        throw new IllegalArgumentException("Unsupported mapping mode [" + value + "], expected one of [" + acceptedModes() + "]");
+    }
+
+    private static String acceptedModes() {
+        StringBuilder acceptedModes = new StringBuilder();
+        for (MappingMode mode : values()) {
+            if (acceptedModes.isEmpty() == false) {
+                acceptedModes.append(", ");
+            }
+            acceptedModes.append(mode.name);
+        }
+        return acceptedModes.toString();
     }
 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionRequest.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/OTLPActionRequest.java
@@ -35,6 +35,7 @@ public class OTLPActionRequest extends ActionRequest implements CompositeIndices
 
     @Override
     public void writeTo(StreamOutput out) {
+        // OTLP REST actions execute locally; the request body is not serialized over transport.
         TransportAction.localOnly();
     }
 

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndex.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/TargetIndex.java
@@ -117,7 +117,9 @@ public final class TargetIndex {
             String overrideType = firstAttributeValue(DATA_STREAM_TYPE, attributes, scopeAttributes, resourceAttributes);
             if (overrideType != null) {
                 if (TYPE_LOGS.equals(overrideType) == false && TYPE_METRICS.equals(overrideType) == false) {
-                    throw new IllegalArgumentException("data_stream.type cannot be other than logs or metrics, got [" + overrideType + "]");
+                    throw new IllegalArgumentException(
+                        "data_stream.type can only be set to \"logs\" or \"metrics\", got [" + overrideType + "]"
+                    );
                 }
                 target.type = overrideType;
             }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/LogDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/LogDocumentBuilder.java
@@ -79,6 +79,7 @@ public class LogDocumentBuilder extends OTelDocumentBuilder {
      */
     public void buildBodyMapLogDocument(XContentBuilder builder, LogRecord logRecord) throws IOException {
         AnyValue body = logRecord.getBody();
+        // Keep this guard for direct callers even though transport actions pre-validate bodymap records.
         if (body.getValueCase() != AnyValue.ValueCase.KVLIST_VALUE) {
             throw new IllegalArgumentException("invalid log record body type for 'bodymap' mapping mode: " + body.getValueCase());
         }

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPRestActionTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/AbstractOTLPRestActionTests.java
@@ -131,7 +131,7 @@ public abstract class AbstractOTLPRestActionTests extends ESTestCase {
             IllegalArgumentException.class,
             () -> execute(1024, 0, Map.of(MappingMode.HEADER, List.of("ecs")))
         );
-        assertThat(e.getMessage(), containsString("Unsupported mapping mode [ecs]"));
+        assertThat(e.getMessage(), equalTo("Unsupported mapping mode [ecs], expected one of [otel, bodymap]"));
     }
 
     public void testEmptyBodyReturnsSuccess() throws Exception {

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OTLPLogsTransportActionTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OTLPLogsTransportActionTests.java
@@ -103,7 +103,7 @@ public class OTLPLogsTransportActionTests extends AbstractOTLPTransportActionTes
             .build();
         BulkRequestBuilder bulkRequestBuilder = new BulkRequestBuilder(client);
 
-        ProcessingContext context = logsAction.prepareBulkRequest(createBodyMapRequest(List.of(logRecord)), bulkRequestBuilder);
+        ProcessingContext context = logsAction.prepareBulkRequest(createRequestWithBodyMapScope(List.of(logRecord)), bulkRequestBuilder);
 
         assertThat(context.totalItems(), equalTo(1));
         assertThat(context.getIgnoredItems(), equalTo(0));
@@ -247,7 +247,7 @@ public class OTLPLogsTransportActionTests extends AbstractOTLPTransportActionTes
             IllegalArgumentException.class,
             () -> logsAction.prepareBulkRequest(createBodyMapRequest(List.of(logRecord), null, MappingMode.BODYMAP), bulkRequestBuilder)
         );
-        assertThat(e.getMessage(), containsString("data_stream.type cannot be other than logs or metrics"));
+        assertThat(e.getMessage(), equalTo("data_stream.type can only be set to \"logs\" or \"metrics\", got [traces]"));
     }
 
     public void testBodyMapModeRoutesWithoutOtelSuffix() throws Exception {
@@ -279,7 +279,7 @@ public class OTLPLogsTransportActionTests extends AbstractOTLPTransportActionTes
         BulkRequestBuilder bulkRequestBuilder = new BulkRequestBuilder(client);
 
         ProcessingContext context = logsAction.prepareBulkRequest(
-            createBodyMapRequest(List.of(invalidLogRecord1, invalidLogRecord2, validLogRecord)),
+            createRequestWithBodyMapScope(List.of(invalidLogRecord1, invalidLogRecord2, validLogRecord)),
             bulkRequestBuilder
         );
 
@@ -297,7 +297,7 @@ public class OTLPLogsTransportActionTests extends AbstractOTLPTransportActionTes
         assertThat(((Number) indexRequest.sourceAsMap().get("a")).longValue(), equalTo(42L));
     }
 
-    private static OTLPActionRequest createBodyMapRequest(List<LogRecord> logRecords) {
+    private static OTLPActionRequest createRequestWithBodyMapScope(List<LogRecord> logRecords) {
         return createBodyMapRequest(logRecords, "bodymap", MappingMode.OTEL);
     }
 


### PR DESCRIPTION
This follows up on review comments from the bodymap mapping mode PR. It clarifies the difference between the `otel` and `bodymap` mapping modes, including that `otel` routes to data streams backed by the built-in OTel templates using the `<type>-<dataset>.otel-<namespace>` naming pattern.

It also keeps accepted mapping mode names derived from the enum values, tightens a couple of error assertions/messages, documents why the local-only OTLP action request does not serialize its body, and makes the bodymap validation/test naming a little clearer.