### PR TITLE
Enable remote-fetch late materialization in planner and compute wiring.

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -134,6 +134,7 @@ import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ChangePointExec;
 import org.elasticsearch.xpack.esql.plan.physical.CompoundOutputEvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
+import org.elasticsearch.xpack.esql.plan.physical.EmitRemoteFetchHandleExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsStatsQueryExec;
@@ -159,6 +160,7 @@ import org.elasticsearch.xpack.esql.plan.physical.OutputExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.RegisteredDomainExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchExec;
 import org.elasticsearch.xpack.esql.plan.physical.SampleExec;
 import org.elasticsearch.xpack.esql.plan.physical.ShowExec;
 import org.elasticsearch.xpack.esql.plan.physical.SparklineGenerateEmptyBucketsExec;
@@ -172,12 +174,16 @@ import org.elasticsearch.xpack.esql.plan.physical.inference.CompletionExec;
 import org.elasticsearch.xpack.esql.plan.physical.inference.RerankExec;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.ShardContext;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.elasticsearch.xpack.esql.plugin.RemoteFetchHandleOperator;
+import org.elasticsearch.xpack.esql.plugin.RemoteFetchOperator;
+import org.elasticsearch.xpack.esql.plugin.RemoteFetchService;
 import org.elasticsearch.xpack.esql.score.ScoreMapper;
 import org.elasticsearch.xpack.esql.session.Configuration;
 import org.elasticsearch.xpack.esql.session.EsqlCCSUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -218,10 +224,12 @@ public class LocalExecutionPlanner {
     private final Supplier<ExchangeSink> exchangeSinkSupplier;
     private final EnrichLookupService enrichLookupService;
     private final LookupFromIndexService lookupFromIndexService;
+    private final RemoteFetchService remoteFetchService;
     private final InferenceService inferenceService;
     private final UserAgentParserRegistry userAgentParserRegistry;
     private final PhysicalOperationProviders physicalOperationProviders;
     private final OperatorFactoryRegistry operatorFactoryRegistry;
+    private final String localNodeId;
 
     public LocalExecutionPlanner(
         String sessionId,
@@ -240,6 +248,46 @@ public class LocalExecutionPlanner {
         PhysicalOperationProviders physicalOperationProviders,
         OperatorFactoryRegistry operatorFactoryRegistry
     ) {
+        this(
+            sessionId,
+            clusterAlias,
+            parentTask,
+            bigArrays,
+            blockFactory,
+            settings,
+            configuration,
+            exchangeSourceSupplier,
+            exchangeSinkSupplier,
+            enrichLookupService,
+            lookupFromIndexService,
+            null,
+            inferenceService,
+            userAgentParserRegistry,
+            physicalOperationProviders,
+            operatorFactoryRegistry,
+            null
+        );
+    }
+
+    public LocalExecutionPlanner(
+        String sessionId,
+        String clusterAlias,
+        CancellableTask parentTask,
+        BigArrays bigArrays,
+        BlockFactory blockFactory,
+        Settings settings,
+        Configuration configuration,
+        Supplier<ExchangeSource> exchangeSourceSupplier,
+        Supplier<ExchangeSink> exchangeSinkSupplier,
+        EnrichLookupService enrichLookupService,
+        LookupFromIndexService lookupFromIndexService,
+        RemoteFetchService remoteFetchService,
+        InferenceService inferenceService,
+        UserAgentParserRegistry userAgentParserRegistry,
+        PhysicalOperationProviders physicalOperationProviders,
+        OperatorFactoryRegistry operatorFactoryRegistry,
+        String localNodeId
+    ) {
 
         this.sessionId = sessionId;
         this.clusterAlias = clusterAlias;
@@ -252,10 +300,12 @@ public class LocalExecutionPlanner {
         this.exchangeSinkSupplier = exchangeSinkSupplier;
         this.enrichLookupService = enrichLookupService;
         this.lookupFromIndexService = lookupFromIndexService;
+        this.remoteFetchService = remoteFetchService;
         this.inferenceService = inferenceService;
         this.userAgentParserRegistry = userAgentParserRegistry;
         this.physicalOperationProviders = physicalOperationProviders;
         this.operatorFactoryRegistry = operatorFactoryRegistry;
+        this.localNodeId = localNodeId;
     }
 
     /**
@@ -316,6 +366,10 @@ public class LocalExecutionPlanner {
             return planAggregation(aggregate, context);
         } else if (node instanceof FieldExtractExec fieldExtractExec) {
             return planFieldExtractNode(fieldExtractExec, context);
+        } else if (node instanceof EmitRemoteFetchHandleExec emitRemoteFetchHandleExec) {
+            return planRemoteFetchHandleNode(emitRemoteFetchHandleExec, context);
+        } else if (node instanceof RemoteFetchExec remoteFetchExec) {
+            return planRemoteFetchNode(remoteFetchExec, context);
         } else if (node instanceof ExchangeExec exchangeExec) {
             return planExchange(exchangeExec, context);
         } else if (node instanceof TopNExec topNExec) {
@@ -534,6 +588,54 @@ public class LocalExecutionPlanner {
         return physicalOperationProviders.fieldExtractPhysicalOperation(fieldExtractExec, plan(fieldExtractExec.child(), context), context);
     }
 
+    private PhysicalOperation planRemoteFetchHandleNode(
+        EmitRemoteFetchHandleExec emitRemoteFetchHandleExec,
+        LocalExecutionPlannerContext context
+    ) {
+        if (localNodeId == null) {
+            throw new IllegalStateException("remote fetch handle emission requires the local node id");
+        }
+        PhysicalOperation source = plan(emitRemoteFetchHandleExec.child(), context);
+        int docChannel = source.layout.get(emitRemoteFetchHandleExec.sourceAttribute().id()).channel();
+        Layout outputLayout = replaceLayoutAttribute(
+            source.layout,
+            emitRemoteFetchHandleExec.sourceAttribute(),
+            emitRemoteFetchHandleExec.handleAttribute()
+        );
+        return source.with(new RemoteFetchHandleOperator.Factory(localNodeId, sessionId, docChannel), outputLayout);
+    }
+
+    private PhysicalOperation planRemoteFetchNode(RemoteFetchExec remoteFetchExec, LocalExecutionPlannerContext context) {
+        if (remoteFetchService == null) {
+            throw new IllegalStateException("remote fetch planning requires a remote fetch service");
+        }
+        if (parentTask == null) {
+            throw new IllegalStateException("remote fetch planning requires a cancellable parent task");
+        }
+        PhysicalOperation source = plan(remoteFetchExec.child(), context);
+        int handleChannel = source.layout.get(remoteFetchExec.handleAttribute().id()).channel();
+        List<RemoteFetchService.FetchField> requestFields = remoteFetchExec.attributesToFetch().stream().map(attribute -> {
+            String fieldName = attribute instanceof FieldAttribute fieldAttribute ? fieldAttribute.fieldName().string() : attribute.name();
+            return new RemoteFetchService.FetchField(fieldName, attribute.dataType());
+        }).toList();
+        Layout.Builder outputLayoutBuilder = source.layout.builder();
+        outputLayoutBuilder.append(remoteFetchExec.fetchedOutputAttributes());
+        Layout outputLayout = outputLayoutBuilder.build();
+        return source.with(
+            new RemoteFetchOperator.Factory(
+                handleChannel,
+                requestFields,
+                remoteFetchExec.fetchedOutputAttributes(),
+                remoteFetchExec.pushdownPlan(),
+                configuration,
+                Math.max(1, context.queryPragmas().concurrentExchangeClients()),
+                remoteFetchService.threadContext(),
+                () -> remoteFetchService.newBatchExchangeClient(parentTask)
+            ),
+            outputLayout
+        );
+    }
+
     private PhysicalOperation planOutput(OutputExec outputExec, LocalExecutionPlannerContext context) {
         PhysicalOperation source = plan(outputExec.child(), context);
         var output = outputExec.output();
@@ -570,6 +672,20 @@ public class LocalExecutionPlanner {
         } : Function.identity();
 
         return transformer;
+    }
+
+    private static Layout replaceLayoutAttribute(Layout inputLayout, Attribute oldAttribute, Attribute newAttribute) {
+        Layout.Builder builder = new Layout.Builder();
+        for (Layout.ChannelSet channel : inputLayout.inverse()) {
+            var ids = new HashSet<>(channel.nameIds());
+            if (ids.remove(oldAttribute.id())) {
+                ids.add(newAttribute.id());
+                builder.append(new Layout.ChannelSet(ids, newAttribute.dataType()));
+            } else {
+                builder.append(new Layout.ChannelSet(ids, channel.type()));
+            }
+        }
+        return builder.build();
     }
 
     private PhysicalOperation planExchange(ExchangeExec exchangeExec, LocalExecutionPlannerContext context) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerSettings.java
@@ -89,6 +89,18 @@ public class PlannerSettings {
     );
 
     /**
+     * Enables the prototype substrate for coordinator-side remote fetch after a distributed TopN narrowing phase.
+     * This setting is intentionally separate from {@link #REDUCTION_LATE_MATERIALIZATION} so the new cross-node
+     * continuation path can be developed and tested without changing the existing late-materialization behavior.
+     */
+    public static final Setting<Boolean> REMOTE_FETCH_LATE_MATERIALIZATION = Setting.boolSetting(
+        "esql.remote_fetch_late_materialization",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Circuit breaker space reserved for each script {@link BlockLoader.Reader}. The default
      * is pretty poor estimate for the overhead of the script, but it'll do for now. We're
      * estimating 100kb for loading ordinals from doc values and 2kb for loading numbers from
@@ -238,6 +250,7 @@ public class PlannerSettings {
             LUCENE_TOPN_LIMIT,
             INTERMEDIATE_LOCAL_RELATION_MAX_SIZE,
             REDUCTION_LATE_MATERIALIZATION,
+            REMOTE_FETCH_LATE_MATERIALIZATION,
             PARTIAL_AGGREGATION_EMIT_KEYS_THRESHOLD,
             PARTIAL_AGGREGATION_EMIT_UNIQUENESS_THRESHOLD,
             REUSE_COLUMN_LOADERS_THRESHOLD,
@@ -266,6 +279,10 @@ public class PlannerSettings {
             clusterSettings.initializeAndWatch(
                 INTERMEDIATE_LOCAL_RELATION_MAX_SIZE,
                 v -> settings.updateAndGet(s -> s.intermediateLocalRelationMaxSize(v))
+            );
+            clusterSettings.initializeAndWatch(
+                REMOTE_FETCH_LATE_MATERIALIZATION,
+                v -> settings.updateAndGet(s -> s.remoteFetchLateMaterialization(v))
             );
             clusterSettings.initializeAndWatch(
                 PARTIAL_AGGREGATION_EMIT_KEYS_THRESHOLD,
@@ -307,6 +324,7 @@ public class PlannerSettings {
     private final ByteSizeValue valuesLoadingJumboSize;
     private final int luceneTopNLimit;
     private final ByteSizeValue intermediateLocalRelationMaxSize;
+    private final boolean remoteFetchLateMaterialization;
     private final int partialEmitKeysThreshold;
     private final double partialEmitUniquenessThreshold;
     private final int reuseColumnLoadersThreshold;
@@ -327,6 +345,7 @@ public class PlannerSettings {
         VALUES_LOADING_JUMBO_SIZE.get(Settings.EMPTY),
         LUCENE_TOPN_LIMIT.getDefault(Settings.EMPTY),
         INTERMEDIATE_LOCAL_RELATION_MAX_SIZE.getDefault(Settings.EMPTY),
+        REMOTE_FETCH_LATE_MATERIALIZATION.getDefault(Settings.EMPTY),
         PARTIAL_AGGREGATION_EMIT_KEYS_THRESHOLD.getDefault(Settings.EMPTY),
         PARTIAL_AGGREGATION_EMIT_UNIQUENESS_THRESHOLD.getDefault(Settings.EMPTY),
         REUSE_COLUMN_LOADERS_THRESHOLD.getDefault(Settings.EMPTY),
@@ -348,6 +367,7 @@ public class PlannerSettings {
         ByteSizeValue valuesLoadingJumboSize,
         int luceneTopNLimit,
         ByteSizeValue intermediateLocalRelationMaxSize,
+        boolean remoteFetchLateMaterialization,
         int partialEmitKeysThreshold,
         double partialEmitUniquenessThreshold,
         int reuseColumnLoadersThreshold,
@@ -364,6 +384,7 @@ public class PlannerSettings {
         this.valuesLoadingJumboSize = valuesLoadingJumboSize;
         this.luceneTopNLimit = luceneTopNLimit;
         this.intermediateLocalRelationMaxSize = intermediateLocalRelationMaxSize;
+        this.remoteFetchLateMaterialization = remoteFetchLateMaterialization;
         this.partialEmitKeysThreshold = partialEmitKeysThreshold;
         this.partialEmitUniquenessThreshold = partialEmitUniquenessThreshold;
         this.reuseColumnLoadersThreshold = reuseColumnLoadersThreshold;
@@ -383,6 +404,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -407,6 +429,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -431,6 +454,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -469,6 +493,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -486,6 +511,31 @@ public class PlannerSettings {
         return intermediateLocalRelationMaxSize;
     }
 
+    public PlannerSettings remoteFetchLateMaterialization(boolean remoteFetchLateMaterialization) {
+        return new PlannerSettings(
+            defaultDataPartitioning,
+            docsThresholdForAutoPartitioning,
+            valuesLoadingJumboSize,
+            luceneTopNLimit,
+            intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
+            partialEmitKeysThreshold,
+            partialEmitUniquenessThreshold,
+            reuseColumnLoadersThreshold,
+            blockLoaderSizeOrdinals,
+            blockLoaderSizeScript,
+            maxKeywordSortFields,
+            sourceReservationFactor,
+            bytesRefRamOverestimateThreshold,
+            bytesRefRamOverestimateFactor,
+            docSequenceBytesRefFieldThreshold
+        );
+    }
+
+    public boolean remoteFetchLateMaterialization() {
+        return remoteFetchLateMaterialization;
+    }
+
     public PlannerSettings partialEmitKeysThreshold(int partialEmitKeysThreshold) {
         return new PlannerSettings(
             defaultDataPartitioning,
@@ -493,6 +543,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -517,6 +568,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -541,6 +593,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -572,6 +625,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -599,6 +653,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -626,6 +681,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -650,6 +706,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -674,6 +731,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -698,6 +756,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -722,6 +781,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -746,6 +806,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
@@ -301,7 +301,8 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                         configuration,
                         configuration.newFoldContext(),
                         exchangeSource::createExchangeSource,
-                        () -> exchangeSink.createExchangeSink(() -> {})
+                        () -> exchangeSink.createExchangeSink(() -> {}),
+                        false
                     ),
                     coordinatorPlan,
                     computeService.plannerSettings().get(),
@@ -322,6 +323,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                     originalIndices,
                     exchangeSource,
                     cancelQueryOnFailure,
+                    null,
                     computeListener.acquireCompute().map(r -> {
                         finalResponse.set(r);
                         return r.getCompletionInfo();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeContext.java
@@ -25,7 +25,8 @@ record ComputeContext(
     Configuration configuration,
     FoldContext foldCtx,
     Supplier<ExchangeSource> exchangeSourceSupplier,
-    Supplier<ExchangeSink> exchangeSinkSupplier
+    Supplier<ExchangeSink> exchangeSinkSupplier,
+    boolean retainSearchContexts
 ) {
     IndexedByShardId<? extends SearchExecutionContext> searchExecutionContexts() {
         return searchContexts.map(s -> s.searchContext().getSearchExecutionContext());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -102,6 +102,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -169,6 +170,7 @@ public class ComputeService {
     private final DriverTaskRunner driverRunner;
     private final EnrichLookupService enrichLookupService;
     private final LookupFromIndexService lookupFromIndexService;
+    private final RemoteFetchService remoteFetchService;
     private final InferenceService inferenceService;
     private final UserAgentParserRegistry userAgentParserRegistry;
     private final ClusterService clusterService;
@@ -201,6 +203,7 @@ public class ComputeService {
         this.driverRunner = new DriverTaskRunner(transportService, esqlExecutor);
         this.enrichLookupService = enrichLookupService;
         this.lookupFromIndexService = lookupFromIndexService;
+        this.remoteFetchService = new RemoteFetchService(transportActionServices, this.bigArrays, blockFactory);
         this.inferenceService = transportActionServices.inferenceService();
         this.userAgentParserRegistry = transportActionServices.userAgentParserRegistry();
         this.clusterService = transportActionServices.clusterService();
@@ -228,6 +231,14 @@ public class ComputeService {
 
     PlannerSettings.Holder plannerSettings() {
         return plannerSettings;
+    }
+
+    RemoteFetchService remoteFetchService() {
+        return remoteFetchService;
+    }
+
+    FilterPushdownRegistry filterPushdownRegistry() {
+        return filterPushdownRegistry;
     }
 
     FormatReaderRegistry formatReaderRegistry() {
@@ -521,7 +532,8 @@ public class ComputeService {
             configuration,
             foldContext,
             mainExchangeSource::createExchangeSource,
-            null
+            null,
+            false
         );
 
         Runnable cancelQueryOnFailure = cancelQueryOnFailure(rootTask);
@@ -750,7 +762,8 @@ public class ComputeService {
                 configuration,
                 foldContext,
                 null,
-                exchangeSinkSupplier
+                exchangeSinkSupplier,
+                false
             );
             updateShardCountForCoordinatorOnlyQuery(execInfo);
             try (
@@ -804,6 +817,25 @@ public class ComputeService {
             listener.onFailure(new IllegalStateException(error));
             return;
         }
+        RemoteFetchService.TrackedSessions trackedRemoteFetchSessions = null;
+        boolean supportsRemoteFetchRetainedContexts = clusterService.state()
+            .getMinTransportVersion()
+            .supports(DataNodeRequest.ESQL_REMOTE_FETCH_RETAINED_CONTEXTS);
+        if (plannerSettings.get().remoteFetchLateMaterialization()
+            && supportsRemoteFetchRetainedContexts
+            && dataNodePlan instanceof ExchangeSinkExec exchangeSinkExec
+            && clusterToConcreteIndices.size() == 1
+            && clusterToConcreteIndices.containsKey(LOCAL_CLUSTER)) {
+            Optional<PhysicalPlan> remoteFetchCoordinatorPlan = RemoteFetchPlanner.planCoordinatorTopN(
+                stats -> new LocalPhysicalOptimizerContext(plannerSettings.get(), flags, configuration, foldContext, stats),
+                coordinatorPlan,
+                exchangeSinkExec
+            );
+            if (remoteFetchCoordinatorPlan.isPresent()) {
+                coordinatorPlan = remoteFetchCoordinatorPlan.get();
+                trackedRemoteFetchSessions = remoteFetchService.trackedSessions();
+            }
+        }
         Map<String, OriginalIndices> clusterToOriginalIndices = getIndices(resolvedPlan, EsRelation::originalIndices);
         var localOriginalIndices = clusterToOriginalIndices.remove(LOCAL_CLUSTER);
         var localConcreteIndices = clusterToConcreteIndices.remove(LOCAL_CLUSTER);
@@ -817,6 +849,9 @@ public class ComputeService {
             configuration.pragmas().exchangeBufferSize(),
             transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
         );
+        if (trackedRemoteFetchSessions != null) {
+            listener = ActionListener.runBefore(listener, trackedRemoteFetchSessions::close);
+        }
         listener = ActionListener.runBefore(listener, () -> exchangeService.removeExchangeSourceHandler(sessionId));
         exchangeService.addExchangeSourceHandler(sessionId, exchangeSource);
         try (
@@ -871,7 +906,8 @@ public class ComputeService {
                             configuration,
                             foldContext,
                             exchangeSource::createExchangeSource,
-                            exchangeSinkSupplier
+                            exchangeSinkSupplier,
+                            false
                         ),
                         coordinatorPlan,
                         plannerSettings.get(),
@@ -893,6 +929,7 @@ public class ComputeService {
                             localOriginalIndices,
                             exchangeSource,
                             cancelQueryOnFailure,
+                            trackedRemoteFetchSessions,
                             ActionListener.wrap(r -> {
                                 localClusterWasInterrupted.set(execInfo.isStopped());
                                 execInfo.swapCluster(
@@ -1018,7 +1055,8 @@ public class ComputeService {
                     configuration,
                     foldContext,
                     exchangeSource::createExchangeSource,
-                    exchangeSinkSupplier
+                    exchangeSinkSupplier,
+                    false
                 ),
                 coordinatorPlan,
                 plannerSettings.get(),
@@ -1140,7 +1178,8 @@ public class ComputeService {
         PlanTimeProfile planTimeProfile,
         ActionListener<DriverCompletionInfo> listener
     ) {
-        var shardContexts = context.searchContexts().map(ComputeSearchContext::shardContext);
+        var shardContexts = context.searchContexts()
+            .map(context.retainSearchContexts() ? ComputeSearchContext::newDetachedShardContext : ComputeSearchContext::shardContext);
         EsPhysicalOperationProviders physicalOperationProviders = new EsPhysicalOperationProviders(
             context.foldCtx(),
             shardContexts,
@@ -1161,10 +1200,12 @@ public class ComputeService {
                 context.exchangeSinkSupplier(),
                 enrichLookupService,
                 lookupFromIndexService,
+                remoteFetchService,
                 inferenceService,
                 userAgentParserRegistry,
                 physicalOperationProviders,
-                operatorFactoryRegistry
+                operatorFactoryRegistry,
+                clusterService.localNode().getId()
             );
 
             LOGGER.debug("Received physical plan for {}:\n{}", context.description(), plan);
@@ -1316,10 +1357,39 @@ public class ComputeService {
         boolean reduceNodeLateMaterialization,
         PlanTimeProfile planTimeProfile
     ) {
+        return reductionPlan(
+            plannerSettings,
+            flags,
+            configuration,
+            foldCtx,
+            originalPlan,
+            runNodeLevelReduction,
+            reduceNodeLateMaterialization,
+            false,
+            planTimeProfile
+        );
+    }
+
+    public static ReductionPlan reductionPlan(
+        PlannerSettings plannerSettings,
+        EsqlFlags flags,
+        Configuration configuration,
+        FoldContext foldCtx,
+        ExchangeSinkExec originalPlan,
+        boolean runNodeLevelReduction,
+        boolean reduceNodeLateMaterialization,
+        boolean remoteFetchLateMaterialization,
+        PlanTimeProfile planTimeProfile
+    ) {
         long startTime = planTimeProfile == null ? 0 : System.nanoTime();
         PhysicalPlan source = new ExchangeSourceExec(originalPlan.source(), originalPlan.output(), originalPlan.isIntermediateAgg());
-        ReductionPlan passThroughReduction = new ReductionPlan(originalPlan.replaceChild(source), originalPlan);
-        if (reduceNodeLateMaterialization == false && runNodeLevelReduction == false) {
+        // Just send out everything through a single exchange as a fallback
+        ReductionPlan passThroughReduction = new ReductionPlan(
+            originalPlan.replaceChild(source),
+            originalPlan,
+            LocalPhysicalOptimization.ENABLED
+        );
+        if (remoteFetchLateMaterialization == false && reduceNodeLateMaterialization == false && runNodeLevelReduction == false) {
             return passThroughReduction;
         }
 
@@ -1330,6 +1400,10 @@ public class ComputeService {
 
         // The default plan is just the exchange source piped directly into the exchange sink.
         ReductionPlan reductionPlan = switch (PlannerUtils.reductionPlan(originalPlan)) {
+            case PlannerUtils.TopNReduction ignored when remoteFetchLateMaterialization -> RemoteFetchPlanner.planReduceDriverTopN(
+                stats -> new LocalPhysicalOptimizerContext(plannerSettings, flags, configuration, foldCtx, stats),
+                originalPlan
+            ).orElseThrow(() -> new IllegalStateException("remote fetch late materialization was selected but planning failed"));
             case PlannerUtils.TopNReduction topN when reduceNodeLateMaterialization ->
                 // In the case of TopN, the source output type is replaced since we're pulling the FieldExtractExec to the reduction node,
                 // so essentially we are splitting the TopNExec into two parts, similar to other aggregations, but unlike other

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -122,6 +122,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         OriginalIndices originalIndices,
         ExchangeSourceHandler exchangeSource,
         Runnable runOnTaskFailure,
+        RemoteFetchService.TrackedSessions remoteFetchSessions,
         ActionListener<ComputeResponse> outListener
     ) {
         Integer maxConcurrentNodesPerCluster = PlanConcurrencyCalculator.INSTANCE.calculateNodesConcurrency(dataNodePlan, configuration);
@@ -198,6 +199,11 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                                 .equals(connection.getNode().getId());
                             boolean enableReduceNodeLateMaterialization = EsqlCapabilities.Cap.ENABLE_REDUCE_NODE_LATE_MATERIALIZATION
                                 .isEnabled();
+                            boolean supportsRetainedSearchContexts = connection.getTransportVersion()
+                                .supports(DataNodeRequest.ESQL_REMOTE_FETCH_RETAINED_CONTEXTS);
+                            boolean retainSearchContexts = remoteFetchSessions != null
+                                && computeService.plannerSettings().get().remoteFetchLateMaterialization()
+                                && supportsRetainedSearchContexts;
                             var dataNodeRequest = new DataNodeRequest(
                                 childSessionId,
                                 configuration,
@@ -212,8 +218,11 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                                 // work as the final driver.
                                 queryPragmas.nodeLevelReduction() && sameNodeAsCoordinator == false,
                                 queryPragmas.nodeLevelReduction() && enableReduceNodeLateMaterialization,
-                                false
+                                retainSearchContexts
                             );
+                            if (retainSearchContexts) {
+                                remoteFetchSessions.track(connection.getNode(), nodeReduceSessionId(childSessionId));
+                            }
                             transportService.sendChildRequest(
                                 connection,
                                 ComputeService.DATA_ACTION_NAME,
@@ -568,7 +577,8 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                         configuration,
                         configuration.newFoldContext(),
                         null,
-                        () -> exchangeSink.createExchangeSink(pagesProduced::incrementAndGet)
+                        () -> exchangeSink.createExchangeSink(pagesProduced::incrementAndGet),
+                        request.retainSearchContexts()
                     );
                     computeService.runCompute(
                         parentTask,
@@ -734,7 +744,8 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                         request.configuration(),
                         new FoldContext(request.pragmas().foldLimit().getBytes()),
                         exchangeSource::createExchangeSource,
-                        () -> externalSink.createExchangeSink(() -> {})
+                        () -> externalSink.createExchangeSink(() -> {}),
+                        request.retainSearchContexts()
                     ),
                     reducePlan,
                     plannerSettings,
@@ -787,6 +798,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                 plan,
                 request.runNodeLevelReduction(),
                 request.reductionLateMaterialization(),
+                request.retainSearchContexts(),
                 planTimeProfile
             );
         } else {
@@ -794,8 +806,9 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             return;
         }
         final String sessionId = request.sessionId();
+        final String nodeReduceSessionId = nodeReduceSessionId(sessionId);
         request = new DataNodeRequest(
-            sessionId + "[n]", // internal session
+            nodeReduceSessionId, // internal session
             request.configuration(),
             request.clusterAlias(),
             request.shards(),
@@ -811,6 +824,26 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         // the sender doesn't support retry on shard failures, so we need to fail fast here.
         final boolean failFastOnShardFailures = supportShardLevelRetryFailure(channel.getVersion()) == false;
         var computeSearchContexts = new AcquiredSearchContexts(request.shards().size());
+        ActionListener<DataNodeComputeResponse> responseListener;
+        if (request.retainSearchContexts()) {
+            final RetainedSearchContextsRegistry.Registration retainedSearchContexts;
+            try {
+                retainedSearchContexts = computeService.remoteFetchService()
+                    .retainSearchContexts(nodeReduceSessionId, computeSearchContexts);
+            } catch (Exception e) {
+                computeSearchContexts.close();
+                listener.onFailure(e);
+                return;
+            }
+            ((CancellableTask) task).addListener(retainedSearchContexts::close);
+            responseListener = ActionListener.wrap(listener::onResponse, e -> {
+                try (retainedSearchContexts) {
+                    listener.onFailure(e);
+                }
+            });
+        } else {
+            responseListener = ActionListener.releaseAfter(listener, computeSearchContexts);
+        }
         runComputeOnDataNode(
             (CancellableTask) task,
             sessionId,
@@ -820,8 +853,12 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             computeSearchContexts,
             computeService.plannerSettings().get(),
             planTimeProfile,
-            ActionListener.releaseAfter(listener, computeSearchContexts)
+            responseListener
         );
+    }
+
+    private static String nodeReduceSessionId(String sessionId) {
+        return sessionId + "[n]";
     }
 
     private void handleExternalSourceRequest(
@@ -883,7 +920,8 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                     configuration,
                     configuration.newFoldContext(),
                     null,
-                    () -> externalSink.createExchangeSink(() -> {})
+                    () -> externalSink.createExchangeSink(() -> {}),
+                    false
                 );
                 computeService.runCompute(
                     task,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchPlanner.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.InsertFieldExtraction;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ReplaceSourceAttributes;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.plan.physical.EmitRemoteFetchHandleExec;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.EstimatesRowSize;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
+import org.elasticsearch.xpack.esql.plan.physical.LimitExec;
+import org.elasticsearch.xpack.esql.plan.physical.OutputExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
+import org.elasticsearch.xpack.esql.planner.mapper.LocalMapper;
+import org.elasticsearch.xpack.esql.stats.SearchStats;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Planner helpers for the distributed remote fetch prototype on the linear TopN family.
+ */
+final class RemoteFetchPlanner {
+    static final String REMOTE_FETCH_HANDLE_NAME = "_remote_fetch_handle";
+    static final String REMOTE_FETCH_POSITION_NAME = "_remote_fetch_position";
+
+    static Optional<PhysicalPlan> planCoordinatorTopN(
+        Function<SearchStats, LocalPhysicalOptimizerContext> contextFactory,
+        PhysicalPlan coordinatorPlan,
+        ExchangeSinkExec originalDataPlan
+    ) {
+        PlanningInfo info = analyze(contextFactory, originalDataPlan).orElse(null);
+        if (info == null) {
+            return Optional.empty();
+        }
+        return rewriteCoordinatorPlan(coordinatorPlan, info);
+    }
+
+    static Optional<ReductionPlan> planReduceDriverTopN(
+        Function<SearchStats, LocalPhysicalOptimizerContext> contextFactory,
+        ExchangeSinkExec originalPlan
+    ) {
+        PlanningInfo info = analyze(contextFactory, originalPlan).orElse(null);
+        if (info == null) {
+            return Optional.empty();
+        }
+
+        LogicalPlan withAddedDocToRelation = info.topN().transformUp(EsRelation.class, r -> {
+            if (r.indexMode() == IndexMode.LOOKUP) {
+                return r;
+            }
+            List<Attribute> attributes = CollectionUtils.prependToCopy(info.docAttribute(), r.output());
+            return r.withAttributes(attributes);
+        });
+        if (withAddedDocToRelation.output().stream().noneMatch(EsQueryExec::isDocAttribute)) {
+            return Optional.empty();
+        }
+
+        Project updatedFragment = new Project(Source.EMPTY, withAddedDocToRelation, info.carryAttributes());
+        FragmentExec updatedFragmentExec = info.fragmentExec().withFragment(updatedFragment);
+        ExchangeSinkExec updatedDataPlan = originalPlan.replaceChildAndUpdateOutput(updatedFragmentExec);
+
+        PhysicalPlan reductionPlan = toPhysical(updatedFragment, info.context()).transformDown(
+            TopNExec.class,
+            topNExec -> topNExec.replaceChild(new ExchangeSourceExec(info.topN().source(), info.carryAttributes(), false)).withSortedInput()
+        );
+        PhysicalPlan sizedReductionPlan = EstimatesRowSize.estimateRowSize(updatedFragmentExec.estimatedRowSize(), reductionPlan);
+        PhysicalPlan encodedReductionPlan = new EmitRemoteFetchHandleExec(
+            Source.EMPTY,
+            sizedReductionPlan,
+            info.docAttribute(),
+            info.handleAttribute()
+        );
+        ExchangeSinkExec nodeReducePlan = new ExchangeSinkExec(
+            originalPlan.source(),
+            info.externalOutput(),
+            originalPlan.isIntermediateAgg(),
+            encodedReductionPlan
+        );
+        return Optional.of(new ReductionPlan(nodeReducePlan, updatedDataPlan, LocalPhysicalOptimization.DISABLED));
+    }
+
+    private static Optional<PlanningInfo> analyze(
+        Function<SearchStats, LocalPhysicalOptimizerContext> contextFactory,
+        ExchangeSinkExec originalPlan
+    ) {
+        FragmentExec fragmentExec = originalPlan.child() instanceof FragmentExec fe ? fe : null;
+        if (fragmentExec == null) {
+            return Optional.empty();
+        }
+
+        Project topLevelProject = fragmentExec.fragment() instanceof Project p ? p : null;
+        if (topLevelProject == null) {
+            return Optional.empty();
+        }
+
+        TopN topN = topLevelProject.child() instanceof TopN tn ? tn : null;
+        if (topN == null) {
+            return Optional.empty();
+        }
+
+        LocalPhysicalOptimizerContext context = contextFactory.apply(SEARCH_STATS_TOP_N_REPLACEMENT);
+        List<Attribute> physicalPlanOutput = toPhysical(topN, context).output();
+        Attribute doc = physicalPlanOutput.stream().filter(EsQueryExec::isDocAttribute).findFirst().orElse(null);
+        if (doc == null) {
+            return Optional.empty();
+        }
+
+        AttributeSet orderRefsSet = AttributeSet.of(topN.order().stream().flatMap(order -> order.references().stream()).toList());
+        List<Attribute> carryAttributes = new ArrayList<>();
+        for (Attribute attribute : physicalPlanOutput) {
+            if (orderRefsSet.contains(attribute) || EsQueryExec.isDocAttribute(attribute)) {
+                carryAttributes.add(attribute);
+            }
+        }
+        if (carryAttributes.stream().noneMatch(EsQueryExec::isDocAttribute)) {
+            return Optional.empty();
+        }
+
+        ReferenceAttribute handle = new ReferenceAttribute(Source.EMPTY, null, REMOTE_FETCH_HANDLE_NAME, DataType.KEYWORD);
+        return Optional.of(
+            new PlanningInfo(fragmentExec, topN, context, doc, handle, carryAttributes, replaceDocAttribute(carryAttributes, doc, handle))
+        );
+    }
+
+    private static Optional<PhysicalPlan> rewriteCoordinatorPlan(PhysicalPlan coordinatorPlan, PlanningInfo info) {
+        if (coordinatorPlan instanceof OutputExec outputExec) {
+            return rewriteCoordinatorPlan(outputExec.child(), info).map(outputExec::replaceChild);
+        }
+        if (coordinatorPlan instanceof EvalExec evalExec) {
+            Optional<PhysicalPlan> rewritten = rewriteCoordinatorPlan(evalExec.child(), info);
+            if (rewritten.isPresent()) {
+                PhysicalPlan child = rewritten.get();
+                if (child instanceof RemoteFetchExec remoteFetchExec && isPushdownEligible(evalExec, remoteFetchExec.attributesToFetch())) {
+                    return Optional.of(appendPushdown(remoteFetchExec, evalExec));
+                }
+                return Optional.of(evalExec.replaceChild(child));
+            }
+            Optional<RemoteFetchExec> injected = injectRemoteFetch(evalExec.source(), evalExec.child(), evalExec.references(), info);
+            if (injected.isEmpty()) {
+                return Optional.empty();
+            }
+            RemoteFetchExec remoteFetchExec = injected.get();
+            if (isPushdownEligible(evalExec, remoteFetchExec.attributesToFetch())) {
+                return Optional.of(appendPushdown(remoteFetchExec, evalExec));
+            }
+            return Optional.of(evalExec.replaceChild(remoteFetchExec));
+        }
+        if (coordinatorPlan instanceof FilterExec filterExec) {
+            Optional<PhysicalPlan> rewritten = rewriteCoordinatorPlan(filterExec.child(), info);
+            if (rewritten.isPresent()) {
+                PhysicalPlan child = rewritten.get();
+                if (child instanceof RemoteFetchExec remoteFetchExec
+                    && isPushdownEligible(filterExec, remoteFetchExec.attributesToFetch())) {
+                    return Optional.of(appendPushdown(remoteFetchExec, filterExec));
+                }
+                return Optional.of(filterExec.replaceChild(child));
+            }
+            Optional<RemoteFetchExec> injected = injectRemoteFetch(filterExec.source(), filterExec.child(), filterExec.references(), info);
+            if (injected.isEmpty()) {
+                return Optional.empty();
+            }
+            RemoteFetchExec remoteFetchExec = injected.get();
+            if (isPushdownEligible(filterExec, remoteFetchExec.attributesToFetch())) {
+                return Optional.of(appendPushdown(remoteFetchExec, filterExec));
+            }
+            return Optional.of(filterExec.replaceChild(remoteFetchExec));
+        }
+        if (coordinatorPlan instanceof LimitExec limitExec) {
+            return rewriteCoordinatorPlan(limitExec.child(), info).map(limitExec::replaceChild);
+        }
+        if (coordinatorPlan instanceof ProjectExec == false) {
+            return Optional.empty();
+        }
+        ProjectExec projectExec = (ProjectExec) coordinatorPlan;
+
+        Optional<PhysicalPlan> rewritten = rewriteCoordinatorPlan(projectExec.child(), info);
+        if (rewritten.isPresent()) {
+            PhysicalPlan child = rewritten.get();
+            if (child instanceof RemoteFetchExec remoteFetchExec && isPushdownEligible(projectExec, remoteFetchExec.attributesToFetch())) {
+                return Optional.of(appendPushdown(remoteFetchExec, projectExec));
+            }
+            return Optional.of(projectExec.replaceChild(child));
+        }
+
+        Optional<RemoteFetchExec> injected = injectRemoteFetch(projectExec.source(), projectExec.child(), projectExec.references(), info);
+        if (injected.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(projectExec.replaceChild(injected.get()));
+    }
+
+    private static boolean isPushdownEligible(PhysicalPlan pushdownNode, List<Attribute> fetchedAttributes) {
+        AttributeSet allowed = AttributeSet.of(fetchedAttributes);
+        for (Attribute reference : pushdownNode.references()) {
+            if (allowed.contains(reference) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static RemoteFetchExec appendPushdown(RemoteFetchExec remoteFetchExec, UnaryExec pushdownNode) {
+        PhysicalPlan source = remoteFetchExec.pushdownPlan();
+        Attribute positionAttribute;
+        if (source == null) {
+            positionAttribute = new ReferenceAttribute(Source.EMPTY, null, REMOTE_FETCH_POSITION_NAME, DataType.INTEGER);
+            List<Attribute> sourceOutput = new ArrayList<>(remoteFetchExec.attributesToFetch());
+            sourceOutput.add(positionAttribute);
+            source = new RemoteFetchSourceExec(Source.EMPTY, sourceOutput);
+        } else {
+            positionAttribute = source.output()
+                .stream()
+                .filter(attr -> REMOTE_FETCH_POSITION_NAME.equals(attr.name()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("pushdown source is missing [" + REMOTE_FETCH_POSITION_NAME + "]"));
+        }
+        UnaryExec adjustedPushdown = switch (pushdownNode) {
+            case ProjectExec projectExec -> {
+                List<NamedExpression> projections = new ArrayList<>(projectExec.projections().size() + 1);
+                projections.addAll(projectExec.projections());
+                if (projectExec.projections().stream().noneMatch(ne -> ne.id().equals(positionAttribute.id()))) {
+                    projections.add(positionAttribute);
+                }
+                yield new ProjectExec(projectExec.source(), source, projections);
+            }
+            default -> (UnaryExec) pushdownNode.replaceChild(source);
+        };
+        PhysicalPlan newPushdown = adjustedPushdown;
+        return new RemoteFetchExec(
+            remoteFetchExec.source(),
+            remoteFetchExec.child(),
+            remoteFetchExec.handleAttribute(),
+            remoteFetchExec.attributesToFetch(),
+            stripPositionAttribute(newPushdown.output(), positionAttribute.id()),
+            newPushdown
+        );
+    }
+
+    private static List<Attribute> stripPositionAttribute(List<Attribute> attributes, NameId positionAttributeId) {
+        return attributes.stream().filter(attr -> attr.id().equals(positionAttributeId) == false).toList();
+    }
+
+    private static boolean isRemoteFetchableAttribute(Attribute attribute) {
+        if (attribute instanceof FieldAttribute) {
+            return true;
+        }
+        return attribute instanceof MetadataAttribute
+            && MetadataAttribute.SCORE.equals(attribute.name()) == false
+            && EsQueryExec.isDocAttribute(attribute) == false;
+    }
+
+    private static Optional<RemoteFetchExec> injectRemoteFetch(
+        Source source,
+        PhysicalPlan child,
+        AttributeSet references,
+        PlanningInfo info
+    ) {
+        List<ExchangeSourceExec> sources = child.collect(ExchangeSourceExec.class);
+        if (sources.size() != 1) {
+            return Optional.empty();
+        }
+        PhysicalPlan updatedChild = child.transformDown(
+            ExchangeSourceExec.class,
+            exchangeSource -> new ExchangeSourceExec(exchangeSource.source(), info.externalOutput(), exchangeSource.isIntermediateAgg())
+        );
+        List<Attribute> missingAttributes = references.stream()
+            .filter(attribute -> updatedChild.outputSet().contains(attribute) == false)
+            .toList();
+        if (missingAttributes.isEmpty()) {
+            return Optional.empty();
+        }
+        if (missingAttributes.stream().allMatch(RemoteFetchPlanner::isRemoteFetchableAttribute) == false) {
+            return Optional.empty();
+        }
+        return Optional.of(new RemoteFetchExec(source, updatedChild, info.handleAttribute(), missingAttributes, missingAttributes, null));
+    }
+
+    private static List<Attribute> replaceDocAttribute(List<Attribute> attributes, Attribute docAttribute, Attribute handleAttribute) {
+        List<Attribute> replaced = new ArrayList<>(attributes.size());
+        for (Attribute attribute : attributes) {
+            replaced.add(attribute.id().equals(docAttribute.id()) ? handleAttribute : attribute);
+        }
+        return replaced;
+    }
+
+    private static PhysicalPlan toPhysical(LogicalPlan plan, LocalPhysicalOptimizerContext context) {
+        return new InsertFieldExtraction().apply(new ReplaceSourceAttributes().apply(LocalMapper.INSTANCE.map(plan)), context);
+    }
+
+    private record PlanningInfo(
+        FragmentExec fragmentExec,
+        TopN topN,
+        LocalPhysicalOptimizerContext context,
+        Attribute docAttribute,
+        ReferenceAttribute handleAttribute,
+        List<Attribute> carryAttributes,
+        List<Attribute> externalOutput
+    ) {}
+
+    private RemoteFetchPlanner() {}
+
+    // A hack to avoid the ReplaceFieldWithConstantOrNull optimization, since we don't have search stats during the reduce planning phase.
+    // This sidesteps the issue by just assuming all fields exist and have no other meaningful stats. The local data optimizer will use the
+    // real statistics.
+    private static final SearchStats SEARCH_STATS_TOP_N_REPLACEMENT = new SearchStats.UnsupportedSearchStats() {
+        @Override
+        public boolean exists(FieldAttribute.FieldName field) {
+            return true;
+        }
+
+        @Override
+        public boolean isIndexed(FieldAttribute.FieldName field) {
+            return false;
+        }
+
+        @Override
+        public Object min(FieldAttribute.FieldName field) {
+            return null;
+        }
+
+        @Override
+        public Object max(FieldAttribute.FieldName field) {
+            return null;
+        }
+    };
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -485,6 +485,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
             ByteSizeValue.ofMb(1),
             10_000,
             ByteSizeValue.ofMb(1),
+            false,
             between(1, 10000),
             randomDoubleBetween(0.1, 1.0, true),
             between(0, 1000),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchPlannerTests.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
+import org.elasticsearch.xpack.esql.TestAnalyzer;
+import org.elasticsearch.xpack.esql.analysis.Analyzer;
+import org.elasticsearch.xpack.esql.analysis.PreAnalyzer;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.optimizer.GoldenTestCase;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.plan.EsqlStatement;
+import org.elasticsearch.xpack.esql.plan.IndexPattern;
+import org.elasticsearch.xpack.esql.plan.QuerySettings;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.EmitRemoteFetchHandleExec;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
+import org.elasticsearch.xpack.esql.session.Configuration;
+import org.elasticsearch.xpack.esql.session.Versioned;
+import org.elasticsearch.xpack.esql.stats.SearchStats;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.CSV_DATASET;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PARSER;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class RemoteFetchPlannerTests extends ESTestCase {
+    public void testCoordinatorPlanIsRewrittenToRemoteFetch() {
+        PlannedQuery planned = planQuery("""
+            FROM employees
+            | KEEP hire_date, salary
+            | SORT hire_date
+            | LIMIT 5
+            """);
+        Tuple<PhysicalPlan, PhysicalPlan> split = PlannerUtils.breakPlanBetweenCoordinatorAndDataNode(
+            planned.physicalPlan(),
+            planned.configuration()
+        );
+
+        PhysicalPlan coordinatorPlan = RemoteFetchPlanner.planCoordinatorTopN(
+            contextFactory(planned.configuration()),
+            split.v1(),
+            (ExchangeSinkExec) split.v2()
+        ).orElseThrow();
+
+        ProjectExec projectExec = (ProjectExec) coordinatorPlan;
+        assertThat(projectExec.child(), instanceOf(RemoteFetchExec.class));
+
+        RemoteFetchExec remoteFetchExec = (RemoteFetchExec) projectExec.child();
+        assertThat(remoteFetchExec.attributesToFetch().stream().map(Attribute::name).toList(), contains("salary"));
+
+        ExchangeSourceExec exchangeSource = singleValue(remoteFetchExec.child().collect(ExchangeSourceExec.class));
+        assertTrue(
+            exchangeSource.output().stream().anyMatch(attribute -> RemoteFetchPlanner.REMOTE_FETCH_HANDLE_NAME.equals(attribute.name()))
+        );
+        assertFalse(exchangeSource.output().stream().anyMatch(EsQueryExec::isDocAttribute));
+    }
+
+    public void testReductionPlanEmitsRemoteFetchHandles() {
+        PlannedQuery planned = planQuery("""
+            FROM employees
+            | KEEP hire_date, salary
+            | SORT hire_date
+            | LIMIT 5
+            """);
+        Tuple<PhysicalPlan, PhysicalPlan> split = PlannerUtils.breakPlanBetweenCoordinatorAndDataNode(
+            planned.physicalPlan(),
+            planned.configuration()
+        );
+
+        ReductionPlan reductionPlan = RemoteFetchPlanner.planReduceDriverTopN(
+            contextFactory(planned.configuration()),
+            (ExchangeSinkExec) split.v2()
+        ).orElseThrow();
+
+        assertThat(reductionPlan.nodeReducePlan().child(), instanceOf(EmitRemoteFetchHandleExec.class));
+        EmitRemoteFetchHandleExec emitRemoteFetchHandleExec = (EmitRemoteFetchHandleExec) reductionPlan.nodeReducePlan().child();
+        assertTrue(EsQueryExec.isDocAttribute(emitRemoteFetchHandleExec.sourceAttribute()));
+        assertEquals(RemoteFetchPlanner.REMOTE_FETCH_HANDLE_NAME, emitRemoteFetchHandleExec.handleAttribute().name());
+        assertTrue(reductionPlan.dataNodePlan().output().stream().anyMatch(EsQueryExec::isDocAttribute));
+        assertFalse(reductionPlan.nodeReducePlan().output().stream().anyMatch(EsQueryExec::isDocAttribute));
+    }
+
+    public void testChainedPushdownsReuseRemoteFetchPositionIdentity() {
+        ReferenceAttribute handleAttribute = new ReferenceAttribute(
+            Source.EMPTY,
+            null,
+            RemoteFetchPlanner.REMOTE_FETCH_HANDLE_NAME,
+            DataType.KEYWORD
+        );
+        ReferenceAttribute fetchedAttribute = new ReferenceAttribute(Source.EMPTY, null, "salary", DataType.LONG);
+        ReferenceAttribute existingPositionAttribute = new ReferenceAttribute(
+            Source.EMPTY,
+            null,
+            RemoteFetchPlanner.REMOTE_FETCH_POSITION_NAME,
+            DataType.INTEGER
+        );
+        PhysicalPlan existingPushdown = new ProjectExec(
+            Source.EMPTY,
+            new RemoteFetchSourceExec(Source.EMPTY, List.of(fetchedAttribute, existingPositionAttribute)),
+            List.of(fetchedAttribute, existingPositionAttribute)
+        );
+        RemoteFetchExec remoteFetchExec = new RemoteFetchExec(
+            Source.EMPTY,
+            new ExchangeSourceExec(Source.EMPTY, List.of(handleAttribute), false),
+            handleAttribute,
+            List.of(fetchedAttribute),
+            List.of(fetchedAttribute),
+            existingPushdown
+        );
+        ProjectExec nextPushdown = new ProjectExec(Source.EMPTY, remoteFetchExec.child(), List.of(fetchedAttribute));
+        RemoteFetchExec appendedPushdownRemoteFetch = invokeAppendPushdown(remoteFetchExec, nextPushdown);
+        assertNotNull(appendedPushdownRemoteFetch.pushdownPlan());
+
+        Set<NameId> positionAttributeIds = new HashSet<>();
+        collectPositionAttributeIds(appendedPushdownRemoteFetch.pushdownPlan(), positionAttributeIds);
+        assertEquals(1, positionAttributeIds.size());
+    }
+
+    public void testPushdownPositionStrippingKeepsUserNamedField() {
+        ReferenceAttribute handleAttribute = new ReferenceAttribute(
+            Source.EMPTY,
+            null,
+            RemoteFetchPlanner.REMOTE_FETCH_HANDLE_NAME,
+            DataType.KEYWORD
+        );
+        ReferenceAttribute fetchedAttribute = new ReferenceAttribute(Source.EMPTY, null, "salary", DataType.LONG);
+        ReferenceAttribute userNamedPositionAttribute = new ReferenceAttribute(
+            Source.EMPTY,
+            null,
+            RemoteFetchPlanner.REMOTE_FETCH_POSITION_NAME,
+            DataType.LONG
+        );
+        RemoteFetchExec remoteFetchExec = new RemoteFetchExec(
+            Source.EMPTY,
+            new ExchangeSourceExec(Source.EMPTY, List.of(handleAttribute), false),
+            handleAttribute,
+            List.of(fetchedAttribute, userNamedPositionAttribute),
+            List.of(fetchedAttribute, userNamedPositionAttribute),
+            null
+        );
+        ProjectExec pushdown = new ProjectExec(
+            Source.EMPTY,
+            remoteFetchExec.child(),
+            List.of(fetchedAttribute, userNamedPositionAttribute)
+        );
+        RemoteFetchExec appendedPushdownRemoteFetch = invokeAppendPushdown(remoteFetchExec, pushdown);
+
+        assertTrue(
+            appendedPushdownRemoteFetch.fetchedOutputAttributes().stream().anyMatch(a -> a.id().equals(userNamedPositionAttribute.id()))
+        );
+    }
+
+    public void testLimitBoundaryStillPushesDownFilter() {
+        PlannedQuery planned = planQuery("""
+            FROM employees
+            | SORT hire_date DESC
+            | LIMIT 5
+            | WHERE salary > 1000
+            | KEEP hire_date, salary
+            """);
+        Tuple<PhysicalPlan, PhysicalPlan> split = PlannerUtils.breakPlanBetweenCoordinatorAndDataNode(
+            planned.physicalPlan(),
+            planned.configuration()
+        );
+
+        PhysicalPlan coordinatorPlan = RemoteFetchPlanner.planCoordinatorTopN(
+            contextFactory(planned.configuration()),
+            split.v1(),
+            (ExchangeSinkExec) split.v2()
+        ).orElseThrow();
+
+        RemoteFetchExec remoteFetchExec = singleValue(coordinatorPlan.collect(RemoteFetchExec.class));
+        assertNotNull(remoteFetchExec.pushdownPlan());
+        assertFalse(remoteFetchExec.pushdownPlan().collect(FilterExec.class).isEmpty());
+        assertTrue(remoteFetchExec.child().collect(FilterExec.class).isEmpty());
+    }
+
+    private PlannedQuery planQuery(String query) {
+        TransportVersion transportVersion = TransportVersion.current();
+        EsqlStatement statement = TEST_PARSER.createStatement(query);
+        LogicalPlan parsedPlan = statement.plan();
+        TestAnalyzer testAnalyzer = analyzer().addLanguagesLookup()
+            .addAnalysisTestsEnrichResolution()
+            .addAnalysisTestsInferenceResolution()
+            .minimumTransportVersion(transportVersion)
+            .unmappedResolution(statement.setting(QuerySettings.UNMAPPED_FIELDS));
+        GoldenTestCase.loadIndexResolution(testDatasets(parsedPlan))
+            .forEach((pattern, resolution) -> testAnalyzer.addIndex(pattern.indexPattern(), resolution));
+        Analyzer analyzer = testAnalyzer.buildAnalyzer();
+        Configuration configuration = analyzer.context().configuration();
+        LogicalPlan logicalPlan = new LogicalPlanOptimizer(
+            new LogicalOptimizerContext(configuration, configuration.newFoldContext(), transportVersion)
+        ).optimize(analyzer.analyze(parsedPlan));
+        PhysicalPlan physicalPlan = new PhysicalPlanOptimizer(new PhysicalOptimizerContext(configuration, transportVersion)).optimize(
+            new Mapper().map(new Versioned<>(logicalPlan, transportVersion))
+        );
+        return new PlannedQuery(configuration, physicalPlan);
+    }
+
+    private static Function<SearchStats, LocalPhysicalOptimizerContext> contextFactory(Configuration configuration) {
+        return stats -> new LocalPhysicalOptimizerContext(
+            PlannerSettings.DEFAULTS,
+            new EsqlFlags(false),
+            configuration,
+            configuration.newFoldContext(),
+            stats
+        );
+    }
+
+    private static Map<IndexPattern, CsvTestsDataLoader.MultiIndexTestDataset> testDatasets(LogicalPlan parsed) {
+        var preAnalysis = new PreAnalyzer().preAnalyze(parsed);
+        if (preAnalysis.indexes().isEmpty()) {
+            return Map.of(
+                new IndexPattern(Source.EMPTY, "employees"),
+                CsvTestsDataLoader.MultiIndexTestDataset.of(CSV_DATASET.get("employees"))
+            );
+        }
+
+        List<String> missing = new ArrayList<>();
+        Map<IndexPattern, CsvTestsDataLoader.MultiIndexTestDataset> all = new HashMap<>();
+        for (IndexPattern indexPattern : preAnalysis.indexes().keySet()) {
+            List<CsvTestsDataLoader.TestDataset> datasets = new ArrayList<>();
+            String indexName = indexPattern.indexPattern();
+            if (indexName.endsWith("*")) {
+                String indexPrefix = indexName.substring(0, indexName.length() - 1);
+                for (var entry : CSV_DATASET.entrySet()) {
+                    if (entry.getKey().startsWith(indexPrefix)) {
+                        datasets.add(entry.getValue());
+                    }
+                }
+            } else {
+                for (String index : indexName.split(",")) {
+                    var dataset = CSV_DATASET.get(index);
+                    if (dataset == null) {
+                        throw new IllegalArgumentException("unknown CSV dataset for table [" + index + "]");
+                    }
+                    datasets.add(dataset);
+                }
+            }
+            if (datasets.isEmpty() == false) {
+                all.put(indexPattern, new CsvTestsDataLoader.MultiIndexTestDataset(indexName, datasets));
+            } else {
+                missing.add(indexName);
+            }
+        }
+        if (all.isEmpty()) {
+            throw new IllegalArgumentException("Found no CSV datasets for table [" + preAnalysis.indexes() + "]");
+        }
+        if (missing.isEmpty() == false) {
+            throw new IllegalArgumentException("Did not find datasets for tables: " + missing);
+        }
+        return all;
+    }
+
+    private static <T> T singleValue(List<T> values) {
+        assertEquals(1, values.size());
+        return values.get(0);
+    }
+
+    private static void collectPositionAttributeIds(PhysicalPlan plan, Set<NameId> ids) {
+        for (Attribute attribute : plan.output()) {
+            if (RemoteFetchPlanner.REMOTE_FETCH_POSITION_NAME.equals(attribute.name())) {
+                ids.add(attribute.id());
+            }
+        }
+        for (PhysicalPlan child : plan.children()) {
+            collectPositionAttributeIds(child, ids);
+        }
+    }
+
+    private static RemoteFetchExec invokeAppendPushdown(RemoteFetchExec remoteFetchExec, UnaryExec pushdownNode) {
+        try {
+            var method = RemoteFetchPlanner.class.getDeclaredMethod("appendPushdown", RemoteFetchExec.class, UnaryExec.class);
+            method.setAccessible(true);
+            return (RemoteFetchExec) method.invoke(null, remoteFetchExec, pushdownNode);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("failed to invoke appendPushdown", e);
+        }
+    }
+
+    private record PlannedQuery(Configuration configuration, PhysicalPlan physicalPlan) {}
+}


### PR DESCRIPTION
Part 3 of a 4-PR stack.

Depends on:
- #148029 (and transitively #148028)

Stack order:
- #148028
- #148029
- #148030 (this PR)
- #148031

Changes in this PR:
- Enables remote-fetch late materialization planning behind planner settings.
- Integrates planner rewrites with compute execution wiring for eligible TopN reduction paths.
- Adds planner/execution tests to validate remote-fetch planning and local execution integration.