### PR TITLE
[ESQL] Skip split discovery for aggregate pushdown

### DIFF
--- a/docs/changelog/148086.yaml
+++ b/docs/changelog/148086.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148086
+summary: Skip split discovery for aggregate pushdown
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -276,11 +276,21 @@ public class ExternalSourceResolver {
 
         extMetadata = enrichWithFileCount(extMetadata, listing.fileCount());
         if (listing.fileCount() > 1) {
-            // For multi-file FIRST_FILE_WINS, read all files' metadata in parallel to aggregate
-            // statistics across all files. This allows pushdown (COUNT/MIN/MAX) to use accurate
-            // global stats without needing split discovery (Phase 2).
-            // For the cacheable path we use the schema cache for every file (including the anchor)
-            // so that repeated resolves benefit from cached results.
+            // For multi-file FIRST_FILE_WINS, read all files' metadata in parallel during Phase 1
+            // to aggregate statistics across all files. This allows aggregate pushdown
+            // (COUNT/MIN/MAX) to use accurate global stats and to skip Phase 2 (split discovery)
+            // entirely for those queries.
+            //
+            // Tradeoff: this performs N footer reads up-front for *every* multi-file resolve,
+            // including queries that don't use the stats (e.g. SELECT *). For those queries,
+            // Phase 2 still runs, so the per-file footer is read twice (once here, once during
+            // split discovery). The cost is generally acceptable because:
+            // - the cacheable path consults the schema cache, so repeat resolves are free;
+            // - the non-cacheable path reads footers in parallel up to MAX_PARALLEL_METADATA_READS;
+            // - the aggregated stats unlock skipping Phase 2 entirely for pushable aggregates
+            // (see ComputeService#canSkipSplitDiscovery), which dominates the savings.
+            // We don't gate this on the query (which isn't known here) — see issue #148086 for the
+            // design notes.
             Map<String, Object> aggregatedStats = cacheable
                 ? readAndAggregateAllFileStatsWithCache(listing, config)
                 : readAndAggregateAllFileStats(listing, config);
@@ -499,8 +509,8 @@ public class ExternalSourceResolver {
     }
 
     /**
-     * Reads metadata from all files in {@code listing} in parallel (bounded concurrency),
-     * then aggregates statistics across all files.
+     * Reads metadata from all files in {@code listing} in parallel (bounded concurrency)
+     * via {@link BoundedParallelGather}, then aggregates statistics across all files.
      * Returns a merged flat stats map, or {@code null} if any file fails or lacks statistics.
      * Errors reading individual files are logged at DEBUG and cause the method to return {@code null}
      * (the caller will then mark stats as partial instead of using incomplete aggregations).
@@ -508,65 +518,22 @@ public class ExternalSourceResolver {
     @Nullable
     private Map<String, Object> readAndAggregateAllFileStats(FileList listing, Map<String, Object> config) {
         int fileCount = listing.fileCount();
-        Semaphore semaphore = new Semaphore(Math.min(fileCount, MAX_PARALLEL_METADATA_READS));
-        AtomicBoolean anyFailed = new AtomicBoolean(false);
-
-        @SuppressWarnings("unchecked")
-        CompletableFuture<SourceMetadata>[] futures = new CompletableFuture[fileCount];
-
+        List<StoragePath> paths = new ArrayList<>(fileCount);
         for (int i = 0; i < fileCount; i++) {
-            StoragePath filePath = listing.path(i);
-            futures[i] = CompletableFuture.supplyAsync(() -> {
-                if (anyFailed.get()) {
-                    return null;
-                }
-                try {
-                    semaphore.acquire();
-                    try {
-                        return resolveSingleSource(filePath.toString(), config);
-                    } finally {
-                        semaphore.release();
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    anyFailed.set(true);
-                    LOGGER.debug("Interrupted reading stats from [{}], will use partial stats", filePath);
-                    return null;
-                } catch (Exception e) {
-                    anyFailed.set(true);
-                    LOGGER.debug(() -> "Failed to read stats from [" + filePath + "], will use partial stats: " + e.getMessage());
-                    return null;
-                }
-            }, executor);
+            paths.add(listing.path(i));
         }
-
+        List<SourceMetadata> allMeta;
         try {
-            CompletableFuture.allOf(futures).join();
-        } catch (CompletionException e) {
-            LOGGER.debug("Error reading per-file stats in parallel, will use partial stats", e);
+            allMeta = BoundedParallelGather.gather(
+                paths,
+                filePath -> resolveSingleSource(filePath.toString(), config),
+                MAX_PARALLEL_METADATA_READS,
+                executor
+            );
+        } catch (Exception e) {
+            LOGGER.debug(() -> "Failed to read per-file stats in parallel, will use partial stats: " + e.getMessage());
             return null;
         }
-
-        if (anyFailed.get()) {
-            return null;
-        }
-
-        List<SourceMetadata> allMeta = new ArrayList<>(fileCount);
-        for (CompletableFuture<SourceMetadata> future : futures) {
-            try {
-                SourceMetadata meta = future.getNow(null);
-                if (meta != null) {
-                    allMeta.add(meta);
-                }
-            } catch (Exception e) {
-                return null;
-            }
-        }
-
-        if (allMeta.size() != fileCount) {
-            return null;
-        }
-
         return aggregateFileStatistics(allMeta);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolver.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.esql.datasources.utils.BoundedParallelGather;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -275,7 +276,55 @@ public class ExternalSourceResolver {
 
         extMetadata = enrichWithFileCount(extMetadata, listing.fileCount());
         if (listing.fileCount() > 1) {
-            extMetadata = markStatsAsPartial(extMetadata);
+            // For multi-file FIRST_FILE_WINS, read all files' metadata in parallel to aggregate
+            // statistics across all files. This allows pushdown (COUNT/MIN/MAX) to use accurate
+            // global stats without needing split discovery (Phase 2).
+            // For the cacheable path we use the schema cache for every file (including the anchor)
+            // so that repeated resolves benefit from cached results.
+            Map<String, Object> aggregatedStats = cacheable
+                ? readAndAggregateAllFileStatsWithCache(listing, config)
+                : readAndAggregateAllFileStats(listing, config);
+            if (aggregatedStats != null) {
+                // Replace anchor-only stats with globally-aggregated stats.
+                // Preserve all non-stats keys from the current extMetadata (e.g. file_count, config).
+                Map<String, Object> current = extMetadata.sourceMetadata();
+                Map<String, Object> merged = current != null ? new HashMap<>(current) : new HashMap<>();
+                merged.putAll(aggregatedStats);
+                // Do NOT add STATS_PARTIAL — stats are now complete across all files.
+                merged.remove(SourceStatisticsSerializer.STATS_PARTIAL);
+                final Map<String, Object> finalMerged = Map.copyOf(merged);
+                final ExternalSourceMetadata baseMetadata = extMetadata;
+                extMetadata = new ExternalSourceMetadata() {
+                    @Override
+                    public String location() {
+                        return baseMetadata.location();
+                    }
+
+                    @Override
+                    public List<Attribute> schema() {
+                        return baseMetadata.schema();
+                    }
+
+                    @Override
+                    public String sourceType() {
+                        return baseMetadata.sourceType();
+                    }
+
+                    @Override
+                    public Map<String, Object> sourceMetadata() {
+                        return finalMerged;
+                    }
+
+                    @Override
+                    public Map<String, Object> config() {
+                        return baseMetadata.config();
+                    }
+                };
+            } else {
+                // Could not aggregate stats (some files lacked statistics) — mark as partial
+                // so the optimizer does not rely on incomplete sourceMetadata stats.
+                extMetadata = markStatsAsPartial(extMetadata);
+            }
         }
 
         PartitionMetadata partitionMetadata = listing.partitionMetadata();
@@ -391,7 +440,8 @@ public class ExternalSourceResolver {
 
         List<Attribute> unifiedSchema = result.unifiedSchema();
         SourceMetadata firstMeta = allMetadata.get(firstFile);
-        ExternalSourceMetadata extMetadata = buildUnifiedMetadata(firstMeta, unifiedSchema, config);
+        Map<String, Object> aggregatedStats = aggregateFileStatistics(allMetadata.values());
+        ExternalSourceMetadata extMetadata = buildUnifiedMetadata(firstMeta, unifiedSchema, config, aggregatedStats);
 
         PartitionMetadata partitionMetadata = fileList.partitionMetadata();
         if (partitionMetadata != null && partitionMetadata.isEmpty() == false) {
@@ -428,16 +478,156 @@ public class ExternalSourceResolver {
         return result;
     }
 
+    /**
+     * Aggregates statistics from all files' metadata into a single merged flat stats map.
+     * For each file, embeds its per-file statistics into its flat sourceMetadata map,
+     * then merges all maps using {@link SourceStatisticsSerializer#mergeStatistics}.
+     * Returns {@code null} if any file lacks statistics (prevents incorrect partial results).
+     */
+    @Nullable
+    private static Map<String, Object> aggregateFileStatistics(Collection<SourceMetadata> allMetadata) {
+        List<Map<String, Object>> perFileFlatStats = new ArrayList<>(allMetadata.size());
+        for (SourceMetadata meta : allMetadata) {
+            if (meta.statistics().isEmpty()) {
+                // At least one file has no statistics — cannot produce accurate global stats.
+                return null;
+            }
+            Map<String, Object> flat = SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), meta.statistics().get());
+            perFileFlatStats.add(flat);
+        }
+        return SourceStatisticsSerializer.mergeStatistics(perFileFlatStats);
+    }
+
+    /**
+     * Reads metadata from all files in {@code listing} in parallel (bounded concurrency),
+     * then aggregates statistics across all files.
+     * Returns a merged flat stats map, or {@code null} if any file fails or lacks statistics.
+     * Errors reading individual files are logged at DEBUG and cause the method to return {@code null}
+     * (the caller will then mark stats as partial instead of using incomplete aggregations).
+     */
+    @Nullable
+    private Map<String, Object> readAndAggregateAllFileStats(FileList listing, Map<String, Object> config) {
+        int fileCount = listing.fileCount();
+        Semaphore semaphore = new Semaphore(Math.min(fileCount, MAX_PARALLEL_METADATA_READS));
+        AtomicBoolean anyFailed = new AtomicBoolean(false);
+
+        @SuppressWarnings("unchecked")
+        CompletableFuture<SourceMetadata>[] futures = new CompletableFuture[fileCount];
+
+        for (int i = 0; i < fileCount; i++) {
+            StoragePath filePath = listing.path(i);
+            futures[i] = CompletableFuture.supplyAsync(() -> {
+                if (anyFailed.get()) {
+                    return null;
+                }
+                try {
+                    semaphore.acquire();
+                    try {
+                        return resolveSingleSource(filePath.toString(), config);
+                    } finally {
+                        semaphore.release();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    anyFailed.set(true);
+                    LOGGER.debug("Interrupted reading stats from [{}], will use partial stats", filePath);
+                    return null;
+                } catch (Exception e) {
+                    anyFailed.set(true);
+                    LOGGER.debug(() -> "Failed to read stats from [" + filePath + "], will use partial stats: " + e.getMessage());
+                    return null;
+                }
+            }, executor);
+        }
+
+        try {
+            CompletableFuture.allOf(futures).join();
+        } catch (CompletionException e) {
+            LOGGER.debug("Error reading per-file stats in parallel, will use partial stats", e);
+            return null;
+        }
+
+        if (anyFailed.get()) {
+            return null;
+        }
+
+        List<SourceMetadata> allMeta = new ArrayList<>(fileCount);
+        for (CompletableFuture<SourceMetadata> future : futures) {
+            try {
+                SourceMetadata meta = future.getNow(null);
+                if (meta != null) {
+                    allMeta.add(meta);
+                }
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        if (allMeta.size() != fileCount) {
+            return null;
+        }
+
+        return aggregateFileStatistics(allMeta);
+    }
+
+    /**
+     * Cache-aware variant of {@link #readAndAggregateAllFileStats}.
+     * Uses the schema cache (keyed by path + mtime) for each file so that repeated
+     * multi-file resolves do not re-read footers unnecessarily.
+     * Returns {@code null} if any file cannot be resolved or lacks statistics.
+     */
+    @Nullable
+    private Map<String, Object> readAndAggregateAllFileStatsWithCache(FileList listing, Map<String, Object> config) {
+        int fileCount = listing.fileCount();
+        List<Map<String, Object>> perFileStats = new ArrayList<>(fileCount);
+        for (int i = 0; i < fileCount; i++) {
+            StoragePath filePath = listing.path(i);
+            long mtime = listing.lastModifiedMillis(i);
+            String formatType = detectFormatType(filePath);
+            SchemaCacheKey schemaKey = SchemaCacheKey.build(filePath.toString(), mtime, formatType, config);
+            try {
+                SchemaCacheEntry entry = cacheService.getOrComputeSchema(schemaKey, k -> {
+                    SourceMetadata meta = resolveSingleSource(filePath.toString(), config);
+                    Map<String, Object> enrichedMeta = meta.statistics()
+                        .map(stats -> SourceStatisticsSerializer.embedStatistics(meta.sourceMetadata(), stats))
+                        .orElse(meta.sourceMetadata());
+                    return SchemaCacheEntry.from(meta.schema(), meta.sourceType(), meta.location(), enrichedMeta, meta.config());
+                });
+                Map<String, Object> fileMeta = entry.safeMetadata();
+                if (fileMeta == null || fileMeta.containsKey(SourceStatisticsSerializer.STATS_ROW_COUNT) == false) {
+                    // This file has no statistics — cannot produce accurate global stats.
+                    return null;
+                }
+                perFileStats.add(fileMeta);
+            } catch (Exception e) {
+                LOGGER.debug(() -> "Failed to get cached stats for [" + filePath + "], will use partial stats: " + e.getMessage());
+                return null;
+            }
+        }
+        return SourceStatisticsSerializer.mergeStatistics(perFileStats);
+    }
+
     private ExternalSourceMetadata buildUnifiedMetadata(
         SourceMetadata referenceMeta,
         List<Attribute> unifiedSchema,
-        Map<String, Object> queryConfig
+        Map<String, Object> queryConfig,
+        @Nullable Map<String, Object> aggregatedStats
     ) {
         Map<String, Object> mergedConfig = mergeConfigs(referenceMeta.config(), queryConfig);
         List<Attribute> schema = List.copyOf(unifiedSchema);
-        Map<String, Object> enrichedSourceMetadata = referenceMeta.statistics()
-            .map(stats -> SourceStatisticsSerializer.embedStatistics(referenceMeta.sourceMetadata(), stats))
-            .orElse(referenceMeta.sourceMetadata());
+        Map<String, Object> enrichedSourceMetadata;
+        if (aggregatedStats != null) {
+            // Aggregated stats already contain all the _stats.* keys merged across all files.
+            // Start from the reference meta's base map and overlay the aggregated stats.
+            Map<String, Object> base = referenceMeta.sourceMetadata();
+            Map<String, Object> merged = base != null ? new HashMap<>(base) : new HashMap<>();
+            merged.putAll(aggregatedStats);
+            enrichedSourceMetadata = Map.copyOf(merged);
+        } else {
+            enrichedSourceMetadata = referenceMeta.statistics()
+                .map(stats -> SourceStatisticsSerializer.embedStatistics(referenceMeta.sourceMetadata(), stats))
+                .orElse(referenceMeta.sourceMetadata());
+        }
         return new ExternalSourceMetadata() {
             @Override
             public String location() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -58,6 +58,7 @@ import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
 import org.elasticsearch.xpack.esql.datasources.OperatorFactoryRegistry;
+import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.SplitCoalescer;
 import org.elasticsearch.xpack.esql.datasources.SplitDiscoveryPhase;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
@@ -306,16 +307,63 @@ public class ComputeService {
         List<ExternalSplit> splits = new ArrayList<>();
         plan.forEachDown(ExternalSourceExec.class, exec -> splits.addAll(exec.splits()));
         if (splits.isEmpty()) {
-            discoverSplitsFromFragments(plan, splits);
-            if (splits.size() > SplitCoalescer.COALESCING_THRESHOLD) {
-                List<ExternalSplit> coalesced = SplitCoalescer.coalesce(splits);
-                if (coalesced != splits) {
-                    splits.clear();
-                    splits.addAll(coalesced);
+            if (canSkipSplitDiscovery(plan) == false) {
+                discoverSplitsFromFragments(plan, splits);
+                if (splits.size() > SplitCoalescer.COALESCING_THRESHOLD) {
+                    List<ExternalSplit> coalesced = SplitCoalescer.coalesce(splits);
+                    if (coalesced != splits) {
+                        splits.clear();
+                        splits.addAll(coalesced);
+                    }
                 }
             }
+            // else: splits stays empty — the optimizer will use sourceMetadata for pushdown
         }
         return splits;
+    }
+
+    /**
+     * Returns {@code true} when split discovery (Phase 2 footer reads) can be skipped.
+     * This is safe only when the query is a pure ungrouped aggregate directly over an
+     * {@link ExternalRelation} whose {@code sourceMetadata} already contains complete
+     * (non-partial) statistics with a row count.
+     * <p>
+     * For queries that can be skipped, the local physical optimizer will use
+     * {@code sourceMetadata} statistics to evaluate COUNT(*) and similar aggregates
+     * without reading any data files.
+     * <p>
+     * This method is conservative: any ambiguity returns {@code false} so that
+     * normal split discovery proceeds.
+     */
+    public static boolean canSkipSplitDiscovery(PhysicalPlan plan) {
+        // Walk every FragmentExec in the plan. If any one qualifies for skipping,
+        // the entire split-discovery step can be omitted for that fragment.
+        // We require ALL external relations in the plan to qualify — if any don't,
+        // we must do full discovery. Use a holder that defaults to false.
+        boolean[] foundAny = { false };
+        boolean[] allCanSkip = { true };
+
+        plan.forEachDown(FragmentExec.class, fragment -> {
+            LogicalPlan logical = fragment.fragment();
+            // We only short-circuit for: Aggregate(no groupings) directly over ExternalRelation.
+            // No Filter, Eval, or other operators between them.
+            if (logical instanceof Aggregate agg && agg.groupings().isEmpty() && agg.child() instanceof ExternalRelation ext) {
+                foundAny[0] = true;
+                Map<String, Object> meta = ext.metadata().sourceMetadata();
+                if (meta == null
+                    || meta.containsKey(SourceStatisticsSerializer.STATS_ROW_COUNT) == false
+                    || Boolean.TRUE.equals(meta.get(SourceStatisticsSerializer.STATS_PARTIAL))) {
+                    allCanSkip[0] = false;
+                }
+            } else if (logical.anyMatch(ExternalRelation.class::isInstance)) {
+                // External relation exists but not in the simple Aggregate -> ExternalRelation pattern.
+                // Cannot skip split discovery for this fragment.
+                foundAny[0] = true;
+                allCanSkip[0] = false;
+            }
+        });
+
+        return foundAny[0] && allCanSkip[0];
     }
 
     private void discoverSplitsFromFragments(PhysicalPlan plan, List<ExternalSplit> splits) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -53,17 +53,23 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.useragent.api.UserAgentParserRegistry;
 import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryAction;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.datasources.FormatReaderRegistry;
 import org.elasticsearch.xpack.esql.datasources.OperatorFactoryRegistry;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
 import org.elasticsearch.xpack.esql.datasources.SplitCoalescer;
 import org.elasticsearch.xpack.esql.datasources.SplitDiscoveryPhase;
+import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupService;
 import org.elasticsearch.xpack.esql.enrich.LookupFromIndexService;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.inference.InferenceService;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalVerifier;
@@ -307,7 +313,7 @@ public class ComputeService {
         List<ExternalSplit> splits = new ArrayList<>();
         plan.forEachDown(ExternalSourceExec.class, exec -> splits.addAll(exec.splits()));
         if (splits.isEmpty()) {
-            if (canSkipSplitDiscovery(plan) == false) {
+            if (canSkipSplitDiscovery(plan, formatReaderRegistry) == false) {
                 discoverSplitsFromFragments(plan, splits);
                 if (splits.size() > SplitCoalescer.COALESCING_THRESHOLD) {
                     List<ExternalSplit> coalesced = SplitCoalescer.coalesce(splits);
@@ -323,36 +329,33 @@ public class ComputeService {
     }
 
     /**
-     * Returns {@code true} when split discovery (Phase 2 footer reads) can be skipped.
-     * This is safe only when the query is a pure ungrouped aggregate directly over an
-     * {@link ExternalRelation} whose {@code sourceMetadata} already contains complete
-     * (non-partial) statistics with a row count.
+     * Returns {@code true} when split discovery (Phase 2 footer reads) can be skipped because
+     * every fragment in {@code plan} that references an {@link ExternalRelation} is a pure
+     * ungrouped {@link Aggregate} directly over that relation, the relation's
+     * {@code sourceMetadata} already contains complete (non-partial) statistics, and the
+     * fragment's aggregate functions are metadata-pushable for that source's format reader
+     * (i.e. {@link AggregatePushdownSupport#canPushAggregates} returns {@code YES}).
      * <p>
-     * For queries that can be skipped, the local physical optimizer will use
-     * {@code sourceMetadata} statistics to evaluate COUNT(*) and similar aggregates
-     * without reading any data files.
+     * When eligible, the local physical optimizer uses {@code sourceMetadata} statistics to
+     * evaluate the aggregates (COUNT/MIN/MAX) without reading any data files. Skipping
+     * discovery for non-pushable aggregates (e.g. {@code SUM}, {@code AVG}) would force the
+     * data node to fall back to a single-path read with no slice queue, which is typically
+     * less parallel than per-row-group splits — hence the explicit pushability check.
      * <p>
-     * This method is conservative: any ambiguity returns {@code false} so that
-     * normal split discovery proceeds.
+     * This method is conservative: if the registry has no reader for the source type, if any
+     * fragment containing an {@link ExternalRelation} does not match the
+     * {@code Aggregate -> ExternalRelation} shape, or if any required statistic is missing,
+     * it returns {@code false} so that normal split discovery proceeds.
      */
-    public static boolean canSkipSplitDiscovery(PhysicalPlan plan) {
-        // Walk every FragmentExec in the plan. If any one qualifies for skipping,
-        // the entire split-discovery step can be omitted for that fragment.
-        // We require ALL external relations in the plan to qualify — if any don't,
-        // we must do full discovery. Use a holder that defaults to false.
+    public static boolean canSkipSplitDiscovery(PhysicalPlan plan, FormatReaderRegistry formatReaderRegistry) {
         boolean[] foundAny = { false };
         boolean[] allCanSkip = { true };
 
         plan.forEachDown(FragmentExec.class, fragment -> {
             LogicalPlan logical = fragment.fragment();
-            // We only short-circuit for: Aggregate(no groupings) directly over ExternalRelation.
-            // No Filter, Eval, or other operators between them.
             if (logical instanceof Aggregate agg && agg.groupings().isEmpty() && agg.child() instanceof ExternalRelation ext) {
                 foundAny[0] = true;
-                Map<String, Object> meta = ext.metadata().sourceMetadata();
-                if (meta == null
-                    || meta.containsKey(SourceStatisticsSerializer.STATS_ROW_COUNT) == false
-                    || Boolean.TRUE.equals(meta.get(SourceStatisticsSerializer.STATS_PARTIAL))) {
+                if (canSkipForAggregateOverExternal(agg, ext, formatReaderRegistry) == false) {
                     allCanSkip[0] = false;
                 }
             } else if (logical.anyMatch(ExternalRelation.class::isInstance)) {
@@ -364,6 +367,49 @@ public class ComputeService {
         });
 
         return foundAny[0] && allCanSkip[0];
+    }
+
+    /**
+     * Returns {@code true} when the given ungrouped {@code Aggregate} over an
+     * {@link ExternalRelation} can rely solely on {@code sourceMetadata} statistics — i.e.
+     * stats are complete and every aggregate function is metadata-pushable for the source's
+     * format reader.
+     */
+    private static boolean canSkipForAggregateOverExternal(Aggregate agg, ExternalRelation ext, FormatReaderRegistry registry) {
+        Map<String, Object> meta = ext.metadata().sourceMetadata();
+        if (meta == null
+            || meta.containsKey(SourceStatisticsSerializer.STATS_ROW_COUNT) == false
+            || Boolean.TRUE.equals(meta.get(SourceStatisticsSerializer.STATS_PARTIAL))) {
+            return false;
+        }
+        if (registry == null) {
+            return false;
+        }
+        FormatReader formatReader = registry.findByName(ext.sourceType());
+        if (formatReader == null) {
+            return false;
+        }
+        AggregatePushdownSupport support = formatReader.aggregatePushdownSupport();
+        if (support == AggregatePushdownSupport.UNSUPPORTED) {
+            return false;
+        }
+        List<Expression> aggFunctions = extractAggregateFunctions(agg.aggregates());
+        // No aggregate functions to push (e.g. only literals): keep normal discovery.
+        if (aggFunctions.isEmpty()) {
+            return false;
+        }
+        return support.canPushAggregates(aggFunctions, List.of()) == AggregatePushdownSupport.Pushability.YES;
+    }
+
+    private static List<Expression> extractAggregateFunctions(List<? extends NamedExpression> aggregates) {
+        List<Expression> result = new ArrayList<>(aggregates.size());
+        for (NamedExpression agg : aggregates) {
+            Expression toCheck = agg instanceof Alias alias ? alias.child() : agg;
+            if (toCheck instanceof AggregateFunction) {
+                result.add(toCheck);
+            }
+        }
+        return result;
     }
 
     private void discoverSplitsFromFragments(PhysicalPlan plan, List<ExternalSplit> splits) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ExternalSourceResolverTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReaderFactory;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatSpec;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceStatistics;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
@@ -45,6 +46,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -202,6 +205,45 @@ public class ExternalSourceResolverTests extends ESTestCase {
         ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
         assertNotNull(resolved);
         assertNull(resolved.metadata().sourceMetadata().get(SourceStatisticsSerializer.STATS_PARTIAL));
+    }
+
+    /**
+     * When all files provide per-file row counts, multi-file FIRST_FILE_WINS resolution
+     * should aggregate statistics and NOT set STATS_PARTIAL.
+     */
+    public void testMultiFileFirstFileWinsAggregatesRowCountWhenStatsAvailable() throws Exception {
+        List<Attribute> schema = List.of(attr("x", DataType.INTEGER));
+
+        Map<String, List<Attribute>> schemasByPath = new HashMap<>();
+        schemasByPath.put("s3://bucket/data/a.parquet", schema);
+        schemasByPath.put("s3://bucket/data/b.parquet", schema);
+        schemasByPath.put("s3://bucket/data/c.parquet", schema);
+
+        Map<String, Long> rowCountsByPath = new HashMap<>();
+        rowCountsByPath.put("s3://bucket/data/a.parquet", 1000L);
+        rowCountsByPath.put("s3://bucket/data/b.parquet", 2000L);
+        rowCountsByPath.put("s3://bucket/data/c.parquet", 3000L);
+
+        ExternalSourceResolution resolution = resolveMultiFileWithStats(
+            "s3://bucket/data/*.parquet",
+            schemasByPath,
+            rowCountsByPath,
+            List.of(
+                entry("s3://bucket/data/a.parquet", 100),
+                entry("s3://bucket/data/b.parquet", 200),
+                entry("s3://bucket/data/c.parquet", 300)
+            )
+        );
+
+        ExternalSourceResolution.ResolvedSource resolved = resolution.resolvedSource("s3://bucket/data/*.parquet");
+        assertNotNull(resolved);
+        Map<String, Object> meta = resolved.metadata().sourceMetadata();
+        // Aggregated row count should be the sum across all files.
+        assertEquals(6000L, meta.get(SourceStatisticsSerializer.STATS_ROW_COUNT));
+        // No STATS_PARTIAL — stats cover all files.
+        assertNull(meta.get(SourceStatisticsSerializer.STATS_PARTIAL));
+        // File count should still be present.
+        assertEquals(3L, meta.get(SourceStatisticsSerializer.STATS_FILE_COUNT));
     }
 
     // ===== GenericFileList threading tests =====
@@ -774,6 +816,61 @@ public class ExternalSourceResolverTests extends ESTestCase {
         return future.actionGet();
     }
 
+    /**
+     * Resolves a multi-file glob pattern using a StubFormatReader that returns per-file row counts
+     * as statistics. This enables testing the aggregated-stats path in resolveMultiFileSource.
+     */
+    private ExternalSourceResolution resolveMultiFileWithStats(
+        String globPattern,
+        Map<String, List<Attribute>> schemasByPath,
+        Map<String, Long> rowCountsByPath,
+        List<StorageEntry> listing
+    ) throws Exception {
+        Map<String, List<StorageEntry>> listingsByPrefix = new HashMap<>();
+        StoragePath sp = StoragePath.of(globPattern);
+        listingsByPrefix.put(sp.patternPrefix().toString(), listing);
+
+        StubFormatReaderWithStats formatReader = new StubFormatReaderWithStats(schemasByPath, rowCountsByPath);
+        StubStorageProvider storageProvider = new StubStorageProvider(listingsByPrefix, schemasByPath);
+
+        DataSourcePlugin plugin = new DataSourcePlugin() {
+            @Override
+            public Set<String> supportedSchemes() {
+                return Set.of("s3");
+            }
+
+            @Override
+            public Set<FormatSpec> formatSpecs() {
+                return Set.of(FormatSpec.of("parquet", ".parquet"));
+            }
+
+            @Override
+            public Map<String, StorageProviderFactory> storageProviders(Settings settings) {
+                return Map.of("s3", s -> storageProvider);
+            }
+
+            @Override
+            public Map<String, FormatReaderFactory> formatReaders(Settings settings) {
+                return Map.of("parquet", (s, bf) -> formatReader);
+            }
+        };
+
+        List<DataSourcePlugin> plugins = List.of(plugin);
+        DataSourceCapabilities capabilities = DataSourceCapabilities.build(plugins);
+        DataSourceModule module = new DataSourceModule(
+            plugins,
+            capabilities,
+            Settings.EMPTY,
+            blockFactory,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        ExternalSourceResolver resolver = new ExternalSourceResolver(EsExecutors.DIRECT_EXECUTOR_SERVICE, module);
+        PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
+        resolver.resolve(List.of(globPattern), Map.of(), future);
+        return future.actionGet();
+    }
+
     private ExternalSourceResolution resolveSingleFile(String path, Map<String, List<Attribute>> schemasByPath) throws Exception {
         ExternalSourceResolver resolver = createResolver(schemasByPath, Map.of());
         PlainActionFuture<ExternalSourceResolution> future = new PlainActionFuture<>();
@@ -937,6 +1034,87 @@ public class ExternalSourceResolverTests extends ESTestCase {
         public String location() {
             return location;
         }
+    }
+
+    /**
+     * A StubFormatReader that also returns per-file row counts as statistics.
+     * Used to test the aggregated stats path in multi-file resolution.
+     */
+    private static class StubFormatReaderWithStats implements FormatReader {
+        private final Map<String, List<Attribute>> schemasByPath;
+        private final Map<String, Long> rowCountsByPath;
+
+        StubFormatReaderWithStats(Map<String, List<Attribute>> schemasByPath, Map<String, Long> rowCountsByPath) {
+            this.schemasByPath = schemasByPath;
+            this.rowCountsByPath = rowCountsByPath;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            String path = object.path().toString();
+            List<Attribute> schema = schemasByPath.get(path);
+            if (schema == null) {
+                throw new IllegalArgumentException("No schema configured for path: " + path);
+            }
+            Long rowCount = rowCountsByPath.get(path);
+            return new SourceMetadata() {
+                @Override
+                public List<Attribute> schema() {
+                    return schema;
+                }
+
+                @Override
+                public String sourceType() {
+                    return "parquet";
+                }
+
+                @Override
+                public String location() {
+                    return path;
+                }
+
+                @Override
+                public Optional<SourceStatistics> statistics() {
+                    if (rowCount == null) {
+                        return Optional.empty();
+                    }
+                    return Optional.of(new SourceStatistics() {
+                        @Override
+                        public OptionalLong rowCount() {
+                            return OptionalLong.of(rowCount);
+                        }
+
+                        @Override
+                        public OptionalLong sizeInBytes() {
+                            return OptionalLong.empty();
+                        }
+
+                        @Override
+                        public Optional<Map<String, ColumnStatistics>> columnStatistics() {
+                            return Optional.empty();
+                        }
+                    });
+                }
+            };
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String formatName() {
+            return "parquet";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".parquet");
+        }
+
+        @Override
+        public void close() {}
     }
 
     private static class StubStorageProvider implements StorageProvider {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/CountPushdownWiringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/CountPushdownWiringTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.ExternalRelation;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
@@ -180,7 +181,10 @@ public class CountPushdownWiringTests extends ESTestCase {
     public void testCanSkipSplitDiscoveryForCountStar() {
         Aggregate agg = countStarAggregate();
         FragmentExec fragment = new FragmentExec(agg);
-        assertTrue("should skip split discovery for COUNT(*) with complete stats", ComputeService.canSkipSplitDiscovery(fragment));
+        assertTrue(
+            "should skip split discovery for COUNT(*) with complete stats",
+            ComputeService.canSkipSplitDiscovery(fragment, buildParquetRegistry())
+        );
     }
 
     /**
@@ -198,7 +202,7 @@ public class CountPushdownWiringTests extends ESTestCase {
         Aggregate agg = new Aggregate(Source.EMPTY, external, List.of(), List.of(countAlias));
         FragmentExec fragment = new FragmentExec(agg);
 
-        assertFalse("should not skip with STATS_PARTIAL=true", ComputeService.canSkipSplitDiscovery(fragment));
+        assertFalse("should not skip with STATS_PARTIAL=true", ComputeService.canSkipSplitDiscovery(fragment, buildParquetRegistry()));
     }
 
     /**
@@ -206,14 +210,13 @@ public class CountPushdownWiringTests extends ESTestCase {
      */
     public void testCannotSkipSplitDiscoveryWhenNoRowCount() {
         List<Attribute> attrs = List.of(referenceAttribute("x", DataType.INTEGER));
-        // sourceMetadata has no row count at all
         SourceMetadata metadata = stubMetadata(attrs, Map.of());
         ExternalRelation external = new ExternalRelation(Source.EMPTY, "file:///test.parquet", metadata, attrs);
         Alias countAlias = alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
         Aggregate agg = new Aggregate(Source.EMPTY, external, List.of(), List.of(countAlias));
         FragmentExec fragment = new FragmentExec(agg);
 
-        assertFalse("should not skip with no row count", ComputeService.canSkipSplitDiscovery(fragment));
+        assertFalse("should not skip with no row count", ComputeService.canSkipSplitDiscovery(fragment, buildParquetRegistry()));
     }
 
     /**
@@ -227,11 +230,75 @@ public class CountPushdownWiringTests extends ESTestCase {
         SourceMetadata metadata = stubMetadata(attrs, sourceMetadata);
         ExternalRelation external = new ExternalRelation(Source.EMPTY, "file:///test.parquet", metadata, attrs);
         Alias countAlias = alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
-        // Add a grouping on AGE
         Aggregate agg = new Aggregate(Source.EMPTY, external, List.of(AGE), List.of(countAlias, AGE));
         FragmentExec fragment = new FragmentExec(agg);
 
-        assertFalse("should not skip with groupings", ComputeService.canSkipSplitDiscovery(fragment));
+        assertFalse("should not skip with groupings", ComputeService.canSkipSplitDiscovery(fragment, buildParquetRegistry()));
+    }
+
+    /**
+     * Ungrouped SUM over ExternalRelation must NOT skip split discovery: the format reader
+     * cannot push SUM from file metadata, so the optimizer leaves the AggregateExec in
+     * place and execution needs real splits to read data efficiently.
+     */
+    public void testCannotSkipSplitDiscoveryForNonPushableAggregate() {
+        List<Attribute> attrs = List.of(referenceAttribute("x", DataType.INTEGER), AGE);
+        Map<String, Object> sourceMetadata = new HashMap<>();
+        sourceMetadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 99_000L);
+
+        SourceMetadata metadata = stubMetadata(attrs, sourceMetadata);
+        ExternalRelation external = new ExternalRelation(Source.EMPTY, "file:///test.parquet", metadata, attrs);
+        Alias sumAlias = alias("s", new Sum(Source.EMPTY, AGE));
+        Aggregate agg = new Aggregate(Source.EMPTY, external, List.of(), List.of(sumAlias));
+        FragmentExec fragment = new FragmentExec(agg);
+
+        assertFalse(
+            "should not skip with non-pushable aggregate (SUM)",
+            ComputeService.canSkipSplitDiscovery(fragment, buildParquetRegistry())
+        );
+    }
+
+    /**
+     * Mixed pushable + non-pushable aggregates (e.g. {@code COUNT(*), SUM(x)}) must NOT skip
+     * split discovery: the optimizer can only push the whole tuple together.
+     */
+    public void testCannotSkipSplitDiscoveryForMixedAggregates() {
+        List<Attribute> attrs = List.of(referenceAttribute("x", DataType.INTEGER), AGE);
+        Map<String, Object> sourceMetadata = new HashMap<>();
+        sourceMetadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 99_000L);
+
+        SourceMetadata metadata = stubMetadata(attrs, sourceMetadata);
+        ExternalRelation external = new ExternalRelation(Source.EMPTY, "file:///test.parquet", metadata, attrs);
+        Alias countAlias = alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
+        Alias sumAlias = alias("s", new Sum(Source.EMPTY, AGE));
+        Aggregate agg = new Aggregate(Source.EMPTY, external, List.of(), List.of(countAlias, sumAlias));
+        FragmentExec fragment = new FragmentExec(agg);
+
+        assertFalse(
+            "should not skip when any aggregate is non-pushable",
+            ComputeService.canSkipSplitDiscovery(fragment, buildParquetRegistry())
+        );
+    }
+
+    /**
+     * A null format reader registry must conservatively return false (cannot verify
+     * pushability without consulting the format reader).
+     */
+    public void testCannotSkipSplitDiscoveryWithoutRegistry() {
+        Aggregate agg = countStarAggregate();
+        FragmentExec fragment = new FragmentExec(agg);
+        assertFalse("should not skip without a registry", ComputeService.canSkipSplitDiscovery(fragment, null));
+    }
+
+    /**
+     * An unknown source type must conservatively return false: we can't determine
+     * whether the aggregates are pushable.
+     */
+    public void testCannotSkipSplitDiscoveryForUnknownSourceType() {
+        FormatReaderRegistry empty = new FormatReaderRegistry(null);
+        Aggregate agg = countStarAggregate();
+        FragmentExec fragment = new FragmentExec(agg);
+        assertFalse("should not skip for unknown source type", ComputeService.canSkipSplitDiscovery(fragment, empty));
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/CountPushdownWiringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/CountPushdownWiringTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.planner.PlannerSettings;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.planner.mapper.LocalMapper;
+import org.elasticsearch.xpack.esql.plugin.ComputeService;
 import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 
@@ -170,7 +171,129 @@ public class CountPushdownWiringTests extends ESTestCase {
         assertEquals(1500L, as(page.getBlock(0), LongBlock.class).getLong(0));
     }
 
+    // ---- canSkipSplitDiscovery tests ----
+
+    /**
+     * A pure ungrouped COUNT(*) over ExternalRelation with complete sourceMetadata stats
+     * qualifies for skipping split discovery.
+     */
+    public void testCanSkipSplitDiscoveryForCountStar() {
+        Aggregate agg = countStarAggregate();
+        FragmentExec fragment = new FragmentExec(agg);
+        assertTrue("should skip split discovery for COUNT(*) with complete stats", ComputeService.canSkipSplitDiscovery(fragment));
+    }
+
+    /**
+     * An ExternalRelation with STATS_PARTIAL=true must NOT skip split discovery.
+     */
+    public void testCannotSkipSplitDiscoveryWhenStatsPartial() {
+        List<Attribute> attrs = List.of(referenceAttribute("x", DataType.INTEGER));
+        Map<String, Object> sourceMetadata = new HashMap<>();
+        sourceMetadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 50_000L);
+        sourceMetadata.put(SourceStatisticsSerializer.STATS_PARTIAL, Boolean.TRUE);
+
+        SourceMetadata metadata = stubMetadata(attrs, sourceMetadata);
+        ExternalRelation external = new ExternalRelation(Source.EMPTY, "file:///test.parquet", metadata, attrs);
+        Alias countAlias = alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
+        Aggregate agg = new Aggregate(Source.EMPTY, external, List.of(), List.of(countAlias));
+        FragmentExec fragment = new FragmentExec(agg);
+
+        assertFalse("should not skip with STATS_PARTIAL=true", ComputeService.canSkipSplitDiscovery(fragment));
+    }
+
+    /**
+     * An ExternalRelation without a row count in sourceMetadata must NOT skip split discovery.
+     */
+    public void testCannotSkipSplitDiscoveryWhenNoRowCount() {
+        List<Attribute> attrs = List.of(referenceAttribute("x", DataType.INTEGER));
+        // sourceMetadata has no row count at all
+        SourceMetadata metadata = stubMetadata(attrs, Map.of());
+        ExternalRelation external = new ExternalRelation(Source.EMPTY, "file:///test.parquet", metadata, attrs);
+        Alias countAlias = alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
+        Aggregate agg = new Aggregate(Source.EMPTY, external, List.of(), List.of(countAlias));
+        FragmentExec fragment = new FragmentExec(agg);
+
+        assertFalse("should not skip with no row count", ComputeService.canSkipSplitDiscovery(fragment));
+    }
+
+    /**
+     * An aggregate WITH groupings (BY clause) cannot push down, so split discovery must run.
+     */
+    public void testCannotSkipSplitDiscoveryWithGroupings() {
+        List<Attribute> attrs = List.of(referenceAttribute("x", DataType.INTEGER), AGE);
+        Map<String, Object> sourceMetadata = new HashMap<>();
+        sourceMetadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 99_000L);
+
+        SourceMetadata metadata = stubMetadata(attrs, sourceMetadata);
+        ExternalRelation external = new ExternalRelation(Source.EMPTY, "file:///test.parquet", metadata, attrs);
+        Alias countAlias = alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
+        // Add a grouping on AGE
+        Aggregate agg = new Aggregate(Source.EMPTY, external, List.of(AGE), List.of(countAlias, AGE));
+        FragmentExec fragment = new FragmentExec(agg);
+
+        assertFalse("should not skip with groupings", ComputeService.canSkipSplitDiscovery(fragment));
+    }
+
+    /**
+     * Multi-file COUNT(*) pushdown: with aggregated sourceMetadata (no STATS_PARTIAL, valid row count),
+     * empty splits should resolve to the total row count from sourceMetadata.
+     */
+    public void testCountStarPushdownWithAggregatedSourceMetadata() {
+        // Simulate multi-file sourceMetadata with aggregated stats (no STATS_PARTIAL).
+        List<Attribute> attrs = List.of(referenceAttribute("x", DataType.INTEGER), AGE);
+        Map<String, Object> sourceMetadata = new HashMap<>();
+        sourceMetadata.put(SourceStatisticsSerializer.STATS_ROW_COUNT, 50_000L);
+        sourceMetadata.put(SourceStatisticsSerializer.STATS_FILE_COUNT, 5L);
+        // No STATS_PARTIAL — stats are global
+
+        SourceMetadata metadata = stubMetadata(attrs, sourceMetadata);
+        ExternalRelation external = new ExternalRelation(Source.EMPTY, "s3://bucket/*.parquet", metadata, attrs);
+        Alias countAlias = alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
+        Aggregate agg = new Aggregate(Source.EMPTY, external, List.of(), List.of(countAlias));
+
+        // With EMPTY splits (as Stage 2 will provide), the optimizer must use sourceMetadata.
+        PhysicalPlan result = runLocalPlanWithSplits(agg, List.of());
+
+        LocalSourceExec local = as(result, LocalSourceExec.class);
+        Page page = local.supplier().get();
+        assertEquals(50_000L, as(page.getBlock(0), LongBlock.class).getLong(0));
+    }
+
     // ---- helpers ----
+
+    private static SourceMetadata stubMetadata(List<Attribute> attrs, Map<String, Object> sourceMetadata) {
+        return new SourceMetadata() {
+            @Override
+            public List<Attribute> schema() {
+                return attrs;
+            }
+
+            @Override
+            public String sourceType() {
+                return "parquet";
+            }
+
+            @Override
+            public String location() {
+                return "file:///test.parquet";
+            }
+
+            @Override
+            public Map<String, Object> sourceMetadata() {
+                return sourceMetadata;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                return o instanceof SourceMetadata;
+            }
+
+            @Override
+            public int hashCode() {
+                return 1;
+            }
+        };
+    }
 
     private PhysicalPlan runLocalPlanWithSplits(Aggregate logicalAgg, List<ExternalSplit> splits) {
         return runLocalPlanWithSplitsAndRegistry(logicalAgg, splits, buildParquetRegistry());


### PR DESCRIPTION
Multi-file EXTERNAL queries read every file's Parquet footer twice:
once during metadata resolution (Phase 1, for schema) and again
during split discovery (Phase 2, for row group byte offsets). For
aggregate pushdown queries (COUNT/MIN/MAX), Phase 2 is unnecessary
— the optimizer only needs file-level statistics, not row group
offsets.

Aggregates per-file statistics during Phase 1 so sourceMetadata has
valid global stats. Skips Phase 2 when the query is a pure ungrouped
aggregate with complete stats. Also fixes a latent bug where
STRICT/UNION_BY_NAME used only the anchor file's stats.

Developed with AI-assisted tooling