### PR TITLE
Add escape hatches for reindex resilience launch

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -48,6 +48,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.FeatureService;
@@ -122,7 +123,10 @@ public class Reindexer {
     /// Allows setting the system property `es.reindex.disable_pit_scroll` as an escape hatch to disable the use of PIT-based search, and
     /// force the use of the legacy scroll-based search.
     // TODO(#2715): Remove this when we're confident the PIT version works
-    private static final boolean DISABLE_PIT_SEARCH = Boolean.getBoolean("es.reindex.disable_pit_search");
+    private static final boolean DISABLE_PIT_SEARCH = Booleans.parseBooleanLenient(
+        System.getProperty("es.reindex.disable_pit_search"),
+        false
+    );
 
     private final ClusterService clusterService;
     private final ReindexSettings reindexSettings;

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -120,7 +120,7 @@ public class Reindexer {
 
     private static final Logger logger = LogManager.getLogger(Reindexer.class);
 
-    /// Allows setting the system property `es.reindex.disable_pit_scroll` as an escape hatch to disable the use of PIT-based search, and
+    /// Allows setting the system property `es.reindex.disable_pit_search` as an escape hatch to disable the use of PIT-based search, and
     /// force the use of the legacy scroll-based search.
     // TODO(#2715): Remove this when we're confident the PIT version works
     private static final boolean DISABLE_PIT_SEARCH = Booleans.parseBooleanLenient(

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -121,7 +121,7 @@ public class Reindexer {
 
     /// Allows setting the system property `es.reindex.disable_pit_scroll` as an escape hatch to disable the use of PIT-based search, and
     /// force the use of the legacy scroll-based search.
-    // TODO: Remove this when we're confident the PIT version works
+    // TODO(#2715): Remove this when we're confident the PIT version works
     private static final boolean DISABLE_PIT_SEARCH = Boolean.getBoolean("es.reindex.disable_pit_search");
 
     private final ClusterService clusterService;

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -119,6 +119,11 @@ public class Reindexer {
 
     private static final Logger logger = LogManager.getLogger(Reindexer.class);
 
+    /// Allows setting the system property `es.reindex.disable_pit_scroll` as an escape hatch to disable the use of PIT-based search, and
+    /// force the use of the legacy scroll-based search.
+    // TODO: Remove this when we're confident the PIT version works
+    private static final boolean DISABLE_PIT_SEARCH = Boolean.getBoolean("es.reindex.disable_pit_search");
+
     private final ClusterService clusterService;
     private final ReindexSettings reindexSettings;
     private final ProjectResolver projectResolver;
@@ -232,7 +237,7 @@ public class Reindexer {
         Consumer<Version> workerAction = createWorkerAction(task, request, bulkClient, responseListener);
 
         // Point-in-time searching is disabled, so default to scroll
-        if (featureService.clusterHasFeature(clusterService.state(), REINDEX_PIT_SEARCH_FEATURE) == false) {
+        if (featureService.clusterHasFeature(clusterService.state(), REINDEX_PIT_SEARCH_FEATURE) == false || DISABLE_PIT_SEARCH) {
             executePaginatedSearch(task, request, responseListener, workerAction, null);
         }
         /**

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -219,15 +219,15 @@ public class ShutdownPrepareService {
 
     // package-private for tests
     static void maybeRequestRelocationForBulkByScroll(Task task) {
-        if (DISABLE_REINDEX_RELOCATION) {
-            logger.info(
-                "Not requesting relocation for task {} because the system property es.reindex.disable_relocation is set",
-                task.getId()
-            );
-            return;
-        }
         if (task instanceof BulkByScrollTask bulkByScrollTask) {
             if (bulkByScrollTask.isEligibleForRelocationOnShutdown() && bulkByScrollTask.isRelocationRequested() == false) {
+                if (DISABLE_REINDEX_RELOCATION) {
+                    logger.info(
+                        "Not requesting relocation for task {} because the system property es.reindex.disable_relocation is set",
+                        task.getId()
+                    );
+                    return;
+                }
                 if (bulkByScrollTask.isLeader()) {
                     logger.info("Requesting relocation task for leader bulk-by-scroll task {} and its workers", bulkByScrollTask.getId());
                 } else {

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 public class ShutdownPrepareService {
 
     /// Allows setting the system property `es.reindex.disable_relocation` as an escape hatch to disable triggering reindex relocation.
-    // TODO: Remove this when we're confident relocation works
+    // TODO(#2715): Remove this when we're confident relocation works
     private static final boolean DISABLE_REINDEX_RELOCATION = Boolean.getBoolean("es.reindex.disable_relocation");
 
     private record ShutdownHook(String name, Runnable action) {}

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -47,6 +47,10 @@ import java.util.stream.Collectors;
  */
 public class ShutdownPrepareService {
 
+    /// Allows setting the system property `es.reindex.disable_relocation` as an escape hatch to disable triggering reindex relocation.
+    // TODO: Remove this when we're confident relocation works
+    private static final boolean DISABLE_REINDEX_RELOCATION = Boolean.getBoolean("es.reindex.disable_relocation");
+
     private record ShutdownHook(String name, Runnable action) {}
 
     public static final Setting<TimeValue> MAXIMUM_SHUTDOWN_TIMEOUT_SETTING = Setting.positiveTimeSetting(
@@ -211,6 +215,13 @@ public class ShutdownPrepareService {
 
     // package-private for tests
     static void maybeRequestRelocationForBulkByScroll(Task task) {
+        if (DISABLE_REINDEX_RELOCATION) {
+            logger.info(
+                "Not requesting relocation task for task {} because the system property es.reindex.disable_relocation is set",
+                task.getId()
+            );
+            return;
+        }
         if (task instanceof BulkByScrollTask bulkByScrollTask) {
             if (bulkByScrollTask.isEligibleForRelocationOnShutdown() && bulkByScrollTask.isRelocationRequested() == false) {
                 if (bulkByScrollTask.isLeader()) {

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -221,7 +221,7 @@ public class ShutdownPrepareService {
     static void maybeRequestRelocationForBulkByScroll(Task task) {
         if (DISABLE_REINDEX_RELOCATION) {
             logger.info(
-                "Not requesting relocation task for task {} because the system property es.reindex.disable_relocation is set",
+                "Not requesting relocation for task {} because the system property es.reindex.disable_relocation is set",
                 task.getId()
             );
             return;

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.http.HttpServerTransport;
@@ -49,7 +50,10 @@ public class ShutdownPrepareService {
 
     /// Allows setting the system property `es.reindex.disable_relocation` as an escape hatch to disable triggering reindex relocation.
     // TODO(#2715): Remove this when we're confident relocation works
-    private static final boolean DISABLE_REINDEX_RELOCATION = Boolean.getBoolean("es.reindex.disable_relocation");
+    private static final boolean DISABLE_REINDEX_RELOCATION = Booleans.parseBooleanLenient(
+        System.getProperty("es.reindex.disable_relocation", "false"),
+        false
+    );
 
     private record ShutdownHook(String name, Runnable action) {}
 


### PR DESCRIPTION
This adds two system settings which we could use in an emergency to disable parts of the functionality.

Note: We cannot unregister the node features once they're registered in any long-lived cluster. And we cannot safely disable any functionality that applies across transport mechanisms or that gets persisted. But we can make purely node-local changes to triggering logic.

Setting `-Des.reindex.disable_relocation=true` will disable the code which requests a relocation on node shutdown. (The relocation mechanism itself is still active, so if a node without this setting requests a relocation and that node decides to relocate a reindex to a node with this setting, it will still proceed.)

Setting `-Des.reindex.disable_pit_search=true` will change the logic which decides whether to do PIT- or scroll-based searching to always choose scroll (as it did before the launch). (The PIT code is still active, so if a PIT-based reindex started on a node without this setting relocations to a node with this setting, it will still proceed.)

We will revert this change once we're confident we don't need the escape hatches any more.