### PR TITLE
ESQL: Replace array constants in Analyzer with Lists

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -171,7 +171,6 @@ import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
@@ -1665,14 +1664,14 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 boolean deferToUnionTypes = resolved instanceof FieldAttribute fa && fa.hasTypeConflicts();
                 if (deferToUnionTypes == false && resolved.resolved() && resolved.dataType() != NULL && enrich.policy() != null) {
                     String matchType = enrich.policy().getType();
-                    DataType[] allowed = allowedEnrichTypes(matchType);
-                    if (Arrays.asList(allowed).contains(resolved.dataType()) == false) {
+                    List<DataType> allowed = allowedEnrichTypes(matchType);
+                    if (allowed.contains(resolved.dataType()) == false) {
                         resolved = ua.withUnresolvedMessage(
                             Strings.format(
                                 "Unsupported type [%s] for enrich matching field [%s]; only [%s] allowed for type [%s]",
                                 resolved.dataType().typeName(),
                                 ua.name(),
-                                Arrays.stream(allowed).map(DataType::typeName).collect(Collectors.joining(", ")),
+                                allowed.stream().map(DataType::typeName).collect(Collectors.joining(", ")),
                                 matchType
                             )
                         );
@@ -1711,10 +1710,10 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             return resolved;
         }
 
-        private static final DataType[] GEO_TYPES = new DataType[] { GEO_POINT, GEO_SHAPE };
-        private static final DataType[] NON_GEO_TYPES = new DataType[] { KEYWORD, TEXT, IP, LONG, INTEGER, FLOAT, DOUBLE, DATETIME };
+        private static final List<DataType> GEO_TYPES = List.of(GEO_POINT, GEO_SHAPE);
+        private static final List<DataType> NON_GEO_TYPES = List.of(KEYWORD, TEXT, IP, LONG, INTEGER, FLOAT, DOUBLE, DATETIME);
 
-        private DataType[] allowedEnrichTypes(String matchType) {
+        private List<DataType> allowedEnrichTypes(String matchType) {
             return matchType.equals(GEO_MATCH_TYPE) ? GEO_TYPES : NON_GEO_TYPES;
         }
     }


### PR DESCRIPTION
A tiny refactor replacing a couple of array constants with `List`s. We wrap them with `Arrays.asList` every time anyway, and then need to wrap them again to turn them into a `Stream`. Might as well make them `List`s to begin with.

Look ma, no AI!