### PR TITLE
[ESQL] Parallel split discovery and provider caching

### DIFF
--- a/docs/changelog/148072.yaml
+++ b/docs/changelog/148072.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148072
+summary: Parallel split discovery and provider caching
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/DataSourceModule.java
@@ -180,7 +180,13 @@ public final class DataSourceModule implements Closeable {
 
         // Register the framework-internal FileSourceFactory as a catch-all fallback.
         // It must be last so that plugin-provided factories (Iceberg, Flight) get priority.
-        FileSourceFactory fileFallback = new FileSourceFactory(storageProviderRegistry, formatReaderRegistry, codecRegistry, settings);
+        FileSourceFactory fileFallback = new FileSourceFactory(
+            storageProviderRegistry,
+            formatReaderRegistry,
+            codecRegistry,
+            settings,
+            executor
+        );
         sourceFactoryMap.put("file", fileFallback);
         // Also register under each format name so OperatorFactoryRegistry can look up
         // by the sourceType returned from FormatReader.formatName() (e.g. "parquet", "csv").

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+import org.elasticsearch.xpack.esql.datasources.utils.BoundedParallelGather;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -44,11 +45,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Resolver for external data sources (Iceberg tables, Parquet files, etc.).
@@ -407,63 +404,26 @@ public class ExternalSourceResolver {
 
     /**
      * Reads metadata from all files in parallel with bounded concurrency.
-     * Uses a semaphore to cap the number of concurrent metadata reads.
+     * Delegates to {@link BoundedParallelGather} which handles semaphore backpressure,
+     * fast-fail on error, and result ordering.
      */
     private Map<StoragePath, SourceMetadata> readAllFileMetadata(FileList fileList, Map<String, Object> config) throws Exception {
         int fileCount = fileList.fileCount();
-
-        if (fileCount == 1) {
-            StoragePath filePath = fileList.path(0);
-            SourceMetadata meta = resolveSingleSource(filePath.toString(), config);
-            return Map.of(filePath, meta);
-        }
-
-        Semaphore semaphore = new Semaphore(Math.min(fileCount, MAX_PARALLEL_METADATA_READS));
-        AtomicBoolean failed = new AtomicBoolean(false);
-
-        @SuppressWarnings("unchecked")
-        CompletableFuture<Map.Entry<StoragePath, SourceMetadata>>[] futures = new CompletableFuture[fileCount];
-
+        List<StoragePath> paths = new ArrayList<>(fileCount);
         for (int i = 0; i < fileCount; i++) {
-            StoragePath filePath = fileList.path(i);
-            futures[i] = CompletableFuture.supplyAsync(() -> {
-                if (failed.get()) {
-                    return null;
-                }
-                try {
-                    semaphore.acquire();
-                    try {
-                        SourceMetadata meta = resolveSingleSource(filePath.toString(), config);
-                        return Map.entry(filePath, meta);
-                    } finally {
-                        semaphore.release();
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException("Interrupted while reading metadata from [" + filePath + "]", e);
-                } catch (Exception e) {
-                    failed.set(true);
-                    throw new RuntimeException("Failed to read metadata from [" + filePath + "]: " + e.getMessage(), e);
-                }
-            }, executor);
+            paths.add(fileList.path(i));
         }
 
-        try {
-            CompletableFuture.allOf(futures).join();
-        } catch (CompletionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof RuntimeException rte) {
-                throw rte;
-            }
-            throw new RuntimeException("Failed to read file metadata in parallel", cause != null ? cause : e);
-        }
+        List<Map.Entry<StoragePath, SourceMetadata>> entries = BoundedParallelGather.gather(
+            paths,
+            filePath -> Map.entry(filePath, resolveSingleSource(filePath.toString(), config)),
+            MAX_PARALLEL_METADATA_READS,
+            executor
+        );
 
         Map<StoragePath, SourceMetadata> result = new LinkedHashMap<>();
-        for (CompletableFuture<Map.Entry<StoragePath, SourceMetadata>> future : futures) {
-            Map.Entry<StoragePath, SourceMetadata> entry = future.get();
-            if (entry != null) {
-                result.put(entry.getKey(), entry.getValue());
-            }
+        for (Map.Entry<StoragePath, SourceMetadata> entry : entries) {
+            result.put(entry.getKey(), entry.getValue());
         }
         return result;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Framework-internal factory that bridges the building-block registries
@@ -43,6 +45,8 @@ final class FileSourceFactory implements ExternalSourceFactory {
     private final FormatReaderRegistry formatRegistry;
     private final DecompressionCodecRegistry codecRegistry;
     private final Settings settings;
+    @Nullable
+    private final ExecutorService splitDiscoveryExecutor;
 
     FileSourceFactory(
         StorageProviderRegistry storageRegistry,
@@ -50,12 +54,23 @@ final class FileSourceFactory implements ExternalSourceFactory {
         DecompressionCodecRegistry codecRegistry,
         Settings settings
     ) {
+        this(storageRegistry, formatRegistry, codecRegistry, settings, null);
+    }
+
+    FileSourceFactory(
+        StorageProviderRegistry storageRegistry,
+        FormatReaderRegistry formatRegistry,
+        DecompressionCodecRegistry codecRegistry,
+        Settings settings,
+        @Nullable ExecutorService splitDiscoveryExecutor
+    ) {
         Check.notNull(storageRegistry, "storageRegistry cannot be null");
         Check.notNull(formatRegistry, "formatRegistry cannot be null");
         this.storageRegistry = storageRegistry;
         this.formatRegistry = formatRegistry;
         this.codecRegistry = codecRegistry != null ? codecRegistry : new DecompressionCodecRegistry();
         this.settings = settings != null ? settings : Settings.EMPTY;
+        this.splitDiscoveryExecutor = splitDiscoveryExecutor;
     }
 
     @Override
@@ -121,7 +136,14 @@ final class FileSourceFactory implements ExternalSourceFactory {
 
     @Override
     public SplitProvider splitProvider() {
-        return new FileSplitProvider(FileSplitProvider.DEFAULT_TARGET_SPLIT_SIZE, codecRegistry, storageRegistry, formatRegistry, settings);
+        return new FileSplitProvider(
+            FileSplitProvider.DEFAULT_TARGET_SPLIT_SIZE,
+            codecRegistry,
+            storageRegistry,
+            formatRegistry,
+            settings,
+            splitDiscoveryExecutor
+        );
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.SplittableDecompressionCodec
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+import org.elasticsearch.xpack.esql.datasources.utils.BoundedParallelGather;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
@@ -50,6 +51,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 
 /**
@@ -76,18 +79,23 @@ public class FileSplitProvider implements SplitProvider {
     static final String FILE_LENGTH_KEY = "_file_length";
     static final String CONFIG_TARGET_SPLIT_SIZE = "target_split_size";
 
+    /** Maximum parallel per-file I/O tasks during split discovery (Parquet footer reads, etc.). */
+    static final int MAX_PARALLEL_SPLIT_DISCOVERY = 16;
+
     private final long targetSplitSizeBytes;
     private final DecompressionCodecRegistry codecRegistry;
     private final StorageProviderRegistry storageRegistry;
     private final FormatReaderRegistry formatRegistry;
     private final Settings settings;
+    @Nullable
+    private final Executor executor;
 
     public FileSplitProvider() {
-        this(DEFAULT_TARGET_SPLIT_SIZE, null, null, null, Settings.EMPTY);
+        this(DEFAULT_TARGET_SPLIT_SIZE, null, null, null, Settings.EMPTY, null);
     }
 
     public FileSplitProvider(long targetSplitSizeBytes) {
-        this(targetSplitSizeBytes, null, null, null, Settings.EMPTY);
+        this(targetSplitSizeBytes, null, null, null, Settings.EMPTY, null);
     }
 
     public FileSplitProvider(
@@ -96,7 +104,7 @@ public class FileSplitProvider implements SplitProvider {
         StorageProviderRegistry storageRegistry,
         Settings settings
     ) {
-        this(targetSplitSizeBytes, codecRegistry, storageRegistry, null, settings);
+        this(targetSplitSizeBytes, codecRegistry, storageRegistry, null, settings, null);
     }
 
     public FileSplitProvider(
@@ -106,11 +114,23 @@ public class FileSplitProvider implements SplitProvider {
         FormatReaderRegistry formatRegistry,
         Settings settings
     ) {
+        this(targetSplitSizeBytes, codecRegistry, storageRegistry, formatRegistry, settings, null);
+    }
+
+    public FileSplitProvider(
+        long targetSplitSizeBytes,
+        DecompressionCodecRegistry codecRegistry,
+        StorageProviderRegistry storageRegistry,
+        FormatReaderRegistry formatRegistry,
+        Settings settings,
+        @Nullable Executor executor
+    ) {
         this.targetSplitSizeBytes = targetSplitSizeBytes;
         this.codecRegistry = codecRegistry;
         this.storageRegistry = storageRegistry;
         this.formatRegistry = formatRegistry;
         this.settings = settings != null ? settings : Settings.EMPTY;
+        this.executor = executor;
     }
 
     @Override
@@ -125,13 +145,27 @@ public class FileSplitProvider implements SplitProvider {
         List<Expression> filterHints = context.filterHints();
         Set<String> projectedDataColumns = fileBackedProjectedColumns(context.projectedDataColumns(), partitionInfo);
         Map<StoragePath, SchemaReconciliation.FileSchemaInfo> schemaInfo = fileList.fileSchemaInfo();
-        List<ExternalSplit> splits = new ArrayList<>();
-        // Dedup cache: files with content-equal mappings share the same ColumnMapping
-        // instance on the coordinator, avoiding redundant allocations.
-        Map<SchemaReconciliation.ColumnMapping, SchemaReconciliation.ColumnMapping> mappingCache = new HashMap<>();
 
         long effectiveSplitSize = resolveTargetSplitSize(config);
 
+        // Hoist provider creation outside the per-file loop when config is non-empty.
+        // This avoids constructing a new S3/GCS/Azure client per file.
+        // For empty config, storageRegistry.provider() returns a cached singleton per scheme.
+        StorageProvider sharedProvider = null;
+        if (config != null && config.isEmpty() == false && storageRegistry != null) {
+            // Derive scheme from the first file (all files in a FileList share the same scheme).
+            if (fileList.fileCount() > 0) {
+                String scheme = fileList.path(0).scheme();
+                sharedProvider = storageRegistry.createProvider(scheme, settings, config);
+            }
+        }
+
+        // Dedup cache for ColumnMapping: concurrent-safe when split discovery is parallel.
+        Map<SchemaReconciliation.ColumnMapping, SchemaReconciliation.ColumnMapping> mappingCache = new ConcurrentHashMap<>();
+
+        // Phase 1: sequential filtering — cheap, in-memory predicates applied per file to
+        // build the list of FileTask items that need I/O (footer reads, boundary scans).
+        List<FileTask> tasks = new ArrayList<>(fileList.fileCount());
         for (int i = 0; i < fileList.fileCount(); i++) {
             StoragePath filePath = fileList.path(i);
 
@@ -188,40 +222,125 @@ public class FileSplitProvider implements SplitProvider {
                 }
             }
 
-            // Try block-aligned splitting for splittable compressed files (e.g. .ndjson.bz2).
-            // This is independent of targetSplitSizeBytes — compressed files with splittable
-            // codecs are always split at block boundaries when possible.
-            if (tryBlockAlignedSplits(filePath, fileLength, format, config, partitionValues, columnMapping, splits)) {
-                continue;
-            }
-
-            if (tryRangeAwareSplits(filePath, fileLength, format, config, partitionValues, columnMapping, splits)) {
-                continue;
-            }
-
-            if (effectiveSplitSize > 0 && fileLength > effectiveSplitSize && isSplittableFormat(format)) {
-                long offset = 0;
-                boolean isFirst = true;
-                while (offset < fileLength) {
-                    long chunkLength = Math.min(effectiveSplitSize, fileLength - offset);
-                    boolean isLast = (offset + chunkLength >= fileLength);
-                    Map<String, Object> splitConfig = new HashMap<>(config);
-                    if (isFirst) {
-                        splitConfig.put(FIRST_SPLIT_KEY, "true");
-                    }
-                    if (isLast) {
-                        splitConfig.put(LAST_SPLIT_KEY, "true");
-                    }
-                    splits.add(new FileSplit("file", filePath, offset, chunkLength, format, splitConfig, partitionValues, columnMapping));
-                    offset += chunkLength;
-                    isFirst = false;
-                }
-            } else {
-                splits.add(new FileSplit("file", filePath, 0, fileLength, format, config, partitionValues, columnMapping));
-            }
+            tasks.add(new FileTask(filePath, fileLength, format, config, partitionValues, columnMapping));
         }
 
+        if (tasks.isEmpty()) {
+            return List.of();
+        }
+
+        // Phase 2: I/O-bound split discovery — parallelize when executor is available.
+        final StorageProvider hoistedProvider = sharedProvider;
+        List<List<ExternalSplit>> perFileSplits;
+        try {
+            if (executor != null && tasks.size() > 1) {
+                perFileSplits = BoundedParallelGather.gather(
+                    tasks,
+                    task -> processFileForSplits(task, effectiveSplitSize, hoistedProvider),
+                    MAX_PARALLEL_SPLIT_DISCOVERY,
+                    executor
+                );
+            } else {
+                perFileSplits = new ArrayList<>(tasks.size());
+                for (FileTask task : tasks) {
+                    perFileSplits.add(processFileForSplits(task, effectiveSplitSize, hoistedProvider));
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to discover splits", e);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to discover splits", e);
+        }
+
+        // Flatten per-file split lists into a single ordered list.
+        List<ExternalSplit> splits = new ArrayList<>();
+        for (List<ExternalSplit> fileSplits : perFileSplits) {
+            splits.addAll(fileSplits);
+        }
         return List.copyOf(splits);
+    }
+
+    /**
+     * Input tuple for per-file split discovery, holding all data needed to compute splits
+     * for a single file without accessing shared mutable state.
+     */
+    private record FileTask(
+        StoragePath filePath,
+        long fileLength,
+        @Nullable String format,
+        Map<String, Object> config,
+        Map<String, Object> partitionValues,
+        @Nullable SchemaReconciliation.ColumnMapping columnMapping
+    ) {}
+
+    /**
+     * Computes the splits for a single file. Uses the hoisted provider when provided (non-null),
+     * otherwise falls back to the registry for per-call provider resolution.
+     * This method is safe to call concurrently from multiple threads.
+     */
+    private List<ExternalSplit> processFileForSplits(FileTask task, long effectiveSplitSize, @Nullable StorageProvider hoistedProvider)
+        throws IOException {
+        List<ExternalSplit> fileSplits = new ArrayList<>();
+
+        // Try block-aligned splitting for splittable compressed files (e.g. .ndjson.bz2).
+        // This is independent of targetSplitSizeBytes — compressed files with splittable
+        // codecs are always split at block boundaries when possible.
+        if (tryBlockAlignedSplits(
+            task.filePath(),
+            task.fileLength(),
+            task.format(),
+            task.config(),
+            task.partitionValues(),
+            task.columnMapping(),
+            fileSplits,
+            hoistedProvider
+        )) {
+            return fileSplits;
+        }
+
+        if (tryRangeAwareSplits(
+            task.filePath(),
+            task.fileLength(),
+            task.format(),
+            task.config(),
+            task.partitionValues(),
+            task.columnMapping(),
+            fileSplits,
+            hoistedProvider
+        )) {
+            return fileSplits;
+        }
+
+        Map<String, Object> config = task.config();
+        StoragePath filePath = task.filePath();
+        long fileLength = task.fileLength();
+        String format = task.format();
+        Map<String, Object> partitionValues = task.partitionValues();
+        SchemaReconciliation.ColumnMapping columnMapping = task.columnMapping();
+
+        if (effectiveSplitSize > 0 && fileLength > effectiveSplitSize && isSplittableFormat(format)) {
+            long offset = 0;
+            boolean isFirst = true;
+            while (offset < fileLength) {
+                long chunkLength = Math.min(effectiveSplitSize, fileLength - offset);
+                boolean isLast = (offset + chunkLength >= fileLength);
+                Map<String, Object> splitConfig = new HashMap<>(config);
+                if (isFirst) {
+                    splitConfig.put(FIRST_SPLIT_KEY, "true");
+                }
+                if (isLast) {
+                    splitConfig.put(LAST_SPLIT_KEY, "true");
+                }
+                fileSplits.add(new FileSplit("file", filePath, offset, chunkLength, format, splitConfig, partitionValues, columnMapping));
+                offset += chunkLength;
+                isFirst = false;
+            }
+        } else {
+            fileSplits.add(new FileSplit("file", filePath, 0, fileLength, format, config, partitionValues, columnMapping));
+        }
+        return fileSplits;
     }
 
     /**
@@ -262,7 +381,8 @@ public class FileSplitProvider implements SplitProvider {
         Map<String, Object> config,
         Map<String, Object> partitionValues,
         @Nullable SchemaReconciliation.ColumnMapping columnMapping,
-        List<ExternalSplit> splits
+        List<ExternalSplit> splits,
+        @Nullable StorageProvider hoistedProvider
     ) {
         if (codecRegistry == null || storageRegistry == null || format == null) {
             return false;
@@ -273,7 +393,17 @@ public class FileSplitProvider implements SplitProvider {
         // Prefer IndexedDecompressionCodec (e.g. zstd seekable) over SplittableDecompressionCodec
         // (e.g. bzip2) when an index is available, since index-based splitting avoids scanning.
         if (codec instanceof IndexedDecompressionCodec indexedCodec) {
-            if (tryIndexedSplits(indexedCodec, filePath, fileLength, format, config, partitionValues, columnMapping, splits)) {
+            if (tryIndexedSplits(
+                indexedCodec,
+                filePath,
+                fileLength,
+                format,
+                config,
+                partitionValues,
+                columnMapping,
+                splits,
+                hoistedProvider
+            )) {
                 return true;
             }
         }
@@ -284,17 +414,9 @@ public class FileSplitProvider implements SplitProvider {
         SplittableDecompressionCodec splittableCodec = (SplittableDecompressionCodec) codec;
 
         try {
-            // When config is empty, provider() returns a cached instance (no leak).
-            // When config is non-empty, createProvider() returns a fresh instance that
-            // is not tracked by the registry. This is acceptable because the same provider
-            // will be created for actual reads, and the boundary-scan provider only holds
-            // lightweight state (no persistent connections).
-            StorageProvider provider;
-            if (config != null && config.isEmpty() == false) {
-                provider = storageRegistry.createProvider(filePath.scheme(), settings, config);
-            } else {
-                provider = storageRegistry.provider(filePath);
-            }
+            // Use the hoisted provider when available to avoid constructing a new cloud client
+            // per file. Fall back to the registry for zero-config or legacy callers.
+            StorageProvider provider = resolveProvider(filePath, config, hoistedProvider);
             StorageObject object = provider.newObject(filePath, fileLength);
             long[] boundaries = splittableCodec.findBlockBoundaries(object, 0, fileLength);
 
@@ -361,7 +483,8 @@ public class FileSplitProvider implements SplitProvider {
         Map<String, Object> config,
         Map<String, Object> partitionValues,
         @Nullable SchemaReconciliation.ColumnMapping columnMapping,
-        List<ExternalSplit> splits
+        List<ExternalSplit> splits,
+        @Nullable StorageProvider hoistedProvider
     ) {
         if (formatRegistry == null || storageRegistry == null || format == null) {
             return false;
@@ -380,12 +503,7 @@ public class FileSplitProvider implements SplitProvider {
         RangeAwareFormatReader rangeReader = (RangeAwareFormatReader) reader;
 
         try {
-            StorageProvider provider;
-            if (config != null && config.isEmpty() == false) {
-                provider = storageRegistry.createProvider(filePath.scheme(), settings, config);
-            } else {
-                provider = storageRegistry.provider(filePath);
-            }
+            StorageProvider provider = resolveProvider(filePath, config, hoistedProvider);
             StorageObject object = provider.newObject(filePath, fileLength);
 
             List<SplitRange> ranges = rangeReader.discoverSplitRanges(object);
@@ -428,15 +546,11 @@ public class FileSplitProvider implements SplitProvider {
         Map<String, Object> config,
         Map<String, Object> partitionValues,
         @Nullable SchemaReconciliation.ColumnMapping columnMapping,
-        List<ExternalSplit> splits
+        List<ExternalSplit> splits,
+        @Nullable StorageProvider hoistedProvider
     ) {
         try {
-            StorageProvider provider;
-            if (config != null && config.isEmpty() == false) {
-                provider = storageRegistry.createProvider(filePath.scheme(), settings, config);
-            } else {
-                provider = storageRegistry.provider(filePath);
-            }
+            StorageProvider provider = resolveProvider(filePath, config, hoistedProvider);
             StorageObject object = provider.newObject(filePath, fileLength);
 
             if (indexedCodec.hasIndex(object) == false) {
@@ -493,6 +607,21 @@ public class FileSplitProvider implements SplitProvider {
             LOGGER.warn("Failed to read frame index for [{}], falling back", filePath, e);
             return false;
         }
+    }
+
+    /**
+     * Resolves the {@link StorageProvider} to use for a single-file operation.
+     * Returns the hoisted provider if available (non-null), otherwise falls back to the
+     * registry: per-config provider for non-empty config, or cached default for empty config.
+     */
+    private StorageProvider resolveProvider(StoragePath filePath, Map<String, Object> config, @Nullable StorageProvider hoistedProvider) {
+        if (hoistedProvider != null) {
+            return hoistedProvider;
+        }
+        if (config != null && config.isEmpty() == false) {
+            return storageRegistry.createProvider(filePath.scheme(), settings, config);
+        }
+        return storageRegistry.provider(filePath);
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageProviderRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StorageProviderRegistry.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.datasources;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.xpack.esql.datasources.cache.StorageProviderCache;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProviderFactory;
@@ -54,6 +55,10 @@ public class StorageProviderRegistry implements Closeable {
     private final Map<String, ConcurrencyLimiter> limiters = new ConcurrentHashMap<>();
     private final Map<String, ConcurrencyBudgetAllocator> allocators = new ConcurrentHashMap<>();
     private final Map<String, AdaptiveBackoff> backoffs = new ConcurrentHashMap<>();
+
+    // Cache for providers created with a non-empty config (WITH clause queries).
+    // Avoids reconstructing cloud clients (S3, GCS, Azure) for repeated calls with the same config.
+    private final StorageProviderCache configuredProviderCache = new StorageProviderCache();
 
     private final Settings settings;
     private volatile int maxConcurrentRequests;
@@ -111,7 +116,18 @@ public class StorageProviderRegistry implements Closeable {
         if (factory == null) {
             throw new IllegalArgumentException("No SPI storage factory registered for scheme: " + scheme);
         }
-        return wrapProvider(factory.create(settings, config), normalizedScheme);
+
+        // Cache providers by (scheme, config) so queries with the same WITH-clause config
+        // reuse the same cloud client and connection pool instead of constructing a new one.
+        StorageProviderCache.CacheKey cacheKey = new StorageProviderCache.CacheKey(normalizedScheme, config);
+        try {
+            return configuredProviderCache.getOrCreate(cacheKey, () -> wrapProvider(factory.create(settings, config), normalizedScheme));
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            // The factory does not declare checked exceptions, so this path is unreachable.
+            throw new RuntimeException("Unexpected checked exception from StorageProviderFactory", e);
+        }
     }
 
     private synchronized StorageProvider createDefaultProvider(String normalizedScheme) {
@@ -182,6 +198,8 @@ public class StorageProviderRegistry implements Closeable {
         List<StorageProvider> toClose = new ArrayList<>(createdProviders);
         createdProviders.clear();
         providers.clear();
+        // Close default (zero-config) providers first, then the config-keyed cache.
         IOUtils.close(toClose);
+        configuredProviderCache.close();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/StorageProviderCache.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/StorageProviderCache.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * LRU cache for {@link StorageProvider} instances, keyed by {@code (scheme, config)}.
+ *
+ * <p>When a query supplies a {@code WITH} clause (non-empty config), a cloud client
+ * (S3, GCS, Azure) is constructed per {@link StorageProvider}. Without this cache,
+ * consecutive calls to {@code StorageProviderRegistry.createProvider()} with the same
+ * config would each create a new client instance and its associated connection pool.
+ * This cache ensures that the same config reuses the same client across calls.
+ *
+ * <p>Entries expire after {@link #DEFAULT_TTL_MINUTES} minutes of inactivity.
+ * On eviction, the removed provider is closed so that connection pools and cloud
+ * resources are released.
+ *
+ * <p>The cache is bounded at {@link #MAX_ENTRIES} entries — large enough to serve
+ * typical workloads (a handful of distinct S3 credentials) while preventing unbounded
+ * growth when queries use many distinct configs.
+ *
+ * <p>Thread-safe: backed by {@link Cache#computeIfAbsent}.
+ */
+public class StorageProviderCache implements Closeable {
+
+    private static final Logger logger = LogManager.getLogger(StorageProviderCache.class);
+
+    /** Maximum number of distinct (scheme, config) entries retained. */
+    static final int MAX_ENTRIES = 32;
+
+    /** Default TTL in minutes for cached providers. */
+    static final long DEFAULT_TTL_MINUTES = 5L;
+
+    /**
+     * Cache key that combines the URI scheme with the config map.
+     * Full map equality is used — two configs are the same key only if they
+     * contain identical key-value pairs.
+     *
+     * @param scheme normalized (lower-case) URI scheme, e.g. {@code "s3"}
+     * @param config the WITH-clause config map from the query
+     */
+    public record CacheKey(String scheme, Map<String, Object> config) {}
+
+    /**
+     * Factory interface for creating a new {@link StorageProvider} on cache miss.
+     */
+    @FunctionalInterface
+    public interface ProviderFactory {
+        StorageProvider create() throws Exception;
+    }
+
+    private final Cache<CacheKey, StorageProvider> cache;
+
+    public StorageProviderCache() {
+        this(DEFAULT_TTL_MINUTES);
+    }
+
+    StorageProviderCache(long ttlMinutes) {
+        this.cache = CacheBuilder.<CacheKey, StorageProvider>builder()
+            .setMaximumWeight(MAX_ENTRIES)
+            .weigher((key, value) -> 1)
+            .setExpireAfterWrite(TimeValue.timeValueMinutes(ttlMinutes))
+            .removalListener(notification -> {
+                StorageProvider evicted = notification.getValue();
+                if (evicted != null) {
+                    try {
+                        evicted.close();
+                    } catch (IOException e) {
+                        logger.warn("Failed to close evicted StorageProvider for scheme [{}]", notification.getKey().scheme(), e);
+                    }
+                }
+            })
+            .build();
+    }
+
+    /**
+     * Returns a cached provider for the given key, or creates one via the factory on a cache miss.
+     * The factory is invoked at most once per key under concurrent access.
+     *
+     * @param key     the cache key (scheme + config)
+     * @param factory supplier to create the provider on a miss; may throw any exception
+     * @return the cached or newly created provider
+     * @throws Exception if the factory throws during a cache miss
+     */
+    public StorageProvider getOrCreate(CacheKey key, ProviderFactory factory) throws Exception {
+        try {
+            return cache.computeIfAbsent(key, k -> factory.create());
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception ex) {
+                throw ex;
+            }
+            throw new RuntimeException("Failed to create StorageProvider for key " + key, cause);
+        }
+    }
+
+    /** Removes all entries and closes the associated providers. */
+    public void invalidateAll() {
+        cache.invalidateAll();
+    }
+
+    @Override
+    public void close() {
+        invalidateAll();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/utils/BoundedParallelGather.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/utils/BoundedParallelGather.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.utils;
+
+import org.elasticsearch.core.CheckedFunction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Applies a function to a list of items with bounded parallelism, collecting results in input order.
+ *
+ * <p>Dispatches work to the provided executor with a semaphore to cap the number of concurrent
+ * in-flight calls. Blocks the calling thread until all items complete (join pattern), then
+ * returns the results in the same order as the input list.
+ *
+ * <p>Fast-fail semantics: once any item throws, remaining not-yet-started items are skipped.
+ * The first exception is re-thrown after all in-flight tasks complete. Additional exceptions
+ * from other tasks are suppressed onto the first.
+ *
+ * <p>For zero or one items, the function is executed inline on the calling thread — no thread
+ * dispatch occurs. This avoids executor overhead for the common trivial case.
+ */
+public final class BoundedParallelGather {
+
+    private BoundedParallelGather() {}
+
+    /**
+     * Applies {@code fn} to each item in {@code items} with at most {@code maxConcurrency}
+     * calls in flight simultaneously. Results are returned in the same order as the input list.
+     *
+     * @param items          the inputs to process; must not be null
+     * @param fn             the function to apply to each input; may throw any exception
+     * @param maxConcurrency maximum number of concurrent calls; must be {@code >= 1}
+     * @param executor       the executor used to dispatch work
+     * @param <T>            input type
+     * @param <R>            result type
+     * @return a list of results in the same order as {@code items}
+     * @throws Exception     the first exception thrown by any invocation of {@code fn},
+     *                       with remaining exceptions suppressed onto it
+     */
+    public static <T, R> List<R> gather(List<T> items, CheckedFunction<T, R, Exception> fn, int maxConcurrency, Executor executor)
+        throws Exception {
+        if (maxConcurrency < 1) {
+            throw new IllegalArgumentException("maxConcurrency must be >= 1, got: " + maxConcurrency);
+        }
+
+        int size = items.size();
+        if (size == 0) {
+            return List.of();
+        }
+
+        // For a single item, run inline — avoids executor overhead and keeps stack traces clean.
+        if (size == 1) {
+            return List.of(fn.apply(items.get(0)));
+        }
+
+        Semaphore semaphore = new Semaphore(Math.min(size, maxConcurrency));
+        AtomicBoolean failed = new AtomicBoolean(false);
+        AtomicReference<Exception> firstError = new AtomicReference<>();
+
+        @SuppressWarnings("unchecked")
+        CompletableFuture<R>[] futures = new CompletableFuture[size];
+
+        for (int i = 0; i < size; i++) {
+            T item = items.get(i);
+            futures[i] = CompletableFuture.supplyAsync(() -> {
+                if (failed.get()) {
+                    return null;
+                }
+                try {
+                    semaphore.acquire();
+                    try {
+                        if (failed.get()) {
+                            return null;
+                        }
+                        return fn.apply(item);
+                    } finally {
+                        semaphore.release();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    Exception wrapped = new RuntimeException("Interrupted while processing item", e);
+                    recordError(failed, firstError, wrapped);
+                    throw new CompletionException(wrapped);
+                } catch (Exception e) {
+                    recordError(failed, firstError, e);
+                    if (e instanceof RuntimeException re) {
+                        throw re;
+                    }
+                    throw new CompletionException(e);
+                }
+            }, executor);
+        }
+
+        try {
+            CompletableFuture.allOf(futures).join();
+        } catch (CompletionException ignored) {
+            // The real error is in firstError; we will rethrow below.
+        }
+
+        Exception error = firstError.get();
+        if (error != null) {
+            throw error;
+        }
+
+        List<R> results = new ArrayList<>(size);
+        for (CompletableFuture<R> future : futures) {
+            // All futures are complete at this point; get() will not block and
+            // will not throw because firstError is null (all succeeded).
+            try {
+                results.add(future.get());
+            } catch (Exception e) {
+                // Should not happen since firstError is null, but propagate defensively.
+                throw new RuntimeException("Unexpected error collecting gather results", e);
+            }
+        }
+        return results;
+    }
+
+    private static void recordError(AtomicBoolean failed, AtomicReference<Exception> firstError, Exception e) {
+        failed.set(true);
+        if (firstError.compareAndSet(null, e) == false) {
+            firstError.get().addSuppressed(e);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/StorageProviderCacheTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/StorageProviderCacheTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * Tests for {@link StorageProviderCache}: hit/miss behaviour, provider reuse,
+ * close-on-eviction, and registry-close behaviour.
+ */
+public class StorageProviderCacheTests extends ESTestCase {
+
+    /**
+     * Minimal StorageProvider that tracks whether it has been closed.
+     * Used to verify that cache eviction triggers close().
+     */
+    static class TrackingProvider implements StorageProvider {
+        final AtomicInteger closeCalls = new AtomicInteger();
+
+        @Override
+        public StorageObject newObject(StoragePath path) {
+            return null;
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length) {
+            return null;
+        }
+
+        @Override
+        public StorageObject newObject(StoragePath path, long length, Instant lastModified) {
+            return null;
+        }
+
+        @Override
+        public org.elasticsearch.xpack.esql.datasources.StorageIterator listObjects(StoragePath prefix, boolean recursive)
+            throws IOException {
+            return null;
+        }
+
+        @Override
+        public boolean exists(StoragePath path) throws IOException {
+            return false;
+        }
+
+        @Override
+        public List<String> supportedSchemes() {
+            return List.of();
+        }
+
+        @Override
+        public void close() {
+            closeCalls.incrementAndGet();
+        }
+    }
+
+    public void testSameConfigReturnsSameProvider() throws Exception {
+        StorageProviderCache cache = new StorageProviderCache();
+        Map<String, Object> config = Map.of("key", "value");
+        StorageProviderCache.CacheKey key = new StorageProviderCache.CacheKey("s3", config);
+
+        AtomicInteger supplierCalls = new AtomicInteger();
+        StorageProvider provider1 = cache.getOrCreate(key, () -> {
+            supplierCalls.incrementAndGet();
+            return new TrackingProvider();
+        });
+        StorageProvider provider2 = cache.getOrCreate(key, () -> {
+            supplierCalls.incrementAndGet();
+            return new TrackingProvider();
+        });
+
+        assertThat(provider1, sameInstance(provider2));
+        assertEquals("supplier should only be called once for the same key", 1, supplierCalls.get());
+    }
+
+    public void testDifferentConfigReturnsDifferentProvider() throws Exception {
+        StorageProviderCache cache = new StorageProviderCache();
+        Map<String, Object> configA = Map.of("key", "value-a");
+        Map<String, Object> configB = Map.of("key", "value-b");
+        StorageProviderCache.CacheKey keyA = new StorageProviderCache.CacheKey("s3", configA);
+        StorageProviderCache.CacheKey keyB = new StorageProviderCache.CacheKey("s3", configB);
+
+        StorageProvider providerA = cache.getOrCreate(keyA, TrackingProvider::new);
+        StorageProvider providerB = cache.getOrCreate(keyB, TrackingProvider::new);
+
+        assertNotSame("different configs should yield different providers", providerA, providerB);
+    }
+
+    public void testDifferentSchemeReturnsDifferentProvider() throws Exception {
+        StorageProviderCache cache = new StorageProviderCache();
+        Map<String, Object> config = Map.of("key", "value");
+        StorageProviderCache.CacheKey keyS3 = new StorageProviderCache.CacheKey("s3", config);
+        StorageProviderCache.CacheKey keyGcs = new StorageProviderCache.CacheKey("gs", config);
+
+        StorageProvider s3Provider = cache.getOrCreate(keyS3, TrackingProvider::new);
+        StorageProvider gcsProvider = cache.getOrCreate(keyGcs, TrackingProvider::new);
+
+        assertNotSame("different schemes should yield different providers", s3Provider, gcsProvider);
+    }
+
+    public void testInvalidateAllClosesProviders() throws Exception {
+        StorageProviderCache cache = new StorageProviderCache();
+        StorageProviderCache.CacheKey key = new StorageProviderCache.CacheKey("s3", Map.of("a", "b"));
+
+        TrackingProvider provider = new TrackingProvider();
+        cache.getOrCreate(key, () -> provider);
+
+        assertEquals("provider should not be closed before invalidation", 0, provider.closeCalls.get());
+        cache.invalidateAll();
+        assertEquals("provider should be closed after invalidateAll", 1, provider.closeCalls.get());
+    }
+
+    public void testCloseInvalidatesAndClosesProviders() throws Exception {
+        StorageProviderCache cache = new StorageProviderCache();
+        StorageProviderCache.CacheKey key = new StorageProviderCache.CacheKey("s3", Map.of("region", "us-east-1"));
+
+        TrackingProvider provider = new TrackingProvider();
+        cache.getOrCreate(key, () -> provider);
+
+        cache.close();
+        assertEquals("provider should be closed when cache is closed", 1, provider.closeCalls.get());
+    }
+
+    public void testSupplierExceptionPropagates() {
+        StorageProviderCache cache = new StorageProviderCache();
+        StorageProviderCache.CacheKey key = new StorageProviderCache.CacheKey("s3", Map.of("bad", "config"));
+
+        IllegalArgumentException thrown = expectThrows(IllegalArgumentException.class, () -> {
+            cache.getOrCreate(key, () -> { throw new IllegalArgumentException("bad credentials"); });
+        });
+        assertEquals("bad credentials", thrown.getMessage());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/utils/BoundedParallelGatherTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/utils/BoundedParallelGatherTests.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.utils;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BoundedParallelGatherTests extends ESTestCase {
+
+    public void testEmptyList() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            List<Integer> empty = List.of();
+            List<Integer> result = BoundedParallelGather.gather(empty, item -> item * 2, 4, executor);
+            assertEquals(List.of(), result);
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    public void testSingleItemRunsInline() throws Exception {
+        // Single item must execute on the calling thread (no executor dispatch).
+        Thread callingThread = Thread.currentThread();
+        AtomicInteger executionThread = new AtomicInteger();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            List<Integer> result = BoundedParallelGather.gather(List.of(42), item -> {
+                // Record whether we are on the calling thread (0) or another thread (1).
+                executionThread.set(Thread.currentThread() == callingThread ? 0 : 1);
+                return item * 2;
+            }, 4, executor);
+            assertEquals(List.of(84), result);
+            assertEquals("single item should run inline, not on executor", 0, executionThread.get());
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    public void testResultOrderMatchesInput() throws Exception {
+        int count = 50;
+        List<Integer> items = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            items.add(i);
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            List<Integer> results = BoundedParallelGather.gather(items, item -> item * 10, 8, executor);
+            assertEquals(count, results.size());
+            for (int i = 0; i < count; i++) {
+                assertEquals(Integer.valueOf(i * 10), results.get(i));
+            }
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    public void testMaxConcurrencyRespected() throws Exception {
+        int itemCount = 20;
+        int maxConcurrency = 4;
+        AtomicInteger inFlight = new AtomicInteger(0);
+        AtomicInteger peakConcurrency = new AtomicInteger(0);
+        // Latch to ensure all tasks start before any complete, amplifying the concurrency check.
+        CountDownLatch allStarted = new CountDownLatch(maxConcurrency);
+        Semaphore proceed = new Semaphore(0);
+
+        List<Integer> items = new ArrayList<>();
+        for (int i = 0; i < itemCount; i++) {
+            items.add(i);
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(itemCount);
+        try {
+            List<Integer> results = BoundedParallelGather.gather(items, item -> {
+                int current = inFlight.incrementAndGet();
+                int peak = peakConcurrency.get();
+                while (current > peak) {
+                    if (peakConcurrency.compareAndSet(peak, current)) break;
+                    peak = peakConcurrency.get();
+                }
+                // Simulate some work
+                Thread.sleep(5);
+                inFlight.decrementAndGet();
+                return item;
+            }, maxConcurrency, executor);
+
+            assertEquals(itemCount, results.size());
+            assertTrue(
+                "peak concurrency " + peakConcurrency.get() + " should be <= maxConcurrency " + maxConcurrency,
+                peakConcurrency.get() <= maxConcurrency
+            );
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    public void testFastFailOnException() throws Exception {
+        int itemCount = 100;
+        AtomicInteger startedCount = new AtomicInteger(0);
+        List<Integer> items = new ArrayList<>();
+        for (int i = 0; i < itemCount; i++) {
+            items.add(i);
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            Exception thrown = expectThrows(Exception.class, () -> {
+                BoundedParallelGather.gather(items, item -> {
+                    startedCount.incrementAndGet();
+                    if (item == 5) {
+                        throw new IllegalArgumentException("test failure at item 5");
+                    }
+                    // Small delay so failure is detected before all items start.
+                    Thread.sleep(10);
+                    return item;
+                }, 4, executor);
+            });
+            assertNotNull(thrown);
+            // Not all 100 items should have started — fast-fail should have skipped some.
+            assertTrue(
+                "Expected fewer than " + itemCount + " items to start, but got " + startedCount.get(),
+                startedCount.get() < itemCount
+            );
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    public void testFirstExceptionPropagated() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            Exception thrown = expectThrows(IllegalStateException.class, () -> {
+                BoundedParallelGather.gather(List.of(1, 2, 3), item -> {
+                    if (item == 1) throw new IllegalStateException("first error");
+                    return item;
+                }, 4, executor);
+            });
+            assertEquals("first error", thrown.getMessage());
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    public void testInvalidMaxConcurrency() {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            expectThrows(IllegalArgumentException.class, () -> BoundedParallelGather.gather(List.of(1, 2), item -> item, 0, executor));
+        } finally {
+            executor.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
Split discovery for multi-file external sources reads each file's
Parquet/ORC footer sequentially. For 100 S3 files this takes ~33s
(two S3 round-trips per file at ~150ms each). Additionally, queries
with per-query config (WITH clause) create a fresh S3 client per
file, multiplying connection pools.

Adds BoundedParallelGather utility for bounded-concurrency parallel
I/O, parallelizes FileSplitProvider at 16 concurrent, hoists provider
creation out of the per-file loop, and caches providers by config to
reuse clients across calls.

Developed with AI-assisted tooling