### PR TITLE
Backport #147462 to 9.3: ES|QL fix _index LIKE with ? wildcard

### DIFF
--- a/docs/changelog/147462.yaml
+++ b/docs/changelog/147462.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 146364
+pr: 147462
+summary: Fix `_index` LIKE with ? wildcard
+type: bug

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -17,6 +17,7 @@ import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.Nullable;
@@ -132,9 +133,14 @@ public class IndexFieldMapper extends MetadataFieldMapper {
                 value = value.toLowerCase(Locale.ROOT);
                 indexName = indexName.toLowerCase(Locale.ROOT);
             }
-            CharacterRunAutomaton runAutomaton = new CharacterRunAutomaton(
-                WildcardQuery.toAutomaton(new Term(null, value), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
-            );
+            CharacterRunAutomaton runAutomaton;
+            try {
+                runAutomaton = new CharacterRunAutomaton(
+                    WildcardQuery.toAutomaton(new Term(null, value), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
+                );
+            } catch (TooComplexToDeterminizeException e) {
+                throw new IllegalArgumentException("Pattern was too complex to determinize", e);
+            }
             if (runAutomaton.run(indexName)) {
                 return Queries.ALL_DOCS_INSTANCE;
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -9,13 +9,16 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.CharacterRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FieldDataContext;
@@ -129,7 +132,10 @@ public class IndexFieldMapper extends MetadataFieldMapper {
                 value = value.toLowerCase(Locale.ROOT);
                 indexName = indexName.toLowerCase(Locale.ROOT);
             }
-            if (Regex.simpleMatch(value, indexName)) {
+            CharacterRunAutomaton runAutomaton = new CharacterRunAutomaton(
+                WildcardQuery.toAutomaton(new Term(null, value), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
+            );
+            if (runAutomaton.run(indexName)) {
                 return Queries.ALL_DOCS_INSTANCE;
             }
             return new MatchNoDocsQuery("The \"" + indexName + "\" query was rewritten to a \"match_none\" query.");

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
@@ -58,6 +58,16 @@ public class IndexFieldTypeTests extends ConstantFieldTypeTestCase {
         assertEquals(Queries.ALL_DOCS_INSTANCE, ft.wildcardLikeQuery("iNd?x", null, true, context));
     }
 
+    public void testWildcardLikeQueryTooComplex() {
+        IndexFieldMapper.IndexFieldType ft = IndexFieldMapper.IndexFieldType.INSTANCE;
+        SearchExecutionContext context = createContext();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ft.wildcardLikeQuery("*a?????????????", null, false, context)
+        );
+        assertThat(e.getMessage(), containsString("Pattern was too complex to determinize"));
+    }
+
     public void testRegexpQuery() {
         MappedFieldType ft = IndexFieldMapper.IndexFieldType.INSTANCE;
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
@@ -40,6 +40,24 @@ public class IndexFieldTypeTests extends ConstantFieldTypeTestCase {
         assertEquals(Queries.NO_DOCS_INSTANCE, ft.wildcardQuery("Other_ind*x", null, true, createContext()));
     }
 
+    public void testWildcardLikeQuery() {
+        IndexFieldMapper.IndexFieldType ft = IndexFieldMapper.IndexFieldType.INSTANCE;
+        SearchExecutionContext context = createContext();
+
+        // ? matches exactly one character
+        assertEquals(Queries.ALL_DOCS_INSTANCE, ft.wildcardLikeQuery("ind?x", null, false, context));
+        // two ? wildcards do not match a five-character name
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.wildcardLikeQuery("ind??x", null, false, context));
+        // * still works (regression)
+        assertEquals(Queries.ALL_DOCS_INSTANCE, ft.wildcardLikeQuery("ind*x", null, false, context));
+        // mixed ? and *
+        assertEquals(Queries.ALL_DOCS_INSTANCE, ft.wildcardLikeQuery("i?d*x", null, false, context));
+        // no match
+        assertEquals(Queries.NO_DOCS_INSTANCE, ft.wildcardLikeQuery("other?ndex", null, false, context));
+        // case insensitive
+        assertEquals(Queries.ALL_DOCS_INSTANCE, ft.wildcardLikeQuery("iNd?x", null, true, context));
+    }
+
     public void testRegexpQuery() {
         MappedFieldType ft = IndexFieldMapper.IndexFieldType.INSTANCE;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1611,7 +1611,9 @@ true
 ;
 
 // https://github.com/elastic/elasticsearch/issues/146364
-likeSingleCharOnIndexWithMinusWhere-Ignore
+likeSingleCharOnIndexWithMinusWhere
+required_capability: fix_starts_with_ends_with_pushdown_on_index
+required_capability: fix_index_like_question_mark_wildcard
 
 FROM k8s-downsampled METADATA _index
 | WHERE _index LIKE "k8s?downsampled"

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
@@ -1467,3 +1467,16 @@ FROM airport_city_boundaries
 region:text
 Свердлов району
 ;
+
+likeQuestionMarkWildcardOnIndexMetadataField
+FROM employees METADATA _index | WHERE _index LIKE "employ?es" | KEEP emp_no | SORT emp_no | LIMIT 1;
+
+emp_no:integer
+10001
+;
+
+likeQuestionMarkWildcardNoMatchOnIndexMetadataField
+FROM employees METADATA _index | WHERE _index LIKE "employ??es" | KEEP emp_no;
+
+emp_no:integer
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
@@ -1469,6 +1469,7 @@ region:text
 ;
 
 likeQuestionMarkWildcardOnIndexMetadataField
+required_capability: fix_index_like_question_mark_wildcard
 FROM employees METADATA _index | WHERE _index LIKE "employ?es" | KEEP emp_no | SORT emp_no | LIMIT 1;
 
 emp_no:integer
@@ -1476,6 +1477,7 @@ emp_no:integer
 ;
 
 likeQuestionMarkWildcardNoMatchOnIndexMetadataField
+required_capability: fix_index_like_question_mark_wildcard
 FROM employees METADATA _index | WHERE _index LIKE "employ??es" | KEEP emp_no;
 
 emp_no:integer

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -2001,6 +2001,12 @@ public class EsqlCapabilities {
          * see <a href="https://github.com/elastic/elasticsearch/issues/145873">ES|QL: wrong line/column number #145873</a>
          */
         FIX_SET_WRONG_LINE_COLUMN,
+
+        /**
+         * Fix for {@code _index LIKE} not supporting the {@code ?} wildcard character.
+         * see <a href="https://github.com/elastic/elasticsearch/issues/146364">ES|QL: _index LIKE with ? #146364</a>
+         */
+        FIX_INDEX_LIKE_QUESTION_MARK_WILDCARD,
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/50_index_patterns.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/50_index_patterns.yml
@@ -397,3 +397,18 @@ same_name_different_type_same_family:
   - match: { values.2.0: foo3 }
   - match: { values.3.0: foo4 }
 
+---
+"_index LIKE with overly complex pattern":
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ method, path, parameters, capabilities ]
+          capabilities: [ fix_index_like_question_mark_wildcard ]
+      reason: "determinization complexity for _index LIKE not handled until fix"
+  - do:
+      catch: /Pattern was too complex to determinize/
+      esql.query:
+        body:
+          query: 'FROM test1 | WHERE _index LIKE "*a?????????????"'
+

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/50_index_patterns.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/50_index_patterns.yml
@@ -2,7 +2,7 @@ setup:
   - requires:
       cluster_features: ["gte_v8.11.0"]
       reason: "ESQL is available in 8.11+"
-      test_runner_features: allowed_warnings_regex
+      test_runner_features: [allowed_warnings_regex, capabilities]
 
 ---
 disjoint_mappings:
@@ -407,8 +407,14 @@ same_name_different_type_same_family:
           capabilities: [ fix_index_like_question_mark_wildcard ]
       reason: "determinization complexity for _index LIKE not handled until fix"
   - do:
+      indices.create:
+        index: test-complex-pattern
+  - do:
       catch: /Pattern was too complex to determinize/
       esql.query:
         body:
-          query: 'FROM test1 | WHERE _index LIKE "*a?????????????"'
+          query: 'FROM test-complex-pattern METADATA _index | WHERE _index LIKE "*a?????????????"'
+  - do:
+      indices.delete:
+        index: test-complex-pattern
 


### PR DESCRIPTION
Backports the following commits to 9.3:

ES|QL: fix _index LIKE with ? wildcard (https://github.com/elastic/elasticsearch/pull/147462)