### PR TITLE
Fix MlMemoryIT muted test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -246,9 +246,6 @@ tests:
 - class: org.elasticsearch.index.mapper.IpOffsetDocValuesLoaderTests
   method: testOffsetArrayRandomHighCardinality
   issue: https://github.com/elastic/elasticsearch/issues/147086
-- class: org.elasticsearch.xpack.ml.integration.MlMemoryIT
-  method: testMemoryStats
-  issue: https://github.com/elastic/elasticsearch/issues/147122
 - class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
   method: testReplaceChildren {class org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec}
   issue: https://github.com/elastic/elasticsearch/issues/147164

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlMemoryIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlMemoryIT.java
@@ -64,13 +64,16 @@ public class MlMemoryIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         String dfaJobId = "dfa";
         startDataFrameAnalyticsJob(dfaJobId);
 
-        MlMemoryAction.Response response = client().execute(MlMemoryAction.INSTANCE, new MlMemoryAction.Request("_all")).actionGet();
-
-        assertThat(response.failures(), empty());
-
-        List<MlMemoryStats> statsList = response.getNodes();
-        // There are 4 nodes: 3 in the external cluster plus the test harness
-        assertThat(statsList, hasSize(4));
+        // Retry until the test-harness node has joined the cluster and all 4 nodes report stats.
+        MlMemoryAction.Response[] holder = new MlMemoryAction.Response[1];
+        assertBusy(() -> {
+            MlMemoryAction.Response r = client().execute(MlMemoryAction.INSTANCE, new MlMemoryAction.Request("_all")).actionGet();
+            assertThat(r.failures(), empty());
+            // There are 4 nodes: 3 in the external cluster plus the test harness
+            assertThat(r.getNodes(), hasSize(4));
+            holder[0] = r;
+        });
+        List<MlMemoryStats> statsList = holder[0].getNodes();
 
         int mlNodes = 0;
         int nodesWithPytorchModel = 0;


### PR DESCRIPTION
Fixes - https://github.com/elastic/elasticsearch/issues/147122

The most likely root cause for the test failure is a discovery/membership race in the test harness: the internal test-harness client node was not yet visible in the cluster's node list (or was transiently unreachable) when the action was dispatched. This change adds `assertBusy` around the stats call to wait for the nodes to all be available before proceeding with the rest of the test.