### PR TITLE
VectorScoringUtils: assert docID == index in dense vector scorer

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/VectorScoringUtils.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/VectorScoringUtils.java
@@ -36,6 +36,7 @@ public final class VectorScoringUtils {
         return new VectorScorer() {
             @Override
             public float score() throws IOException {
+                assert iterator.docID() == iterator.index() : "Dense iterator docID " + iterator.docID() + " != index " + iterator.index();
                 return scorer.score(iterator.index());
             }
 


### PR DESCRIPTION
This is a follow up on the change/discussion here: https://github.com/elastic/elasticsearch/pull/145835#discussion_r3047125720.

In the prior change, I replaced a call to `iterator.docID()` with `iterator.index()`. This PR simply asserts that those two are the same, which is what it means to be dense already.