### PR TITLE
Reindexing Throws 5XX Error

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSearchContextFailuresIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSearchContextFailuresIT.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.reindex;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.action.support.ActionFilterChain;
+import org.elasticsearch.action.support.MappedActionFilter;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.reindex.ReindexSettings;
+import org.elasticsearch.reindex.TransportReindexAction;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.root.MainRestPlugin;
+import org.elasticsearch.search.SearchContextMissingException;
+import org.elasticsearch.search.internal.ShardSearchContextId;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.After;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Integration tests for HTTP status codes when reindexing hits a ({@link SearchContextMissingException}).
+ * Note that this test assumes we're using point-in-time searching rather than scroll search, since we only control the
+ * keep-alive value for PIT. Scroll search, now used exclusively when reindexing from a remote cluster on a version &lt; 7.10,
+ * uses a customer set keep-alive through the API, and so returning a 4XX error due to a timeout is always appropriate
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 1, numClientNodes = 0)
+public class ReindexSearchContextFailuresIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(ReindexPlugin.class, MainRestPlugin.class, SearchContextFailureInjectionPlugin.class);
+    }
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(TransportReindexAction.REMOTE_CLUSTER_WHITELIST.getKey(), "*:*")
+            .build();
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        try {
+            assertAcked(
+                clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                    .setPersistentSettings(Settings.builder().putNull(ReindexSettings.REINDEX_PIT_KEEP_ALIVE_SETTING.getKey()).build())
+            );
+        } finally {
+            SearchContextFailureInjectionPlugin.CONFIG.set(null);
+            SearchContextFailureInjectionPlugin.PIT_SEARCH_COUNTER.set(0);
+            super.tearDown();
+        }
+    }
+
+    /**
+     * Failures that occur after the client-side keep-alive deadline are surfaced as {@link RestStatus#INTERNAL_SERVER_ERROR}
+     */
+    public void testPitKeepaliveExpiredReturns500StatusCode() {
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+
+        TimeValue pitKeepAlive = TimeValue.timeValueMillis(200);
+        assertAcked(
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                .setPersistentSettings(
+                    Settings.builder().put(ReindexSettings.REINDEX_PIT_KEEP_ALIVE_SETTING.getKey(), pitKeepAlive.getStringRep()).build()
+                )
+        );
+
+        String source = randomAlphanumericOfLength(12).toLowerCase(Locale.ROOT);
+        String dest = randomAlphanumericOfLength(12).toLowerCase(Locale.ROOT);
+        assertAcked(prepareCreate(source));
+        assertAcked(prepareCreate(dest));
+        indexRandom(
+            true,
+            false,
+            true,
+            IntStream.range(0, 3).mapToObj(i -> prepareIndex(source).setId(Integer.toString(i)).setSource("n", i)).toList()
+        );
+        assertHitCount(prepareSearch(source).setSize(0).setTrackTotalHits(true), 3L);
+
+        SearchContextFailureInjectionPlugin.PIT_SEARCH_COUNTER.set(0);
+        SearchContextFailureInjectionPlugin.CONFIG.set(
+            new SearchContextFailureInjectionPlugin.InjectionConfig(
+                2,
+                TimeValue.timeValueMillis(pitKeepAlive.millis() + 100),
+                testMissingContext()
+            )
+        );
+
+        // Use a HTTP request to hit the REST layer and assert the exception returned
+        Request request = new Request("POST", "/_reindex");
+        request.setJsonEntity(Strings.format("""
+            {
+              "source": { "index": "%s", "size": 1 },
+              "dest": { "index": "%s" }
+            }""", source, dest));
+
+        ResponseException ex = expectThrows(ResponseException.class, () -> getRestClient().performRequest(request));
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.INTERNAL_SERVER_ERROR.getStatus()));
+    }
+
+    /**
+     * Failures that occur during the client-side keep-alive deadline are surfaced as {@link RestStatus#NOT_FOUND}
+     */
+    public void testPitSearchContextMissingInsideKeepaliveReturns404StatusCode() {
+        assumeTrue("reindex with point-in-time search must be enabled", ReindexPlugin.REINDEX_PIT_SEARCH_ENABLED);
+
+        TimeValue pitKeepAlive = TimeValue.timeValueSeconds(5);
+        assertAcked(
+            clusterAdmin().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT)
+                .setPersistentSettings(
+                    Settings.builder().put(ReindexSettings.REINDEX_PIT_KEEP_ALIVE_SETTING.getKey(), pitKeepAlive.getStringRep()).build()
+                )
+        );
+
+        String source = randomAlphanumericOfLength(12).toLowerCase(Locale.ROOT);
+        String dest = randomAlphanumericOfLength(12).toLowerCase(Locale.ROOT);
+        assertAcked(prepareCreate(source));
+        assertAcked(prepareCreate(dest));
+        indexRandom(
+            true,
+            false,
+            true,
+            IntStream.range(0, 3).mapToObj(i -> prepareIndex(source).setId(Integer.toString(i)).setSource("n", i)).toList()
+        );
+        assertHitCount(prepareSearch(source).setSize(0).setTrackTotalHits(true), 3L);
+
+        SearchContextFailureInjectionPlugin.PIT_SEARCH_COUNTER.set(0);
+        SearchContextFailureInjectionPlugin.CONFIG.set(
+            new SearchContextFailureInjectionPlugin.InjectionConfig(2, TimeValue.ZERO, testMissingContext())
+        );
+
+        // Use a HTTP request to hit the REST layer and assert the exception returned
+        Request request = new Request("POST", "/_reindex");
+        request.setJsonEntity(Strings.format("""
+            {
+              "source": { "index": "%s", "size": 1 },
+              "dest": { "index": "%s" }
+            }""", source, dest));
+
+        ResponseException ex = expectThrows(ResponseException.class, () -> getRestClient().performRequest(request));
+        assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.NOT_FOUND.getStatus()));
+    }
+
+    // TODO - Why make this N?
+    /**
+     * {@link MappedActionFilter} that fails the Nth local PIT continuation search used by reindex
+     * ({@link SearchRequest} with point-in-time and no explicit indices after {@link ReindexRequest#convertSearchRequestToUsePit}).
+     */
+    public static final class SearchContextFailureInjectionPlugin extends Plugin implements ActionPlugin {
+
+        static final AtomicReference<InjectionConfig> CONFIG = new AtomicReference<>();
+        static final AtomicInteger PIT_SEARCH_COUNTER = new AtomicInteger(0);
+
+        public record InjectionConfig(/** 1-based ordinal among matching PIT searches; 2 = second page. */
+        int failOnPitSearchOrdinal, TimeValue sleepBeforeFail, SearchContextMissingException exception) {}
+
+        @Override
+        public Collection<MappedActionFilter> getMappedActionFilters() {
+            return List.of(new MappedActionFilter() {
+                @Override
+                public String actionName() {
+                    return TransportSearchAction.NAME;
+                }
+
+                @Override
+                @SuppressWarnings("unchecked")
+                public <Request extends ActionRequest, Response extends ActionResponse> void apply(
+                    Task task,
+                    String action,
+                    Request request,
+                    ActionListener<Response> listener,
+                    ActionFilterChain<Request, Response> chain
+                ) {
+                    InjectionConfig cfg = CONFIG.get();
+                    if (cfg == null || request instanceof SearchRequest == false) {
+                        chain.proceed(task, action, request, listener);
+                        return;
+                    }
+                    SearchRequest searchRequest = (SearchRequest) request;
+                    if (matchesReindexPitSearch(searchRequest) == false) {
+                        chain.proceed(task, action, request, listener);
+                        return;
+                    }
+                    int n = PIT_SEARCH_COUNTER.incrementAndGet();
+                    if (n != cfg.failOnPitSearchOrdinal) {
+                        chain.proceed(task, action, request, listener);
+                        return;
+                    }
+                    if (cfg.sleepBeforeFail != null && cfg.sleepBeforeFail.millis() > 0) {
+                        try {
+                            Thread.sleep(cfg.sleepBeforeFail.millis());
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            listener.onFailure(new ElasticsearchException(e));
+                            return;
+                        }
+                    }
+                    listener.onFailure(cfg.exception());
+                }
+            });
+        }
+
+        /**
+         * After {@link ReindexRequest#convertSearchRequestToUsePit}, reindex PIT searches carry an empty
+         * {@link SearchRequest#indices()} array and a non-null point-in-time in the source.
+         */
+        static boolean matchesReindexPitSearch(SearchRequest searchRequest) {
+            if (searchRequest.source() == null || searchRequest.source().pointInTimeBuilder() == null) {
+                return false;
+            }
+            return searchRequest.indices().length == 0;
+        }
+    }
+
+    private static SearchContextMissingException testMissingContext() {
+        return new SearchContextMissingException(new ShardSearchContextId("it_session", 1L));
+    }
+}

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSearchContextFailuresIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSearchContextFailuresIT.java
@@ -31,6 +31,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.root.MainRestPlugin;
 import org.elasticsearch.search.SearchContextMissingException;
 import org.elasticsearch.search.internal.ShardSearchContextId;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
@@ -70,6 +71,7 @@ public class ReindexSearchContextFailuresIT extends ESIntegTestCase {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put(TransportReindexAction.REMOTE_CLUSTER_WHITELIST.getKey(), "*:*")
+            .put(ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING.getKey(), 0) // uncached millis for SearchContextKeepaliveDeadline
             .build();
     }
 

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSearchContextFailuresIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSearchContextFailuresIT.java
@@ -31,9 +31,9 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.root.MainRestPlugin;
 import org.elasticsearch.search.SearchContextMissingException;
 import org.elasticsearch.search.internal.ShardSearchContextId;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 
 import java.util.Collection;

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSearchContextFailuresIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexSearchContextFailuresIT.java
@@ -117,7 +117,6 @@ public class ReindexSearchContextFailuresIT extends ESIntegTestCase {
         SearchContextFailureInjectionPlugin.PIT_SEARCH_COUNTER.set(0);
         SearchContextFailureInjectionPlugin.CONFIG.set(
             new SearchContextFailureInjectionPlugin.InjectionConfig(
-                2,
                 TimeValue.timeValueMillis(pitKeepAlive.millis() + 100),
                 testMissingContext()
             )
@@ -163,7 +162,7 @@ public class ReindexSearchContextFailuresIT extends ESIntegTestCase {
 
         SearchContextFailureInjectionPlugin.PIT_SEARCH_COUNTER.set(0);
         SearchContextFailureInjectionPlugin.CONFIG.set(
-            new SearchContextFailureInjectionPlugin.InjectionConfig(2, TimeValue.ZERO, testMissingContext())
+            new SearchContextFailureInjectionPlugin.InjectionConfig(TimeValue.ZERO, testMissingContext())
         );
 
         // Use a HTTP request to hit the REST layer and assert the exception returned
@@ -178,18 +177,21 @@ public class ReindexSearchContextFailuresIT extends ESIntegTestCase {
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.NOT_FOUND.getStatus()));
     }
 
-    // TODO - Why make this N?
     /**
-     * {@link MappedActionFilter} that fails the Nth local PIT continuation search used by reindex
-     * ({@link SearchRequest} with point-in-time and no explicit indices after {@link ReindexRequest#convertSearchRequestToUsePit}).
+     * {@link MappedActionFilter} that fails the second local PIT continuation search used by reindex
+     * (the first {@link SearchRequest} after opening the point-in-time, when {@code source.size} splits work
+     * across pages). Matching requests carry point-in-time and no explicit indices after
+     * {@link ReindexRequest#convertSearchRequestToUsePit}.
      */
     public static final class SearchContextFailureInjectionPlugin extends Plugin implements ActionPlugin {
+
+        /** Fixed at 2 so the injected failure is always the continuation page. */
+        private static final int PIT_SEARCH_TO_FAIL = 2;
 
         static final AtomicReference<InjectionConfig> CONFIG = new AtomicReference<>();
         static final AtomicInteger PIT_SEARCH_COUNTER = new AtomicInteger(0);
 
-        public record InjectionConfig(/** 1-based ordinal among matching PIT searches; 2 = second page. */
-        int failOnPitSearchOrdinal, TimeValue sleepBeforeFail, SearchContextMissingException exception) {}
+        public record InjectionConfig(TimeValue sleepBeforeFail, SearchContextMissingException exception) {}
 
         @Override
         public Collection<MappedActionFilter> getMappedActionFilters() {
@@ -200,7 +202,6 @@ public class ReindexSearchContextFailuresIT extends ESIntegTestCase {
                 }
 
                 @Override
-                @SuppressWarnings("unchecked")
                 public <Request extends ActionRequest, Response extends ActionResponse> void apply(
                     Task task,
                     String action,
@@ -219,7 +220,7 @@ public class ReindexSearchContextFailuresIT extends ESIntegTestCase {
                         return;
                     }
                     int n = PIT_SEARCH_COUNTER.incrementAndGet();
-                    if (n != cfg.failOnPitSearchOrdinal) {
+                    if (n != PIT_SEARCH_TO_FAIL) {
                         chain.proceed(task, action, request, listener);
                         return;
                     }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -10,6 +10,8 @@
 package org.elasticsearch.reindex;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
@@ -45,10 +47,12 @@ import org.elasticsearch.index.reindex.ResumeInfo.WorkerResumeInfo;
 import org.elasticsearch.index.reindex.WorkerBulkByScrollTaskState;
 import org.elasticsearch.reindex.remote.RemotePitPaginatedHitSource;
 import org.elasticsearch.reindex.remote.RemoteScrollablePaginatedHitSource;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.CtxMap;
 import org.elasticsearch.script.Metadata;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.SearchContextMissingException;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.sort.FieldSortBuilder;
@@ -799,6 +803,60 @@ public abstract class AbstractAsyncBulkByScrollAction<
     }
 
     /**
+     * When pagination used PIT and the inferred keep-alive window has passed, {@link SearchContextMissingException} failures are mapped to
+     * HTTP 500; otherwise their default ({@link RestStatus#NOT_FOUND}) is preserved for BWC.
+     */
+    static List<PaginatedSearchFailure> remapSearchFailures(
+        boolean pitPagination,
+        boolean pastKeepaliveDeadline,
+        List<PaginatedSearchFailure> searchFailures
+    ) {
+        if (pitPagination == false || pastKeepaliveDeadline == false || searchFailures.isEmpty()) {
+            return searchFailures;
+        }
+        boolean anyScm = false;
+        for (PaginatedSearchFailure f : searchFailures) {
+            if (ExceptionsHelper.unwrap(f.getReason(), SearchContextMissingException.class) != null) {
+                anyScm = true;
+                break;
+            }
+        }
+        if (anyScm == false) {
+            return searchFailures;
+        }
+        List<PaginatedSearchFailure> remapped = new ArrayList<>(searchFailures.size());
+        for (PaginatedSearchFailure f : searchFailures) {
+            if (ExceptionsHelper.unwrap(f.getReason(), SearchContextMissingException.class) != null) {
+                remapped.add(
+                    new PaginatedSearchFailure(f.getReason(), f.getIndex(), f.getShardId(), f.getNodeId(), RestStatus.INTERNAL_SERVER_ERROR)
+                );
+            } else {
+                remapped.add(f);
+            }
+        }
+        return remapped;
+    }
+
+    /**
+     * Same policy as {@link #remapSearchFailures} for catastrophic failure on {@link ActionListener#onFailure}.
+     */
+    static Exception maybeWrapCatastrophicFailure(boolean pitPagination, boolean pastKeepaliveDeadline, Exception failure) {
+        if (failure == null || pitPagination == false || pastKeepaliveDeadline == false) {
+            return failure;
+        }
+        if (ExceptionsHelper.unwrap(failure, SearchContextMissingException.class) == null) {
+            return failure;
+        }
+        Throwable root = ExceptionsHelper.unwrapCause(failure);
+        String message = root.getMessage();
+        return new ElasticsearchStatusException(
+            message != null ? message : "search context missing",
+            RestStatus.INTERNAL_SERVER_ERROR,
+            failure
+        );
+    }
+
+    /**
      * Finish the request.
      *
      * @param failure if non null then the request failed catastrophically with this exception
@@ -835,6 +893,14 @@ public abstract class AbstractAsyncBulkByScrollAction<
                 paginatedHitSource instanceof PitPaginatedHitSource ? "point-in-time" : "scroll"
             );
         }
+        final boolean pitPagination = paginatedHitSource instanceof PitPaginatedHitSource;
+        final boolean pastKeepaliveDeadline = searchContextKeepaliveDeadline.isPastKeepaliveDeadline();
+        final List<PaginatedSearchFailure> resolvedSearchFailures = remapSearchFailures(
+            pitPagination,
+            pastKeepaliveDeadline,
+            searchFailures
+        );
+        final Exception resolvedFailure = maybeWrapCatastrophicFailure(pitPagination, pastKeepaliveDeadline, failure);
         requestFinishing.set(true);
         // Atomically claim the current response. If prepareBulkRequest already claimed it (null), this is a no-op.
         // If we win the CAS, we release any hits that were not yet consumed (i.e. from consumedOffset to end).
@@ -844,16 +910,16 @@ public abstract class AbstractAsyncBulkByScrollAction<
             toRelease.releaseRemainingHits();
         }
         paginatedHitSource.close(threadPool.getThreadContext().preserveContext(() -> {
-            if (failure == null) {
+            if (resolvedFailure == null) {
                 BulkByScrollResponse response = buildResponse(
                     timeValueMillis(System.currentTimeMillis() - startTimeEpochMillis.get()),
                     indexingFailures,
-                    searchFailures,
+                    resolvedSearchFailures,
                     timedOut
                 );
                 listener.onResponse(response);
             } else {
-                listener.onFailure(failure);
+                listener.onFailure(resolvedFailure);
             }
         }));
     }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.reindex;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.index.reindex.PaginatedSearchFailure;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchContextMissingException;
+import org.elasticsearch.search.internal.ShardSearchContextId;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * Unit tests for {@link AbstractAsyncBulkByScrollAction#remapSearchFailures} and
+ * {@link AbstractAsyncBulkByScrollAction#maybeWrapCatastrophicFailure}: how PIT keep-alive
+ * semantics map {@link SearchContextMissingException} to {@link RestStatus} for HTTP-style failure handling.
+ */
+public class AbstractAsyncBulkByScrollActionPitKeepaliveHttpTests extends ESTestCase {
+
+    /**
+     * Scroll pagination keeps the original failure list and {@link RestStatus#NOT_FOUND} for
+     * {@link SearchContextMissingException} even when the keep-alive deadline has passed, for backwards compatibility.
+     */
+    public void testRemapSearchFailuresScrollPastDeadlineLeavesListUntouched() {
+        PaginatedSearchFailure paginatedSearchFailure = new PaginatedSearchFailure(missingContext());
+        assertThat(paginatedSearchFailure.getStatus(), equalTo(RestStatus.NOT_FOUND));
+        List<PaginatedSearchFailure> originalSearchFailures = singletonList(paginatedSearchFailure);
+        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByScrollAction.remapSearchFailures(
+            false,
+            true,
+            originalSearchFailures
+        );
+        assertThat(remappedSearchFailures, sameInstance(originalSearchFailures));
+        assertThat(remappedSearchFailures.get(0).getStatus(), equalTo(RestStatus.NOT_FOUND));
+    }
+
+    /**
+     * PIT pagination leaves search failures unchanged when the inferred keep-alive deadline has not yet passed,
+     * so {@link SearchContextMissingException} remains {@link RestStatus#NOT_FOUND}.
+     */
+    public void testRemapSearchFailuresPitDeadlineNotPassedLeavesListUntouched() {
+        PaginatedSearchFailure paginatedSearchFailure = new PaginatedSearchFailure(missingContext());
+        List<PaginatedSearchFailure> originalSearchFailures = singletonList(paginatedSearchFailure);
+        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByScrollAction.remapSearchFailures(
+            true,
+            false,
+            originalSearchFailures
+        );
+        assertThat(remappedSearchFailures, sameInstance(originalSearchFailures));
+    }
+
+    /**
+     * When using PIT and the keep-alive deadline has passed, {@link SearchContextMissingException} shard failures are
+     * rewrapped with {@link RestStatus#INTERNAL_SERVER_ERROR} while preserving the same {@link Throwable} reason.
+     */
+    public void testRemapSearchFailuresPitPastDeadlineThrowsInternalServerError() {
+        PaginatedSearchFailure paginatedSearchFailure = new PaginatedSearchFailure(missingContext());
+        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByScrollAction.remapSearchFailures(
+            true,
+            true,
+            singletonList(paginatedSearchFailure)
+        );
+        assertThat(remappedSearchFailures, hasSize(1));
+        assertThat(remappedSearchFailures.get(0).getReason(), sameInstance(paginatedSearchFailure.getReason()));
+        assertThat(remappedSearchFailures.get(0).getStatus(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    /**
+     * When using PIT and the keep-alive deadline has passed, does not remap the list when no failure
+     * unwraps to {@link SearchContextMissingException}. In this case, the original list instance is returned.
+     */
+    public void testRemapSearchFailuresPitPastDeadlineReturnsOriginalListForOtherFailures() {
+        PaginatedSearchFailure paginatedSearchFailure = new PaginatedSearchFailure(new RuntimeException("other"));
+        List<PaginatedSearchFailure> originalSearchFailures = singletonList(paginatedSearchFailure);
+        List<PaginatedSearchFailure> remappedSearchFailures = AbstractAsyncBulkByScrollAction.remapSearchFailures(
+            true,
+            true,
+            originalSearchFailures
+        );
+        assertThat(remappedSearchFailures, sameInstance(originalSearchFailures));
+    }
+
+    /** A null catastrophic failure stays null regardless of PIT and deadline flags. */
+    public void testMaybeWrapCatastrophicFailureReturnsNullForNullFailure() {
+        assertNull(AbstractAsyncBulkByScrollAction.maybeWrapCatastrophicFailure(true, true, null));
+    }
+
+    /**
+     * Scroll pagination does not wrap a top-level {@link SearchContextMissingException} even after the keep-alive deadline.
+     */
+    public void testMaybeWrapCatastrophicFailureScrollPastDeadlinePreservesOriginalException() {
+        Exception originalFailure = missingContext();
+        Exception maybeWrappedFailure = AbstractAsyncBulkByScrollAction.maybeWrapCatastrophicFailure(false, true, originalFailure);
+        assertThat(maybeWrappedFailure, sameInstance(originalFailure));
+    }
+
+    /**
+     * PIT with the keep-alive deadline still open returns the original exception for {@link SearchContextMissingException}.
+     */
+    public void testMaybeWrapCatastrophicFailurePitDeadlineNotPastPreservesOriginalException() {
+        Exception originalFailure = missingContext();
+        Exception maybeWrappedFailure = AbstractAsyncBulkByScrollAction.maybeWrapCatastrophicFailure(true, false, originalFailure);
+        assertThat(maybeWrappedFailure, sameInstance(originalFailure));
+    }
+
+    /**
+     * PIT + past keep-alive deadline wraps a catastrophic {@link SearchContextMissingException} in
+     * {@link ElasticsearchStatusException} with {@link RestStatus#INTERNAL_SERVER_ERROR} and the original as cause.
+     */
+    public void testMaybeWrapCatastrophicFailurePitPastDeadlineWrapsSearchContextMissing() {
+        Exception originalFailure = missingContext();
+        Exception maybeWrappedFailure = AbstractAsyncBulkByScrollAction.maybeWrapCatastrophicFailure(true, true, originalFailure);
+        assertThat(maybeWrappedFailure, instanceOf(ElasticsearchStatusException.class));
+        ElasticsearchStatusException elasticsearchStatusException = (ElasticsearchStatusException) maybeWrappedFailure;
+        assertThat(elasticsearchStatusException.status(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
+        assertThat(elasticsearchStatusException.getCause(), sameInstance(originalFailure));
+        assertThat(elasticsearchStatusException.getMessage(), containsString("No search context found"));
+    }
+
+    /** Fixed {@link SearchContextMissingException} for assertions; details are irrelevant to HTTP remapping behavior. */
+    private static SearchContextMissingException missingContext() {
+        return new SearchContextMissingException(new ShardSearchContextId("session", 1L));
+    }
+}


### PR DESCRIPTION
Modifies the reindexing workflow to throw a 5XX error when a reindexing task fails because the underlying search context timed out. Previously, when reindexing used scroll-based search, the scroll timeout was a user configurable property. However, now we use PIT, we set the keep-alive ourselves, and so any failures due to timeouts should be an internal server error.

Relates: elastic/elasticsearch-team#2334
