### PR TITLE
Rename inference Request interfaces

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/HttpUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/HttpUtils.java
@@ -8,16 +8,21 @@
 package org.elasticsearch.xpack.inference.external.http;
 
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 import static org.elasticsearch.core.Strings.format;
 
 public class HttpUtils {
 
-    public static void checkForFailureStatusCode(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result) {
+    public static void checkForFailureStatusCode(
+        ThrottlerManager throttlerManager,
+        Logger logger,
+        OutboundRequest outboundRequest,
+        HttpResult result
+    ) {
         if (result.response().getStatusLine().getStatusCode() >= 300) {
-            String message = getStatusCodeErrorMessage(request, result);
+            String message = getStatusCodeErrorMessage(outboundRequest, result);
 
             throttlerManager.warn(logger, message);
 
@@ -25,19 +30,19 @@ public class HttpUtils {
         }
     }
 
-    private static String getStatusCodeErrorMessage(Request request, HttpResult result) {
+    private static String getStatusCodeErrorMessage(OutboundRequest outboundRequest, HttpResult result) {
         int statusCode = result.response().getStatusLine().getStatusCode();
 
         if (statusCode >= 400) {
             return format(
                 "Received a failure status code for request from inference entity id [%s] status [%s]",
-                request.getInferenceEntityId(),
+                outboundRequest.getInferenceEntityId(),
                 result.response().getStatusLine().getStatusCode()
             );
         } else if (statusCode >= 300) {
             return format(
                 "Unhandled redirection for request from inference entity id [%s] status [%s]",
-                request.getInferenceEntityId(),
+                outboundRequest.getInferenceEntityId(),
                 result.response().getStatusLine().getStatusCode()
             );
         } else {
@@ -45,9 +50,17 @@ public class HttpUtils {
         }
     }
 
-    public static void checkForEmptyBody(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result) {
-        if (result.isBodyEmpty() && (request.isStreaming() == false)) {
-            String message = format("Response body was empty for request from inference entity id [%s]", request.getInferenceEntityId());
+    public static void checkForEmptyBody(
+        ThrottlerManager throttlerManager,
+        Logger logger,
+        OutboundRequest outboundRequest,
+        HttpResult result
+    ) {
+        if (result.isBodyEmpty() && (outboundRequest.isStreaming() == false)) {
+            String message = format(
+                "Response body was empty for request from inference entity id [%s]",
+                outboundRequest.getInferenceEntityId()
+            );
             throttlerManager.warn(logger, message);
             throw new IllegalStateException(message);
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandler.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 import java.util.Objects;
@@ -62,9 +62,9 @@ public abstract class BaseResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, HttpResult result) throws RetryException {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         try {
-            return parseFunction.apply(request, result);
+            return parseFunction.apply(outboundRequest, result);
         } catch (Exception e) {
             throw new RetryException(true, e);
         }
@@ -76,35 +76,45 @@ public abstract class BaseResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result) {
-        checkForFailureStatusCode(request, result);
-        checkForEmptyBody(throttlerManager, logger, request, result);
+    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, OutboundRequest outboundRequest, HttpResult result) {
+        checkForFailureStatusCode(outboundRequest, result);
+        checkForEmptyBody(throttlerManager, logger, outboundRequest, result);
     }
 
-    protected abstract void checkForFailureStatusCode(Request request, HttpResult result);
+    protected abstract void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result);
 
-    protected Exception buildError(String message, Request request, HttpResult result) {
+    protected Exception buildError(String message, OutboundRequest outboundRequest, HttpResult result) {
         var errorEntityMsg = errorParseFunction.apply(result);
-        return buildError(message, request, result, errorEntityMsg);
+        return buildError(message, outboundRequest, result, errorEntityMsg);
     }
 
-    protected Exception buildError(String message, Request request, HttpResult result, ErrorResponse errorResponse) {
+    protected Exception buildError(String message, OutboundRequest outboundRequest, HttpResult result, ErrorResponse errorResponse) {
         var responseStatusCode = result.response().getStatusLine().getStatusCode();
         return new ElasticsearchStatusException(
-            constructErrorMessage(message, request, errorResponse, responseStatusCode),
+            constructErrorMessage(message, outboundRequest, errorResponse, responseStatusCode),
             toRestStatus(responseStatusCode)
         );
     }
 
-    public static String constructErrorMessage(String message, Request request, ErrorResponse errorResponse, int statusCode) {
+    public static String constructErrorMessage(
+        String message,
+        OutboundRequest outboundRequest,
+        ErrorResponse errorResponse,
+        int statusCode
+    ) {
         return (errorResponse == null
             || errorResponse.errorStructureFound() == false
             || Strings.isNullOrEmpty(errorResponse.getErrorMessage()))
-                ? format("%s for request from inference entity id [%s] status [%s]", message, request.getInferenceEntityId(), statusCode)
+                ? format(
+                    "%s for request from inference entity id [%s] status [%s]",
+                    message,
+                    outboundRequest.getInferenceEntityId(),
+                    statusCode
+                )
                 : format(
                     "%s for request from inference entity id [%s] status [%s]. Error message: [%s]",
                     message,
-                    request.getInferenceEntityId(),
+                    outboundRequest.getInferenceEntityId(),
                     statusCode,
                     errorResponse.getErrorMessage()
                 );
@@ -119,7 +129,7 @@ public abstract class BaseResponseHandler implements ResponseHandler {
         return code == null ? RestStatus.BAD_REQUEST : code;
     }
 
-    protected static String resourceNotFoundError(Request request) {
-        return format("Resource not found at [%s]", request.getURI());
+    protected static String resourceNotFoundError(OutboundRequest outboundRequest) {
+        return format("Resource not found at [%s]", outboundRequest.getURI());
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ChatCompletionErrorResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ChatCompletionErrorResponseHandler.java
@@ -11,7 +11,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.util.Locale;
 import java.util.Objects;
@@ -29,20 +29,20 @@ public class ChatCompletionErrorResponseHandler {
         this.unifiedChatCompletionErrorParser = Objects.requireNonNull(errorParser);
     }
 
-    public UnifiedChatCompletionException buildChatCompletionError(String message, Request request, HttpResult result) {
+    public UnifiedChatCompletionException buildChatCompletionError(String message, OutboundRequest outboundRequest, HttpResult result) {
         var errorResponse = unifiedChatCompletionErrorParser.parse(result);
-        return buildChatCompletionErrorInternal(message, request, result, errorResponse);
+        return buildChatCompletionErrorInternal(message, outboundRequest, result, errorResponse);
     }
 
     private UnifiedChatCompletionException buildChatCompletionErrorInternal(
         String message,
-        Request request,
+        OutboundRequest outboundRequest,
         HttpResult result,
         UnifiedChatCompletionErrorResponse errorResponse
     ) {
-        assert request.isStreaming() : "Only streaming requests support this format";
+        assert outboundRequest.isStreaming() : "Only streaming requests support this format";
         var statusCode = result.response().getStatusLine().getStatusCode();
-        var errorMessage = BaseResponseHandler.constructErrorMessage(message, request, errorResponse, statusCode);
+        var errorMessage = BaseResponseHandler.constructErrorMessage(message, outboundRequest, errorResponse, statusCode);
         var restStatus = toRestStatus(statusCode);
 
         if (errorResponse.errorStructureFound()) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ContentTooLargeException.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ContentTooLargeException.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.inference.external.http.retry;
 
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 /**
  * Provides an exception for truncating the request input.
@@ -19,7 +19,7 @@ public class ContentTooLargeException extends RetryException {
     }
 
     @Override
-    public Request rebuildRequest(Request original) {
+    public OutboundRequest rebuildRequest(OutboundRequest original) {
         return original.truncate();
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RequestSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RequestSender.java
@@ -10,14 +10,14 @@ package org.elasticsearch.xpack.inference.external.http.retry;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.inference.InferenceServiceResults;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.util.function.Supplier;
 
 public interface RequestSender {
     void send(
         Logger logger,
-        Request request,
+        OutboundRequest outboundRequest,
         Supplier<Boolean> hasRequestTimedOutFunction,
         ResponseHandler responseHandler,
         ActionListener<InferenceServiceResults> listener

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ResponseHandler.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.inference.external.http.retry;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 import java.util.concurrent.Flow;
@@ -27,20 +27,21 @@ public interface ResponseHandler {
      *
      * @param throttlerManager a throttler for the logs
      * @param logger the logger to use for logging
-     * @param request the original request
+     * @param outboundRequest the original request
      * @param result the response from the server
      * @throws RetryException if the response is invalid
      */
-    void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result) throws RetryException;
+    void validateResponse(ThrottlerManager throttlerManager, Logger logger, OutboundRequest outboundRequest, HttpResult result)
+        throws RetryException;
 
     /**
      * A method for parsing the response from the server.
-     * @param request The original request sent to the server
+     * @param outboundRequest The original request sent to the server
      * @param result The wrapped response from the server
      * @return the parsed inference results
      * @throws RetryException if a parsing error occurs
      */
-    InferenceServiceResults parseResult(Request request, HttpResult result) throws RetryException;
+    InferenceServiceResults parseResult(OutboundRequest outboundRequest, HttpResult result) throws RetryException;
 
     /**
      * A string to uniquely identify the type of request that is being handled. This allows loggers to clarify which type of request
@@ -60,12 +61,12 @@ public interface ResponseHandler {
      * {@link Flow.Publisher#subscribe(Flow.Subscriber)} method on the {@code Flow.Publisher<HttpResult> flow} parameter in order to stream
      * HttpResults to the InferenceServiceResults.
      *
-     * @param request The original request sent to the server
+     * @param outboundRequest The original request sent to the server
      * @param flow    The remaining stream of results from the server.  If the result is HTTP 200, these results will contain content bytes
      * @return an inference results with {@link InferenceServiceResults#publisher()} set and {@link InferenceServiceResults#isStreaming()}
      * set to true.
      */
-    default InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
+    default InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
         assert canHandleStreamingResponses() == false : "This must be implemented when canHandleStreamingResponses() == true";
         throw new UnsupportedOperationException("This must be implemented when canHandleStreamingResponses() == true");
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ResponseParser.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ResponseParser.java
@@ -9,11 +9,11 @@ package org.elasticsearch.xpack.inference.external.http.retry;
 
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 
 @FunctionalInterface
 public interface ResponseParser {
-    InferenceServiceResults apply(Request request, HttpResult result) throws IOException;
+    InferenceServiceResults apply(OutboundRequest outboundRequest, HttpResult result) throws IOException;
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryException.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryException.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.external.http.retry;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchWrapperException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 public class RetryException extends ElasticsearchException implements ElasticsearchWrapperException, Retryable {
     private final boolean shouldRetry;
@@ -34,7 +34,7 @@ public class RetryException extends ElasticsearchException implements Elasticsea
     }
 
     @Override
-    public Request rebuildRequest(Request original) {
+    public OutboundRequest rebuildRequest(OutboundRequest original) {
         return original;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/Retryable.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/Retryable.java
@@ -7,14 +7,14 @@
 
 package org.elasticsearch.xpack.inference.external.http.retry;
 
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 /**
  * Provides an interface for determining if an error should be retried and a way to modify
  * the request to based on the type of failure that occurred.
  */
 public interface Retryable {
-    Request rebuildRequest(Request original);
+    OutboundRequest rebuildRequest(OutboundRequest original);
 
     boolean shouldRetry();
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
@@ -24,7 +24,7 @@ import org.elasticsearch.xpack.inference.common.SizeLimitInputStream;
 import org.elasticsearch.xpack.inference.external.http.HttpClient;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 import java.io.IOException;
@@ -94,7 +94,7 @@ public class RetryingHttpSender implements RequestSender {
     }
 
     private class InternalRetrier extends RetryableAction<InferenceServiceResults> {
-        private Request request;
+        private OutboundRequest outboundRequest;
         private final ResponseHandler responseHandler;
         private final Logger logger;
         private final HttpClientContext context;
@@ -103,7 +103,7 @@ public class RetryingHttpSender implements RequestSender {
 
         InternalRetrier(
             Logger logger,
-            Request request,
+            OutboundRequest outboundRequest,
             HttpClientContext context,
             Supplier<Boolean> hasRequestCompletedFunction,
             ResponseHandler responseHandler,
@@ -119,7 +119,7 @@ public class RetryingHttpSender implements RequestSender {
                 executor
             );
             this.logger = logger;
-            this.request = Objects.requireNonNull(request);
+            this.outboundRequest = Objects.requireNonNull(outboundRequest);
             this.context = Objects.requireNonNull(context);
             this.responseHandler = Objects.requireNonNull(responseHandler);
             this.hasRequestCompletedFunction = Objects.requireNonNull(hasRequestCompletedFunction);
@@ -133,7 +133,7 @@ public class RetryingHttpSender implements RequestSender {
             if (hasRequestCompletedFunction.get()) {
                 // TimedListener will drop this, just being safe to avoid a hanging listener
                 listener.onFailure(
-                    new ElasticsearchStatusException(timeoutString(request.getInferenceEntityId()), RestStatus.GATEWAY_TIMEOUT)
+                    new ElasticsearchStatusException(timeoutString(outboundRequest.getInferenceEntityId()), RestStatus.GATEWAY_TIMEOUT)
                 );
                 return;
             }
@@ -144,9 +144,15 @@ public class RetryingHttpSender implements RequestSender {
                 if (exceptionToUse instanceof SenderException senderException) {
                     exceptionToUse = senderException.getOriginalException();
 
-                    logResponseException(logger, request, senderException.getResult(), responseHandler.getRequestType(), exceptionToUse);
+                    logResponseException(
+                        logger,
+                        outboundRequest,
+                        senderException.getResult(),
+                        responseHandler.getRequestType(),
+                        exceptionToUse
+                    );
                 } else {
-                    logRequestException(logger, request, responseHandler.getRequestType(), exceptionToUse);
+                    logRequestException(logger, outboundRequest, responseHandler.getRequestType(), exceptionToUse);
                 }
 
                 /*
@@ -158,19 +164,19 @@ public class RetryingHttpSender implements RequestSender {
                 l.onFailure(transformIfRetryable(exceptionToUse));
             });
 
-            SubscribableListener.<HttpRequest>newForked(createHttpRequestListener -> request.createHttpRequest(createHttpRequestListener))
-                .<InferenceServiceResults>andThen((inferenceServiceResultsActionListener, httpRequest) -> {
-                    if (hasRequestCompletedFunction.get()) {
-                        // TimedListener will drop this, just being safe to avoid a hanging listener
-                        inferenceServiceResultsActionListener.onFailure(
-                            new ElasticsearchStatusException(timeoutString(request.getInferenceEntityId()), RestStatus.GATEWAY_TIMEOUT)
-                        );
-                        return;
-                    }
+            SubscribableListener.<HttpRequest>newForked(
+                createHttpRequestListener -> outboundRequest.createHttpRequest(createHttpRequestListener)
+            ).<InferenceServiceResults>andThen((inferenceServiceResultsActionListener, httpRequest) -> {
+                if (hasRequestCompletedFunction.get()) {
+                    // TimedListener will drop this, just being safe to avoid a hanging listener
+                    inferenceServiceResultsActionListener.onFailure(
+                        new ElasticsearchStatusException(timeoutString(outboundRequest.getInferenceEntityId()), RestStatus.GATEWAY_TIMEOUT)
+                    );
+                    return;
+                }
 
-                    sendRequest(httpRequest, inferenceServiceResultsActionListener);
-                })
-                .addListener(failureListener);
+                sendRequest(httpRequest, inferenceServiceResultsActionListener);
+            }).addListener(failureListener);
         }
 
         private static String timeoutString(String inferenceId) {
@@ -178,10 +184,10 @@ public class RetryingHttpSender implements RequestSender {
         }
 
         private void sendRequest(HttpRequest httpRequest, ActionListener<InferenceServiceResults> listener) throws IOException {
-            if (request.isStreaming() && responseHandler.canHandleStreamingResponses()) {
+            if (outboundRequest.isStreaming() && responseHandler.canHandleStreamingResponses()) {
                 httpClient.stream(httpRequest, context, listener.delegateFailureAndWrap((l, r) -> {
                     if (r.isSuccessfulResponse()) {
-                        l.onResponse(responseHandler.parseResult(request, r.toHttpResult()));
+                        l.onResponse(responseHandler.parseResult(outboundRequest, r.toHttpResult()));
                     } else {
                         r.readFullResponse(
                             l.delegateFailureAndWrap(
@@ -203,8 +209,8 @@ public class RetryingHttpSender implements RequestSender {
 
         private void validateAndParseInferenceResults(HttpResult httpResult, ActionListener<InferenceServiceResults> listener) {
             try {
-                responseHandler.validateResponse(throttlerManager, logger, request, httpResult);
-                InferenceServiceResults inferenceResults = responseHandler.parseResult(request, httpResult);
+                responseHandler.validateResponse(throttlerManager, logger, outboundRequest, httpResult);
+                InferenceServiceResults inferenceResults = responseHandler.parseResult(outboundRequest, httpResult);
 
                 listener.onResponse(inferenceResults);
             } catch (Exception e) {
@@ -222,7 +228,7 @@ public class RetryingHttpSender implements RequestSender {
         private Exception transformIfRetryable(Exception e) {
             if (e instanceof UnknownHostException) {
                 return new ElasticsearchStatusException(
-                    format("Invalid host [%s], please check that the URL is correct.", request.getURI()),
+                    format("Invalid host [%s], please check that the URL is correct.", outboundRequest.getURI()),
                     RestStatus.BAD_REQUEST,
                     e
                 );
@@ -242,7 +248,7 @@ public class RetryingHttpSender implements RequestSender {
             }
 
             if (e instanceof Retryable retry) {
-                request = retry.rebuildRequest(request);
+                outboundRequest = retry.rebuildRequest(outboundRequest);
                 return retry.shouldRetry();
             }
 
@@ -253,14 +259,14 @@ public class RetryingHttpSender implements RequestSender {
     @Override
     public void send(
         Logger logger,
-        Request request,
+        OutboundRequest outboundRequest,
         Supplier<Boolean> hasRequestTimedOutFunction,
         ResponseHandler responseHandler,
         ActionListener<InferenceServiceResults> listener
     ) {
         var retrier = new InternalRetrier(
             logger,
-            request,
+            outboundRequest,
             HttpClientContext.create(),
             hasRequestTimedOutFunction,
             responseHandler,
@@ -271,13 +277,13 @@ public class RetryingHttpSender implements RequestSender {
 
     private void logResponseException(
         Logger logger,
-        Request request,
+        OutboundRequest outboundRequest,
         @Nullable HttpResult result,
         String requestType,
         Exception exception
     ) {
         if (result == null) {
-            logRequestException(logger, request, requestType, exception);
+            logRequestException(logger, outboundRequest, requestType, exception);
             return;
         }
 
@@ -287,7 +293,7 @@ public class RetryingHttpSender implements RequestSender {
             logger,
             format(
                 "Failed to process the response for request from inference entity id [%s] of type [%s] with status [%s] [%s]",
-                request.getInferenceEntityId(),
+                outboundRequest.getInferenceEntityId(),
                 requestType,
                 result.response().getStatusLine().getStatusCode(),
                 result.response().getStatusLine().getReasonPhrase()
@@ -296,12 +302,16 @@ public class RetryingHttpSender implements RequestSender {
         );
     }
 
-    private void logRequestException(Logger logger, Request request, String requestType, Exception exception) {
+    private void logRequestException(Logger logger, OutboundRequest outboundRequest, String requestType, Exception exception) {
         var causeException = ExceptionsHelper.unwrapCause(exception);
 
         throttlerManager.warn(
             logger,
-            format("Failed while sending request from inference entity id [%s] of type [%s]", request.getInferenceEntityId(), requestType),
+            format(
+                "Failed while sending request from inference entity id [%s] of type [%s]",
+                outboundRequest.getInferenceEntityId(),
+                requestType
+            ),
             causeException
         );
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/ExecutableInferenceRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/ExecutableInferenceRequest.java
@@ -14,14 +14,14 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.retry.RequestSender;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.util.function.Supplier;
 
 public record ExecutableInferenceRequest(
     RequestSender requestSender,
     Logger logger,
-    Request request,
+    OutboundRequest outboundRequest,
     ResponseHandler responseHandler,
     Supplier<Boolean> hasFinished,
     ActionListener<InferenceServiceResults> listener
@@ -29,10 +29,10 @@ public record ExecutableInferenceRequest(
 
     @Override
     public void run() {
-        var inferenceEntityId = request.getInferenceEntityId();
+        var inferenceEntityId = outboundRequest.getInferenceEntityId();
 
         try {
-            requestSender.send(logger, request, hasFinished, responseHandler, listener);
+            requestSender.send(logger, outboundRequest, hasFinished, responseHandler, listener);
         } catch (Exception e) {
             var errorMessage = Strings.format("Failed to send request from inference entity id [%s]", inferenceEntityId);
             logger.warn(errorMessage, e);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/GenericRequestManager.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/GenericRequestManager.java
@@ -14,7 +14,7 @@ import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.inference.external.http.retry.RequestSender;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.RateLimitGroupingModel;
 
 import java.util.Objects;
@@ -29,14 +29,14 @@ public class GenericRequestManager<T extends InferenceInputs> extends BaseReques
     private static final Logger logger = LogManager.getLogger(GenericRequestManager.class);
 
     protected final ResponseHandler responseHandler;
-    protected final Function<T, Request> requestCreator;
+    protected final Function<T, OutboundRequest> requestCreator;
     protected final Class<T> inputType;
 
     public GenericRequestManager(
         ThreadPool threadPool,
         RateLimitGroupingModel rateLimitGroupingModel,
         ResponseHandler responseHandler,
-        Function<T, Request> requestCreator,
+        Function<T, OutboundRequest> requestCreator,
         Class<T> inputType
     ) {
         super(threadPool, rateLimitGroupingModel);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSender.java
@@ -26,7 +26,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.RequestSender;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.RetrySettings;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryingHttpSender;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 
 import java.io.IOException;
@@ -193,14 +193,14 @@ public class HttpRequestSender implements Sender {
      * Startup is initiated automatically if it has not already been started.
      *
      * @param logger          A logger to use for messages
-     * @param request         A request to be sent
+     * @param outboundRequest         A request to be sent
      * @param responseHandler A handler for parsing the response
      * @param timeout         the maximum time the request should wait for a response before timing out. If null, the timeout is ignored
      * @param listener        a listener to handle the response
      */
     public void sendWithoutQueuing(
         Logger logger,
-        Request request,
+        OutboundRequest outboundRequest,
         ResponseHandler responseHandler,
         @Nullable TimeValue timeout,
         ActionListener<InferenceServiceResults> listener
@@ -208,10 +208,16 @@ public class HttpRequestSender implements Sender {
         SubscribableListener.<Void>newForked(startListener -> startAsynchronously(startListener, STARTUP_TIMEOUT))
             .<InferenceServiceResults>andThen(sendListener -> {
                 var preservedListener = ContextPreservingActionListener.wrapPreservingContext(sendListener, threadPool.getThreadContext());
-                var timedListener = new TimedListener<>(timeout, preservedListener, threadPool, request.getInferenceEntityId());
+                var timedListener = new TimedListener<>(timeout, preservedListener, threadPool, outboundRequest.getInferenceEntityId());
                 threadPool.executor(UTILITY_THREAD_POOL_NAME)
                     .execute(
-                        () -> requestSender.send(logger, request, timedListener::hasCompleted, responseHandler, timedListener.getListener())
+                        () -> requestSender.send(
+                            logger,
+                            outboundRequest,
+                            timedListener::hasCompleted,
+                            responseHandler,
+                            timedListener.getListener()
+                        )
                     );
             })
             .addListener(listener);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/Sender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/Sender.java
@@ -13,7 +13,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.Closeable;
 
@@ -35,7 +35,7 @@ public interface Sender extends Closeable {
      */
     void sendWithoutQueuing(
         Logger logger,
-        Request request,
+        OutboundRequest outboundRequest,
         ResponseHandler responseHandler,
         @Nullable TimeValue timeout,
         ActionListener<InferenceServiceResults> listener

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/TruncatingRequestManager.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/TruncatingRequestManager.java
@@ -16,7 +16,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.external.http.retry.RequestSender;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.RateLimitGroupingModel;
 
 import java.util.Objects;
@@ -29,14 +29,14 @@ public class TruncatingRequestManager extends BaseRequestManager {
     private static final Logger logger = LogManager.getLogger(TruncatingRequestManager.class);
 
     private final ResponseHandler responseHandler;
-    private final Function<Truncator.TruncationResult, Request> requestCreator;
+    private final Function<Truncator.TruncationResult, OutboundRequest> requestCreator;
     private final Integer maxInputTokens;
 
     public TruncatingRequestManager(
         ThreadPool threadPool,
         RateLimitGroupingModel rateLimitGroupingModel,
         ResponseHandler responseHandler,
-        Function<Truncator.TruncationResult, Request> requestCreator,
+        Function<Truncator.TruncationResult, OutboundRequest> requestCreator,
         @Nullable Integer maxInputTokens
     ) {
         super(threadPool, rateLimitGroupingModel);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundCompletionRequest.java
@@ -10,7 +10,14 @@ package org.elasticsearch.xpack.inference.external.request;
 import org.elasticsearch.inference.TaskType;
 
 /**
- * Marker interface for requests that may be {@link TaskType#CHAT_COMPLETION} or {@link TaskType#COMPLETION}. Implementing classes should
- * implement the {@link Request#getTaskType()} method to return the appropriate task type.
+ * Implementation of {@link OutboundRequest} for {@link TaskType#COMPLETION} requests
  */
-public interface ChatCompletionRequest extends Request {}
+public interface OutboundCompletionRequest extends OutboundRequest {
+    /**
+     * Should not be overridden
+     */
+    @Override
+    default TaskType getTaskType() {
+        return TaskType.COMPLETION;
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundDenseEmbeddingRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundDenseEmbeddingRequest.java
@@ -10,14 +10,7 @@ package org.elasticsearch.xpack.inference.external.request;
 import org.elasticsearch.inference.TaskType;
 
 /**
- * Implementation of {@link Request} for {@link TaskType#SPARSE_EMBEDDING} requests
+ * Marker interface for requests that may be {@link TaskType#TEXT_EMBEDDING} or {@link TaskType#EMBEDDING}. Implementing classes should
+ * implement the {@link OutboundRequest#getTaskType()} method to return the appropriate task type.
  */
-public interface SparseEmbeddingRequest extends Request {
-    /**
-     * Should not be overridden
-     */
-    @Override
-    default TaskType getTaskType() {
-        return TaskType.SPARSE_EMBEDDING;
-    }
-}
+public interface OutboundDenseEmbeddingRequest extends OutboundRequest {}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundRequest.java
@@ -12,16 +12,16 @@ import org.elasticsearch.inference.TaskType;
 
 import java.net.URI;
 
-public interface Request {
+public interface OutboundRequest {
     void createHttpRequest(ActionListener<HttpRequest> listener);
 
     URI getURI();
 
     /**
      * Create a new request with less input text.
-     * @return a new {@link Request} with the truncated input text
+     * @return a new {@link OutboundRequest} with the truncated input text
      */
-    Request truncate();
+    OutboundRequest truncate();
 
     /**
      * Returns an array of booleans indicating if the text input at that same array index was truncated in the request

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundRerankRequest.java
@@ -10,7 +10,14 @@ package org.elasticsearch.xpack.inference.external.request;
 import org.elasticsearch.inference.TaskType;
 
 /**
- * Marker interface for requests that may be {@link TaskType#TEXT_EMBEDDING} or {@link TaskType#EMBEDDING}. Implementing classes should
- * implement the {@link Request#getTaskType()} method to return the appropriate task type.
+ * Implementation of {@link OutboundRequest} for {@link TaskType#RERANK} requests
  */
-public interface DenseEmbeddingRequest extends Request {}
+public interface OutboundRerankRequest extends OutboundRequest {
+    /**
+     * Should not be overridden
+     */
+    @Override
+    default TaskType getTaskType() {
+        return TaskType.RERANK;
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundSparseEmbeddingRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundSparseEmbeddingRequest.java
@@ -10,14 +10,14 @@ package org.elasticsearch.xpack.inference.external.request;
 import org.elasticsearch.inference.TaskType;
 
 /**
- * Implementation of {@link Request} for {@link TaskType#RERANK} requests
+ * Implementation of {@link OutboundRequest} for {@link TaskType#SPARSE_EMBEDDING} requests
  */
-public interface RerankRequest extends Request {
+public interface OutboundSparseEmbeddingRequest extends OutboundRequest {
     /**
      * Should not be overridden
      */
     @Override
     default TaskType getTaskType() {
-        return TaskType.RERANK;
+        return TaskType.SPARSE_EMBEDDING;
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundUnifiedCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/OutboundUnifiedCompletionRequest.java
@@ -10,14 +10,7 @@ package org.elasticsearch.xpack.inference.external.request;
 import org.elasticsearch.inference.TaskType;
 
 /**
- * Implementation of {@link Request} for {@link TaskType#COMPLETION} requests
+ * Marker interface for requests that may be {@link TaskType#CHAT_COMPLETION} or {@link TaskType#COMPLETION}. Implementing classes should
+ * implement the {@link OutboundRequest#getTaskType()} method to return the appropriate task type.
  */
-public interface CompletionRequest extends Request {
-    /**
-     * Should not be overridden
-     */
-    @Override
-    default TaskType getTaskType() {
-        return TaskType.COMPLETION;
-    }
-}
+public interface OutboundUnifiedCompletionRequest extends OutboundRequest {}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/BaseResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/BaseResponseEntity.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.inference.external.response;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 
@@ -19,9 +19,9 @@ import java.io.IOException;
  * to be able to override the `fromReponse` method to avoid using a static reference to the method.
  */
 public abstract class BaseResponseEntity implements ResponseParser {
-    protected abstract InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException;
+    protected abstract InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException;
 
-    public InferenceServiceResults apply(Request request, HttpResult response) throws IOException {
-        return fromResponse(request, response);
+    public InferenceServiceResults apply(OutboundRequest outboundRequest, HttpResult response) throws IOException {
+        return fromResponse(outboundRequest, response);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ai21/request/Ai21ChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ai21/request/Ai21ChatCompletionRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.ai21.completion.Ai21ChatCompletionModel;
 
 import java.net.URI;
@@ -31,7 +31,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * This class is responsible for creating a request to the AI21 chat completion model.
  * It constructs an HTTP POST request with the necessary headers and body content.
  */
-public class Ai21ChatCompletionRequest implements ChatCompletionRequest {
+public class Ai21ChatCompletionRequest implements OutboundUnifiedCompletionRequest {
 
     private final Ai21ChatCompletionModel model;
     private final UnifiedChatInput chatInput;
@@ -63,7 +63,7 @@ public class Ai21ChatCompletionRequest implements ChatCompletionRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation for AI21 chat completions
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchResponseHandler.java
@@ -12,7 +12,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.response.AlibabaCloudSearchErrorResponseEntity;
 
 /**
@@ -27,12 +27,12 @@ public class AlibabaCloudSearchResponseHandler extends BaseResponseHandler {
     /**
      * Validates the status code throws an RetryException if not in the range [200, 300).
      *
-     * @param request The http request
+     * @param outboundRequest The http request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (RestStatus.isSuccessful(statusCode)) {
             return;
@@ -40,15 +40,15 @@ public class AlibabaCloudSearchResponseHandler extends BaseResponseHandler {
 
         // handle error codes
         if (statusCode >= 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         } else if (statusCode == 401) {
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/request/AlibabaCloudSearchEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/request/AlibabaCloudSearchEmbeddingsRequest.java
@@ -16,9 +16,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.AlibabaCloudSearchAccount;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.embeddings.AlibabaCloudSearchEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.embeddings.AlibabaCloudSearchEmbeddingsTaskSettings;
@@ -32,7 +32,7 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.buildUri;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public class AlibabaCloudSearchEmbeddingsRequest extends AlibabaCloudSearchRequest implements DenseEmbeddingRequest {
+public class AlibabaCloudSearchEmbeddingsRequest extends AlibabaCloudSearchRequest implements OutboundDenseEmbeddingRequest {
 
     private final AlibabaCloudSearchAccount account;
     private final List<String> input;
@@ -95,7 +95,7 @@ public class AlibabaCloudSearchEmbeddingsRequest extends AlibabaCloudSearchReque
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/request/AlibabaCloudSearchRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/request/AlibabaCloudSearchRequest.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.inference.services.alibabacloudsearch.request;
 
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
-public abstract class AlibabaCloudSearchRequest implements Request {
+public abstract class AlibabaCloudSearchRequest implements OutboundRequest {
     private final long startTime;
 
     public AlibabaCloudSearchRequest() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/request/AlibabaCloudSearchRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/request/AlibabaCloudSearchRerankRequest.java
@@ -16,8 +16,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.AlibabaCloudSearchAccount;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.rerank.AlibabaCloudSearchRerankModel;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.rerank.AlibabaCloudSearchRerankTaskSettings;
@@ -31,7 +31,7 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.buildUri;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public class AlibabaCloudSearchRerankRequest implements RerankRequest {
+public class AlibabaCloudSearchRerankRequest implements OutboundRerankRequest {
     private final AlibabaCloudSearchAccount account;
     private final String query;
     private final List<String> input;
@@ -98,7 +98,7 @@ public class AlibabaCloudSearchRerankRequest implements RerankRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/request/AlibabaCloudSearchSparseRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/request/AlibabaCloudSearchSparseRequest.java
@@ -16,8 +16,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.SparseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundSparseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.AlibabaCloudSearchAccount;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.sparse.AlibabaCloudSearchSparseModel;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.sparse.AlibabaCloudSearchSparseTaskSettings;
@@ -31,7 +31,7 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.buildUri;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public class AlibabaCloudSearchSparseRequest extends AlibabaCloudSearchRequest implements SparseEmbeddingRequest {
+public class AlibabaCloudSearchSparseRequest extends AlibabaCloudSearchRequest implements OutboundSparseEmbeddingRequest {
 
     private final AlibabaCloudSearchAccount account;
     private final List<String> input;
@@ -92,7 +92,7 @@ public class AlibabaCloudSearchSparseRequest extends AlibabaCloudSearchRequest i
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/request/completion/AlibabaCloudSearchCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/request/completion/AlibabaCloudSearchCompletionRequest.java
@@ -14,9 +14,9 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.inference.external.request.CompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundCompletionRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.AlibabaCloudSearchAccount;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.completion.AlibabaCloudSearchCompletionModel;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.completion.AlibabaCloudSearchCompletionTaskSettings;
@@ -32,7 +32,7 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.buildUri;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public class AlibabaCloudSearchCompletionRequest extends AlibabaCloudSearchRequest implements CompletionRequest {
+public class AlibabaCloudSearchCompletionRequest extends AlibabaCloudSearchRequest implements OutboundCompletionRequest {
     private final AlibabaCloudSearchAccount account;
     private final List<String> input;
     private final URI uri;
@@ -89,7 +89,7 @@ public class AlibabaCloudSearchCompletionRequest extends AlibabaCloudSearchReque
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchCompletionResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchCompletionResponseEntity.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.inference.services.alibabacloudsearch.response;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -79,8 +79,8 @@ public class AlibabaCloudSearchCompletionResponseEntity extends AlibabaCloudSear
      * </pre>
      */
 
-    public static ChatCompletionResults fromResponse(Request request, HttpResult response) throws IOException {
-        return fromResponse(request, response, jsonParser -> {
+    public static ChatCompletionResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
+        return fromResponse(outboundRequest, response, jsonParser -> {
             positionParserAtTokenAfterField(jsonParser, "text", FAILED_TO_FIND_FIELD_TEMPLATE);
 
             XContentParser.Token contentToken = jsonParser.currentToken();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchEmbeddingsResponseEntity.java
@@ -11,7 +11,7 @@ import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -70,8 +70,8 @@ public class AlibabaCloudSearchEmbeddingsResponseEntity extends AlibabaCloudSear
      * </code>
      * </pre>
      */
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
-        return fromResponse(request, response, parser -> {
+    public static DenseEmbeddingFloatResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
+        return fromResponse(outboundRequest, response, parser -> {
             positionParserAtTokenAfterField(parser, "embeddings", FAILED_TO_FIND_FIELD_TEMPLATE);
 
             List<DenseEmbeddingFloatResults.Embedding> embeddingList = XContentParserUtils.parseList(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchRerankResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchRerankResponseEntity.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 
@@ -73,7 +73,7 @@ public class AlibabaCloudSearchRerankResponseEntity {
      * </code>
      * </pre>
      */
-    public static InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchResponseEntity.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.request.AlibabaCloudSearchRequest;
 
 import java.io.IOException;
@@ -28,10 +28,13 @@ import static org.elasticsearch.xpack.inference.external.response.XContentUtils.
 public abstract class AlibabaCloudSearchResponseEntity {
     private static final Logger logger = LogManager.getLogger(AlibabaCloudSearchResponseEntity.class);
 
-    public static <R> R fromResponse(Request request, HttpResult response, CheckedFunction<XContentParser, R, IOException> function)
-        throws IOException {
+    public static <R> R fromResponse(
+        OutboundRequest outboundRequest,
+        HttpResult response,
+        CheckedFunction<XContentParser, R, IOException> function
+    ) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
-        AlibabaCloudSearchRequest alibabaCloudSearchRequest = (AlibabaCloudSearchRequest) request;
+        AlibabaCloudSearchRequest alibabaCloudSearchRequest = (AlibabaCloudSearchRequest) outboundRequest;
 
         try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
             moveToFirstToken(parser);
@@ -66,7 +69,7 @@ public abstract class AlibabaCloudSearchResponseEntity {
 
             logger.debug(
                 "AlibabaCloud Search uri [{}] response: request_id [{}], latency [{}ms], client cost [{}ms], usage [{}]",
-                request.getURI().getPath(),
+                outboundRequest.getURI().getPath(),
                 requestID,
                 latency,
                 System.currentTimeMillis() - alibabaCloudSearchRequest.getStartTime(),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchSparseResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchSparseResponseEntity.java
@@ -12,7 +12,7 @@ import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -120,8 +120,8 @@ public class AlibabaCloudSearchSparseResponseEntity extends AlibabaCloudSearchRe
      * </code>
      * </pre>
      */
-    public static SparseEmbeddingResults fromResponse(Request request, HttpResult response) throws IOException {
-        return fromResponse(request, response, jsonParser -> {
+    public static SparseEmbeddingResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
+        return fromResponse(outboundRequest, response, jsonParser -> {
             positionParserAtTokenAfterField(jsonParser, "sparse_embeddings", FAILED_TO_FIND_FIELD_TEMPLATE);
 
             List<SparseEmbeddingResults.Embedding> embeddingList = XContentParserUtils.parseList(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockExecuteOnlyRequestSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockExecuteOnlyRequestSender.java
@@ -14,7 +14,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.retry.RequestSender;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.request.AmazonBedrockRequest;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.request.completion.AmazonBedrockChatCompletionRequest;
@@ -44,12 +44,13 @@ public class AmazonBedrockExecuteOnlyRequestSender implements RequestSender {
     @Override
     public void send(
         Logger logger,
-        Request request,
+        OutboundRequest outboundRequest,
         Supplier<Boolean> hasRequestTimedOutFunction,
         ResponseHandler responseHandler,
         ActionListener<InferenceServiceResults> listener
     ) {
-        if (request instanceof AmazonBedrockRequest awsRequest && responseHandler instanceof AmazonBedrockResponseHandler awsResponse) {
+        if (outboundRequest instanceof AmazonBedrockRequest awsRequest
+            && responseHandler instanceof AmazonBedrockResponseHandler awsResponse) {
             try {
                 var executor = createExecutor(awsRequest, awsResponse, logger, hasRequestTimedOutFunction, listener);
 
@@ -57,8 +58,8 @@ public class AmazonBedrockExecuteOnlyRequestSender implements RequestSender {
                 executor.run();
                 return;
             } catch (Exception e) {
-                logException(logger, request, e);
-                listener.onFailure(wrapWithElasticsearchException(e, request.getInferenceEntityId()));
+                logException(logger, outboundRequest, e);
+                listener.onFailure(wrapWithElasticsearchException(e, outboundRequest.getInferenceEntityId()));
             }
         }
 
@@ -112,12 +113,15 @@ public class AmazonBedrockExecuteOnlyRequestSender implements RequestSender {
         }
     }
 
-    private void logException(Logger logger, Request request, Exception exception) {
+    private void logException(Logger logger, OutboundRequest outboundRequest, Exception exception) {
         var causeException = ExceptionsHelper.unwrapCause(exception);
 
         throttleManager.warn(
             logger,
-            format("Failed while sending request from inference entity id [%s] of type [amazonbedrock]", request.getInferenceEntityId()),
+            format(
+                "Failed while sending request from inference entity id [%s] of type [amazonbedrock]",
+                outboundRequest.getInferenceEntityId()
+            ),
             causeException
         );
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockRequestSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockRequestSender.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.inference.external.http.sender.InferenceInputs;
 import org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceSettings;
 import org.elasticsearch.xpack.inference.external.http.sender.RequestManager;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockRequestExecutorService;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockRequestManager;
@@ -141,7 +141,7 @@ public class AmazonBedrockRequestSender implements Sender {
     @Override
     public void sendWithoutQueuing(
         Logger logger,
-        Request request,
+        OutboundRequest outboundRequest,
         ResponseHandler responseHandler,
         TimeValue timeout,
         ActionListener<InferenceServiceResults> listener

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/AmazonBedrockRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/AmazonBedrockRequest.java
@@ -11,14 +11,14 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockModel;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.client.AmazonBedrockBaseClient;
 
 import java.net.URI;
 import java.util.Objects;
 
-public abstract class AmazonBedrockRequest implements Request {
+public abstract class AmazonBedrockRequest implements OutboundRequest {
 
     protected final AmazonBedrockModel amazonBedrockModel;
     protected final String inferenceId;
@@ -58,7 +58,7 @@ public abstract class AmazonBedrockRequest implements Request {
      * @return null
      */
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockChatCompletionRequest.java
@@ -25,7 +25,7 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.completion.ToolChoice.ToolChoiceObject;
 import org.elasticsearch.inference.completion.ToolChoice.ToolChoiceString;
 import org.elasticsearch.xpack.core.inference.results.StreamingUnifiedChatCompletionResults;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.client.AmazonBedrockBaseClient;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.completion.AmazonBedrockChatCompletionModel;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.request.AmazonBedrockRequest;
@@ -46,7 +46,7 @@ import static org.elasticsearch.xpack.inference.services.amazonbedrock.translati
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.translation.Constants.NONE_TOOL_CHOICE;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.translation.Constants.REQUIRED_TOOL_CHOICE;
 
-public class AmazonBedrockChatCompletionRequest extends AmazonBedrockRequest implements ChatCompletionRequest {
+public class AmazonBedrockChatCompletionRequest extends AmazonBedrockRequest implements OutboundUnifiedCompletionRequest {
     private static final Set<String> VALID_TOOL_CHOICES = Set.of(AUTO_TOOL_CHOICE, REQUIRED_TOOL_CHOICE, NONE_TOOL_CHOICE);
 
     private final AmazonBedrockChatCompletionRequestEntity requestEntity;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/completion/AmazonBedrockCompletionRequest.java
@@ -13,7 +13,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamReques
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
-import org.elasticsearch.xpack.inference.external.request.CompletionRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundCompletionRequest;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.client.AmazonBedrockBaseClient;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.completion.AmazonBedrockChatCompletionModel;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.request.AmazonBedrockRequest;
@@ -25,7 +25,7 @@ import java.util.concurrent.Flow;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.request.completion.AmazonBedrockConverseUtils.getConverseMessageList;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.request.completion.AmazonBedrockConverseUtils.inferenceConfig;
 
-public class AmazonBedrockCompletionRequest extends AmazonBedrockRequest implements CompletionRequest {
+public class AmazonBedrockCompletionRequest extends AmazonBedrockRequest implements OutboundCompletionRequest {
     private final AmazonBedrockCompletionRequestEntity requestEntity;
     private AmazonBedrockChatCompletionResponseListener listener;
     private final boolean stream;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/embeddings/AmazonBedrockEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/request/embeddings/AmazonBedrockEmbeddingsRequest.java
@@ -17,8 +17,8 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.client.AmazonBedrockBaseClient;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.embeddings.AmazonBedrockEmbeddingsModel;
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public class AmazonBedrockEmbeddingsRequest extends AmazonBedrockRequest implements DenseEmbeddingRequest {
+public class AmazonBedrockEmbeddingsRequest extends AmazonBedrockRequest implements OutboundDenseEmbeddingRequest {
     private final AmazonBedrockEmbeddingsModel embeddingsModel;
     private final ToXContent requestEntity;
     private final Truncator truncator;
@@ -75,7 +75,7 @@ public class AmazonBedrockEmbeddingsRequest extends AmazonBedrockRequest impleme
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         if (provider == AmazonBedrockProvider.COHERE) {
             return this; // Cohere has its own truncation logic
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/response/AmazonBedrockResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/response/AmazonBedrockResponseHandler.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 public abstract class AmazonBedrockResponseHandler implements ResponseHandler {
@@ -22,7 +22,7 @@ public abstract class AmazonBedrockResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public final void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result)
+    public final void validateResponse(ThrottlerManager throttlerManager, Logger logger, OutboundRequest outboundRequest, HttpResult result)
         throws RetryException {
         // do nothing as the AWS SDK will take care of validation for us
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/response/completion/AmazonBedrockChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/response/completion/AmazonBedrockChatCompletionResponseHandler.java
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.request.AmazonBedrockRequest;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.response.AmazonBedrockResponseHandler;
 
@@ -23,9 +23,9 @@ public class AmazonBedrockChatCompletionResponseHandler extends AmazonBedrockRes
     public AmazonBedrockChatCompletionResponseHandler() {}
 
     @Override
-    public InferenceServiceResults parseResult(Request request, HttpResult result) throws RetryException {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         var response = new AmazonBedrockChatCompletionResponse(responseResult);
-        return response.accept((AmazonBedrockRequest) request);
+        return response.accept((AmazonBedrockRequest) outboundRequest);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/response/embeddings/AmazonBedrockEmbeddingsResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/response/embeddings/AmazonBedrockEmbeddingsResponseHandler.java
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.request.AmazonBedrockRequest;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.response.AmazonBedrockResponseHandler;
 
@@ -21,9 +21,9 @@ public class AmazonBedrockEmbeddingsResponseHandler extends AmazonBedrockRespons
     private InvokeModelResponse invokeModelResult;
 
     @Override
-    public InferenceServiceResults parseResult(Request request, HttpResult result) throws RetryException {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         var responseParser = new AmazonBedrockEmbeddingsResponse(invokeModelResult);
-        return responseParser.accept((AmazonBedrockRequest) request);
+        return responseParser.accept((AmazonBedrockRequest) outboundRequest);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionResponseHandler.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.ChatCompletionError
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.UnifiedChatCompletionErrorParserContract;
 import org.elasticsearch.xpack.inference.external.http.retry.UnifiedChatCompletionErrorResponseUtils;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
 import org.elasticsearch.xpack.inference.services.anthropic.response.AnthropicChatCompletionResponseEntity;
@@ -43,10 +43,10 @@ public class AnthropicChatCompletionResponseHandler extends AnthropicResponseHan
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
         var serverSentEventProcessor = new ServerSentEventProcessor(new ServerSentEventParser());
         var anthropicProcessor = new AnthropicChatCompletionStreamingProcessor(
-            (m, e) -> chatCompletionErrorResponseHandler.buildMidStreamChatCompletionError(request.getInferenceEntityId(), m, e)
+            (m, e) -> chatCompletionErrorResponseHandler.buildMidStreamChatCompletionError(outboundRequest.getInferenceEntityId(), m, e)
         );
         flow.subscribe(serverSentEventProcessor);
         serverSentEventProcessor.subscribe(anthropicProcessor);
@@ -54,7 +54,7 @@ public class AnthropicChatCompletionResponseHandler extends AnthropicResponseHan
     }
 
     @Override
-    protected UnifiedChatCompletionException buildError(String message, Request request, HttpResult result) {
-        return chatCompletionErrorResponseHandler.buildChatCompletionError(message, request, result);
+    protected UnifiedChatCompletionException buildError(String message, OutboundRequest outboundRequest, HttpResult result) {
+        return chatCompletionErrorResponseHandler.buildChatCompletionError(message, outboundRequest, result);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicResponseHandler.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.ErrorMessageResponseEntity;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
@@ -49,7 +49,7 @@ public class AnthropicResponseHandler extends BaseResponseHandler {
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
         var sseProcessor = new ServerSentEventProcessor(new ServerSentEventParser());
         var anthropicProcessor = new AnthropicStreamingProcessor();
         sseProcessor.subscribe(anthropicProcessor);
@@ -61,12 +61,12 @@ public class AnthropicResponseHandler extends BaseResponseHandler {
      * Validates the status code throws an RetryException if not in the range [200, 300).
      *
      * The Anthropic API error codes are documented <a href="https://docs.anthropic.com/en/api/errors">here</a>.
-     * @param request The originating request
+     * @param outboundRequest The originating request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
@@ -74,21 +74,21 @@ public class AnthropicResponseHandler extends BaseResponseHandler {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 529) {
-            throw new RetryException(true, buildError(SERVER_BUSY, request, result));
+            throw new RetryException(true, buildError(SERVER_BUSY, outboundRequest, result));
         } else if (statusCode > 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(buildRateLimitErrorMessage(result), request, result));
+            throw new RetryException(true, buildError(buildRateLimitErrorMessage(result), outboundRequest, result));
         } else if (statusCode == 403) {
-            throw new RetryException(false, buildError(PERMISSION_DENIED, request, result));
+            throw new RetryException(false, buildError(PERMISSION_DENIED, outboundRequest, result));
         } else if (statusCode == 401) {
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/request/AnthropicChatCompletionRequest.java
@@ -13,9 +13,9 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.inference.external.request.CompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundCompletionRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.anthropic.AnthropicAccount;
 import org.elasticsearch.xpack.inference.services.anthropic.completion.AnthropicChatCompletionModel;
 
@@ -26,7 +26,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.services.anthropic.request.AnthropicRequestUtils.createVersionHeader;
 
-public class AnthropicChatCompletionRequest implements CompletionRequest {
+public class AnthropicChatCompletionRequest implements OutboundCompletionRequest {
 
     private final AnthropicAccount account;
     private final List<String> input;
@@ -63,7 +63,7 @@ public class AnthropicChatCompletionRequest implements CompletionRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation for Anthropic completions
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/response/AnthropicChatCompletionResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/response/AnthropicChatCompletionResponseEntity.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -70,7 +70,7 @@ public class AnthropicChatCompletionResponseEntity {
      * </pre>
      */
 
-    public static ChatCompletionResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static ChatCompletionResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
             moveToFirstToken(jsonParser);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/request/AzureAiStudioChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/request/AzureAiStudioChatCompletionRequest.java
@@ -13,16 +13,16 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.inference.external.request.CompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundCompletionRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.azureaistudio.completion.AzureAiStudioChatCompletionModel;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 
-public class AzureAiStudioChatCompletionRequest extends AzureAiStudioRequest implements CompletionRequest {
+public class AzureAiStudioChatCompletionRequest extends AzureAiStudioRequest implements OutboundCompletionRequest {
     private final List<String> input;
     private final AzureAiStudioChatCompletionModel completionModel;
     private final boolean stream;
@@ -52,7 +52,7 @@ public class AzureAiStudioChatCompletionRequest extends AzureAiStudioRequest imp
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // no truncation
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/request/AzureAiStudioEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/request/AzureAiStudioEmbeddingsRequest.java
@@ -16,14 +16,14 @@ import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.azureaistudio.embeddings.AzureAiStudioEmbeddingsModel;
 
 import java.nio.charset.StandardCharsets;
 
-public class AzureAiStudioEmbeddingsRequest extends AzureAiStudioRequest implements DenseEmbeddingRequest {
+public class AzureAiStudioEmbeddingsRequest extends AzureAiStudioRequest implements OutboundDenseEmbeddingRequest {
 
     private final AzureAiStudioEmbeddingsModel embeddingsModel;
     private final Truncator.TruncationResult truncationResult;
@@ -65,7 +65,7 @@ public class AzureAiStudioEmbeddingsRequest extends AzureAiStudioRequest impleme
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
         return new AzureAiStudioEmbeddingsRequest(truncator, truncatedInput, inputType, embeddingsModel);
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/request/AzureAiStudioRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/request/AzureAiStudioRequest.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.azureaistudio.request;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioEndpointType;
 import org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioModel;
 import org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioProvider;
@@ -19,7 +19,7 @@ import java.net.URI;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 import static org.elasticsearch.xpack.inference.services.azureaistudio.request.AzureAiStudioRequestFields.API_KEY_HEADER;
 
-public abstract class AzureAiStudioRequest implements Request {
+public abstract class AzureAiStudioRequest implements OutboundRequest {
 
     protected final URI uri;
     protected final String inferenceEntityId;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/request/AzureAiStudioRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/request/AzureAiStudioRerankRequest.java
@@ -15,15 +15,15 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.azureaistudio.rerank.AzureAiStudioRerankModel;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 
-public class AzureAiStudioRerankRequest extends AzureAiStudioRequest implements RerankRequest {
+public class AzureAiStudioRerankRequest extends AzureAiStudioRequest implements OutboundRerankRequest {
     private final String query;
     private final List<String> input;
     private final Boolean returnDocuments;
@@ -59,7 +59,7 @@ public class AzureAiStudioRerankRequest extends AzureAiStudioRequest implements 
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // Not applicable for rerank, only used in text embedding requests
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/response/AzureAiStudioChatCompletionResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/response/AzureAiStudioChatCompletionResponseEntity.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.BaseResponseEntity;
 import org.elasticsearch.xpack.inference.services.azureaistudio.request.AzureAiStudioChatCompletionRequest;
 import org.elasticsearch.xpack.inference.services.openai.response.OpenAiChatCompletionResponseEntity;
@@ -29,14 +29,14 @@ import static org.elasticsearch.xpack.inference.external.response.XContentUtils.
 public class AzureAiStudioChatCompletionResponseEntity extends BaseResponseEntity {
 
     @Override
-    protected InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException {
-        if (request instanceof AzureAiStudioChatCompletionRequest asChatCompletionRequest) {
+    protected InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
+        if (outboundRequest instanceof AzureAiStudioChatCompletionRequest asChatCompletionRequest) {
             if (asChatCompletionRequest.isRealtimeEndpoint()) {
                 return parseRealtimeEndpointResponse(response);
             }
 
             // we can use the OpenAI chat completion type if it's not a realtime endpoint
-            return OpenAiChatCompletionResponseEntity.fromResponse(request, response);
+            return OpenAiChatCompletionResponseEntity.fromResponse(outboundRequest, response);
         }
 
         return null;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/response/AzureAiStudioEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/response/AzureAiStudioEmbeddingsResponseEntity.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.azureaistudio.response;
 
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.BaseResponseEntity;
 import org.elasticsearch.xpack.inference.services.openai.response.OpenAiEmbeddingsResponseEntity;
 
@@ -17,8 +17,8 @@ import java.io.IOException;
 
 public class AzureAiStudioEmbeddingsResponseEntity extends BaseResponseEntity {
     @Override
-    protected InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException {
+    protected InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         // expected response type is the same as the Open AI Embeddings
-        return OpenAiEmbeddingsResponseEntity.fromResponse(request, response);
+        return OpenAiEmbeddingsResponseEntity.fromResponse(outboundRequest, response);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/response/AzureAiStudioRerankResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureaistudio/response/AzureAiStudioRerankResponseEntity.java
@@ -18,7 +18,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.BaseResponseEntity;
 
 import java.io.IOException;
@@ -79,7 +79,7 @@ public class AzureAiStudioRerankResponseEntity extends BaseResponseEntity {
      * </pre>
      */
     @Override
-    protected InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException {
+    protected InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         final var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiResponseHandler.java
@@ -11,7 +11,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.openai.OpenAiResponseHandler;
 
 import static org.elasticsearch.xpack.inference.external.http.retry.ResponseHandlerUtils.getFirstHeaderOrUnknown;
@@ -36,8 +36,8 @@ public class AzureOpenAiResponseHandler extends OpenAiResponseHandler {
     }
 
     @Override
-    protected RetryException buildExceptionHandling429(Request request, HttpResult result) {
-        return new RetryException(true, buildError(buildRateLimitErrorMessage(result), request, result));
+    protected RetryException buildExceptionHandling429(OutboundRequest outboundRequest, HttpResult result) {
+        return new RetryException(true, buildError(buildRateLimitErrorMessage(result), outboundRequest, result));
     }
 
     static String buildRateLimitErrorMessage(HttpResult result) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/request/AzureOpenAiChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/request/AzureOpenAiChatCompletionRequest.java
@@ -10,12 +10,14 @@ package org.elasticsearch.xpack.inference.services.azureopenai.request;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.azureopenai.completion.AzureOpenAiCompletionModel;
 
 import java.util.Objects;
 
-public class AzureOpenAiChatCompletionRequest extends AzureOpenAiRequest<AzureOpenAiCompletionModel> implements ChatCompletionRequest {
+public class AzureOpenAiChatCompletionRequest extends AzureOpenAiRequest<AzureOpenAiCompletionModel>
+    implements
+        OutboundUnifiedCompletionRequest {
 
     private final UnifiedChatInput chatInput;
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/request/AzureOpenAiCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/request/AzureOpenAiCompletionRequest.java
@@ -8,13 +8,13 @@
 package org.elasticsearch.xpack.inference.services.azureopenai.request;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.xpack.inference.external.request.CompletionRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundCompletionRequest;
 import org.elasticsearch.xpack.inference.services.azureopenai.completion.AzureOpenAiCompletionModel;
 
 import java.util.List;
 import java.util.Objects;
 
-public class AzureOpenAiCompletionRequest extends AzureOpenAiRequest<AzureOpenAiCompletionModel> implements CompletionRequest {
+public class AzureOpenAiCompletionRequest extends AzureOpenAiRequest<AzureOpenAiCompletionModel> implements OutboundCompletionRequest {
 
     private final boolean stream;
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/request/AzureOpenAiEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/request/AzureOpenAiEmbeddingsRequest.java
@@ -11,13 +11,13 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.azureopenai.embeddings.AzureOpenAiEmbeddingsModel;
 
 import java.util.Objects;
 
-public class AzureOpenAiEmbeddingsRequest extends AzureOpenAiRequest<AzureOpenAiEmbeddingsModel> implements DenseEmbeddingRequest {
+public class AzureOpenAiEmbeddingsRequest extends AzureOpenAiRequest<AzureOpenAiEmbeddingsModel> implements OutboundDenseEmbeddingRequest {
 
     private final Truncator truncator;
     private final Truncator.TruncationResult truncationResult;
@@ -48,7 +48,7 @@ public class AzureOpenAiEmbeddingsRequest extends AzureOpenAiRequest<AzureOpenAi
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
         return new AzureOpenAiEmbeddingsRequest(truncator, truncatedInput, inputType, model);
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/request/AzureOpenAiRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/request/AzureOpenAiRequest.java
@@ -14,7 +14,7 @@ import org.apache.http.message.BasicHeader;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiModel;
 import org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAiTaskSettings;
 
@@ -22,7 +22,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public abstract class AzureOpenAiRequest<M extends AzureOpenAiModel> implements Request {
+public abstract class AzureOpenAiRequest<M extends AzureOpenAiModel> implements OutboundRequest {
 
     protected final M model;
     private final AzureOpenAiTaskSettings<?> taskSettings;
@@ -66,7 +66,7 @@ public abstract class AzureOpenAiRequest<M extends AzureOpenAiModel> implements 
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // Default implementation: no truncation. Subclasses may override to apply truncation if needed.
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureMistralOpenAiExternalResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureMistralOpenAiExternalResponseHandler.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.ContentTooLargeExce
 import org.elasticsearch.xpack.inference.external.http.retry.ErrorResponse;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.ErrorMessageResponseEntity;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
@@ -63,10 +63,10 @@ public class AzureMistralOpenAiExternalResponseHandler extends BaseResponseHandl
     }
 
     @Override
-    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result)
+    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, OutboundRequest outboundRequest, HttpResult result)
         throws RetryException {
-        checkForFailureStatusCode(request, result);
-        checkForEmptyBody(throttlerManager, logger, request, result);
+        checkForFailureStatusCode(outboundRequest, result);
+        checkForEmptyBody(throttlerManager, logger, outboundRequest, result);
     }
 
     @Override
@@ -75,7 +75,7 @@ public class AzureMistralOpenAiExternalResponseHandler extends BaseResponseHandl
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
         var serverSentEventProcessor = new ServerSentEventProcessor(new ServerSentEventParser());
         var openAiProcessor = new OpenAiStreamingProcessor();
 
@@ -84,7 +84,7 @@ public class AzureMistralOpenAiExternalResponseHandler extends BaseResponseHandl
         return new StreamingChatCompletionResults(openAiProcessor);
     }
 
-    public void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    public void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
@@ -92,46 +92,46 @@ public class AzureMistralOpenAiExternalResponseHandler extends BaseResponseHandl
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
-            throw handle500Error(request, result);
+            throw handle500Error(outboundRequest, result);
         } else if (statusCode == 503) {
-            throw handle503Error(request, result);
+            throw handle503Error(outboundRequest, result);
         } else if (statusCode > 500) {
-            throw handleOther500Error(request, result);
+            throw handleOther500Error(outboundRequest, result);
         } else if (statusCode == 429) {
-            throw handleRateLimitingError(request, result);
+            throw handleRateLimitingError(outboundRequest, result);
         } else if (isContentTooLarge(result)) {
-            throw new ContentTooLargeException(buildError(CONTENT_TOO_LARGE, request, result));
+            throw new ContentTooLargeException(buildError(CONTENT_TOO_LARGE, outboundRequest, result));
         } else if (statusCode == 401) {
-            throw handleAuthenticationError(request, result);
+            throw handleAuthenticationError(outboundRequest, result);
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw handleRedirectionStatusCode(request, result);
+            throw handleRedirectionStatusCode(outboundRequest, result);
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 
-    protected RetryException handle500Error(Request request, HttpResult result) {
-        return new RetryException(true, buildError(SERVER_ERROR, request, result));
+    protected RetryException handle500Error(OutboundRequest outboundRequest, HttpResult result) {
+        return new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
     }
 
-    protected RetryException handle503Error(Request request, HttpResult result) {
-        return new RetryException(true, buildError(SERVER_BUSY_ERROR, request, result));
+    protected RetryException handle503Error(OutboundRequest outboundRequest, HttpResult result) {
+        return new RetryException(true, buildError(SERVER_BUSY_ERROR, outboundRequest, result));
     }
 
-    protected RetryException handleOther500Error(Request request, HttpResult result) {
-        return new RetryException(false, buildError(SERVER_ERROR, request, result));
+    protected RetryException handleOther500Error(OutboundRequest outboundRequest, HttpResult result) {
+        return new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
     }
 
-    protected RetryException handleAuthenticationError(Request request, HttpResult result) {
-        return new RetryException(false, buildError(AUTHENTICATION, request, result));
+    protected RetryException handleAuthenticationError(OutboundRequest outboundRequest, HttpResult result) {
+        return new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
     }
 
-    protected RetryException handleRateLimitingError(Request request, HttpResult result) {
-        return new RetryException(true, buildError(buildRateLimitErrorMessage(result), request, result));
+    protected RetryException handleRateLimitingError(OutboundRequest outboundRequest, HttpResult result) {
+        return new RetryException(true, buildError(buildRateLimitErrorMessage(result), outboundRequest, result));
     }
 
-    protected RetryException handleRedirectionStatusCode(Request request, HttpResult result) {
-        throw new RetryException(false, buildError(REDIRECTION, request, result));
+    protected RetryException handleRedirectionStatusCode(OutboundRequest outboundRequest, HttpResult result) {
+        throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
     }
 
     public static boolean isContentTooLarge(HttpResult result) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureOpenAiCompletionResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureOpenAiCompletionResponseEntity.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -82,7 +82,7 @@ public class AzureOpenAiCompletionResponseEntity {
      *     </code>
      * </pre>
      */
-    public static ChatCompletionResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static ChatCompletionResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
             moveToFirstToken(jsonParser);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereResponseHandler.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.streaming.NewlineDelimitedByteProcessor;
 import org.elasticsearch.xpack.inference.services.cohere.response.CohereErrorResponseEntity;
 
@@ -40,7 +40,7 @@ public class CohereResponseHandler extends BaseResponseHandler {
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
         var ndProcessor = new NewlineDelimitedByteProcessor();
         var cohereProcessor = new CohereStreamingProcessor();
         flow.subscribe(ndProcessor);
@@ -51,12 +51,12 @@ public class CohereResponseHandler extends BaseResponseHandler {
     /**
      * Validates the status code throws an RetryException if not in the range [200, 300).
      *
-     * @param request The http request
+     * @param outboundRequest The http request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
@@ -64,19 +64,19 @@ public class CohereResponseHandler extends BaseResponseHandler {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode > 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         } else if (isTextsArrayTooLarge(result)) {
-            throw new RetryException(false, buildError(TEXTS_ARRAY_ERROR_MESSAGE, request, result));
+            throw new RetryException(false, buildError(TEXTS_ARRAY_ERROR_MESSAGE, outboundRequest, result));
         } else if (statusCode == 401) {
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereActionCreator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereActionCreator.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xpack.inference.external.http.sender.EmbeddingsInput;
 import org.elasticsearch.xpack.inference.external.http.sender.GenericRequestManager;
 import org.elasticsearch.xpack.inference.external.http.sender.QueryAndDocsInputs;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.cohere.CohereResponseHandler;
 import org.elasticsearch.xpack.inference.services.cohere.completion.CohereCompletionModel;
@@ -75,7 +75,7 @@ public class CohereActionCreator implements CohereActionVisitor {
     public ExecutableAction create(CohereEmbeddingsModel model, Map<String, Object> taskSettings) {
         var overriddenModel = CohereEmbeddingsModel.of(model, taskSettings);
 
-        Function<EmbeddingsInput, Request> requestCreator = inferenceInputs -> {
+        Function<EmbeddingsInput, OutboundRequest> requestCreator = inferenceInputs -> {
             var requestInputType = InputType.isSpecified(inferenceInputs.getInputType())
                 ? inferenceInputs.getInputType()
                 : overriddenModel.getTaskSettings().getInputType();
@@ -101,7 +101,7 @@ public class CohereActionCreator implements CohereActionVisitor {
     public ExecutableAction create(CohereRerankModel model, Map<String, Object> taskSettings) {
         var overriddenModel = CohereRerankModel.of(model, taskSettings);
 
-        Function<QueryAndDocsInputs, Request> requestCreator = inferenceInputs -> switch (overriddenModel.getServiceSettings()
+        Function<QueryAndDocsInputs, OutboundRequest> requestCreator = inferenceInputs -> switch (overriddenModel.getServiceSettings()
             .apiVersion()) {
             case V1 -> new CohereV1RerankRequest(
                 inferenceInputs.getQuery(),
@@ -135,7 +135,8 @@ public class CohereActionCreator implements CohereActionVisitor {
     public ExecutableAction create(CohereCompletionModel model, Map<String, Object> taskSettings) {
         // no overridden model as task settings are always empty for cohere completion model
 
-        Function<ChatCompletionInput, Request> requestCreator = completionInput -> switch (model.getServiceSettings().apiVersion()) {
+        Function<ChatCompletionInput, OutboundRequest> requestCreator = completionInput -> switch (model.getServiceSettings()
+            .apiVersion()) {
             case V1 -> new CohereV1CompletionRequest(completionInput.getInputs(), model, completionInput.stream());
             case V2 -> new CohereV2CompletionRequest(completionInput.getInputs(), model, completionInput.stream());
         };

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/CohereRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/CohereRequest.java
@@ -19,7 +19,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.cohere.CohereAccount;
 import org.elasticsearch.xpack.inference.services.cohere.CohereService;
 
@@ -31,7 +31,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public abstract class CohereRequest implements Request, ToXContentObject {
+public abstract class CohereRequest implements OutboundRequest, ToXContentObject {
 
     public static void decorateWithAuthHeader(HttpPost request, CohereAccount account) {
         request.setHeader(HttpHeaders.CONTENT_TYPE, XContentType.JSON.mediaType());
@@ -101,7 +101,7 @@ public abstract class CohereRequest implements Request, ToXContentObject {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // no truncation
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v1/CohereV1CompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v1/CohereV1CompletionRequest.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.inference.services.cohere.request.v1;
 
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.inference.external.request.CompletionRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundCompletionRequest;
 import org.elasticsearch.xpack.inference.services.cohere.CohereAccount;
 import org.elasticsearch.xpack.inference.services.cohere.completion.CohereCompletionModel;
 import org.elasticsearch.xpack.inference.services.cohere.request.CohereRequest;
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class CohereV1CompletionRequest extends CohereRequest implements CompletionRequest {
+public class CohereV1CompletionRequest extends CohereRequest implements OutboundCompletionRequest {
     private final List<String> input;
 
     public CohereV1CompletionRequest(List<String> input, CohereCompletionModel model, boolean stream) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v1/CohereV1EmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v1/CohereV1EmbeddingsRequest.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.inference.services.cohere.request.v1;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.services.cohere.CohereAccount;
 import org.elasticsearch.xpack.inference.services.cohere.CohereServiceFields;
 import org.elasticsearch.xpack.inference.services.cohere.CohereServiceSettings;
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class CohereV1EmbeddingsRequest extends CohereRequest implements DenseEmbeddingRequest {
+public class CohereV1EmbeddingsRequest extends CohereRequest implements OutboundDenseEmbeddingRequest {
 
     private final List<String> input;
     private final InputType inputType;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v1/CohereV1RerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v1/CohereV1RerankRequest.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.cohere.request.v1;
 
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.cohere.CohereAccount;
 import org.elasticsearch.xpack.inference.services.cohere.request.CohereRequest;
 import org.elasticsearch.xpack.inference.services.cohere.request.CohereUtils;
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class CohereV1RerankRequest extends CohereRequest implements RerankRequest {
+public class CohereV1RerankRequest extends CohereRequest implements OutboundRerankRequest {
 
     private final String query;
     private final List<String> input;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v2/CohereV2CompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v2/CohereV2CompletionRequest.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.inference.services.cohere.request.v2;
 
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.inference.external.request.CompletionRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundCompletionRequest;
 import org.elasticsearch.xpack.inference.services.cohere.CohereAccount;
 import org.elasticsearch.xpack.inference.services.cohere.completion.CohereCompletionModel;
 import org.elasticsearch.xpack.inference.services.cohere.request.CohereRequest;
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class CohereV2CompletionRequest extends CohereRequest implements CompletionRequest {
+public class CohereV2CompletionRequest extends CohereRequest implements OutboundCompletionRequest {
     private final List<String> input;
 
     public CohereV2CompletionRequest(List<String> input, CohereCompletionModel model, boolean stream) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v2/CohereV2EmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v2/CohereV2EmbeddingsRequest.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.inference.services.cohere.request.v2;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.services.cohere.CohereAccount;
 import org.elasticsearch.xpack.inference.services.cohere.CohereServiceFields;
 import org.elasticsearch.xpack.inference.services.cohere.embeddings.CohereEmbeddingType;
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-public class CohereV2EmbeddingsRequest extends CohereRequest implements DenseEmbeddingRequest {
+public class CohereV2EmbeddingsRequest extends CohereRequest implements OutboundDenseEmbeddingRequest {
 
     private final List<String> input;
     private final InputType inputType;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v2/CohereV2RerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/request/v2/CohereV2RerankRequest.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.cohere.request.v2;
 
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.cohere.CohereAccount;
 import org.elasticsearch.xpack.inference.services.cohere.request.CohereRequest;
 import org.elasticsearch.xpack.inference.services.cohere.request.CohereUtils;
@@ -24,7 +24,7 @@ import static org.elasticsearch.xpack.inference.services.cohere.request.CohereUt
 import static org.elasticsearch.xpack.inference.services.cohere.request.CohereUtils.MODEL_FIELD;
 import static org.elasticsearch.xpack.inference.services.cohere.request.CohereUtils.QUERY_FIELD;
 
-public class CohereV2RerankRequest extends CohereRequest implements RerankRequest {
+public class CohereV2RerankRequest extends CohereRequest implements OutboundRerankRequest {
 
     private final String query;
     private final List<String> input;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereCompletionResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereCompletionResponseEntity.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -76,7 +76,7 @@ public class CohereCompletionResponseEntity {
      * </pre>
      */
 
-    public static ChatCompletionResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static ChatCompletionResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereEmbeddingsResponseEntity.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
 import org.elasticsearch.xpack.inference.services.cohere.embeddings.CohereEmbeddingType;
 
@@ -136,7 +136,7 @@ public class CohereEmbeddingsResponseEntity {
      * </code>
      * </pre>
      */
-    public static InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/contextualai/ContextualAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/contextualai/ContextualAiResponseHandler.java
@@ -12,7 +12,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler
 import org.elasticsearch.xpack.inference.external.http.retry.ErrorResponse;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 /**
  * Response handler for ContextualAI API calls.
@@ -24,7 +24,7 @@ public class ContextualAiResponseHandler extends BaseResponseHandler {
     }
 
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
@@ -32,19 +32,19 @@ public class ContextualAiResponseHandler extends BaseResponseHandler {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 503) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode > 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         } else if (statusCode == 401) {
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/contextualai/action/ContextualAiActionCreator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/contextualai/action/ContextualAiActionCreator.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.sender.GenericRequestManager;
 import org.elasticsearch.xpack.inference.external.http.sender.QueryAndDocsInputs;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.contextualai.ContextualAiResponseHandler;
 import org.elasticsearch.xpack.inference.services.contextualai.request.ContextualAiRerankRequest;
@@ -49,7 +49,7 @@ public class ContextualAiActionCreator implements ContextualAiActionVisitor {
     public ExecutableAction create(ContextualAiRerankModel model, Map<String, Object> taskSettings) {
         var overriddenModel = ContextualAiRerankModel.of(model, taskSettings);
 
-        Function<QueryAndDocsInputs, Request> requestCreator = rerankInput -> new ContextualAiRerankRequest(
+        Function<QueryAndDocsInputs, OutboundRequest> requestCreator = rerankInput -> new ContextualAiRerankRequest(
             rerankInput.getQuery(),
             rerankInput.getChunks(),
             rerankInput.getTopN(),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/contextualai/request/ContextualAiRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/contextualai/request/ContextualAiRerankRequest.java
@@ -15,8 +15,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.contextualai.rerank.ContextualAiRerankModel;
 
 import java.net.URI;
@@ -26,7 +26,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public class ContextualAiRerankRequest implements RerankRequest {
+public class ContextualAiRerankRequest implements OutboundRerankRequest {
 
     private final String query;
     private final List<String> documents;
@@ -78,7 +78,7 @@ public class ContextualAiRerankRequest implements RerankRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // Not applicable for rerank, only used in text embedding requests
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/CustomResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/CustomResponseHandler.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler
 import org.elasticsearch.xpack.inference.external.http.retry.ErrorResponse;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
@@ -39,9 +39,9 @@ public class CustomResponseHandler extends BaseResponseHandler {
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, HttpResult result) throws RetryException {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         try {
-            return parseFunction.apply(request, result);
+            return parseFunction.apply(outboundRequest, result);
         } catch (Exception e) {
             // if we get a parse failure it's probably an incorrect configuration of the service so report the error back to the user
             // immediately without retrying
@@ -59,12 +59,12 @@ public class CustomResponseHandler extends BaseResponseHandler {
     /**
      * Validates the status code throws an RetryException if not in the range [200, 300).
      *
-     * @param request The http request
+     * @param outboundRequest The http request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode >= 200 && statusCode < 300) {
             return;
@@ -72,15 +72,15 @@ public class CustomResponseHandler extends BaseResponseHandler {
 
         // handle error codes
         if (statusCode >= 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         } else if (statusCode == 401) {
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequest.java
@@ -19,7 +19,7 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.ValidatingSubstitutor;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.custom.CustomModel;
 import org.elasticsearch.xpack.inference.services.custom.CustomServiceSettings;
 
@@ -34,7 +34,7 @@ import static org.elasticsearch.xpack.inference.common.JsonUtils.toJson;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.URL;
 import static org.elasticsearch.xpack.inference.services.custom.CustomServiceSettings.REQUEST;
 
-public class CustomRequest implements Request {
+public class CustomRequest implements OutboundRequest {
 
     private final URI uri;
     private final ValidatingSubstitutor jsonPlaceholderReplacer;
@@ -136,7 +136,7 @@ public class CustomRequest implements Request {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/response/CustomResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/response/CustomResponseEntity.java
@@ -10,14 +10,14 @@ package org.elasticsearch.xpack.inference.services.custom.response;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.custom.request.CustomRequest;
 
 import java.io.IOException;
 
 public class CustomResponseEntity {
-    public static InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException {
-        if (request instanceof CustomRequest customRequest) {
+    public static InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
+        if (outboundRequest instanceof CustomRequest customRequest) {
             var responseJsonParser = customRequest.getServiceSettings().getResponseJsonParser();
 
             return responseJsonParser.parse(response);
@@ -25,7 +25,7 @@ public class CustomResponseEntity {
             throw new IllegalArgumentException(
                 Strings.format(
                     "Original request is an invalid type [%s], expected [%s]",
-                    request.getClass().getSimpleName(),
+                    outboundRequest.getClass().getSimpleName(),
                     CustomRequest.class.getSimpleName()
                 )
             );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/deepseek/request/DeepSeekChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/deepseek/request/DeepSeekChatCompletionRequest.java
@@ -21,9 +21,9 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.external.unified.UnifiedChatCompletionRequestEntity;
 import org.elasticsearch.xpack.inference.services.deepseek.DeepSeekChatCompletionModel;
 
@@ -34,7 +34,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public class DeepSeekChatCompletionRequest implements ChatCompletionRequest {
+public class DeepSeekChatCompletionRequest implements OutboundUnifiedCompletionRequest {
     private static final Logger logger = LogManager.getLogger(DeepSeekChatCompletionRequest.class);
     private static final String MODEL_FIELD = "model";
     private static final String MAX_TOKENS = "max_tokens";
@@ -84,7 +84,7 @@ public class DeepSeekChatCompletionRequest implements ChatCompletionRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandler.java
@@ -12,7 +12,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler
 import org.elasticsearch.xpack.inference.external.http.retry.ContentTooLargeException;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.elastic.response.ElasticInferenceServiceErrorResponseEntity;
 
 public class ElasticInferenceServiceResponseHandler extends BaseResponseHandler {
@@ -26,25 +26,25 @@ public class ElasticInferenceServiceResponseHandler extends BaseResponseHandler 
     }
 
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
 
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500 || statusCode == 503) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 400) {
-            throw new RetryException(false, buildError(BAD_REQUEST, request, result));
+            throw new RetryException(false, buildError(BAD_REQUEST, outboundRequest, result));
         } else if (statusCode == 405) {
-            throw new RetryException(false, buildError(METHOD_NOT_ALLOWED, request, result));
+            throw new RetryException(false, buildError(METHOD_NOT_ALLOWED, outboundRequest, result));
         } else if (statusCode == 413) {
-            throw new ContentTooLargeException(buildError(CONTENT_TOO_LARGE, request, result));
+            throw new ContentTooLargeException(buildError(CONTENT_TOO_LARGE, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         }
 
-        throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+        throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
     }
 
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceUnifiedChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceUnifiedChatCompletionResponseHandler.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionExcep
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.ErrorResponse;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
 import org.elasticsearch.xpack.inference.services.elastic.response.ElasticInferenceServiceErrorResponseEntity;
@@ -31,10 +31,10 @@ public class ElasticInferenceServiceUnifiedChatCompletionResponseHandler extends
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
         var serverSentEventProcessor = new ServerSentEventProcessor(new ServerSentEventParser());
         // EIS uses the unified API spec
-        var openAiProcessor = new OpenAiUnifiedStreamingProcessor((m, e) -> buildMidStreamError(request, m, e));
+        var openAiProcessor = new OpenAiUnifiedStreamingProcessor((m, e) -> buildMidStreamError(outboundRequest, m, e));
 
         flow.subscribe(serverSentEventProcessor);
         serverSentEventProcessor.subscribe(openAiProcessor);
@@ -42,23 +42,23 @@ public class ElasticInferenceServiceUnifiedChatCompletionResponseHandler extends
     }
 
     @Override
-    protected Exception buildError(String message, Request request, HttpResult result, ErrorResponse errorResponse) {
-        assert request.isStreaming() : "Only streaming requests support this format";
+    protected Exception buildError(String message, OutboundRequest outboundRequest, HttpResult result, ErrorResponse errorResponse) {
+        assert outboundRequest.isStreaming() : "Only streaming requests support this format";
         var responseStatusCode = result.response().getStatusLine().getStatusCode();
-        if (request.isStreaming()) {
+        if (outboundRequest.isStreaming()) {
             var restStatus = toRestStatus(responseStatusCode);
             return new UnifiedChatCompletionException(
                 restStatus,
-                constructErrorMessage(message, request, errorResponse, responseStatusCode),
+                constructErrorMessage(message, outboundRequest, errorResponse, responseStatusCode),
                 "error",
                 restStatus.name().toLowerCase(Locale.ROOT)
             );
         } else {
-            return super.buildError(message, request, result, errorResponse);
+            return super.buildError(message, outboundRequest, result, errorResponse);
         }
     }
 
-    private static Exception buildMidStreamError(Request request, String message, Exception e) {
+    private static Exception buildMidStreamError(OutboundRequest outboundRequest, String message, Exception e) {
         var errorResponse = ElasticInferenceServiceErrorResponseEntity.fromString(message);
         if (errorResponse.errorStructureFound()) {
             return new UnifiedChatCompletionException(
@@ -66,7 +66,7 @@ public class ElasticInferenceServiceUnifiedChatCompletionResponseHandler extends
                 format(
                     "%s for request from inference entity id [%s]. Error message: [%s]",
                     SERVER_ERROR_OBJECT,
-                    request.getInferenceEntityId(),
+                    outboundRequest.getInferenceEntityId(),
                     errorResponse.getErrorMessage()
                 ),
                 "error",
@@ -77,7 +77,7 @@ public class ElasticInferenceServiceUnifiedChatCompletionResponseHandler extends
         } else {
             return new UnifiedChatCompletionException(
                 RestStatus.INTERNAL_SERVER_ERROR,
-                format("%s for request from inference entity id [%s]", SERVER_ERROR_OBJECT, request.getInferenceEntityId()),
+                format("%s for request from inference entity id [%s]", SERVER_ERROR_OBJECT, outboundRequest.getInferenceEntityId()),
                 "error",
                 "stream_error"
             );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceAuthorizationRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceAuthorizationRequest.java
@@ -13,7 +13,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
 import org.elasticsearch.xpack.inference.telemetry.TraceContext;
@@ -76,7 +76,7 @@ public class ElasticInferenceServiceAuthorizationRequest extends ElasticInferenc
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseEmbeddingsRequest.java
@@ -17,8 +17,8 @@ import org.elasticsearch.inference.InferenceStringGroup;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceUsageContext;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
 import org.elasticsearch.xpack.inference.services.elastic.denseembeddings.ElasticInferenceServiceDenseEmbeddingsModel;
@@ -32,7 +32,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER;
 
-public class ElasticInferenceServiceDenseEmbeddingsRequest extends ElasticInferenceServiceRequest implements DenseEmbeddingRequest {
+public class ElasticInferenceServiceDenseEmbeddingsRequest extends ElasticInferenceServiceRequest implements OutboundDenseEmbeddingRequest {
 
     private final URI uri;
     private final ElasticInferenceServiceDenseEmbeddingsModel model;
@@ -87,7 +87,7 @@ public class ElasticInferenceServiceDenseEmbeddingsRequest extends ElasticInfere
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequest.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
 
 import java.util.Objects;
@@ -22,7 +22,7 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_ES_VERSION;
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER;
 
-public abstract class ElasticInferenceServiceRequest implements Request {
+public abstract class ElasticInferenceServiceRequest implements OutboundRequest {
 
     private final ElasticInferenceServiceRequestMetadata metadata;
     protected final CCMAuthenticationApplierFactory.AuthApplier authApplier;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRerankRequest.java
@@ -14,8 +14,8 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.message.BasicHeader;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
 import org.elasticsearch.xpack.inference.services.elastic.rerank.ElasticInferenceServiceRerankModel;
 import org.elasticsearch.xpack.inference.telemetry.TraceContext;
@@ -26,7 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 
-public class ElasticInferenceServiceRerankRequest extends ElasticInferenceServiceRequest implements RerankRequest {
+public class ElasticInferenceServiceRerankRequest extends ElasticInferenceServiceRequest implements OutboundRerankRequest {
 
     private final String query;
     private final List<String> documents;
@@ -82,7 +82,7 @@ public class ElasticInferenceServiceRerankRequest extends ElasticInferenceServic
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // no truncation
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequest.java
@@ -16,8 +16,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.SparseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundSparseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceUsageContext;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
 import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.ElasticInferenceServiceSparseEmbeddingsModel;
@@ -30,7 +30,9 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER;
 
-public class ElasticInferenceServiceSparseEmbeddingsRequest extends ElasticInferenceServiceRequest implements SparseEmbeddingRequest {
+public class ElasticInferenceServiceSparseEmbeddingsRequest extends ElasticInferenceServiceRequest
+    implements
+        OutboundSparseEmbeddingRequest {
 
     private final URI uri;
     private final ElasticInferenceServiceSparseEmbeddingsModel model;
@@ -94,7 +96,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequest extends ElasticInfer
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
         return new ElasticInferenceServiceSparseEmbeddingsRequest(
             truncator,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceUnifiedChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceUnifiedChatCompletionRequest.java
@@ -16,8 +16,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
 import org.elasticsearch.xpack.inference.services.elastic.completion.ElasticInferenceServiceCompletionModel;
 import org.elasticsearch.xpack.inference.telemetry.TraceContext;
@@ -27,7 +27,9 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public class ElasticInferenceServiceUnifiedChatCompletionRequest extends ElasticInferenceServiceRequest implements ChatCompletionRequest {
+public class ElasticInferenceServiceUnifiedChatCompletionRequest extends ElasticInferenceServiceRequest
+    implements
+        OutboundUnifiedCompletionRequest {
 
     private final ElasticInferenceServiceCompletionModel model;
     private final UnifiedChatInput unifiedChatInput;
@@ -68,7 +70,7 @@ public class ElasticInferenceServiceUnifiedChatCompletionRequest extends Elastic
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/response/ElasticInferenceServiceAuthorizationResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/response/ElasticInferenceServiceAuthorizationResponseEntity.java
@@ -22,7 +22,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -183,7 +183,8 @@ public record ElasticInferenceServiceAuthorizationResponseEntity(List<Authorized
         this.removedEndpoints = Objects.requireNonNull(removedEndpoints);
     }
 
-    public static ElasticInferenceServiceAuthorizationResponseEntity fromResponse(Request request, HttpResult response) throws IOException {
+    public static ElasticInferenceServiceAuthorizationResponseEntity fromResponse(OutboundRequest outboundRequest, HttpResult response)
+        throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/response/ElasticInferenceServiceDenseEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/response/ElasticInferenceServiceDenseEmbeddingsResponseEntity.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults
 import org.elasticsearch.xpack.core.inference.results.EmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.GenericDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceDenseEmbeddingsRequest;
 
 import java.io.IOException;
@@ -74,8 +74,8 @@ public class ElasticInferenceServiceDenseEmbeddingsResponseEntity {
      *  }
      * </pre>
      */
-    public static EmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
-        if (request instanceof ElasticInferenceServiceDenseEmbeddingsRequest embeddingRequest) {
+    public static EmbeddingFloatResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
+        if (outboundRequest instanceof ElasticInferenceServiceDenseEmbeddingsRequest embeddingRequest) {
             try (var p = XContentFactory.xContent(XContentType.JSON).createParser(XContentParserConfiguration.EMPTY, response.body())) {
                 return EmbeddingFloatResult.PARSER.apply(p, null).toEmbeddingFloatResults(embeddingRequest.getTaskType());
             }
@@ -83,7 +83,7 @@ public class ElasticInferenceServiceDenseEmbeddingsResponseEntity {
             throw new IllegalStateException(
                 Strings.format(
                     "Invalid request type [%s]. Expected [%s]",
-                    request.getClass().getSimpleName(),
+                    outboundRequest.getClass().getSimpleName(),
                     ElasticInferenceServiceDenseEmbeddingsRequest.class.getSimpleName()
                 )
             );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/response/ElasticInferenceServiceSparseEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/response/ElasticInferenceServiceSparseEmbeddingsResponseEntity.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -66,7 +66,7 @@ public class ElasticInferenceServiceSparseEmbeddingsResponseEntity {
      * </pre>
      */
 
-    public static SparseEmbeddingResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static SparseEmbeddingResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
@@ -77,7 +77,7 @@ public class ElasticInferenceServiceSparseEmbeddingsResponseEntity {
 
             positionParserAtTokenAfterField(jsonParser, "data", FAILED_TO_FIND_FIELD_TEMPLATE);
 
-            var truncationResults = request.getTruncationInfo();
+            var truncationResults = outboundRequest.getTruncationInfo();
             List<SparseEmbeddingResults.Embedding> parsedEmbeddings = parseList(
                 jsonParser,
                 (parser, index) -> ElasticInferenceServiceSparseEmbeddingsResponseEntity.parseExpansionResult(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/fireworksai/FireworksAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/fireworksai/FireworksAiResponseHandler.java
@@ -11,7 +11,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.ErrorMessageResponseEntity;
 
 /**
@@ -26,7 +26,7 @@ public class FireworksAiResponseHandler extends BaseResponseHandler {
     }
 
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
@@ -35,22 +35,22 @@ public class FireworksAiResponseHandler extends BaseResponseHandler {
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
             // 500 errors are retryable (temporary server issues)
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode > 500) {
             // 501+ errors are generally not retryable
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
             // Rate limit - retryable after backoff
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         } else if (statusCode == 401) {
             // Authentication error - not retryable
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
             // Redirection - not retryable
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
             // Other 4xx errors - not retryable
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/fireworksai/request/FireworksAiEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/fireworksai/request/FireworksAiEmbeddingsRequest.java
@@ -14,9 +14,9 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.fireworksai.embeddings.FireworksAiEmbeddingsModel;
 
 import java.net.URI;
@@ -30,7 +30,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * HTTP request wrapper for FireworksAI embeddings API calls.
  * Handles request construction, authentication, truncation, and serialization.
  */
-public class FireworksAiEmbeddingsRequest implements DenseEmbeddingRequest {
+public class FireworksAiEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
 
     private final List<String> input;
     private final FireworksAiEmbeddingsModel model;
@@ -74,7 +74,7 @@ public class FireworksAiEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/fireworksai/request/FireworksAiUnifiedChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/fireworksai/request/FireworksAiUnifiedChatCompletionRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.fireworksai.completion.FireworksAiChatCompletionModel;
 
 import java.net.URI;
@@ -26,7 +26,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public class FireworksAiUnifiedChatCompletionRequest implements ChatCompletionRequest {
+public class FireworksAiUnifiedChatCompletionRequest implements OutboundUnifiedCompletionRequest {
 
     private final UnifiedChatInput unifiedChatInput;
     private final FireworksAiChatCompletionModel model;
@@ -62,7 +62,7 @@ public class FireworksAiUnifiedChatCompletionRequest implements ChatCompletionRe
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioResponseHandler.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
 import org.elasticsearch.xpack.inference.services.googleaistudio.response.GoogleAiStudioErrorResponseEntity;
@@ -49,12 +49,12 @@ public class GoogleAiStudioResponseHandler extends BaseResponseHandler {
      * Validates the status code and throws a RetryException if not in the range [200, 300).
      *
      * The Google AI Studio error codes are documented <a href="https://ai.google.dev/gemini-api/docs/troubleshooting">here</a>.
-     * @param request The originating request
+     * @param outboundRequest The originating request
      * @param result The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
@@ -62,26 +62,26 @@ public class GoogleAiStudioResponseHandler extends BaseResponseHandler {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 503) {
-            throw new RetryException(true, buildError(GOOGLE_AI_STUDIO_UNAVAILABLE, request, result));
+            throw new RetryException(true, buildError(GOOGLE_AI_STUDIO_UNAVAILABLE, outboundRequest, result));
         } else if (statusCode > 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         } else if (statusCode == 404) {
-            throw new RetryException(false, buildError(resourceNotFoundError(request), request, result));
+            throw new RetryException(false, buildError(resourceNotFoundError(outboundRequest), outboundRequest, result));
         } else if (statusCode == 403) {
-            throw new RetryException(false, buildError(PERMISSION_DENIED, request, result));
+            throw new RetryException(false, buildError(PERMISSION_DENIED, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
         var serverSentEventProcessor = new ServerSentEventProcessor(new ServerSentEventParser());
         var googleAiProcessor = new GoogleAiStudioStreamingProcessor(content);
         flow.subscribe(serverSentEventProcessor);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/request/GoogleAiStudioCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/request/GoogleAiStudioCompletionRequest.java
@@ -16,16 +16,16 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.ChatCompletionInput;
-import org.elasticsearch.xpack.inference.external.request.CompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundCompletionRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.googleaistudio.completion.GoogleAiStudioCompletionModel;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public class GoogleAiStudioCompletionRequest implements CompletionRequest {
+public class GoogleAiStudioCompletionRequest implements OutboundCompletionRequest {
     private static final String ALT_PARAM = "alt";
     private static final String SSE_VALUE = "sse";
 
@@ -73,7 +73,7 @@ public class GoogleAiStudioCompletionRequest implements CompletionRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation for Google AI Studio completion
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/request/GoogleAiStudioEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/request/GoogleAiStudioEmbeddingsRequest.java
@@ -16,16 +16,16 @@ import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.googleaistudio.embeddings.GoogleAiStudioEmbeddingsModel;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public class GoogleAiStudioEmbeddingsRequest implements DenseEmbeddingRequest {
+public class GoogleAiStudioEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
 
     private final Truncator truncator;
 
@@ -81,7 +81,7 @@ public class GoogleAiStudioEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
 
         return new GoogleAiStudioEmbeddingsRequest(truncator, truncatedInput, inputType, model);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioCompletionResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioCompletionResponseEntity.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -74,7 +74,7 @@ public class GoogleAiStudioCompletionResponseEntity {
      *
      */
 
-    public static ChatCompletionResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static ChatCompletionResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
             return new ChatCompletionResults(List.of(new ChatCompletionResults.Result(content(jsonParser))));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioEmbeddingsResponseEntity.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
 
 import java.io.IOException;
@@ -70,7 +70,7 @@ public class GoogleAiStudioEmbeddingsResponseEntity {
      * </pre>
      */
 
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static DenseEmbeddingFloatResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiResponseHandler.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler
 import org.elasticsearch.xpack.inference.external.http.retry.ErrorResponse;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
 import org.elasticsearch.xpack.inference.services.googlevertexai.response.GoogleVertexAiErrorResponseEntity;
@@ -40,7 +40,7 @@ public class GoogleVertexAiResponseHandler extends BaseResponseHandler {
     }
 
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
@@ -48,26 +48,26 @@ public class GoogleVertexAiResponseHandler extends BaseResponseHandler {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 503) {
-            throw new RetryException(true, buildError(GOOGLE_VERTEX_AI_UNAVAILABLE, request, result));
+            throw new RetryException(true, buildError(GOOGLE_VERTEX_AI_UNAVAILABLE, outboundRequest, result));
         } else if (statusCode > 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         } else if (statusCode == 404) {
-            throw new RetryException(false, buildError(resourceNotFoundError(request), request, result));
+            throw new RetryException(false, buildError(resourceNotFoundError(outboundRequest), outboundRequest, result));
         } else if (statusCode == 403) {
-            throw new RetryException(false, buildError(PERMISSION_DENIED, request, result));
+            throw new RetryException(false, buildError(PERMISSION_DENIED, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
         var serverSentEventProcessor = new ServerSentEventProcessor(new ServerSentEventParser());
         var googleVertexAiProcessor = new GoogleVertexAiStreamingProcessor();
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiUnifiedChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiUnifiedChatCompletionResponseHandler.java
@@ -22,7 +22,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.ChatCompletionErrorResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.UnifiedChatCompletionErrorParserContract;
 import org.elasticsearch.xpack.inference.external.http.retry.UnifiedChatCompletionErrorResponse;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
 import org.elasticsearch.xpack.inference.services.googlevertexai.response.GoogleVertexAiCompletionResponseEntity;
@@ -47,12 +47,12 @@ public class GoogleVertexAiUnifiedChatCompletionResponseHandler extends GoogleVe
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
-        assert request.isStreaming() : "GoogleVertexAiUnifiedChatCompletionResponseHandler only supports streaming requests";
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
+        assert outboundRequest.isStreaming() : "GoogleVertexAiUnifiedChatCompletionResponseHandler only supports streaming requests";
 
         var serverSentEventProcessor = new ServerSentEventProcessor(new ServerSentEventParser());
         var googleVertexAiProcessor = new GoogleVertexAiUnifiedStreamingProcessor(
-            (m, e) -> chatCompletionErrorResponseHandler.buildMidStreamChatCompletionError(request.getInferenceEntityId(), m, e)
+            (m, e) -> chatCompletionErrorResponseHandler.buildMidStreamChatCompletionError(outboundRequest.getInferenceEntityId(), m, e)
         );
 
         flow.subscribe(serverSentEventProcessor);
@@ -61,8 +61,8 @@ public class GoogleVertexAiUnifiedChatCompletionResponseHandler extends GoogleVe
     }
 
     @Override
-    protected UnifiedChatCompletionException buildError(String message, Request request, HttpResult result) {
-        return chatCompletionErrorResponseHandler.buildChatCompletionError(message, request, result);
+    protected UnifiedChatCompletionException buildError(String message, OutboundRequest outboundRequest, HttpResult result) {
+        return chatCompletionErrorResponseHandler.buildChatCompletionError(message, outboundRequest, result);
     }
 
     private static class GoogleVertexAiErrorParser implements UnifiedChatCompletionErrorParserContract {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequest.java
@@ -16,16 +16,16 @@ import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsModel;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public class GoogleVertexAiEmbeddingsRequest implements DenseEmbeddingRequest {
+public class GoogleVertexAiEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
 
     private final Truncator truncator;
 
@@ -97,7 +97,7 @@ public class GoogleVertexAiEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
 
         return new GoogleVertexAiEmbeddingsRequest(truncator, truncatedInput, inputType, model);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiRerankRequest.java
@@ -15,8 +15,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.googlevertexai.rerank.GoogleVertexAiRerankModel;
 
 import java.net.URI;
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 
-public class GoogleVertexAiRerankRequest implements RerankRequest {
+public class GoogleVertexAiRerankRequest implements OutboundRerankRequest {
 
     private final GoogleVertexAiRerankModel model;
 
@@ -93,7 +93,7 @@ public class GoogleVertexAiRerankRequest implements RerankRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequest.java
@@ -16,9 +16,9 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.googlevertexai.completion.GoogleVertexAiChatCompletionModel;
 import org.elasticsearch.xpack.inference.services.googlevertexai.request.GoogleVertexAiRequestUtils;
 
@@ -26,7 +26,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public class GoogleVertexAiUnifiedChatCompletionRequest implements ChatCompletionRequest {
+public class GoogleVertexAiUnifiedChatCompletionRequest implements OutboundUnifiedCompletionRequest {
 
     private final GoogleVertexAiChatCompletionModel model;
     private final UnifiedChatInput unifiedChatInput;
@@ -75,7 +75,7 @@ public class GoogleVertexAiUnifiedChatCompletionRequest implements ChatCompletio
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation for Google VertexAI Chat completions
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiCompletionResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiCompletionResponseEntity.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.StreamingUnifiedChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiUnifiedStreamingProcessor;
 
 import java.io.IOException;
@@ -80,9 +80,9 @@ public class GoogleVertexAiCompletionResponseEntity {
      *    </code>
      * </pre>
      *
-     * @param request The original request made to the service.
+     * @param outboundRequest The original request made to the service.
      **/
-    public static InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var responseJson = new String(response.body(), StandardCharsets.UTF_8);
 
         // Response from generateContent has the same shape as streamGenerateContent. We reuse the already implemented

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiEmbeddingsResponseEntity.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -64,7 +64,7 @@ public class GoogleVertexAiEmbeddingsResponseEntity {
      * </pre>
      */
 
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static DenseEmbeddingFloatResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/groq/request/GroqUnifiedChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/groq/request/GroqUnifiedChatCompletionRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.groq.GroqUtils;
 import org.elasticsearch.xpack.inference.services.groq.completion.GroqChatCompletionModel;
 
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public class GroqUnifiedChatCompletionRequest implements ChatCompletionRequest {
+public class GroqUnifiedChatCompletionRequest implements OutboundUnifiedCompletionRequest {
 
     private final UnifiedChatInput unifiedChatInput;
     private final GroqChatCompletionModel model;
@@ -68,7 +68,7 @@ public class GroqUnifiedChatCompletionRequest implements ChatCompletionRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceResponseHandler.java
@@ -12,7 +12,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler
 import org.elasticsearch.xpack.inference.external.http.retry.ContentTooLargeException;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.huggingface.response.HuggingFaceErrorResponseEntity;
 
 public class HuggingFaceResponseHandler extends BaseResponseHandler {
@@ -25,29 +25,29 @@ public class HuggingFaceResponseHandler extends BaseResponseHandler {
      * Validates the status code and throws a RetryException if it is not in the range [200, 300).
      *
      * The Hugging Face error codes are loosely defined <a href="https://huggingface.co/docs/api-inference/faq">here</a>.
-     * @param request the http request
+     * @param outboundRequest the http request
      * @param result the http response and body
      * @throws RetryException thrown if status code is {@code >= 300 or < 200}
      */
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
 
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 503 || statusCode == 502 || statusCode == 429) {
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         } else if (statusCode >= 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 413) {
-            throw new ContentTooLargeException(buildError(CONTENT_TOO_LARGE, request, result));
+            throw new ContentTooLargeException(buildError(CONTENT_TOO_LARGE, outboundRequest, result));
         } else if (statusCode == 401) {
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/request/completion/HuggingFaceUnifiedChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/request/completion/HuggingFaceUnifiedChatCompletionRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceAccount;
 import org.elasticsearch.xpack.inference.services.huggingface.completion.HuggingFaceChatCompletionModel;
 
@@ -31,7 +31,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * This class is responsible for creating Hugging Face chat completions HTTP requests.
  * It handles the preparation of the HTTP request with the necessary headers and body.
  */
-public class HuggingFaceUnifiedChatCompletionRequest implements ChatCompletionRequest {
+public class HuggingFaceUnifiedChatCompletionRequest implements OutboundUnifiedCompletionRequest {
 
     private final HuggingFaceAccount account;
     private final HuggingFaceChatCompletionModel model;
@@ -73,7 +73,7 @@ public class HuggingFaceUnifiedChatCompletionRequest implements ChatCompletionRe
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // Truncation is not applicable for chat completion requests
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/request/embeddings/HuggingFaceEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/request/embeddings/HuggingFaceEmbeddingsRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceAccount;
 import org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceModel;
 
@@ -31,7 +31,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * This class is responsible for creating Hugging Face embeddings HTTP requests.
  * It handles the truncation of input data and prepares the HTTP request with the necessary headers and body.
  */
-public class HuggingFaceEmbeddingsRequest implements DenseEmbeddingRequest {
+public class HuggingFaceEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
 
     private final Truncator truncator;
     private final HuggingFaceAccount account;
@@ -73,7 +73,7 @@ public class HuggingFaceEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncateResult = truncator.truncate(truncationResult.input());
 
         return new HuggingFaceEmbeddingsRequest(truncator, truncateResult, model);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/request/rerank/HuggingFaceRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/request/rerank/HuggingFaceRerankRequest.java
@@ -15,8 +15,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceAccount;
 import org.elasticsearch.xpack.inference.services.huggingface.rerank.HuggingFaceRerankModel;
 
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public class HuggingFaceRerankRequest implements RerankRequest {
+public class HuggingFaceRerankRequest implements OutboundRerankRequest {
 
     private final HuggingFaceAccount account;
     private final String query;
@@ -88,7 +88,7 @@ public class HuggingFaceRerankRequest implements RerankRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // Not applicable for rerank, only used in text embedding requests
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceElserResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceElserResponseEntity.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,13 +59,13 @@ public class HuggingFaceElserResponseEntity {
      *   </code>
      * </pre>
      */
-    public static SparseEmbeddingResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static SparseEmbeddingResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
             moveToFirstToken(jsonParser);
 
-            var truncationResults = request.getTruncationInfo();
+            var truncationResults = outboundRequest.getTruncationInfo();
             List<SparseEmbeddingResults.Embedding> parsedEmbeddings = parseList(
                 jsonParser,
                 (parser, index) -> HuggingFaceElserResponseEntity.parseExpansionResult(truncationResults, parser, index)

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceEmbeddingsResponseEntity.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
 
 import java.io.IOException;
@@ -33,7 +33,7 @@ public class HuggingFaceEmbeddingsResponseEntity {
      * Parse the response from hugging face. The known formats are an array of arrays and object with an {@code embeddings} field containing
      * an array of arrays.
      */
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static DenseEmbeddingFloatResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxResponseHandler.java
@@ -11,7 +11,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.response.IbmWatsonxErrorResponseEntity;
 
 public class IbmWatsonxResponseHandler extends BaseResponseHandler {
@@ -24,31 +24,31 @@ public class IbmWatsonxResponseHandler extends BaseResponseHandler {
      *
      * The IBM Cloud error codes for text_embedding are loosely
      * defined <a href="https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings">here</a>.
-     * @param request the http request
+     * @param outboundRequest the http request
      * @param result the http response and body
      * @throws RetryException thrown if status code is {@code >= 300 or < 200}
      */
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
 
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 404) {
-            throw new RetryException(false, buildError(resourceNotFoundError(request), request, result));
+            throw new RetryException(false, buildError(resourceNotFoundError(outboundRequest), outboundRequest, result));
         } else if (statusCode == 403) {
-            throw new RetryException(false, buildError(PERMISSION_DENIED, request, result));
+            throw new RetryException(false, buildError(PERMISSION_DENIED, outboundRequest, result));
         } else if (statusCode == 401) {
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode == 400) {
-            throw new RetryException(false, buildError(BAD_REQUEST, request, result));
+            throw new RetryException(false, buildError(BAD_REQUEST, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxChatCompletionRequest.java
@@ -15,16 +15,16 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.completion.IbmWatsonxChatCompletionModel;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public class IbmWatsonxChatCompletionRequest implements ChatCompletionRequest {
+public class IbmWatsonxChatCompletionRequest implements OutboundUnifiedCompletionRequest {
     private final IbmWatsonxChatCompletionModel model;
     private final UnifiedChatInput chatInput;
 
@@ -59,7 +59,7 @@ public class IbmWatsonxChatCompletionRequest implements ChatCompletionRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation for IBM watsonx chat completions
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxEmbeddingsRequest.java
@@ -15,16 +15,16 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModel;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-public class IbmWatsonxEmbeddingsRequest implements DenseEmbeddingRequest {
+public class IbmWatsonxEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
 
     private final Truncator truncator;
     private final Truncator.TruncationResult truncationResult;
@@ -85,7 +85,7 @@ public class IbmWatsonxEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
 
         return new IbmWatsonxEmbeddingsRequest(truncator, truncatedInput, model);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxRerankRequest.java
@@ -14,8 +14,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank.IbmWatsonxRerankModel;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank.IbmWatsonxRerankTaskSettings;
 
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 
-public class IbmWatsonxRerankRequest implements RerankRequest {
+public class IbmWatsonxRerankRequest implements OutboundRerankRequest {
 
     private final String query;
     private final List<String> input;
@@ -88,7 +88,7 @@ public class IbmWatsonxRerankRequest implements RerankRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/response/IbmWatsonxEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/response/IbmWatsonxEmbeddingsResponseEntity.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
 
 import java.io.IOException;
@@ -30,7 +30,7 @@ public class IbmWatsonxEmbeddingsResponseEntity {
 
     private static final String FAILED_TO_FIND_FIELD_TEMPLATE = "Failed to find required field [%s] in IBM watsonx embeddings response";
 
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static DenseEmbeddingFloatResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIResponseHandler.java
@@ -11,7 +11,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.jinaai.response.JinaAIErrorResponseEntity;
 
 /**
@@ -29,12 +29,12 @@ public class JinaAIResponseHandler extends BaseResponseHandler {
     /**
      * Validates the status code throws an RetryException if not in the range [200, 300).
      *
-     * @param request The http request
+     * @param outboundRequest The http request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
@@ -42,21 +42,21 @@ public class JinaAIResponseHandler extends BaseResponseHandler {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode > 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         } else if (statusCode == 400 || statusCode == 422) {
-            throw new RetryException(false, buildError(VALIDATION_ERROR_MESSAGE, request, result));
+            throw new RetryException(false, buildError(VALIDATION_ERROR_MESSAGE, outboundRequest, result));
         } else if (statusCode == 401) {
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode == 402) {
-            throw new RetryException(false, buildError(PAYMENT_ERROR_MESSAGE, request, result));
+            throw new RetryException(false, buildError(PAYMENT_ERROR_MESSAGE, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequest.java
@@ -14,9 +14,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.InferenceStringGroup;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.jinaai.embeddings.JinaAIEmbeddingType;
 import org.elasticsearch.xpack.inference.services.jinaai.embeddings.JinaAIEmbeddingsModel;
 
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.services.jinaai.request.JinaAIRequestUtils.decorateWithAuthHeader;
 
-public class JinaAIEmbeddingsRequest implements DenseEmbeddingRequest {
+public class JinaAIEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
 
     private final List<InferenceStringGroup> input;
     private final InputType inputType;
@@ -64,7 +64,7 @@ public class JinaAIEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIRerankRequest.java
@@ -13,8 +13,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.jinaai.rerank.JinaAIRerankModel;
 
 import java.net.URI;
@@ -24,7 +24,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.services.jinaai.request.JinaAIRequestUtils.decorateWithAuthHeader;
 
-public class JinaAIRerankRequest implements RerankRequest {
+public class JinaAIRerankRequest implements OutboundRerankRequest {
 
     private final String query;
     private final List<String> input;
@@ -71,7 +71,7 @@ public class JinaAIRerankRequest implements RerankRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/response/JinaAIEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/response/JinaAIEmbeddingsResponseEntity.java
@@ -24,7 +24,7 @@ import org.elasticsearch.xpack.core.inference.results.EmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.GenericDenseEmbeddingBitResults;
 import org.elasticsearch.xpack.core.inference.results.GenericDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
 import org.elasticsearch.xpack.inference.services.jinaai.embeddings.JinaAIEmbeddingType;
 import org.elasticsearch.xpack.inference.services.jinaai.request.JinaAIEmbeddingsRequest;
@@ -103,9 +103,9 @@ public class JinaAIEmbeddingsResponseEntity {
      * </code>
      * </pre>
      */
-    public static InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         // embeddings type is not specified anywhere in the response so grab it from the request
-        JinaAIEmbeddingsRequest embeddingsRequest = (JinaAIEmbeddingsRequest) request;
+        JinaAIEmbeddingsRequest embeddingsRequest = (JinaAIEmbeddingsRequest) outboundRequest;
         var embeddingType = embeddingsRequest.getEmbeddingType().toString();
         var embeddingValueParser = EMBEDDING_PARSERS.get(embeddingType);
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/llama/request/completion/LlamaChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/llama/request/completion/LlamaChatCompletionRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.llama.completion.LlamaChatCompletionModel;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
@@ -32,7 +32,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * This class is responsible for creating a request to the Llama chat completion model.
  * It constructs an HTTP POST request with the necessary headers and body content.
  */
-public class LlamaChatCompletionRequest implements ChatCompletionRequest {
+public class LlamaChatCompletionRequest implements OutboundUnifiedCompletionRequest {
 
     private final LlamaChatCompletionModel model;
     private final UnifiedChatInput chatInput;
@@ -72,7 +72,7 @@ public class LlamaChatCompletionRequest implements ChatCompletionRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation for Llama chat completions
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/llama/request/embeddings/LlamaEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/llama/request/embeddings/LlamaEmbeddingsRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.llama.embeddings.LlamaEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
@@ -31,7 +31,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * This class is responsible for creating a request to the Llama embeddings model.
  * It constructs an HTTP POST request with the necessary headers and body content.
  */
-public class LlamaEmbeddingsRequest implements DenseEmbeddingRequest {
+public class LlamaEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
     private final URI uri;
     private final LlamaEmbeddingsModel model;
     private final String inferenceEntityId;
@@ -77,7 +77,7 @@ public class LlamaEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
         return new LlamaEmbeddingsRequest(truncator, truncatedInput, model);
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/request/completion/MistralChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/request/completion/MistralChatCompletionRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.mistral.completion.MistralChatCompletionModel;
 
 import java.net.URI;
@@ -31,7 +31,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * This class is responsible for creating a request to the Mistral chat completion model.
  * It constructs an HTTP POST request with the necessary headers and body content.
  */
-public class MistralChatCompletionRequest implements ChatCompletionRequest {
+public class MistralChatCompletionRequest implements OutboundUnifiedCompletionRequest {
 
     private final MistralChatCompletionModel model;
     private final UnifiedChatInput chatInput;
@@ -63,7 +63,7 @@ public class MistralChatCompletionRequest implements ChatCompletionRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation for Mistral chat completions
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/request/embeddings/MistralEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/request/embeddings/MistralEmbeddingsRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.mistral.embeddings.MistralEmbeddingsModel;
 
 import java.net.URI;
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 
-public class MistralEmbeddingsRequest implements DenseEmbeddingRequest {
+public class MistralEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
     private final URI uri;
     private final MistralEmbeddingsModel embeddingsModel;
     private final String inferenceEntityId;
@@ -62,7 +62,7 @@ public class MistralEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
         return new MistralEmbeddingsRequest(truncator, truncatedInput, embeddingsModel);
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/response/MistralEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/response/MistralEmbeddingsResponseEntity.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.mistral.response;
 
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.BaseResponseEntity;
 import org.elasticsearch.xpack.inference.services.openai.response.OpenAiEmbeddingsResponseEntity;
 
@@ -17,8 +17,8 @@ import java.io.IOException;
 
 public class MistralEmbeddingsResponseEntity extends BaseResponseEntity {
     @Override
-    protected InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException {
+    protected InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         // expected response type is the same as the Open AI Embeddings
-        return OpenAiEmbeddingsResponseEntity.fromResponse(request, response);
+        return OpenAiEmbeddingsResponseEntity.fromResponse(outboundRequest, response);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/completion/NvidiaChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/completion/NvidiaChatCompletionResponseHandler.java
@@ -12,7 +12,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
 import org.elasticsearch.xpack.inference.external.http.retry.UnifiedChatCompletionErrorParserContract;
 import org.elasticsearch.xpack.inference.external.http.retry.UnifiedChatCompletionErrorResponseUtils;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.nvidia.NvidiaUtils;
 import org.elasticsearch.xpack.inference.services.openai.OpenAiUnifiedChatCompletionResponseHandler;
 
@@ -38,8 +38,8 @@ public class NvidiaChatCompletionResponseHandler extends OpenAiUnifiedChatComple
     }
 
     @Override
-    protected RetryException buildExceptionHandlingContentTooLarge(Request request, HttpResult result) {
-        return new RetryException(false, buildError(CONTENT_TOO_LARGE, request, result));
+    protected RetryException buildExceptionHandlingContentTooLarge(OutboundRequest outboundRequest, HttpResult result) {
+        return new RetryException(false, buildError(CONTENT_TOO_LARGE, outboundRequest, result));
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/completion/NvidiaCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/completion/NvidiaCompletionResponseHandler.java
@@ -11,7 +11,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.ErrorResponse;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.nvidia.NvidiaUtils;
 import org.elasticsearch.xpack.inference.services.openai.OpenAiChatCompletionResponseHandler;
 
@@ -31,8 +31,8 @@ public class NvidiaCompletionResponseHandler extends OpenAiChatCompletionRespons
     }
 
     @Override
-    protected RetryException buildExceptionHandlingContentTooLarge(Request request, HttpResult result) {
-        return new RetryException(false, buildError(CONTENT_TOO_LARGE, request, result));
+    protected RetryException buildExceptionHandlingContentTooLarge(OutboundRequest outboundRequest, HttpResult result) {
+        return new RetryException(false, buildError(CONTENT_TOO_LARGE, outboundRequest, result));
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/request/completion/NvidiaChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/request/completion/NvidiaChatCompletionRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.nvidia.completion.NvidiaChatCompletionModel;
 
 import java.net.URI;
@@ -31,7 +31,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * This class is responsible for creating a request to the Nvidia chat completion model.
  * It constructs an HTTP POST request with the necessary headers and body content.
  */
-public class NvidiaChatCompletionRequest implements ChatCompletionRequest {
+public class NvidiaChatCompletionRequest implements OutboundUnifiedCompletionRequest {
 
     private final NvidiaChatCompletionModel model;
     private final UnifiedChatInput chatInput;
@@ -63,7 +63,7 @@ public class NvidiaChatCompletionRequest implements ChatCompletionRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation for Nvidia chat completions
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/request/embeddings/NvidiaEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/request/embeddings/NvidiaEmbeddingsRequest.java
@@ -17,9 +17,9 @@ import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.nvidia.embeddings.NvidiaEmbeddingsModel;
 
 import java.net.URI;
@@ -33,7 +33,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * This class is responsible for creating a request to the Nvidia embeddings endpoint.
  * It constructs an HTTP POST request with the necessary headers and body content.
  */
-public class NvidiaEmbeddingsRequest implements DenseEmbeddingRequest {
+public class NvidiaEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
     private final NvidiaEmbeddingsModel model;
     private final Truncator.TruncationResult truncationResult;
     private final Truncator truncator;
@@ -104,7 +104,7 @@ public class NvidiaEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
         return new NvidiaEmbeddingsRequest(truncator, truncatedInput, model, inputType);
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/request/rerank/NvidiaRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/nvidia/request/rerank/NvidiaRerankRequest.java
@@ -14,8 +14,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.nvidia.rerank.NvidiaRerankModel;
 
 import java.net.URI;
@@ -33,7 +33,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * @param input the list of input documents to be reranked
  * @param model the Nvidia rerank model configuration
  */
-public record NvidiaRerankRequest(String query, List<String> input, NvidiaRerankModel model) implements RerankRequest {
+public record NvidiaRerankRequest(String query, List<String> input, NvidiaRerankModel model) implements OutboundRerankRequest {
 
     public NvidiaRerankRequest {
         Objects.requireNonNull(input);
@@ -68,7 +68,7 @@ public record NvidiaRerankRequest(String query, List<String> input, NvidiaRerank
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // Not applicable for rerank, only used in text embedding requests
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiChatCompletionResponseHandler.java
@@ -11,7 +11,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.ErrorResponse;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.util.function.Function;
 
@@ -29,8 +29,8 @@ public class OpenAiChatCompletionResponseHandler extends OpenAiResponseHandler {
     }
 
     @Override
-    protected RetryException buildExceptionHandling429(Request request, HttpResult result) {
+    protected RetryException buildExceptionHandling429(OutboundRequest outboundRequest, HttpResult result) {
         // We don't retry, if the chat completion input is too large
-        return new RetryException(false, buildError(RATE_LIMIT, request, result));
+        return new RetryException(false, buildError(RATE_LIMIT, outboundRequest, result));
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiResponseHandler.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.ContentTooLargeExce
 import org.elasticsearch.xpack.inference.external.http.retry.ErrorResponse;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.ErrorMessageResponseEntity;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
@@ -61,12 +61,12 @@ public class OpenAiResponseHandler extends BaseResponseHandler {
      * Validates the status code throws an RetryException if not in the range [200, 300).
      *
      * The OpenAI API error codes are documented <a href="https://platform.openai.com/docs/guides/error-codes/api-errors">here</a>.
-     * @param request The originating request
+     * @param outboundRequest The originating request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    public void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    public void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
@@ -74,38 +74,38 @@ public class OpenAiResponseHandler extends BaseResponseHandler {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 503) {
-            throw new RetryException(true, buildError(OPENAI_SERVER_BUSY, request, result));
+            throw new RetryException(true, buildError(OPENAI_SERVER_BUSY, outboundRequest, result));
         } else if (statusCode > 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw buildExceptionHandling429(request, result);
+            throw buildExceptionHandling429(outboundRequest, result);
         } else if (isContentTooLarge(result)) {
-            throw buildExceptionHandlingContentTooLarge(request, result);
+            throw buildExceptionHandlingContentTooLarge(outboundRequest, result);
         } else if (statusCode == 401) {
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else if (statusCode == 422) {
             // OpenAI does not return 422 at the time of writing, but Mistral does and follows most of OpenAI's format.
             // TODO: Revisit this in the future to decouple OpenAI and Mistral error handling.
-            throw new RetryException(false, buildError(VALIDATION_ERROR_MESSAGE, request, result));
+            throw new RetryException(false, buildError(VALIDATION_ERROR_MESSAGE, outboundRequest, result));
         } else if (statusCode == 400) {
-            throw new RetryException(false, buildError(BAD_REQUEST, request, result));
+            throw new RetryException(false, buildError(BAD_REQUEST, outboundRequest, result));
         } else if (statusCode == 404) {
-            throw new RetryException(false, buildError(resourceNotFoundError(request), request, result));
+            throw new RetryException(false, buildError(resourceNotFoundError(outboundRequest), outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 
-    protected RetryException buildExceptionHandlingContentTooLarge(Request request, HttpResult result) {
-        return new ContentTooLargeException(buildError(CONTENT_TOO_LARGE, request, result));
+    protected RetryException buildExceptionHandlingContentTooLarge(OutboundRequest outboundRequest, HttpResult result) {
+        return new ContentTooLargeException(buildError(CONTENT_TOO_LARGE, outboundRequest, result));
     }
 
-    protected RetryException buildExceptionHandling429(Request request, HttpResult result) {
-        return new RetryException(true, buildError(buildRateLimitErrorMessage(result), request, result));
+    protected RetryException buildExceptionHandling429(OutboundRequest outboundRequest, HttpResult result) {
+        return new RetryException(true, buildError(buildRateLimitErrorMessage(result), outboundRequest, result));
     }
 
     /**
@@ -149,7 +149,7 @@ public class OpenAiResponseHandler extends BaseResponseHandler {
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
         var serverSentEventProcessor = new ServerSentEventProcessor(new ServerSentEventParser());
         var openAiProcessor = new OpenAiStreamingProcessor();
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedChatCompletionResponseHandler.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xpack.inference.external.http.retry.ErrorResponse;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.UnifiedChatCompletionErrorParserContract;
 import org.elasticsearch.xpack.inference.external.http.retry.UnifiedChatCompletionErrorResponse;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
 
@@ -63,10 +63,10 @@ public class OpenAiUnifiedChatCompletionResponseHandler extends OpenAiChatComple
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, Flow.Publisher<HttpResult> flow) {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, Flow.Publisher<HttpResult> flow) {
         var serverSentEventProcessor = new ServerSentEventProcessor(new ServerSentEventParser());
         var openAiProcessor = new OpenAiUnifiedStreamingProcessor(
-            (m, e) -> chatCompletionErrorResponseHandler.buildMidStreamChatCompletionError(request.getInferenceEntityId(), m, e)
+            (m, e) -> chatCompletionErrorResponseHandler.buildMidStreamChatCompletionError(outboundRequest.getInferenceEntityId(), m, e)
         );
         flow.subscribe(serverSentEventProcessor);
         serverSentEventProcessor.subscribe(openAiProcessor);
@@ -74,8 +74,8 @@ public class OpenAiUnifiedChatCompletionResponseHandler extends OpenAiChatComple
     }
 
     @Override
-    protected UnifiedChatCompletionException buildError(String message, Request request, HttpResult result) {
-        return chatCompletionErrorResponseHandler.buildChatCompletionError(message, request, result);
+    protected UnifiedChatCompletionException buildError(String message, OutboundRequest outboundRequest, HttpResult result) {
+        return chatCompletionErrorResponseHandler.buildChatCompletionError(message, outboundRequest, result);
     }
 
     public static UnifiedChatCompletionException buildMidStreamError(String inferenceEntityId, String message, Exception e) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/request/OpenAiEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/request/OpenAiEmbeddingsRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsModel;
 
 import java.net.URI;
@@ -27,7 +27,7 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 import static org.elasticsearch.xpack.inference.services.openai.OpenAiUtils.createOrgHeader;
 
-public class OpenAiEmbeddingsRequest implements DenseEmbeddingRequest {
+public class OpenAiEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
 
     private final Truncator truncator;
     private final Truncator.TruncationResult truncationResult;
@@ -84,7 +84,7 @@ public class OpenAiEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
 
         return new OpenAiEmbeddingsRequest(truncator, truncatedInput, model);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/request/OpenAiUnifiedChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/request/OpenAiUnifiedChatCompletionRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.openai.completion.OpenAiChatCompletionModel;
 
 import java.net.URI;
@@ -27,7 +27,7 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 import static org.elasticsearch.xpack.inference.services.openai.OpenAiUtils.createOrgHeader;
 
-public class OpenAiUnifiedChatCompletionRequest implements ChatCompletionRequest {
+public class OpenAiUnifiedChatCompletionRequest implements OutboundUnifiedCompletionRequest {
 
     private final OpenAiChatCompletionModel model;
     private final UnifiedChatInput unifiedChatInput;
@@ -69,7 +69,7 @@ public class OpenAiUnifiedChatCompletionRequest implements ChatCompletionRequest
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation for OpenAI chat completions
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiChatCompletionResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiChatCompletionResponseEntity.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -66,7 +66,7 @@ public class OpenAiChatCompletionResponseEntity {
      * </pre>
      */
 
-    public static ChatCompletionResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static ChatCompletionResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         return fromResponse(response.body());
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiEmbeddingsResponseEntity.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults
 import org.elasticsearch.xpack.core.inference.results.EmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.GenericDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.util.List;
@@ -68,10 +68,10 @@ public class OpenAiEmbeddingsResponseEntity {
      * </code>
      * </pre>
      */
-    public static EmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static EmbeddingFloatResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         try (var p = XContentFactory.xContent(XContentType.JSON).createParser(XContentParserConfiguration.EMPTY, response.body())) {
             var result = EmbeddingFloatResult.PARSER.apply(p, null);
-            if (request.getTaskType().equals(TaskType.TEXT_EMBEDDING)) {
+            if (outboundRequest.getTaskType().equals(TaskType.TEXT_EMBEDDING)) {
                 return result.toDenseEmbeddingFloatResults();
             } else {
                 return result.toGenericDenseEmbeddingFloatResults();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openshiftai/request/completion/OpenShiftAiChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openshiftai/request/completion/OpenShiftAiChatCompletionRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.ChatCompletionRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.openshiftai.completion.OpenShiftAiChatCompletionModel;
 
 import java.net.URI;
@@ -31,7 +31,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * This class is responsible for creating a request to the OpenShift AI chat completion model.
  * It constructs an HTTP POST request with the necessary headers and body content.
  */
-public class OpenShiftAiChatCompletionRequest implements ChatCompletionRequest {
+public class OpenShiftAiChatCompletionRequest implements OutboundUnifiedCompletionRequest {
 
     private final OpenShiftAiChatCompletionModel model;
     private final UnifiedChatInput chatInput;
@@ -69,7 +69,7 @@ public class OpenShiftAiChatCompletionRequest implements ChatCompletionRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // No truncation for OpenShift AI chat completions
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openshiftai/request/embeddings/OpenShiftAiEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openshiftai/request/embeddings/OpenShiftAiEmbeddingsRequest.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.openshiftai.embeddings.OpenShiftAiEmbeddingsModel;
 
 import java.net.URI;
@@ -30,7 +30,7 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
  * This class is responsible for creating a request to the OpenShift AI embeddings endpoint.
  * It constructs an HTTP POST request with the necessary headers and body content.
  */
-public class OpenShiftAiEmbeddingsRequest implements DenseEmbeddingRequest {
+public class OpenShiftAiEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
     private final OpenShiftAiEmbeddingsModel model;
     private final Truncator.TruncationResult truncationResult;
     private final Truncator truncator;
@@ -76,7 +76,7 @@ public class OpenShiftAiEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         var truncatedInput = truncator.truncate(truncationResult.input());
         return new OpenShiftAiEmbeddingsRequest(truncator, truncatedInput, model);
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openshiftai/request/rarank/OpenShiftAiRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openshiftai/request/rarank/OpenShiftAiRerankRequest.java
@@ -15,8 +15,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.openshiftai.rerank.OpenShiftAiRerankModel;
 
 import java.net.URI;
@@ -41,7 +41,7 @@ public record OpenShiftAiRerankRequest(
     @Nullable Boolean returnDocuments,
     @Nullable Integer topN,
     OpenShiftAiRerankModel model
-) implements RerankRequest {
+) implements OutboundRerankRequest {
 
     public OpenShiftAiRerankRequest {
         Objects.requireNonNull(input);
@@ -85,7 +85,7 @@ public record OpenShiftAiRerankRequest(
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         // Not applicable for rerank, only used in text embedding requests
         return this;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIResponseHandler.java
@@ -11,7 +11,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.voyageai.response.VoyageAIErrorResponseEntity;
 
 /**
@@ -29,12 +29,12 @@ public class VoyageAIResponseHandler extends BaseResponseHandler {
     /**
      * Validates the status code throws an RetryException if not in the range [200, 300).
      *
-     * @param request The http request
+     * @param outboundRequest The http request
      * @param result  The http response and body
      * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
      */
     @Override
-    protected void checkForFailureStatusCode(Request request, HttpResult result) throws RetryException {
+    protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         if (result.isSuccessfulResponse()) {
             return;
         }
@@ -42,21 +42,21 @@ public class VoyageAIResponseHandler extends BaseResponseHandler {
         // handle error codes
         int statusCode = result.response().getStatusLine().getStatusCode();
         if (statusCode == 500) {
-            throw new RetryException(true, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(true, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode > 500) {
-            throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+            throw new RetryException(false, buildError(SERVER_ERROR, outboundRequest, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(RATE_LIMIT, request, result));
+            throw new RetryException(true, buildError(RATE_LIMIT, outboundRequest, result));
         } else if (statusCode == 400 || statusCode == 422) {
-            throw new RetryException(false, buildError(VALIDATION_ERROR_MESSAGE, request, result));
+            throw new RetryException(false, buildError(VALIDATION_ERROR_MESSAGE, outboundRequest, result));
         } else if (statusCode == 401) {
-            throw new RetryException(false, buildError(AUTHENTICATION, request, result));
+            throw new RetryException(false, buildError(AUTHENTICATION, outboundRequest, result));
         } else if (statusCode == 402) {
-            throw new RetryException(false, buildError(PAYMENT_ERROR_MESSAGE, request, result));
+            throw new RetryException(false, buildError(PAYMENT_ERROR_MESSAGE, outboundRequest, result));
         } else if (statusCode >= 300 && statusCode < 400) {
-            throw new RetryException(false, buildError(REDIRECTION, request, result));
+            throw new RetryException(false, buildError(REDIRECTION, outboundRequest, result));
         } else {
-            throw new RetryException(false, buildError(UNSUCCESSFUL, request, result));
+            throw new RetryException(false, buildError(UNSUCCESSFUL, outboundRequest, result));
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/request/VoyageAIEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/request/VoyageAIEmbeddingsRequest.java
@@ -13,9 +13,9 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
-import org.elasticsearch.xpack.inference.external.request.DenseEmbeddingRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundDenseEmbeddingRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.voyageai.embeddings.VoyageAIEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.voyageai.embeddings.VoyageAIEmbeddingsServiceSettings;
 
@@ -26,7 +26,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.services.voyageai.request.VoyageAIRequestUtils.decorateWithHeaders;
 
-public class VoyageAIEmbeddingsRequest implements DenseEmbeddingRequest {
+public class VoyageAIEmbeddingsRequest implements OutboundDenseEmbeddingRequest {
 
     private final List<String> input;
     private final InputType inputType;
@@ -76,7 +76,7 @@ public class VoyageAIEmbeddingsRequest implements DenseEmbeddingRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/request/VoyageAIRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/request/VoyageAIRerankRequest.java
@@ -13,8 +13,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
-import org.elasticsearch.xpack.inference.external.request.Request;
-import org.elasticsearch.xpack.inference.external.request.RerankRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
+import org.elasticsearch.xpack.inference.external.request.OutboundRerankRequest;
 import org.elasticsearch.xpack.inference.services.voyageai.rerank.VoyageAIRerankModel;
 
 import java.net.URI;
@@ -24,7 +24,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.services.voyageai.request.VoyageAIRequestUtils.decorateWithHeaders;
 
-public class VoyageAIRerankRequest implements RerankRequest {
+public class VoyageAIRerankRequest implements OutboundRerankRequest {
 
     private final String query;
     private final List<String> input;
@@ -81,7 +81,7 @@ public class VoyageAIRerankRequest implements RerankRequest {
     }
 
     @Override
-    public Request truncate() {
+    public OutboundRequest truncate() {
         return this;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/response/VoyageAIEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/response/VoyageAIEmbeddingsResponseEntity.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.voyageai.embeddings.VoyageAIEmbeddingType;
 import org.elasticsearch.xpack.inference.services.voyageai.request.VoyageAIEmbeddingsRequest;
 
@@ -158,9 +158,9 @@ public class VoyageAIEmbeddingsResponseEntity {
      * </code>
      * </pre>
      */
-    public static InferenceServiceResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static InferenceServiceResults fromResponse(OutboundRequest outboundRequest, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
-        VoyageAIEmbeddingType embeddingType = ((VoyageAIEmbeddingsRequest) request).getServiceSettings().getEmbeddingType();
+        VoyageAIEmbeddingType embeddingType = ((VoyageAIEmbeddingsRequest) outboundRequest).getServiceSettings().getEmbeddingType();
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
             if (embeddingType == null || embeddingType == VoyageAIEmbeddingType.FLOAT) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/HttpUtilsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/HttpUtilsTests.java
@@ -11,7 +11,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import static org.elasticsearch.xpack.inference.external.http.HttpUtils.checkForEmptyBody;
 import static org.elasticsearch.xpack.inference.external.http.HttpUtils.checkForFailureStatusCode;
@@ -48,7 +48,7 @@ public class HttpUtilsTests extends ESTestCase {
 
         var result = new HttpResult(httpResponse, new byte[0]);
 
-        checkForFailureStatusCode(mockThrottlerManager(), mock(Logger.class), mock(Request.class), result);
+        checkForFailureStatusCode(mockThrottlerManager(), mock(Logger.class), mock(OutboundRequest.class), result);
     }
 
     public void testCheckForEmptyBody_DoesNotThrowWhenTheBodyIsNotEmpty() {
@@ -57,7 +57,7 @@ public class HttpUtilsTests extends ESTestCase {
 
         var result = new HttpResult(httpResponse, new byte[] { 'a' });
 
-        checkForEmptyBody(mockThrottlerManager(), mock(Logger.class), mock(Request.class), result);
+        checkForEmptyBody(mockThrottlerManager(), mock(Logger.class), mock(OutboundRequest.class), result);
     }
 
     public void testCheckForEmptyBody_ThrowsWhenTheBodyIsEmpty() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/AlwaysRetryingResponseHandler.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/AlwaysRetryingResponseHandler.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 import java.io.IOException;
@@ -36,11 +36,11 @@ public class AlwaysRetryingResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result)
+    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, OutboundRequest outboundRequest, HttpResult result)
         throws RetryException {
         try {
-            checkForFailureStatusCode(throttlerManager, logger, request, result);
-            checkForEmptyBody(throttlerManager, logger, request, result);
+            checkForFailureStatusCode(throttlerManager, logger, outboundRequest, result);
+            checkForEmptyBody(throttlerManager, logger, outboundRequest, result);
         } catch (Exception e) {
             throw new RetryException(true, e);
         }
@@ -51,7 +51,7 @@ public class AlwaysRetryingResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public InferenceServiceResults parseResult(Request request, HttpResult result) throws RetryException {
+    public InferenceServiceResults parseResult(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
         try {
             return parseFunction.apply(result);
         } catch (Exception e) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandlerTests.java
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.response.ErrorMessageResponseEntity;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
@@ -52,7 +52,7 @@ public class BaseResponseHandlerTests extends ESTestCase {
 
         var response = mock200Response();
 
-        var request = mock(Request.class);
+        var request = mock(OutboundRequest.class);
         when(request.getInferenceEntityId()).thenReturn("abc");
 
         handler.validateResponse(
@@ -76,7 +76,7 @@ public class BaseResponseHandlerTests extends ESTestCase {
 
         var response = mock200Response();
 
-        var request = mock(Request.class);
+        var request = mock(OutboundRequest.class);
         when(request.getInferenceEntityId()).thenReturn("abc");
 
         handler.validateResponse(
@@ -101,7 +101,7 @@ public class BaseResponseHandlerTests extends ESTestCase {
 
         var response = mock200Response();
 
-        var request = mock(Request.class);
+        var request = mock(OutboundRequest.class);
         when(request.getInferenceEntityId()).thenReturn("abc");
 
         handler.validateResponse(
@@ -126,7 +126,7 @@ public class BaseResponseHandlerTests extends ESTestCase {
 
         var response = mock200Response();
 
-        var request = mock(Request.class);
+        var request = mock(OutboundRequest.class);
         when(request.getInferenceEntityId()).thenReturn("abc");
 
         handler.validateResponse(
@@ -149,9 +149,13 @@ public class BaseResponseHandlerTests extends ESTestCase {
     }
 
     private static BaseResponseHandler getBaseResponseHandler() {
-        return new BaseResponseHandler("abc", (Request request, HttpResult result) -> null, ErrorMessageResponseEntity::fromResponse) {
+        return new BaseResponseHandler(
+            "abc",
+            (OutboundRequest outboundRequest, HttpResult result) -> null,
+            ErrorMessageResponseEntity::fromResponse
+        ) {
             @Override
-            protected void checkForFailureStatusCode(Request request, HttpResult result) {}
+            protected void checkForFailureStatusCode(OutboundRequest outboundRequest, HttpResult result) {}
         };
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSenderTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.StreamingHttpResult;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
 import org.elasticsearch.xpack.inference.external.request.HttpRequestTests;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 import org.junit.Before;
 import org.mockito.ArgumentMatchers;
@@ -83,7 +83,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         doThrow(new RetryException(true, "failed")).doNothing().when(handler).validateResponse(any(), any(), any(), any());
         // Mockito.thenReturn() does not compile when returning a
         // bounded wild card list, thenAnswer must be used instead.
-        when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
+        when(handler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);
 
@@ -142,7 +142,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenThrow(new RetryException(true, "failed"))
+        when(handler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenThrow(new RetryException(true, "failed"))
             .thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);
@@ -171,7 +171,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenThrow(new IllegalStateException("failed"))
+        when(handler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenThrow(new IllegalStateException("failed"))
             .thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);
@@ -207,7 +207,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
+        when(handler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);
 
@@ -240,7 +240,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
+        when(handler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);
 
@@ -273,7 +273,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
+        when(handler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);
 
@@ -300,7 +300,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
+        when(handler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);
 
@@ -359,7 +359,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
+        when(handler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);
 
@@ -393,7 +393,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         doThrow(new RetryException(true, "failed")).doThrow(new IllegalStateException("failed again"))
             .when(handler)
             .validateResponse(any(), any(), any(), any());
-        when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
+        when(handler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(sender);
 
@@ -430,7 +430,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         doThrow(new RetryException(true, "failed")).doThrow(new RetryException(false, "failed again"))
             .when(handler)
             .validateResponse(any(), any(), any(), any());
-        when(handler.parseResult(any(Request.class), any(HttpResult.class))).thenAnswer(answer);
+        when(handler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenAnswer(answer);
 
         var retrier = createRetrier(httpClient);
 
@@ -562,7 +562,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         var request = mockRequest();
         when(request.isStreaming()).thenReturn(true);
         var responseHandler = mock(ResponseHandler.class);
-        when(responseHandler.parseResult(any(Request.class), any(HttpResult.class))).thenReturn(expectedResponse);
+        when(responseHandler.parseResult(any(OutboundRequest.class), any(HttpResult.class))).thenReturn(expectedResponse);
         when(responseHandler.canHandleStreamingResponses()).thenReturn(false);
         executeTasks(() -> retrier.send(mock(Logger.class), request, () -> false, responseHandler, listener), 0);
 
@@ -713,12 +713,12 @@ public class RetryingHttpSenderTests extends ESTestCase {
         }
     }
 
-    private static Request mockRequest() {
+    private static OutboundRequest mockRequest() {
         return mockRequest("inferenceEntityId");
     }
 
-    private static Request mockRequest(String inferenceEntityId) {
-        var request = mock(Request.class);
+    private static OutboundRequest mockRequest(String inferenceEntityId) {
+        var request = mock(OutboundRequest.class);
         when(request.truncate()).thenReturn(request);
         doAnswer(invocation -> {
             ActionListener<HttpRequest> listener = invocation.getArgument(0);
@@ -746,13 +746,17 @@ public class RetryingHttpSenderTests extends ESTestCase {
         // testing failed requests
         return new ResponseHandler() {
             @Override
-            public void validateResponse(ThrottlerManager throttlerManager, Logger logger, Request request, HttpResult result)
-                throws RetryException {
+            public void validateResponse(
+                ThrottlerManager throttlerManager,
+                Logger logger,
+                OutboundRequest outboundRequest,
+                HttpResult result
+            ) throws RetryException {
                 throw new RetryException(true, new IOException("response handler validate failed as designed"));
             }
 
             @Override
-            public InferenceServiceResults parseResult(Request request, HttpResult result) throws RetryException {
+            public InferenceServiceResults parseResult(OutboundRequest outboundRequest, HttpResult result) throws RetryException {
                 throw new RetryException(true, new IOException("response handler parse failed as designed"));
             }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
@@ -31,7 +31,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.RequestExecutor;
 import org.elasticsearch.xpack.inference.external.http.retry.RequestSender;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 import org.elasticsearch.xpack.inference.services.ServiceComponentsTests;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceServiceResponseHandler;
@@ -434,7 +434,7 @@ public class HttpRequestSenderTests extends ESTestCase {
         );
 
         try (var sender = senderFactory.createSender()) {
-            var request = mock(Request.class);
+            var request = mock(OutboundRequest.class);
             when(request.getInferenceEntityId()).thenReturn(INFERENCE_ID);
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
             sender.sendWithoutQueuing(mock(Logger.class), request, mock(ResponseHandler.class), TimeValue.timeValueNanos(1), listener);
@@ -484,7 +484,7 @@ public class HttpRequestSenderTests extends ESTestCase {
             var sender = new HttpRequestSender(smallThreadPool, mockManager, mock(RequestSender.class), mock(RequestExecutor.class));
 
             runConcurrentSendTest(mockManager, maxUtilityThreads, (barrier, future) -> {
-                var request = mock(Request.class);
+                var request = mock(OutboundRequest.class);
                 when(request.getInferenceEntityId()).thenReturn(INFERENCE_ID);
                 return new Thread(() -> {
                     safeAwait(barrier);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/RequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/RequestTests.java
@@ -17,8 +17,8 @@ public class RequestTests {
 
     private RequestTests() {}
 
-    public static Request mockRequest(String modelId) {
-        var request = mock(Request.class);
+    public static OutboundRequest mockRequest(String modelId) {
+        var request = mock(OutboundRequest.class);
         when(request.getInferenceEntityId()).thenReturn(modelId);
 
         return request;
@@ -26,15 +26,15 @@ public class RequestTests {
 
     /**
      * Synchronously obtain the {@link HttpRequest} from {@code request} by calling
-     * {@link Request#createHttpRequest} and blocking on the result. For use in tests that
+     * {@link OutboundRequest#createHttpRequest} and blocking on the result. For use in tests that
      * assert on the built HTTP request without restructuring to async.
      *
-     * @param request the request to build
+     * @param outboundRequest the request to build
      * @return the built HTTP request
      */
-    public static HttpRequest getHttpRequestSync(Request request) {
+    public static HttpRequest getHttpRequestSync(OutboundRequest outboundRequest) {
         var future = new PlainActionFuture<HttpRequest>();
-        request.createHttpRequest(future);
+        outboundRequest.createHttpRequest(future);
         return future.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ai21/completion/Ai21ChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ai21/completion/Ai21ChatCompletionResponseHandlerTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.net.URI;
@@ -117,12 +117,12 @@ public class Ai21ChatCompletionResponseHandlerTests extends ESTestCase {
         );
     }
 
-    private static Request mockRequest() throws URISyntaxException {
-        var request = mock(Request.class);
-        when(request.getInferenceEntityId()).thenReturn("id");
-        when(request.isStreaming()).thenReturn(true);
-        when(request.getURI()).thenReturn(new URI("https://api.ai21.com/studio/v1/chat/completions"));
-        return request;
+    private static OutboundRequest mockRequest() throws URISyntaxException {
+        var outboundRequest = mock(OutboundRequest.class);
+        when(outboundRequest.getInferenceEntityId()).thenReturn("id");
+        when(outboundRequest.isStreaming()).thenReturn(true);
+        when(outboundRequest.getURI()).thenReturn(new URI("https://api.ai21.com/studio/v1/chat/completions"));
+        return outboundRequest;
     }
 
     private static HttpResponse mockErrorResponse(int statusCode) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchCompletionRequestManagerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchCompletionRequestManagerTests.java
@@ -55,7 +55,7 @@ public class AlibabaCloudSearchCompletionRequestManagerTests extends ESTestCase 
         verify(mockExecutorService).execute(captor.capture());
 
         ExecutableInferenceRequest executableRequest = captor.getValue();
-        assertThat(executableRequest.request(), is(instanceOf(AlibabaCloudSearchCompletionRequest.class)));
+        assertThat(executableRequest.outboundRequest(), is(instanceOf(AlibabaCloudSearchCompletionRequest.class)));
         assertThat(executableRequest.responseHandler().getRequestType(), is("alibaba cloud search completion"));
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchRerankResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchRerankResponseEntityTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
@@ -28,7 +28,7 @@ public class AlibabaCloudSearchRerankResponseEntityTests extends ESTestCase {
 
     public void testFromResponse_CreatesResultsForASingleItem() throws IOException {
         InferenceServiceResults parsedResults = AlibabaCloudSearchRerankResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseLiteral.getBytes(StandardCharsets.UTF_8))
         );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockMockRequestSender.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockMockRequestSender.java
@@ -21,7 +21,7 @@ import org.elasticsearch.xpack.inference.external.http.sender.InferenceInputs;
 import org.elasticsearch.xpack.inference.external.http.sender.RequestManager;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 
 import java.io.IOException;
@@ -105,7 +105,7 @@ public class AmazonBedrockMockRequestSender implements Sender {
     @Override
     public void sendWithoutQueuing(
         Logger logger,
-        Request request,
+        OutboundRequest outboundRequest,
         ResponseHandler responseHandler,
         TimeValue timeout,
         ActionListener<InferenceServiceResults> listener

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicChatCompletionResponseHandlerTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -56,11 +56,11 @@ public class AnthropicChatCompletionResponseHandlerTests extends ESTestCase {
             """, INFERENCE_ID)));
     }
 
-    private static Request mockRequest() {
-        var request = mock(Request.class);
-        when(request.getInferenceEntityId()).thenReturn(INFERENCE_ID);
-        when(request.isStreaming()).thenReturn(true);
-        return request;
+    private static OutboundRequest mockRequest() {
+        var outboundRequest = mock(OutboundRequest.class);
+        when(outboundRequest.getInferenceEntityId()).thenReturn(INFERENCE_ID);
+        when(outboundRequest.isStreaming()).thenReturn(true);
+        return outboundRequest;
     }
 
     private static HttpResponse mockHttpResponse(int statusCode) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicResponseHandlerTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -157,7 +157,7 @@ public class AnthropicResponseHandlerTests extends ESTestCase {
         when(header.getElements()).thenReturn(new HeaderElement[] {});
         when(httpResponse.getFirstHeader(anyString())).thenReturn(header);
 
-        var mockRequest = mock(Request.class);
+        var mockRequest = mock(OutboundRequest.class);
         when(mockRequest.getInferenceEntityId()).thenReturn(inferenceEntityId);
         var httpResult = new HttpResult(httpResponse, new byte[] {});
         var handler = new AnthropicResponseHandler("", (request, result) -> null, false);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/response/AnthropicChatCompletionResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/response/AnthropicChatCompletionResponseEntityTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -45,7 +45,7 @@ public class AnthropicChatCompletionResponseEntityTests extends ESTestCase {
             """;
 
         ChatCompletionResults chatCompletionResults = AnthropicChatCompletionResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -80,7 +80,7 @@ public class AnthropicChatCompletionResponseEntityTests extends ESTestCase {
             """;
 
         ChatCompletionResults chatCompletionResults = AnthropicChatCompletionResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -124,7 +124,7 @@ public class AnthropicChatCompletionResponseEntityTests extends ESTestCase {
             """;
 
         ChatCompletionResults chatCompletionResults = AnthropicChatCompletionResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -158,7 +158,7 @@ public class AnthropicChatCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> AnthropicChatCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -189,7 +189,7 @@ public class AnthropicChatCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> AnthropicChatCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -224,7 +224,7 @@ public class AnthropicChatCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> AnthropicChatCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -252,7 +252,7 @@ public class AnthropicChatCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> AnthropicChatCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/response/AzureAiStudioRerankResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/response/AzureAiStudioRerankResponseEntityTests.java
@@ -11,7 +11,7 @@ import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -48,7 +48,7 @@ public class AzureAiStudioRerankResponseEntityTests extends ESTestCase {
     private RankedDocsResults getParsedResults(String responseJson) throws IOException {
         final var entity = new AzureAiStudioRerankResponseEntity();
         return (RankedDocsResults) entity.apply(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureOpenAiCompletionResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/response/AzureOpenAiCompletionResponseEntityTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -87,7 +87,7 @@ public class AzureOpenAiCompletionResponseEntityTests extends ESTestCase {
              }""";
 
         ChatCompletionResults chatCompletionResults = AzureOpenAiCompletionResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -116,7 +116,7 @@ public class AzureOpenAiCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> AzureOpenAiCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -144,7 +144,7 @@ public class AzureOpenAiCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> AzureOpenAiCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -176,7 +176,7 @@ public class AzureOpenAiCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> AzureOpenAiCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -203,7 +203,7 @@ public class AzureOpenAiCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> AzureOpenAiCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereResponseHandlerTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.hamcrest.MatcherAssert;
 
 import java.nio.charset.StandardCharsets;
@@ -129,7 +129,7 @@ public class CohereResponseHandlerTests extends ESTestCase {
                 }
             """, errorMessage);
 
-        var mockRequest = mock(Request.class);
+        var mockRequest = mock(OutboundRequest.class);
         when(mockRequest.getInferenceEntityId()).thenReturn(modelId);
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : responseJson.getBytes(StandardCharsets.UTF_8));
         var handler = new CohereResponseHandler("", (request, result) -> null, false);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereCompletionResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereCompletionResponseEntityTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -56,7 +56,7 @@ public class CohereCompletionResponseEntityTests extends ESTestCase {
             """;
 
         ChatCompletionResults chatCompletionResults = CohereCompletionResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -92,7 +92,7 @@ public class CohereCompletionResponseEntityTests extends ESTestCase {
             """;
 
         ChatCompletionResults chatCompletionResults = CohereCompletionResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -136,7 +136,7 @@ public class CohereCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> CohereCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -182,7 +182,7 @@ public class CohereCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> CohereCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereEmbeddingsResponseEntityTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
@@ -52,7 +52,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         InferenceServiceResults parsedResults = CohereEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -91,7 +91,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -135,7 +135,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -179,7 +179,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingByteResults parsedResults = (DenseEmbeddingByteResults) CohereEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -217,7 +217,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingByteResults parsedResults = (DenseEmbeddingByteResults) CohereEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -258,7 +258,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingBitResults parsedResults = (DenseEmbeddingBitResults) CohereEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -298,7 +298,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -345,7 +345,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -398,7 +398,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingBitResults parsedResults = (DenseEmbeddingBitResults) CohereEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -441,7 +441,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> CohereEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -482,7 +482,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalArgumentException.class,
             () -> CohereEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -520,7 +520,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalArgumentException.class,
             () -> CohereEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -558,7 +558,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalArgumentException.class,
             () -> CohereEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -596,7 +596,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalArgumentException.class,
             () -> CohereEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -634,7 +634,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> CohereEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/contextualai/ContextualAiResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/contextualai/ContextualAiResponseHandlerTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.nio.charset.StandardCharsets;
 
@@ -144,7 +144,7 @@ public class ContextualAiResponseHandlerTests extends ESTestCase {
         when(header.getElements()).thenReturn(new HeaderElement[] {});
         when(httpResponse.getFirstHeader(anyString())).thenReturn(header);
 
-        var mockRequest = mock(Request.class);
+        var mockRequest = mock(OutboundRequest.class);
         when(mockRequest.getInferenceEntityId()).thenReturn(TEST_INFERENCE_ENTITY_ID);
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : errorMessage.getBytes(StandardCharsets.UTF_8));
         var handler = new ContextualAiResponseHandler("", (request, result) -> null, false);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceResponseHandlerTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.hamcrest.MatcherAssert;
 
 import java.nio.charset.StandardCharsets;
@@ -122,7 +122,7 @@ public class ElasticInferenceServiceResponseHandlerTests extends ESTestCase {
                 }
             """, errorMessage);
 
-        var mockRequest = mock(Request.class);
+        var mockRequest = mock(OutboundRequest.class);
         when(mockRequest.getInferenceEntityId()).thenReturn(modelId);
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : responseJson.getBytes(StandardCharsets.UTF_8));
         var handler = new ElasticInferenceServiceResponseHandler("", (request, result) -> null);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
 import org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactory;
 
@@ -102,7 +102,7 @@ public class ElasticInferenceServiceRequestTests extends ESTestCase {
             }
 
             @Override
-            public Request truncate() {
+            public OutboundRequest truncate() {
                 return null;
             }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/response/ElasticInferenceServiceSparseEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/response/ElasticInferenceServiceSparseEmbeddingsResponseEntityTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -37,7 +37,7 @@ public class ElasticInferenceServiceSparseEmbeddingsResponseEntityTests extends 
             """;
 
         SparseEmbeddingResults parsedResults = ElasticInferenceServiceSparseEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -73,7 +73,7 @@ public class ElasticInferenceServiceSparseEmbeddingsResponseEntityTests extends 
             """;
 
         SparseEmbeddingResults parsedResults = ElasticInferenceServiceSparseEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -107,7 +107,7 @@ public class ElasticInferenceServiceSparseEmbeddingsResponseEntityTests extends 
             }
             """;
 
-        var request = mock(Request.class);
+        var request = mock(OutboundRequest.class);
         when(request.getTruncationInfo()).thenReturn(new boolean[] { true });
 
         SparseEmbeddingResults parsedResults = ElasticInferenceServiceSparseEmbeddingsResponseEntity.fromResponse(
@@ -146,7 +146,7 @@ public class ElasticInferenceServiceSparseEmbeddingsResponseEntityTests extends 
             }
             """;
 
-        var request = mock(Request.class);
+        var request = mock(OutboundRequest.class);
         when(request.getTruncationInfo()).thenReturn(new boolean[] { true, false });
 
         SparseEmbeddingResults parsedResults = ElasticInferenceServiceSparseEmbeddingsResponseEntity.fromResponse(
@@ -188,7 +188,7 @@ public class ElasticInferenceServiceSparseEmbeddingsResponseEntityTests extends 
             """;
 
         SparseEmbeddingResults parsedResults = ElasticInferenceServiceSparseEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -222,7 +222,7 @@ public class ElasticInferenceServiceSparseEmbeddingsResponseEntityTests extends 
             """;
 
         SparseEmbeddingResults parsedResults = ElasticInferenceServiceSparseEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/fireworksai/FireworksAiResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/fireworksai/FireworksAiResponseHandlerTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.hamcrest.MatcherAssert;
 
 import java.nio.charset.StandardCharsets;
@@ -111,7 +111,7 @@ public class FireworksAiResponseHandlerTests extends ESTestCase {
         when(header.getElements()).thenReturn(new HeaderElement[] {});
         when(httpResponse.getFirstHeader(anyString())).thenReturn(header);
 
-        var mockRequest = mock(Request.class);
+        var mockRequest = mock(OutboundRequest.class);
         when(mockRequest.getInferenceEntityId()).thenReturn(modelId);
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : errorMessage.getBytes(StandardCharsets.UTF_8));
         var handler = new FireworksAiResponseHandler("", (request, result) -> null, false);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioResponseHandlerTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -122,7 +122,7 @@ public class GoogleAiStudioResponseHandlerTests extends ESTestCase {
         when(header.getElements()).thenReturn(new HeaderElement[] {});
         when(httpResponse.getFirstHeader(anyString())).thenReturn(header);
 
-        var mockRequest = mock(Request.class);
+        var mockRequest = mock(OutboundRequest.class);
         when(mockRequest.getInferenceEntityId()).thenReturn(modelId);
         var httpResult = new HttpResult(httpResponse, new byte[] {});
         var handler = new GoogleAiStudioResponseHandler("", (request, result) -> null);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioCompletionResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioCompletionResponseEntityTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -66,7 +66,7 @@ public class GoogleAiStudioCompletionResponseEntityTests extends ESTestCase {
             """;
 
         ChatCompletionResults chatCompletionResults = GoogleAiStudioCompletionResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -120,7 +120,7 @@ public class GoogleAiStudioCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> GoogleAiStudioCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -176,7 +176,7 @@ public class GoogleAiStudioCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> GoogleAiStudioCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioEmbeddingsResponseEntityTests.java
@@ -11,7 +11,7 @@ import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -37,7 +37,7 @@ public class GoogleAiStudioEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = GoogleAiStudioEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -65,7 +65,7 @@ public class GoogleAiStudioEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = GoogleAiStudioEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -103,7 +103,7 @@ public class GoogleAiStudioEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> GoogleAiStudioEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiResponseHandlerTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -122,7 +122,7 @@ public class GoogleVertexAiResponseHandlerTests extends ESTestCase {
         when(header.getElements()).thenReturn(new HeaderElement[] {});
         when(httpResponse.getFirstHeader(anyString())).thenReturn(header);
 
-        var mockRequest = mock(Request.class);
+        var mockRequest = mock(OutboundRequest.class);
         when(mockRequest.getInferenceEntityId()).thenReturn(modelId);
         var httpResult = new HttpResult(httpResponse, new byte[] {});
         var handler = new GoogleVertexAiResponseHandler("", (request, result) -> null);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiUnifiedChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiUnifiedChatCompletionResponseHandlerTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -76,11 +76,11 @@ public class GoogleVertexAiUnifiedChatCompletionResponseHandlerTests extends EST
             """, INFERENCE_ID)));
     }
 
-    private static Request mockRequest() {
-        var request = mock(Request.class);
-        when(request.getInferenceEntityId()).thenReturn(INFERENCE_ID);
-        when(request.isStreaming()).thenReturn(true);
-        return request;
+    private static OutboundRequest mockRequest() {
+        var outboundRequest = mock(OutboundRequest.class);
+        when(outboundRequest.getInferenceEntityId()).thenReturn(INFERENCE_ID);
+        when(outboundRequest.isStreaming()).thenReturn(true);
+        return outboundRequest;
     }
 
     private static HttpResponse mockHttpResponse(int statusCode) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequestTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.InputTypeTests;
 import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.common.TruncatorTests;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
 import org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiSecretSettings;
 import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsModel;
@@ -307,7 +307,7 @@ public class GoogleVertexAiEmbeddingsRequestTests extends ESTestCase {
         }
 
         @Override
-        public Request truncate() {
+        public OutboundRequest truncate() {
             GoogleVertexAiEmbeddingsRequest embeddingsRequest = (GoogleVertexAiEmbeddingsRequest) super.truncate();
             return new GoogleVertexAiEmbeddingsWithoutAuthRequest(
                 embeddingsRequest.truncator(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiCompletionResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiCompletionResponseEntityTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -66,7 +66,7 @@ public class GoogleVertexAiCompletionResponseEntityTests extends ESTestCase {
             """, responseText);
 
         var parsedResults = GoogleVertexAiCompletionResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiEmbeddingsResponseEntityTests.java
@@ -11,7 +11,7 @@ import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -43,7 +43,7 @@ public class GoogleVertexAiEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = GoogleVertexAiEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -83,7 +83,7 @@ public class GoogleVertexAiEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = GoogleVertexAiEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -133,7 +133,7 @@ public class GoogleVertexAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> GoogleVertexAiEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -164,7 +164,7 @@ public class GoogleVertexAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> GoogleVertexAiEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -195,7 +195,7 @@ public class GoogleVertexAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> GoogleVertexAiEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceChatCompletionResponseHandlerTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -116,11 +116,11 @@ public class HuggingFaceChatCompletionResponseHandlerTests extends ESTestCase {
         );
     }
 
-    private static Request mockRequest() {
-        var request = mock(Request.class);
-        when(request.getInferenceEntityId()).thenReturn("id");
-        when(request.isStreaming()).thenReturn(true);
-        return request;
+    private static OutboundRequest mockRequest() {
+        var outboundRequest = mock(OutboundRequest.class);
+        when(outboundRequest.getInferenceEntityId()).thenReturn("id");
+        when(outboundRequest.isStreaming()).thenReturn(true);
+        return outboundRequest;
     }
 
     private static HttpResponse mock500Response() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceElserResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceElserResponseEntityTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResultsTests;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -39,7 +39,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
             ]""";
 
         SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -54,7 +54,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
     }
 
     public void testFromResponse_CreatesTextExpansionResults_ThatAreTruncated() throws IOException {
-        var request = mock(Request.class);
+        var request = mock(OutboundRequest.class);
         when(request.getTruncationInfo()).thenReturn(new boolean[] { true });
 
         String responseJson = """
@@ -94,7 +94,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
             ]""";
 
         SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -124,7 +124,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
                 }
             ]""";
 
-        var request = mock(Request.class);
+        var request = mock(OutboundRequest.class);
         when(request.getTruncationInfo()).thenReturn(new boolean[] { true, false });
 
         SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
@@ -158,11 +158,11 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
                 }
             ]""";
 
-        var request = mock(Request.class);
+        var request = mock(OutboundRequest.class);
         when(request.getTruncationInfo()).thenReturn(new boolean[] {});
 
         SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -189,7 +189,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceElserResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -212,7 +212,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceElserResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -233,7 +233,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
             """;
 
         SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -257,7 +257,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
             """;
 
         SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -283,7 +283,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceElserResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -305,7 +305,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentEOFException.class,
             () -> HuggingFaceElserResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -325,7 +325,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentParseException.class,
             () -> HuggingFaceElserResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceEmbeddingsResponseEntityTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -33,7 +33,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -56,7 +56,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -81,7 +81,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -113,7 +113,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -138,7 +138,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -164,7 +164,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -187,7 +187,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -210,7 +210,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -235,7 +235,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -256,7 +256,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -275,7 +275,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -292,7 +292,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -311,7 +311,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -332,7 +332,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -351,7 +351,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
@@ -48,7 +48,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 import org.elasticsearch.xpack.inference.services.InferenceServiceTestCase;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
@@ -1094,7 +1094,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
         }
 
         @Override
-        public Request truncate() {
+        public OutboundRequest truncate() {
             IbmWatsonxEmbeddingsRequest embeddingsRequest = (IbmWatsonxEmbeddingsRequest) super.truncate();
             return new IbmWatsonxEmbeddingsWithoutAuthRequest(
                 embeddingsRequest.truncator(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/action/IbmWatsonxEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/action/IbmWatsonxEmbeddingsActionTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.EmbeddingsInput;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxEmbeddingsRequestManager;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModel;
@@ -232,7 +232,7 @@ public class IbmWatsonxEmbeddingsActionTests extends ESTestCase {
         }
 
         @Override
-        public Request truncate() {
+        public OutboundRequest truncate() {
             IbmWatsonxEmbeddingsRequest embeddingsRequest = (IbmWatsonxEmbeddingsRequest) super.truncate();
             return new IbmWatsonxEmbeddingsWithoutAuthRequest(
                 embeddingsRequest.truncator(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxEmbeddingsRequestTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.common.TruncatorTests;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModelTests;
@@ -147,7 +147,7 @@ public class IbmWatsonxEmbeddingsRequestTests extends ESTestCase {
         }
 
         @Override
-        public Request truncate() {
+        public OutboundRequest truncate() {
             IbmWatsonxEmbeddingsRequest embeddingsRequest = (IbmWatsonxEmbeddingsRequest) super.truncate();
             return new IbmWatsonxEmbeddingsWithoutAuthRequest(
                 embeddingsRequest.truncator(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/response/IbmWatsonxEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/response/IbmWatsonxEmbeddingsResponseEntityTests.java
@@ -11,7 +11,7 @@ import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -37,7 +37,7 @@ public class IbmWatsonxEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = IbmWatsonxEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -67,7 +67,7 @@ public class IbmWatsonxEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         DenseEmbeddingFloatResults parsedResults = IbmWatsonxEmbeddingsResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -107,7 +107,7 @@ public class IbmWatsonxEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> IbmWatsonxEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIResponseHandlerTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.nio.charset.StandardCharsets;
 
@@ -127,7 +127,7 @@ public class JinaAIResponseHandlerTests extends ESTestCase {
                 }
             """, escapedErrorMessage);
 
-        var mockRequest = mock(Request.class);
+        var mockRequest = mock(OutboundRequest.class);
         when(mockRequest.getInferenceEntityId()).thenReturn(modelId);
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : responseJson.getBytes(StandardCharsets.UTF_8));
         var handler = new JinaAIResponseHandler("", (request, result) -> null);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/llama/completion/LlamaChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/llama/completion/LlamaChatCompletionResponseHandlerTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.net.URI;
@@ -128,12 +128,12 @@ public class LlamaChatCompletionResponseHandlerTests extends ESTestCase {
         );
     }
 
-    private static Request mockRequest() throws URISyntaxException {
-        var request = mock(Request.class);
-        when(request.getInferenceEntityId()).thenReturn("id");
-        when(request.isStreaming()).thenReturn(true);
-        when(request.getURI()).thenReturn(new URI("https://api.llama.ai/v1/chat/completions"));
-        return request;
+    private static OutboundRequest mockRequest() throws URISyntaxException {
+        var outboundRequest = mock(OutboundRequest.class);
+        when(outboundRequest.getInferenceEntityId()).thenReturn("id");
+        when(outboundRequest.isStreaming()).thenReturn(true);
+        when(outboundRequest.getURI()).thenReturn(new URI("https://api.llama.ai/v1/chat/completions"));
+        return outboundRequest;
     }
 
     private static HttpResponse mockErrorResponse(int statusCode) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralUnifiedChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralUnifiedChatCompletionResponseHandlerTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.net.URI;
@@ -121,12 +121,12 @@ public class MistralUnifiedChatCompletionResponseHandlerTests extends ESTestCase
         );
     }
 
-    private static Request mockRequest() throws URISyntaxException {
-        var request = mock(Request.class);
-        when(request.getInferenceEntityId()).thenReturn("id");
-        when(request.isStreaming()).thenReturn(true);
-        when(request.getURI()).thenReturn(new URI("https://api.mistral.ai/v1/chat/completions"));
-        return request;
+    private static OutboundRequest mockRequest() throws URISyntaxException {
+        var outboundRequest = mock(OutboundRequest.class);
+        when(outboundRequest.getInferenceEntityId()).thenReturn("id");
+        when(outboundRequest.isStreaming()).thenReturn(true);
+        when(outboundRequest.getURI()).thenReturn(new URI("https://api.mistral.ai/v1/chat/completions"));
+        return outboundRequest;
     }
 
     private static HttpResponse mockErrorResponse(int statusCode) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/action/NvidiaActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/action/NvidiaActionCreatorTests.java
@@ -811,7 +811,7 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         }
     }
 
-    private static void assertContentTypeAndAuthorization(MockRequest outboundRequest) {
+    private static void assertContentTypeAndAuthorization(MockRequest request) {
         assertThat(request.getHeader(HttpHeaders.CONTENT_TYPE), is(XContentType.JSON.mediaTypeWithoutParameters()));
         assertThat(request.getHeader(HttpHeaders.AUTHORIZATION), is(Strings.format("Bearer %s", API_KEY_VALUE)));
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/action/NvidiaActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/action/NvidiaActionCreatorTests.java
@@ -811,7 +811,7 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         }
     }
 
-    private static void assertContentTypeAndAuthorization(MockRequest request) {
+    private static void assertContentTypeAndAuthorization(MockRequest outboundRequest) {
         assertThat(request.getHeader(HttpHeaders.CONTENT_TYPE), is(XContentType.JSON.mediaTypeWithoutParameters()));
         assertThat(request.getHeader(HttpHeaders.AUTHORIZATION), is(Strings.format("Bearer %s", API_KEY_VALUE)));
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/completion/NvidiaChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/completion/NvidiaChatCompletionResponseHandlerTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.net.URI;
@@ -118,12 +118,12 @@ public class NvidiaChatCompletionResponseHandlerTests extends ESTestCase {
         );
     }
 
-    private static Request mockRequest() throws URISyntaxException {
-        var request = mock(Request.class);
-        when(request.getInferenceEntityId()).thenReturn(INFERENCE_ID);
-        when(request.isStreaming()).thenReturn(true);
-        when(request.getURI()).thenReturn(new URI(URL_VALUE));
-        return request;
+    private static OutboundRequest mockRequest() throws URISyntaxException {
+        var outboundRequest = mock(OutboundRequest.class);
+        when(outboundRequest.getInferenceEntityId()).thenReturn(INFERENCE_ID);
+        when(outboundRequest.isStreaming()).thenReturn(true);
+        when(outboundRequest.getURI()).thenReturn(new URI(URL_VALUE));
+        return outboundRequest;
     }
 
     private static HttpResponse mockErrorResponse(int statusCode) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedChatCompletionResponseHandlerTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -111,11 +111,11 @@ public class OpenAiUnifiedChatCompletionResponseHandlerTests extends ESTestCase 
         );
     }
 
-    private static Request mockRequest() {
-        var request = mock(Request.class);
-        when(request.getInferenceEntityId()).thenReturn("abc");
-        when(request.isStreaming()).thenReturn(true);
-        return request;
+    private static OutboundRequest mockRequest() {
+        var outboundRequest = mock(OutboundRequest.class);
+        when(outboundRequest.getInferenceEntityId()).thenReturn("abc");
+        when(outboundRequest.isStreaming()).thenReturn(true);
+        return outboundRequest;
     }
 
     private static HttpResponse mock500Response() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiChatCompletionResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiChatCompletionResponseEntityTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -51,7 +51,7 @@ public class OpenAiChatCompletionResponseEntityTests extends ESTestCase {
             """;
 
         ChatCompletionResults chatCompletionResults = OpenAiChatCompletionResponseEntity.fromResponse(
-            mock(Request.class),
+            mock(OutboundRequest.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -89,7 +89,7 @@ public class OpenAiChatCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalArgumentException.class,
             () -> OpenAiChatCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -127,7 +127,7 @@ public class OpenAiChatCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentParseException.class,
             () -> OpenAiChatCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -165,7 +165,7 @@ public class OpenAiChatCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentParseException.class,
             () -> OpenAiChatCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -200,7 +200,7 @@ public class OpenAiChatCompletionResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentParseException.class,
             () -> OpenAiChatCompletionResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiEmbeddingsResponseEntityTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults
 import org.elasticsearch.xpack.core.inference.results.EmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.GenericDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -142,7 +142,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalArgumentException.class,
             () -> OpenAiEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -175,7 +175,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentParseException.class,
             () -> OpenAiEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -208,7 +208,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentParseException.class,
             () -> OpenAiEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -240,7 +240,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentParseException.class,
             () -> OpenAiEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -340,7 +340,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentParseException.class,
             () -> OpenAiEmbeddingsResponseEntity.fromResponse(
-                mock(Request.class),
+                mock(OutboundRequest.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -413,10 +413,10 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
     }
 
     private static EmbeddingFloatResults getEmbeddingFloatResultsAndAssertType(TaskType taskType, String response) throws IOException {
-        Request requestMock = mock(Request.class);
-        when(requestMock.getTaskType()).thenReturn(taskType);
+        OutboundRequest outboundRequestMock = mock(OutboundRequest.class);
+        when(outboundRequestMock.getTaskType()).thenReturn(taskType);
         EmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
-            requestMock,
+            outboundRequestMock,
             new HttpResult(mock(HttpResponse.class), response.getBytes(StandardCharsets.UTF_8))
         );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openshiftai/completion/OpenShiftAiChatCompletionResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openshiftai/completion/OpenShiftAiChatCompletionResponseHandlerTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 
 import java.io.IOException;
 import java.net.URI;
@@ -126,12 +126,12 @@ public class OpenShiftAiChatCompletionResponseHandlerTests extends ESTestCase {
         );
     }
 
-    private static Request mockRequest() throws URISyntaxException {
-        var request = mock(Request.class);
-        when(request.getInferenceEntityId()).thenReturn(INFERENCE_ID);
-        when(request.isStreaming()).thenReturn(true);
-        when(request.getURI()).thenReturn(new URI(URL_VALUE));
-        return request;
+    private static OutboundRequest mockRequest() throws URISyntaxException {
+        var outboundRequest = mock(OutboundRequest.class);
+        when(outboundRequest.getInferenceEntityId()).thenReturn(INFERENCE_ID);
+        when(outboundRequest.isStreaming()).thenReturn(true);
+        when(outboundRequest.getURI()).thenReturn(new URI(URL_VALUE));
+        return outboundRequest;
     }
 
     private static HttpResponse mockErrorResponse(int statusCode) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIResponseHandlerTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
-import org.elasticsearch.xpack.inference.external.request.Request;
+import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.hamcrest.MatcherAssert;
 
 import java.nio.charset.StandardCharsets;
@@ -128,7 +128,7 @@ public class VoyageAIResponseHandlerTests extends ESTestCase {
                 }
             """, escapedErrorMessage);
 
-        var mockRequest = mock(Request.class);
+        var mockRequest = mock(OutboundRequest.class);
         when(mockRequest.getInferenceEntityId()).thenReturn(modelId);
         var httpResult = new HttpResult(httpResponse, errorMessage == null ? new byte[] {} : responseJson.getBytes(StandardCharsets.UTF_8));
         var handler = new VoyageAIResponseHandler("", (request, result) -> null);


### PR DESCRIPTION
This commit renames the \*Request interfaces found in the org.elasticsearch.xpack.inference.external.request package of x-pack/plugin/inference/ to be Outbound\*Request to prevent confusion with the similarly named classes found in the
org.elasticsearch.inference package of server