### PR TITLE
[ESQL] Tune NDJSON parallel parsing throughput

### DIFF
--- a/docs/changelog/148143.yaml
+++ b/docs/changelog/148143.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148143
+summary: Tune NDJSON parallel parsing throughput
+type: enhancement

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonFormatReader.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasource.ndjson;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
@@ -38,6 +39,27 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
     public static final String SCHEMA_SAMPLE_SIZE_SETTING = "esql.datasource.ndjson.schema_sample_size";
     public static final int DEFAULT_SCHEMA_SAMPLE_SIZE = 20_000;
 
+    /**
+     * Node-level setting for the parallel-parsing segment size. Larger segments amortise the fixed
+     * Java/Jackson per-segment setup cost; smaller segments enable parallelism on smaller files.
+     * Also overridable per-query via the {@code segment_size} key in {@code WITH (...)}.
+     */
+    public static final String SEGMENT_SIZE_SETTING = "esql.datasource.ndjson.segment_size";
+
+    /**
+     * 4 MiB, larger than the SPI's 1 MiB. Each NDJSON segment pays a fixed Java/Jackson setup cost
+     * (schema lookup, {@link FormatReadContext} creation, {@link NdJsonPageIterator} +
+     * {@link NdJsonPageDecoder} construction, range-stream wrapping, queue coordination), so cutting
+     * the segment count by 4x cuts that overhead by ~4x. ClickHouse's 1 MiB sweet spot does not
+     * carry over because their per-chunk overhead is much lower (no per-chunk object allocation in
+     * the C++ path). Files below {@code 2 * segment_size} (~8 MiB at the default) parse
+     * single-threaded; that matches where per-chunk setup actually amortises.
+     */
+    public static final ByteSizeValue DEFAULT_SEGMENT_SIZE = ByteSizeValue.ofMb(4);
+
+    /** Below 64 KiB, per-chunk overhead dominates parse cost; reject silly configurations early. */
+    static final ByteSizeValue MIN_SEGMENT_SIZE = ByteSizeValue.ofKb(64);
+
     /** Buffer size used to accelerate {@link #scanForTerminator} on cold (unbuffered) streams. */
     private static final int SCAN_BUFFER_SIZE = 8 * 1024;
 
@@ -45,25 +67,33 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
     private final Settings settings;
     private final List<Attribute> resolvedSchema;
     private final int schemaSampleSize;
+    private final long segmentSizeBytes;
 
     public NdJsonFormatReader(Settings settings, BlockFactory blockFactory, List<Attribute> resolvedSchema) {
-        this(settings, blockFactory, resolvedSchema, schemaSampleSize(settings));
+        this(settings, blockFactory, resolvedSchema, schemaSampleSize(settings), segmentSize(settings));
     }
 
     NdJsonFormatReader(Settings settings, BlockFactory blockFactory) {
         this(settings, blockFactory, null);
     }
 
-    private NdJsonFormatReader(Settings settings, BlockFactory blockFactory, List<Attribute> resolvedSchema, int schemaSampleSize) {
+    private NdJsonFormatReader(
+        Settings settings,
+        BlockFactory blockFactory,
+        List<Attribute> resolvedSchema,
+        int schemaSampleSize,
+        long segmentSizeBytes
+    ) {
         this.blockFactory = blockFactory;
         this.settings = settings == null ? Settings.EMPTY : settings;
         this.resolvedSchema = resolvedSchema;
         this.schemaSampleSize = schemaSampleSize;
+        this.segmentSizeBytes = segmentSizeBytes;
     }
 
     @Override
     public NdJsonFormatReader withSchema(List<Attribute> schema) {
-        return new NdJsonFormatReader(settings, blockFactory, schema, schemaSampleSize);
+        return new NdJsonFormatReader(settings, blockFactory, schema, schemaSampleSize, segmentSizeBytes);
     }
 
     @Override
@@ -73,15 +103,22 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
         }
         int newSampleSize = parseInt(config.get("schema_sample_size"), schemaSampleSize);
         Check.isTrue(newSampleSize > 0, "schema_sample_size must be positive, got: {}", newSampleSize);
-        if (newSampleSize == schemaSampleSize) {
+        long newSegmentSize = parseSegmentSize(config.get("segment_size"), segmentSizeBytes);
+        if (newSampleSize == schemaSampleSize && newSegmentSize == segmentSizeBytes) {
             return this;
         }
-        return new NdJsonFormatReader(settings, blockFactory, resolvedSchema, newSampleSize);
+        return new NdJsonFormatReader(settings, blockFactory, resolvedSchema, newSampleSize, newSegmentSize);
     }
 
     private List<Attribute> inferSchemaIfNeeded(List<Attribute> attributes, StorageObject object, boolean skipFirstLine)
         throws IOException {
-        if (attributes != null && attributes.isEmpty() == false) {
+        if (attributes != null) {
+            // Empty schema means the optimizer pruned every column (COUNT(*) etc.); skip inference
+            // entirely. The decoder treats an empty projection list as "structure-only", so there
+            // is nothing to type-check against.
+            if (attributes.isEmpty()) {
+                return attributes;
+            }
             if (needsFullSchemaSupplement(attributes)) {
                 List<Attribute> inferred;
                 try (var stream = openForSchemaInference(object, skipFirstLine)) {
@@ -174,6 +211,14 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
         return resolved.getAsInt(SCHEMA_SAMPLE_SIZE_SETTING, DEFAULT_SCHEMA_SAMPLE_SIZE);
     }
 
+    private static long segmentSize(Settings settings) {
+        Settings resolved = settings == null ? Settings.EMPTY : settings;
+        ByteSizeValue value = resolved.getAsBytesSize(SEGMENT_SIZE_SETTING, DEFAULT_SEGMENT_SIZE);
+        long bytes = value.getBytes();
+        Check.isTrue(bytes >= MIN_SEGMENT_SIZE.getBytes(), "{} must be >= {}, got: {}", SEGMENT_SIZE_SETTING, MIN_SEGMENT_SIZE, value);
+        return bytes;
+    }
+
     private static int parseInt(Object value, int defaultValue) {
         if (value == null) {
             return defaultValue;
@@ -183,6 +228,16 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid integer value [" + value + "]", e);
         }
+    }
+
+    private static long parseSegmentSize(Object value, long defaultValueBytes) {
+        if (value == null) {
+            return defaultValueBytes;
+        }
+        ByteSizeValue parsed = ByteSizeValue.parseBytesSizeValue(value.toString(), "segment_size");
+        long bytes = parsed.getBytes();
+        Check.isTrue(bytes >= MIN_SEGMENT_SIZE.getBytes(), "segment_size must be >= {}, got: {}", MIN_SEGMENT_SIZE, parsed);
+        return bytes;
     }
 
     @Override
@@ -266,6 +321,15 @@ public class NdJsonFormatReader implements SegmentableFormatReader {
             }
         }
         return LineScan.EOF;
+    }
+
+    /**
+     * Resolved per-reader from {@link #SEGMENT_SIZE_SETTING} (node-level) or the {@code segment_size}
+     * key in the per-query {@code WITH (...)} config. Defaults to {@link #DEFAULT_SEGMENT_SIZE}.
+     */
+    @Override
+    public long minimumSegmentSize() {
+        return segmentSizeBytes;
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageDecoder.java
@@ -40,11 +40,11 @@ import org.elasticsearch.xpack.esql.datasources.spi.SkipWarnings;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Parses NDJSON into {@link Page}s for a single input stream.
@@ -106,17 +106,32 @@ public class NdJsonPageDecoder implements Closeable {
         );
 
         List<Attribute> fullSchema = attributes;
-        var projectedAttributes = attributes;
-        if (projectedColumns != null && projectedColumns.isEmpty() == false) {
-            // Keep projected columns in order, adding NULL for missing columns
-            projectedAttributes = projectedColumns.stream()
-                .map(
-                    col -> attributes.stream()
-                        .filter(a -> a.name().equals(col))
-                        .findFirst()
-                        .orElseGet(() -> NdJsonSchemaInferrer.attribute(col, DataType.NULL, false))
-                )
-                .toList();
+        // Three projection cases:
+        // - null : caller has no projection info (e.g. metadata path); materialize every attribute.
+        // - empty : optimizer pruned every column (COUNT(*) and similar); produce row-count-only Pages.
+        // - other : project the listed columns in the requested order, with NULL for missing names.
+        List<Attribute> projectedAttributes;
+        if (projectedColumns == null) {
+            projectedAttributes = attributes;
+        } else if (projectedColumns.isEmpty()) {
+            projectedAttributes = List.of();
+        } else {
+            // Build the lookup map once: O(N) here vs. O(N*M) for a per-projection nested scan,
+            // which matters on wide schemas (the NYC taxis fixture has 100+ columns). putIfAbsent
+            // preserves the first-wins semantics of the prior findFirst() call so a schema with
+            // duplicated names (rare, but legal) keeps the same attribute the optimizer would have
+            // picked. We never iterate the map, so HashMap suffices (no LinkedHashMap overhead).
+            // Capacity 2*N keeps us safely above the 0.75 load factor for at most N entries.
+            Map<String, Attribute> byName = new HashMap<>(attributes.size() * 2);
+            for (Attribute a : attributes) {
+                byName.putIfAbsent(a.name(), a);
+            }
+            var resolved = new ArrayList<Attribute>(projectedColumns.size());
+            for (String col : projectedColumns) {
+                Attribute match = byName.get(col);
+                resolved.add(match != null ? match : NdJsonSchemaInferrer.attribute(col, DataType.NULL, false));
+            }
+            projectedAttributes = resolved;
         }
 
         this.decoder = prepareSchema(projectedAttributes, fullSchema);
@@ -236,7 +251,10 @@ public class NdJsonPageDecoder implements Closeable {
      */
     private Page decodePageLenient(Block.Builder[] blockBuilders) throws IOException {
         ensureLenientScratchBuffers();
-        final Block.Builder[] rowScratch = Objects.requireNonNull(lenientScratchBuilders);
+        final Block.Builder[] rowScratch = lenientScratchBuilders;
+        if (rowScratch == null) {
+            throw new EsqlIllegalArgumentException("lenient scratch builders missing after ensureLenientScratchBuffers");
+        }
 
         int lineCount = 0;
         while (lineCount < batchSize) {
@@ -289,6 +307,11 @@ public class NdJsonPageDecoder implements Closeable {
         if (lineCount == 0) {
             return null;
         }
+        // Row-count-only Page (zero-column projection, e.g. COUNT(*)). new Page(Block[]) rejects an
+        // empty block array, so route through the explicit positionCount constructor.
+        if (blockBuilders.length == 0) {
+            return new Page(lineCount);
+        }
 
         var blocks = new Block[this.projectedAttributes.size()];
         var success = false;
@@ -312,7 +335,10 @@ public class NdJsonPageDecoder implements Closeable {
      */
     private void appendDecodedScratchRow(Block.Builder[] pageBuilders, Block.Builder[] scratchBuilders) {
         final int columns = scratchBuilders.length;
-        Block[] rowBlocks = Objects.requireNonNull(lenientScratchRowBlocks);
+        Block[] rowBlocks = lenientScratchRowBlocks;
+        if (rowBlocks == null) {
+            throw new EsqlIllegalArgumentException("lenient scratch row blocks missing after ensureLenientScratchBuffers");
+        }
         try {
             for (int i = 0; i < columns; i++) {
                 rowBlocks[i] = scratchBuilders[i].build();

--- a/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtils.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/main/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonUtils.java
@@ -8,7 +8,9 @@
 package org.elasticsearch.xpack.esql.datasource.ndjson;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadFeature;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -18,15 +20,29 @@ import java.io.SequenceInputStream;
 
 class NdJsonUtils {
     /**
-     * Schema inference may call {@link JsonParser#close()} while recovering from malformed JSON;
-     * that must not close a wrapping codec stream (e.g. bzip2) that is still being read.
+     * Shared {@link JsonFactory} for all NDJSON parsing. All settings are valid on the server-wide
+     * Jackson 2.15 used here (no separate Jackson dependency for this plugin).
+     * <ul>
+     *   <li>{@link StreamReadFeature#AUTO_CLOSE_SOURCE} disabled - schema inference may call
+     *       {@link JsonParser#close()} while recovering from malformed JSON; that must not close a
+     *       wrapping codec stream (e.g. bzip2) that is still being read.</li>
+     *   <li>{@link StreamReadFeature#USE_FAST_DOUBLE_PARSER} enabled - dispatches numeric parsing
+     *       to FastDoubleParser (~+20% on numeric-heavy fixtures); harmless when columns are
+     *       non-numeric. Available since Jackson 2.14.</li>
+     *   <li>{@link StreamReadFeature#INCLUDE_SOURCE_IN_LOCATION} disabled - we never echo source
+     *       payloads back via {@code JsonLocation.contentReference()}; skipping the per-token
+     *       book-keeping shaves allocations in the hot loop. Default flips to {@code false} in
+     *       Jackson 2.16; we want the same behaviour now.</li>
+     *   <li>{@link JsonFactory.Feature#INTERN_FIELD_NAMES} disabled - eliminates the global
+     *       {@code String.intern()} synchronization point under parallel parsing. Field names
+     *       live only as long as the {@code Attribute} lookup keys; interning gains us nothing.</li>
+     * </ul>
      */
-    static final JsonFactory JSON_FACTORY;
-    static {
-        JsonFactory factory = new JsonFactory();
-        factory.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false);
-        JSON_FACTORY = factory;
-    }
+    static final JsonFactory JSON_FACTORY = new JsonFactoryBuilder().disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+        .enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER)
+        .disable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+        .disable(JsonFactory.Feature.INTERN_FIELD_NAMES)
+        .build();
 
     /**
      * Given a parser and the stream it reads from, restart parsing at the next line.

--- a/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
+++ b/x-pack/plugin/esql-datasource-ndjson/src/test/java/org/elasticsearch/xpack/esql/datasource/ndjson/NdJsonPageIteratorTests.java
@@ -467,7 +467,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         assertEquals("still_hired", schema.get(9).name());
         assertEquals(DataType.BOOLEAN, schema.get(9).dataType());
 
-        try (var iterator = reader.read(object, List.of(), 1000)) {
+        try (var iterator = reader.read(object, null, 1000)) {
             var page = iterator.next();
             checkBlockSizes(page);
 
@@ -957,7 +957,7 @@ public class NdJsonPageIteratorTests extends ESTestCase {
         var schema = reader.metadata(object).schema();
         assertSchema(schema, "timestamp:DATETIME");
 
-        try (var iterator = reader.read(object, List.of(), 100)) {
+        try (var iterator = reader.read(object, null, 100)) {
             var page = iterator.next();
             assertPage(page, """
                      LONG     \s
@@ -1014,6 +1014,366 @@ public class NdJsonPageIteratorTests extends ESTestCase {
                 1              |Infinity      \s
                 2              |42.0          \s
                 """);
+        }
+    }
+
+    // --- empty projection (COUNT(*)) tests ---
+
+    /**
+     * COUNT(*) path: an empty (not null) projection list means the optimizer pruned every column.
+     * The decoder must produce row-count-only Pages (zero blocks) and skip every JSON field via
+     * {@code parser.skipChildren()} rather than materializing the file's full schema.
+     */
+    public void testEmptyProjectionProducesRowCountOnlyPage() throws IOException {
+        StringBuilder ndjson = new StringBuilder();
+        for (int i = 1; i <= 7; i++) {
+            ndjson.append("{\"a\":").append(i).append(",\"b\":\"v").append(i).append("\",\"c\":[1,2,3]}\n");
+        }
+        var object = new BytesStorageObject("memory://count-star.ndjson", ndjson.toString().getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+
+        int totalRows = 0;
+        try (var iterator = reader.read(object, List.of(), 100)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                assertEquals("Empty projection must produce zero-block Pages", 0, page.getBlockCount());
+                totalRows += page.getPositionCount();
+            }
+        }
+        assertEquals(7, totalRows);
+    }
+
+    /**
+     * Distinguishes the {@code null} projection case ("caller has no projection info; load
+     * everything") from the empty list case ("optimizer pruned every column"); same fixture, two
+     * outcomes.
+     */
+    public void testNullProjectionLoadsAllColumns() throws IOException {
+        String ndjson = """
+            {"a":1,"b":"x"}
+            {"a":2,"b":"y"}
+            """;
+        var object = new BytesStorageObject("memory://null-proj.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+
+        try (var iterator = reader.read(object, null, 100)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals("Null projection must load every inferred column", 2, page.getBlockCount());
+            assertEquals(2, page.getPositionCount());
+        }
+    }
+
+    /**
+     * Empty projection with {@link ErrorPolicy#STRICT}: malformed lines must abort the read; a
+     * row-count-only Page would otherwise silently swallow corruption.
+     */
+    public void testEmptyProjectionFailFastOnMalformedLine() throws IOException {
+        String ndjson = """
+            {"a":1}
+            {"a":2}
+            {{{not-an-object
+            {"a":4}
+            """;
+        var object = new BytesStorageObject("memory://strict-count.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var ctx = FormatReadContext.builder().projectedColumns(List.of()).batchSize(2).errorPolicy(ErrorPolicy.STRICT).build();
+        try (var iterator = reader.read(object, ctx)) {
+            assertTrue(iterator.hasNext());
+            Page first = iterator.next();
+            assertEquals(0, first.getBlockCount());
+            assertEquals(2, first.getPositionCount());
+            EsqlIllegalArgumentException ex = expectThrows(EsqlIllegalArgumentException.class, iterator::hasNext);
+            assertThat(ex.getMessage(), Matchers.containsString("Malformed NDJSON"));
+        }
+    }
+
+    /**
+     * Empty projection with {@link ErrorPolicy#LENIENT}: malformed lines are excluded from the
+     * count just like in the value-extracting paths; only valid records contribute to the total.
+     */
+    public void testEmptyProjectionLenientSkipsMalformedLines() throws IOException {
+        String ndjson = """
+            {"a":1}
+            {{{not-an-object
+            {"a":3}
+            {"a":4}
+            """;
+        var object = new BytesStorageObject("memory://lenient-count.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var ctx = FormatReadContext.builder().projectedColumns(List.of()).batchSize(100).errorPolicy(ErrorPolicy.LENIENT).build();
+        int totalRows = 0;
+        try (var iterator = reader.read(object, ctx)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                assertEquals(0, page.getBlockCount());
+                totalRows += page.getPositionCount();
+            }
+        }
+        assertEquals("Malformed line must not contribute to COUNT(*)", 3, totalRows);
+    }
+
+    /**
+     * Empty projection still respects {@code rowLimit}; the truncated last page must be a
+     * row-count-only Page with the trimmed position count.
+     */
+    public void testEmptyProjectionRespectsRowLimit() throws IOException {
+        StringBuilder ndjson = new StringBuilder();
+        for (int i = 1; i <= 20; i++) {
+            ndjson.append("{\"a\":").append(i).append("}\n");
+        }
+        var object = new BytesStorageObject("memory://limit-count.ndjson", ndjson.toString().getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var ctx = FormatReadContext.builder().projectedColumns(List.of()).batchSize(8).rowLimit(5).build();
+        int totalRows = 0;
+        try (var iterator = reader.read(object, ctx)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                assertEquals(0, page.getBlockCount());
+                totalRows += page.getPositionCount();
+            }
+        }
+        assertEquals(5, totalRows);
+    }
+
+    /**
+     * Filter-only column path: ESQL's PruneColumns leaves filter references in the projection list
+     * even when they are not in the SELECT. The decoder must materialize them so a downstream
+     * filter operator can evaluate the predicate.
+     */
+    public void testProjectionLoadsOnlyRequestedColumnsAndSkipsRest() throws IOException {
+        String ndjson = """
+            {"a":1,"b":"x","c":1.5,"d":true}
+            {"a":2,"b":"y","c":2.5,"d":false}
+            {"a":3,"b":"z","c":3.5,"d":true}
+            """;
+        var object = new BytesStorageObject("memory://selective.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        try (var iterator = reader.read(object, List.of("a", "c"), 100)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getBlockCount());
+            assertEquals(3, page.getPositionCount());
+            assertThat(page.getBlock(0), Matchers.instanceOf(IntBlock.class));
+            assertThat(page.getBlock(1), Matchers.instanceOf(DoubleBlock.class));
+            assertEquals(1, ((IntBlock) page.getBlock(0)).getInt(0));
+            assertEquals(3.5, ((DoubleBlock) page.getBlock(1)).getDouble(2), 1e-9);
+        }
+    }
+
+    /**
+     * Filter-and-output sharing a column: the projection list must not duplicate the column in the
+     * Page (same identity coming from filter and SELECT references).
+     */
+    public void testProjectionDoesNotDuplicateSharedFilterAndOutputColumn() throws IOException {
+        String ndjson = """
+            {"a":1,"b":"x"}
+            {"a":2,"b":"y"}
+            """;
+        var object = new BytesStorageObject("memory://shared.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        // Single "a" stands in for the deduplicated projection list the optimizer hands down when
+        // filter and output reference the same column.
+        try (var iterator = reader.read(object, List.of("a"), 100)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getBlockCount());
+            assertEquals(2, page.getPositionCount());
+        }
+    }
+
+    /**
+     * Filter-only column with no SELECT match: the optimizer's PruneColumns adds filter references
+     * to the projection list even when no output column matches. Decoder must still materialise the
+     * filter column so the downstream WHERE operator can evaluate; rest must be skipped.
+     * Mirrors the cross-system contract (ClickHouse skipJSONField, Spark parser.skipChildren).
+     */
+    public void testProjectionLoadsFilterOnlyColumnWithNoSelectMatch() throws IOException {
+        String ndjson = """
+            {"a":1,"b":"x","c":1.5}
+            {"a":2,"b":"y","c":2.5}
+            {"a":3,"b":"z","c":3.5}
+            """;
+        var object = new BytesStorageObject("memory://filter-only.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        // Models `EXTERNAL "..." | WHERE a > 0 | STATS c = COUNT(*)`: the optimizer keeps `a` in
+        // projectedColumns for the filter, drops `b` and `c` since neither is referenced by the
+        // aggregate. The decoder produces a single-block Page; the filter operator runs against
+        // block[0] and the COUNT(*) aggregator counts rows that pass.
+        try (var iterator = reader.read(object, List.of("a"), 100)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals("Only the filter-referenced column should materialise", 1, page.getBlockCount());
+            assertEquals(3, page.getPositionCount());
+            assertThat(page.getBlock(0), Matchers.instanceOf(IntBlock.class));
+            assertEquals(1, ((IntBlock) page.getBlock(0)).getInt(0));
+            assertEquals(2, ((IntBlock) page.getBlock(0)).getInt(1));
+            assertEquals(3, ((IntBlock) page.getBlock(0)).getInt(2));
+        }
+    }
+
+    /**
+     * Lenient projection: the LENIENT path runs through {@code decodePageLenient}, which uses
+     * scratch buffers ({@code lenientScratchBuilders}) and a different {@code decodeObject} call
+     * site than STRICT. The malformed line in the middle of the fixture is dropped; the projected
+     * columns of the surviving rows reach the page in the requested order. Paired with
+     * {@link #testProjectionUnderStrictErrorPolicyFailsFastOnSameFixture} to nail down the
+     * lenient-vs-fail-fast contract on the same input.
+     */
+    public void testProjectionUnderLenientErrorPolicy() throws IOException {
+        var object = new BytesStorageObject("memory://lenient-proj.ndjson", lenientStrictProjectionFixture());
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var ctx = FormatReadContext.builder().projectedColumns(List.of("a", "c")).batchSize(100).errorPolicy(ErrorPolicy.LENIENT).build();
+        int rows = 0;
+        try (var iterator = reader.read(object, ctx)) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                assertEquals("LENIENT projection still drops unprojected columns", 2, page.getBlockCount());
+                assertThat(page.getBlock(0), Matchers.instanceOf(IntBlock.class));
+                assertThat(page.getBlock(1), Matchers.instanceOf(DoubleBlock.class));
+                for (int i = 0; i < page.getPositionCount(); i++, rows++) {
+                    int aValue = ((IntBlock) page.getBlock(0)).getInt(i);
+                    double cValue = ((DoubleBlock) page.getBlock(1)).getDouble(i);
+                    // The malformed line is dropped, so we should only see {a:1,c:1.5} and {a:3,c:3.5}
+                    assertTrue(
+                        "Unexpected row a=" + aValue + " c=" + cValue,
+                        (aValue == 1 && cValue == 1.5) || (aValue == 3 && cValue == 3.5)
+                    );
+                }
+            }
+        }
+        assertEquals("Malformed line must not contribute under LENIENT", 2, rows);
+    }
+
+    /**
+     * STRICT counterpart to {@link #testProjectionUnderLenientErrorPolicy}: the same fixture must
+     * fail-fast at the malformed line. With {@code batchSize >= 3} the decoder accumulates rows
+     * into one batch; the malformed line in the middle aborts that batch before any page surfaces.
+     * This pair establishes that the lenient test exercises the scratch-buffer / drop-row path
+     * rather than accidentally avoiding the malformed line.
+     */
+    public void testProjectionUnderStrictErrorPolicyFailsFastOnSameFixture() throws IOException {
+        var object = new BytesStorageObject("memory://strict-proj.ndjson", lenientStrictProjectionFixture());
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        var ctx = FormatReadContext.builder().projectedColumns(List.of("a", "c")).batchSize(100).errorPolicy(ErrorPolicy.STRICT).build();
+        try (var iterator = reader.read(object, ctx)) {
+            EsqlIllegalArgumentException ex = expectThrows(EsqlIllegalArgumentException.class, iterator::hasNext);
+            assertThat(ex.getMessage(), Matchers.containsString("Malformed NDJSON"));
+        }
+    }
+
+    private static byte[] lenientStrictProjectionFixture() {
+        return """
+            {"a":1,"b":"x","c":1.5,"d":true}
+            {{{not-a-record
+            {"a":3,"b":"z","c":3.5,"d":true}
+            """.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Projected column missing from the file's schema: the inferrer never sees {@code missing}, so
+     * the decoder substitutes a NULL-typed attribute. The corresponding block must be a constant-
+     * null block of the right length (asserts the {@code NdJsonSchemaInferrer.attribute(col,
+     * DataType.NULL, false)} fallback in the projection branch).
+     */
+    public void testProjectionFillsMissingColumnWithNullBlock() throws IOException {
+        String ndjson = """
+            {"a":1}
+            {"a":2}
+            {"a":3}
+            """;
+        var object = new BytesStorageObject("memory://missing.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        try (var iterator = reader.read(object, List.of("a", "missing"), 100)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getBlockCount());
+            assertEquals(3, page.getPositionCount());
+            assertThat(page.getBlock(0), Matchers.instanceOf(IntBlock.class));
+            assertThat(
+                "Unknown column must collapse to a constant-null block",
+                page.getBlock(1),
+                Matchers.instanceOf(ConstantNullBlock.class)
+            );
+            assertEquals(3, page.getBlock(1).getPositionCount());
+        }
+    }
+
+    /**
+     * Nested-object projection: dotted columns ({@code user.id}) drive a tree of {@code BlockDecoder}s.
+     * Sibling fields under the same parent ({@code user.name}) and unrelated top-level fields
+     * ({@code other}) must not materialise. Asserts the recursive {@code decodeObject} path
+     * correctly inherits the skip behaviour into nested objects.
+     */
+    public void testNestedProjectionLoadsLeafAndSkipsSiblings() throws IOException {
+        String ndjson = """
+            {"user":{"id":1,"name":"alice"},"other":"ignored-1"}
+            {"user":{"id":2,"name":"bob"},"other":"ignored-2"}
+            {"user":{"id":3,"name":"carol"},"other":"ignored-3"}
+            """;
+        var object = new BytesStorageObject("memory://nested.ndjson", ndjson.getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        try (var iterator = reader.read(object, List.of("user.id"), 100)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals("Only the projected nested leaf must materialise", 1, page.getBlockCount());
+            assertEquals(3, page.getPositionCount());
+            assertThat(page.getBlock(0), Matchers.instanceOf(IntBlock.class));
+            assertEquals(1, ((IntBlock) page.getBlock(0)).getInt(0));
+            assertEquals(2, ((IntBlock) page.getBlock(0)).getInt(1));
+            assertEquals(3, ((IntBlock) page.getBlock(0)).getInt(2));
+        }
+    }
+
+    /**
+     * Wide-schema projection regression: 8 fields of varied types (int, keyword, double, boolean,
+     * datetime-as-string, long, nested object, array) reduced to just 2. Locks the structural
+     * invariant that unprojected fields never reach a block builder.
+     * <p>
+     * For unreferenced top-level fields, the only branch through {@code BlockDecoder.decodeObject}
+     * is {@code parser.skipChildren()} (the {@code childDecoder == null} sibling of
+     * {@code childDecoder.decodeValue(...)}). So an exactly-2-block Page with the right values
+     * across the nested object and the array - the most expensive shapes to materialise - implies
+     * those fields were skipped at parse time, not silently materialised into a discarded buffer.
+     * (Note: {@code skipChildren} is also called by {@code unexpectedValue} and the {@code NULL}
+     * branch of {@code decodeValue}; this test does not depend on those paths.)
+     */
+    public void testWideSchemaProjectionDropsAllUnreferencedFields() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= 5; i++) {
+            sb.append("{\"f_int\":")
+                .append(i)
+                .append(",\"f_keyword\":\"k")
+                .append(i)
+                .append("\",\"f_double\":")
+                .append(i + 0.5)
+                .append(",\"f_bool\":")
+                .append(i % 2 == 0)
+                .append(",\"f_long\":")
+                .append(1_000_000L * i)
+                .append(",\"f_nested\":{\"inner\":")
+                .append(i * 10)
+                .append(",\"deeper\":{\"x\":\"")
+                .append(i)
+                .append("\"}}")
+                .append(",\"f_array\":[1,2,3,4,5,6,7,8]")
+                .append(",\"f_extra\":\"unused-")
+                .append(i)
+                .append("\"}\n");
+        }
+        var object = new BytesStorageObject("memory://wide.ndjson", sb.toString().getBytes(StandardCharsets.UTF_8));
+        var reader = new NdJsonFormatReader(null, blockFactory);
+        try (var iterator = reader.read(object, List.of("f_int", "f_double"), 100)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals("8-field schema reduced to 2 projected blocks", 2, page.getBlockCount());
+            assertEquals(5, page.getPositionCount());
+            assertThat(page.getBlock(0), Matchers.instanceOf(IntBlock.class));
+            assertThat(page.getBlock(1), Matchers.instanceOf(DoubleBlock.class));
+            for (int i = 0; i < 5; i++) {
+                assertEquals(i + 1, ((IntBlock) page.getBlock(0)).getInt(i));
+                assertEquals(i + 1 + 0.5, ((DoubleBlock) page.getBlock(1)).getDouble(i), 1e-9);
+            }
         }
     }
 
@@ -1128,6 +1488,53 @@ public class NdJsonPageIteratorTests extends ESTestCase {
 
     public void testDefaultErrorPolicyIsStrictLikeOtherFormats() {
         assertEquals(ErrorPolicy.STRICT, new NdJsonFormatReader(Settings.EMPTY, blockFactory).defaultErrorPolicy());
+    }
+
+    /**
+     * Default segment size: 4 MiB, larger than the SPI's 1 MiB default. Locked in so a refactor
+     * that drops the override (and silently falls back to 1 MiB) trips a precommit failure.
+     */
+    public void testMinimumSegmentSizeDefaultIsFourMiB() {
+        assertEquals(4L * 1024 * 1024, new NdJsonFormatReader(Settings.EMPTY, blockFactory).minimumSegmentSize());
+    }
+
+    /**
+     * Node-level override via {@link NdJsonFormatReader#SEGMENT_SIZE_SETTING}. Operators tuning
+     * for clusters of small files (or memory-constrained nodes that prefer smaller chunks) should
+     * be able to lower the threshold without recompiling.
+     */
+    public void testMinimumSegmentSizeRespectsNodeSetting() {
+        var settings = Settings.builder().put(NdJsonFormatReader.SEGMENT_SIZE_SETTING, "8mb").build();
+        assertEquals(8L * 1024 * 1024, new NdJsonFormatReader(settings, blockFactory).minimumSegmentSize());
+    }
+
+    /**
+     * Per-query override via {@code WITH (segment_size = ...)}; mirrors the existing
+     * {@code schema_sample_size} pattern. Withconfig returns a new reader; the original is left
+     * unchanged so other concurrent queries keep their own values.
+     */
+    public void testMinimumSegmentSizeRespectsWithConfig() {
+        var reader = new NdJsonFormatReader(Settings.EMPTY, blockFactory);
+        FormatReader tuned = reader.withConfig(Map.of("segment_size", "2mb"));
+        assertNotSame(reader, tuned);
+        assertEquals("Per-query override applied", 2L * 1024 * 1024, ((NdJsonFormatReader) tuned).minimumSegmentSize());
+        assertEquals("Original reader still uses the default", 4L * 1024 * 1024, reader.minimumSegmentSize());
+    }
+
+    /** Configurations that hurt more than they help (sub-64 KiB) must be rejected up front. */
+    public void testSegmentSizeTooSmallIsRejected() {
+        var settings = Settings.builder().put(NdJsonFormatReader.SEGMENT_SIZE_SETTING, "1kb").build();
+        QlIllegalArgumentException ex = expectThrows(
+            QlIllegalArgumentException.class,
+            () -> new NdJsonFormatReader(settings, blockFactory)
+        );
+        assertThat(ex.getMessage(), Matchers.containsString("segment_size"));
+        var reader = new NdJsonFormatReader(Settings.EMPTY, blockFactory);
+        QlIllegalArgumentException ex2 = expectThrows(
+            QlIllegalArgumentException.class,
+            () -> reader.withConfig(Map.of("segment_size", "1kb"))
+        );
+        assertThat(ex2.getMessage(), Matchers.containsString("segment_size"));
     }
 
     private static DataType dataType(Block block) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -219,7 +219,7 @@ public final class ParallelParsingCoordinator {
                 final int segIdx = i;
                 final long[] seg = segments.get(i);
                 try {
-                    executor.execute(() -> parseSegment(segIdx, seg[0], seg[1], segments.size()));
+                    executor.execute(() -> parseSegment(segIdx, seg[0], seg[1]));
                 } catch (RejectedExecutionException e) {
                     firstError.compareAndSet(null, e);
                     enqueuePoison(segmentQueues.get(segIdx));
@@ -228,20 +228,27 @@ public final class ParallelParsingCoordinator {
             }
         }
 
-        private void parseSegment(int segmentIndex, long offset, long length, int totalSegments) {
+        private void parseSegment(int segmentIndex, long offset, long length) {
             BlockingQueue<Page> queue = segmentQueues.get(segmentIndex);
             try {
-                boolean lastSplit = segmentIndex == totalSegments - 1;
                 StorageObject segObj = new RangeStorageObject(storageObject, offset, length);
 
-                // All segments start at record boundaries (probed by computeSegments),
-                // so firstSplit is true for every segment: no line needs to be skipped.
+                // Both record-boundary flags are true for every segment:
+                // - firstSplit: computeSegments probes the next record boundary, so each segment
+                // starts on a complete record; no leading partial line to skip.
+                // - lastSplit: each non-final segment's length runs through the full record
+                // terminator that the next segment starts after (LF, CRLF, or lone CR for formats
+                // that handle it), so the segment's final byte is the last byte of a terminator.
+                // The final segment runs to fileLength; behavior there is unchanged from the
+                // previous code which also marked it lastSplit=true. Setting this everywhere lets
+                // line-oriented readers (e.g. NDJSON) skip the byte-by-byte trailing-partial-line
+                // scan that the format would otherwise apply per chunk.
                 FormatReadContext ctx = FormatReadContext.builder()
                     .projectedColumns(projectedColumns)
                     .batchSize(batchSize)
                     .errorPolicy(errorPolicy)
                     .firstSplit(true)
-                    .lastSplit(lastSplit)
+                    .lastSplit(true)
                     .build();
                 CloseableIterator<Page> pages = reader.read(segObj, ctx);
                 try (pages) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -269,6 +270,80 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
         }
     }
 
+    /**
+     * Each segment ends at a record boundary by construction: non-final segments stop at the byte
+     * after the next segment's leading newline, and the final segment runs to {@code fileLength}.
+     * The coordinator therefore must mark every segment as {@code lastSplit=true} so the NDJSON
+     * reader can skip its byte-by-byte {@code TrimLastPartialLineInputStream} scan over the chunk.
+     */
+    public void testParseSegmentMarksAllChunksAsLastSplit() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 200; i++) {
+            sb.append("line-").append(String.format(java.util.Locale.ROOT, "%04d", i)).append("\n");
+        }
+        byte[] content = sb.toString().getBytes(StandardCharsets.UTF_8);
+        StorageObject obj = new InMemoryStorageObject(content);
+        BlockFactory blockFactory = blockFactory();
+        ContextRecordingFormatReader reader = new ContextRecordingFormatReader(blockFactory);
+
+        // Force several segments by setting parallelism > 1 with a small minimum segment size on
+        // the recording reader (1 byte) so computeSegments produces multiple chunks.
+        ExecutorService exec = Executors.newFixedThreadPool(4);
+        try {
+            CloseableIterator<Page> iter = ParallelParsingCoordinator.parallelRead(reader, obj, List.of("line"), 50, 4, exec);
+            try (iter) {
+                while (iter.hasNext()) {
+                    iter.next().releaseBlocks();
+                }
+            }
+        } finally {
+            exec.shutdown();
+        }
+
+        List<FormatReadContext> seen = reader.contexts();
+        assertTrue("Expected at least 2 segments, recorded " + seen.size(), seen.size() >= 2);
+        for (int i = 0; i < seen.size(); i++) {
+            FormatReadContext ctx = seen.get(i);
+            assertTrue("segment[" + i + "] must have firstSplit=true", ctx.firstSplit());
+            assertTrue("segment[" + i + "] must have lastSplit=true (record-boundary aligned)", ctx.lastSplit());
+        }
+    }
+
+    /**
+     * Files smaller than {@code 2 * minimumSegmentSize()} fall back to single-threaded reading;
+     * the coordinator skips segment computation and forwards the original {@link StorageObject}
+     * directly. Verifies that NDJSON's bumped 4 MiB threshold (Stage 5) actually enforces the
+     * "no parallelism below ~8 MiB" contract documented on {@code minimumSegmentSize()}.
+     */
+    public void testFallsBackToSingleThreadedReadWhenFileTooSmall() throws Exception {
+        // 64 KiB minimum vs ~21 byte fixture: file is far below `2 * minSegmentSize`, must fall
+        // back to a whole-file read instead of fanning out across the executor.
+        byte[] content = "line-a\nline-b\nline-c\n".getBytes(StandardCharsets.UTF_8);
+        StorageObject obj = new InMemoryStorageObject(content);
+        ContextRecordingFormatReader reader = new ContextRecordingFormatReader(blockFactory(), 64 * 1024);
+
+        ExecutorService exec = Executors.newFixedThreadPool(4);
+        try {
+            CloseableIterator<Page> iter = ParallelParsingCoordinator.parallelRead(reader, obj, List.of("line"), 100, 4, exec);
+            try (iter) {
+                while (iter.hasNext()) {
+                    iter.next().releaseBlocks();
+                }
+            }
+        } finally {
+            exec.shutdown();
+        }
+
+        List<FormatReadContext> seen = reader.contexts();
+        assertEquals("Below the 2*minSegmentSize threshold, parallelRead must call read() exactly once", 1, seen.size());
+        // Single-threaded fallback uses the baseCtx with the builder's defaults (firstSplit=true,
+        // lastSplit=true) - the file is read whole, so it is by definition both the first and last
+        // split. The parallel path sets the same flags but only after slicing.
+        FormatReadContext only = seen.get(0);
+        assertTrue("Whole-file fallback path must mark firstSplit=true", only.firstSplit());
+        assertTrue("Whole-file fallback path must mark lastSplit=true", only.lastSplit());
+    }
+
     private static final BlockFactory TEST_BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
         .breaker(new NoopCircuitBreaker("test"))
         .build();
@@ -452,6 +527,73 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
         @Override
         public String formatName() {
             return "test-line";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".txt");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * SegmentableFormatReader that records the {@link FormatReadContext} it was handed for each
+     * {@link #read} call. Lets tests assert per-segment flag wiring without re-implementing line
+     * parsing.
+     */
+    private static class ContextRecordingFormatReader implements SegmentableFormatReader {
+        private final BlockFactory blockFactory;
+        private final long minSegmentSize;
+        private final List<FormatReadContext> contexts = new CopyOnWriteArrayList<>();
+
+        /** Convenience: matches the original test behaviour (force multi-segment even on tiny fixtures). */
+        ContextRecordingFormatReader(BlockFactory blockFactory) {
+            this(blockFactory, 1);
+        }
+
+        ContextRecordingFormatReader(BlockFactory blockFactory, long minSegmentSize) {
+            this.blockFactory = blockFactory;
+            this.minSegmentSize = minSegmentSize;
+        }
+
+        List<FormatReadContext> contexts() {
+            return contexts;
+        }
+
+        @Override
+        public long findNextRecordBoundary(InputStream stream) throws IOException {
+            long consumed = 0;
+            int b;
+            while ((b = stream.read()) != -1) {
+                consumed++;
+                if (b == '\n') {
+                    return consumed;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public long minimumSegmentSize() {
+            return minSegmentSize;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            return null;
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+            contexts.add(context);
+            return new LineFormatReader(blockFactory).read(object, context);
+        }
+
+        @Override
+        public String formatName() {
+            return "test-recording";
         }
 
         @Override


### PR DESCRIPTION
Five independent NDJSON parsing wins, gated on COUNT(*)/projection-aware
profiling.

- NdJsonPageDecoder treats an empty projectedColumns list as "row-count
  only" (COUNT(*), pure WHERE on hot columns), producing zero-block Pages
  via skipChildren() instead of materialising every column. NdJsonFormat-
  Reader.inferSchemaIfNeeded() short-circuits the same case so schema
  inference is skipped on every read. The selective-projection path
  resolves columns through a one-shot HashMap (O(N) build, O(1) lookup)
  instead of the prior O(N*M) nested scan, which matters on wide
  schemas (the NYC taxis fixture has 100+ columns).

- NdJsonUtils tunes the shared JsonFactory for high-throughput streams on
  the existing server-wide Jackson 2.15: USE_FAST_DOUBLE_PARSER (~+20%
  on numeric parses), INCLUDE_SOURCE_IN_LOCATION off (matches Jackson
  2.16's future default; trims per-token book-keeping), INTERN_FIELD_NAMES
  off (eliminates String.intern() lock contention under parallel reads).
  No version bump.

- ParallelParsingCoordinator marks every chunk lastSplit=true. Segments
  produced by computeSegments end on a record terminator by construction
  (LF, CRLF, or lone CR), so TrimLastPartialLineInputStream's per-byte
  tail scan was pure overhead on interior chunks. Final-chunk behaviour
  is unchanged.

- NdJsonFormatReader.minimumSegmentSize() defaults to 4 MiB instead of
  the SPI's 1 MiB. Java/Jackson per-segment setup (reader/decoder
  construction, range-stream wrapping, queue coordination) doesn't
  amortise at 1 MiB; cutting the segment count by 4x cuts that overhead
  proportionally. Files below ~8 MiB now parse single-threaded (was
  ~2 MiB), which matches where per-chunk setup actually pays off.
  Operators can override per-node via esql.datasource.ndjson.segment_size
  or per-query via WITH (segment_size = "Nmb"); sub-64 KiB values are
  rejected up front.

Tests cover: empty/null/selective projection (filter columns shared with
output, filter-only column with no SELECT match, missing column collapses
to a constant-null block, nested-object projection drops siblings, wide
8-field schema down to 2), both error policies (LENIENT scratch path +
matching STRICT fail-fast on the same fixture), the segment-flag
contract via a recording reader, single-threaded fallback below the
2*minSegmentSize threshold, and the new segment_size knob (default,
node setting, WITH override, and validation).

Developed with AI-assisted tooling