### PR TITLE
use supplier pattern for dlm license state checks

### DIFF
--- a/x-pack/plugin/dlm-frozen-transition/src/internalClusterTest/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenMarkReadOnlyIT.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/internalClusterTest/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenMarkReadOnlyIT.java
@@ -108,7 +108,7 @@ public class DLMConvertToFrozenMarkReadOnlyIT extends ESIntegTestCase {
             Metadata.DEFAULT_PROJECT_ID,
             client(),
             internalCluster().clusterService(),
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -139,7 +139,7 @@ public class DLMConvertToFrozenMarkReadOnlyIT extends ESIntegTestCase {
             Metadata.DEFAULT_PROJECT_ID,
             client(),
             internalCluster().clusterService(),
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -174,7 +174,7 @@ public class DLMConvertToFrozenMarkReadOnlyIT extends ESIntegTestCase {
             Metadata.DEFAULT_PROJECT_ID,
             client(),
             internalCluster().clusterService(),
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -204,7 +204,7 @@ public class DLMConvertToFrozenMarkReadOnlyIT extends ESIntegTestCase {
             Metadata.DEFAULT_PROJECT_ID,
             client(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -225,7 +225,7 @@ public class DLMConvertToFrozenMarkReadOnlyIT extends ESIntegTestCase {
             Metadata.DEFAULT_PROJECT_ID,
             client(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -279,7 +279,7 @@ public class DLMConvertToFrozenMarkReadOnlyIT extends ESIntegTestCase {
                 Metadata.DEFAULT_PROJECT_ID,
                 client(),
                 internalCluster().clusterService(),
-                licenseState,
+                () -> licenseState,
                 Clock.systemUTC()
             );
 
@@ -307,7 +307,7 @@ public class DLMConvertToFrozenMarkReadOnlyIT extends ESIntegTestCase {
             Metadata.DEFAULT_PROJECT_ID,
             client(),
             internalCluster().clusterService(),
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -343,7 +343,7 @@ public class DLMConvertToFrozenMarkReadOnlyIT extends ESIntegTestCase {
             Metadata.DEFAULT_PROJECT_ID,
             client(),
             internalCluster().clusterService(),
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 

--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozen.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozen.java
@@ -88,6 +88,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.support.master.MasterNodeRequest.INFINITE_MASTER_NODE_TIMEOUT;
@@ -118,7 +119,7 @@ public class DLMConvertToFrozen implements DLMFrozenTransitionRunnable {
     private final ProjectId projectId;
     private final Client client;
     private final ClusterService clusterService;
-    private final XPackLicenseState licenseState;
+    private final Supplier<XPackLicenseState> licenseStateSupplier;
     private final Clock clock;
 
     public DLMConvertToFrozen(
@@ -126,14 +127,14 @@ public class DLMConvertToFrozen implements DLMFrozenTransitionRunnable {
         ProjectId projectId,
         Client client,
         ClusterService clusterService,
-        XPackLicenseState licenseState,
+        Supplier<XPackLicenseState> licenseStateSupplier,
         Clock clock
     ) {
         this.indexName = indexName;
         this.projectId = projectId;
         this.client = client;
         this.clusterService = clusterService;
-        this.licenseState = licenseState;
+        this.licenseStateSupplier = licenseStateSupplier;
         this.clock = clock;
     }
 
@@ -223,7 +224,7 @@ public class DLMConvertToFrozen implements DLMFrozenTransitionRunnable {
             );
         }
 
-        if (SEARCHABLE_SNAPSHOT_FEATURE.checkWithoutTracking(licenseState) == false) {
+        if (SEARCHABLE_SNAPSHOT_FEATURE.checkWithoutTracking(licenseStateSupplier.get()) == false) {
             throw LicenseUtils.newComplianceException("searchable-snapshots");
         }
     }

--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionPlugin.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionPlugin.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Plugin that registers the {@link DLMFrozenTransitionService} for converting data stream backing indices to the frozen tier as part of
@@ -26,6 +27,10 @@ import java.util.Set;
 public class DLMFrozenTransitionPlugin extends Plugin {
 
     private final List<AbstractDLMPeriodicMasterOnlyService> managedServices = new ArrayList<>();
+
+    protected Supplier<XPackLicenseState> getLicenseStateSupplier() {
+        return XPackPlugin::getSharedLicenseState;
+    }
 
     public DLMFrozenTransitionPlugin() {}
 
@@ -39,14 +44,13 @@ public class DLMFrozenTransitionPlugin extends Plugin {
     public Collection<?> createComponents(PluginServices services) {
         Set<Object> components = new HashSet<>(super.createComponents(services));
         if (DataStreamLifecycle.DLM_SEARCHABLE_SNAPSHOTS_FEATURE_FLAG.isEnabled()) {
-            XPackLicenseState licenseState = XPackPlugin.getSharedLicenseState();
             var transitionSettings = DLMFrozenTransitionSettings.create(services.clusterService());
             components.add(transitionSettings);
 
             var transitionService = new DLMFrozenTransitionService(
                 services.clusterService(),
                 services.client(),
-                licenseState,
+                getLicenseStateSupplier(),
                 transitionSettings,
                 services.dlmErrorStore()
             );

--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionService.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMFrozenTransitionService.java
@@ -23,6 +23,7 @@ import org.elasticsearch.logging.Logger;
 import java.time.Clock;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.datastreams.lifecycle.DataStreamLifecycleService.indexMarkedForFrozen;
 import static org.elasticsearch.logging.LogManager.getLogger;
@@ -68,13 +69,13 @@ class DLMFrozenTransitionService extends AbstractDLMPeriodicMasterOnlyService {
     DLMFrozenTransitionService(
         ClusterService clusterService,
         Client client,
-        XPackLicenseState licenseState,
+        Supplier<XPackLicenseState> licenseStateSupplier,
         DLMFrozenTransitionSettings transitionSettings,
         DataStreamLifecycleErrorStore errorStore
     ) {
         this(
             clusterService,
-            (index, pid) -> new DLMConvertToFrozen(index, pid, client, clusterService, licenseState, Clock.systemUTC()),
+            (index, pid) -> new DLMConvertToFrozen(index, pid, client, clusterService, licenseStateSupplier, Clock.systemUTC()),
             POLL_INTERVAL_SETTING.get(clusterService.getSettings()).millis(),
             transitionSettings,
             errorStore

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenCleanupTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenCleanupTests.java
@@ -144,7 +144,14 @@ public class DLMConvertToFrozenCleanupTests extends ESTestCase {
         String cloneIndexName = CLONE_INDEX_PREFIX + indexName;
         buildAndSetProjectState(dataStreamName, indexName, cloneIndexName);
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         convert.maybeCleanup(cloneIndexName);
 
         ModifyDataStreamsAction.Request modifyRequest = capturedModifyDataStreamsRequest.get();
@@ -174,7 +181,14 @@ public class DLMConvertToFrozenCleanupTests extends ESTestCase {
         String cloneIndexName = CLONE_INDEX_PREFIX + indexName;
         buildAndSetProjectState(null, indexName, cloneIndexName);
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         convert.maybeCleanup(cloneIndexName);
 
         // Should NOT have issued a modify data streams request
@@ -196,7 +210,14 @@ public class DLMConvertToFrozenCleanupTests extends ESTestCase {
 
         mockModifyDataStreamsFailure.set(new ElasticsearchException("swap failed"));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         expectThrows(ElasticsearchException.class, () -> convert.maybeCleanup(cloneIndexName));
 
@@ -217,7 +238,14 @@ public class DLMConvertToFrozenCleanupTests extends ESTestCase {
 
         mockModifyDataStreamsResponse.set(AcknowledgedResponse.FALSE);
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         expectThrows(ElasticsearchException.class, () -> convert.maybeCleanup(cloneIndexName));
 
@@ -240,7 +268,14 @@ public class DLMConvertToFrozenCleanupTests extends ESTestCase {
         // Build a state where original and clone are gone, and the frozen index is in the data stream
         buildAndSetProjectState(dataStreamName, frozenIndexName);
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         convert.maybeCleanup(cloneIndexName);
 
         // No swap or delete should have been attempted

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenCloneIndexTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenCloneIndexTests.java
@@ -146,14 +146,28 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
 
     public void testGetIndexForForceMergeReturnsCloneIndexWhenNoExistingClone() {
         createProjectState(2);
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         String indexForForceMerge = convert.getIndexForForceMerge();
         assertThat(indexForForceMerge, is(convert.getDLMCloneIndexName()));
     }
 
     public void testGetIndexForForceMergeReturnsCloneWhenCloneExists() {
         createProjectStateWithClone(true);
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         String indexForForceMerge = convert.getIndexForForceMerge();
         assertThat(indexForForceMerge, is(notNullValue()));
         assertThat(indexForForceMerge, equalTo(convert.getDLMCloneIndexName()));
@@ -165,7 +179,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
         ClusterHealthResponse healthResponse = new ClusterHealthResponse();
         mockHealthResponse.set(healthResponse);
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         String indexForForceMerge = convert.getIndexForForceMerge();
 
         // Should have issued a health request to wait for clone to become active
@@ -182,7 +203,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
         mockHealthResponse.set(healthResponse);
         mockDeleteResponse.set(AcknowledgedResponse.of(true));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, convert::getIndexForForceMerge);
         assertThat(exception.getMessage(), containsString("timed out waiting for clone index"));
@@ -190,7 +218,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
 
     public void testGetIndexForForceMergeReturnsOriginalIndexWhenZeroReplicas() {
         createProjectState(0);
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         String indexForForceMerge = convert.getIndexForForceMerge();
         assertThat(indexForForceMerge, is(notNullValue()));
         assertThat(indexForForceMerge, equalTo(indexName));
@@ -202,7 +237,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
         timedOut.setTimedOut(true);
         mockHealthResponse.set(timedOut);
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, convert::maybeCloneIndex);
         assertThat(exception.getMessage(), containsString("timed out"));
@@ -213,7 +255,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
 
     public void testMaybeCloneIndexCreatesCloneWithCorrectSettings() throws InterruptedException {
         createProjectState(2); // replicas > 0 to trigger cloning
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         mockCloneResponse.set(new CreateIndexResponse(true, true, convert.getDLMCloneIndexName()));
         convert.maybeCloneIndex();
 
@@ -230,7 +279,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
         mockCloneFailure.set(new ElasticsearchException("clone failed"));
         mockDeleteResponse.set(AcknowledgedResponse.of(true));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, convert::maybeCloneIndex);
         assertThat(exception.getMessage(), containsString("failed to clone"));
 
@@ -244,7 +300,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
         createProjectState(1);
         mockDeleteResponse.set(AcknowledgedResponse.of(true));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         convert.deleteIndex(convert.getDLMCloneIndexName());
 
         String cloneIndexName = convert.getDLMCloneIndexName();
@@ -256,7 +319,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
         createProjectState(1);
         mockDeleteResponse.set(AcknowledgedResponse.of(false));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         ElasticsearchException exception = expectThrows(
             ElasticsearchException.class,
@@ -274,7 +344,7 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
             projectId,
             client,
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -291,7 +361,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
         ClusterHealthResponse healthResponse = new ClusterHealthResponse();
         mockHealthResponse.set(healthResponse);
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         // Should not throw
         convert.waitForCloneToBeActive();
 
@@ -308,7 +385,14 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
         mockHealthResponse.set(healthResponse);
         mockDeleteResponse.set(AcknowledgedResponse.of(true));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, convert::waitForCloneToBeActive);
         assertThat(exception.getMessage(), containsString("timed out waiting for clone index"));
@@ -325,7 +409,7 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
             projectId,
             client,
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -343,7 +427,7 @@ public class DLMConvertToFrozenCloneIndexTests extends ESTestCase {
             projectId,
             client,
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
         converter.waitForCloneToBeActive();

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenForceMergeTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenForceMergeTests.java
@@ -154,7 +154,7 @@ public class DLMConvertToFrozenForceMergeTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -178,7 +178,7 @@ public class DLMConvertToFrozenForceMergeTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -205,7 +205,7 @@ public class DLMConvertToFrozenForceMergeTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -224,7 +224,7 @@ public class DLMConvertToFrozenForceMergeTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -243,7 +243,7 @@ public class DLMConvertToFrozenForceMergeTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -263,7 +263,7 @@ public class DLMConvertToFrozenForceMergeTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -282,7 +282,7 @@ public class DLMConvertToFrozenForceMergeTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenMarkReadOnlyTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenMarkReadOnlyTests.java
@@ -158,7 +158,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
         converter.maybeMarkIndexReadOnly();
@@ -176,7 +176,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
         // Acknowledged response - should not throw
@@ -197,7 +197,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -215,7 +215,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -240,7 +240,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -257,7 +257,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -298,7 +298,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
         converter.maybeMarkIndexReadOnly();
@@ -334,7 +334,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -357,7 +357,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -374,7 +374,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
         converter.maybeMarkIndexReadOnly();
@@ -394,7 +394,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -411,7 +411,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -434,7 +434,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            basicLicenseState,
+            () -> basicLicenseState,
             Clock.systemUTC()
         );
 
@@ -455,7 +455,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 
@@ -474,7 +474,7 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
             projectId,
             createMockClient(),
             clusterService,
-            licenseState,
+            () -> licenseState,
             Clock.systemUTC()
         );
 

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenMountSnapshotTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenMountSnapshotTests.java
@@ -131,7 +131,14 @@ public class DLMConvertToFrozenMountSnapshotTests extends ESTestCase {
     public void testSkipsWhenSnapshotAlreadyMounted() throws InterruptedException {
         String snapshotName = DLMConvertToFrozen.snapshotName(indexName);
         createProjectStateWithMountedSnapshot(snapshotName);
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         convert.maybeMountSearchableSnapshot(indexName);
 
@@ -144,7 +151,14 @@ public class DLMConvertToFrozenMountSnapshotTests extends ESTestCase {
         RestoreInfo restoreInfo = new RestoreInfo("snap", List.of(indexName), 1, 1);
         mockMountResponse.set(new RestoreSnapshotResponse(restoreInfo));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
         convert.maybeMountSearchableSnapshot(indexName);
 
         MountSearchableSnapshotRequest req = capturedMountRequest.get();
@@ -161,7 +175,14 @@ public class DLMConvertToFrozenMountSnapshotTests extends ESTestCase {
         createProjectState();
         mockMountResponse.set(new RestoreSnapshotResponse((RestoreInfo) null));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         ElasticsearchException exception = expectThrows(
             ElasticsearchException.class,
@@ -175,7 +196,14 @@ public class DLMConvertToFrozenMountSnapshotTests extends ESTestCase {
         RestoreInfo restoreInfo = new RestoreInfo("snap", List.of(indexName), 2, 1);
         mockMountResponse.set(new RestoreSnapshotResponse(restoreInfo));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         ElasticsearchException exception = expectThrows(
             ElasticsearchException.class,
@@ -189,7 +217,14 @@ public class DLMConvertToFrozenMountSnapshotTests extends ESTestCase {
         RestoreInfo restoreInfo = new RestoreInfo("snap", List.of(indexName), 0, 0);
         mockMountResponse.set(new RestoreSnapshotResponse(restoreInfo));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         ElasticsearchException exception = expectThrows(
             ElasticsearchException.class,
@@ -202,7 +237,14 @@ public class DLMConvertToFrozenMountSnapshotTests extends ESTestCase {
         createProjectState();
         mockMountFailure.set(new ElasticsearchException("mount failed"));
 
-        DLMConvertToFrozen convert = new DLMConvertToFrozen(indexName, projectId, client, clusterService, licenseState, Clock.systemUTC());
+        DLMConvertToFrozen convert = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            client,
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
 
         ElasticsearchException exception = expectThrows(
             ElasticsearchException.class,

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenSnapshotTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenSnapshotTests.java
@@ -179,7 +179,7 @@ public class DLMConvertToFrozenSnapshotTests extends ESTestCase {
     }
 
     private DLMConvertToFrozen createConverter() {
-        return new DLMConvertToFrozen(indexName, projectId, createMockClient(), clusterService, licenseState, clock);
+        return new DLMConvertToFrozen(indexName, projectId, createMockClient(), clusterService, () -> licenseState, clock);
     }
 
     private CreateSnapshotResponse createSuccessfulSnapshotResponse() {


### PR DESCRIPTION
**Note: We had to revert a [similar PR](https://github.com/elastic/elasticsearch/pull/147515/changes) earlier due to a CI issue. Failing tests have been fixed in this PR**

TLDR: This PR updates the DLMConvertToFrozen constructor to take a Supplier<XPackLicenseState> instead of XPackLicenseState. This aligns more closely to how this is typically done in the ES codebase, and makes it easier to test.

original problem: When doing integ tests I noticed we were getting a NPE when fetching the license state. In tests, XPackPlugin.getSharedLicenseState() always returns null b/c the static field it reads from is never populated when using the LocalStateCompositeXPackPlugin (used by integ tests). LocalStateCompositeXPackPlugin overrides setLicenseState() to store the license state in an instance field rather than the static field that XPackPlugin.getSharedLicenseState() reads from.
my proposed solution: switch to a supplier pattern, expose getLicenseStateSupplier() as a protected method. our integ tests can override it to return the instance field that's actually populated, without needing to modify the LocalStateCompositeXPackPlugin itself (which I'd like to avoid as this is used by many tests). From what i've seen, this is how we traditionally handle this case, e.g. https://github.com/seanzatzdev/elasticsearch/blob/817ec4a587de3ea166c64db61def0b4cd5c8470d/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlPlugin.java#L137
other benefits: the license state can change at runtime (e.g. license upgrades/expirations), so this should allow us to get the most up-to-date license info rather than just capturing that once when we load the plugin
/closes https://github.com/elastic/elasticsearch-team/issues/2671