### PR TITLE
[9.4] [Inference API] Add inference id to the timeout string and use internal timeout exception (#146531)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSender.java
@@ -227,7 +227,7 @@ public class HttpRequestSender implements Sender {
         waitForStartToComplete();
 
         var preservedListener = ContextPreservingActionListener.wrapPreservingContext(listener, threadPool.getThreadContext());
-        var timedListener = new TimedListener<>(timeout, preservedListener, threadPool);
+        var timedListener = new TimedListener<>(timeout, preservedListener, threadPool, request.getInferenceEntityId());
 
         threadPool.executor(UTILITY_THREAD_POOL_NAME)
             .execute(() -> requestSender.send(logger, request, timedListener::hasCompleted, responseHandler, timedListener.getListener()));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestTask.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestTask.java
@@ -30,7 +30,7 @@ class RequestTask implements RejectableTask {
         ActionListener<InferenceServiceResults> listener
     ) {
         this.requestCreator = Objects.requireNonNull(requestCreator);
-        this.timedListener = new TimedListener<>(timeout, listener, threadPool);
+        this.timedListener = new TimedListener<>(timeout, listener, threadPool, requestCreator.inferenceEntityId());
         this.inferenceInputs = Objects.requireNonNull(inferenceInputs);
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/TimedListener.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/TimedListener.java
@@ -7,13 +7,11 @@
 
 package org.elasticsearch.xpack.inference.external.http.sender;
 
-import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ListenerTimeouts;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Objects;
@@ -32,14 +30,20 @@ public class TimedListener<Response> {
     private final ActionListener<Response> listenerWithTimeout;
     private final AtomicBoolean completed = new AtomicBoolean();
 
-    public TimedListener(@Nullable TimeValue timeout, ActionListener<Response> listener, ThreadPool threadPool) {
-        listenerWithTimeout = getListener(Objects.requireNonNull(listener), timeout, Objects.requireNonNull(threadPool));
+    public TimedListener(@Nullable TimeValue timeout, ActionListener<Response> listener, ThreadPool threadPool, String inferenceId) {
+        listenerWithTimeout = getListener(
+            Objects.requireNonNull(listener),
+            timeout,
+            Objects.requireNonNull(threadPool),
+            Objects.requireNonNull(inferenceId)
+        );
     }
 
     private ActionListener<Response> getListener(
         ActionListener<Response> origListener,
         @Nullable TimeValue timeout,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        String inferenceId
     ) {
         ActionListener<Response> notificationListener = ActionListener.wrap(result -> {
             completed.set(true);
@@ -58,9 +62,7 @@ public class TimedListener<Response> {
             timeout,
             threadPool.executor(UTILITY_THREAD_POOL_NAME),
             notificationListener,
-            (ignored) -> notificationListener.onFailure(
-                new ElasticsearchStatusException(Strings.format("Request timed out after [%s]", timeout), RestStatus.GATEWAY_TIMEOUT)
-            )
+            (ignored) -> notificationListener.onFailure(timeoutException(timeout, inferenceId))
         );
     }
 
@@ -70,5 +72,15 @@ public class TimedListener<Response> {
 
     public ActionListener<Response> getListener() {
         return listenerWithTimeout;
+    }
+
+    /**
+     * Creates an {@link ElasticsearchTimeoutException} with a message indicating that the request timed out.
+     * @param timeout the timeout that was reached
+     * @param inferenceId the id of the inference request that timed out
+     * @return an {@link ElasticsearchTimeoutException} indicating a timeout occurred
+     */
+    public static ElasticsearchTimeoutException timeoutException(TimeValue timeout, String inferenceId) {
+        return new ElasticsearchTimeoutException("Request timed out after [{}] for inference id [{}]", timeout, inferenceId);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerClient.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerClient.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.xpack.inference.InferencePlugin.UTILITY_THREAD_POOL_NAME;
+import static org.elasticsearch.xpack.inference.external.http.sender.TimedListener.timeoutException;
 
 public class SageMakerClient implements Closeable {
     private static final Logger log = LogManager.getLogger(SageMakerClient.class);
@@ -71,6 +72,7 @@ public class SageMakerClient implements Closeable {
         RegionAndSecrets regionAndSecrets,
         InvokeEndpointRequest request,
         TimeValue timeout,
+        String inferenceId,
         ActionListener<InvokeEndpointResponse> listener
     ) {
         SageMakerRuntimeAsyncClient asyncClient;
@@ -94,9 +96,7 @@ public class SageMakerClient implements Closeable {
             contextPreservingListener,
             ignored -> {
                 FutureUtils.cancel(awsFuture);
-                contextPreservingListener.onFailure(
-                    new ElasticsearchStatusException("Request timed out after [{}]", RestStatus.REQUEST_TIMEOUT, timeout)
-                );
+                contextPreservingListener.onFailure(timeoutException(timeout, inferenceId));
             }
         );
         awsFuture.thenAcceptAsync(timeoutListener::onResponse, threadPool.executor(UTILITY_THREAD_POOL_NAME))
@@ -130,6 +130,7 @@ public class SageMakerClient implements Closeable {
         RegionAndSecrets regionAndSecrets,
         InvokeEndpointWithResponseStreamRequest request,
         TimeValue timeout,
+        String inferenceId,
         ActionListener<SageMakerStream> listener
     ) {
         SageMakerRuntimeAsyncClient asyncClient;
@@ -154,9 +155,7 @@ public class SageMakerClient implements Closeable {
             contextPreservingListener,
             ignored -> {
                 FutureUtils.cancel(cancelAwsRequestListener.get());
-                contextPreservingListener.onFailure(
-                    new ElasticsearchStatusException("Request timed out after [{}]", RestStatus.REQUEST_TIMEOUT, timeout)
-                );
+                contextPreservingListener.onFailure(timeoutException(timeout, inferenceId));
             }
         );
         // To stay consistent with HTTP providers, we cancel the TimeoutListener onResponse because we are measuring the time it takes to

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerService.java
@@ -184,6 +184,7 @@ public class SageMakerService implements InferenceService, RerankingInferenceSer
                     regionAndSecrets,
                     request,
                     timeout,
+                    model.getInferenceEntityId(),
                     ActionListener.wrap(
                         response -> listener.onResponse(schema.streamResponse(sageMakerModel, response)),
                         e -> listener.onFailure(schema.error(sageMakerModel, e))
@@ -196,6 +197,7 @@ public class SageMakerService implements InferenceService, RerankingInferenceSer
                     regionAndSecrets,
                     request,
                     timeout,
+                    model.getInferenceEntityId(),
                     ActionListener.wrap(
                         response -> listener.onResponse(schema.response(sageMakerModel, response, threadPool.getThreadContext())),
                         e -> listener.onFailure(schema.error(sageMakerModel, e))
@@ -253,6 +255,7 @@ public class SageMakerService implements InferenceService, RerankingInferenceSer
                 regionAndSecrets,
                 sagemakerRequest,
                 timeout != null ? timeout : DEFAULT_TIMEOUT,
+                model.getInferenceEntityId(),
                 ActionListener.wrap(
                     response -> listener.onResponse(schema.chatCompletionStreamResponse(sageMakerModel, response)),
                     e -> listener.onFailure(schema.chatCompletionError(sageMakerModel, e))

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.external.http.sender;
 
 import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -74,6 +74,9 @@ import static org.mockito.Mockito.when;
 
 public class HttpRequestSenderTests extends ESTestCase {
     private static final TimeValue TIMEOUT = new TimeValue(30, TimeUnit.SECONDS);
+    private static final String INFERENCE_ID = "id";
+    private static final TimeValue ONE_NANOSECOND = TimeValue.timeValueNanos(1);
+
     private final MockWebServer webServer = new MockWebServer();
     private ThreadPool threadPool;
     private HttpClientManager clientManager;
@@ -350,8 +353,7 @@ public class HttpRequestSenderTests extends ESTestCase {
     }
 
     public void testHttpRequestSender_Throws_WhenATimeoutOccurs() throws Exception {
-        var mockManager = mock(HttpClientManager.class);
-        when(mockManager.getHttpClient()).thenReturn(mock(HttpClient.class));
+        var mockManager = createMockHttpClientManager();
 
         var senderFactory = new HttpRequestSender.Factory(
             ServiceComponentsTests.createWithEmptySettings(threadPool),
@@ -365,43 +367,19 @@ public class HttpRequestSenderTests extends ESTestCase {
 
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
             sender.send(
-                RequestManagerTests.createMockWithRateLimitingEnabled(),
+                RequestManagerTests.createMockWithRateLimitingEnabled(INFERENCE_ID),
                 new EmbeddingsInput(List.of(), null),
                 TimeValue.timeValueNanos(1),
                 listener
             );
 
-            var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
+            var thrownException = expectThrows(ElasticsearchTimeoutException.class, () -> listener.actionGet(TIMEOUT));
 
-            assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueNanos(1))));
-            assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
-        }
-    }
-
-    public void testHttpRequestSenderWithTimeout_Throws_WhenATimeoutOccurs() throws Exception {
-        var mockManager = createMockHttpClientManager();
-
-        var senderFactory = new HttpRequestSender.Factory(
-            ServiceComponentsTests.createWithEmptySettings(threadPool),
-            mockManager,
-            mockClusterServiceEmpty()
-        );
-
-        try (var sender = senderFactory.createSender()) {
-            sender.startSynchronously();
-
-            PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
-            sender.send(
-                RequestManagerTests.createMockWithRateLimitingEnabled(),
-                new EmbeddingsInput(List.of(), null),
-                TimeValue.timeValueNanos(1),
-                listener
+            assertThat(
+                thrownException.getMessage(),
+                is(format("Request timed out after [%s] for inference id [%s]", ONE_NANOSECOND, INFERENCE_ID))
             );
-
-            var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
-
-            assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueNanos(1))));
-            assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
+            assertThat(thrownException.status(), is(RestStatus.TOO_MANY_REQUESTS));
         }
     }
 
@@ -417,19 +395,18 @@ public class HttpRequestSenderTests extends ESTestCase {
         try (var sender = senderFactory.createSender()) {
             sender.startSynchronously();
 
+            var request = mock(Request.class);
+            when(request.getInferenceEntityId()).thenReturn(INFERENCE_ID);
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
-            sender.sendWithoutQueuing(
-                mock(Logger.class),
-                mock(Request.class),
-                mock(ResponseHandler.class),
-                TimeValue.timeValueNanos(1),
-                listener
+            sender.sendWithoutQueuing(mock(Logger.class), request, mock(ResponseHandler.class), TimeValue.timeValueNanos(1), listener);
+
+            var thrownException = expectThrows(ElasticsearchTimeoutException.class, () -> listener.actionGet(TIMEOUT));
+
+            assertThat(
+                thrownException.getMessage(),
+                is(format("Request timed out after [%s] for inference id [%s]", ONE_NANOSECOND, INFERENCE_ID))
             );
-
-            var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
-
-            assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueNanos(1))));
-            assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
+            assertThat(thrownException.status(), is(RestStatus.TOO_MANY_REQUESTS));
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.inference.external.http.sender;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Strings;
@@ -61,6 +61,8 @@ import static org.mockito.Mockito.when;
 
 public class RequestExecutorServiceTests extends ESTestCase {
     private static final TimeValue TIMEOUT = new TimeValue(30, TimeUnit.SECONDS);
+    private static final String INFERENCE_ID = "id";
+
     private ThreadPool threadPool;
 
     @Before
@@ -259,16 +261,19 @@ public class RequestExecutorServiceTests extends ESTestCase {
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
         service.execute(
-            RequestManagerTests.createMockWithRateLimitingEnabled(),
+            RequestManagerTests.createMockWithRateLimitingEnabled(INFERENCE_ID),
             new EmbeddingsInput(List.of(), InputTypeTests.randomWithNull()),
             TimeValue.timeValueNanos(1),
             listener
         );
 
-        var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
+        var thrownException = expectThrows(ElasticsearchTimeoutException.class, () -> listener.actionGet(TIMEOUT));
 
-        assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueNanos(1))));
-        assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
+        assertThat(
+            thrownException.getMessage(),
+            is(format("Request timed out after [%s] for inference id [%s]", TimeValue.timeValueNanos(1), INFERENCE_ID))
+        );
+        assertThat(thrownException.status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
     public void testExecute_PreservesThreadContext() throws InterruptedException, ExecutionException, TimeoutException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestTaskTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestTaskTests.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.inference.external.http.sender;
 
-import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.core.TimeValue;
@@ -40,7 +40,14 @@ import static org.mockito.Mockito.when;
 
 public class RequestTaskTests extends ESTestCase {
 
-    private static final TimeValue TIMEOUT = new TimeValue(30, TimeUnit.SECONDS);
+    private static final String INFERENCE_ID = "id";
+    private static final TimeValue ONE_MILLISECOND = TimeValue.timeValueMillis(1);
+    private static final String REQUEST_TIMED_OUT_MESSAGE = format(
+        "Request timed out after [%s] for inference id [%s]",
+        ONE_MILLISECOND,
+        INFERENCE_ID
+    );
+
     private ThreadPool threadPool;
 
     @Before
@@ -61,9 +68,9 @@ public class RequestTaskTests extends ESTestCase {
         ActionListener<InferenceServiceResults> listener = mock(ActionListener.class);
 
         var requestTask = new RequestTask(
-            OpenAiEmbeddingsRequestManagerTests.makeCreator("url", null, "key", "model", null, "id", threadPool),
+            OpenAiEmbeddingsRequestManagerTests.makeCreator("url", null, "key", "model", null, INFERENCE_ID, threadPool),
             new EmbeddingsInput(List.of("abc"), InputTypeTests.randomWithNull()),
-            TimeValue.timeValueMillis(1),
+            ONE_MILLISECOND,
             mockThreadPool,
             listener
         );
@@ -81,18 +88,18 @@ public class RequestTaskTests extends ESTestCase {
 
         PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
         var requestTask = new RequestTask(
-            OpenAiEmbeddingsRequestManagerTests.makeCreator("url", null, "key", "model", null, "id", threadPool),
+            OpenAiEmbeddingsRequestManagerTests.makeCreator("url", null, "key", "model", null, INFERENCE_ID, threadPool),
             new EmbeddingsInput(List.of("abc"), InputTypeTests.randomWithNull()),
-            TimeValue.timeValueMillis(1),
+            ONE_MILLISECOND,
             threadPool,
             listener
         );
 
-        var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
-        assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueMillis(1))));
+        var thrownException = expectThrows(ElasticsearchTimeoutException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(thrownException.getMessage(), is(REQUEST_TIMED_OUT_MESSAGE));
         assertTrue(requestTask.hasCompleted());
         assertTrue(requestTask.getRequestCompletedFunction().get());
-        assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
+        assertThat(thrownException.status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
     public void testRequest_DoesNotCallOnFailureTwiceWhenTimingOut() throws Exception {
@@ -105,18 +112,18 @@ public class RequestTaskTests extends ESTestCase {
         }).when(listener).onFailure(any());
 
         var requestTask = new RequestTask(
-            OpenAiEmbeddingsRequestManagerTests.makeCreator("url", null, "key", "model", null, "id", threadPool),
+            OpenAiEmbeddingsRequestManagerTests.makeCreator("url", null, "key", "model", null, INFERENCE_ID, threadPool),
             new EmbeddingsInput(List.of("abc"), InputTypeTests.randomWithNull()),
-            TimeValue.timeValueMillis(1),
+            ONE_MILLISECOND,
             threadPool,
             listener
         );
 
-        calledOnFailureLatch.await(TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        calledOnFailureLatch.await(ESTestCase.TEST_REQUEST_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argument = ArgumentCaptor.forClass(Exception.class);
         verify(listener, times(1)).onFailure(argument.capture());
-        assertThat(argument.getValue().getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueMillis(1))));
+        assertThat(argument.getValue().getMessage(), is(REQUEST_TIMED_OUT_MESSAGE));
         assertTrue(requestTask.hasCompleted());
         assertTrue(requestTask.getRequestCompletedFunction().get());
 
@@ -134,18 +141,18 @@ public class RequestTaskTests extends ESTestCase {
         }).when(listener).onFailure(any());
 
         var requestTask = new RequestTask(
-            OpenAiEmbeddingsRequestManagerTests.makeCreator("url", null, "key", "model", null, "id", threadPool),
+            OpenAiEmbeddingsRequestManagerTests.makeCreator("url", null, "key", "model", null, INFERENCE_ID, threadPool),
             new EmbeddingsInput(List.of("abc"), InputTypeTests.randomWithNull()),
-            TimeValue.timeValueMillis(1),
+            ONE_MILLISECOND,
             threadPool,
             listener
         );
 
-        calledOnFailureLatch.await(TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        calledOnFailureLatch.await(ESTestCase.TEST_REQUEST_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argument = ArgumentCaptor.forClass(Exception.class);
         verify(listener, times(1)).onFailure(argument.capture());
-        assertThat(argument.getValue().getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueMillis(1))));
+        assertThat(argument.getValue().getMessage(), is(REQUEST_TIMED_OUT_MESSAGE));
         assertTrue(requestTask.hasCompleted());
         assertTrue(requestTask.getRequestCompletedFunction().get());
 
@@ -161,9 +168,9 @@ public class RequestTaskTests extends ESTestCase {
         ActionListener<InferenceServiceResults> listener = mock(ActionListener.class);
 
         var requestTask = new RequestTask(
-            OpenAiEmbeddingsRequestManagerTests.makeCreator("url", null, "key", "model", null, "id", threadPool),
+            OpenAiEmbeddingsRequestManagerTests.makeCreator("url", null, "key", "model", null, INFERENCE_ID, threadPool),
             new EmbeddingsInput(List.of("abc"), InputTypeTests.randomWithNull()),
-            TimeValue.timeValueMillis(1),
+            ONE_MILLISECOND,
             mockThreadPool,
             listener
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/TimedListenerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/TimedListenerTests.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.inference.external.http.sender;
 
-import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.core.TimeValue;
@@ -38,7 +38,14 @@ import static org.mockito.Mockito.when;
 
 public class TimedListenerTests extends ESTestCase {
 
-    private static final TimeValue TIMEOUT = new TimeValue(30, TimeUnit.SECONDS);
+    private static final String INFERENCE_ID = "test-inference-id";
+    private static final TimeValue ONE_MILLISECOND = TimeValue.timeValueMillis(1);
+    private static final String REQUEST_TIMED_OUT_MESSAGE = format(
+        "Request timed out after [%s] for inference id [%s]",
+        ONE_MILLISECOND,
+        INFERENCE_ID
+    );
+
     private ThreadPool threadPool;
 
     @Before
@@ -57,7 +64,7 @@ public class TimedListenerTests extends ESTestCase {
 
         @SuppressWarnings("unchecked")
         ActionListener<InferenceServiceResults> listener = mock(ActionListener.class);
-        var timedListener = new TimedListener<>(TimeValue.timeValueMillis(1), listener, mockThreadPool);
+        var timedListener = new TimedListener<>(ONE_MILLISECOND, listener, mockThreadPool, INFERENCE_ID);
 
         timedListener.getListener().onFailure(new IllegalArgumentException("failed"));
         verify(listener, times(1)).onFailure(any());
@@ -69,12 +76,12 @@ public class TimedListenerTests extends ESTestCase {
 
     public void testRequest_ReturnsTimeoutException() {
         PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
-        var timedListener = new TimedListener<>(TimeValue.timeValueMillis(1), listener, threadPool);
+        var timedListener = new TimedListener<>(ONE_MILLISECOND, listener, threadPool, INFERENCE_ID);
 
-        var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
-        assertThat(thrownException.getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueMillis(1))));
+        var thrownException = expectThrows(ElasticsearchTimeoutException.class, () -> listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT));
+        assertThat(thrownException.getMessage(), is(REQUEST_TIMED_OUT_MESSAGE));
         assertTrue(timedListener.hasCompleted());
-        assertThat(thrownException.status(), is(RestStatus.GATEWAY_TIMEOUT));
+        assertThat(thrownException.status(), is(RestStatus.TOO_MANY_REQUESTS));
     }
 
     public void testRequest_DoesNotCallOnFailureTwiceWhenTimingOut() throws Exception {
@@ -86,13 +93,13 @@ public class TimedListenerTests extends ESTestCase {
             return Void.TYPE;
         }).when(listener).onFailure(any());
 
-        var timedListener = new TimedListener<>(TimeValue.timeValueMillis(1), listener, threadPool);
+        var timedListener = new TimedListener<>(ONE_MILLISECOND, listener, threadPool, INFERENCE_ID);
 
-        calledOnFailureLatch.await(TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        calledOnFailureLatch.await(ESTestCase.TEST_REQUEST_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argument = ArgumentCaptor.forClass(Exception.class);
         verify(listener, times(1)).onFailure(argument.capture());
-        assertThat(argument.getValue().getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueMillis(1))));
+        assertThat(argument.getValue().getMessage(), is(REQUEST_TIMED_OUT_MESSAGE));
         assertTrue(timedListener.hasCompleted());
 
         timedListener.getListener().onFailure(new IllegalArgumentException("failed"));
@@ -108,13 +115,13 @@ public class TimedListenerTests extends ESTestCase {
             return Void.TYPE;
         }).when(listener).onFailure(any());
 
-        var timedListener = new TimedListener<>(TimeValue.timeValueMillis(1), listener, threadPool);
+        var timedListener = new TimedListener<>(ONE_MILLISECOND, listener, threadPool, INFERENCE_ID);
 
-        calledOnFailureLatch.await(TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        calledOnFailureLatch.await(ESTestCase.TEST_REQUEST_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
 
         ArgumentCaptor<Exception> argument = ArgumentCaptor.forClass(Exception.class);
         verify(listener, times(1)).onFailure(argument.capture());
-        assertThat(argument.getValue().getMessage(), is(format("Request timed out after [%s]", TimeValue.timeValueMillis(1))));
+        assertThat(argument.getValue().getMessage(), is(REQUEST_TIMED_OUT_MESSAGE));
         assertTrue(timedListener.hasCompleted());
 
         timedListener.getListener().onResponse(mock(InferenceServiceResults.class));
@@ -127,7 +134,7 @@ public class TimedListenerTests extends ESTestCase {
 
         @SuppressWarnings("unchecked")
         ActionListener<InferenceServiceResults> listener = mock(ActionListener.class);
-        var timedListener = new TimedListener<>(TimeValue.timeValueMillis(1), listener, mockThreadPool);
+        var timedListener = new TimedListener<>(ONE_MILLISECOND, listener, mockThreadPool, INFERENCE_ID);
 
         timedListener.getListener().onResponse(mock(InferenceServiceResults.class));
         verify(listener, times(1)).onResponse(any());

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerClientTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerClientTests.java
@@ -16,10 +16,13 @@ import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointWith
 import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointWithResponseStreamResponseHandler;
 import software.amazon.awssdk.services.sagemakerruntime.model.ResponseStream;
 
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.cache.CacheLoader;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.inference.common.amazon.AwsSecretSettings;
@@ -49,6 +52,9 @@ import static org.mockito.Mockito.when;
 public class SageMakerClientTests extends ESTestCase {
     private static final InvokeEndpointRequest REQUEST = InvokeEndpointRequest.builder().build();
     private static final InvokeEndpointWithResponseStreamRequest STREAM_REQUEST = InvokeEndpointWithResponseStreamRequest.builder().build();
+    private static final String INFERENCE_ID = "test-inference-id";
+    private static final TimeValue INVOKE_TIMEOUT = TimeValue.timeValueMillis(10);
+
     private SageMakerRuntimeAsyncClient awsClient;
     private CacheLoader<SageMakerClient.RegionAndSecrets, SageMakerRuntimeAsyncClient> clientFactory;
     private SageMakerClient client;
@@ -92,7 +98,7 @@ public class SageMakerClientTests extends ESTestCase {
     private ActionListener<InvokeEndpointResponse> invoke(TimeValue timeout) throws InterruptedException {
         var latch = new CountDownLatch(1);
         ActionListener<InvokeEndpointResponse> listener = spy(ActionListener.noop());
-        client.invoke(regionAndSecrets(), REQUEST, timeout, ActionListener.runAfter(listener, latch::countDown));
+        client.invoke(regionAndSecrets(), REQUEST, timeout, INFERENCE_ID, ActionListener.runAfter(listener, latch::countDown));
         assertTrue("Timed out waiting for invoke call", latch.await(5, TimeUnit.SECONDS));
         return listener;
     }
@@ -110,14 +116,20 @@ public class SageMakerClientTests extends ESTestCase {
     public void testInvokeTimeout() throws Exception {
         when(awsClient.invokeEndpoint(any(InvokeEndpointRequest.class))).thenReturn(new CompletableFuture<>());
 
-        var listener = invoke(TimeValue.timeValueMillis(10));
+        var listener = invoke(INVOKE_TIMEOUT);
 
         verify(clientFactory, times(1)).load(any());
-        verifyTimeout(listener);
+        verifyTimeout(INVOKE_TIMEOUT, listener);
     }
 
-    private static void verifyTimeout(ActionListener<?> listener) {
-        verify(listener, times(1)).onFailure(assertArg(e -> assertThat(e.getMessage(), equalTo("Request timed out after [10ms]"))));
+    private static void verifyTimeout(TimeValue timeout, ActionListener<?> listener) {
+        verify(listener, times(1)).onFailure(assertArg(e -> {
+            assertThat(
+                e.getMessage(),
+                equalTo(Strings.format("Request timed out after [%s] for inference id [%s]", timeout, INFERENCE_ID))
+            );
+            assertThat(((ElasticsearchTimeoutException) e).status(), equalTo(RestStatus.TOO_MANY_REQUESTS));
+        }));
     }
 
     public void testInvokeStream() throws Exception {
@@ -144,7 +156,7 @@ public class SageMakerClientTests extends ESTestCase {
     private ActionListener<SageMakerClient.SageMakerStream> invokeStream(TimeValue timeout) throws Exception {
         var latch = new CountDownLatch(1);
         ActionListener<SageMakerClient.SageMakerStream> listener = spy(ActionListener.noop());
-        client.invokeStream(regionAndSecrets(), STREAM_REQUEST, timeout, ActionListener.runAfter(listener, latch::countDown));
+        client.invokeStream(regionAndSecrets(), STREAM_REQUEST, timeout, INFERENCE_ID, ActionListener.runAfter(listener, latch::countDown));
         assertTrue("Timed out waiting for invoke call", latch.await(5, TimeUnit.SECONDS));
         return listener;
     }
@@ -163,10 +175,10 @@ public class SageMakerClientTests extends ESTestCase {
             new CompletableFuture<>()
         );
 
-        var listener = invokeStream(TimeValue.timeValueMillis(10));
+        var listener = invokeStream(INVOKE_TIMEOUT);
 
         verify(clientFactory, times(1)).load(any());
-        verifyTimeout(listener);
+        verifyTimeout(INVOKE_TIMEOUT, listener);
     }
 
     public void testClose() throws Exception {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerServiceTests.java
@@ -201,7 +201,7 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
                 verify(schema, times(1)).response(eq(model), any(), any());
             })
         );
-        verify(client, only()).invoke(any(), any(), any(), any());
+        verify(client, only()).invoke(any(), any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
     }
 
@@ -220,9 +220,9 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
         var capturedTimeout = new AtomicReference<TimeValue>();
         doAnswer(ans -> {
             capturedTimeout.set(ans.getArgument(2));
-            ((ActionListener<InvokeEndpointResponse>) ans.getArgument(3)).onResponse(null);
+            ((ActionListener<InvokeEndpointResponse>) ans.getArgument(4)).onResponse(null);
             return null;
-        }).when(client).invoke(any(), any(), any(), any());
+        }).when(client).invoke(any(), any(), any(), any(), any());
 
         var latch = new CountDownLatch(1);
         var latchedListener = new LatchedActionListener<>(ActionListener.<InferenceServiceResults>noop(), latch);
@@ -247,9 +247,9 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
         var capturedTimeout = new AtomicReference<TimeValue>();
         doAnswer(ans -> {
             capturedTimeout.set(ans.getArgument(2));
-            ((ActionListener<InvokeEndpointResponse>) ans.getArgument(3)).onResponse(null);
+            ((ActionListener<InvokeEndpointResponse>) ans.getArgument(4)).onResponse(null);
             return null;
-        }).when(client).invoke(any(), any(), any(), any());
+        }).when(client).invoke(any(), any(), any(), any(), any());
 
         var latch = new CountDownLatch(1);
         var latchedListener = new LatchedActionListener<>(ActionListener.<InferenceServiceResults>noop(), latch);
@@ -270,10 +270,10 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
 
     private void mockInvoke() {
         doAnswer(ans -> {
-            ActionListener<InvokeEndpointResponse> responseListener = ans.getArgument(3);
+            ActionListener<InvokeEndpointResponse> responseListener = ans.getArgument(4);
             responseListener.onResponse(InvokeEndpointResponse.builder().build());
             return null; // Void
-        }).when(client).invoke(any(), any(), any(), any());
+        }).when(client).invoke(any(), any(), any(), any(), any());
     }
 
     private static SageMakerInferenceRequest assertRequest() {
@@ -298,18 +298,18 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
             verify(schema, times(1)).streamRequest(eq(model), assertRequest());
             verify(schema, times(1)).streamResponse(eq(model), any());
         }));
-        verify(client, only()).invokeStream(any(), any(), any(), any());
+        verify(client, only()).invokeStream(any(), any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
     }
 
     private void mockInvokeStream() {
         doAnswer(ans -> {
-            ActionListener<SageMakerClient.SageMakerStream> responseListener = ans.getArgument(3);
+            ActionListener<SageMakerClient.SageMakerStream> responseListener = ans.getArgument(4);
             responseListener.onResponse(
                 new SageMakerClient.SageMakerStream(InvokeEndpointWithResponseStreamResponse.builder().build(), mock())
             );
             return null; // Void
-        }).when(client).invokeStream(any(), any(), any(), any());
+        }).when(client).invokeStream(any(), any(), any(), any(), any());
     }
 
     public void testInferError() {
@@ -336,16 +336,16 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
                 verify(schema, times(1)).error(eq(model), assertArg(e -> assertThat(e, equalTo(expectedException))));
             })
         );
-        verify(client, only()).invoke(any(), any(), any(), any());
+        verify(client, only()).invoke(any(), any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
     }
 
     private void mockInvokeFailure(Exception e) {
         doAnswer(ans -> {
-            ActionListener<?> responseListener = ans.getArgument(3);
+            ActionListener<?> responseListener = ans.getArgument(4);
             responseListener.onFailure(e);
             return null; // Void
-        }).when(client).invoke(any(), any(), any(), any());
+        }).when(client).invoke(any(), any(), any(), any(), any());
     }
 
     public void testInferException() {
@@ -354,7 +354,7 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
 
         SageMakerStreamSchema schema = mock();
         when(schemas.streamSchemaFor(model)).thenReturn(schema);
-        doThrow(new IllegalArgumentException("wow, really?")).when(client).invokeStream(any(), any(), any(), any());
+        doThrow(new IllegalArgumentException("wow, really?")).when(client).invokeStream(any(), any(), any(), any(), any());
 
         sageMakerService.infer(model, QUERY, null, null, INPUT, true, null, INPUT_TYPE, THIRTY_SECONDS, assertNoSuccessListener(e -> {
             verify(schemas, only()).streamSchemaFor(eq(model));
@@ -363,7 +363,7 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
             assertThat(((ElasticsearchStatusException) e).status(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
             assertThat(e.getMessage(), equalTo("Failed to call SageMaker for inference id [some id]."));
         }));
-        verify(client, only()).invokeStream(any(), any(), any(), any());
+        verify(client, only()).invokeStream(any(), any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
     }
 
@@ -393,7 +393,7 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
                 verify(schema, times(1)).chatCompletionStreamResponse(eq(model), any());
             })
         );
-        verify(client, only()).invokeStream(any(), any(), any(), any());
+        verify(client, only()).invokeStream(any(), any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
     }
 
@@ -415,16 +415,16 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
                 verify(schema, times(1)).chatCompletionError(eq(model), assertArg(e -> assertThat(e, equalTo(expectedException))));
             })
         );
-        verify(client, only()).invokeStream(any(), any(), any(), any());
+        verify(client, only()).invokeStream(any(), any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
     }
 
     private void mockInvokeStreamFailure(Exception e) {
         doAnswer(ans -> {
-            ActionListener<?> responseListener = ans.getArgument(3);
+            ActionListener<?> responseListener = ans.getArgument(4);
             responseListener.onFailure(e);
             return null; // Void
-        }).when(client).invokeStream(any(), any(), any(), any());
+        }).when(client).invokeStream(any(), any(), any(), any(), any());
     }
 
     public void testUnifiedInferException() {
@@ -433,7 +433,7 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
 
         SageMakerStreamSchema schema = mock();
         when(schemas.streamSchemaFor(model)).thenReturn(schema);
-        doThrow(new IllegalArgumentException("wow, rude")).when(client).invokeStream(any(), any(), any(), any());
+        doThrow(new IllegalArgumentException("wow, rude")).when(client).invokeStream(any(), any(), any(), any(), any());
 
         sageMakerService.unifiedCompletionInfer(
             model,
@@ -447,7 +447,7 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
                 assertThat(e.getMessage(), equalTo("Failed to call SageMaker for inference id [some id]."));
             })
         );
-        verify(client, only()).invokeStream(any(), any(), any(), any());
+        verify(client, only()).invokeStream(any(), any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
     }
 
@@ -486,7 +486,7 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
                 verify(schema, times(2)).response(eq(model), any(), any());
             }))
         );
-        verify(client, times(2)).invoke(any(), any(), any(), any());
+        verify(client, times(2)).invoke(any(), any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
     }
 
@@ -510,7 +510,7 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
                 verify(schema, never()).response(any(), any(), any());
             }))
         );
-        verify(client, never()).invoke(any(), any(), any(), any());
+        verify(client, never()).invoke(any(), any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
     }
 
@@ -561,7 +561,7 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
                 assertThat(chunkedInferences, containsInAnyOrder(expectedOutput));
             }))
         );
-        verify(client, times(2)).invoke(any(), any(), any(), any());
+        verify(client, times(2)).invoke(any(), any(), any(), any(), any());
         verifyNoMoreInteractions(client, schemas, schema);
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Inference API] Add inference id to the timeout string and use internal timeout exception (#146531)](https://github.com/elastic/elasticsearch/pull/146531)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)