### PR TITLE
[Native] i7u bulk AVX-512 shared-b and prefetch optimizations

### DIFF
--- a/docs/changelog/147999.yaml
+++ b/docs/changelog/147999.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 147999
+summary: "[Native] i7u bulk AVX-512 shared-b"
+type: enhancement

--- a/libs/native/libraries/build.gradle
+++ b/libs/native/libraries/build.gradle
@@ -19,7 +19,7 @@ configurations {
 }
 
 var zstdVersion = "1.5.7"
-var vecVersion = "1.0.113"
+var vecVersion = "1.0.115"
 var pqrsVersion = "0.2.0"
 
 repositories {

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
@@ -94,9 +94,9 @@ public final class JdkVectorLibrary implements VectorLibrary {
     /**
      * Native functions in the native simdvec library can have multiple implementations, one for each "capability level".
      * A capability level of "0" means that there is no native function for that platform.
-     * Functions for the base ("1") level are exposed with a simple function name (e.g. "vec_dot7u")
+     * Functions for the base ("1") level are exposed with a simple function name (e.g. "vec_doti7u")
      * Functions for the more advanced levels (2, 3, ...) are exported with a name "decorated" by adding the capability level as
-     * a suffix: if the capability level is N, the suffix will be "_N" (e.g. "vec_dot7u_2").
+     * a suffix: if the capability level is N, the suffix will be "_N" (e.g. "vec_doti7u_2").
      * Capability levels maps to the availability of advanced vector instructions sets for a platform. For example, for x64 we currently
      * define 2 capability levels, 1 (base, processor supports AVX2) and 2 (processor supports AVX-512 with VNNI and VPOPCNT).
      * <p>

--- a/libs/simdvec/native/publish_vec_binaries.sh
+++ b/libs/simdvec/native/publish_vec_binaries.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.113"
+VERSION="1.0.115"
 
 LOCAL=false
 FORCE_UPLOAD=false

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i7_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i7_2.cpp
@@ -112,6 +112,16 @@ EXPORT int32_t vec_doti7u_2(const int8_t* a, const int8_t* b, const int32_t dims
  *
  * The single-pair scorer `dot7u_inner` above uses the same dim-axis pattern
  * under its local `batches` constant.
+ *
+ * Prefetch strategy (head + spread):
+ *   - At each batch boundary, software-prefetches the first `unroll_dim`
+ *     cache lines of every next-batch vector so the very first inner-loop
+ *     iter never waits on a demand miss.
+ *   - At each inner iter, software-prefetches the next `unroll_dim` lines
+ *     (the lines that the *next* outer iter will consume) of every
+ *     next-batch vector. Spreading the issues across the inner loop keeps
+ *     the L1d fill buffer occupancy below the per-core ceiling and lets the
+ *     prefetched lines arrive ~1 outer iter before they are used.
  */
 template <
     typename TData,
@@ -140,8 +150,8 @@ static inline void dot7u_bulk_avx512(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
-                prefetch(next_vecs[I], lines_to_fetch);
             });
+            head_prefetch<batches, unroll_dim>(next_vecs);
         }
 
         // Row-major layout: acc[I * unroll_dim + U] keeps the unroll_dim
@@ -154,6 +164,9 @@ static inline void dot7u_bulk_avx512(
 
         int i = 0;
         for (; i + dimStride <= blk; i += dimStride) {
+            if (has_next) {
+                spread_prefetch<batches, unroll_dim>(next_vecs, i, lines_to_fetch);
+            }
             apply_indexed<unroll_dim>([&](auto U) {
                 __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i + U * stride));
                 apply_indexed<batches>([&](auto I) {
@@ -173,6 +186,9 @@ static inline void dot7u_bulk_avx512(
                 acc[I] = tree_reduce<unroll_dim, __m512i, _mm512_add_epi32>(&acc[I * unroll_dim]);
             });
             for (; i + stride <= blk; i += stride) {
+                if (has_next) {
+                    spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
+                }
                 __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
                 apply_indexed<batches>([&](auto I) {
                     __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));
@@ -323,6 +339,9 @@ EXPORT int32_t vec_sqri7u_2(const int8_t* a, const int8_t* b, const int32_t dims
  * already saturates the issue ports at one accumulator per batch on Sapphire
  * Rapids, so a dim-axis unroll would only add register pressure without
  * throughput. Only the batch-axis (shared-b) parallelism is applied.
+ *
+ * Prefetch strategy: see dot7u_bulk_avx512. Inner step is one cache line per
+ * iter, so this kernel uses head=1 + 1-line spread per iter.
  */
 template <
     typename TData,
@@ -349,8 +368,8 @@ static inline void sqr7u_bulk_avx512(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
-                prefetch(next_vecs[I], lines_to_fetch);
             });
+            head_prefetch<batches, 1>(next_vecs);
         }
 
         __m512i acc[batches];
@@ -360,6 +379,9 @@ static inline void sqr7u_bulk_avx512(
 
         int i = 0;
         for (; i + stride <= blk; i += stride) {
+            if (has_next) {
+                spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
+            }
             __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
             apply_indexed<batches>([&](auto I) {
                 __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i7_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i7_2.cpp
@@ -93,8 +93,124 @@ EXPORT int32_t vec_doti7u_2(const int8_t* a, const int8_t* b, const int32_t dims
     return dot7u_inner(a, b, dims);
 }
 
+/*
+ * Bulk dot product for 7-bit unsigned int lanes with shared query loads.
+ *
+ * Iterates over `batches` document vectors in parallel per dimension step,
+ * loading the query once per step and reusing it across all batched documents
+ * to amortise b-side L1D bandwidth across the batch.
+ *
+ * Two independent unroll axes:
+ *   batches    - number of distinct document vectors scored in parallel;
+ *                amortises the query load and adds independent madd chains
+ *                across documents.
+ *   unroll_dim - number of consecutive 64-byte blocks of the same document
+ *                processed per inner-loop iteration, each into its own
+ *                accumulator. Hides the maddubs/madd port-5 latency on hosts
+ *                whose throughput exceeds what `batches` chains alone can
+ *                saturate.
+ *
+ * The single-pair scorer `dot7u_inner` above uses the same dim-axis pattern
+ * under its local `batches` constant.
+ */
+template <
+    typename TData,
+    const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
+    int batches = 4,
+    int unroll_dim = 1
+>
+static inline void dot7u_bulk_avx512(
+    const TData* a, const int8_t* b, const int32_t dims,
+    const int32_t pitch, const int32_t* offsets,
+    const int32_t count, f32_t* results
+) {
+    constexpr int stride = sizeof(__m512i);              // 64 bytes
+    constexpr int dimStride = stride * unroll_dim;
+    const int blk = dims & ~(stride - 1);
+    const __m512i ones = _mm512_set1_epi16(1);
+    const int lines_to_fetch = dims / CACHE_LINE_SIZE + 1;
+    int c = 0;
+
+    const int8_t* current_vecs[batches];
+    init_pointers<batches, TData, int8_t, mapper>(current_vecs, a, pitch, offsets, 0, count);
+
+    for (; c + batches - 1 < count; c += batches) {
+        const int8_t* next_vecs[batches];
+        const bool has_next = c + 2 * batches - 1 < count;
+        if (has_next) {
+            apply_indexed<batches>([&](auto I) {
+                next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
+                prefetch(next_vecs[I], lines_to_fetch);
+            });
+        }
+
+        // Row-major layout: acc[I * unroll_dim + U] keeps the unroll_dim
+        // accumulators for batch member I contiguous, so tree_reduce can fold
+        // them in one call.
+        __m512i acc[batches * unroll_dim];
+        apply_indexed<batches * unroll_dim>([&](auto I) {
+            acc[I] = _mm512_setzero_si512();
+        });
+
+        int i = 0;
+        for (; i + dimStride <= blk; i += dimStride) {
+            apply_indexed<unroll_dim>([&](auto U) {
+                __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i + U * stride));
+                apply_indexed<batches>([&](auto I) {
+                    __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i + U * stride));
+                    acc[I * unroll_dim + U] = _mm512_add_epi32(
+                        acc[I * unroll_dim + U],
+                        _mm512_madd_epi16(ones, _mm512_maddubs_epi16(av, bv)));
+                });
+            });
+        }
+
+        // Fold the unroll_dim accumulators per batch back into acc[I] before
+        // the unroll_dim=1 tail and the masked tail. Skipped at unroll_dim=1,
+        // where the main loop already wrote into acc[I*1+0] = acc[I].
+        if constexpr (unroll_dim > 1) {
+            apply_indexed<batches>([&](auto I) {
+                acc[I] = tree_reduce<unroll_dim, __m512i, _mm512_add_epi32>(&acc[I * unroll_dim]);
+            });
+            for (; i + stride <= blk; i += stride) {
+                __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
+                apply_indexed<batches>([&](auto I) {
+                    __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));
+                    acc[I] = _mm512_add_epi32(
+                        acc[I], _mm512_madd_epi16(ones, _mm512_maddubs_epi16(av, bv)));
+                });
+            }
+        }
+
+        // Masked tail: zeroed lanes from maskz_loadu contribute nothing to the sum.
+        const int rem = dims - i;
+        if (rem > 0) {
+            __mmask64 mask = (__mmask64)((1ULL << rem) - 1);
+            __m512i bv = _mm512_maskz_loadu_epi8(mask, b + i);
+            apply_indexed<batches>([&](auto I) {
+                __m512i av = _mm512_maskz_loadu_epi8(mask, current_vecs[I] + i);
+                acc[I] = _mm512_add_epi32(
+                    acc[I], _mm512_madd_epi16(ones, _mm512_maddubs_epi16(av, bv)));
+            });
+        }
+
+        apply_indexed<batches>([&](auto I) {
+            results[c + I] = (f32_t)_mm512_reduce_add_epi32(acc[I]);
+        });
+
+        if (has_next) {
+            std::copy_n(next_vecs, batches, current_vecs);
+        }
+    }
+
+    for (; c < count; c++) {
+        const int8_t* a0 = mapper(a, c, offsets, pitch);
+        results[c] = (f32_t)dot7u_inner(a0, b, dims);
+    }
+}
+
 EXPORT void vec_doti7u_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
-    call_i8_bulk<int8_t, sequential_mapper, dot7u_inner, 4>(a, b, dims, dims, NULL, count, results);
+    dot7u_bulk_avx512<int8_t, sequential_mapper, 4, 1>(a, b, dims, dims, NULL, count, results);
 }
 
 EXPORT void vec_doti7u_bulk_offsets_2(
@@ -105,7 +221,7 @@ EXPORT void vec_doti7u_bulk_offsets_2(
     const int32_t* offsets,
     const int32_t count,
     f32_t* results) {
-    call_i8_bulk<int8_t, offsets_mapper, dot7u_inner, 4>(a, b, dims, pitch, offsets, count, results);
+    dot7u_bulk_avx512<int8_t, offsets_mapper, 4, 1>(a, b, dims, pitch, offsets, count, results);
 }
 
 EXPORT void vec_doti7u_bulk_sparse_2(
@@ -114,7 +230,7 @@ EXPORT void vec_doti7u_bulk_sparse_2(
     const int32_t dims,
     const int32_t count,
     f32_t* results) {
-    call_i8_bulk<const int8_t*, sparse_mapper, dot7u_inner, 4>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
+    dot7u_bulk_avx512<const int8_t*, sparse_mapper, 4, 1>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
 }
 
 // Accumulates acc += sqr_distance(pa, pb) for unsigned 7-bit int lanes (64 bytes per step).
@@ -198,8 +314,92 @@ EXPORT int32_t vec_sqri7u_2(const int8_t* a, const int8_t* b, const int32_t dims
     return sqr7u_inner(a, b, dims);
 }
 
+/*
+ * Bulk squared distance for 7-bit unsigned int lanes with shared query loads.
+ *
+ * Same shape as dot7u_bulk_avx512 (parallel batches, shared b per dimension
+ * step) but with sub_epi8 + abs_epi8 + maddubs_epi16(abs,abs) per step. The
+ * per-step op count (5 ops on ports 0/5: sub, abs, maddubs, madd, add)
+ * already saturates the issue ports at one accumulator per batch on Sapphire
+ * Rapids, so a dim-axis unroll would only add register pressure without
+ * throughput. Only the batch-axis (shared-b) parallelism is applied.
+ */
+template <
+    typename TData,
+    const int8_t*(*mapper)(const TData*, const int32_t, const int32_t*, const int32_t),
+    int batches = 4
+>
+static inline void sqr7u_bulk_avx512(
+    const TData* a, const int8_t* b, const int32_t dims,
+    const int32_t pitch, const int32_t* offsets,
+    const int32_t count, f32_t* results
+) {
+    constexpr int stride = sizeof(__m512i);
+    const int blk = dims & ~(stride - 1);
+    const __m512i ones = _mm512_set1_epi16(1);
+    const int lines_to_fetch = dims / CACHE_LINE_SIZE + 1;
+    int c = 0;
+
+    const int8_t* current_vecs[batches];
+    init_pointers<batches, TData, int8_t, mapper>(current_vecs, a, pitch, offsets, 0, count);
+
+    for (; c + batches - 1 < count; c += batches) {
+        const int8_t* next_vecs[batches];
+        const bool has_next = c + 2 * batches - 1 < count;
+        if (has_next) {
+            apply_indexed<batches>([&](auto I) {
+                next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
+                prefetch(next_vecs[I], lines_to_fetch);
+            });
+        }
+
+        __m512i acc[batches];
+        apply_indexed<batches>([&](auto I) {
+            acc[I] = _mm512_setzero_si512();
+        });
+
+        int i = 0;
+        for (; i + stride <= blk; i += stride) {
+            __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
+            apply_indexed<batches>([&](auto I) {
+                __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));
+                __m512i dist = _mm512_sub_epi8(av, bv);
+                __m512i abs_dist = _mm512_abs_epi8(dist);
+                __m512i sqr_add = _mm512_maddubs_epi16(abs_dist, abs_dist);
+                acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(ones, sqr_add));
+            });
+        }
+
+        const int rem = dims - i;
+        if (rem > 0) {
+            __mmask64 mask = (__mmask64)((1ULL << rem) - 1);
+            __m512i bv = _mm512_maskz_loadu_epi8(mask, b + i);
+            apply_indexed<batches>([&](auto I) {
+                __m512i av = _mm512_maskz_loadu_epi8(mask, current_vecs[I] + i);
+                __m512i dist = _mm512_sub_epi8(av, bv);
+                __m512i abs_dist = _mm512_abs_epi8(dist);
+                acc[I] = _mm512_add_epi32(acc[I],
+                    _mm512_madd_epi16(ones, _mm512_maddubs_epi16(abs_dist, abs_dist)));
+            });
+        }
+
+        apply_indexed<batches>([&](auto I) {
+            results[c + I] = (f32_t)_mm512_reduce_add_epi32(acc[I]);
+        });
+
+        if (has_next) {
+            std::copy_n(next_vecs, batches, current_vecs);
+        }
+    }
+
+    for (; c < count; c++) {
+        const int8_t* a0 = mapper(a, c, offsets, pitch);
+        results[c] = (f32_t)sqr7u_inner(a0, b, dims);
+    }
+}
+
 EXPORT void vec_sqri7u_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
-    call_i8_bulk<int8_t, sequential_mapper, sqr7u_inner, 4>(a, b, dims, dims, NULL, count, results);
+    sqr7u_bulk_avx512<int8_t, sequential_mapper>(a, b, dims, dims, NULL, count, results);
 }
 
 EXPORT void vec_sqri7u_bulk_offsets_2(
@@ -210,7 +410,7 @@ EXPORT void vec_sqri7u_bulk_offsets_2(
     const int32_t* offsets,
     const int32_t count,
     f32_t* results) {
-    call_i8_bulk<int8_t, offsets_mapper, sqr7u_inner, 4>(a, b, dims, pitch, offsets, count, results);
+    sqr7u_bulk_avx512<int8_t, offsets_mapper>(a, b, dims, pitch, offsets, count, results);
 }
 
 EXPORT void vec_sqri7u_bulk_sparse_2(
@@ -219,5 +419,5 @@ EXPORT void vec_sqri7u_bulk_sparse_2(
     const int32_t dims,
     const int32_t count,
     f32_t* results) {
-    call_i8_bulk<const int8_t*, sparse_mapper, sqr7u_inner, 4>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
+    sqr7u_bulk_avx512<const int8_t*, sparse_mapper>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
 }

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i7_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i7_2.cpp
@@ -249,18 +249,26 @@ EXPORT void vec_doti7u_bulk_sparse_2(
     dot7u_bulk_avx512<const int8_t*, sparse_mapper, 4, 1>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
 }
 
+// Accumulates acc += sqr_distance(a, b) for unsigned 7-bit int lanes already
+// loaded into 64-byte SIMD registers.
+inline void sqri7u(__m512i& acc, __m512i a, __m512i b) {
+    const __m512i dist = _mm512_sub_epi8(a, b);
+    // abs_epi8 makes the difference non-negative so it fits the unsigned
+    // slot of maddubs_epi16, which treats its first operand as unsigned and
+    // its second as signed. Squared value is unchanged: (a-b)^2 == |a-b|^2.
+    const __m512i abs_dist = _mm512_abs_epi8(dist);
+    const __m512i sqr_add = _mm512_maddubs_epi16(abs_dist, abs_dist);
+    const __m512i ones = _mm512_set1_epi16(1);
+    acc = _mm512_add_epi32(_mm512_madd_epi16(ones, sqr_add), acc);
+}
+
 // Accumulates acc += sqr_distance(pa, pb) for unsigned 7-bit int lanes (64 bytes per step).
 template<int offsetRegs>
 inline void sqri7u(__m512i& acc, const int8_t* pa, const int8_t* pb) {
     constexpr int lanes = offsetRegs * sizeof(__m512i);
     const __m512i a = _mm512_loadu_si512((const __m512i*)(pa + lanes));
     const __m512i b = _mm512_loadu_si512((const __m512i*)(pb + lanes));
-
-    const __m512i dist = _mm512_sub_epi8(a, b);
-    const __m512i abs_dist = _mm512_abs_epi8(dist);
-    const __m512i sqr_add = _mm512_maddubs_epi16(abs_dist, abs_dist);
-    const __m512i ones = _mm512_set1_epi16(1);
-    acc = _mm512_add_epi32(_mm512_madd_epi16(ones, sqr_add), acc);
+    sqri7u(acc, a, b);
 }
 
 static inline int32_t sqr7u_inner(const int8_t* a, const int8_t* b, const int32_t dims) {
@@ -355,7 +363,6 @@ static inline void sqr7u_bulk_avx512(
 ) {
     constexpr int stride = sizeof(__m512i);
     const int blk = dims & ~(stride - 1);
-    const __m512i ones = _mm512_set1_epi16(1);
     const int lines_to_fetch = dims / CACHE_LINE_SIZE + 1;
     int c = 0;
 
@@ -385,10 +392,7 @@ static inline void sqr7u_bulk_avx512(
             __m512i bv = _mm512_loadu_si512((const __m512i*)(b + i));
             apply_indexed<batches>([&](auto I) {
                 __m512i av = _mm512_loadu_si512((const __m512i*)(current_vecs[I] + i));
-                __m512i dist = _mm512_sub_epi8(av, bv);
-                __m512i abs_dist = _mm512_abs_epi8(dist);
-                __m512i sqr_add = _mm512_maddubs_epi16(abs_dist, abs_dist);
-                acc[I] = _mm512_add_epi32(acc[I], _mm512_madd_epi16(ones, sqr_add));
+                sqri7u(acc[I], av, bv);
             });
         }
 
@@ -398,10 +402,7 @@ static inline void sqr7u_bulk_avx512(
             __m512i bv = _mm512_maskz_loadu_epi8(mask, b + i);
             apply_indexed<batches>([&](auto I) {
                 __m512i av = _mm512_maskz_loadu_epi8(mask, current_vecs[I] + i);
-                __m512i dist = _mm512_sub_epi8(av, bv);
-                __m512i abs_dist = _mm512_abs_epi8(dist);
-                acc[I] = _mm512_add_epi32(acc[I],
-                    _mm512_madd_epi16(ones, _mm512_maddubs_epi16(abs_dist, abs_dist)));
+                sqri7u(acc[I], av, bv);
             });
         }
 

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i7_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i7_2.cpp
@@ -89,15 +89,15 @@ static inline int32_t dot7u_inner(const int8_t* a, const int8_t* b, const int32_
     return _mm512_reduce_add_epi32(total_sum);
 }
 
-EXPORT int32_t vec_dot7u_2(const int8_t* a, const int8_t* b, const int32_t dims) {
+EXPORT int32_t vec_doti7u_2(const int8_t* a, const int8_t* b, const int32_t dims) {
     return dot7u_inner(a, b, dims);
 }
 
-EXPORT void vec_dot7u_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
+EXPORT void vec_doti7u_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
     call_i8_bulk<int8_t, sequential_mapper, dot7u_inner, 4>(a, b, dims, dims, NULL, count, results);
 }
 
-EXPORT void vec_dot7u_bulk_offsets_2(
+EXPORT void vec_doti7u_bulk_offsets_2(
     const int8_t* a,
     const int8_t* b,
     const int32_t dims,
@@ -106,6 +106,15 @@ EXPORT void vec_dot7u_bulk_offsets_2(
     const int32_t count,
     f32_t* results) {
     call_i8_bulk<int8_t, offsets_mapper, dot7u_inner, 4>(a, b, dims, pitch, offsets, count, results);
+}
+
+EXPORT void vec_doti7u_bulk_sparse_2(
+    const void* const* addresses,
+    const int8_t* b,
+    const int32_t dims,
+    const int32_t count,
+    f32_t* results) {
+    call_i8_bulk<const int8_t*, sparse_mapper, dot7u_inner, 4>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
 }
 
 // Accumulates acc += sqr_distance(pa, pb) for unsigned 7-bit int lanes (64 bytes per step).
@@ -185,15 +194,15 @@ static inline int32_t sqr7u_inner(const int8_t* a, const int8_t* b, const int32_
     return _mm512_reduce_add_epi32(total_sum);
 }
 
-EXPORT int32_t vec_sqr7u_2(const int8_t* a, const int8_t* b, const int32_t dims) {
+EXPORT int32_t vec_sqri7u_2(const int8_t* a, const int8_t* b, const int32_t dims) {
     return sqr7u_inner(a, b, dims);
 }
 
-EXPORT void vec_sqr7u_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
+EXPORT void vec_sqri7u_bulk_2(const int8_t* a, const int8_t* b, const int32_t dims, const int32_t count, f32_t* results) {
     call_i8_bulk<int8_t, sequential_mapper, sqr7u_inner, 4>(a, b, dims, dims, NULL, count, results);
 }
 
-EXPORT void vec_sqr7u_bulk_offsets_2(
+EXPORT void vec_sqri7u_bulk_offsets_2(
     const int8_t* a,
     const int8_t* b,
     const int32_t dims,
@@ -202,4 +211,13 @@ EXPORT void vec_sqr7u_bulk_offsets_2(
     const int32_t count,
     f32_t* results) {
     call_i8_bulk<int8_t, offsets_mapper, sqr7u_inner, 4>(a, b, dims, pitch, offsets, count, results);
+}
+
+EXPORT void vec_sqri7u_bulk_sparse_2(
+    const void* const* addresses,
+    const int8_t* b,
+    const int32_t dims,
+    const int32_t count,
+    f32_t* results) {
+    call_i8_bulk<const int8_t*, sparse_mapper, sqr7u_inner, 4>((const int8_t* const*)addresses, b, dims, 0, NULL, count, results);
 }


### PR DESCRIPTION
## Summary

Three-commit PR for the AVX-512 Tier-2 INT7U bulk kernels. Headline is a critical bug fix (`vec_i7_2.cpp` `_2` exports were named so the `JdkVectorLibrary` dispatcher couldn't find them; AVX-512 INT7U has silently been falling back to the AVX2 `vec_i7_1.cpp` implementation in production). Then layers shared-b loads + a head + spread prefetch schedule on the now-live AVX-512 path, and adds the missing `_sparse_2` HNSW production exports. Sister PR to #147865 (i8 equivalent).

## Commit layout

| commit | subject | contribution |
|---|---|---|
| `79b0e94` | `[Native] i7u: fix dispatcher names + add sparse_2` | Renames the 6 existing `_2` exports to match the dispatcher, adds 2 new `_sparse_2` exports using the existing `call_i8_bulk<sparse_mapper, ...>` pattern. Bug fix only — no implementation changes. |
| `3c940d1` | `[Native] i7u bulk AVX-512 shared-b` | Replaces `call_i8_bulk` bodies with new `dot7u_bulk_avx512` (with `unroll_dim` infrastructure, all i7u entry points instantiate at `unroll_dim=1`) and `sqr7u_bulk_avx512` templates. |
| `f434c12` | `[Native] i7u bulk head + spread prefetch` | Adds B2 head + per-iter spread prefetch schedule to both templates. |

## The bug

The dispatcher in [`JdkVectorLibrary.java`](libs/native/src/main/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java) builds the export name as `"vec_" + getFuncName(f) + typeName + getOpName(op) + suffix`. For INT7U, `typeName="i7u"` and `getFuncName` returns `"dot"` / `"sqr"`, so it expects `vec_doti7u_*_2` / `vec_sqri7u_*_2`. `main`'s `vec_i7_2.cpp` exports `vec_dot7u_*_2` / `vec_sqr7u_*_2` (no `i`). The dispatcher fall-through pattern (`for (int caps = capability; caps > 0; --caps)`) lands on the AVX2 base names `vec_doti7u_*` from `vec_i7_1.cpp`. INT8 doesn't have this asymmetry because `typeName="i8"` makes the expected name `vec_doti8_*`, which matches the actual exports in `vec_i8_2.cpp`.

## Why shared-b

The previous `call_i8_bulk<inner_op>` pattern (in [`amd64_vec_common.h`](libs/simdvec/native/src/vec/headers/amd64/amd64_vec_common.h)) calls the single-pair scorer per document, redoing the per-step `vpmaddubsw + vpmaddwd` work on `b` four times per outer iter. Hoisting `b` to the inner loop cuts L1D bandwidth on `b` 4× and lets the inner loop reuse the same `b` register across all 4 docs.

## Why head + spread prefetch

Burst prefetch at the batch boundary issues `lines_to_fetch * batches` (~28-100) software prefetches back-to-back; on Intel server cores the per-core line-fill buffer (16 entries) saturates and most of those prefetches are silently dropped, leaving the inner loop to take demand misses.

The head + spread schedule:

- At the batch boundary, issues only `unroll_dim` prefetches per next-batch vector — covering the first cache lines the inner loop will consume.
- At each inner-loop iter, issues `unroll_dim` more prefetches per next-batch vector, targeting the lines the *next* outer iter will consume.

The total prefetch count per batch is unchanged; the LFB occupancy peak drops from `lines_to_fetch * batches` to `batches * unroll_dim` (4-8). Prefetched lines arrive ~1 outer iter before they are demand-loaded, hiding the L2 → L1 transfer latency. The L2 stream prefetcher coordinates better with the steady stride than with the boundary burst. Cross-references the more detailed comment on `dot7u_bulk_avx512`.

## Performance — JMH on EMR

Hardware: Intel Xeon Platinum 8573C (Emerald Rapids, AVX-512-VNNI), JDK 25. JMH params: `-wi 3 -w 3s -i 10 -r 3s -f 2` (20 iters × 2 forks). `libvec.so` swapped between runs; Java code identical.

Three libraries are compared so the bug-fix unlock and the algorithmic work can be attributed cleanly:

- **A**: unmodified `main` — silently runs AVX2 `vec_i7_1.cpp` on AVX-512 hardware due to the dispatcher mismatch (see "The bug" above).
- **B**: `main` + `c1` only (rename + new `_sparse_2` exports). The AVX-512 path is now active but each entry point still uses the original `call_i8_bulk<inner_op>` per-doc pattern — no shared-b, no B2 prefetch.
- **C**: `main` + `c1` + `c2` + `c3` — the full PR.

The tables below report **`C − B`**: what the algorithmic work in `c2`+`c3` (shared-b + B2 prefetch) adds on top of the AVX-512 path being live. The bug-fix unlock alone (`B − A`) is essentially perf-neutral — **+2.78% geomean across 11 cells** with some per-cell regressions — and serves as a prerequisite for `c2`+`c3` rather than a standalone win.

### `VectorScorerInt7uBulkBenchmark` — random-ordinal HNSW production pattern, `dims=1024`, `bulkSize=32`

| function    | numV   | shared-b + B2 (`C−B`) |
| ----------- | -----: | --------------------: |
| DOT_PRODUCT |   1500 |               +18.03% |
| DOT_PRODUCT | 130000 |               +13.76% |
| EUCLIDEAN   |   1500 |           **+48.49%** |
| EUCLIDEAN   | 130000 |               +19.55% |

### `VectorScorerInt7Benchmark.scoreFromMemorySegmentBulk` — sequential L3-resident

| dims | shared-b + B2 (`C−B`) |
| ---: | --------------------: |
|  384 |                +4.63% |
|  782 |                +6.74% |
| 1024 |                +6.07% |

### Geomean of `C−B` across the 11 measured cells

| bench               |     geomean |
| ------------------- | ----------: |
| i7 sequential       |      +5.81% |
| i7u sequential      |     +17.09% |
| i7u random (HNSW)   |     +22.91% |
| **all 11 cells**    | **+15.61%** |

### Key findings

1. **shared-b + B2 deliver consistently** — positive in every single one of the 11 cells (per-cell range +3.99% to +48.49%).
2. **EUCLIDEAN @ L2-resident gains the most** (+48.49%) because its previous code path (256-bit `sub_epi8 + abs_epi8 + maddubs_epi16` per stride, no batching) was the most behind. The new `sqr7u_bulk_avx512` does the same work at 64 bytes per stride across 4 docs in parallel with B2 prefetch.
3. **DOT @ DRAM is entirely `c2`+`c3` driven**: the AVX-512 path through `call_i8_bulk` slightly regresses these cells (LFB pressure with no extra arithmetic to hide it); layering shared-b + B2 cuts L1D bandwidth on `b` 4× and caps LFB occupancy, turning a small regression into a +14% to +19% win on top.

Total branch impact vs `main` (`C − A`, what production gets once this PR lands and the binary is rebuilt): **+18.81% geomean across the 11 cells**, with the i7u random-ordinal HNSW path at **+32.05% geomean**.

### Per-export coverage

| native export                   | now bound to                    | JMH covers via                                         |
|:--------------------------------|:--------------------------------|:-------------------------------------------------------|
| `vec_doti7u_2`                  | unrolled-inner AVX-512          | not directly (single-pair); covered indirectly         |
| `vec_doti7u_bulk_2`             | shared-b + B2                   | `VectorScorerInt7Benchmark` (sequential, 3 cells)      |
| `vec_doti7u_bulk_offsets_2`     | shared-b + B2                   | indirect (sparse path runs on the same templates)      |
| `vec_doti7u_bulk_sparse_2` *(NEW)* | shared-b + B2                | `VectorScorerInt7uBulkBenchmark` random / sequential   |
| `vec_sqri7u_2`                  | unrolled-inner AVX-512          | not directly                                           |
| `vec_sqri7u_bulk_2`             | shared-b + B2                   | (no direct sqr-sequential JMH; sparse exercises same templates) |
| `vec_sqri7u_bulk_offsets_2`     | shared-b + B2                   | indirect                                               |
| `vec_sqri7u_bulk_sparse_2` *(NEW)* | shared-b + B2                | `VectorScorerInt7uBulkBenchmark` random / sequential   |

## Correctness

Validated locally with `bench/i8_i7u_bulk_correctness.cpp` (not in tree, same convention as #147672) against an i32-exact reference for `dot7u` and `sqr7u` on sequential / offsets / sparse layouts across `dims ∈ {64, 65, 96, 128, 256, 257, 768, 1024, 1536, 4096}` × `count ∈ {1, 8, 16, 17, 32, 100, 1000}`. All sub-checks pass on the current branch state.

## Caveats

- Single-pair `vec_doti7u_2` / `vec_sqri7u_2` and `_offsets_2` aren't directly exercised by current JMH suites; they share the same shared-b + B2 templates as the sparse exports above.