### PR TITLE
[9.4] ESQL: Validate unsupported grouping types earlier (#147650)

### DIFF
--- a/docs/changelog/147650.yaml
+++ b/docs/changelog/147650.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+  - 147596
+pr: 147650
+summary: "ESQL: Validate unsupported grouping types earlier"
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Aggregate.java
@@ -42,6 +42,10 @@ import java.util.Objects;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.esql.common.Failure.fail;
+import static org.elasticsearch.xpack.esql.core.type.DataType.AGGREGATE_METRIC_DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_RANGE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DENSE_VECTOR;
+import static org.elasticsearch.xpack.esql.core.type.DataType.EXPONENTIAL_HISTOGRAM;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 import static org.elasticsearch.xpack.esql.plan.logical.Filter.checkFilterConditionDataType;
 
@@ -226,9 +230,7 @@ public class Aggregate extends UnaryPlan
             if (attr != null) {
                 groupRefsBuilder.add(attr);
             }
-            if (e instanceof FieldAttribute f && f.dataType().isCounter()) {
-                failures.add(fail(e, "cannot group by on [{}] type for grouping [{}]", f.dataType().typeName(), e.sourceText()));
-            }
+            checkUnsupportedStatsGroupingType(e, failures);
         });
         var groupRefs = groupRefsBuilder.build();
 
@@ -247,6 +249,22 @@ public class Aggregate extends UnaryPlan
         checkTimeSeriesAggregates(failures);
         checkCategorizeGrouping(failures);
         checkMultipleScoreAggregations(failures);
+    }
+
+    static void checkUnsupportedGroupingType(Expression e, Failures failures) {
+        if ((e instanceof FieldAttribute f && f.dataType().isCounter())
+            || e.dataType() == AGGREGATE_METRIC_DOUBLE
+            || e.dataType() == DATE_RANGE
+            || e.dataType() == EXPONENTIAL_HISTOGRAM) {
+            failures.add(fail(e, "cannot group by on [{}] type for grouping [{}]", e.dataType().typeName(), e.sourceText()));
+        }
+    }
+
+    private static void checkUnsupportedStatsGroupingType(Expression e, Failures failures) {
+        checkUnsupportedGroupingType(e, failures);
+        if (e.dataType() == DENSE_VECTOR) {
+            failures.add(fail(e, "cannot group by on [{}] type for grouping [{}]", e.dataType().typeName(), e.sourceText()));
+        }
     }
 
     protected void checkTimeSeriesAggregates(Failures failures) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/LimitBy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/LimitBy.java
@@ -9,7 +9,9 @@ package org.elasticsearch.xpack.esql.plan.logical;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
+import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.capabilities.Resolvables;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -20,11 +22,13 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.esql.plan.logical.Aggregate.checkUnsupportedGroupingType;
+
 /**
  * Retains at most N rows per group defined by one or more grouping key expressions.
  * This is the {@code LIMIT N BY expr1, expr2, ...} command.
  */
-public class LimitBy extends UnaryPlan implements TelemetryAware, PipelineBreaker {
+public class LimitBy extends UnaryPlan implements PostAnalysisVerificationAware, TelemetryAware, PipelineBreaker {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "LimitBy", LimitBy::new);
 
     private final Expression limitPerGroup;
@@ -106,6 +110,11 @@ public class LimitBy extends UnaryPlan implements TelemetryAware, PipelineBreake
     @Override
     public boolean expressionsResolved() {
         return limitPerGroup.resolved() && Resolvables.resolved(groupings);
+    }
+
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        groupings.forEach(e -> checkUnsupportedGroupingType(e, failures));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -809,6 +809,55 @@ public class VerifierTests extends ESTestCase {
         );
     }
 
+    public void testUnsupportedGroupKeyTypesNotAllowedInLimitBy() {
+        analyzer().addK8sDownsampled()
+            .stripErrorPrefix(true)
+            .error(
+                "FROM k8s | LIMIT 1 BY network.eth0.tx",
+                equalTo("1:23: cannot group by on [aggregate_metric_double] type for grouping [network.eth0.tx]")
+            );
+        analyzer().addIndex("exp_histo_sample", "exp_histo_sample-mappings.json")
+            .stripErrorPrefix(true)
+            .error(
+                "FROM exp_histo_sample | LIMIT 1 BY responseTime",
+                equalTo("1:36: cannot group by on [exponential_histogram] type for grouping [responseTime]")
+            );
+        analyzer().addIndex("decades", "mapping-decades.json")
+            .stripErrorPrefix(true)
+            .error("FROM decades | LIMIT 1 BY date_range", equalTo("1:27: cannot group by on [date_range] type for grouping [date_range]"));
+        tsdb().error(
+            "FROM test | LIMIT 1 BY network.bytes_in",
+            equalTo("1:24: cannot group by on [counter_long] type for grouping [network.bytes_in]")
+        );
+    }
+
+    public void testUnsupportedGroupKeyTypesNotAllowedInStatsBy() {
+        analyzer().addK8sDownsampled()
+            .stripErrorPrefix(true)
+            .error(
+                "FROM k8s | STATS count(*) BY network.eth0.tx",
+                equalTo("1:30: cannot group by on [aggregate_metric_double] type for grouping [network.eth0.tx]")
+            );
+        analyzer().addIndex("exp_histo_sample", "exp_histo_sample-mappings.json")
+            .stripErrorPrefix(true)
+            .error(
+                "FROM exp_histo_sample | STATS count(*) BY responseTime",
+                equalTo("1:43: cannot group by on [exponential_histogram] type for grouping [responseTime]")
+            );
+        analyzer().addIndex("decades", "mapping-decades.json")
+            .stripErrorPrefix(true)
+            .error(
+                "FROM decades | STATS count(*) BY date_range",
+                equalTo("1:34: cannot group by on [date_range] type for grouping [date_range]")
+            );
+        analyzer().addIndex("test", "mapping-all-types.json")
+            .stripErrorPrefix(true)
+            .error(
+                "FROM test | STATS count(*) BY dense_vector",
+                equalTo("1:31: cannot group by on [dense_vector] type for grouping [dense_vector]")
+            );
+    }
+
     public void testDoubleRenamingField() {
         defaultAnalyzer().error(
             "from test | rename emp_no as r1, r1 as r2, emp_no as r3 | keep r3",


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ESQL: Validate unsupported grouping types earlier (#147650)