### PR TITLE
Remove brittle BWC serialization test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -505,9 +505,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:fuse.fuseWithRowLinearAndMultiValueGroupColumn}
   issue: https://github.com/elastic/elasticsearch/issues/147988
-- class: org.elasticsearch.xpack.core.inference.action.InferenceActionRequestTests
-  method: testWriteTo_ForHasBeenReroutedChanges
-  issue: https://github.com/elastic/elasticsearch/issues/148000
 - class: org.elasticsearch.search.CCSDuelIT
   method: testPagination
   issue: https://github.com/elastic/elasticsearch/issues/148006

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import static org.elasticsearch.xpack.core.inference.action.BaseInferenceActionRequest.INFERENCE_REQUEST_PER_TASK_TIMEOUT_ADDED;
 import static org.elasticsearch.xpack.core.inference.action.BaseInferenceActionRequest.TIMEOUT_NOT_DETERMINED;
@@ -604,31 +603,5 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             false,
             context
         );
-    }
-
-    public void testWriteTo_ForHasBeenReroutedChanges() throws IOException {
-        var instance = new InferenceAction.Request(
-            TaskType.TEXT_EMBEDDING,
-            "model",
-            null,
-            null,
-            null,
-            List.of("input"),
-            Map.of(),
-            InputType.UNSPECIFIED,
-            randomTimeValue(),
-            false
-        );
-        {
-            // From a version with rerouting removed
-            InferenceAction.Request deserializedInstance = copyWriteable(
-                instance,
-                getNamedWriteableRegistry(),
-                instanceReader(),
-                BaseInferenceActionRequest.INFERENCE_REQUEST_ADAPTIVE_RATE_LIMITING_REMOVED
-            );
-
-            assertEquals(instance, deserializedInstance);
-        }
     }
 }


### PR DESCRIPTION
InferenceActionRequestTests.testWriteTo_ForHasBeenReroutedChanges() was testing serialization with a specific transport version, but not using mutateInstanceForVersion() to ensure that any expected changes to the object due to other transport versions were accounted for. The behaviour the test is covering is already covered by the testBwcSerialization() method on the base class, so the test is unnecessary and can be removed.

Closes #148000