### PR TITLE
Preload AllPermissionCollection to avoid JDK 21 circularity

### DIFF
--- a/docs/changelog/148051.yaml
+++ b/docs/changelog/148051.yaml
@@ -1,0 +1,5 @@
+area: Infra/Entitlements
+issues: []
+pr: 148051
+summary: Preload `AllPermissionCollection` to avoid JDK 21 circularity
+type: bug

--- a/docs/changelog/148051.yaml
+++ b/docs/changelog/148051.yaml
@@ -1,5 +1,0 @@
-area: Infra/Entitlements
-issues: []
-pr: 148051
-summary: Preload `AllPermissionCollection` to avoid JDK 21 circularity
-type: bug

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -134,7 +134,29 @@ public class EntitlementInitialization {
         }
     }
 
+    /**
+     * On JDKs that still carry the SecurityManager scaffolding (Java 21 and earlier),
+     * {@link Class#getProtectionDomain()} lazily builds a {@code Permissions} collection containing
+     * {@link java.security.AllPermission}. The first such call triggers loading of
+     * {@code java.security.AllPermissionCollection}, which the bootstrap class loader resolves via the
+     * URL classpath — calling {@link java.net.URL#URL(String)} along the way. Since URL construction
+     * is instrumented by entitlements, the lookup re-enters the policy check (which itself calls
+     * {@code getProtectionDomain()}), producing a {@link ClassCircularityError}.
+     * <p>
+     * Force the lazy initialization once here, before instrumentation is wired up, so subsequent calls
+     * from inside an entitlement check find the class already loaded and the static
+     * {@code Class.allPermDomain} field already populated. Java 22 removed the SecurityManager and no
+     * longer takes this path, so the workaround is unnecessary there.
+     */
+    private static void preloadProtectionDomainSupport() {
+        if (Runtime.version().feature() <= 21) {
+            Object.class.getProtectionDomain();
+        }
+    }
+
     static void initInstrumentation(Instrumentation instrumentation) throws Exception {
+        preloadProtectionDomainSupport();
+
         var verifyBytecode = Booleans.parseBoolean(System.getProperty("es.entitlements.verify_bytecode", "false"));
         if (verifyBytecode) {
             ensureClassesSensitiveToVerificationAreInitialized();


### PR DESCRIPTION
## Summary

On Java 21 and earlier, the first call to `Class.getProtectionDomain()` lazily builds a `Permissions` collection containing `AllPermission`. Building it triggers a first-time load of `java.security.AllPermissionCollection`, which the bootstrap class loader resolves via the URL classpath — calling `URL.<init>` along the way. Because URL construction is instrumented by entitlements, the load re-enters the policy check (which itself calls `getProtectionDomain()` from `TestPolicyManager.isTestCode` / `PolicyManager.getComponentPathsFromClass`), producing a `ClassCircularityError`. This was observed on tests like `BulkOperationTests` running against JDK 21 ([build scan](https://gradle-enterprise.elastic.co/s/obvzvanxboima)).

```
java.lang.ClassCircularityError: java/security/AllPermissionCollection
    at java.security.AllPermission.newPermissionCollection(AllPermission.java:132)
    at java.security.Permissions.add(Permissions.java:132)
    at java.lang.Class.protectionDomain(Class.java:3185)
    at java.lang.Class.getProtectionDomain(Class.java:3175)
    at org.elasticsearch.entitlement.runtime.policy.TestPolicyManager.isTestCode(TestPolicyManager.java:196)
    ...
    at org.elasticsearch.entitlement.runtime.registry.InstrumentationRegistryImpl.check$(InstrumentationRegistryImpl.java:44)
    at java.net.URL.<init>(URL.java)
    at jdk.internal.loader.URLClassPath$FileLoader.getResource(URLClassPath.java:1091)
    ...
```

Force the lazy initialization once before instrumentation is wired up, so the static `Class.allPermDomain` field is already populated when policy checks run. Java 22 removed the SecurityManager scaffolding and no longer takes this path, so the call is gated to `Runtime.version().feature() <= 21`.