### PR TITLE
ESQL: Add streaming parallel parsing for gzip-compressed files

### DIFF
--- a/docs/changelog/148093.yaml
+++ b/docs/changelog/148093.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148093
+summary: Add streaming parallel parsing for gzip-compressed files
+type: enhancement

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -158,8 +158,14 @@ public class NdJsonPageDecoder implements Closeable {
             int end = Math.addExact(sourceOffset, sourceLength);
             Check.isTrue(end <= sourceBytes.length, "byte slice [{}, {}) exceeds buffer length {}", sourceOffset, end, sourceBytes.length);
             this.sourceEnd = end;
+            this.parserSliceStart = sourceOffset;
         } else {
+            // The default-zero values are unreachable on the InputStream path: every read of these
+            // fields is gated on {@code sourceBytes != null}. Assign explicitly so the dependency is
+            // self-documenting and a future refactor that lifts the gate fails at the source rather
+            // than reading silently from a zero-initialized field.
             this.sourceEnd = 0;
+            this.parserSliceStart = 0;
         }
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
         this.errorPolicy = errorPolicy;
@@ -208,7 +214,6 @@ public class NdJsonPageDecoder implements Closeable {
         this.blockTracker = new BitSet(projectedAttributes.size());
 
         if (sourceBytes != null) {
-            this.parserSliceStart = sourceOffset;
             this.parser = NdJsonUtils.JSON_FACTORY.createParser(sourceBytes, sourceOffset, sourceLength);
         } else {
             this.parser = NdJsonUtils.JSON_FACTORY.createParser(input);
@@ -511,8 +516,12 @@ public class NdJsonPageDecoder implements Closeable {
     @Override
     public void close() throws IOException {
         // input may be null on the byte-array fast path; IOUtils.close tolerates null entries.
-        IOUtils.close(input);
+        // We also close `parser` so its internal buffers (small but real) are released on the byte-array
+        // path, where there is no `input` to close. AUTO_CLOSE_SOURCE is disabled on the shared
+        // JsonFactory, so closing the parser does not double-close the wrapping codec stream.
+        IOUtils.close(parser, input);
         input = null;
+        parser = null;
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -57,6 +57,28 @@ public class NdJsonPageDecoder implements Closeable {
     private static final Logger logger = LogManager.getLogger(NdJsonPageDecoder.class);
 
     private InputStream input;
+    /**
+     * Non-null when the decoder is reading from a fully buffered byte array (no {@link InputStream}
+     * indirection); in that case {@link #input} is {@code null} and recovery uses the byte-array
+     * fast path. Streaming-parallel parsing uses this path because every chunk is already a
+     * bounded {@code byte[]} region — going straight to Jackson's {@code createParser(byte[])}
+     * skips the per-call dispatch through {@link InputStream#read} and lets Jackson 2.16+ pick
+     * its small-input fast paths.
+     */
+    private final byte[] sourceBytes;
+    /**
+     * Exclusive end of the readable region in {@link #sourceBytes}. The decoder may read bytes in
+     * the half-open range {@code [parserSliceStart, sourceEnd)}; everything outside it must not
+     * be touched (e.g. when the byte array is a large pooled buffer and only a prefix is data).
+     */
+    private final int sourceEnd;
+    /**
+     * Absolute offset (within {@link #sourceBytes}) where {@link #parser}'s input slice starts;
+     * tracked because {@code JsonParser.getCurrentLocation().getByteOffset()} is relative to the
+     * slice the parser was created over, not to the underlying byte array. Updated each time
+     * {@link #recoverFromParseException} restarts the parser at a later offset.
+     */
+    private int parserSliceStart;
     private final BlockDecoder decoder;
     private final int batchSize;
     private final BlockFactory blockFactory;
@@ -93,7 +115,52 @@ public class NdJsonPageDecoder implements Closeable {
         ErrorPolicy errorPolicy,
         String sourceLocation
     ) throws IOException {
+        this(input, null, 0, 0, attributes, projectedColumns, batchSize, blockFactory, errorPolicy, sourceLocation);
+    }
+
+    /**
+     * Buffered-bytes constructor for the streaming-parallel path: {@code data[offset .. offset+length)}
+     * is the entire input. Recovery from {@link JsonParseException} stays inside the byte array
+     * (no buffered-bytes shuttling through {@link NdJsonUtils#moveToNextLine}) by scanning for the
+     * next {@code '\n'} from the parser's current byte offset.
+     */
+    NdJsonPageDecoder(
+        byte[] data,
+        int offset,
+        int length,
+        List<Attribute> attributes,
+        List<String> projectedColumns,
+        int batchSize,
+        BlockFactory blockFactory,
+        ErrorPolicy errorPolicy,
+        String sourceLocation
+    ) throws IOException {
+        this(null, data, offset, length, attributes, projectedColumns, batchSize, blockFactory, errorPolicy, sourceLocation);
+    }
+
+    private NdJsonPageDecoder(
+        InputStream input,
+        byte[] sourceBytes,
+        int sourceOffset,
+        int sourceLength,
+        List<Attribute> attributes,
+        List<String> projectedColumns,
+        int batchSize,
+        BlockFactory blockFactory,
+        ErrorPolicy errorPolicy,
+        String sourceLocation
+    ) throws IOException {
         this.input = input;
+        this.sourceBytes = sourceBytes;
+        if (sourceBytes != null) {
+            Check.isTrue(sourceOffset >= 0, "sourceOffset must be non-negative, got: {}", sourceOffset);
+            Check.isTrue(sourceLength >= 0, "sourceLength must be non-negative, got: {}", sourceLength);
+            int end = Math.addExact(sourceOffset, sourceLength);
+            Check.isTrue(end <= sourceBytes.length, "byte slice [{}, {}) exceeds buffer length {}", sourceOffset, end, sourceBytes.length);
+            this.sourceEnd = end;
+        } else {
+            this.sourceEnd = 0;
+        }
         Check.isTrue(errorPolicy != null, "errorPolicy must not be null");
         this.errorPolicy = errorPolicy;
         this.skipWarnings = SkipWarnings.of(
@@ -140,12 +207,55 @@ public class NdJsonPageDecoder implements Closeable {
         this.projectedAttributes = projectedAttributes;
         this.blockTracker = new BitSet(projectedAttributes.size());
 
-        this.parser = NdJsonUtils.JSON_FACTORY.createParser(input);
+        if (sourceBytes != null) {
+            this.parserSliceStart = sourceOffset;
+            this.parser = NdJsonUtils.JSON_FACTORY.createParser(sourceBytes, sourceOffset, sourceLength);
+        } else {
+            this.parser = NdJsonUtils.JSON_FACTORY.createParser(input);
+        }
     }
 
     private void recoverFromParseException(JsonParser failedParser) throws IOException {
-        this.input = NdJsonUtils.moveToNextLine(failedParser, this.input);
-        this.parser = NdJsonUtils.JSON_FACTORY.createParser(this.input);
+        if (sourceBytes != null) {
+            int next = nextLineStartByteAfter(failedParser);
+            failedParser.close();
+            this.parserSliceStart = next;
+            this.parser = NdJsonUtils.JSON_FACTORY.createParser(sourceBytes, next, sourceEnd - next);
+        } else {
+            this.input = NdJsonUtils.moveToNextLine(failedParser, this.input);
+            this.parser = NdJsonUtils.JSON_FACTORY.createParser(this.input);
+        }
+    }
+
+    /**
+     * Returns the absolute byte offset (into {@link #sourceBytes}) of the start of the line
+     * following the failed parser's current position (the byte after the next {@code '\n'} or
+     * {@code '\r'}, or {@link #sourceEnd} on EOF). The new parser created from this offset will
+     * not re-encounter the malformed line. {@code getByteOffset()} is added to
+     * {@link #parserSliceStart} because it is relative to the slice the failed parser was created
+     * over, not to {@link #sourceBytes}. Both LF and CR terminate a line so the byte-array path
+     * handles the same record terminators as {@link NdJsonUtils#moveToNextLine}.
+     */
+    private int nextLineStartByteAfter(JsonParser failedParser) {
+        long sliceOffsetLong = failedParser.getCurrentLocation().getByteOffset();
+        // getByteOffset() returns -1 only for non-byte-backed sources; we always pass byte[].
+        int sliceOffset = sliceOffsetLong < 0 ? (sourceEnd - parserSliceStart) : Math.toIntExact(sliceOffsetLong);
+        int from = Math.min(parserSliceStart + sliceOffset, sourceEnd);
+        for (int i = from; i < sourceEnd; i++) {
+            byte b = sourceBytes[i];
+            if (b == '\n') {
+                return i + 1;
+            }
+            if (b == '\r') {
+                // Consume an immediately-following LF so CRLF advances by two bytes (matches the
+                // streaming-side scanForTerminator semantics).
+                if (i + 1 < sourceEnd && sourceBytes[i + 1] == '\n') {
+                    return i + 2;
+                }
+                return i + 1;
+            }
+        }
+        return sourceEnd;
     }
 
     /**
@@ -400,6 +510,7 @@ public class NdJsonPageDecoder implements Closeable {
 
     @Override
     public void close() throws IOException {
+        // input may be null on the byte-array fast path; IOUtils.close tolerates null entries.
         IOUtils.close(input);
         input = null;
     }

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
@@ -40,6 +40,14 @@ final class NdJsonPageIterator implements CloseableIterator<Page> {
     private boolean endOfFile = false;
     private Page nextPage;
 
+    /**
+     * Storage objects up to this size are eagerly slurped into a {@code byte[]} so the decoder can
+     * use Jackson's {@code createParser(byte[])} fast path instead of the {@code InputStream}
+     * dispatch. Streaming-parallel chunks are ~1 MiB, single-file reads are usually well under
+     * this; very large files fall back to streaming so they do not pin a multi-hundred-MiB array.
+     */
+    static final int BYTE_ARRAY_FAST_PATH_MAX_SIZE = 16 * 1024 * 1024;
+
     NdJsonPageIterator(
         StorageObject object,
         List<String> projectedColumns,
@@ -61,15 +69,51 @@ final class NdJsonPageIterator implements CloseableIterator<Page> {
             inputStream = trimLastPartialLine(inputStream, errorPolicy, sourceLocation);
         }
         this.rowLimit = rowLimit;
-        this.pageDecoder = new NdJsonPageDecoder(
-            inputStream,
-            resolvedAttributes,
-            projectedColumns,
-            batchSize,
-            blockFactory,
-            errorPolicy,
-            sourceLocation
-        );
+        if (canUseByteArrayFastPath(object)) {
+            byte[] data;
+            try (InputStream toClose = inputStream) {
+                data = toClose.readAllBytes();
+            }
+            this.pageDecoder = new NdJsonPageDecoder(
+                data,
+                0,
+                data.length,
+                resolvedAttributes,
+                projectedColumns,
+                batchSize,
+                blockFactory,
+                errorPolicy,
+                sourceLocation
+            );
+        } else {
+            this.pageDecoder = new NdJsonPageDecoder(
+                inputStream,
+                resolvedAttributes,
+                projectedColumns,
+                batchSize,
+                blockFactory,
+                errorPolicy,
+                sourceLocation
+            );
+        }
+    }
+
+    /**
+     * The byte-array fast path is available for storage objects with a known, bounded length;
+     * decompressing wrappers throw {@link UnsupportedOperationException} from {@link StorageObject#length()}
+     * and stay on the streaming path. Transient {@link IOException}s from {@link StorageObject#length()}
+     * also fall back to streaming so a metadata hiccup does not abort an open call; the streaming
+     * read will surface the same condition if the data itself is unreachable.
+     */
+    private static boolean canUseByteArrayFastPath(StorageObject object) {
+        try {
+            long len = object.length();
+            return len >= 0 && len <= BYTE_ARRAY_FAST_PATH_MAX_SIZE;
+        } catch (UnsupportedOperationException e) {
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIterator.java
@@ -11,6 +11,8 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
@@ -33,6 +35,8 @@ import java.util.NoSuchElementException;
  * from the split data, avoiding the risk of schema divergence across splits.
  */
 final class NdJsonPageIterator implements CloseableIterator<Page> {
+
+    private static final Logger logger = LogManager.getLogger(NdJsonPageIterator.class);
 
     private final NdJsonPageDecoder pageDecoder;
     private final int rowLimit;
@@ -112,6 +116,10 @@ final class NdJsonPageIterator implements CloseableIterator<Page> {
         } catch (UnsupportedOperationException e) {
             return false;
         } catch (IOException e) {
+            // Surface the metadata hiccup at DEBUG so a transient S3 head-object failure is not
+            // completely invisible during diagnosis. The streaming path will surface the same
+            // condition on read if the data itself is unreachable.
+            logger.debug(() -> "byte-array fast path disabled for [" + object.path() + "]: object length unavailable", e);
             return false;
         }
     }

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtils.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtils.java
@@ -20,22 +20,29 @@ import java.io.SequenceInputStream;
 
 class NdJsonUtils {
     /**
-     * Shared {@link JsonFactory} for all NDJSON parsing. All settings are valid on the server-wide
-     * Jackson 2.15 used here (no separate Jackson dependency for this plugin).
+     * Shared {@link JsonFactory} for all NDJSON parsing. Tuned for high-throughput streaming reads.
+     * <p>
+     * We deliberately do <b>not</b> reuse {@code org.elasticsearch.xcontent.provider.json.ESJsonFactory}
+     * from {@code libs/x-content/impl}: that factory lives in a JPMS package which the
+     * {@code org.elasticsearch.xcontent.impl} module does not export, so it isn't reachable as a
+     * type from this plugin, and its settings target full-document XContent parsing rather than
+     * line-bounded NDJSON streamed in parallel. In particular {@code STRICT_DUPLICATE_DETECTION},
+     * {@code ALLOW_COMMENTS}, source-in-location bookkeeping, and the relaxed
+     * {@code streamReadConstraints} are correct for that path but unnecessary or counter-productive
+     * here.
      * <ul>
      *   <li>{@link StreamReadFeature#AUTO_CLOSE_SOURCE} disabled - schema inference may call
      *       {@link JsonParser#close()} while recovering from malformed JSON; that must not close a
      *       wrapping codec stream (e.g. bzip2) that is still being read.</li>
-     *   <li>{@link StreamReadFeature#USE_FAST_DOUBLE_PARSER} enabled - dispatches numeric parsing
-     *       to FastDoubleParser (~+20% on numeric-heavy fixtures); harmless when columns are
-     *       non-numeric. Available since Jackson 2.14.</li>
-     *   <li>{@link StreamReadFeature#INCLUDE_SOURCE_IN_LOCATION} disabled - we never echo source
-     *       payloads back via {@code JsonLocation.contentReference()}; skipping the per-token
-     *       book-keeping shaves allocations in the hot loop. Default flips to {@code false} in
-     *       Jackson 2.16; we want the same behaviour now.</li>
+     *   <li>{@link StreamReadFeature#USE_FAST_DOUBLE_PARSER} enabled - dispatches to FastDoubleParser
+     *       for numeric columns; harmless when columns are not numeric.</li>
+     *   <li>{@link StreamReadFeature#INCLUDE_SOURCE_IN_LOCATION} disabled - we never echo the source
+     *       payload back via {@code JsonLocation.contentReference()}; skipping it avoids per-token
+     *       book-keeping.</li>
      *   <li>{@link JsonFactory.Feature#INTERN_FIELD_NAMES} disabled - eliminates the global
-     *       {@code String.intern()} synchronization point under parallel parsing. Field names
-     *       live only as long as the {@code Attribute} lookup keys; interning gains us nothing.</li>
+     *       {@code String.intern()} synchronization point under parallel parsing. Field names live
+     *       only as long as the column attribute lookup keys, so interning gains us nothing while
+     *       serializing parser threads on the JVM string-table monitor.</li>
      * </ul>
      */
     static final JsonFactory JSON_FACTORY = new JsonFactoryBuilder().disable(StreamReadFeature.AUTO_CLOSE_SOURCE)

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtils.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtils.java
@@ -42,7 +42,11 @@ class NdJsonUtils {
      *   <li>{@link JsonFactory.Feature#INTERN_FIELD_NAMES} disabled - eliminates the global
      *       {@code String.intern()} synchronization point under parallel parsing. Field names live
      *       only as long as the column attribute lookup keys, so interning gains us nothing while
-     *       serializing parser threads on the JVM string-table monitor.</li>
+     *       serializing parser threads on the JVM string-table monitor. Disabling is safe because
+     *       this factory is package-private to the NDJSON plugin and every consumer (currently the
+     *       schema inferrer and {@link NdJsonPageDecoder}) treats {@code parser.currentName()} as a
+     *       hash-map key — there are no identity (==) comparisons that would silently break when
+     *       names stop being interned.</li>
      * </ul>
      */
     static final JsonFactory JSON_FACTORY = new JsonFactoryBuilder().disable(StreamReadFeature.AUTO_CLOSE_SOURCE)

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -35,6 +35,8 @@ import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.formatter.TextFormat;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.hamcrest.Matchers;
@@ -1535,6 +1537,139 @@ public class NdJsonPageIteratorTests extends ESTestCase {
             () -> reader.withConfig(Map.of("segment_size", "1kb"))
         );
         assertThat(ex2.getMessage(), Matchers.containsString("segment_size"));
+    }
+
+    /**
+     * Storage objects whose {@link org.elasticsearch.xpack.esql.datasources.spi.StorageObject#length()}
+     * throws {@link UnsupportedOperationException} (e.g. decompressing wrappers around a non-seekable
+     * stream) must transparently fall back to the streaming {@code InputStream} decoder rather than
+     * blowing up. Verifies the fast-path detector treats the exception as "size unknown".
+     */
+    public void testFallsBackWhenLengthUnsupported() throws IOException {
+        String ndjson = "{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n";
+        byte[] bytes = ndjson.getBytes(StandardCharsets.UTF_8);
+        StorageObject lengthUnsupported = new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(bytes);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                return new ByteArrayInputStream(bytes, (int) position, (int) length);
+            }
+
+            @Override
+            public long length() {
+                throw new UnsupportedOperationException("length unknown for streaming sources");
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.EPOCH;
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://no-length.ndjson");
+            }
+        };
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var ctx = FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(10).errorPolicy(ErrorPolicy.STRICT).build();
+        int totalRows = 0;
+        try (var iterator = reader.read(lengthUnsupported, ctx)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                totalRows += page.getPositionCount();
+            }
+        }
+        assertEquals(3, totalRows);
+    }
+
+    /**
+     * Storage objects larger than {@link NdJsonPageIterator#BYTE_ARRAY_FAST_PATH_MAX_SIZE} must
+     * fall back to the streaming decoder so a multi-hundred-MB file does not get slurped into a
+     * single {@code byte[]}. Uses a stub that lies about its length to avoid materializing data.
+     */
+    public void testLargeObjectFallsBackToStreaming() throws IOException {
+        byte[] payload = "{\"id\":42}\n".getBytes(StandardCharsets.UTF_8);
+        StorageObject oversized = new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(payload);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                return new ByteArrayInputStream(payload, (int) position, (int) length);
+            }
+
+            @Override
+            public long length() {
+                return ((long) NdJsonPageIterator.BYTE_ARRAY_FAST_PATH_MAX_SIZE) + 1L;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.EPOCH;
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://oversized.ndjson");
+            }
+        };
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var ctx = FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(10).errorPolicy(ErrorPolicy.STRICT).build();
+        int totalRows = 0;
+        try (var iterator = reader.read(oversized, ctx)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                totalRows += page.getPositionCount();
+            }
+        }
+        // The oversized stub really only contains one row; what we are exercising is the fallback
+        // dispatch (no IOException, no OOM from trying to allocate a 16MB+ array).
+        assertEquals(1, totalRows);
+    }
+
+    /**
+     * The byte-array fast path must recover from a malformed line in the middle of the buffer the
+     * same way the streaming path does: subsequent good lines are still emitted and the bad line
+     * is reported once. Regression for the relative-vs-absolute byte offset bug in the byte[]
+     * recovery path: if the new parser used the wrong offset basis, the loop would re-fail on the
+     * same line and either spin forever or skip data.
+     */
+    public void testByteArrayPathRecoversFromMalformedLine() throws IOException {
+        String ndjson = "{\"id\":1}\n{{{not-an-object\n{\"id\":3}\n{{{nope\n{\"id\":5}\n";
+        var object = new BytesStorageObject("memory://recover.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var ctx = FormatReadContext.builder().projectedColumns(List.of("id")).batchSize(10).errorPolicy(ErrorPolicy.LENIENT).build();
+        List<Integer> ids = new ArrayList<>();
+        try (var iterator = reader.read(object, ctx)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                IntBlock idBlock = (IntBlock) page.getBlock(0);
+                for (int i = 0; i < idBlock.getPositionCount(); i++) {
+                    if (idBlock.isNull(i) == false) {
+                        ids.add(idBlock.getInt(i));
+                    }
+                }
+            }
+        }
+        assertEquals(List.of(1, 3, 5), ids);
+        // Also drain warnings emitted by the LENIENT policy so the suite-level no-warnings check passes.
+        drainWarnings();
     }
 
     private static DataType dataType(Block block) {

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtilsTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtilsTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.ndjson;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadFeature;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Unit tests for {@link NdJsonUtils#JSON_FACTORY}.
+ *
+ * <p>The shared factory carries non-default tuning that the streaming-parallel NDJSON path
+ * relies on; pin those settings here so accidental drift (e.g. a refactor to the central
+ * {@code ESJsonFactory}) is caught at build time rather than as a runtime regression.
+ */
+public class NdJsonUtilsTests extends ESTestCase {
+
+    public void testFactoryDisablesAutoCloseSource() {
+        assertFalse(
+            "AUTO_CLOSE_SOURCE must be off so recovery from JsonParseException does not close a wrapping codec stream",
+            NdJsonUtils.JSON_FACTORY.isEnabled(StreamReadFeature.AUTO_CLOSE_SOURCE)
+        );
+    }
+
+    public void testFactoryEnablesFastDoubleParser() {
+        assertTrue(
+            "USE_FAST_DOUBLE_PARSER must be on for numeric-column throughput",
+            NdJsonUtils.JSON_FACTORY.isEnabled(StreamReadFeature.USE_FAST_DOUBLE_PARSER)
+        );
+    }
+
+    public void testFactoryDisablesIncludeSourceInLocation() {
+        assertFalse(
+            "INCLUDE_SOURCE_IN_LOCATION must be off; we never echo the source payload back on parse errors",
+            NdJsonUtils.JSON_FACTORY.isEnabled(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+        );
+    }
+
+    public void testFactoryDisablesInternFieldNames() {
+        assertFalse(
+            "INTERN_FIELD_NAMES must be off so parallel parsers do not serialize on String.intern()'s monitor",
+            NdJsonUtils.JSON_FACTORY.isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES)
+        );
+    }
+
+    /**
+     * Behavioural check for {@code AUTO_CLOSE_SOURCE = false}: closing the parser must not
+     * close the underlying stream. Schema inference and parse-error recovery rely on this.
+     */
+    public void testParserCloseDoesNotCloseUnderlyingStream() throws IOException {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        InputStream raw = new FilterInputStream(new ByteArrayInputStream("{\"a\":1}\n".getBytes(StandardCharsets.UTF_8))) {
+            @Override
+            public void close() throws IOException {
+                closed.set(true);
+                super.close();
+            }
+        };
+        try (JsonParser parser = NdJsonUtils.JSON_FACTORY.createParser(raw)) {
+            parser.nextToken();
+        }
+        assertFalse("Closing the parser must not close the wrapping stream when AUTO_CLOSE_SOURCE is disabled", closed.get());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -999,6 +999,13 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     throw e;
                 }
             }
+            // Splittable / indexed codecs (e.g. bzip2) need codec-aware segmenting because
+            // ParallelParsingCoordinator works in raw-file byte space and would feed the inner
+            // line-oriented reader compressed bytes (yielding "Unrecognized token 'BZh91A...'"
+            // for bzip2). Until we wire splittable parallel decompression here, fall back to
+            // the single-threaded path through the CompressionDelegatingFormatReader, which
+            // wraps the StorageObject in a DecompressingStorageObject before reading.
+            return null;
         }
         return ParallelParsingCoordinator.parallelRead(seg, obj, cols, batchSize, parsingParallelism, executor, policy);
     }
@@ -1011,6 +1018,10 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         } else if (resolveSegmentableReader(formatReader) != null && parsingParallelism > 1) {
             if (isStreamOnlyCompressed(formatReader)) {
                 asyncMode = "streaming-parallel-parse(" + parsingParallelism + ")";
+            } else if (formatReader instanceof CompressionDelegatingFormatReader) {
+                // Splittable / indexed compressed paths fall back to single-threaded reads
+                // until codec-aware parallel decompression is wired in openWithParallelism.
+                asyncMode = "sync-wrapper";
             } else {
                 asyncMode = "parallel-parse(" + parsingParallelism + ")";
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -960,12 +960,35 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         return null;
     }
 
-    static boolean isStreamOnlyCompressed(FormatReader reader) {
+    /**
+     * Single source of truth for how a {@link FormatReader} should be dispatched against parsing parallelism.
+     * Both {@link #openWithParallelism} and {@link #describe} resolve the same enum so the runtime path
+     * and the diagnostic string cannot drift.
+     */
+    enum ParallelDispatchMode {
+        /** Reader is a {@link SegmentableFormatReader} over an uncompressed input. */
+        SEGMENTABLE_UNCOMPRESSED,
+        /** Reader wraps a stream-only codec (gzip, zstd); use the streaming-parallel coordinator. */
+        STREAM_ONLY_COMPRESSED,
+        /** Reader wraps a splittable / indexed codec (bzip2); falls back to single-threaded reads for now. */
+        SPLITTABLE_OR_INDEXED_COMPRESSED,
+        /** Reader is not segmentable; parallel parsing does not apply. */
+        NOT_PARALLELIZABLE
+    }
+
+    static ParallelDispatchMode resolveDispatchMode(FormatReader reader) {
+        SegmentableFormatReader seg = resolveSegmentableReader(reader);
+        if (seg == null) {
+            return ParallelDispatchMode.NOT_PARALLELIZABLE;
+        }
         if (reader instanceof CompressionDelegatingFormatReader cdr) {
             DecompressionCodec codec = cdr.codec();
-            return (codec instanceof SplittableDecompressionCodec) == false && (codec instanceof IndexedDecompressionCodec) == false;
+            if (codec instanceof SplittableDecompressionCodec || codec instanceof IndexedDecompressionCodec) {
+                return ParallelDispatchMode.SPLITTABLE_OR_INDEXED_COMPRESSED;
+            }
+            return ParallelDispatchMode.STREAM_ONLY_COMPRESSED;
         }
-        return false;
+        return ParallelDispatchMode.SEGMENTABLE_UNCOMPRESSED;
     }
 
     CloseableIterator<Page> openWithParallelism(FormatReader reader, StorageObject obj, List<String> cols, ErrorPolicy policy)
@@ -973,13 +996,19 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         if (rowLimit != FormatReader.NO_LIMIT || parsingParallelism <= 1) {
             return null;
         }
-        SegmentableFormatReader seg = resolveSegmentableReader(reader);
-        if (seg == null) {
-            return null;
-        }
-        if (reader instanceof CompressionDelegatingFormatReader cdr) {
-            DecompressionCodec codec = cdr.codec();
-            if ((codec instanceof SplittableDecompressionCodec) == false && (codec instanceof IndexedDecompressionCodec) == false) {
+        ParallelDispatchMode mode = resolveDispatchMode(reader);
+        switch (mode) {
+            case NOT_PARALLELIZABLE -> {
+                return null;
+            }
+            case SEGMENTABLE_UNCOMPRESSED -> {
+                SegmentableFormatReader seg = resolveSegmentableReader(reader);
+                return ParallelParsingCoordinator.parallelRead(seg, obj, cols, batchSize, parsingParallelism, executor, policy);
+            }
+            case STREAM_ONLY_COMPRESSED -> {
+                CompressionDelegatingFormatReader cdr = (CompressionDelegatingFormatReader) reader;
+                SegmentableFormatReader seg = resolveSegmentableReader(reader);
+                DecompressionCodec codec = cdr.codec();
                 InputStream raw = obj.newStream();
                 InputStream decompressed;
                 try {
@@ -1007,19 +1036,23 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     throw e;
                 }
             }
-            // Splittable / indexed codecs (e.g. bzip2) need codec-aware segmenting because
-            // ParallelParsingCoordinator works in raw-file byte space and would feed the inner
-            // line-oriented reader compressed bytes (yielding "Unrecognized token 'BZh91A...'"
-            // for bzip2). Until we wire splittable parallel decompression here, fall back to
-            // the single-threaded path through the CompressionDelegatingFormatReader, which
-            // wraps the StorageObject in a DecompressingStorageObject before reading.
-            logger.debug(
-                "falling back to single-threaded read for splittable/indexed codec [{}]: codec-aware parallel decompression not yet wired",
-                codec.name()
-            );
-            return null;
+            case SPLITTABLE_OR_INDEXED_COMPRESSED -> {
+                // Splittable / indexed codecs (e.g. bzip2) need codec-aware segmenting because
+                // ParallelParsingCoordinator works in raw-file byte space and would feed the inner
+                // line-oriented reader compressed bytes (yielding "Unrecognized token 'BZh91A...'"
+                // for bzip2). Until we wire splittable parallel decompression here, fall back to
+                // the single-threaded path through the CompressionDelegatingFormatReader, which
+                // wraps the StorageObject in a DecompressingStorageObject before reading.
+                CompressionDelegatingFormatReader cdr = (CompressionDelegatingFormatReader) reader;
+                logger.debug(
+                    "falling back to single-threaded read for splittable/indexed codec [{}]: "
+                        + "codec-aware parallel decompression not yet wired",
+                    cdr.codec().name()
+                );
+                return null;
+            }
+            default -> throw new IllegalStateException("Unhandled dispatch mode: " + mode);
         }
-        return ParallelParsingCoordinator.parallelRead(seg, obj, cols, batchSize, parsingParallelism, executor, policy);
     }
 
     @Override
@@ -1027,16 +1060,15 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         String asyncMode;
         if (formatReader instanceof RangeAwareFormatReader) {
             asyncMode = "range-split";
-        } else if (resolveSegmentableReader(formatReader) != null && parsingParallelism > 1) {
-            if (isStreamOnlyCompressed(formatReader)) {
-                asyncMode = "streaming-parallel-parse(" + parsingParallelism + ")";
-            } else if (formatReader instanceof CompressionDelegatingFormatReader) {
+        } else if (parsingParallelism > 1) {
+            asyncMode = switch (resolveDispatchMode(formatReader)) {
+                case SEGMENTABLE_UNCOMPRESSED -> "parallel-parse(" + parsingParallelism + ")";
+                case STREAM_ONLY_COMPRESSED -> "streaming-parallel-parse(" + parsingParallelism + ")";
                 // Splittable / indexed compressed paths fall back to single-threaded reads
                 // until codec-aware parallel decompression is wired in openWithParallelism.
-                asyncMode = "sync-wrapper";
-            } else {
-                asyncMode = "parallel-parse(" + parsingParallelism + ")";
-            }
+                case SPLITTABLE_OR_INDEXED_COMPRESSED -> "sync-wrapper";
+                case NOT_PARALLELIZABLE -> formatReader.supportsNativeAsync() ? "native-async" : "sync-wrapper";
+            };
         } else if (formatReader.supportsNativeAsync()) {
             asyncMode = "native-async";
         } else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -17,6 +17,8 @@ import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -84,6 +86,8 @@ import static org.elasticsearch.xpack.esql.datasources.ExternalSourceDrainUtils.
  * @see AsyncExternalSourceOperator
  */
 public class AsyncExternalSourceOperatorFactory implements SourceOperator.SourceOperatorFactory {
+
+    private static final Logger logger = LogManager.getLogger(AsyncExternalSourceOperatorFactory.class);
 
     private final StorageProvider storageProvider;
     private final FormatReader formatReader;
@@ -946,7 +950,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
      * Resolves the effective inner reader and codec from a possibly-wrapped format reader.
      * Used by dispatch sites to determine whether streaming parallel parsing is applicable.
      */
-    private static SegmentableFormatReader resolveSegmentableReader(FormatReader reader) {
+    static SegmentableFormatReader resolveSegmentableReader(FormatReader reader) {
         if (reader instanceof SegmentableFormatReader seg) {
             return seg;
         }
@@ -956,7 +960,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         return null;
     }
 
-    private static boolean isStreamOnlyCompressed(FormatReader reader) {
+    static boolean isStreamOnlyCompressed(FormatReader reader) {
         if (reader instanceof CompressionDelegatingFormatReader cdr) {
             DecompressionCodec codec = cdr.codec();
             return (codec instanceof SplittableDecompressionCodec) == false && (codec instanceof IndexedDecompressionCodec) == false;
@@ -964,7 +968,7 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         return false;
     }
 
-    private CloseableIterator<Page> openWithParallelism(FormatReader reader, StorageObject obj, List<String> cols, ErrorPolicy policy)
+    CloseableIterator<Page> openWithParallelism(FormatReader reader, StorageObject obj, List<String> cols, ErrorPolicy policy)
         throws IOException {
         if (rowLimit != FormatReader.NO_LIMIT || parsingParallelism <= 1) {
             return null;
@@ -985,6 +989,10 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                     throw e;
                 }
                 try {
+                    // The stream-only codecs reachable here (gzip via GZIPInputStream, zstd via
+                    // ZstdInputStream) follow the JDK FilterInputStream convention: closing the
+                    // wrapper closes the underlying `raw`. New stream-only codecs added to this
+                    // path must preserve that contract.
                     return StreamingParallelParsingCoordinator.parallelRead(
                         seg,
                         decompressed,
@@ -1005,6 +1013,10 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
             // for bzip2). Until we wire splittable parallel decompression here, fall back to
             // the single-threaded path through the CompressionDelegatingFormatReader, which
             // wraps the StorageObject in a DecompressingStorageObject before reading.
+            logger.debug(
+                "falling back to single-threaded read for splittable/indexed codec [{}]: codec-aware parallel decompression not yet wired",
+                codec.name()
+            );
             return null;
         }
         return ParallelParsingCoordinator.parallelRead(seg, obj, cols, batchSize, parsingParallelism, executor, policy);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -20,21 +20,25 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.IndexedDecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeAwareFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.RangeReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SplittableDecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -694,17 +698,21 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
                 state.lastFileContext = rangeCtx.fileContext();
             } else {
                 StorageObject obj = FileSplitProvider.storageObjectForSplit(storageProvider, fileSplit);
-                boolean firstSplit = fileSplit.offset() == 0 || "true".equals(fileSplit.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
-                boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
-                FormatReadContext ctx = FormatReadContext.builder()
-                    .projectedColumns(cols)
-                    .batchSize(batchSize)
-                    .rowLimit(FormatReader.NO_LIMIT)
-                    .errorPolicy(errorPolicy)
-                    .firstSplit(firstSplit)
-                    .lastSplit(lastSplit)
-                    .build();
-                pages = fileReader.read(obj, ctx);
+                pages = openWithParallelism(fileReader, obj, cols, errorPolicy);
+                if (pages == null) {
+                    boolean firstSplit = fileSplit.offset() == 0
+                        || "true".equals(fileSplit.config().get(FileSplitProvider.FIRST_SPLIT_KEY));
+                    boolean lastSplit = "true".equals(fileSplit.config().get(FileSplitProvider.LAST_SPLIT_KEY));
+                    FormatReadContext ctx = FormatReadContext.builder()
+                        .projectedColumns(cols)
+                        .batchSize(batchSize)
+                        .rowLimit(FormatReader.NO_LIMIT)
+                        .errorPolicy(errorPolicy)
+                        .firstSplit(firstSplit)
+                        .lastSplit(lastSplit)
+                        .build();
+                    pages = fileReader.read(obj, ctx);
+                }
             }
             CloseableIterator<Page> adapted = adaptSchema(pages, fileSplit.columnMapping(), state.driverContext);
             state.pages = wrapWithInjector(adapted, injector);
@@ -729,22 +737,12 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         }
         int fileIndex = state.fileIndex++;
         List<String> cols = state.projectedColumns;
-        boolean useParallel = rowLimit == FormatReader.NO_LIMIT && formatReader instanceof SegmentableFormatReader;
 
         CloseableIterator<Page> pages = null;
         try {
             StorageObject obj = storageProvider.newObject(files.path(fileIndex));
-            if (useParallel) {
-                pages = ParallelParsingCoordinator.parallelRead(
-                    (SegmentableFormatReader) formatReader,
-                    obj,
-                    cols,
-                    batchSize,
-                    parsingParallelism,
-                    executor,
-                    errorPolicy
-                );
-            } else {
+            pages = openWithParallelism(formatReader, obj, cols, errorPolicy);
+            if (pages == null) {
                 int fileBudget = rowLimit == FormatReader.NO_LIMIT ? FormatReader.NO_LIMIT : state.rowsRemaining;
                 FormatReadContext ctx = FormatReadContext.builder()
                     .projectedColumns(cols)
@@ -803,18 +801,8 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
     ) {
         ActionListener<Void> failureListener = failureListener(buffer, driverContext);
         executor.execute(ActionRunnable.run(failureListener, () -> {
-            CloseableIterator<Page> pages;
-            if (rowLimit == FormatReader.NO_LIMIT && formatReader instanceof SegmentableFormatReader segmentable) {
-                pages = ParallelParsingCoordinator.parallelRead(
-                    segmentable,
-                    storageObject,
-                    projectedColumns,
-                    batchSize,
-                    parsingParallelism,
-                    executor,
-                    errorPolicy
-                );
-            } else {
+            CloseableIterator<Page> pages = openWithParallelism(formatReader, storageObject, projectedColumns, errorPolicy);
+            if (pages == null) {
                 FormatReadContext ctx = FormatReadContext.builder()
                     .projectedColumns(projectedColumns)
                     .batchSize(batchSize)
@@ -954,13 +942,64 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         }
     }
 
+    /**
+     * Resolves the effective inner reader and codec from a possibly-wrapped format reader.
+     * Used by dispatch sites to determine whether streaming parallel parsing is applicable.
+     */
+    private static SegmentableFormatReader resolveSegmentableReader(FormatReader reader) {
+        if (reader instanceof SegmentableFormatReader seg) {
+            return seg;
+        }
+        if (reader instanceof CompressionDelegatingFormatReader cdr && cdr.unwrap() instanceof SegmentableFormatReader seg) {
+            return seg;
+        }
+        return null;
+    }
+
+    private static boolean isStreamOnlyCompressed(FormatReader reader) {
+        if (reader instanceof CompressionDelegatingFormatReader cdr) {
+            DecompressionCodec codec = cdr.codec();
+            return (codec instanceof SplittableDecompressionCodec) == false && (codec instanceof IndexedDecompressionCodec) == false;
+        }
+        return false;
+    }
+
+    private CloseableIterator<Page> openWithParallelism(FormatReader reader, StorageObject obj, List<String> cols, ErrorPolicy policy)
+        throws IOException {
+        if (rowLimit != FormatReader.NO_LIMIT || parsingParallelism <= 1) {
+            return null;
+        }
+        SegmentableFormatReader seg = resolveSegmentableReader(reader);
+        if (seg == null) {
+            return null;
+        }
+        if (isStreamOnlyCompressed(reader)) {
+            CompressionDelegatingFormatReader cdr = (CompressionDelegatingFormatReader) reader;
+            InputStream decompressed = cdr.codec().decompress(obj.newStream());
+            return StreamingParallelParsingCoordinator.parallelRead(
+                seg,
+                decompressed,
+                cols,
+                batchSize,
+                parsingParallelism,
+                executor,
+                policy
+            );
+        }
+        return ParallelParsingCoordinator.parallelRead(seg, obj, cols, batchSize, parsingParallelism, executor, policy);
+    }
+
     @Override
     public String describe() {
         String asyncMode;
         if (formatReader instanceof RangeAwareFormatReader) {
             asyncMode = "range-split";
-        } else if (formatReader instanceof SegmentableFormatReader && parsingParallelism > 1) {
-            asyncMode = "parallel-parse(" + parsingParallelism + ")";
+        } else if (resolveSegmentableReader(formatReader) != null && parsingParallelism > 1) {
+            if (isStreamOnlyCompressed(formatReader)) {
+                asyncMode = "streaming-parallel-parse(" + parsingParallelism + ")";
+            } else {
+                asyncMode = "parallel-parse(" + parsingParallelism + ")";
+            }
         } else if (formatReader.supportsNativeAsync()) {
             asyncMode = "native-async";
         } else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactory.java
@@ -973,18 +973,32 @@ public class AsyncExternalSourceOperatorFactory implements SourceOperator.Source
         if (seg == null) {
             return null;
         }
-        if (isStreamOnlyCompressed(reader)) {
-            CompressionDelegatingFormatReader cdr = (CompressionDelegatingFormatReader) reader;
-            InputStream decompressed = cdr.codec().decompress(obj.newStream());
-            return StreamingParallelParsingCoordinator.parallelRead(
-                seg,
-                decompressed,
-                cols,
-                batchSize,
-                parsingParallelism,
-                executor,
-                policy
-            );
+        if (reader instanceof CompressionDelegatingFormatReader cdr) {
+            DecompressionCodec codec = cdr.codec();
+            if ((codec instanceof SplittableDecompressionCodec) == false && (codec instanceof IndexedDecompressionCodec) == false) {
+                InputStream raw = obj.newStream();
+                InputStream decompressed;
+                try {
+                    decompressed = codec.decompress(raw);
+                } catch (Exception e) {
+                    raw.close();
+                    throw e;
+                }
+                try {
+                    return StreamingParallelParsingCoordinator.parallelRead(
+                        seg,
+                        decompressed,
+                        cols,
+                        batchSize,
+                        parsingParallelism,
+                        executor,
+                        policy
+                    );
+                } catch (Exception e) {
+                    decompressed.close();
+                    throw e;
+                }
+            }
         }
         return ParallelParsingCoordinator.parallelRead(seg, obj, cols, batchSize, parsingParallelism, executor, policy);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObject.java
@@ -27,6 +27,9 @@ final class ByteArrayStorageObject implements StorageObject {
     private final int length;
 
     ByteArrayStorageObject(StoragePath path, byte[] data, int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException("Invalid region: offset=" + offset + ", length=" + length + ", data.length=" + data.length);
+        }
         this.path = path;
         this.data = data;
         this.offset = offset;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObject.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+
+/**
+ * A {@link StorageObject} backed by a region of a byte array.
+ * Used to wrap decompressed chunks as seekable storage objects for parallel parsing.
+ */
+final class ByteArrayStorageObject implements StorageObject {
+
+    private final StoragePath path;
+    private final byte[] data;
+    private final int offset;
+    private final int length;
+
+    ByteArrayStorageObject(StoragePath path, byte[] data, int offset, int length) {
+        this.path = path;
+        this.data = data;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    @Override
+    public InputStream newStream() {
+        return new ByteArrayInputStream(data, offset, length);
+    }
+
+    @Override
+    public InputStream newStream(long position, long len) {
+        int pos = Math.toIntExact(position);
+        int l = Math.toIntExact(len);
+        return new ByteArrayInputStream(data, offset + pos, l);
+    }
+
+    @Override
+    public long length() {
+        return length;
+    }
+
+    @Override
+    public Instant lastModified() {
+        return Instant.EPOCH;
+    }
+
+    @Override
+    public boolean exists() {
+        return true;
+    }
+
+    @Override
+    public StoragePath path() {
+        return path;
+    }
+
+    @Override
+    public int readBytes(long position, ByteBuffer target) {
+        if (position >= length) {
+            return -1;
+        }
+        int pos = Math.toIntExact(position);
+        int available = length - pos;
+        int toRead = Math.min(available, target.remaining());
+        target.put(data, offset + pos, toRead);
+        return toRead;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObject.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObject.java
@@ -27,7 +27,18 @@ final class ByteArrayStorageObject implements StorageObject {
     private final int length;
 
     ByteArrayStorageObject(StoragePath path, byte[] data, int offset, int length) {
-        if (offset < 0 || length < 0 || offset + length > data.length) {
+        if (offset < 0 || length < 0) {
+            throw new IllegalArgumentException("Invalid region: offset=" + offset + ", length=" + length);
+        }
+        // Math.addExact rejects the corner case where both ints are large positives and `offset + length`
+        // silently wraps to a negative value, which would let the < data.length check pass.
+        int end;
+        try {
+            end = Math.addExact(offset, length);
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException("offset + length overflows int: offset=" + offset + ", length=" + length, e);
+        }
+        if (end > data.length) {
             throw new IllegalArgumentException("Invalid region: offset=" + offset + ", length=" + length + ", data.length=" + data.length);
         }
         this.path = path;
@@ -45,6 +56,14 @@ final class ByteArrayStorageObject implements StorageObject {
     public InputStream newStream(long position, long len) {
         int pos = Math.toIntExact(position);
         int l = Math.toIntExact(len);
+        // Validate the sub-region against the logical [0, length) window: ByteArrayInputStream itself
+        // would only catch a read past data.length, so without this guard a caller could read into
+        // bytes that belong to an adjacent region of the same backing array.
+        if (pos < 0 || l < 0 || Math.addExact(pos, l) > length) {
+            throw new IllegalArgumentException(
+                "Invalid sub-region: position=" + position + ", length=" + len + ", region length=" + length
+            );
+        }
         return new ByteArrayInputStream(data, offset + pos, l);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CompressionDelegatingFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/CompressionDelegatingFormatReader.java
@@ -87,6 +87,14 @@ final class CompressionDelegatingFormatReader implements FormatReader {
         return configured == inner ? this : new CompressionDelegatingFormatReader(configured, codec);
     }
 
+    FormatReader unwrap() {
+        return inner;
+    }
+
+    DecompressionCodec codec() {
+        return codec;
+    }
+
     @Override
     public void close() throws IOException {
         inner.close();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -14,11 +14,15 @@ import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -106,6 +110,7 @@ public final class StreamingParallelParsingCoordinator {
         private final ArrayBlockingQueue<byte[]> bufferPool;
         private final ArrayBlockingQueue<Chunk> chunkQueue;
         private final int windowSize;
+        private final int chunkSize;
         private final ArrayBlockingQueue<Page>[] pageQueues;
 
         private final AtomicReference<Throwable> firstError = new AtomicReference<>();
@@ -131,7 +136,7 @@ public final class StreamingParallelParsingCoordinator {
             this.errorPolicy = errorPolicy;
             this.windowSize = parallelism + 1;
 
-            int chunkSize = Math.toIntExact(reader.minimumSegmentSize());
+            this.chunkSize = Math.toIntExact(reader.minimumSegmentSize());
 
             this.bufferPool = new ArrayBlockingQueue<>(windowSize);
             for (int i = 0; i < windowSize; i++) {
@@ -151,7 +156,7 @@ public final class StreamingParallelParsingCoordinator {
             this.allDone = new CountDownLatch(1 + parallelism);
 
             try {
-                executor.execute(() -> runSegmentator(decompressedStream, chunkSize));
+                executor.execute(() -> runSegmentator(decompressedStream, this.chunkSize));
             } catch (RejectedExecutionException e) {
                 firstError.compareAndSet(null, e);
                 allDone.countDown();
@@ -197,7 +202,7 @@ public final class StreamingParallelParsingCoordinator {
                     }
 
                     int totalBytes = offset + Math.max(bytesRead, 0);
-                    boolean isEof = bytesRead < 0 || (offset + bytesRead) < buf.length;
+                    boolean isEof = bytesRead < 0 || totalBytes < buf.length;
 
                     int lastNewline = findLastNewline(buf, totalBytes);
 
@@ -241,9 +246,8 @@ public final class StreamingParallelParsingCoordinator {
                     stream.close();
                 } catch (IOException ignored) {}
 
-                // Send poison pills to stop all parser threads
-                int dispatched = chunksDispatched.get();
-                for (int i = 0; i < windowSize; i++) {
+                int parserCount = windowSize - 1;
+                for (int i = 0; i < parserCount; i++) {
                     try {
                         chunkQueue.put(Chunk.POISON);
                     } catch (InterruptedException e) {
@@ -318,8 +322,7 @@ public final class StreamingParallelParsingCoordinator {
         }
 
         private void recycleBuffer(byte[] buf) {
-            // Only recycle buffers that match the pool's buffer size
-            if (bufferPool.remainingCapacity() > 0) {
+            if (buf.length <= chunkSize) {
                 bufferPool.offer(buf);
             }
         }
@@ -354,19 +357,19 @@ public final class StreamingParallelParsingCoordinator {
                 int n = stream.read(grown, offset, grown.length - offset);
                 if (n < 0) {
                     if (offset == existingLen) {
-                        return java.util.Arrays.copyOf(existing, existingLen);
+                        return Arrays.copyOf(existing, existingLen);
                     }
-                    return java.util.Arrays.copyOf(grown, offset);
+                    return Arrays.copyOf(grown, offset);
                 }
                 // Check for newline in the newly read bytes
                 for (int i = offset; i < offset + n; i++) {
                     if (grown[i] == '\n') {
-                        return java.util.Arrays.copyOf(grown, offset + n);
+                        return Arrays.copyOf(grown, offset + n);
                     }
                 }
                 offset += n;
                 if (offset >= grown.length) {
-                    grown = java.util.Arrays.copyOf(grown, grown.length + growBy);
+                    grown = Arrays.copyOf(grown, grown.length + growBy);
                 }
             }
         }
@@ -403,7 +406,7 @@ public final class StreamingParallelParsingCoordinator {
         @Override
         public Page next() {
             if (hasNext() == false) {
-                throw new java.util.NoSuchElementException();
+                throw new NoSuchElementException();
             }
             Page result = buffered;
             buffered = null;
@@ -411,8 +414,7 @@ public final class StreamingParallelParsingCoordinator {
         }
 
         private Page takeNextPage() throws InterruptedException {
-            int totalDispatched = chunksDispatched.get();
-            while (currentChunk < totalDispatched || firstError.get() == null) {
+            while (true) {
                 checkError();
 
                 if (currentChunk >= chunksDispatched.get()) {
@@ -440,8 +442,6 @@ public final class StreamingParallelParsingCoordinator {
                 }
                 return page;
             }
-            checkError();
-            return null;
         }
 
         private void checkError() {
@@ -498,7 +498,7 @@ public final class StreamingParallelParsingCoordinator {
     /**
      * Minimal StorageObject wrapping an InputStream for the parallelism=1 fallback path.
      */
-    private static final class InputStreamStorageObject implements org.elasticsearch.xpack.esql.datasources.spi.StorageObject {
+    private static final class InputStreamStorageObject implements StorageObject {
         private final InputStream stream;
 
         InputStreamStorageObject(InputStream stream) {
@@ -522,7 +522,7 @@ public final class StreamingParallelParsingCoordinator {
 
         @Override
         public java.time.Instant lastModified() {
-            return java.time.Instant.EPOCH;
+            return Instant.EPOCH;
         }
 
         @Override
@@ -532,7 +532,7 @@ public final class StreamingParallelParsingCoordinator {
 
         @Override
         public org.elasticsearch.xpack.esql.datasources.spi.StoragePath path() {
-            return org.elasticsearch.xpack.esql.datasources.spi.StoragePath.of("stream://decompressed");
+            return StoragePath.of("stream://decompressed");
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -126,6 +127,15 @@ public final class StreamingParallelParsingCoordinator {
         private final AtomicReference<Throwable> firstError = new AtomicReference<>();
         private final CountDownLatch allDone;
         private final AtomicInteger chunksDispatched = new AtomicInteger();
+        /**
+         * Bounds the gap between dispatched and consumed chunks. {@link #pageQueues} is indexed by
+         * {@code chunk.index % windowSize}; without this semaphore a fast parser could recycle a
+         * buffer (and a slow segmentator could dispatch a new chunk) before the consumer drained
+         * the previous chunk's slot, interleaving pages from two generations into the same queue.
+         * Acquired by the segmentator before {@link #dispatchChunk}, released by the consumer when
+         * a chunk's POISON has been observed.
+         */
+        private final Semaphore consumerSlots;
 
         private int currentChunk = 0;
         private Page buffered = null;
@@ -154,6 +164,7 @@ public final class StreamingParallelParsingCoordinator {
             }
 
             this.chunkQueue = new ArrayBlockingQueue<>(parallelism);
+            this.consumerSlots = new Semaphore(windowSize);
 
             @SuppressWarnings("unchecked")
             ArrayBlockingQueue<Page>[] queues = new ArrayBlockingQueue[windowSize];
@@ -311,6 +322,17 @@ public final class StreamingParallelParsingCoordinator {
         }
 
         private void dispatchChunk(int index, byte[] buffer, int length, boolean last) {
+            // Wait until the consumer has released a slot — pageQueues are indexed by
+            // chunk.index % windowSize, so dispatching chunk N+windowSize before chunk N's
+            // POISON has been observed would push pages from two generations into the same
+            // queue and break ordering.
+            try {
+                consumerSlots.acquire();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                firstError.compareAndSet(null, e);
+                return;
+            }
             chunksDispatched.incrementAndGet();
             try {
                 chunkQueue.put(new Chunk(index, buffer, length, last));
@@ -500,6 +522,7 @@ public final class StreamingParallelParsingCoordinator {
                 }
                 if (page == POISON) {
                     currentChunk++;
+                    consumerSlots.release();
                     continue;
                 }
                 return page;
@@ -522,6 +545,9 @@ public final class StreamingParallelParsingCoordinator {
                 return;
             }
             closed = true;
+            // Wake the segmentator if it is parked on consumerSlots.acquire(); a stale permit count
+            // is harmless because the segmentator also checks `closed` after acquiring.
+            consumerSlots.release(Integer.MAX_VALUE / 2);
             drainAllQueues();
             try {
                 if (allDone.await(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS) == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -1,0 +1,538 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Coordinates parallel parsing of a sequential (non-seekable) decompressed stream
+ * by chunking it at record boundaries and dispatching each chunk to a parser thread.
+ * <p>
+ * This is the streaming counterpart to {@link ParallelParsingCoordinator}, designed for
+ * stream-only compression codecs (gzip, zstd without seekable frames) where the
+ * decompressed data is only available as a sequential {@link InputStream}.
+ * <p>
+ * Architecture:
+ * <ol>
+ *   <li>A segmentator thread reads the decompressed stream into byte buffers from a pool</li>
+ *   <li>Each buffer is split at the last record boundary (newline) to form a complete chunk</li>
+ *   <li>Chunks are dispatched to parser threads via a bounded queue</li>
+ *   <li>Parser threads parse each chunk independently using the format reader</li>
+ *   <li>Results are yielded in chunk order via per-slot page queues</li>
+ * </ol>
+ */
+public final class StreamingParallelParsingCoordinator {
+
+    private static final Logger logger = LogManager.getLogger(StreamingParallelParsingCoordinator.class);
+
+    private StreamingParallelParsingCoordinator() {}
+
+    /**
+     * Creates a parallel-parsing iterator over a sequential decompressed stream.
+     *
+     * @param reader              the segmentable format reader (provides record boundary semantics)
+     * @param decompressedStream  the sequential decompressed input stream
+     * @param projectedColumns    columns to project
+     * @param batchSize           rows per page
+     * @param parallelism         number of parallel parser threads
+     * @param executor            executor for segmentator and parser threads
+     * @param errorPolicy         error handling policy
+     * @return an iterator that yields pages in chunk order
+     */
+    public static CloseableIterator<Page> parallelRead(
+        SegmentableFormatReader reader,
+        InputStream decompressedStream,
+        List<String> projectedColumns,
+        int batchSize,
+        int parallelism,
+        Executor executor,
+        ErrorPolicy errorPolicy
+    ) throws IOException {
+        ErrorPolicy effectivePolicy = errorPolicy != null ? errorPolicy : ErrorPolicy.STRICT;
+
+        if (parallelism <= 1) {
+            FormatReadContext ctx = FormatReadContext.builder()
+                .projectedColumns(projectedColumns)
+                .batchSize(batchSize)
+                .errorPolicy(effectivePolicy)
+                .build();
+            return reader.read(new InputStreamStorageObject(decompressedStream), ctx);
+        }
+
+        return new StreamingParallelIterator(
+            reader,
+            decompressedStream,
+            projectedColumns,
+            batchSize,
+            parallelism,
+            executor,
+            effectivePolicy
+        );
+    }
+
+    private static final class StreamingParallelIterator implements CloseableIterator<Page> {
+
+        private static final Page POISON = new Page(0);
+        private static final long CLOSE_TIMEOUT_SECONDS = 60;
+
+        private final SegmentableFormatReader reader;
+        private final List<String> projectedColumns;
+        private final int batchSize;
+        private final ErrorPolicy errorPolicy;
+
+        private final ArrayBlockingQueue<byte[]> bufferPool;
+        private final ArrayBlockingQueue<Chunk> chunkQueue;
+        private final int windowSize;
+        private final ArrayBlockingQueue<Page>[] pageQueues;
+
+        private final AtomicReference<Throwable> firstError = new AtomicReference<>();
+        private final CountDownLatch allDone;
+        private final AtomicInteger chunksDispatched = new AtomicInteger();
+
+        private int currentChunk = 0;
+        private Page buffered = null;
+        private volatile boolean closed = false;
+
+        StreamingParallelIterator(
+            SegmentableFormatReader reader,
+            InputStream decompressedStream,
+            List<String> projectedColumns,
+            int batchSize,
+            int parallelism,
+            Executor executor,
+            ErrorPolicy errorPolicy
+        ) {
+            this.reader = reader;
+            this.projectedColumns = projectedColumns;
+            this.batchSize = batchSize;
+            this.errorPolicy = errorPolicy;
+            this.windowSize = parallelism + 1;
+
+            int chunkSize = Math.toIntExact(reader.minimumSegmentSize());
+
+            this.bufferPool = new ArrayBlockingQueue<>(windowSize);
+            for (int i = 0; i < windowSize; i++) {
+                bufferPool.add(new byte[chunkSize]);
+            }
+
+            this.chunkQueue = new ArrayBlockingQueue<>(parallelism);
+
+            @SuppressWarnings("unchecked")
+            ArrayBlockingQueue<Page>[] queues = new ArrayBlockingQueue[windowSize];
+            this.pageQueues = queues;
+            for (int i = 0; i < windowSize; i++) {
+                pageQueues[i] = new ArrayBlockingQueue<>(16);
+            }
+
+            // 1 segmentator + N parsers
+            this.allDone = new CountDownLatch(1 + parallelism);
+
+            try {
+                executor.execute(() -> runSegmentator(decompressedStream, chunkSize));
+            } catch (RejectedExecutionException e) {
+                firstError.compareAndSet(null, e);
+                allDone.countDown();
+            }
+
+            for (int i = 0; i < parallelism; i++) {
+                try {
+                    executor.execute(this::runParser);
+                } catch (RejectedExecutionException e) {
+                    firstError.compareAndSet(null, e);
+                    allDone.countDown();
+                }
+            }
+        }
+
+        private void runSegmentator(InputStream stream, int chunkSize) {
+            byte[] carry = null;
+            int carryLen = 0;
+            int chunkIndex = 0;
+
+            try {
+                while (closed == false && firstError.get() == null) {
+                    byte[] buf;
+                    try {
+                        buf = bufferPool.take();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+
+                    int offset = 0;
+                    if (carry != null) {
+                        System.arraycopy(carry, 0, buf, 0, carryLen);
+                        offset = carryLen;
+                        carry = null;
+                        carryLen = 0;
+                    }
+
+                    int bytesRead = readFromStream(stream, buf, offset, buf.length - offset);
+                    if (bytesRead <= 0 && offset == 0) {
+                        recycleBuffer(buf);
+                        break;
+                    }
+
+                    int totalBytes = offset + Math.max(bytesRead, 0);
+                    boolean isEof = bytesRead < 0 || (offset + bytesRead) < buf.length;
+
+                    int lastNewline = findLastNewline(buf, totalBytes);
+
+                    if (lastNewline < 0) {
+                        if (isEof) {
+                            dispatchChunk(chunkIndex++, buf, totalBytes, true);
+                        } else {
+                            // Single record larger than chunk size — grow a temporary buffer
+                            byte[] grown = growUntilNewline(stream, buf, totalBytes, chunkSize);
+                            int grownNewline = findLastNewline(grown, grown.length);
+                            if (grownNewline < 0) {
+                                dispatchChunk(chunkIndex++, grown, grown.length, true);
+                            } else {
+                                int validLen = grownNewline + 1;
+                                carryLen = grown.length - validLen;
+                                carry = new byte[carryLen];
+                                System.arraycopy(grown, validLen, carry, 0, carryLen);
+                                dispatchChunk(chunkIndex++, grown, validLen, false);
+                            }
+                            // The original buffer was consumed by grow; don't recycle it
+                        }
+                        if (isEof) break;
+                        continue;
+                    }
+
+                    int validLen = isEof ? totalBytes : lastNewline + 1;
+
+                    if (isEof == false && validLen < totalBytes) {
+                        carryLen = totalBytes - validLen;
+                        carry = new byte[carryLen];
+                        System.arraycopy(buf, validLen, carry, 0, carryLen);
+                    }
+
+                    dispatchChunk(chunkIndex++, buf, validLen, isEof);
+                    if (isEof) break;
+                }
+            } catch (Exception e) {
+                firstError.compareAndSet(null, e);
+            } finally {
+                try {
+                    stream.close();
+                } catch (IOException ignored) {}
+
+                // Send poison pills to stop all parser threads
+                int dispatched = chunksDispatched.get();
+                for (int i = 0; i < windowSize; i++) {
+                    try {
+                        chunkQueue.put(Chunk.POISON);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                allDone.countDown();
+            }
+        }
+
+        private void dispatchChunk(int index, byte[] buffer, int length, boolean last) {
+            chunksDispatched.incrementAndGet();
+            try {
+                chunkQueue.put(new Chunk(index, buffer, length, last));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                firstError.compareAndSet(null, e);
+            }
+        }
+
+        private void runParser() {
+            try {
+                while (closed == false && firstError.get() == null) {
+                    Chunk chunk;
+                    try {
+                        chunk = chunkQueue.take();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+
+                    if (chunk == Chunk.POISON) {
+                        break;
+                    }
+
+                    int queueSlot = chunk.index % windowSize;
+                    ArrayBlockingQueue<Page> queue = pageQueues[queueSlot];
+                    try {
+                        ByteArrayStorageObject chunkObj = new ByteArrayStorageObject(
+                            StoragePath.of("mem://chunk-" + chunk.index),
+                            chunk.buffer,
+                            0,
+                            chunk.length
+                        );
+
+                        FormatReadContext ctx = FormatReadContext.builder()
+                            .projectedColumns(projectedColumns)
+                            .batchSize(batchSize)
+                            .errorPolicy(errorPolicy)
+                            .firstSplit(true)
+                            .lastSplit(chunk.last)
+                            .build();
+
+                        try (CloseableIterator<Page> pages = reader.read(chunkObj, ctx)) {
+                            while (pages.hasNext()) {
+                                if (firstError.get() != null || closed) {
+                                    break;
+                                }
+                                queue.put(pages.next());
+                            }
+                        }
+                    } catch (Exception e) {
+                        firstError.compareAndSet(null, e);
+                    } finally {
+                        recycleBuffer(chunk.buffer);
+                        enqueuePoison(queue);
+                    }
+                }
+            } finally {
+                allDone.countDown();
+            }
+        }
+
+        private void recycleBuffer(byte[] buf) {
+            // Only recycle buffers that match the pool's buffer size
+            if (bufferPool.remainingCapacity() > 0) {
+                bufferPool.offer(buf);
+            }
+        }
+
+        private static int readFromStream(InputStream stream, byte[] buf, int offset, int length) throws IOException {
+            int totalRead = 0;
+            while (totalRead < length) {
+                int n = stream.read(buf, offset + totalRead, length - totalRead);
+                if (n < 0) {
+                    return totalRead == 0 ? -1 : totalRead;
+                }
+                totalRead += n;
+            }
+            return totalRead;
+        }
+
+        private static int findLastNewline(byte[] buf, int length) {
+            for (int i = length - 1; i >= 0; i--) {
+                if (buf[i] == '\n') {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        private static byte[] growUntilNewline(InputStream stream, byte[] existing, int existingLen, int growBy) throws IOException {
+            byte[] grown = new byte[existingLen + growBy];
+            System.arraycopy(existing, 0, grown, 0, existingLen);
+
+            int offset = existingLen;
+            while (true) {
+                int n = stream.read(grown, offset, grown.length - offset);
+                if (n < 0) {
+                    if (offset == existingLen) {
+                        return java.util.Arrays.copyOf(existing, existingLen);
+                    }
+                    return java.util.Arrays.copyOf(grown, offset);
+                }
+                // Check for newline in the newly read bytes
+                for (int i = offset; i < offset + n; i++) {
+                    if (grown[i] == '\n') {
+                        return java.util.Arrays.copyOf(grown, offset + n);
+                    }
+                }
+                offset += n;
+                if (offset >= grown.length) {
+                    grown = java.util.Arrays.copyOf(grown, grown.length + growBy);
+                }
+            }
+        }
+
+        private static void enqueuePoison(ArrayBlockingQueue<Page> queue) {
+            boolean poisoned = false;
+            while (poisoned == false) {
+                try {
+                    queue.put(POISON);
+                    poisoned = true;
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (closed) {
+                return false;
+            }
+            if (buffered != null) {
+                return true;
+            }
+            try {
+                buffered = takeNextPage();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for streaming parallel parse results", e);
+            }
+            return buffered != null;
+        }
+
+        @Override
+        public Page next() {
+            if (hasNext() == false) {
+                throw new java.util.NoSuchElementException();
+            }
+            Page result = buffered;
+            buffered = null;
+            return result;
+        }
+
+        private Page takeNextPage() throws InterruptedException {
+            int totalDispatched = chunksDispatched.get();
+            while (currentChunk < totalDispatched || firstError.get() == null) {
+                checkError();
+
+                if (currentChunk >= chunksDispatched.get()) {
+                    // Segmentator hasn't dispatched more chunks yet; briefly wait
+                    if (allDone.await(10, TimeUnit.MILLISECONDS)) {
+                        // All threads done; check if more chunks were dispatched
+                        if (currentChunk >= chunksDispatched.get()) {
+                            checkError();
+                            return null;
+                        }
+                    }
+                    continue;
+                }
+
+                int slot = currentChunk % windowSize;
+                ArrayBlockingQueue<Page> queue = pageQueues[slot];
+                Page page = queue.poll(100, TimeUnit.MILLISECONDS);
+
+                if (page == null) {
+                    continue;
+                }
+                if (page == POISON) {
+                    currentChunk++;
+                    continue;
+                }
+                return page;
+            }
+            checkError();
+            return null;
+        }
+
+        private void checkError() {
+            Throwable t = firstError.get();
+            if (t != null) {
+                if (t instanceof RuntimeException re) {
+                    throw re;
+                }
+                throw new RuntimeException("Streaming parallel parsing failed", t);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            drainAllQueues();
+            try {
+                if (allDone.await(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS) == false) {
+                    logger.warn("Timed out waiting for streaming parallel parsing threads to finish after [{}]s", CLOSE_TIMEOUT_SECONDS);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            drainAllQueues();
+        }
+
+        private void drainAllQueues() {
+            // Drain chunk queue
+            Chunk chunk;
+            while ((chunk = chunkQueue.poll()) != null) {
+                if (chunk != Chunk.POISON) {
+                    recycleBuffer(chunk.buffer);
+                }
+            }
+            // Drain page queues
+            for (ArrayBlockingQueue<Page> queue : pageQueues) {
+                Page p;
+                while ((p = queue.poll()) != null) {
+                    if (p != POISON && p.getPositionCount() > 0) {
+                        p.releaseBlocks();
+                    }
+                }
+            }
+        }
+    }
+
+    private record Chunk(int index, byte[] buffer, int length, boolean last) {
+        static final Chunk POISON = new Chunk(-1, new byte[0], 0, true);
+    }
+
+    /**
+     * Minimal StorageObject wrapping an InputStream for the parallelism=1 fallback path.
+     */
+    private static final class InputStreamStorageObject implements org.elasticsearch.xpack.esql.datasources.spi.StorageObject {
+        private final InputStream stream;
+
+        InputStreamStorageObject(InputStream stream) {
+            this.stream = stream;
+        }
+
+        @Override
+        public InputStream newStream() {
+            return stream;
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            throw new UnsupportedOperationException("Streaming storage object does not support random access");
+        }
+
+        @Override
+        public long length() {
+            throw new UnsupportedOperationException("Streaming storage object has unknown length");
+        }
+
+        @Override
+        public java.time.Instant lastModified() {
+            return java.time.Instant.EPOCH;
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public org.elasticsearch.xpack.esql.datasources.spi.StoragePath path() {
+            return org.elasticsearch.xpack.esql.datasources.spi.StoragePath.of("stream://decompressed");
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -345,12 +345,22 @@ public final class StreamingParallelParsingCoordinator {
                             chunk.length
                         );
 
+                        // Both record-boundary flags are true for every chunk:
+                        // - firstSplit: the segmentator slices on \n carry-over, so each chunk
+                        // starts on a complete record; no leading partial line to skip.
+                        // - lastSplit: the segmentator only dispatches a chunk after locating its
+                        // trailing \n via findLastNewline (or grows the buffer until one is found),
+                        // so the chunk's final byte is always a record terminator. The original
+                        // chunk.last flag was set only on the EOF chunk, leaving every interior
+                        // chunk wrapped in TrimLastPartialLineInputStream's per-byte tail scan —
+                        // pure overhead on already-aligned data. Setting lastSplit=true everywhere
+                        // lets line-oriented readers (NDJSON) skip that scan.
                         FormatReadContext ctx = FormatReadContext.builder()
                             .projectedColumns(projectedColumns)
                             .batchSize(batchSize)
                             .errorPolicy(errorPolicy)
                             .firstSplit(true)
-                            .lastSplit(chunk.last)
+                            .lastSplit(true)
                             .build();
 
                         try (CloseableIterator<Page> pages = reader.read(chunkObj, ctx)) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -257,8 +258,12 @@ public final class StreamingParallelParsingCoordinator {
                                 break;
                             }
                         } else {
-                            // Single record larger than chunk size — grow a temporary buffer
+                            // Single record larger than chunk size — grow a temporary buffer.
+                            // {@link #growUntilNewline} only copies from {@code buf}; the original pool buffer
+                            // is independent of {@code grown} and must be returned to the pool here so the
+                            // pool does not leak one entry per oversized record.
                             byte[] grown = growUntilNewline(stream, buf, totalBytes, chunkSize);
+                            recycleBuffer(buf);
                             int grownNewline = findLastNewline(grown, grown.length);
                             if (grownNewline < 0) {
                                 if (chunkIndex == 0) {
@@ -267,7 +272,6 @@ public final class StreamingParallelParsingCoordinator {
                                 if (dispatchChunk(chunkIndex, grown, grown.length, true)) {
                                     chunkIndex++;
                                 } else {
-                                    recycleBuffer(buf);
                                     recycleBuffer(grown);
                                     break;
                                 }
@@ -282,12 +286,10 @@ public final class StreamingParallelParsingCoordinator {
                                 if (dispatchChunk(chunkIndex, grown, validLen, false)) {
                                     chunkIndex++;
                                 } else {
-                                    recycleBuffer(buf);
                                     recycleBuffer(grown);
                                     break;
                                 }
                             }
-                            // The original buffer was consumed by grow; don't recycle it
                         }
                         if (isEof) break;
                         continue;
@@ -599,6 +601,24 @@ public final class StreamingParallelParsingCoordinator {
             return dispatchPermits.hasQueuedThreads();
         }
 
+        /**
+         * Two-phase shutdown sequenced to drain pages a parser thread may publish after the first drain
+         * but before {@link #allDone} fires.
+         * <p>
+         * Phase 1: set {@code closed=true} (causes parser threads to exit their inner loop and the
+         * segmentator to bail on its next post-acquire check), wake any segmentator parked on
+         * {@link #dispatchPermits}, and drain whatever is already queued.
+         * <p>
+         * Phase 2: wait up to {@link #CLOSE_TIMEOUT_SECONDS} for {@link #allDone}, then drain again
+         * to catch pages a parser put into a queue between the first drain and the latch fire.
+         * <p>
+         * <strong>Timeout contract:</strong> if {@code allDone.await} times out we log a warning and
+         * run the second drain anyway, but parser threads may still be alive at return time. Any pages
+         * they publish after that — and any blocks those pages reference — are leaked. We do not
+         * interrupt the parser executor: it is shared (typically {@code esql_worker}) and an interrupt
+         * could disrupt unrelated tasks. The timeout is intentionally generous (60s) to make the leak
+         * window an exceptional condition; production workloads should not hit it under normal pressure.
+         */
         @Override
         public void close() throws IOException {
             if (closed) {
@@ -611,7 +631,11 @@ public final class StreamingParallelParsingCoordinator {
             drainAllQueues();
             try {
                 if (allDone.await(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS) == false) {
-                    logger.warn("Timed out waiting for streaming parallel parsing threads to finish after [{}]s", CLOSE_TIMEOUT_SECONDS);
+                    logger.warn(
+                        "Timed out waiting for streaming parallel parsing threads to finish after [{}]s; "
+                            + "any pages published by still-running parsers after this point will leak their blocks",
+                        CLOSE_TIMEOUT_SECONDS
+                    );
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -645,9 +669,16 @@ public final class StreamingParallelParsingCoordinator {
 
     /**
      * Minimal StorageObject wrapping an InputStream for the parallelism=1 fallback path.
+     * <p>
+     * <strong>Single-use:</strong> the wrapped stream is sequential and cannot be re-opened, so
+     * {@link #newStream()} hands out the same underlying stream exactly once. Callers that need
+     * to consume the stream twice (e.g. metadata inference followed by a separate read pass)
+     * must buffer the data themselves; the production path here calls {@code newStream()} only
+     * once via {@code reader.read(...)}.
      */
     private static final class InputStreamStorageObject implements StorageObject {
         private final InputStream stream;
+        private final AtomicBoolean handedOut = new AtomicBoolean(false);
 
         InputStreamStorageObject(InputStream stream) {
             this.stream = stream;
@@ -655,6 +686,11 @@ public final class StreamingParallelParsingCoordinator {
 
         @Override
         public InputStream newStream() {
+            if (handedOut.compareAndSet(false, true) == false) {
+                throw new IllegalStateException(
+                    "InputStreamStorageObject is single-use; the wrapped sequential stream cannot be re-opened"
+                );
+            }
             return stream;
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -11,9 +11,12 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
@@ -102,7 +105,14 @@ public final class StreamingParallelParsingCoordinator {
         private static final Page POISON = new Page(0);
         private static final long CLOSE_TIMEOUT_SECONDS = 60;
 
-        private final SegmentableFormatReader reader;
+        /**
+         * The reader used by parser threads. Initially the caller-supplied reader; the segmentator
+         * thread replaces it with a schema-bound variant after inferring the schema from the first
+         * chunk (see {@link #runSegmentator}). The replacement happens-before the first chunk is
+         * dispatched (via the {@link ArrayBlockingQueue} synchronization on {@link #chunkQueue}),
+         * so parser threads always observe the schema-bound reader by the time they pick up work.
+         */
+        private volatile SegmentableFormatReader reader;
         private final List<String> projectedColumns;
         private final int batchSize;
         private final ErrorPolicy errorPolicy;
@@ -208,18 +218,27 @@ public final class StreamingParallelParsingCoordinator {
 
                     if (lastNewline < 0) {
                         if (isEof) {
+                            if (chunkIndex == 0) {
+                                bindSchemaFromFirstChunk(buf, totalBytes);
+                            }
                             dispatchChunk(chunkIndex++, buf, totalBytes, true);
                         } else {
                             // Single record larger than chunk size — grow a temporary buffer
                             byte[] grown = growUntilNewline(stream, buf, totalBytes, chunkSize);
                             int grownNewline = findLastNewline(grown, grown.length);
                             if (grownNewline < 0) {
+                                if (chunkIndex == 0) {
+                                    bindSchemaFromFirstChunk(grown, grown.length);
+                                }
                                 dispatchChunk(chunkIndex++, grown, grown.length, true);
                             } else {
                                 int validLen = grownNewline + 1;
                                 carryLen = grown.length - validLen;
                                 carry = new byte[carryLen];
                                 System.arraycopy(grown, validLen, carry, 0, carryLen);
+                                if (chunkIndex == 0) {
+                                    bindSchemaFromFirstChunk(grown, validLen);
+                                }
                                 dispatchChunk(chunkIndex++, grown, validLen, false);
                             }
                             // The original buffer was consumed by grow; don't recycle it
@@ -236,6 +255,9 @@ public final class StreamingParallelParsingCoordinator {
                         System.arraycopy(buf, validLen, carry, 0, carryLen);
                     }
 
+                    if (chunkIndex == 0) {
+                        bindSchemaFromFirstChunk(buf, validLen);
+                    }
                     dispatchChunk(chunkIndex++, buf, validLen, isEof);
                     if (isEof) break;
                 }
@@ -255,6 +277,36 @@ public final class StreamingParallelParsingCoordinator {
                     }
                 }
                 allDone.countDown();
+            }
+        }
+
+        /**
+         * Infers the schema from the first chunk and swaps {@link #reader} for the schema-bound
+         * variant returned by {@link FormatReader#withSchema(List)}; parser threads thereafter
+         * skip per-chunk inference. Same approach as ClickHouse / DuckDB / Spark.
+         */
+        private void bindSchemaFromFirstChunk(byte[] buffer, int length) throws IOException {
+            ByteArrayStorageObject firstChunkObj = new ByteArrayStorageObject(
+                StoragePath.of("mem://chunk-schema-probe"),
+                buffer,
+                0,
+                length
+            );
+            SourceMetadata metadata = reader.metadata(firstChunkObj);
+            List<Attribute> schema = metadata == null ? null : metadata.schema();
+            if (schema == null) {
+                return;
+            }
+            FormatReader bound = reader.withSchema(schema);
+            if (bound == reader) {
+                return;
+            }
+            if (bound instanceof SegmentableFormatReader segBound) {
+                this.reader = segBound;
+            } else {
+                throw new IllegalStateException(
+                    "FormatReader#withSchema returned a non-SegmentableFormatReader: " + bound.getClass().getName()
+                );
             }
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -51,6 +51,16 @@ import java.util.concurrent.atomic.AtomicReference;
  *   <li>Parser threads parse each chunk independently using the format reader</li>
  *   <li>Results are yielded in chunk order via per-slot page queues</li>
  * </ol>
+ * <p>
+ * Shutdown blocking sites: when the iterator's {@code close()} is invoked the segmentator may
+ * be parked on (a) the upstream {@link InputStream#read(byte[], int, int)}, (b) {@code bufferPool.take()},
+ * (c) {@code chunkQueue.put()}, or (d) {@code dispatchPermits.acquire()}. Close sets
+ * {@code closed=true}, releases one permit on {@code dispatchPermits} (covers (d)), and drains
+ * both the chunk queue and page queues (covers (b) and (c) by freeing slots so {@code put}/{@code take}
+ * either succeeds or completes after the post-acquire {@code closed} re-check). Case (a) is the
+ * responsibility of the upstream stream wrapper — most stream-only codecs return on close; if the
+ * upstream blocks indefinitely on read, close will time out after the iterator's close-timeout and
+ * log a warning.
  */
 public final class StreamingParallelParsingCoordinator {
 
@@ -101,7 +111,9 @@ public final class StreamingParallelParsingCoordinator {
         );
     }
 
-    private static final class StreamingParallelIterator implements CloseableIterator<Page> {
+    // Package-private so close-path tests can assert on segmentator wait state via
+    // isSegmentatorParkedOnDispatchPermits(); production callers see only CloseableIterator<Page>.
+    static final class StreamingParallelIterator implements CloseableIterator<Page> {
 
         private static final Page POISON = new Page(0);
         private static final long CLOSE_TIMEOUT_SECONDS = 60;
@@ -116,11 +128,15 @@ public final class StreamingParallelParsingCoordinator {
         private volatile SegmentableFormatReader reader;
         private final List<String> projectedColumns;
         private final int batchSize;
+        private final int parallelism;
         private final ErrorPolicy errorPolicy;
 
         private final ArrayBlockingQueue<byte[]> bufferPool;
         private final ArrayBlockingQueue<Chunk> chunkQueue;
-        private final int windowSize;
+        /** Capacity of {@link #bufferPool} (one pooled buffer per possible in-flight chunk-sized slice). */
+        private final int bufferPoolSize;
+        /** Length of {@link #pageQueues}; must match {@link #bufferPoolSize} so chunk index modulo never collides. */
+        private final int pageQueueRingSize;
         private final int chunkSize;
         private final ArrayBlockingQueue<Page>[] pageQueues;
 
@@ -128,14 +144,14 @@ public final class StreamingParallelParsingCoordinator {
         private final CountDownLatch allDone;
         private final AtomicInteger chunksDispatched = new AtomicInteger();
         /**
-         * Bounds the gap between dispatched and consumed chunks. {@link #pageQueues} is indexed by
-         * {@code chunk.index % windowSize}; without this semaphore a fast parser could recycle a
-         * buffer (and a slow segmentator could dispatch a new chunk) before the consumer drained
-         * the previous chunk's slot, interleaving pages from two generations into the same queue.
-         * Acquired by the segmentator before {@link #dispatchChunk}, released by the consumer when
-         * a chunk's POISON has been observed.
+         * Bounds how far ahead of the consumer the segmentator may dispatch. {@link #pageQueues} is
+         * indexed by {@code chunk.index % pageQueueRingSize}; without this semaphore a fast parser
+         * could recycle a buffer (and the segmentator could dispatch a new chunk) before the consumer
+         * drained the previous chunk's slot, interleaving pages from two generations into the same queue.
+         * Acquired by the segmentator in {@link #dispatchChunk}; released by the consumer when a chunk's
+         * POISON has been observed.
          */
-        private final Semaphore consumerSlots;
+        private final Semaphore dispatchPermits;
 
         private int currentChunk = 0;
         private Page buffered = null;
@@ -153,23 +169,25 @@ public final class StreamingParallelParsingCoordinator {
             this.reader = reader;
             this.projectedColumns = projectedColumns;
             this.batchSize = batchSize;
+            this.parallelism = parallelism;
             this.errorPolicy = errorPolicy;
-            this.windowSize = parallelism + 1;
+            this.bufferPoolSize = parallelism + 1;
+            this.pageQueueRingSize = parallelism + 1;
 
             this.chunkSize = Math.toIntExact(reader.minimumSegmentSize());
 
-            this.bufferPool = new ArrayBlockingQueue<>(windowSize);
-            for (int i = 0; i < windowSize; i++) {
+            this.bufferPool = new ArrayBlockingQueue<>(bufferPoolSize);
+            for (int i = 0; i < bufferPoolSize; i++) {
                 bufferPool.add(new byte[chunkSize]);
             }
 
             this.chunkQueue = new ArrayBlockingQueue<>(parallelism);
-            this.consumerSlots = new Semaphore(windowSize);
+            this.dispatchPermits = new Semaphore(pageQueueRingSize);
 
             @SuppressWarnings("unchecked")
-            ArrayBlockingQueue<Page>[] queues = new ArrayBlockingQueue[windowSize];
+            ArrayBlockingQueue<Page>[] queues = new ArrayBlockingQueue[pageQueueRingSize];
             this.pageQueues = queues;
-            for (int i = 0; i < windowSize; i++) {
+            for (int i = 0; i < pageQueueRingSize; i++) {
                 pageQueues[i] = new ArrayBlockingQueue<>(16);
             }
 
@@ -232,7 +250,12 @@ public final class StreamingParallelParsingCoordinator {
                             if (chunkIndex == 0) {
                                 bindSchemaFromFirstChunk(buf, totalBytes);
                             }
-                            dispatchChunk(chunkIndex++, buf, totalBytes, true);
+                            if (dispatchChunk(chunkIndex, buf, totalBytes, true)) {
+                                chunkIndex++;
+                            } else {
+                                recycleBuffer(buf);
+                                break;
+                            }
                         } else {
                             // Single record larger than chunk size — grow a temporary buffer
                             byte[] grown = growUntilNewline(stream, buf, totalBytes, chunkSize);
@@ -241,7 +264,13 @@ public final class StreamingParallelParsingCoordinator {
                                 if (chunkIndex == 0) {
                                     bindSchemaFromFirstChunk(grown, grown.length);
                                 }
-                                dispatchChunk(chunkIndex++, grown, grown.length, true);
+                                if (dispatchChunk(chunkIndex, grown, grown.length, true)) {
+                                    chunkIndex++;
+                                } else {
+                                    recycleBuffer(buf);
+                                    recycleBuffer(grown);
+                                    break;
+                                }
                             } else {
                                 int validLen = grownNewline + 1;
                                 carryLen = grown.length - validLen;
@@ -250,7 +279,13 @@ public final class StreamingParallelParsingCoordinator {
                                 if (chunkIndex == 0) {
                                     bindSchemaFromFirstChunk(grown, validLen);
                                 }
-                                dispatchChunk(chunkIndex++, grown, validLen, false);
+                                if (dispatchChunk(chunkIndex, grown, validLen, false)) {
+                                    chunkIndex++;
+                                } else {
+                                    recycleBuffer(buf);
+                                    recycleBuffer(grown);
+                                    break;
+                                }
                             }
                             // The original buffer was consumed by grow; don't recycle it
                         }
@@ -269,8 +304,13 @@ public final class StreamingParallelParsingCoordinator {
                     if (chunkIndex == 0) {
                         bindSchemaFromFirstChunk(buf, validLen);
                     }
-                    dispatchChunk(chunkIndex++, buf, validLen, isEof);
-                    if (isEof) break;
+                    if (dispatchChunk(chunkIndex, buf, validLen, isEof)) {
+                        chunkIndex++;
+                        if (isEof) break;
+                    } else {
+                        recycleBuffer(buf);
+                        break;
+                    }
                 }
             } catch (Exception e) {
                 firstError.compareAndSet(null, e);
@@ -279,7 +319,7 @@ public final class StreamingParallelParsingCoordinator {
                     stream.close();
                 } catch (IOException ignored) {}
 
-                int parserCount = windowSize - 1;
+                int parserCount = parallelism;
                 for (int i = 0; i < parserCount; i++) {
                     try {
                         chunkQueue.put(Chunk.POISON);
@@ -321,25 +361,36 @@ public final class StreamingParallelParsingCoordinator {
             }
         }
 
-        private void dispatchChunk(int index, byte[] buffer, int length, boolean last) {
-            // Wait until the consumer has released a slot — pageQueues are indexed by
-            // chunk.index % windowSize, so dispatching chunk N+windowSize before chunk N's
-            // POISON has been observed would push pages from two generations into the same
-            // queue and break ordering.
+        /**
+         * Waits for {@link #dispatchPermits}, then enqueues a chunk for parsers unless the coordinator
+         * is closed or the calling thread is interrupted.
+         *
+         * @return {@code true} if the chunk was queued; {@code false} if dispatch aborted. On {@code false},
+         *         {@link #chunksDispatched} is unchanged and the caller must {@link #recycleBuffer(byte[])}
+         *         when {@code buffer} is pool-sized (oversized temporary buffers are simply dropped).
+         */
+        private boolean dispatchChunk(int index, byte[] buffer, int length, boolean last) {
             try {
-                consumerSlots.acquire();
+                dispatchPermits.acquire();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 firstError.compareAndSet(null, e);
-                return;
+                return false;
             }
-            chunksDispatched.incrementAndGet();
+            if (closed) {
+                dispatchPermits.release();
+                return false;
+            }
             try {
                 chunkQueue.put(new Chunk(index, buffer, length, last));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 firstError.compareAndSet(null, e);
+                dispatchPermits.release();
+                return false;
             }
+            chunksDispatched.incrementAndGet();
+            return true;
         }
 
         private void runParser() {
@@ -357,7 +408,7 @@ public final class StreamingParallelParsingCoordinator {
                         break;
                     }
 
-                    int queueSlot = chunk.index % windowSize;
+                    int queueSlot = chunk.index % pageQueueRingSize;
                     ArrayBlockingQueue<Page> queue = pageQueues[queueSlot];
                     try {
                         ByteArrayStorageObject chunkObj = new ByteArrayStorageObject(
@@ -513,7 +564,7 @@ public final class StreamingParallelParsingCoordinator {
                     continue;
                 }
 
-                int slot = currentChunk % windowSize;
+                int slot = currentChunk % pageQueueRingSize;
                 ArrayBlockingQueue<Page> queue = pageQueues[slot];
                 Page page = queue.poll(100, TimeUnit.MILLISECONDS);
 
@@ -522,7 +573,7 @@ public final class StreamingParallelParsingCoordinator {
                 }
                 if (page == POISON) {
                     currentChunk++;
-                    consumerSlots.release();
+                    dispatchPermits.release();
                     continue;
                 }
                 return page;
@@ -539,15 +590,24 @@ public final class StreamingParallelParsingCoordinator {
             }
         }
 
+        /**
+         * Test-only accessor: returns {@code true} when at least one thread is parked on
+         * {@link #dispatchPermits}. Used by close-path tests to deterministically wait for the
+         * segmentator to reach the permit-acquire blocking site instead of relying on wall-clock sleeps.
+         */
+        boolean isSegmentatorParkedOnDispatchPermits() {
+            return dispatchPermits.hasQueuedThreads();
+        }
+
         @Override
         public void close() throws IOException {
             if (closed) {
                 return;
             }
             closed = true;
-            // Wake the segmentator if it is parked on consumerSlots.acquire(); a stale permit count
-            // is harmless because the segmentator also checks `closed` after acquiring.
-            consumerSlots.release(Integer.MAX_VALUE / 2);
+            // Wake the segmentator if parked on dispatchPermits.acquire(); after a successful acquire it
+            // re-checks {@code closed} and exits {@link #dispatchChunk} without enqueueing.
+            dispatchPermits.release();
             drainAllQueues();
             try {
                 if (allDone.await(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS) == false) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -24,19 +24,25 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasource.gzip.GzipDecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.glob.GlobExpander;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.ExternalSplit;
 import org.elasticsearch.xpack.esql.datasources.spi.FileList;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.SplittableDecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageProvider;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +55,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.GZIPOutputStream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -2284,6 +2291,222 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
                 assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
             }
         }
+    }
+
+    public void testDescribeSplittableCompressedUsesSyncWrapperMode() throws IOException {
+        SegmentableFormatReader inner = mockInnerForParallelDescribeAndOpen();
+        CompressionDelegatingFormatReader cdr = new CompressionDelegatingFormatReader(inner, new StubSplittableCodec());
+        AsyncExternalSourceOperatorFactory factory = factoryForCompressionDescribeTests(cdr, 4);
+        String description = factory.describe();
+        assertTrue("describe should mention sync-wrapper: " + description, description.contains("sync-wrapper"));
+    }
+
+    public void testDescribeGzipCompressedUsesStreamingParallelParseInDescription() throws IOException {
+        SegmentableFormatReader inner = mockInnerForParallelDescribeAndOpen();
+        CompressionDelegatingFormatReader cdr = new CompressionDelegatingFormatReader(inner, new GzipDecompressionCodec());
+        AsyncExternalSourceOperatorFactory factory = factoryForCompressionDescribeTests(cdr, 4);
+        String description = factory.describe();
+        assertTrue("describe should mention streaming parallel parse: " + description, description.contains("streaming-parallel-parse(4)"));
+    }
+
+    public void testOpenWithParallelismSplittableCompressedReturnsNull() throws IOException {
+        AsyncExternalSourceOperatorFactory factory = factoryForCompressionDescribeTests(dummyFormatReaderForOpenParallelismTests(), 4);
+
+        SegmentableFormatReader inner = mockInnerForParallelDescribeAndOpen();
+        CompressionDelegatingFormatReader cdr = new CompressionDelegatingFormatReader(inner, new StubSplittableCodec());
+        byte[] payload = "{\"a\":1}\n".repeat(20).getBytes(StandardCharsets.UTF_8);
+        assertNull(factory.openWithParallelism(cdr, bytesStorageObject(payload), List.of("a"), ErrorPolicy.STRICT));
+    }
+
+    public void testOpenWithParallelismGzipCompressedReturnsIterator() throws IOException {
+        ExecutorService exec = Executors.newFixedThreadPool(8);
+        try {
+            AsyncExternalSourceOperatorFactory factory = factoryForOpenParallelismStreamingTests(
+                dummyFormatReaderForOpenParallelismTests(),
+                exec
+            );
+            SegmentableFormatReader inner = mockInnerForParallelDescribeAndOpen();
+            CompressionDelegatingFormatReader cdr = new CompressionDelegatingFormatReader(inner, new GzipDecompressionCodec());
+            byte[] plain = "{\"a\":1}\n".repeat(100).getBytes(StandardCharsets.UTF_8);
+            byte[] gzipped = gzipCompress(plain);
+
+            CloseableIterator<Page> iterator = factory.openWithParallelism(
+                cdr,
+                bytesStorageObject(gzipped),
+                List.of("a"),
+                ErrorPolicy.STRICT
+            );
+            assertNotNull(iterator);
+            iterator.close();
+        } finally {
+            exec.shutdownNow();
+        }
+    }
+
+    public void testOpenWithParallelismBareSegmentableReturnsIterator() throws IOException {
+        ExecutorService exec = Executors.newFixedThreadPool(8);
+        try {
+            AsyncExternalSourceOperatorFactory factory = factoryForOpenParallelismStreamingTests(
+                dummyFormatReaderForOpenParallelismTests(),
+                exec
+            );
+
+            SegmentableFormatReader inner = mockInnerForParallelDescribeAndOpen();
+            byte[] plain = "{\"a\":1}\n".repeat(100).getBytes(StandardCharsets.UTF_8);
+            CloseableIterator<Page> iterator = factory.openWithParallelism(
+                inner,
+                bytesStorageObject(plain),
+                List.of("a"),
+                ErrorPolicy.STRICT
+            );
+            assertNotNull(iterator);
+            iterator.close();
+        } finally {
+            exec.shutdownNow();
+        }
+    }
+
+    /**
+     * Minimal splittable codec stub so dispatch tests avoid wiring real bzip2 parallel scanners.
+     */
+    private static final class StubSplittableCodec implements SplittableDecompressionCodec {
+        @Override
+        public String name() {
+            return "stub-splittable";
+        }
+
+        @Override
+        public List<String> extensions() {
+            return List.of(".stub");
+        }
+
+        @Override
+        public InputStream decompress(InputStream raw) {
+            return raw;
+        }
+
+        @Override
+        public long[] findBlockBoundaries(StorageObject object, long start, long end) throws IOException {
+            return new long[0];
+        }
+
+        @Override
+        public InputStream decompressRange(StorageObject object, long blockStart, long nextBlockStart) throws IOException {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+    }
+
+    private static SegmentableFormatReader mockInnerForParallelDescribeAndOpen() throws IOException {
+        SegmentableFormatReader inner = mock(SegmentableFormatReader.class);
+        when(inner.minimumSegmentSize()).thenReturn(1024L);
+        when(inner.formatName()).thenReturn("ndjson");
+        when(inner.supportsNativeAsync()).thenReturn(false);
+        when(inner.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+        when(inner.metadata(any())).thenReturn(null);
+        when(inner.read(any(), any())).thenReturn(emptyPageIterator());
+        return inner;
+    }
+
+    private static FormatReader dummyFormatReaderForOpenParallelismTests() {
+        FormatReader dummyReader = mock(FormatReader.class);
+        when(dummyReader.formatName()).thenReturn("dummy");
+        when(dummyReader.supportsNativeAsync()).thenReturn(false);
+        when(dummyReader.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
+        return dummyReader;
+    }
+
+    private static CloseableIterator<Page> emptyPageIterator() {
+        return new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public Page next() {
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public void close() {}
+        };
+    }
+
+    private static AsyncExternalSourceOperatorFactory factoryForCompressionDescribeTests(FormatReader formatReader, int parallelism) {
+        StorageProvider storageProvider = mock(StorageProvider.class);
+        StoragePath path = StoragePath.of("file:///data/stream.ndjson.gz");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "col1",
+                new EsField("col1", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+        return AsyncExternalSourceOperatorFactory.builder(storageProvider, formatReader, path, attributes, 500, 10, Runnable::run)
+            .rowLimit(FormatReader.NO_LIMIT)
+            .parsingParallelism(parallelism)
+            .build();
+    }
+
+    private static AsyncExternalSourceOperatorFactory factoryForOpenParallelismStreamingTests(
+        FormatReader formatReader,
+        Executor executor
+    ) {
+        StorageProvider storageProvider = mock(StorageProvider.class);
+        StoragePath path = StoragePath.of("file:///data/stream.ndjson.gz");
+        List<Attribute> attributes = List.of(
+            new FieldAttribute(
+                Source.EMPTY,
+                "col1",
+                new EsField("col1", DataType.INTEGER, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+            )
+        );
+        return AsyncExternalSourceOperatorFactory.builder(storageProvider, formatReader, path, attributes, 500, 10, executor)
+            .rowLimit(FormatReader.NO_LIMIT)
+            .parsingParallelism(4)
+            .build();
+    }
+
+    private static StorageObject bytesStorageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.EPOCH;
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("mem:///parallelism-open-test");
+            }
+        };
+    }
+
+    private static byte[] gzipCompress(byte[] uncompressed) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gz = new GZIPOutputStream(bos)) {
+            gz.write(uncompressed);
+        }
+        return bos.toByteArray();
     }
 
     /**

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObjectTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+public class ByteArrayStorageObjectTests extends ESTestCase {
+
+    public void testNewStreamReadsFullContent() throws IOException {
+        byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), data, 0, data.length);
+
+        try (InputStream stream = obj.newStream()) {
+            assertEquals("hello world", new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    public void testNewStreamWithOffset() throws IOException {
+        byte[] data = "XXXhelloXXX".getBytes(StandardCharsets.UTF_8);
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), data, 3, 5);
+
+        try (InputStream stream = obj.newStream()) {
+            assertEquals("hello", new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    public void testNewStreamRange() throws IOException {
+        byte[] data = "abcdefghij".getBytes(StandardCharsets.UTF_8);
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), data, 0, data.length);
+
+        try (InputStream stream = obj.newStream(3, 4)) {
+            assertEquals("defg", new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+
+    public void testLength() throws IOException {
+        byte[] data = new byte[42];
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), data, 10, 20);
+        assertEquals(20, obj.length());
+    }
+
+    public void testReadBytesIntoHeapBuffer() throws IOException {
+        byte[] data = "abcdef".getBytes(StandardCharsets.UTF_8);
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), data, 0, data.length);
+
+        ByteBuffer buf = ByteBuffer.allocate(3);
+        int read = obj.readBytes(2, buf);
+        assertEquals(3, read);
+        buf.flip();
+        byte[] result = new byte[3];
+        buf.get(result);
+        assertEquals("cde", new String(result, StandardCharsets.UTF_8));
+    }
+
+    public void testReadBytesPastEnd() throws IOException {
+        byte[] data = "abc".getBytes(StandardCharsets.UTF_8);
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), data, 0, data.length);
+
+        assertEquals(-1, obj.readBytes(3, ByteBuffer.allocate(1)));
+    }
+
+    public void testExists() throws IOException {
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), new byte[0], 0, 0);
+        assertTrue(obj.exists());
+    }
+
+    public void testPath() {
+        StoragePath path = StoragePath.of("mem://test/file.ndjson");
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(path, new byte[0], 0, 0);
+        assertEquals(path, obj.path());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObjectTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ByteArrayStorageObjectTests.java
@@ -80,4 +80,33 @@ public class ByteArrayStorageObjectTests extends ESTestCase {
         ByteArrayStorageObject obj = new ByteArrayStorageObject(path, new byte[0], 0, 0);
         assertEquals(path, obj.path());
     }
+
+    public void testConstructorRejectsOverflowingOffsetPlusLength() {
+        // offset + length silently wrapped to negative before the addExact guard, so the < data.length
+        // check passed and a downstream read could touch arbitrary bytes.
+        byte[] data = new byte[16];
+        IllegalArgumentException ex = expectThrows(
+            IllegalArgumentException.class,
+            () -> new ByteArrayStorageObject(StoragePath.of("mem://test"), data, Integer.MAX_VALUE - 8, Integer.MAX_VALUE - 8)
+        );
+        assertTrue(ex.getMessage(), ex.getMessage().contains("overflows int"));
+    }
+
+    public void testNewStreamSubRegionRejectsNegativePosition() {
+        byte[] data = "abcdefghij".getBytes(StandardCharsets.UTF_8);
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), data, 0, data.length);
+        expectThrows(IllegalArgumentException.class, () -> obj.newStream(-1, 4));
+    }
+
+    public void testNewStreamSubRegionRejectsReadPastLogicalEnd() {
+        // Data backing array is 32 bytes but the logical region is the inner [10, 30) window. A caller
+        // passing position+len past `length` was allowed pre-fix because ByteArrayInputStream only
+        // validated against data.length, exposing adjacent bytes.
+        byte[] data = new byte[32];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+        ByteArrayStorageObject obj = new ByteArrayStorageObject(StoragePath.of("mem://test"), data, 10, 20);
+        expectThrows(IllegalArgumentException.class, () -> obj.newStream(15, 10));
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/CompressionDelegatingFormatReaderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/CompressionDelegatingFormatReaderTests.java
@@ -106,6 +106,29 @@ public class CompressionDelegatingFormatReaderTests extends ESTestCase {
         expectThrows(QlIllegalArgumentException.class, () -> new CompressionDelegatingFormatReader(inner, null));
     }
 
+    public void testUnwrapReturnsInnerReader() {
+        FormatReader inner = new CapturingFormatReader();
+        DecompressionCodec codec = mockCodec();
+        CompressionDelegatingFormatReader delegating = new CompressionDelegatingFormatReader(inner, codec);
+
+        assertSame(inner, delegating.unwrap());
+        assertSame(codec, delegating.codec());
+    }
+
+    public void testUnwrapPreservedThroughWithConfig() {
+        FormatReader inner = new CapturingFormatReader();
+        DecompressionCodec codec = mockCodec();
+        CompressionDelegatingFormatReader delegating = new CompressionDelegatingFormatReader(inner, codec);
+
+        FormatReader configured = delegating.withConfig(java.util.Map.of());
+        assertSame(delegating, configured);
+
+        if (configured instanceof CompressionDelegatingFormatReader cdr) {
+            assertSame(inner, cdr.unwrap());
+            assertSame(codec, cdr.codec());
+        }
+    }
+
     private static byte[] gzip(byte[] input) throws IOException {
         java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
         try (GZIPOutputStream gzipOut = new GZIPOutputStream(baos)) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -15,11 +15,6 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
-import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
@@ -32,7 +27,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -41,10 +35,6 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
     private static final BlockFactory TEST_BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
         .breaker(new NoopCircuitBreaker("test"))
         .build();
-
-    private static final List<Attribute> SCHEMA = List.of(
-        new FieldAttribute(Source.EMPTY, "line", new EsField("line", DataType.KEYWORD, Map.of(), false, EsField.TimeSeriesFieldType.NONE))
-    );
 
     public void testBasicStreamingParallelParse() throws Exception {
         int lineCount = 200;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -15,9 +15,16 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
@@ -29,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
 
@@ -134,6 +142,37 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
         }
     }
 
+    /**
+     * Verifies the Stage-1 contract: the coordinator infers schema exactly once (from the first
+     * chunk on the segmentator thread) and every parser-thread {@code read()} dispatches against
+     * the schema-bound reader. Without this, each chunk re-inferred the schema from 20K sample
+     * lines — for a 100M-row file split into ~24K chunks, that wasted ~33% of total parsing CPU.
+     */
+    public void testSchemaInferredOnceAndBoundReaderUsedByParsers() throws Exception {
+        int lineCount = 5000;
+        String content = buildContent(lineCount);
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            // Small chunkSize forces many chunks so per-chunk inference would be obvious.
+            LineFormatReader reader = new LineFormatReader(1024);
+            List<String> allLines = collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(reader, stream, List.of("line"), 100, 4, executor, ErrorPolicy.STRICT)
+            );
+
+            assertEquals(lineCount, allLines.size());
+            assertEquals("metadata() should be called exactly once for the whole stream", 1, reader.metadataCalls.get());
+            assertTrue(
+                "expected many parser invocations against the bound reader, got " + reader.boundReadCalls.get(),
+                reader.boundReadCalls.get() > 1
+            );
+            assertEquals("no parser invocation should land on the unbound root reader", 0, reader.unboundReadCalls.get());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
     private static String buildContent(int lineCount) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < lineCount; i++) {
@@ -160,12 +199,35 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
 
     /**
      * A minimal format reader that treats each line as a record, producing one keyword block per page.
+     * <p>
+     * Tracks {@link #metadataCalls}, {@link #boundReadCalls}, and {@link #unboundReadCalls} per
+     * <strong>root</strong> reader (the counters are aliased into every {@link #withSchema}
+     * variant). Tests use these counters to assert that the coordinator infers schema once and
+     * dispatches every parser-thread read to the schema-bound variant.
      */
     private static class LineFormatReader implements SegmentableFormatReader {
         private final long minSegment;
+        private final List<Attribute> resolvedSchema;
+        final AtomicInteger metadataCalls;
+        final AtomicInteger boundReadCalls;
+        final AtomicInteger unboundReadCalls;
 
         LineFormatReader(long minSegment) {
+            this(minSegment, null, new AtomicInteger(), new AtomicInteger(), new AtomicInteger());
+        }
+
+        private LineFormatReader(
+            long minSegment,
+            List<Attribute> resolvedSchema,
+            AtomicInteger metadataCalls,
+            AtomicInteger boundReadCalls,
+            AtomicInteger unboundReadCalls
+        ) {
             this.minSegment = minSegment;
+            this.resolvedSchema = resolvedSchema;
+            this.metadataCalls = metadataCalls;
+            this.boundReadCalls = boundReadCalls;
+            this.unboundReadCalls = unboundReadCalls;
         }
 
         @Override
@@ -188,11 +250,21 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
 
         @Override
         public SourceMetadata metadata(StorageObject object) {
-            return null;
+            metadataCalls.incrementAndGet();
+            List<Attribute> schema = List.of(
+                new ReferenceAttribute(Source.EMPTY, null, "line", DataType.KEYWORD, Nullability.TRUE, null, false)
+            );
+            return new SimpleSourceMetadata(schema, formatName(), object.path().toString());
+        }
+
+        @Override
+        public FormatReader withSchema(List<Attribute> schema) {
+            return new LineFormatReader(minSegment, schema, metadataCalls, boundReadCalls, unboundReadCalls);
         }
 
         @Override
         public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+            (resolvedSchema != null ? boundReadCalls : unboundReadCalls).incrementAndGet();
             InputStream stream = object.newStream();
             List<String> lines = new ArrayList<>();
             StringBuilder current = new StringBuilder();
@@ -296,7 +368,13 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
 
         @Override
         public SourceMetadata metadata(StorageObject object) {
-            return null;
+            // Return a non-null schema so the coordinator's first-chunk inference does not
+            // mask the injected parser failure being tested here.
+            return new SimpleSourceMetadata(
+                List.of(new ReferenceAttribute(Source.EMPTY, null, "line", DataType.KEYWORD, Nullability.TRUE, null, false)),
+                formatName(),
+                object.path().toString()
+            );
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -173,6 +174,43 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
         }
     }
 
+    /**
+     * The segmentator only dispatches a chunk after locating its trailing {@code \n} (carry-over
+     * is shifted into the next chunk), so every chunk handed to a parser ends on a record
+     * terminator. The coordinator therefore must mark every chunk {@code lastSplit=true} so the
+     * NDJSON reader can skip its byte-by-byte {@code TrimLastPartialLineInputStream} scan; an
+     * earlier version only set this on the EOF chunk, leaving every interior chunk paying the
+     * tail-scan cost (visible as ~5% CPU in async-profiler runs over gzip-compressed COUNT(*)).
+     */
+    public void testParseChunkMarksAllChunksAsLastSplit() throws Exception {
+        int lineCount = 1000;
+        String content = buildContent(lineCount);
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            // Small chunkSize forces several parser-thread invocations so the assertion exercises
+            // both interior chunks and the final EOF chunk.
+            LineFormatReader reader = new LineFormatReader(1024);
+            collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(reader, stream, List.of("line"), 100, 4, executor, ErrorPolicy.STRICT)
+            );
+
+            List<FormatReadContext> seen;
+            synchronized (reader.seenContexts) {
+                seen = new ArrayList<>(reader.seenContexts);
+            }
+            assertTrue("Expected at least 2 chunks, recorded " + seen.size(), seen.size() >= 2);
+            for (int i = 0; i < seen.size(); i++) {
+                FormatReadContext ctx = seen.get(i);
+                assertTrue("chunk[" + i + "] must have firstSplit=true", ctx.firstSplit());
+                assertTrue("chunk[" + i + "] must have lastSplit=true (record-boundary aligned)", ctx.lastSplit());
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
     private static String buildContent(int lineCount) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < lineCount; i++) {
@@ -211,9 +249,17 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
         final AtomicInteger metadataCalls;
         final AtomicInteger boundReadCalls;
         final AtomicInteger unboundReadCalls;
+        final List<FormatReadContext> seenContexts;
 
         LineFormatReader(long minSegment) {
-            this(minSegment, null, new AtomicInteger(), new AtomicInteger(), new AtomicInteger());
+            this(
+                minSegment,
+                null,
+                new AtomicInteger(),
+                new AtomicInteger(),
+                new AtomicInteger(),
+                Collections.synchronizedList(new ArrayList<>())
+            );
         }
 
         private LineFormatReader(
@@ -221,13 +267,15 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             List<Attribute> resolvedSchema,
             AtomicInteger metadataCalls,
             AtomicInteger boundReadCalls,
-            AtomicInteger unboundReadCalls
+            AtomicInteger unboundReadCalls,
+            List<FormatReadContext> seenContexts
         ) {
             this.minSegment = minSegment;
             this.resolvedSchema = resolvedSchema;
             this.metadataCalls = metadataCalls;
             this.boundReadCalls = boundReadCalls;
             this.unboundReadCalls = unboundReadCalls;
+            this.seenContexts = seenContexts;
         }
 
         @Override
@@ -259,12 +307,13 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
 
         @Override
         public FormatReader withSchema(List<Attribute> schema) {
-            return new LineFormatReader(minSegment, schema, metadataCalls, boundReadCalls, unboundReadCalls);
+            return new LineFormatReader(minSegment, schema, metadataCalls, boundReadCalls, unboundReadCalls, seenContexts);
         }
 
         @Override
         public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
             (resolvedSchema != null ? boundReadCalls : unboundReadCalls).incrementAndGet();
+            seenContexts.add(context);
             InputStream stream = object.newStream();
             List<String> lines = new ArrayList<>();
             StringBuilder current = new StringBuilder();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -33,10 +33,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
@@ -211,6 +213,93 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
         }
     }
 
+    /**
+     * Guards against reuse of {@code chunk.index % pageQueueRingSize} slots ahead of the consumer:
+     * without {@code dispatchPermits} a fast parser could recycle buffers and interleave pages from
+     * different chunk generations into the same queue while the consumer is still draining an earlier chunk.
+     * <p>
+     * Internally repeats {@value #SLOT_REUSE_REPEATS} times to make the race likely to surface on any single CI
+     * run instead of relying on the framework's repeat-the-suite mechanism (which forbidden APIs disallows).
+     */
+    private static final int SLOT_REUSE_REPEATS = 20;
+
+    public void testFastParserSlowConsumerPreservesOrder() throws Exception {
+        int lineCount = 20_000;
+        String content = buildContent(lineCount);
+        byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
+
+        ExecutorService executor = Executors.newFixedThreadPool(16);
+        try {
+            for (int attempt = 0; attempt < SLOT_REUSE_REPEATS; attempt++) {
+                InputStream stream = new ByteArrayInputStream(contentBytes);
+                LineFormatReader reader = new LineFormatReader(1024);
+                CloseableIterator<Page> iterator = StreamingParallelParsingCoordinator.parallelRead(
+                    reader,
+                    stream,
+                    List.of("line"),
+                    50,
+                    8,
+                    executor,
+                    ErrorPolicy.STRICT
+                );
+                List<String> allLines = collectLinesSlow(iterator, 1);
+                assertEquals("attempt " + attempt, lineCount, allLines.size());
+                int prev = -1;
+                for (String line : allLines) {
+                    assertTrue(line, line.startsWith("line-"));
+                    int ord = Integer.parseInt(line.substring("line-".length()), 10);
+                    assertTrue("attempt " + attempt + ": lines must be strictly increasing, saw " + ord + " after " + prev, ord > prev);
+                    prev = ord;
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Closing must unblock the segmentator when it is parked on {@code dispatchPermits.acquire()}
+     * while no consumer drains permits — relies on {@code dispatchChunk} observing {@code closed} after a wake-up acquire.
+     * <p>
+     * Synchronisation is deterministic: we wait via {@link #assertBusy} until
+     * {@link StreamingParallelParsingCoordinator.StreamingParallelIterator#isSegmentatorParkedOnDispatchPermits()}
+     * returns {@code true}, then assert that {@link CloseableIterator#close()} returns within a generous
+     * deadline. A timing-only sleep would leave the test passing for the wrong reason if the segmentator
+     * happened to be blocked on {@code chunkQueue.put} or upstream {@code read()} instead.
+     */
+    public void testCloseWhileSegmentatorParkedOnDispatchPermit() throws Exception {
+        int parallelism = 2;
+        byte[] payload = new byte[100 * 1024];
+        Arrays.fill(payload, (byte) 'x');
+        for (int i = 127; i < payload.length - 1; i += 128) {
+            payload[i] = '\n';
+        }
+        payload[payload.length - 1] = '\n';
+
+        InputStream stream = new ByteArrayInputStream(payload);
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            LineFormatReader reader = new LineFormatReader(256);
+            CloseableIterator<Page> iterator = StreamingParallelParsingCoordinator.parallelRead(
+                reader,
+                stream,
+                List.of("line"),
+                50,
+                parallelism,
+                executor,
+                ErrorPolicy.STRICT
+            );
+            StreamingParallelParsingCoordinator.StreamingParallelIterator streamingIterator =
+                (StreamingParallelParsingCoordinator.StreamingParallelIterator) iterator;
+            assertBusy(() -> assertTrue(streamingIterator.isSegmentatorParkedOnDispatchPermits()), 5, TimeUnit.SECONDS);
+            long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            iterator.close();
+            assertTrue("close() must return within 5s of segmentator being parked", System.nanoTime() <= deadlineNanos);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
     private static String buildContent(int lineCount) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < lineCount; i++) {
@@ -230,6 +319,27 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                     lines.add(block.getBytesRef(i, scratch).utf8ToString());
                 }
                 page.releaseBlocks();
+            }
+        }
+        return lines;
+    }
+
+    private static List<String> collectLinesSlow(CloseableIterator<Page> iterator, int sleepEveryNPages) throws Exception {
+        List<String> lines = new ArrayList<>();
+        try (iterator) {
+            BytesRef scratch = new BytesRef();
+            int pageOrdinal = 0;
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                BytesRefBlock block = page.<BytesRefBlock>getBlock(0);
+                for (int i = 0; i < block.getPositionCount(); i++) {
+                    lines.add(block.getBytesRef(i, scratch).utf8ToString());
+                }
+                page.releaseBlocks();
+                pageOrdinal++;
+                if (sleepEveryNPages > 0 && pageOrdinal % sleepEveryNPages == 0) {
+                    Thread.sleep(1L);
+                }
             }
         }
         return lines;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
+import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
+
+    private static final BlockFactory TEST_BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
+        .breaker(new NoopCircuitBreaker("test"))
+        .build();
+
+    private static final List<Attribute> SCHEMA = List.of(
+        new FieldAttribute(Source.EMPTY, "line", new EsField("line", DataType.KEYWORD, Map.of(), false, EsField.TimeSeriesFieldType.NONE))
+    );
+
+    public void testBasicStreamingParallelParse() throws Exception {
+        int lineCount = 200;
+        String content = buildContent(lineCount);
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        ExecutorService executor = Executors.newFixedThreadPool(6);
+        try {
+            LineFormatReader reader = new LineFormatReader(1024);
+            List<String> allLines = collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(reader, stream, List.of("line"), 50, 4, executor, ErrorPolicy.STRICT)
+            );
+
+            assertEquals(lineCount, allLines.size());
+            for (int i = 0; i < lineCount; i++) {
+                assertEquals("line-" + String.format(java.util.Locale.ROOT, "%04d", i), allLines.get(i));
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    public void testSingleLineFallback() throws Exception {
+        String content = "line-0000\n";
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            LineFormatReader reader = new LineFormatReader(1024);
+            List<String> allLines = collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(reader, stream, List.of("line"), 50, 1, executor, ErrorPolicy.STRICT)
+            );
+
+            assertEquals(1, allLines.size());
+            assertEquals("line-0000", allLines.get(0));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    public void testEmptyStream() throws Exception {
+        InputStream stream = new ByteArrayInputStream(new byte[0]);
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            LineFormatReader reader = new LineFormatReader(1024);
+            List<String> allLines = collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(reader, stream, List.of("line"), 50, 4, executor, ErrorPolicy.STRICT)
+            );
+
+            assertEquals(0, allLines.size());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    public void testLargeContentPreservesOrder() throws Exception {
+        int lineCount = 5000;
+        String content = buildContent(lineCount);
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        try {
+            LineFormatReader reader = new LineFormatReader(4096);
+            List<String> allLines = collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(reader, stream, List.of("line"), 100, 8, executor, ErrorPolicy.STRICT)
+            );
+
+            assertEquals(lineCount, allLines.size());
+            for (int i = 0; i < lineCount; i++) {
+                assertEquals("line-" + String.format(java.util.Locale.ROOT, "%04d", i), allLines.get(i));
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    public void testParserErrorPropagates() throws Exception {
+        String content = buildContent(100);
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            FailingFormatReader reader = new FailingFormatReader(5, 1024);
+            RuntimeException ex = expectThrows(
+                RuntimeException.class,
+                () -> collectLines(
+                    StreamingParallelParsingCoordinator.parallelRead(reader, stream, List.of("line"), 50, 4, executor, ErrorPolicy.STRICT)
+                )
+            );
+            assertTrue(
+                "Expected injected failure message but got: " + ex.getMessage(),
+                ex.getMessage().contains("injected") || (ex.getCause() != null && ex.getCause().getMessage().contains("injected"))
+            );
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static String buildContent(int lineCount) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < lineCount; i++) {
+            sb.append("line-").append(String.format(java.util.Locale.ROOT, "%04d", i)).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static List<String> collectLines(CloseableIterator<Page> iterator) throws IOException {
+        List<String> lines = new ArrayList<>();
+        try (iterator) {
+            BytesRef scratch = new BytesRef();
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                BytesRefBlock block = page.<BytesRefBlock>getBlock(0);
+                for (int i = 0; i < block.getPositionCount(); i++) {
+                    lines.add(block.getBytesRef(i, scratch).utf8ToString());
+                }
+                page.releaseBlocks();
+            }
+        }
+        return lines;
+    }
+
+    /**
+     * A minimal format reader that treats each line as a record, producing one keyword block per page.
+     */
+    private static class LineFormatReader implements SegmentableFormatReader {
+        private final long minSegment;
+
+        LineFormatReader(long minSegment) {
+            this.minSegment = minSegment;
+        }
+
+        @Override
+        public long findNextRecordBoundary(InputStream stream) throws IOException {
+            long consumed = 0;
+            int b;
+            while ((b = stream.read()) != -1) {
+                consumed++;
+                if (b == '\n') {
+                    return consumed;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public long minimumSegmentSize() {
+            return minSegment;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+            InputStream stream = object.newStream();
+            List<String> lines = new ArrayList<>();
+            StringBuilder current = new StringBuilder();
+
+            boolean skipFirst = context.firstSplit() == false;
+
+            int b;
+            while ((b = stream.read()) != -1) {
+                if (b == '\n') {
+                    if (skipFirst) {
+                        skipFirst = false;
+                        current.setLength(0);
+                        continue;
+                    }
+                    if (current.length() > 0) {
+                        lines.add(current.toString());
+                    }
+                    current.setLength(0);
+                } else {
+                    current.append((char) b);
+                }
+            }
+            if (current.length() > 0 && skipFirst == false) {
+                lines.add(current.toString());
+            }
+
+            List<Page> pages = new ArrayList<>();
+            int batchSize = context.batchSize();
+            for (int start = 0; start < lines.size(); start += batchSize) {
+                int end = Math.min(start + batchSize, lines.size());
+                int count = end - start;
+                try (var builder = TEST_BLOCK_FACTORY.newBytesRefBlockBuilder(count)) {
+                    for (int i = start; i < end; i++) {
+                        builder.appendBytesRef(new BytesRef(lines.get(i)));
+                    }
+                    pages.add(new Page(count, builder.build()));
+                }
+            }
+
+            return new CloseableIterator<>() {
+                int idx = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return idx < pages.size();
+                }
+
+                @Override
+                public Page next() {
+                    return pages.get(idx++);
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
+
+        @Override
+        public String formatName() {
+            return "line";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".txt");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * A format reader that fails after reading a configured number of lines.
+     */
+    private static class FailingFormatReader implements SegmentableFormatReader {
+        private final int failAfterLines;
+        private final long minSegment;
+
+        FailingFormatReader(int failAfterLines, long minSegment) {
+            this.failAfterLines = failAfterLines;
+            this.minSegment = minSegment;
+        }
+
+        @Override
+        public long findNextRecordBoundary(InputStream stream) throws IOException {
+            long consumed = 0;
+            int b;
+            while ((b = stream.read()) != -1) {
+                consumed++;
+                if (b == '\n') {
+                    return consumed;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public long minimumSegmentSize() {
+            return minSegment;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+            InputStream stream = object.newStream();
+            int lineCount = 0;
+            int b;
+            while ((b = stream.read()) != -1) {
+                if (b == '\n') {
+                    lineCount++;
+                    if (lineCount >= failAfterLines) {
+                        throw new IOException("injected failure after " + failAfterLines + " lines");
+                    }
+                }
+            }
+            return new CloseableIterator<>() {
+                @Override
+                public boolean hasNext() {
+                    return false;
+                }
+
+                @Override
+                public Page next() {
+                    throw new java.util.NoSuchElementException();
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
+
+        @Override
+        public String formatName() {
+            return "failing";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of();
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
Gzip-compressed NDJSON/CSV files were parsed single-threaded because the compression wrapper hid the inner reader's segmentable capability. This adds a streaming parallel parsing coordinator that decompresses sequentially while dispatching record-boundary-aligned chunks to multiple parser threads, enabling pipeline parallelism for stream-only codecs.

Developed with AI-assisted tooling