### PR TITLE
Bugfix - Block Loader Pushdown + Union Types (#147940)

### DIFF
--- a/docs/changelog/147940.yaml
+++ b/docs/changelog/147940.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 147940
+summary: Bugfix - Block Loader Pushdown + Union Types
+type: bug

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushExpressionToLoadIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushExpressionToLoadIT.java
@@ -372,6 +372,103 @@ public class PushExpressionToLoadIT extends ESRestTestCase {
         );
     }
 
+    /**
+     * Scalar MV_MAX pushdown on a keyword field cast to ip — verifies that
+     * the block loader respects the type conversion (single index, no union types).
+     */
+    public void testMvMaxEvalKeywordCastToIp() throws IOException {
+        deleteIndexIfExists("test_kw");
+
+        createSingleShardIndex("test_kw", Map.of("val", "keyword"));
+
+        bulkIndex("test_kw", List.of(Map.of("val", List.of("192.168.0.1", "192.168.3.1"))));
+
+        Map<String, Object> result = runEsql(requestObjectBuilder().query("""
+            FROM test_kw
+            | EVAL ip_val = MV_MAX(val::ip)
+            | KEEP ip_val
+            """), new AssertWarnings.NoWarnings(), profileLogger, RestEsqlTestCase.Mode.SYNC);
+
+        @SuppressWarnings("unchecked")
+        List<List<Object>> values = (List<List<Object>>) result.get("values");
+        assertEquals(1, values.size());
+        assertEquals("192.168.3.1", values.get(0).get(0));
+    }
+
+    /**
+     * Scalar MV_MAX pushdown across union types (ip + keyword) — verifies
+     * that the existing scalar block loader path handles the type mismatch.
+     */
+    public void testMvMaxEvalUnionIpAndKeyword() throws IOException {
+        deleteIndexIfExists("test_ip");
+        deleteIndexIfExists("test_kw");
+
+        createSingleShardIndex("test_ip", Map.of("val", "ip"));
+        createSingleShardIndex("test_kw", Map.of("val", "keyword"));
+
+        bulkIndex("test_ip", List.of(Map.of("val", List.of("192.168.0.1", "192.168.3.1"))));
+        bulkIndex("test_kw", List.of(Map.of("val", "192.168.2.1")));
+
+        Map<String, Object> result = runEsql(requestObjectBuilder().query("""
+            FROM test_ip, test_kw
+            | EVAL ip_val = MV_MAX(val::ip)
+            | KEEP ip_val
+            | SORT ip_val DESC
+            | LIMIT 1
+            """), new AssertWarnings.NoWarnings(), profileLogger, RestEsqlTestCase.Mode.SYNC);
+
+        @SuppressWarnings("unchecked")
+        List<List<Object>> values = (List<List<Object>>) result.get("values");
+        assertEquals(1, values.size());
+        assertEquals("192.168.3.1", values.get(0).get(0));
+    }
+
+    private void deleteIndexIfExists(String name) throws IOException {
+        try {
+            client().performRequest(new Request("DELETE", name));
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                throw e;
+            }
+        }
+    }
+
+    private void createSingleShardIndex(String name, Map<String, String> fieldTypes) throws IOException {
+        Request createIndex = new Request("PUT", name);
+        try (XContentBuilder config = JsonXContent.contentBuilder()) {
+            config.startObject();
+            config.startObject("settings");
+            config.startObject("index").field("number_of_shards", 1).endObject();
+            config.endObject();
+            config.startObject("mappings");
+            config.startObject("properties");
+            for (var entry : fieldTypes.entrySet()) {
+                config.startObject(entry.getKey()).field("type", entry.getValue()).endObject();
+            }
+            config.endObject();
+            config.endObject();
+            createIndex.setJsonEntity(Strings.toString(config.endObject()));
+        }
+        Response createResponse = client().performRequest(createIndex);
+        assertThat(
+            entityToMap(createResponse.getEntity(), XContentType.JSON),
+            matchesMap().entry("shards_acknowledged", true).entry("index", name).entry("acknowledged", true)
+        );
+    }
+
+    private void bulkIndex(String indexName, List<Map<String, Object>> docs) throws IOException {
+        Request bulk = new Request("POST", "/_bulk");
+        bulk.addParameter("refresh", "");
+        StringBuilder body = new StringBuilder();
+        for (Map<String, Object> doc : docs) {
+            body.append("{\"create\":{\"_index\":\"").append(indexName).append("\"}}\n");
+            body.append(Strings.toString(JsonXContent.contentBuilder().map(doc))).append("\n");
+        }
+        bulk.setJsonEntity(body.toString());
+        Response bulkResponse = client().performRequest(bulk);
+        assertThat(entityToMap(bulkResponse.getEntity(), XContentType.JSON), matchesMap().entry("errors", false).extraOk());
+    }
+
     public void testVCosine() throws IOException {
         test(
             justType("dense_vector"),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoad.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushExpressionsToFieldLoad.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.FunctionEsField;
+import org.elasticsearch.xpack.esql.core.type.MultiTypeEsField;
 import org.elasticsearch.xpack.esql.expression.function.blockloader.BlockLoaderExpression;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
@@ -173,6 +174,9 @@ public class PushExpressionsToFieldLoad extends ParameterizedRule<PhysicalPlan, 
         private Expression transformExpression(PhysicalPlan nodeWithExpression, Expression e, BlockLoaderExpression ble) {
             BlockLoaderExpression.PushedBlockLoaderExpression fuse = ble.tryPushToFieldLoading(context.searchStats());
             if (fuse == null) {
+                return e;
+            }
+            if (fuse.field().field() instanceof MultiTypeEsField) {
                 return e;
             }
             if (primaries.canPush(nodeWithExpression) == false) {


### PR DESCRIPTION
While working on #147761, I found a bug in the existing Block Loader Pushdown optimization. Specifically, it seems to have some issues with union types. The specific case I encountered was with Max of IP fields, and I was able to reproduce it with a scalar MV_MAX (the test in this PR). I have not investigated if this is unique to that combination or a more general problem.

In the interest of getting a quick fix out and unblocking my work, I've just disabled the optimization for all cases where there is a union type.

Actually written by Mark Tozzi <mark.tozzi@gmail.com>.