### PR TITLE
Update ilm-wait-for-snapshot.md

### DIFF
--- a/docs/reference/elasticsearch/index-lifecycle-actions/ilm-wait-for-snapshot.md
+++ b/docs/reference/elasticsearch/index-lifecycle-actions/ilm-wait-for-snapshot.md
@@ -8,8 +8,7 @@ mapped_pages:
 Phases allowed: delete.
 
 Waits for the specified {{slm-init}} policy to be executed before removing the index.
-This only checks that an SLM policy has had a successful execution at some point after the wait action has started.
-It does not ensure that a snapshot of the index is available before deletion.
+This  checks that an SLM policy has had a successful execution at some point after the wait action has started, and that the index is included in the snapshot.
 
 ## Options [ilm-wait-for-snapshot-options]
 


### PR DESCRIPTION
This has been fixed to include a check for a backup of the index as of https://github.com/elastic/elasticsearch/pull/100911

Documentation for 7.17 onwards and 8.12 onwards should be amended as well
