### PR TITLE
Fix lenient:false synonym test cleanup wedge

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -454,15 +454,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.StatelessCommitServiceTests
   method: testOldCommitsAreRetainedIfSearchNodesUseThem
   issue: https://github.com/elastic/elasticsearch/issues/147888
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=synonyms/110_synonyms_invalid/Load index with an invalid synonym rule with lenient set to false}
-  issue: https://github.com/elastic/elasticsearch/issues/147907
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=synonyms/20_synonyms_get/Cursor-based pagination with search_after}
-  issue: https://github.com/elastic/elasticsearch/issues/147908
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/41_knn_search_bbq_hnsw_bfloat16/Test index configured rescore vector score consistency}
-  issue: https://github.com/elastic/elasticsearch/issues/147909
 - class: org.elasticsearch.xpack.ml.integration.MlDistributedFailureIT
   method: testClusterWithTwoMlNodes_RunsDatafeed_GivenOriginalNodeGoesDown
   issue: https://github.com/elastic/elasticsearch/issues/147914

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/110_synonyms_invalid.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/110_synonyms_invalid.yml
@@ -210,6 +210,13 @@ setup:
 
   - length: { indices: 0 }
 
+  # Explicit cleanup: the broken shard would otherwise be stuck in
+  # INITIALIZING state and ESClientYamlSuiteTestCase would get stuck
+  # in cleanUpCluster's ensureNoInitializingShards.
+  - do:
+      indices.delete:
+        index: test_index
+
 ---
 "Reload index with an invalid synonym rule with lenient set to false":
   - do:
@@ -307,6 +314,13 @@ setup:
       indices.stats: { index: test_index }
 
   - length: { indices: 0 }
+
+  # Explicit cleanup: the broken shard would otherwise be stuck in
+  # INITIALIZING state and ESClientYamlSuiteTestCase would get stuck
+  # in cleanUpCluster's ensureNoInitializingShards.
+  - do:
+      indices.delete:
+        index: test_index
 
 ---
 "Load index with non existent synonyms set":


### PR DESCRIPTION
Add indices.delete to the two lenient:false cases so the broken 
shard is removed before cleanup's ensureNoInitializingShards. 

Closes #147907, #147908, #147909
