### PR TITLE
Consolidate reindex resilience features

### DIFF
--- a/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexCancelIT.java
+++ b/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexCancelIT.java
@@ -92,7 +92,7 @@ public class ReindexCancelIT extends ESIntegTestCase {
      * We test synchronous (<code>?wait_for_completion=true</code>) invocation of the _cancel endpoint in this test.
      */
     public void testCancelEndpointEndToEndSynchronously() throws Exception {
-        assumeTrue("PIT-based reindex path", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT-based reindex path", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final TaskId parentTaskId = startAsyncThrottledReindex();
 
@@ -153,7 +153,7 @@ public class ReindexCancelIT extends ESIntegTestCase {
 
     /** Same test as above but calling _cancel asynchronously and wrapping assertions after cancellation in assertBusy. */
     public void testCancelEndpointEndToEndAsynchronously() throws Exception {
-        assumeTrue("PIT-based reindex path", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT-based reindex path", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final TaskId parentTaskId = startAsyncThrottledReindex();
 
@@ -238,7 +238,7 @@ public class ReindexCancelIT extends ESIntegTestCase {
      * Cancelling a reindex sub-task (slice worker) by its task id must be rejected with a reindex 404
      */
     public void testCancellingChildTaskRejected() throws Exception {
-        assumeTrue("PIT-based reindex path", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT-based reindex path", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final TaskId parentTaskId = startAsyncThrottledReindex();
         try {

--- a/modules/reindex-management/src/main/java/org/elasticsearch/reindex/management/ReindexManagementFeatures.java
+++ b/modules/reindex-management/src/main/java/org/elasticsearch/reindex/management/ReindexManagementFeatures.java
@@ -13,26 +13,16 @@ import org.elasticsearch.features.FeatureSpecification;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.reindex.ReindexPlugin;
 
-import java.util.HashSet;
 import java.util.Set;
 
 public class ReindexManagementFeatures implements FeatureSpecification {
 
-    public static final NodeFeature NEW_ENDPOINTS = new NodeFeature("reindex_management_endpoints");
-
     @Override
     public Set<NodeFeature> getFeatures() {
-        final Set<NodeFeature> features = new HashSet<>();
-        // TODO: Before we release any functionality behind FeatureFlags, we should see whether we can
-        // consolidate the node features. These are a constrained resource, so we should combine the features for anything that is being
-        // released at the same time while we still can.
         if (ReindexPlugin.REINDEX_RESILIENCE_ENABLED) {
-            features.add(NEW_ENDPOINTS);
-            features.add(ReindexPlugin.RELOCATE_ON_SHUTDOWN_NODE_FEATURE);
+            return Set.of(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE);
+        } else {
+            return Set.of();
         }
-        if (ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED) {
-            features.add(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE);
-        }
-        return Set.copyOf(features);
     }
 }

--- a/modules/reindex-management/src/main/java/org/elasticsearch/reindex/management/RestCancelReindexAction.java
+++ b/modules/reindex-management/src/main/java/org/elasticsearch/reindex/management/RestCancelReindexAction.java
@@ -11,6 +11,7 @@ package org.elasticsearch.reindex.management;
 
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
@@ -48,7 +49,7 @@ public class RestCancelReindexAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) {
-        if (clusterSupportsFeature.test(ReindexManagementFeatures.NEW_ENDPOINTS) == false) {
+        if (clusterSupportsFeature.test(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE) == false) {
             throw new IllegalArgumentException("endpoint not supported on all nodes in the cluster");
         }
         final String taskIdParam = request.param("task_id");

--- a/modules/reindex-management/src/main/java/org/elasticsearch/reindex/management/RestGetReindexAction.java
+++ b/modules/reindex-management/src/main/java/org/elasticsearch/reindex/management/RestGetReindexAction.java
@@ -12,6 +12,7 @@ package org.elasticsearch.reindex.management;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestUtils;
@@ -49,7 +50,7 @@ public class RestGetReindexAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
-        if (clusterSupportsFeature.test(ReindexManagementFeatures.NEW_ENDPOINTS) == false) {
+        if (clusterSupportsFeature.test(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE) == false) {
             throw new IllegalArgumentException("endpoint not supported on all nodes in the cluster");
         }
 

--- a/modules/reindex-management/src/main/java/org/elasticsearch/reindex/management/RestListReindexAction.java
+++ b/modules/reindex-management/src/main/java/org/elasticsearch/reindex/management/RestListReindexAction.java
@@ -11,6 +11,7 @@ package org.elasticsearch.reindex.management;
 
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.ServerlessScope;
@@ -49,7 +50,7 @@ public class RestListReindexAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
-        if (clusterSupportsFeature.test(ReindexManagementFeatures.NEW_ENDPOINTS) == false) {
+        if (clusterSupportsFeature.test(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE) == false) {
             throw new IllegalArgumentException("endpoint not supported on all nodes in the cluster");
         }
         ListReindexRequest listReindexRequest = new ListReindexRequest(request.paramAsBoolean("detailed", false));

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/LocalReindexResumeIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/LocalReindexResumeIT.java
@@ -59,7 +59,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 /**
  * Tests local reindexing tasks resumed after node relocation.
  * NB This test includes tests for both scroll and point-in-time search. The scroll-based tests can be removed once
- * {@link ReindexPlugin#REINDEX_PIT_SEARCH_ENABLED} is defaulted to true.
+ * {@link ReindexPlugin#REINDEX_RESILIENCE_ENABLED} is defaulted to true.
  */
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0)
 public class LocalReindexResumeIT extends ESIntegTestCase {
@@ -83,7 +83,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromScroll() {
-        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         int totalDocs = randomIntBetween(20, 100);
@@ -131,7 +131,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromPit() {
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         int totalDocs = randomIntBetween(20, 100);
@@ -205,7 +205,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromScroll_slicedN() {
-        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         final int totalDocs = randomIntBetween(200, 300);
@@ -262,7 +262,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromPit_slicedN() {
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         final int totalDocs = randomIntBetween(200, 300);
@@ -349,7 +349,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromScroll_slicedN_partialCompleted() {
-        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         final int totalDocs = randomIntBetween(200, 300);
@@ -420,7 +420,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromPit_slicedN_partialCompleted() {
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         final int totalDocs = randomIntBetween(200, 300);
@@ -520,7 +520,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromScroll_slicedAuto() {
-        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         final int totalDocs = randomIntBetween(200, 300);
@@ -587,7 +587,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromPit_slicedAuto() {
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         final int totalDocs = randomIntBetween(200, 300);
@@ -683,7 +683,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromScroll_slicedManual() {
-        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         final int totalDocs = randomIntBetween(200, 300);
@@ -748,7 +748,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromPit_slicedManual() {
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         final int totalDocs = randomIntBetween(200, 300);
@@ -842,7 +842,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexMetricsRecordsDurationFromRelocationOrigin() {
-        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         assertThat(internalCluster().numDataNodes(), equalTo(1));
         final String dataNodeName = internalCluster().getRandomDataNodeName();
         final TestTelemetryPlugin telemetryPlugin = internalCluster().getInstance(PluginsService.class, dataNodeName)
@@ -915,7 +915,7 @@ public class LocalReindexResumeIT extends ESIntegTestCase {
     }
 
     public void testResumeReindexFromPit_metricsRecordsDurationFromRelocationOrigin() {
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         assertThat(internalCluster().numDataNodes(), equalTo(1));
         final String dataNodeName = internalCluster().getRandomDataNodeName();
         final TestTelemetryPlugin telemetryPlugin = internalCluster().getInstance(PluginsService.class, dataNodeName)

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexPitKeepAliveIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexPitKeepAliveIT.java
@@ -113,7 +113,7 @@ public class ReindexPitKeepAliveIT extends ESIntegTestCase {
      * {@link org.elasticsearch.action.search.OpenPointInTimeRequest#keepAlive()}.
      */
     public void testClusterSettingControlsLocalReindexOpenPitKeepAlive() throws Exception {
-        assumeTrue("reindex PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final TimeValue configured = TimeValue.timeValueMinutes(randomIntBetween(10, 20));
         assertAcked(

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexPluginMetricsIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexPluginMetricsIT.java
@@ -338,7 +338,7 @@ public class ReindexPluginMetricsIT extends ESIntegTestCase {
      * (e.g. connection refused, host unreachable).
      */
     public void testRemoteReindexVersionLookupFailureMetrics() throws Exception {
-        assumeTrue("PIT search must be enabled for remote version lookup path", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled for remote version lookup path", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final String dataNodeName = internalCluster().startNode();
 
@@ -396,7 +396,7 @@ public class ReindexPluginMetricsIT extends ESIntegTestCase {
      * Verifies that local reindex metrics record failures when PIT open fails (e.g. source index is closed).
      */
     public void testLocalReindexPitOpenFailureMetrics() throws Exception {
-        assumeTrue("PIT search must be enabled for local PIT path", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled for local PIT path", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final String dataNodeName = internalCluster().startNode();
 

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexRelocationOnShutdownIT.java
@@ -92,7 +92,7 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
      */
     public void testReindexTaskRelocatesOnNodeShutdown() throws Exception {
         assumeTrue("reindex resilience must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         internalCluster().startMasterOnlyNode();
@@ -213,7 +213,7 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
      */
     public void testReindexFailsWhenPitRelocationFails() throws Exception {
         assumeTrue("reindex resilience must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         internalCluster().startMasterOnlyNode();
@@ -333,7 +333,7 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
      */
     public void testReindexTaskFailsWhenDataNodeIsShuttingDownAndTaskDoesNotFinishInTime() throws Exception {
         assumeTrue("reindex resilience must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         final String masterNodeName = internalCluster().startMasterOnlyNode();
@@ -422,7 +422,7 @@ public class ReindexRelocationOnShutdownIT extends ESIntegTestCase {
      */
     public void testReindexTaskFinishesBeforeNodeShutsDown() throws Exception {
         assumeTrue("reindex resilience must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         final String masterNodeName = internalCluster().startMasterOnlyNode();

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/RemoteReindexResumeIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/RemoteReindexResumeIT.java
@@ -105,11 +105,11 @@ public class RemoteReindexResumeIT extends ESIntegTestCase {
     }
 
     /**
-     * Resume remote reindex using scroll when {@link ReindexPlugin#REINDEX_PIT_SEARCH_ENABLED} is off.
+     * Resume remote reindex using scroll when {@link ReindexPlugin#REINDEX_RESILIENCE_ENABLED} is off.
      * The remote URL is this cluster's HTTP endpoint (real Elasticsearch), matching the scroll id obtained locally.
      */
     public void testResumeReindexFromScroll() {
-        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeFalse("reindex with point-in-time search must not be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         int totalDocs = randomIntBetween(20, 100);
@@ -174,12 +174,12 @@ public class RemoteReindexResumeIT extends ESIntegTestCase {
     }
 
     /**
-     * Resume remote reindex using PIT when {@link ReindexPlugin#REINDEX_PIT_SEARCH_ENABLED} is on.
+     * Resume remote reindex using PIT when {@link ReindexPlugin#REINDEX_RESILIENCE_ENABLED} is on.
      * A mock HTTP server reports a remote {@link Version} on {@code GET /} that is 7.10 or later so
      * {@link org.elasticsearch.reindex.Reindexer} takes the remote PIT path
      */
     public void testResumeReindexFromPit_mockRemoteVersionSupportsPit() throws Exception {
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         final Version reportedRemoteVersion = randomFrom(Version.V_7_10_0, Version.V_8_0_0, Version.V_8_15_0);
         String sourceIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
         String destIndex = randomAlphanumericOfLength(10).toLowerCase(Locale.ROOT);
@@ -265,7 +265,7 @@ public class RemoteReindexResumeIT extends ESIntegTestCase {
      * With PIT enabled locally, a remote still reports {@link Version} &lt; 7.10.0 so reindex falls back to scroll against that cluster.
      */
     public void testResumeReindexFromPit_mockRemoteVersionDoesNotSupportPit() throws Exception {
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         final Version reportedRemoteVersion = randomFrom(Version.V_7_9_0, Version.V_7_8_0, Version.V_7_0_0);
         assertTrue(reportedRemoteVersion.before(Version.V_7_10_0));
 

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexPlugin.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexPlugin.java
@@ -46,22 +46,22 @@ public class ReindexPlugin extends Plugin implements ActionPlugin, ExtensiblePlu
 
     public static final ActionType<ListTasksResponse> RETHROTTLE_ACTION = new ActionType<>("cluster:admin/reindex/rethrottle");
 
-    // N.B. We declare these in the reindex module, so that we can check whether the features are available on the cluster here - but we
-    // register them via a FeatureSpecification in the reindex-management module, to work around build problems caused by doing it here.
+    /**
+     * Whether reindex resilience features are available. This includes relocating reindex tasks on node shutdown, the reindex management
+     * APIs added alongside that change, and the change from scroll-based to PIT-based search.
+     */
+    // N.B. We declare this in the reindex module, so that we can check whether the features are available on the cluster here - but we
+    // register it via a FeatureSpecification in the reindex-management module, to work around build problems caused by doing it here.
     // (The enrich plugin depends on this module, and registering features leads to either duplicate feature or JAR hell errors.)
     // (This approach means that the functionality requires both reindex and reindex-management modules to be present and enabled.)
-    public static final NodeFeature RELOCATE_ON_SHUTDOWN_NODE_FEATURE = new NodeFeature("reindex_relocate_on_shutdown");
-    public static final NodeFeature REINDEX_PIT_SEARCH_FEATURE = new NodeFeature("reindex_pit_search");
+    public static final NodeFeature REINDEX_RESILIENCE_NODE_FEATURE = new NodeFeature("reindex_resilience");
 
     /**
-     * Whether the feature flag to guard the work to make reindex more resilient while it is under development.
+     * Whether the feature flag to guard the work to make reindex more resilient while it is under development. This includes relocating
+     * reindex tasks on node shutdown, the reindex management APIs added alongside that change, and the change from scroll-based to
+     * PIT-based search.
      */
     public static final boolean REINDEX_RESILIENCE_ENABLED = new FeatureFlag("reindex_resilience").isEnabled();
-
-    /**
-     * Guards the development work to change reindexing to use point in time (PIT) searching
-     */
-    public static final boolean REINDEX_PIT_SEARCH_ENABLED = new FeatureFlag("reindex_pit_search").isEnabled();
 
     public static ReindexRelocationNodePicker getReindexRelocationNodePicker(final Environment environment) {
         return DiscoveryNode.isStateless(environment.settings())

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -111,7 +111,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.synchronizedList;
 import static org.elasticsearch.common.BackoffPolicy.exponentialBackoff;
 import static org.elasticsearch.index.VersionType.INTERNAL;
-import static org.elasticsearch.reindex.ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE;
 import static org.elasticsearch.reindex.remote.RemoteReindexingUtils.closePit;
 import static org.elasticsearch.reindex.remote.RemoteReindexingUtils.openPit;
 
@@ -228,7 +227,7 @@ public class Reindexer {
         Consumer<Version> workerAction = createWorkerAction(task, request, bulkClient, responseListener);
 
         // Point-in-time searching is disabled, so default to scroll
-        if (featureService.clusterHasFeature(clusterService.state(), REINDEX_PIT_SEARCH_FEATURE) == false) {
+        if (featureService.clusterHasFeature(clusterService.state(), ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE) == false) {
             executePaginatedSearch(task, request, responseListener, workerAction, null);
         }
         /**

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/RestReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/RestReindexAction.java
@@ -91,7 +91,7 @@ public class RestReindexAction extends AbstractBaseReindexRestHandler<ReindexReq
         if (request.hasParam(DocWriteRequest.REQUIRE_ALIAS)) {
             internal.setRequireAlias(request.paramAsBoolean(DocWriteRequest.REQUIRE_ALIAS, false));
         }
-        if (clusterSupportsFeature.test(ReindexPlugin.RELOCATE_ON_SHUTDOWN_NODE_FEATURE)
+        if (clusterSupportsFeature.test(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE)
             && request.paramAsBoolean("wait_for_completion", true) == false) {
             // On shutdown, we can try to relocate an asynchronous reindex task to another node. We cannot do this for synchronous ones,
             // where a client is waiting for a response from this node (but they should not be long-lived anyway).

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexerTests.java
@@ -901,7 +901,7 @@ public class ReindexerTests extends ESTestCase {
      * When a worker with PIT already set completes normally, the PIT must be closed.
      */
     public void testWorkerWithPitAlreadySetClosesPitOnCompletion() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -916,7 +916,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final ClusterService clusterService = clusterServiceMock();
                 final Reindexer reindexer = new Reindexer(
@@ -982,7 +982,7 @@ public class ReindexerTests extends ESTestCase {
      */
     @SuppressForbidden(reason = "use http server for testing")
     public void testRemoteReindexingRequestFailsWhenVersionLookupFails() throws Exception {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         HttpServer server = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         server.createContext("/", exchange -> {
@@ -1006,7 +1006,7 @@ public class ReindexerTests extends ESTestCase {
      */
     @SuppressForbidden(reason = "use http server for testing")
     public void testRemoteReindexingRequestFailsWhenVersionLookupRejected() throws Exception {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         HttpServer server = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         server.createContext("/", exchange -> {
@@ -1029,7 +1029,7 @@ public class ReindexerTests extends ESTestCase {
      */
     @SuppressForbidden(reason = "use http server for testing")
     public void testRemoteReindexingRequestFailsToOpenPit() throws Exception {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         AtomicInteger requestCount = new AtomicInteger(0);
         HttpServer server = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
@@ -1059,7 +1059,7 @@ public class ReindexerTests extends ESTestCase {
      */
     @SuppressForbidden(reason = "use http server for testing")
     public void testRemoteReindexingRequestFailsToClosePit() throws Exception {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         HttpServer server = createRemotePitMockServer((path, method) -> path.contains("_pit") && "DELETE".equals(method), exchange -> {
             try {
@@ -1099,7 +1099,7 @@ public class ReindexerTests extends ESTestCase {
      */
     @SuppressForbidden(reason = "use http server for testing")
     public void testRemoteReindexingRequestFailsWhenClosePitIsRejected() throws Exception {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         HttpServer server = createRemotePitMockServer((path, method) -> path.contains("_pit") && "DELETE".equals(method), exchange -> {
             try {
@@ -1138,7 +1138,7 @@ public class ReindexerTests extends ESTestCase {
      * We use a custom Client that fails on OpenPointInTimeRequest; the listener receives that failure.
      */
     public void testLocalReindexingRequestFailsToOpenPit() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final String expectedMessage = "open-pit-failure-" + randomAlphaOfLength(8);
         final OpenPitFailingClient client = new OpenPitFailingClient(getTestName(), expectedMessage);
@@ -1157,7 +1157,7 @@ public class ReindexerTests extends ESTestCase {
             when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
             FeatureService featureService = mock(FeatureService.class);
-            when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+            when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
             final Reindexer reindexer = new Reindexer(
                 clusterService,
@@ -1207,7 +1207,7 @@ public class ReindexerTests extends ESTestCase {
      * still receives success. This verifies that close failures are handled gracefully and don't propagate.
      */
     public void testLocalReindexingRequestFailsToClosePit() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final String closeFailureMessage = "close-pit-failure-" + randomAlphaOfLength(8);
         final ClosePitFailingClient client = new ClosePitFailingClient(getTestName(), closeFailureMessage);
@@ -1223,7 +1223,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final ClusterService clusterService = clusterServiceMock();
                 final Reindexer reindexer = new Reindexer(
@@ -1284,7 +1284,7 @@ public class ReindexerTests extends ESTestCase {
      * and allowPartialSearchResults explicitly set to false.
      */
     public void testLocalOpenPitRequestHasExpectedProperties() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -1299,7 +1299,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final ClusterService clusterService = clusterServiceMock();
                 final Reindexer reindexer = new Reindexer(
@@ -1355,7 +1355,7 @@ public class ReindexerTests extends ESTestCase {
      * The case when the source query is null is tested in {@link #testLocalOpenPitRequestHasExpectedProperties} above
      */
     public void testLocalOpenPitSetsIndexFilterFromSourceQuery() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -1372,7 +1372,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final Reindexer reindexer = new Reindexer(
                     clusterService,
@@ -1427,7 +1427,7 @@ public class ReindexerTests extends ESTestCase {
      * so PIT searches validate (see {@link org.elasticsearch.action.search.SearchRequest#validate()}).
      */
     public void testLocalOpenPitCopiesProjectRoutingAndClearsSearchRequest() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -1442,7 +1442,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final ClusterService clusterService = clusterServiceMock();
                 final Reindexer reindexer = new Reindexer(
@@ -1500,7 +1500,7 @@ public class ReindexerTests extends ESTestCase {
      * Verifies that no OpenPointInTimeRequest is sent in this case.
      */
     public void testWorkerWithPitAlreadySetSkipsOpenPit() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -1515,7 +1515,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final ClusterService clusterService = clusterServiceMock();
                 final Reindexer reindexer = new Reindexer(
@@ -1576,7 +1576,7 @@ public class ReindexerTests extends ESTestCase {
      * Verifies that openPitAndExecute throws AssertionError when the SearchRequest has routing set.
      */
     public void testLocalOpenPitFailsWhenRoutingSet() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -1591,7 +1591,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final ClusterService clusterService = clusterServiceMock();
                 final Reindexer reindexer = new Reindexer(
@@ -1648,7 +1648,7 @@ public class ReindexerTests extends ESTestCase {
      * Verifies that openPitAndExecute throws AssertionError when the SearchRequest has preference set.
      */
     public void testLocalOpenPitFailsWhenPreferenceSet() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -1663,7 +1663,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final ClusterService clusterService = clusterServiceMock();
                 final Reindexer reindexer = new Reindexer(
@@ -1720,7 +1720,7 @@ public class ReindexerTests extends ESTestCase {
      * Verifies that openPitAndExecute throws AssertionError when the SearchRequest has allowPartialSearchResults set to true.
      */
     public void testLocalOpenPitFailsWhenAllowPartialSearchResultsTrue() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -1735,7 +1735,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final ClusterService clusterService = clusterServiceMock();
                 final Reindexer reindexer = new Reindexer(
@@ -1796,7 +1796,7 @@ public class ReindexerTests extends ESTestCase {
      * share it. Verifies there is exactly one {@code OpenPointInTime} and one {@code ClosePointInTime} request on the local client
      */
     public void testLocalSlicedReindexOpensPitOnceAndClosesOnce() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final TestThreadPool threadPool = new TestThreadPool(getTestName()) {
             @Override
@@ -1811,7 +1811,7 @@ public class ReindexerTests extends ESTestCase {
             when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
             final FeatureService featureService = mock(FeatureService.class);
-            when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+            when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
             final long leaderTaskId = randomLongBetween(1_000L, Long.MAX_VALUE / 4);
             final long firstChildTaskId = leaderTaskId + randomIntBetween(1, 10_000);
@@ -1888,7 +1888,7 @@ public class ReindexerTests extends ESTestCase {
      */
     @SuppressForbidden(reason = "use http server for testing")
     public void testRemoteReindexUsesScrollWhenVersionBeforePitSupport() throws Exception {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final TimeValue expectedScroll = TimeValue.timeValueMinutes(randomIntBetween(1, 8));
         final long expectedScrollNanos = expectedScroll.nanos();
@@ -1952,7 +1952,7 @@ public class ReindexerTests extends ESTestCase {
      */
     @SuppressForbidden(reason = "use http server for testing")
     public void testRemoteOpenPitUsesClusterPitKeepAliveSetting() throws Exception {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final TimeValue expected = TimeValue.timeValueMinutes(randomIntBetween(5, 20));
         final AtomicReference<String> capturedKeepAlive = new AtomicReference<>();
@@ -2005,7 +2005,7 @@ public class ReindexerTests extends ESTestCase {
      * does not affect PIT.
      */
     public void testLocalOpenPitUsesClusterPitKeepAliveSetting() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -2023,7 +2023,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 final FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final Reindexer reindexer = new Reindexer(
                     clusterService,
@@ -2077,7 +2077,7 @@ public class ReindexerTests extends ESTestCase {
      * {@link ReindexSettings#REINDEX_PIT_KEEP_ALIVE_SETTING} (five minutes).
      */
     public void testLocalOpenPitUsesDefaultKeepAliveWhenScrollTimeUnset() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -2094,7 +2094,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 final FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final Reindexer reindexer = new Reindexer(
                     clusterService,
@@ -2148,7 +2148,7 @@ public class ReindexerTests extends ESTestCase {
      * {@link IndicesOptions} as the reindex search request so PIT resolution matches the user's source selection.
      */
     public void testLocalOpenPitRequestCopiesIndicesAndIndicesOptions() {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final OpenPitCapturingClient client = new OpenPitCapturingClient(getTestName());
         try {
@@ -2165,7 +2165,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 final FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 final Reindexer reindexer = new Reindexer(
                     clusterService,
@@ -2217,7 +2217,7 @@ public class ReindexerTests extends ESTestCase {
     }
 
     /**
-     * If the cluster does not advertise {@link ReindexPlugin#REINDEX_PIT_SEARCH_FEATURE}, reindex stays on the scroll path and
+     * If the cluster does not advertise {@link ReindexPlugin#REINDEX_RESILIENCE_NODE_FEATURE}, reindex stays on the scroll path and
      * must not invoke local open-PIT transport actions.
      */
     public void testLocalReindexDoesNotOpenPitWhenClusterFeatureDisabled() {
@@ -2236,7 +2236,7 @@ public class ReindexerTests extends ESTestCase {
                 when(projectResolver.getProjectState(any())).thenReturn(ClusterState.EMPTY_STATE.projectState(Metadata.DEFAULT_PROJECT_ID));
 
                 final FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(false);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(false);
 
                 final Reindexer reindexer = new Reindexer(
                     clusterService,
@@ -2289,7 +2289,7 @@ public class ReindexerTests extends ESTestCase {
      */
     @SuppressForbidden(reason = "use http server for testing")
     public void testRemoteReindexSkipsOpenPitWhenPointInTimeAlreadySet() throws Exception {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         final AtomicInteger pitOpenPostCount = new AtomicInteger();
         HttpServer server = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
@@ -2356,7 +2356,7 @@ public class ReindexerTests extends ESTestCase {
                 ReindexSslConfig sslConfig = new ReindexSslConfig(environment.settings(), environment, mock(ResourceWatcherService.class));
 
                 FeatureService featureService = mock(FeatureService.class);
-                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+                when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
                 Reindexer reindexer = new Reindexer(
                     clusterService,
@@ -2421,7 +2421,7 @@ public class ReindexerTests extends ESTestCase {
      */
     @SuppressForbidden(reason = "use http server for testing")
     public void testRemoteReindexingFailsWhenOpenPitIsRejected() throws Exception {
-        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("PIT search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
 
         AtomicInteger requestSeq = new AtomicInteger();
         HttpServer server = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
@@ -2829,7 +2829,7 @@ public class ReindexerTests extends ESTestCase {
             ReindexSslConfig sslConfig = new ReindexSslConfig(environment.settings(), environment, mock(ResourceWatcherService.class));
 
             FeatureService featureService = mock(FeatureService.class);
-            when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_PIT_SEARCH_FEATURE))).thenReturn(true);
+            when(featureService.clusterHasFeature(any(), eq(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE))).thenReturn(true);
 
             Reindexer reindexer = new Reindexer(
                 clusterService,
@@ -3017,7 +3017,7 @@ public class ReindexerTests extends ESTestCase {
             null,
             transportService,
             mock(ReindexRelocationNodePicker.class),
-            // Will default REINDEX_PIT_SEARCH_FEATURE to false
+            // Will default REINDEX_RESILIENCE_NODE_FEATURE to false
             mock(FeatureService.class),
             taskResultsService
         );

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RestReindexActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RestReindexActionTests.java
@@ -44,7 +44,7 @@ public class RestReindexActionTests extends RestActionTestCase {
     @Before
     public void setUpAction() {
         action = new RestReindexAction(
-            nf -> nf.equals(ReindexPlugin.RELOCATE_ON_SHUTDOWN_NODE_FEATURE) && relocateOnShutdownFeatureEnabled,
+            nf -> nf.equals(ReindexPlugin.REINDEX_RESILIENCE_NODE_FEATURE) && relocateOnShutdownFeatureEnabled,
             CrossProjectModeDecider.NOOP
         );
         controller().registerHandler(action);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotReindexRelocationOnShutdownIT.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotReindexRelocationOnShutdownIT.java
@@ -77,7 +77,7 @@ public class SearchableSnapshotReindexRelocationOnShutdownIT extends BaseSearcha
     public void testReindexRelocatesWithSearchableSnapshotSource() throws Exception {
         disableRepoConsistencyCheck("When the assumeTrue below fails for REINDEX_RESILIENCE_ENABLED, no node has been started");
         assumeTrue("reindex resilience must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
-        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_RESILIENCE_ENABLED);
         assumeTrue("pit relocation must be enabled", SearchService.PIT_RELOCATION_FEATURE_FLAG.isEnabled());
 
         internalCluster().startMasterOnlyNode();


### PR DESCRIPTION
This merges the three node features into one, and the two feature flags into one. They were originally split out because it was not known whether the features would launch together or separately, but they are going to launch separately (and node features aren't free).

This change is safe to make because the features have not been enabled on any long-lived environment.
