### PR TITLE
Rename TimeSeriesGroupByAll to ResolveImplicitTimeSeriesIdentityGrouping

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -252,7 +252,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             new InsertDefaultInnerTimeSeriesAggregate(),
             new ImplicitCastAggregateMetricDoubles(),
             new InsertFromAggregateMetricDouble(),
-            new TimeSeriesGroupByAll(),
+            new ResolveImplicitTimeSeriesIdentityGrouping(),
             new ResolveUnionTypesInUnionAll(),
             new ResolveUnmapped()
         ),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/ResolveImplicitTimeSeriesIdentityGrouping.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/ResolveImplicitTimeSeriesIdentityGrouping.java
@@ -32,7 +32,7 @@ import java.util.List;
  * <p>
  * This rule will operate on "bare" over time aggregations.
  */
-public class TimeSeriesGroupByAll extends Rule<LogicalPlan, LogicalPlan> {
+public class ResolveImplicitTimeSeriesIdentityGrouping extends Rule<LogicalPlan, LogicalPlan> {
     @Override
     public LogicalPlan apply(LogicalPlan logicalPlan) {
         return logicalPlan.transformUp(node -> node instanceof TimeSeriesAggregate, this::rule);


### PR DESCRIPTION
Follow-up from the @sidosera comment:
https://github.com/elastic/elasticsearch/pull/147990/changes#r3168836507