### PR TITLE
Fix CsvIT using wrong version of capabilities

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -353,8 +353,6 @@ tests:
 - class: org.elasticsearch.cluster.routing.IndexRoutingTests
   method: testRequiredRoutingUsesSliceMessageWhenSliceEnabled
   issue: https://github.com/elastic/elasticsearch/issues/147777
-- class: org.elasticsearch.xpack.esql.CsvIT
-  issue: https://github.com/elastic/elasticsearch/issues/147971
 
 # Examples:
 #

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_range.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date_range.csv-spec
@@ -1,5 +1,5 @@
 dateRange
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 FROM decades
 | SORT decade;
 
@@ -20,7 +20,7 @@ date_range:date_range  | decade:integer | description:keyword
 ;
 
 dateRangeToString
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE decade == 1900
@@ -32,7 +32,7 @@ date_range:date_range  | decade:integer | description:keyword | range:keyword
 ;
 
 dateRangeIdentityFieldType
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE decade == 1900
@@ -44,7 +44,7 @@ date_range:date_range  | decade:integer | description:keyword | range:date_range
 ;
 
 dateRangeToStringFieldType
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE decade == 1900
@@ -57,7 +57,7 @@ date_range:date_range  | decade:integer | description:keyword | range:keyword
 
 // Requires range_within (TO_DATE_RANGE(keyword) support).
 toDateRangeFromString
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 // tag::to_date_range-str[]
 ROW str = "2020-01-01T00:00:00.000Z..2021-01-01T00:00:00.000Z"
@@ -72,7 +72,7 @@ str:keyword                                          | range:date_range
 ;
 
 toDateRangeIdentity
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE decade == 1900
@@ -85,7 +85,7 @@ date_range:date_range  | decade:integer | description:keyword | range:date_range
 
 // Requires range_within (TO_DATE_RANGE(keyword) support).
 toDateRangeFromShortFormat
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 ROW str = "2024-06-01..2024-06-30"
 | EVAL range = TO_DATE_RANGE(str)
@@ -97,7 +97,7 @@ str:keyword            | range:date_range
 
 // Requires range_within (TO_DATE_RANGE(keyword) support).
 toDateRangeWithEval
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 ROW start_date = "2023-01-01T00:00:00.000Z", end_date = "2024-01-01T00:00:00.000Z"
 | EVAL range_str = CONCAT(start_date, "..", end_date)
@@ -111,7 +111,7 @@ start_date:keyword              | end_date:keyword                | range:date_r
 
 // Requires range_within (TO_DATE_RANGE(keyword) support).
 toDateRangeSingleDay
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 ROW str = "2024-07-04T00:00:00.000Z..2024-07-05T00:00:00.000Z"
 | EVAL range = TO_DATE_RANGE(str)
@@ -126,7 +126,7 @@ str:keyword                                          | range:date_range
 ###############################################
 
 rangeWithinWithEmployees
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 // tag::rangeWithin[]
 FROM employees
@@ -144,7 +144,7 @@ emp_no:integer | hire_date:date
 ;
 
 rangeWithinWithDateRangesTable
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE RANGE_WITHIN(TO_DATETIME("1955-06-15"), date_range)
@@ -156,7 +156,7 @@ decade:integer | description:keyword
 ;
 
 rangeWithinAtBoundaryStart
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE RANGE_WITHIN(TO_DATETIME("1950-01-01"), date_range)
@@ -168,7 +168,7 @@ decade:integer | description:keyword
 ;
 
 rangeWithinAtBoundaryEnd
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE RANGE_WITHIN(TO_DATETIME("1959-12-31T23:59:59.999Z"), date_range)
@@ -180,7 +180,7 @@ decade:integer | description:keyword
 ;
 
 rangeWithinOutsideRange
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE RANGE_WITHIN(TO_DATETIME("2050-01-01"), date_range)
@@ -191,7 +191,7 @@ decade:integer | description:keyword
 ;
 
 rangeWithinWithEval
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | EVAL test_date = TO_DATETIME("1965-07-20")
@@ -205,7 +205,7 @@ decade:integer | description:keyword | in_range:boolean
 ;
 
 rangeWithinMultipleMatches
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM employees
 | WHERE RANGE_WITHIN(hire_date, TO_DATE_RANGE("1985-01-01..1986-01-01"))
@@ -217,7 +217,7 @@ count:long
 ;
 
 rangeWithinWithNull
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM employees
 | WHERE emp_no == 10040
@@ -230,7 +230,7 @@ emp_no:integer | birth_date:date | in_range:boolean
 ;
 
 rangeWithinWithStats
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM employees
 | EVAL in_1985 = RANGE_WITHIN(hire_date, TO_DATE_RANGE("1985-01-01..1986-01-01"))
@@ -242,7 +242,7 @@ count_in_1985:long | total:long
 ;
 
 rangeWithinBeforeStart
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE RANGE_WITHIN(TO_DATETIME("1899-12-31T23:59:59.999Z"), date_range)
@@ -253,7 +253,7 @@ decade:integer | description:keyword
 ;
 
 rangeWithinAfterEnd
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE RANGE_WITHIN(TO_DATETIME("2030-01-01T00:00:00.000Z"), date_range)
@@ -264,7 +264,7 @@ decade:integer | description:keyword
 ;
 
 rangeWithinWithLiteralRange
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 ROW date = TO_DATETIME("2024-06-15T12:00:00.000Z")
 | EVAL in_june = RANGE_WITHIN(date, TO_DATE_RANGE("2024-06-01..2024-07-01"))
@@ -279,7 +279,7 @@ date:date                     | in_june:boolean | in_july:boolean
 // RANGE_WITHIN with LOOKUP JOIN: date from lookup, date_range from FROM (existing indices only).
 // join_key=1 matches two rows in multi_column_joinable_lookup, so LOOKUP JOIN emits multi-value warnings.
 rangeWithinDateFromLookupRangeFromFrom
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 required_capability: join_lookup_v12
 required_capability: lookup_join_on_boolean_expression
 
@@ -304,7 +304,7 @@ date_range:date_range                              | decade:integer | descriptio
 ###############################################
 
 literalRangeWithinRange
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 ROW y2020 = TO_DATE_RANGE("2020-01-01T00:00:00.000Z..2021-01-01T00:00:00.000Z"),
     y2021 = TO_DATE_RANGE("2021-01-01T00:00:00.000Z..2022-01-01T00:00:00.000Z"),
@@ -329,7 +329,7 @@ false            | false            | true               | false              | 
 
 
 fieldRangeWithinRange
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | EVAL c1900 = TO_DATE_RANGE("1900-01-01T00:00:00.000Z..2000-01-01T00:00:00.000Z"),
@@ -370,7 +370,7 @@ decade:integer | in1900s:bool | in2000s:bool | inThirty:bool | inFeb2000:bool | 
 
 // Multiple ranges in WHERE (OR) -- test disjunction
 rangeWithinMultipleRangesInWhere
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE RANGE_WITHIN(TO_DATETIME("1955-06-15"), date_range) OR RANGE_WITHIN(TO_DATETIME("1975-06-15"), date_range)
@@ -385,7 +385,7 @@ decade:integer | description:keyword
 
 // Boundary: point at inclusive start of range
 rangeWithinBoundaryCondition
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE RANGE_WITHIN(TO_DATETIME("1980-01-01"), date_range)
@@ -401,7 +401,7 @@ decade:integer | description:keyword
 ###############################################
 
 rangeMin
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 // tag::range_min[]
 FROM decades
@@ -418,7 +418,7 @@ date_range:date_range  | min_bound:date
 ;
 
 rangeMax
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 // tag::range_max[]
 FROM decades
@@ -435,7 +435,7 @@ date_range:date_range  | max_bound:date
 ;
 
 rangeMinMaxReparse
-required_capability: date_range_field_type_v2
+required_capability: date_range_field_type_v3
 
 FROM decades
 | WHERE decade == 1900 OR decade == 2000

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_unsupported_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_unsupported_types.yml
@@ -147,7 +147,7 @@ unsupported:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [dense_vector_agg_metric_double_if_version, date_range_field_type_v2, histogram_release_version]
+          capabilities: [dense_vector_agg_metric_double_if_version, date_range_field_type_v3, histogram_release_version]
       reason: "fetches dense_vector, histogram field support, date_range field type"
 
   - do:
@@ -344,7 +344,7 @@ unsupported with sort:
         - method: POST
           path: /_query
           parameters: [ ]
-          capabilities: [ dense_vector_agg_metric_double_if_version, date_range_field_type_v2, histogram_release_version]
+          capabilities: [ dense_vector_agg_metric_double_if_version, date_range_field_type_v3, histogram_release_version]
       reason: "support for sorting when dense_vector_field_type present, histogram field support, date_range field type"
 
   - do:


### PR DESCRIPTION
Previously this used `date_range_field_type_v2`, however, in https://github.com/elastic/elasticsearch/pull/147602 it was renamed to `date_range_field_type_v3`, so the tests failed.

Resolves #147971
