### PR TITLE
Fix `ListTasksIT.testWaitForCompletion` failure

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -273,9 +273,6 @@ tests:
 - class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
   method: testReindexTaskRelocatesOnNodeShutdown
   issue: https://github.com/elastic/elasticsearch/issues/147449
-- class: org.elasticsearch.action.admin.cluster.tasks.ListTasksIT
-  method: testWaitForCompletion
-  issue: https://github.com/elastic/elasticsearch/issues/146859
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=index/100_field_name_length_limit/Test field name length limit}
   issue: https://github.com/elastic/elasticsearch/issues/147494

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/tasks/ListTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/tasks/ListTasksIT.java
@@ -84,6 +84,7 @@ public class ListTasksIT extends ESSingleNodeTestCase {
 
         final var listWaitFuture = new PlainActionFuture<Void>();
         clusterAdmin().prepareListTasks()
+            .setActions(TestTransportAction.NAME)
             .setTargetTaskId(task.taskId())
             .setWaitForCompletion(true)
             .execute(listWaitFuture.delegateFailure((l, listResult) -> {


### PR DESCRIPTION
Test functionality before https://github.com/elastic/elasticsearch/pull/146598:
- use CyclicBarrier to wait for `TestTransportAction` task to be started
- fire off a single list with `WFC=true` that asserts in listener we have the expected task listed
- flush threadpool to assert all submitted tasks to MANAGEMENT threadpool have been registered (our list)
- use CyclicBarrier again to complete the task

What broke with double-listing (which was implicitly enabled for this task):
- flushing the threadpool guaranteed the first `WFC=false` pass was registered before task completion
- but the second `WFC=true` pass could be fired after task has already completed
- therefore we get the task in the first pass, but not the second, and `reconcileMissedRelocations` will exclude non-relocatable tasks that are present in first but not second pass, so we fail to see the task in the listing

Solution:
- seems entirely like a test setup problem to me, making sure task is alive while we list and we see it in listing
- therefore, opt-out the task from double-listing

Closes https://github.com/elastic/elasticsearch/issues/146859