### PR TITLE
Rename MultiValues.ARRAYS to ARRAY, fix default MultiValue option for text and match_only_text fields

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -109,7 +109,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     private static final FieldMapper.DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new FieldMapper.DocValuesParameter.Values(
         false,
         FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
-        FieldMapper.DocValuesParameter.Values.MultiValue.ARRAYS
+        FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
     );
 
     public static class Defaults {
@@ -130,7 +130,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     public static class Builder extends TextFamilyBuilder {
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
-        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.arraysWithCardinality(
+        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.sortedSetWithCardinality(
             DEFAULT_DOC_VALUES_PARAMS,
             m -> ((MatchOnlyTextFieldMapper) m).docValuesParameters
         );
@@ -913,6 +913,10 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     @Override
     protected boolean isSingleValueEnforced() {
         return docValuesParameters.multiValue().isSingleValued();
+    }
+
+    public FieldMapper.DocValuesParameter.Values docValuesParameters() {
+        return docValuesParameters;
     }
 
     @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -251,7 +251,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 stored.getValue(),
                 this,
                 indexSettings.getIndexVersionCreated(),
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_SCALED_FLOAT
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_SCALED_FLOAT,
+                docValuesParameters.getValue().multiValue()
             );
             return new ScaledFloatFieldMapper(
                 leafName(),

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
@@ -132,6 +132,16 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
         minimalMapping(b);
     }
 
+    public void testMultiValueDefaultIsSortedSet() throws IOException {
+        assumeTrue(
+            "match_only_text field doc_values feature must be enabled",
+            FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()
+        );
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "match_only_text").field("doc_values", true)));
+        MatchOnlyTextFieldMapper mapper = (MatchOnlyTextFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET));
+    }
+
     public void testDefaults() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         assertEquals(Strings.toString(fieldMapping(this::minimalMapping)), mapper.mappingSource().toString());

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapperTests.java
@@ -149,7 +149,7 @@ public class TokenCountFieldMapperTests extends MapperTestCase {
         })));
         assertThat(
             e.getMessage(),
-            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, arrays]")
+            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, array]")
         );
     }
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
@@ -72,7 +72,7 @@
 ---
 "multi_value=no on multi-field sub rejects parent array":
   - requires:
-      cluster_features: ["mapper.doc_values.multi_value_enforcement"]
+      cluster_features: ["mapper.doc_values.multi_value_no_enforcement"]
       reason: "multi_value=no enforcement on indexing"
 
   - do:
@@ -113,7 +113,7 @@
 ---
 "multi_value=no on multi-field parent rejects parent array":
   - requires:
-      cluster_features: ["mapper.doc_values.multi_value_enforcement"]
+      cluster_features: ["mapper.doc_values.multi_value_no_enforcement"]
       reason: "multi_value=no enforcement on indexing"
 
   - do:

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -198,7 +198,8 @@ public class BooleanFieldMapper extends FieldMapper {
                 stored.getValue(),
                 this,
                 indexSettings.getIndexVersionCreated(),
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_BOOLEAN
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_BOOLEAN,
+                docValuesParameters.getValue().multiValue()
             );
             return new BooleanFieldMapper(
                 leafName(),

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldArrayContext.java
@@ -102,8 +102,15 @@ public class FieldArrayContext {
         boolean isStored,
         FieldMapper.Builder fieldMapperBuilder,
         IndexVersion indexCreatedVersion,
-        IndexVersion minSupportedVersionMain
+        IndexVersion minSupportedVersionMain,
+        FieldMapper.DocValuesParameter.Values.MultiValue multiValue
     ) {
+        // multi_value=array trigger: mapping-time validation enforces the safety conditions (copy_to empty, no multi-fields, doc_values
+        // enabled, not nested, index version supports the offsets payload), so the runtime gate here is intentionally minimal.
+        if (multiValue == FieldMapper.DocValuesParameter.Values.MultiValue.ARRAY) {
+            return context.buildFullName(fieldMapperBuilder.leafName() + FieldArrayContext.OFFSETS_FIELD_NAME_SUFFIX);
+        }
+
         var sourceKeepMode = fieldMapperBuilder.sourceKeepMode.orElse(indexSourceKeepMode);
         if (context.isSourceSynthetic()
             && sourceKeepMode == Mapper.SourceKeepMode.ARRAYS
@@ -122,6 +129,51 @@ public class FieldArrayContext {
             return context.buildFullName(fieldMapperBuilder.leafName() + FieldArrayContext.OFFSETS_FIELD_NAME_SUFFIX);
         } else {
             return null;
+        }
+    }
+
+    /**
+     * Mapping-time validation for {@code multi_value=array}. Run from each field mapper builder's {@code validate()} when the user has
+     * explicitly opted into {@code array}. Each rejected combination throws so the failure surfaces at parse / put-mapping time rather
+     * than as a silent ordering bug at read time.
+     * <ul>
+     *     <li>{@code copy_to} non-empty — slot-count coordination across source and copy-to destination is non-trivial.</li>
+     *     <li>multi-fields configured — same coordination issue as {@code copy_to}.</li>
+     *     <li>{@code doc_values=false} — offsets encode positions into the doc-values list; without doc values offsets point to nothing.</li>
+     *     <li>nested context — nested doc-id addressing complicates which doc the offsets attach to.</li>
+     *     <li>index version pre-dates the offsets payload format — old readers cannot decode it.</li>
+     * </ul>
+     */
+    public static void validateMultiValueArray(
+        String fieldName,
+        MapperBuilderContext context,
+        boolean hasDocValues,
+        FieldMapper.Builder fieldMapperBuilder,
+        IndexVersion indexCreatedVersion,
+        IndexVersion minSupportedVersionMain
+    ) {
+        if (fieldMapperBuilder.copyTo.copyToFields().isEmpty() == false) {
+            throw new IllegalArgumentException("Field [" + fieldName + "] has [multi_value=array] which is incompatible with [copy_to]");
+        }
+        if (fieldMapperBuilder.multiFieldsBuilder.hasMultiFields()) {
+            throw new IllegalArgumentException("Field [" + fieldName + "] has [multi_value=array] which is incompatible with [fields]");
+        }
+        if (hasDocValues == false) {
+            throw new IllegalArgumentException(
+                "Field [" + fieldName + "] has [multi_value=array] which requires [doc_values] to be enabled"
+            );
+        }
+        if (context.isInNestedContext()) {
+            throw new IllegalArgumentException(
+                "Field [" + fieldName + "] has [multi_value=array] which is not supported inside a [nested] object"
+            );
+        }
+        if (indexVersionSupportStoringArraysNatively(indexCreatedVersion, minSupportedVersionMain) == false) {
+            throw new IllegalArgumentException(
+                "Field ["
+                    + fieldName
+                    + "] has [multi_value=array] which requires an index created on a version that supports natively storing arrays"
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1489,13 +1489,13 @@ public abstract class FieldMapper extends Mapper {
              * {@code NO} restricts the field to a single value per document.
              * {@code SORTED} stores multiple values sorted per document (numeric types).
              * {@code SORTED_SET} stores multiple values sorted and deduplicated per document (keyword/IP types).
-             * {@code ARRAYS} allows multiple values, keeps original ordering, and supports null values.
+             * {@code ARRAY} allows multiple values, keeps original ordering, and supports null values.
              */
             public enum MultiValue {
                 NO,
                 SORTED,
                 SORTED_SET,
-                ARRAYS;
+                ARRAY;
 
                 /**
                  * Whether this mode restricts the field to a single value per document. Callers use this to branch between single-valued
@@ -1525,7 +1525,7 @@ public abstract class FieldMapper extends Mapper {
                 defaultValue,
                 initializer,
                 false,
-                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED, Values.MultiValue.ARRAYS)
+                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED, Values.MultiValue.ARRAY)
             );
         }
 
@@ -1538,7 +1538,7 @@ public abstract class FieldMapper extends Mapper {
                 defaultValue,
                 initializer,
                 false,
-                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED_SET, Values.MultiValue.ARRAYS)
+                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED_SET, Values.MultiValue.ARRAY)
             );
         }
 
@@ -1550,15 +1550,8 @@ public abstract class FieldMapper extends Mapper {
                 defaultValue,
                 initializer,
                 true,
-                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED_SET, Values.MultiValue.ARRAYS)
+                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED_SET, Values.MultiValue.ARRAY)
             );
-        }
-
-        /**
-         * Factory for field types that support cardinality. Use for text-family fields (text, match_only_text).
-         */
-        public static DocValuesParameter arraysWithCardinality(Values defaultValue, Function<FieldMapper, Values> initializer) {
-            return new DocValuesParameter(defaultValue, initializer, true, EnumSet.of(Values.MultiValue.NO, Values.MultiValue.ARRAYS));
         }
 
         private DocValuesParameter(
@@ -1605,7 +1598,7 @@ public abstract class FieldMapper extends Mapper {
          *   <li>{@code "doc_values": { "multi_value": "no" }} - single value enforced per document</li>
          *   <li>{@code "doc_values": { "multi_value": "sorted" }} - multiple values sorted per document</li>
          *   <li>{@code "doc_values": { "multi_value": "sorted_set" }} - multiple values sorted and deduplicated per document</li>
-         *   <li>{@code "doc_values": { "multi_value": "arrays" }} - multiple values stored as-is (no sorting or deduplication)</li>
+         *   <li>{@code "doc_values": { "multi_value": "array" }} - multiple values stored as-is (no sorting or deduplication)</li>
          * </ul>
          * <p>
          * Not all {@code multi_value} options are supported by every field type; unsupported options are rejected at mapping parse time.

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -235,7 +235,8 @@ public class IpFieldMapper extends FieldMapper {
                 stored.getValue(),
                 this,
                 indexSettings.getIndexVersionCreated(),
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_IP
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_IP,
+                docValuesParameters.getValue().multiValue()
             );
             return new IpFieldMapper(
                 leafName(),

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -487,7 +487,8 @@ public final class KeywordFieldMapper extends FieldMapper {
                 stored.getValue(),
                 this,
                 indexCreatedVersion,
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD,
+                docValuesParameters().multiValue()
             );
             return new KeywordFieldMapper(
                 leafName(),

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -82,6 +82,7 @@ public class MapperFeatures implements FeatureSpecification {
     );
     public static final NodeFeature DOC_VALUES_MULTI_VALUE = new NodeFeature("mapper.doc_values.multi_value");
     public static final NodeFeature DOC_VALUES_MULTI_VALUE_ENFORCEMENT = new NodeFeature("mapper.doc_values.multi_value_enforcement");
+    public static final NodeFeature DOC_VALUES_MULTI_VALUE_ARRAY = new NodeFeature("mapper.doc_values.multi_value_array");
     static final NodeFeature DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX = new NodeFeature(
         "mapper.dense_vector.dynamic_template_nested_object_fix"
     );
@@ -151,6 +152,7 @@ public class MapperFeatures implements FeatureSpecification {
             DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX,
             DOC_VALUES_MULTI_VALUE,
             DOC_VALUES_MULTI_VALUE_ENFORCEMENT,
+            DOC_VALUES_MULTI_VALUE_ARRAY,
             DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX,
             FLATTENED_MAPPED_SUBFIELDS_FEATURE,
             ES940_DISK_BBQ,

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -320,7 +320,8 @@ public class NumberFieldMapper extends FieldMapper {
                 stored.getValue(),
                 this,
                 indexSettings.getIndexVersionCreated(),
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_NUMBER
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_NUMBER,
+                docValuesParameters.getValue().multiValue()
             );
             return new NumberFieldMapper(leafName(), ft, builderParams(this, context), context.isSourceSynthetic(), this, offsetsFieldName);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -115,7 +115,7 @@ public final class TextFieldMapper extends FieldMapper {
     public static final DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new DocValuesParameter.Values(
         false,
         DocValuesParameter.Values.Cardinality.HIGH,
-        DocValuesParameter.Values.MultiValue.ARRAYS
+        DocValuesParameter.Values.MultiValue.SORTED_SET
     );
 
     public static class Defaults {
@@ -267,7 +267,7 @@ public final class TextFieldMapper extends FieldMapper {
 
         private final Parameter<Boolean> index = Parameter.indexParam(m -> ((TextFieldMapper) m).index, true);
 
-        final DocValuesParameter docValuesParameters = DocValuesParameter.arraysWithCardinality(
+        final DocValuesParameter docValuesParameters = DocValuesParameter.sortedSetWithCardinality(
             DEFAULT_DOC_VALUES_PARAMS,
             m -> ((TextFieldMapper) m).docValuesParameters
         );
@@ -1714,6 +1714,10 @@ public final class TextFieldMapper extends FieldMapper {
     @Override
     protected boolean isSingleValueEnforced() {
         return docValuesParameters.multiValue().isSingleValued();
+    }
+
+    public DocValuesParameter.Values docValuesParameters() {
+        return docValuesParameters;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -118,7 +118,7 @@ public class BooleanFieldMapperTests extends MapperTestCase {
         })));
         assertThat(
             e.getMessage(),
-            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, arrays]")
+            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, array]")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -149,7 +149,7 @@ public class DateFieldMapperTests extends MapperTestCase {
         })));
         assertThat(
             e.getMessage(),
-            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, arrays]")
+            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, array]")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
@@ -79,7 +79,7 @@ public class DocValuesParameterTests extends MapperServiceTestCase {
         );
         assertThat(
             e.getMessage(),
-            containsString("Unknown value [invalid] for field [multi_value] - accepted values are [no, sorted_set, arrays]")
+            containsString("Unknown value [invalid] for field [multi_value] - accepted values are [no, sorted_set, array]")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldArrayContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldArrayContextTests.java
@@ -10,11 +10,15 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.elasticsearch.index.mapper.FieldArrayContext.parseOffsetArray;
+import static org.hamcrest.Matchers.containsString;
 
 public class FieldArrayContextTests extends ESTestCase {
 
@@ -64,4 +68,214 @@ public class FieldArrayContextTests extends ESTestCase {
         assertArrayEquals(new int[] {}, offsetToOrd);
     }
 
+    /**
+     * {@code multi_value=array} short-circuits the runtime safety checks because mapping-time validation enforces them. The helper must
+     * return the offsets-name regardless of {@code source_keep_mode}, {@code stored}, or synthetic-source mode.
+     */
+    public void testGetOffsetsFieldNameMultiValueArrayShortCircuits() {
+        var builder = new TestBuilder("field");
+        var context = MapperBuilderContext.root(false, false);
+
+        String name = FieldArrayContext.getOffsetsFieldName(
+            context,
+            Mapper.SourceKeepMode.NONE,
+            randomBoolean(),
+            randomBoolean(),
+            builder,
+            IndexVersion.current(),
+            IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD,
+            FieldMapper.DocValuesParameter.Values.MultiValue.ARRAY
+        );
+        assertEquals("field" + ".offsets", name);
+    }
+
+    /**
+     * Non-ARRAY values fall through to the existing {@code source_keep_mode=arrays} runtime gate, which requires synthetic source.
+     * Without it, the helper returns {@code null} regardless of the multi-value mode.
+     */
+    public void testGetOffsetsFieldNameNonArrayFallsThroughToExistingGate() {
+        var builder = new TestBuilder("field");
+        var context = MapperBuilderContext.root(false, false);
+
+        for (var mv : List.of(
+            FieldMapper.DocValuesParameter.Values.MultiValue.NO,
+            FieldMapper.DocValuesParameter.Values.MultiValue.SORTED,
+            FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+        )) {
+            String name = FieldArrayContext.getOffsetsFieldName(
+                context,
+                Mapper.SourceKeepMode.ARRAYS,
+                true,
+                false,
+                builder,
+                IndexVersion.current(),
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD,
+                mv
+            );
+            // synthetic source disabled, runtime gate denies
+            assertNull("multi_value=" + mv + " must fall through to runtime gate", name);
+        }
+    }
+
+    /**
+     * Synthetic source plus {@code source_keep_mode=arrays} on a non-ARRAY multi-value should still arm the existing runtime gate.
+     */
+    public void testGetOffsetsFieldNameSourceKeepModeArraysTriggersExistingPath() {
+        var builder = new TestBuilder("field");
+        var context = MapperBuilderContext.root(true, false);
+
+        String name = FieldArrayContext.getOffsetsFieldName(
+            context,
+            Mapper.SourceKeepMode.ARRAYS,
+            true,
+            false,
+            builder,
+            IndexVersion.current(),
+            IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD,
+            FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+        );
+        assertEquals("field.offsets", name);
+    }
+
+    public void testValidateMultiValueArrayCopyToRejected() {
+        var builder = new TestBuilder("field");
+        builder.copyTo = builder.copyTo.withAddedFields(List.of("other"));
+        var context = MapperBuilderContext.root(false, false);
+
+        var ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> FieldArrayContext.validateMultiValueArray(
+                "field",
+                context,
+                true,
+                builder,
+                IndexVersion.current(),
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD
+            )
+        );
+        assertThat(ex.getMessage(), containsString("[multi_value=array] which is incompatible with [copy_to]"));
+    }
+
+    public void testValidateMultiValueArrayMultiFieldsRejected() {
+        var builder = new TestBuilder("field");
+        builder.multiFieldsBuilder.add(new TestBuilder("sub"));
+        var context = MapperBuilderContext.root(false, false);
+
+        var ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> FieldArrayContext.validateMultiValueArray(
+                "field",
+                context,
+                true,
+                builder,
+                IndexVersion.current(),
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD
+            )
+        );
+        assertThat(ex.getMessage(), containsString("[multi_value=array] which is incompatible with [fields]"));
+    }
+
+    public void testValidateMultiValueArrayDocValuesFalseRejected() {
+        var builder = new TestBuilder("field");
+        var context = MapperBuilderContext.root(false, false);
+
+        var ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> FieldArrayContext.validateMultiValueArray(
+                "field",
+                context,
+                false,
+                builder,
+                IndexVersion.current(),
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD
+            )
+        );
+        assertThat(ex.getMessage(), containsString("[multi_value=array] which requires [doc_values] to be enabled"));
+    }
+
+    public void testValidateMultiValueArrayNestedRejected() {
+        var builder = new TestBuilder("field");
+        // Use the package-private constructor directly to flip inNestedContext=true without instantiating NestedObjectMapper.
+        var context = new MapperBuilderContext(
+            null,
+            false,
+            false,
+            false,
+            ObjectMapper.Defaults.DYNAMIC,
+            MapperService.MergeReason.MAPPING_UPDATE,
+            true
+        );
+
+        var ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> FieldArrayContext.validateMultiValueArray(
+                "field",
+                context,
+                true,
+                builder,
+                IndexVersion.current(),
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD
+            )
+        );
+        assertThat(ex.getMessage(), containsString("[multi_value=array] which is not supported inside a [nested] object"));
+    }
+
+    public void testValidateMultiValueArrayIndexVersionTooOldRejected() {
+        var builder = new TestBuilder("field");
+        var context = MapperBuilderContext.root(false, false);
+
+        var ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> FieldArrayContext.validateMultiValueArray(
+                "field",
+                context,
+                true,
+                builder,
+                IndexVersions.V_8_0_0,
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD
+            )
+        );
+        assertThat(
+            ex.getMessage(),
+            containsString("[multi_value=array] which requires an index created on a version that supports natively storing arrays")
+        );
+    }
+
+    public void testValidateMultiValueArrayHappyPath() {
+        var builder = new TestBuilder("field");
+        var context = MapperBuilderContext.root(false, false);
+
+        // No exception expected on a well-formed configuration.
+        FieldArrayContext.validateMultiValueArray(
+            "field",
+            context,
+            true,
+            builder,
+            IndexVersion.current(),
+            IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_KEYWORD
+        );
+    }
+
+    /** Minimal {@link FieldMapper.Builder} stub used to drive validator and helper tests without dragging in field-type plumbing. */
+    private static final class TestBuilder extends FieldMapper.Builder {
+
+        TestBuilder(String name) {
+            super(name);
+        }
+
+        @Override
+        protected FieldMapper.Parameter<?>[] getParameters() {
+            return new FieldMapper.Parameter<?>[0];
+        }
+
+        @Override
+        public String contentType() {
+            return "test";
+        }
+
+        @Override
+        public FieldMapper build(MapperBuilderContext context) {
+            throw new UnsupportedOperationException("test stub");
+        }
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
@@ -531,7 +531,7 @@ public class IpFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getMessage(),
-            containsString("Unknown value [sorted] for field [multi_value] - accepted values are [no, sorted_set, arrays]")
+            containsString("Unknown value [sorted] for field [multi_value] - accepted values are [no, sorted_set, array]")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -1113,7 +1113,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getMessage(),
-            containsString("Unknown value [sorted] for field [multi_value] - accepted values are [no, sorted_set, arrays]")
+            containsString("Unknown value [sorted] for field [multi_value] - accepted values are [no, sorted_set, array]")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -508,6 +508,16 @@ public class TextFieldMapperTests extends MapperTestCase {
         assertIgnoredSourceIsEmpty(doc);
     }
 
+    public void testMultiValueDefaultIsSortedSet() throws IOException {
+        assumeTrue(
+            "text field doc_values feature must be enabled",
+            FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()
+        );
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "text").field("doc_values", true)));
+        TextFieldMapper mapper = (TextFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET));
+    }
+
     public void testDocValuesEnabledWithIndexing() throws IOException {
         assumeTrue(
             "text field doc_values feature must be enabled",

--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -322,8 +322,8 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
             case 1 -> Map.of("cardinality", "low");
             case 2 -> Map.of("cardinality", "high");
             case 3 -> true;
-            case 4 -> Map.of("cardinality", "low", "multi_value", "arrays");
-            case 5 -> Map.of("cardinality", "high", "multi_value", "arrays");
+            case 4 -> Map.of("cardinality", "low", "multi_value", "array");
+            case 5 -> Map.of("cardinality", "high", "multi_value", "array");
             default -> throw new IllegalStateException();
         };
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -549,7 +549,7 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         })));
         assertThat(
             e.getMessage(),
-            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, arrays]")
+            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, array]")
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TextFieldFamilySyntheticSourceTestSetup.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TextFieldFamilySyntheticSourceTestSetup.java
@@ -70,12 +70,12 @@ public final class TextFieldFamilySyntheticSourceTestSetup {
             case 0 -> new FieldMapper.DocValuesParameter.Values(
                 true,
                 FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                FieldMapper.DocValuesParameter.Values.MultiValue.ARRAYS
+                FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
             );
             case 1 -> new FieldMapper.DocValuesParameter.Values(
                 true,
                 FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
-                FieldMapper.DocValuesParameter.Values.MultiValue.ARRAYS
+                FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
             );
             case 2 -> FieldMapper.DocValuesParameter.Values.DISABLED;
             default -> throw new IllegalStateException();

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
@@ -102,7 +102,7 @@ public class RandomizedRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTest
             .withDataSourceHandlers(List.of(new DefaultMappingParametersHandler() {
                 @Override
                 protected Object extendedDocValuesParams() {
-                    if (oldClusterHasFeature(MapperFeatures.DOC_VALUES_MULTI_VALUE)) {
+                    if (oldClusterHasFeature(MapperFeatures.DOC_VALUES_MULTI_VALUE_ARRAY)) {
                         return super.extendedDocValuesParams();
                     }
 

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -243,7 +243,8 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 stored.getValue(),
                 this,
                 indexSettings.getIndexVersionCreated(),
-                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_UNSIGNED_LONG
+                IndexVersions.SYNTHETIC_SOURCE_STORE_ARRAYS_NATIVELY_UNSIGNED_LONG,
+                docValuesParameters.getValue().multiValue()
             );
             return new UnsignedLongFieldMapper(
                 leafName(),


### PR DESCRIPTION
Quick clean up before starting the arrays implementation.

Text and match only text fields use SortedSet doc values internally, so their default must reflect that.

Note, extended doc value parameters are currently behind a feature flag, so there should be no BWC issues with old mappings.