### PR TITLE
[9.4] [Inference API] Fix inference initialization thread exhaustion (#147063)

### DIFF
--- a/docs/changelog/147063.yaml
+++ b/docs/changelog/147063.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 147063
+summary: "[Inference API] Fix inference initialization thread exhaustion"
+type: bug

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSender.java
@@ -9,12 +9,16 @@ package org.elasticsearch.xpack.inference.external.http.sender;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
+import org.elasticsearch.action.support.ListenerTimeouts;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.RequestExecutor;
@@ -27,8 +31,6 @@ import org.elasticsearch.xpack.inference.services.ServiceComponents;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.xpack.inference.InferencePlugin.UTILITY_THREAD_POOL_NAME;
@@ -43,7 +45,6 @@ public class HttpRequestSender implements Sender {
      */
     public static class Factory {
         private final HttpRequestSender httpRequestSender;
-        private static final TimeValue START_COMPLETED_WAIT_TIME = TimeValue.timeValueSeconds(5);
 
         public Factory(ServiceComponents serviceComponents, HttpClientManager httpClientManager, ClusterService clusterService) {
             Objects.requireNonNull(serviceComponents);
@@ -57,25 +58,12 @@ public class HttpRequestSender implements Sender {
                 serviceComponents.threadPool()
             );
 
-            var startCompleted = new CountDownLatch(1);
             var executorServiceSettings = new RequestExecutorServiceSettings(serviceComponents.settings());
             executorServiceSettings.init(clusterService);
 
-            var service = new RequestExecutorService(
-                serviceComponents.threadPool(),
-                startCompleted,
-                executorServiceSettings,
-                requestSender
-            );
+            var service = new RequestExecutorService(serviceComponents.threadPool(), executorServiceSettings, requestSender);
 
-            httpRequestSender = new HttpRequestSender(
-                serviceComponents.threadPool(),
-                httpClientManager,
-                requestSender,
-                service,
-                startCompleted,
-                START_COMPLETED_WAIT_TIME
-            );
+            httpRequestSender = new HttpRequestSender(serviceComponents.threadPool(), httpClientManager, requestSender, service);
         }
 
         public Sender createSender() {
@@ -84,98 +72,90 @@ public class HttpRequestSender implements Sender {
     }
 
     private static final Logger logger = LogManager.getLogger(HttpRequestSender.class);
+    private static final TimeValue STARTUP_TIMEOUT = TimeValue.timeValueSeconds(5);
 
     private final ThreadPool threadPool;
     private final HttpClientManager manager;
     private final AtomicBoolean startInitiated = new AtomicBoolean(false);
-    private final AtomicBoolean startCompleted = new AtomicBoolean(false);
     private final RequestSender requestSender;
     private final RequestExecutor service;
-    private final CountDownLatch startCompletedLatch;
-    private final TimeValue startCompletedWaitTime;
+    private final SubscribableListener<Void> startupNotifier = new SubscribableListener<>();
 
     // Visible for testing
     protected HttpRequestSender(
         ThreadPool threadPool,
         HttpClientManager httpClientManager,
         RequestSender requestSender,
-        RequestExecutor service,
-        CountDownLatch startCompletedLatch,
-        TimeValue startCompletedWaitTime
+        RequestExecutor service
     ) {
         this.threadPool = Objects.requireNonNull(threadPool);
         this.manager = Objects.requireNonNull(httpClientManager);
         this.requestSender = Objects.requireNonNull(requestSender);
         this.service = Objects.requireNonNull(service);
-        this.startCompletedLatch = Objects.requireNonNull(startCompletedLatch);
-        this.startCompletedWaitTime = Objects.requireNonNull(startCompletedWaitTime);
     }
 
     /**
+     * This should only be called internally to the class or directly by tests.
      * Start various internal services asynchronously. This is required before sending requests.
+     * All callers (including concurrent ones) are notified via {@code listener} when startup completes
+     * or fails, without blocking any thread pool threads while waiting.
+     * <p>
+     * If {@code timeout} is non-null, the caller's listener is individually wrapped with that timeout.
+     * A per-caller timeout never poisons the shared startup state — subsequent callers can still
+     * succeed once startup completes. Only a real failure (e.g. {@code manager.start()} or
+     * {@code service.start()} throwing) permanently fails all pending listeners.
+     *
+     * @param timeout if non-null, the maximum time this specific caller will wait for startup;
+     *                other callers are unaffected if this caller's timeout fires.
      */
-    @Override
-    public void startAsynchronously(ActionListener<Void> listener) {
+    void startAsynchronously(ActionListener<Void> listener, @Nullable TimeValue timeout) {
         if (startInitiated.compareAndSet(false, true)) {
-            var preservedListener = ContextPreservingActionListener.wrapPreservingContext(listener, threadPool.getThreadContext());
-            threadPool.executor(UTILITY_THREAD_POOL_NAME).execute(() -> startInternal(preservedListener));
-        } else if (startCompleted.get() == false) {
-            var preservedListener = ContextPreservingActionListener.wrapPreservingContext(listener, threadPool.getThreadContext());
-            // wait on another thread so we don't potential block a transport thread
-            threadPool.executor(UTILITY_THREAD_POOL_NAME).execute(() -> waitForStartToCompleteWithListener(preservedListener));
-        } else {
-            listener.onResponse(null);
+            try {
+                threadPool.executor(UTILITY_THREAD_POOL_NAME).execute(this::startInternal);
+            } catch (Exception e) {
+                // Consider making this an error log because it's not recoverable
+                logger.warn("Failed to execute http sender start thread", e);
+                startupNotifier.onFailure(
+                    new ElasticsearchStatusException(
+                        "Failed to begin initializing inference components",
+                        RestStatus.INTERNAL_SERVER_ERROR,
+                        e
+                    )
+                );
+            }
         }
+        // Preserve context before wrapping with timeout so both the normal completion path and
+        // the timeout action restore the original thread context when notifying the caller.
+        var contextPreservedListener = ContextPreservingActionListener.wrapPreservingContext(listener, threadPool.getThreadContext());
+        var wrappedListener = timeout == null
+            ? contextPreservedListener
+            : ListenerTimeouts.wrapWithTimeout(
+                threadPool,
+                timeout,
+                threadPool.executor(UTILITY_THREAD_POOL_NAME),
+                contextPreservedListener,
+                ignored -> contextPreservedListener.onFailure(
+                    new ElasticsearchStatusException("Http sender startup did not complete in time", RestStatus.SERVICE_UNAVAILABLE)
+                )
+            );
+        // All callers — first and concurrent — register here. SubscribableListener fires immediately
+        // if startup is already done, otherwise queues the listener until startInternal completes.
+        startupNotifier.addListener(wrappedListener);
     }
 
-    private void startInternal(ActionListener<Void> listener) {
+    private void startInternal() {
         try {
             // The manager must be started before the executor service. That way we guarantee that the http client
             // is ready prior to the service attempting to use the http client to send a request
             manager.start();
-            threadPool.executor(UTILITY_THREAD_POOL_NAME).execute(service::start);
-            waitForStartToComplete();
-            startCompleted.set(true);
-            listener.onResponse(null);
-        } catch (Exception ex) {
-            listener.onFailure(ex);
-        }
-    }
-
-    private void waitForStartToCompleteWithListener(ActionListener<Void> listener) {
-        try {
-            waitForStartToComplete();
-            listener.onResponse(null);
+            service.start();
+            startupNotifier.onResponse(null);
         } catch (Exception e) {
-            listener.onFailure(e);
-        }
-    }
-
-    /**
-     * Start various internal services. This is required before sending requests.
-     *
-     * NOTE: This method blocks until the startup is complete.
-     */
-    @Override
-    public void startSynchronously() {
-        if (startInitiated.compareAndSet(false, true)) {
-            ActionListener<Void> listener = ActionListener.wrap(
-                unused -> {},
-                exception -> logger.error("Http sender failed to start", exception)
+            // Consider making this an error log because it's not recoverable
+            logger.warn("Failed to initialize http sender components", e);
+            startupNotifier.onFailure(
+                new ElasticsearchStatusException("Failed to initialize inference components", RestStatus.INTERNAL_SERVER_ERROR, e)
             );
-            startInternal(listener);
-        }
-        // Handle the case where start*() was already called and this would return immediately because the started flag is already true
-        waitForStartToComplete();
-    }
-
-    private void waitForStartToComplete() {
-        try {
-            if (startCompletedLatch.await(startCompletedWaitTime.getMillis(), TimeUnit.MILLISECONDS) == false) {
-                throw new IllegalStateException("Http sender startup did not complete in time");
-            }
-        } catch (InterruptedException e) {
-            throw new IllegalStateException("Http sender interrupted while waiting for startup to complete");
         }
     }
 
@@ -187,6 +167,7 @@ public class HttpRequestSender implements Sender {
 
     /**
      * Send a request at some point in the future. The timeout used is retrieved from the settings.
+     * Startup is initiated automatically if it has not already been started.
      *
      * @param requestCreator  a factory for creating a request to be sent to a 3rd party service
      * @param inferenceInputs the list of string input to send in the request
@@ -201,14 +182,15 @@ public class HttpRequestSender implements Sender {
         @Nullable TimeValue timeout,
         ActionListener<InferenceServiceResults> listener
     ) {
-        assert startInitiated.get() : "call start() before sending a request";
-        waitForStartToComplete();
-        service.execute(requestCreator, inferenceInputs, timeout, listener);
+        SubscribableListener.<Void>newForked(startListener -> startAsynchronously(startListener, STARTUP_TIMEOUT))
+            .<InferenceServiceResults>andThen(sendListener -> service.execute(requestCreator, inferenceInputs, timeout, sendListener))
+            .addListener(listener);
     }
 
     /**
      * This method sends a request and parses the response. It does not leverage any queuing or
      * rate limiting logic. This method should only be used for requests that are not sent often.
+     * Startup is initiated automatically if it has not already been started.
      *
      * @param logger          A logger to use for messages
      * @param request         A request to be sent
@@ -223,13 +205,15 @@ public class HttpRequestSender implements Sender {
         @Nullable TimeValue timeout,
         ActionListener<InferenceServiceResults> listener
     ) {
-        assert startInitiated.get() : "call start() before sending a request";
-        waitForStartToComplete();
-
-        var preservedListener = ContextPreservingActionListener.wrapPreservingContext(listener, threadPool.getThreadContext());
-        var timedListener = new TimedListener<>(timeout, preservedListener, threadPool, request.getInferenceEntityId());
-
-        threadPool.executor(UTILITY_THREAD_POOL_NAME)
-            .execute(() -> requestSender.send(logger, request, timedListener::hasCompleted, responseHandler, timedListener.getListener()));
+        SubscribableListener.<Void>newForked(startListener -> startAsynchronously(startListener, STARTUP_TIMEOUT))
+            .<InferenceServiceResults>andThen(sendListener -> {
+                var preservedListener = ContextPreservingActionListener.wrapPreservingContext(sendListener, threadPool.getThreadContext());
+                var timedListener = new TimedListener<>(timeout, preservedListener, threadPool, request.getInferenceEntityId());
+                threadPool.executor(UTILITY_THREAD_POOL_NAME)
+                    .execute(
+                        () -> requestSender.send(logger, request, timedListener::hasCompleted, responseHandler, timedListener.getListener())
+                    );
+            })
+            .addListener(listener);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
@@ -139,7 +139,11 @@ public class RequestExecutorService implements RequestExecutor {
     private final AdjustableCapacityBlockingQueue<RejectableTask> requestQueue;
     private volatile Future<?> requestQueueTask;
 
-    public RequestExecutorService(
+    public RequestExecutorService(ThreadPool threadPool, RequestExecutorServiceSettings settings, RequestSender requestSender) {
+        this(threadPool, null, settings, requestSender);
+    }
+
+    protected RequestExecutorService(
         ThreadPool threadPool,
         @Nullable CountDownLatch startupLatch,
         RequestExecutorServiceSettings settings,
@@ -148,7 +152,7 @@ public class RequestExecutorService implements RequestExecutor {
         this(threadPool, DEFAULT_QUEUE_CREATOR, startupLatch, settings, requestSender, Clock.systemUTC(), DEFAULT_RATE_LIMIT_CREATOR);
     }
 
-    public RequestExecutorService(
+    RequestExecutorService(
         ThreadPool threadPool,
         AdjustableCapacityBlockingQueue.QueueCreator<RejectableTask> queueCreator,
         @Nullable CountDownLatch startupLatch,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/Sender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/Sender.java
@@ -18,10 +18,9 @@ import org.elasticsearch.xpack.inference.external.request.Request;
 import java.io.Closeable;
 
 public interface Sender extends Closeable {
-    void startSynchronously();
-
-    void startAsynchronously(ActionListener<Void> listener);
-
+    /**
+     * Send the inference request to the inference service.
+     */
     void send(
         RequestManager requestCreator,
         InferenceInputs inferenceInputs,
@@ -29,6 +28,11 @@ public interface Sender extends Closeable {
         ActionListener<InferenceServiceResults> listener
     );
 
+    /**
+     * Send the inference request to the inference service without queuing.
+     * This should only be used for infrequent requests that should not be queued
+     * (e.g. {@link org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceAuthorizationRequest})
+     */
     void sendWithoutQueuing(
         Logger logger,
         Request request,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/SenderService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/SenderService.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.inference.services;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.core.IOUtils;
@@ -106,11 +105,13 @@ public abstract class SenderService<M extends Model> implements InferenceService
         @Nullable TimeValue timeout,
         ActionListener<InferenceServiceResults> listener
     ) {
-        SubscribableListener.newForked(this::init).<InferenceServiceResults>andThen((inferListener) -> {
+        try {
             var resolvedInferenceTimeout = ServiceUtils.resolveInferenceTimeout(timeout, inputType, clusterService);
             var inferenceInput = createInput(this, model, input, inputType, query, returnDocuments, topN, stream);
-            doInfer(model, inferenceInput, taskSettings, resolvedInferenceTimeout, inferListener);
-        }).addListener(listener);
+            doInfer(model, inferenceInput, taskSettings, resolvedInferenceTimeout, listener);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
     }
 
     public M parsePersistedConfig(UnparsedModel unparsedModel) {
@@ -195,12 +196,14 @@ public abstract class SenderService<M extends Model> implements InferenceService
         TimeValue timeout,
         ActionListener<InferenceServiceResults> listener
     ) {
-        SubscribableListener.newForked(this::init).<InferenceServiceResults>andThen((completionInferListener) -> {
+        try {
             if (supportsChatCompletionReasoning() == false && request.containsChatCompletionReasoning()) {
                 throwUnsupportedReasoningUnifiedCompletionOperation(name());
             }
-            doUnifiedCompletionInfer(model, new UnifiedChatInput(request, true), timeout, completionInferListener);
-        }).addListener(listener);
+            doUnifiedCompletionInfer(model, new UnifiedChatInput(request, true), timeout, listener);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
     }
 
     protected boolean supportsChatCompletionReasoning() {
@@ -209,13 +212,13 @@ public abstract class SenderService<M extends Model> implements InferenceService
 
     @Override
     public void embeddingInfer(Model model, EmbeddingRequest request, TimeValue timeout, ActionListener<InferenceServiceResults> listener) {
-        SubscribableListener.newForked(this::init).<InferenceServiceResults>andThen((embeddingInferListener) -> {
+        try {
             if (supportsMultipleItemsPerContent()) {
-                doEmbeddingInfer(model, request, timeout, embeddingInferListener);
+                doEmbeddingInfer(model, request, timeout, listener);
             } else {
                 var index = indexContainingMultipleInferenceStrings(request.inputs());
                 if (index == null) {
-                    doEmbeddingInfer(model, request, timeout, embeddingInferListener);
+                    doEmbeddingInfer(model, request, timeout, listener);
                 } else {
                     listener.onFailure(
                         new ElasticsearchStatusException(
@@ -232,7 +235,9 @@ public abstract class SenderService<M extends Model> implements InferenceService
                     );
                 }
             }
-        }).addListener(listener);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
     }
 
     /**
@@ -253,23 +258,25 @@ public abstract class SenderService<M extends Model> implements InferenceService
         TimeValue timeout,
         ActionListener<List<ChunkedInference>> listener
     ) {
-        SubscribableListener.newForked(this::init).<List<ChunkedInference>>andThen((chunkedInferListener) -> {
+        try {
             ValidationException validationException = new ValidationException();
             validateInputType(inputType, model, validationException);
             validationException.throwIfValidationErrorsExist();
             if (supportsChunkedInfer()) {
                 if (input.isEmpty()) {
-                    chunkedInferListener.onResponse(List.of());
+                    listener.onResponse(List.of());
                 } else {
                     // a non-null query is not supported and is dropped by all providers
-                    doChunkedInfer(model, input, taskSettings, inputType, timeout, chunkedInferListener);
+                    doChunkedInfer(model, input, taskSettings, inputType, timeout, listener);
                 }
             } else {
-                chunkedInferListener.onFailure(
+                listener.onFailure(
                     new UnsupportedOperationException(Strings.format("%s service does not support chunked inference", name()))
                 );
             }
-        }).addListener(listener);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
     }
 
     protected abstract void doInfer(
@@ -313,23 +320,9 @@ public abstract class SenderService<M extends Model> implements InferenceService
         return true;
     }
 
-    public void start(Model model, ActionListener<Boolean> listener) {
-        SubscribableListener.newForked(this::init)
-            .<Boolean>andThen((doStartListener) -> doStart(model, doStartListener))
-            .addListener(listener);
-    }
-
     @Override
-    public void start(Model model, @Nullable TimeValue unused, ActionListener<Boolean> listener) {
-        start(model, listener);
-    }
-
-    protected void doStart(Model model, ActionListener<Boolean> listener) {
-        listener.onResponse(true);
-    }
-
-    private void init(ActionListener<Void> listener) {
-        sender.startAsynchronously(listener);
+    public void start(Model model, @Nullable TimeValue timeout, ActionListener<Boolean> listener) {
+        listener.onResponse(Boolean.TRUE);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockRequestSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockRequestSender.java
@@ -100,14 +100,8 @@ public class AmazonBedrockRequestSender implements Sender {
         this.startCompleted = Objects.requireNonNull(startCompleted);
     }
 
-    @Override
-    public void startAsynchronously(ActionListener<Void> listener) {
-
-        throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
-    public void startSynchronously() {
+    // default for testing
+    void startSynchronously() {
         if (started.compareAndSet(false, true)) {
             // The manager must be started before the executor service. That way we guarantee that the http client
             // is ready prior to the service attempting to use the http client to send a request

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandler.java
@@ -164,8 +164,7 @@ public class ElasticInferenceServiceAuthorizationRequestHandler {
             authModelListener.onFailure(e);
         });
 
-        SubscribableListener.newForked(sender::startAsynchronously)
-            .andThen(authFactory::getAuthenticationApplier)
+        SubscribableListener.newForked(authFactory::getAuthenticationApplier)
             .<InferenceServiceResults>andThen((authListener, authApplier) -> {
                 var requestMetadata = extractRequestMetadataFromThreadContext(threadPool.getThreadContext());
                 var request = new ElasticInferenceServiceAuthorizationRequest(baseUrl, getCurrentTraceInfo(), requestMetadata, authApplier);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/Utils.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/Utils.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.when;
 public final class Utils {
 
     public static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(30);
+    private static final int MAX_THREADS = 4;
 
     private Utils() {
         throw new UnsupportedOperationException("Utils is a utility class and should not be instantiated");
@@ -74,11 +75,15 @@ public final class Utils {
     }
 
     public static ScalingExecutorBuilder[] inferenceUtilityExecutors() {
+        return inferenceUtilityExecutors(MAX_THREADS, MAX_THREADS);
+    }
+
+    public static ScalingExecutorBuilder[] inferenceUtilityExecutors(int maxUtilityThreads, int maxResponseThreads) {
         return new ScalingExecutorBuilder[] {
             new ScalingExecutorBuilder(
                 UTILITY_THREAD_POOL_NAME,
                 1,
-                4,
+                maxUtilityThreads,
                 TimeValue.timeValueMinutes(10),
                 false,
                 "xpack.inference.utility_thread_pool"
@@ -86,7 +91,7 @@ public final class Utils {
             new ScalingExecutorBuilder(
                 INFERENCE_RESPONSE_THREAD_POOL_NAME,
                 1,
-                4,
+                maxResponseThreads,
                 TimeValue.timeValueMinutes(10),
                 false,
                 "xpack.inference.inference_response_thread_pool"

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
@@ -9,8 +9,12 @@ package org.elasticsearch.xpack.inference.external.http.sender;
 
 import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
@@ -43,9 +47,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
@@ -70,10 +75,10 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class HttpRequestSenderTests extends ESTestCase {
-    private static final TimeValue TIMEOUT = new TimeValue(30, TimeUnit.SECONDS);
     private static final String INFERENCE_ID = "id";
     private static final TimeValue ONE_NANOSECOND = TimeValue.timeValueNanos(1);
 
@@ -81,6 +86,7 @@ public class HttpRequestSenderTests extends ESTestCase {
     private ThreadPool threadPool;
     private HttpClientManager clientManager;
     private final AtomicReference<Thread> threadRef = new AtomicReference<>();
+    private CountDownLatch blockStartLatch;
 
     @Before
     public void init() throws Exception {
@@ -88,12 +94,16 @@ public class HttpRequestSenderTests extends ESTestCase {
         threadPool = createThreadPool(inferenceUtilityExecutors());
         clientManager = HttpClientManager.create(Settings.EMPTY, threadPool, mockClusterServiceEmpty(), mock(ThrottlerManager.class));
         threadRef.set(null);
+        blockStartLatch = new CountDownLatch(1);
     }
 
     @After
     public void shutdown() throws IOException, InterruptedException {
+        // Unblock any service.start() calls blocked on blockStartLatch before terminating the pool
+        blockStartLatch.countDown();
+
         if (threadRef.get() != null) {
-            threadRef.get().join(TIMEOUT.millis());
+            threadRef.get().join(TEST_REQUEST_TIMEOUT.millis());
         }
 
         clientManager.close();
@@ -118,9 +128,9 @@ public class HttpRequestSenderTests extends ESTestCase {
         var senderFactory = new HttpRequestSender.Factory(createWithEmptySettings(threadPool), mockManager, mockClusterServiceEmpty());
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-            sender.startSynchronously();
-            sender.startSynchronously();
+            startSynchronously(sender);
+            startSynchronously(sender);
+            startSynchronously(sender);
         }
 
         verify(mockManager, times(1)).start();
@@ -135,7 +145,7 @@ public class HttpRequestSenderTests extends ESTestCase {
 
     public void testStart_ThrowsExceptionWaitingForStartToComplete_WhenAnErrorOccurs() throws IOException {
         var mockManager = createMockHttpClientManager();
-        doThrow(new Error("failed")).when(mockManager).start();
+        doThrow(new ElasticsearchException("failed")).when(mockManager).start();
 
         var senderFactory = new HttpRequestSender.Factory(
             ServiceComponentsTests.createWithEmptySettings(threadPool),
@@ -143,60 +153,118 @@ public class HttpRequestSenderTests extends ESTestCase {
             mockClusterServiceEmpty()
         );
 
-        try (var sender = senderFactory.createSender()) {
-            var exception = expectThrows(Error.class, sender::startSynchronously);
+        try (var sender = (HttpRequestSender) senderFactory.createSender()) {
+            var exception = expectThrows(ElasticsearchException.class, () -> startSynchronously(sender));
 
-            assertThat(exception.getMessage(), is("failed"));
+            assertThat(exception.getMessage(), is("Failed to initialize inference components"));
+            assertThat(exception.getCause().getMessage(), is("failed"));
         }
     }
 
-    public void testStart_ThrowsExceptionWaitingForStartToComplete() {
-        var mockManager = createMockHttpClientManager();
-        doThrow(new IllegalArgumentException("failed")).when(mockManager).start();
-
-        // Force the startup to never complete
-        var latch = new CountDownLatch(1);
-        var sender = new HttpRequestSender(
-            threadPool,
-            mockManager,
-            mock(RequestSender.class),
-            mock(RequestExecutor.class),
-            latch,
-            // Override the wait time so we don't block the test for too long
-            TimeValue.timeValueMillis(1)
-        );
-
-        var exception = expectThrows(IllegalStateException.class, sender::startSynchronously);
-
-        assertThat(exception.getMessage(), is("Http sender startup did not complete in time"));
+    private RequestExecutor createMockRequestExecutorThatBlocksOnStart() {
+        var mockService = mock(RequestExecutor.class);
+        doAnswer(invocation -> {
+            // Block service.start() to simulate a hung startup; blockStartLatch is counted down in @After
+            blockStartLatch.await();
+            return null;
+        }).when(mockService).start();
+        return mockService;
     }
 
-    public void testStartAsync_WaitsAsyncForStartToComplete_ThrowsWhenItTimesOut_ThenSucceeds() {
+    public void testStartAsync_ThrowsServiceUnavailableWhenStartupTimesOut() throws Exception {
         var mockManager = createMockHttpClientManager();
-        var latch = new CountDownLatch(1);
-        var sender = new HttpRequestSender(
-            threadPool,
-            mockManager,
-            mock(RequestSender.class),
-            mock(RequestExecutor.class),
-            latch,
-            // Override the wait time so we don't block the test for too long
-            TimeValue.timeValueMillis(1)
-        );
+
+        var mockService = createMockRequestExecutorThatBlocksOnStart();
+        var sender = new HttpRequestSender(threadPool, mockManager, mock(RequestSender.class), mockService);
 
         var listener = new PlainActionFuture<Void>();
-        sender.startAsynchronously(listener);
+        // Pass a very short timeout so the test doesn't hang
+        sender.startAsynchronously(listener, TimeValue.timeValueMillis(1));
 
-        var exception = expectThrows(IllegalStateException.class, () -> listener.actionGet(TIMEOUT));
+        var exception = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TEST_REQUEST_TIMEOUT));
         assertThat(exception.getMessage(), is("Http sender startup did not complete in time"));
+        assertThat(exception.status(), is(RestStatus.SERVICE_UNAVAILABLE));
+    }
 
-        // simulate the start completing
-        latch.countDown();
+    public void testStartAsync_PerCallerTimeoutDoesNotPoisonSharedState() {
+        var mockManager = createMockHttpClientManager();
 
-        var listenerCompleted = new PlainActionFuture<Void>();
-        sender.startAsynchronously(listenerCompleted);
-        assertNull(listenerCompleted.actionGet(TIMEOUT));
+        var mockService = createMockRequestExecutorThatBlocksOnStart();
+        var sender = new HttpRequestSender(threadPool, mockManager, mock(RequestSender.class), mockService);
 
+        // First caller times out — per-caller ListenerTimeouts fires, not the shared startupNotifier
+        var timedListener = new TestPlainActionFuture<Void>();
+        sender.startAsynchronously(timedListener, TimeValue.timeValueMillis(1));
+        var ex = expectThrows(ElasticsearchStatusException.class, () -> timedListener.actionGet(TEST_REQUEST_TIMEOUT));
+        assertThat(ex.getMessage(), is("Http sender startup did not complete in time"));
+        assertThat(ex.status(), is(RestStatus.SERVICE_UNAVAILABLE));
+
+        // Second caller with no timeout should get notified when startup completes, not get a timeout from the first caller's timeout
+        var noTimeoutListener = new TestPlainActionFuture<Void>();
+        sender.startAsynchronously(noTimeoutListener, null);
+
+        // Unblock startup so startupNotifier resolves successfully
+        blockStartLatch.countDown();
+
+        // The second caller should succeed, indicating that the first caller's timeout did not poison the shared startup state
+        assertNull(noTimeoutListener.actionGet(TEST_REQUEST_TIMEOUT));
+
+        // Third caller with no timeout should succeed after the shared startup state is successfully resolved
+        var successListener = new TestPlainActionFuture<Void>();
+        sender.startAsynchronously(successListener, null);
+        assertNull(successListener.actionGet(TEST_REQUEST_TIMEOUT));
+        verify(mockManager, times(1)).start();
+    }
+
+    public void testStartAsync_LateListenerGetsImmediateNotification() {
+        var mockManager = createMockHttpClientManager();
+        var sender = new HttpRequestSender(threadPool, mockManager, mock(RequestSender.class), mock(RequestExecutor.class));
+
+        startSynchronously(sender);  // startup completes, startupNotifier already resolved
+        verify(mockManager, times(1)).start();
+
+        // Listener registered after startup completes should be notified immediately
+        var listener = new TestPlainActionFuture<Void>();
+        sender.startAsynchronously(listener, null);
+        assertNull(listener.actionGet(TEST_REQUEST_TIMEOUT));
+        verifyNoMoreInteractions(mockManager);
+    }
+
+    public void testConcurrentStartAsync_AllListenersReceiveFailure() throws InterruptedException {
+        var mockManager = createMockHttpClientManager();
+        doAnswer(invocation -> {
+            blockStartLatch.await();
+            throw new ElasticsearchException("failed");
+        }).when(mockManager).start();
+        var sender = new HttpRequestSender(threadPool, mockManager, mock(RequestSender.class), mock(RequestExecutor.class));
+
+        final var threadCount = between(4, 8);
+        final var barrier = new CyclicBarrier(threadCount);
+        final var threads = new ArrayList<Thread>();
+        final var futures = new ArrayList<TestPlainActionFuture<Void>>();
+
+        for (int i = 0; i < threadCount; i++) {
+            final var future = new TestPlainActionFuture<Void>();
+            futures.add(future);
+            threads.add(new Thread(() -> {
+                safeAwait(barrier);
+                sender.startAsynchronously(future, null);
+            }));
+        }
+
+        for (var thread : threads) {
+            thread.start();
+        }
+        blockStartLatch.countDown();  // unblock → manager.start() throws → startupNotifier.onFailure
+        for (var thread : threads) {
+            thread.join(TEST_REQUEST_TIMEOUT.millis());
+        }
+
+        for (var future : futures) {
+            var exception = expectThrows(ElasticsearchException.class, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+            assertThat(exception.getMessage(), is("Failed to initialize inference components"));
+            assertThat(exception.getCause().getMessage(), is("failed"));
+        }
         verify(mockManager, times(1)).start();
     }
 
@@ -211,12 +279,12 @@ public class HttpRequestSenderTests extends ESTestCase {
             for (int i = 0; i < asyncCalls; i++) {
                 PlainActionFuture<Void> listener = new PlainActionFuture<>();
                 listenerList.add(listener);
-                sender.startAsynchronously(listener);
+                sender.startAsynchronously(listener, null);
             }
 
             for (int i = 0; i < asyncCalls; i++) {
                 PlainActionFuture<Void> listener = listenerList.get(i);
-                assertNull(listener.actionGet(TIMEOUT));
+                assertNull(listener.actionGet(TEST_REQUEST_TIMEOUT));
             }
         }
 
@@ -234,13 +302,13 @@ public class HttpRequestSenderTests extends ESTestCase {
             for (int i = 0; i < asyncCalls; i++) {
                 PlainActionFuture<Void> listener = new PlainActionFuture<>();
                 listenerList.add(listener);
-                sender.startAsynchronously(listener);
-                sender.startSynchronously();
+                sender.startAsynchronously(listener, null);
+                startSynchronously(sender);
             }
 
             for (int i = 0; i < asyncCalls; i++) {
                 PlainActionFuture<Void> listener = listenerList.get(i);
-                assertNull(listener.actionGet(TIMEOUT));
+                assertNull(listener.actionGet(TEST_REQUEST_TIMEOUT));
             }
         }
 
@@ -251,8 +319,6 @@ public class HttpRequestSenderTests extends ESTestCase {
         var senderFactory = new HttpRequestSender.Factory(createWithEmptySettings(threadPool), clientManager, mockClusterServiceEmpty());
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",
@@ -283,7 +349,7 @@ public class HttpRequestSenderTests extends ESTestCase {
                 listener
             );
 
-            var result = listener.actionGet(TIMEOUT);
+            var result = listener.actionGet(TEST_REQUEST_TIMEOUT);
             assertThat(result.asMap(), is(buildExpectationFloat(List.of(new float[] { 0.0123F, -0.0123F }))));
 
             assertThat(webServer.requests(), hasSize(1));
@@ -303,8 +369,6 @@ public class HttpRequestSenderTests extends ESTestCase {
         var senderFactory = createSenderFactory(clientManager, threadRef);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             var url = getUrl(webServer);
             var elserResponse = getEisElserAuthorizationResponse(url);
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(elserResponse.responseJson()));
@@ -323,32 +387,10 @@ public class HttpRequestSenderTests extends ESTestCase {
 
             sender.sendWithoutQueuing(mock(Logger.class), request, responseHandler, null, listener);
 
-            var result = listener.actionGet(TIMEOUT);
+            var result = listener.actionGet(TEST_REQUEST_TIMEOUT);
             assertThat(result, instanceOf(ElasticInferenceServiceAuthorizationResponseEntity.class));
             var authResponse = (ElasticInferenceServiceAuthorizationResponseEntity) result;
             assertThat(authResponse.authorizedEndpoints(), is(elserResponse.responseEntity().authorizedEndpoints()));
-        }
-    }
-
-    public void testHttpRequestSender_Throws_WhenCallingSendBeforeStart() throws Exception {
-        var senderFactory = new HttpRequestSender.Factory(
-            ServiceComponentsTests.createWithEmptySettings(threadPool),
-            clientManager,
-            mockClusterServiceEmpty()
-        );
-
-        try (var sender = senderFactory.createSender()) {
-            PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
-            var thrownException = expectThrows(
-                AssertionError.class,
-                () -> sender.send(
-                    RequestManagerTests.createMockWithRateLimitingEnabled(),
-                    new EmbeddingsInput(List.of(), null),
-                    null,
-                    listener
-                )
-            );
-            assertThat(thrownException.getMessage(), is("call start() before sending a request"));
         }
     }
 
@@ -363,7 +405,6 @@ public class HttpRequestSenderTests extends ESTestCase {
 
         try (var sender = senderFactory.createSender()) {
             assertThat(sender, instanceOf(HttpRequestSender.class));
-            sender.startSynchronously();
 
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
             sender.send(
@@ -373,7 +414,7 @@ public class HttpRequestSenderTests extends ESTestCase {
                 listener
             );
 
-            var thrownException = expectThrows(ElasticsearchTimeoutException.class, () -> listener.actionGet(TIMEOUT));
+            var thrownException = expectThrows(ElasticsearchTimeoutException.class, () -> listener.actionGet(TEST_REQUEST_TIMEOUT));
 
             assertThat(
                 thrownException.getMessage(),
@@ -393,14 +434,12 @@ public class HttpRequestSenderTests extends ESTestCase {
         );
 
         try (var sender = senderFactory.createSender()) {
-            sender.startSynchronously();
-
             var request = mock(Request.class);
             when(request.getInferenceEntityId()).thenReturn(INFERENCE_ID);
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
             sender.sendWithoutQueuing(mock(Logger.class), request, mock(ResponseHandler.class), TimeValue.timeValueNanos(1), listener);
 
-            var thrownException = expectThrows(ElasticsearchTimeoutException.class, () -> listener.actionGet(TIMEOUT));
+            var thrownException = expectThrows(ElasticsearchTimeoutException.class, () -> listener.actionGet(TEST_REQUEST_TIMEOUT));
 
             assertThat(
                 thrownException.getMessage(),
@@ -408,6 +447,84 @@ public class HttpRequestSenderTests extends ESTestCase {
             );
             assertThat(thrownException.status(), is(RestStatus.TOO_MANY_REQUESTS));
         }
+    }
+
+    public void testConcurrentSend_OnlyStartsOnce() throws Exception {
+        // At a minimum we need 1 for the startAsynchronously to kick off the init tasks, and allowing 1 more to allow for a race to occur
+        final var maxUtilityThreads = 2;
+        final var maxResponseThreads = 2;
+        try (var smallThreadPool = createThreadPool(inferenceUtilityExecutors(maxUtilityThreads, maxResponseThreads))) {
+            var mockManager = createMockHttpClientManager();
+            var mockService = mock(RequestExecutor.class);
+            doAnswer(invocation -> {
+                ActionListener<InferenceServiceResults> listener = invocation.getArgument(3);
+                listener.onFailure(new ElasticsearchStatusException("test", RestStatus.SERVICE_UNAVAILABLE));
+                return null;
+            }).when(mockService).execute(any(), any(), any(), any());
+            var sender = new HttpRequestSender(smallThreadPool, mockManager, mock(RequestSender.class), mockService);
+
+            runConcurrentSendTest(mockManager, maxUtilityThreads, (barrier, future) -> new Thread(() -> {
+                safeAwait(barrier);
+                sender.send(
+                    RequestManagerTests.createMockWithRateLimitingEnabled(),
+                    new EmbeddingsInput(List.of(), null),
+                    TimeValue.timeValueNanos(1),
+                    future
+                );
+            }), ElasticsearchStatusException.class);
+        }
+    }
+
+    public void testConcurrentSendWithoutQueuing_OnlyStartsOnce() throws Exception {
+        // At a minimum we need 1 for the startAsynchronously to kick off the init tasks, and allowing 1 more to allow for a race to occur
+        final var maxUtilityThreads = 2;
+        final var maxResponseThreads = 2;
+        try (var smallThreadPool = createThreadPool(inferenceUtilityExecutors(maxUtilityThreads, maxResponseThreads))) {
+            var mockManager = createMockHttpClientManager();
+            var sender = new HttpRequestSender(smallThreadPool, mockManager, mock(RequestSender.class), mock(RequestExecutor.class));
+
+            runConcurrentSendTest(mockManager, maxUtilityThreads, (barrier, future) -> {
+                var request = mock(Request.class);
+                when(request.getInferenceEntityId()).thenReturn(INFERENCE_ID);
+                return new Thread(() -> {
+                    safeAwait(barrier);
+                    sender.sendWithoutQueuing(mock(Logger.class), request, mock(ResponseHandler.class), ONE_NANOSECOND, future);
+                });
+            }, ElasticsearchTimeoutException.class);
+        }
+    }
+
+    private <E extends Exception> void runConcurrentSendTest(
+        HttpClientManager mockManager,
+        int maxUtilityThreads,
+        BiFunction<CyclicBarrier, PlainActionFuture<InferenceServiceResults>, Thread> threadFactory,
+        Class<E> expectedExceptionClass
+    ) throws InterruptedException {
+        // Use more threads than the utility thread pool size
+        final var threadCountMinimum = maxUtilityThreads + 2;
+        final var threadCount = between(threadCountMinimum, threadCountMinimum + 5);
+        final var barrier = new CyclicBarrier(threadCount);
+        final var threads = new ArrayList<Thread>();
+        final var futures = new ArrayList<PlainActionFuture<InferenceServiceResults>>();
+
+        for (int i = 0; i < threadCount; i++) {
+            final var future = new PlainActionFuture<InferenceServiceResults>();
+            futures.add(future);
+            threads.add(threadFactory.apply(barrier, future));
+        }
+
+        for (var thread : threads) {
+            thread.start();
+        }
+        for (var thread : threads) {
+            thread.join(TEST_REQUEST_TIMEOUT.millis());
+        }
+
+        for (var future : futures) {
+            expectThrows(expectedExceptionClass, () -> future.actionGet(TEST_REQUEST_TIMEOUT));
+        }
+
+        verify(mockManager, times(1)).start();
     }
 
     private static HttpRequestSender.Factory createSenderFactory(HttpClientManager clientManager, AtomicReference<Thread> threadRef) {
@@ -453,7 +570,19 @@ public class HttpRequestSenderTests extends ESTestCase {
         );
     }
 
-    public static Sender createSender(HttpRequestSender.Factory factory) {
-        return factory.createSender();
+    public static HttpRequestSender createSender(HttpRequestSender.Factory factory) {
+        return (HttpRequestSender) factory.createSender();
+    }
+
+    private static void startSynchronously(HttpRequestSender sender) {
+        startSynchronously(sender, TEST_REQUEST_TIMEOUT);
+    }
+
+    private static void startSynchronously(HttpRequestSender sender, TimeValue timeout) {
+        var listener = new TestPlainActionFuture<Void>();
+        sender.startAsynchronously(listener, timeout);
+        // Intentionally using a test timeout. That way a short timeout can be passed to startAsynchronously
+        // to test a valid timeout scenario without the actionGet() accidentally completing first.
+        listener.actionGet(TEST_REQUEST_TIMEOUT);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ChatCompletionActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ChatCompletionActionTests.java
@@ -108,8 +108,6 @@ public abstract class ChatCompletionActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(getResponseJson()));
 
             var action = createAction(getUrl(webServer), sender);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/SenderServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/SenderServiceTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.inference.services;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.settings.Settings;
@@ -58,8 +59,6 @@ import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -81,18 +80,13 @@ public class SenderServiceTests extends ESTestCase {
         terminate(threadPool);
     }
 
-    public void testStart_InitializesTheSender() throws IOException {
+    public void testSenderServiceConstructor_CreatesASender() throws IOException {
         var sender = createMockSender();
 
         var factory = mock(HttpRequestSender.Factory.class);
         when(factory.createSender()).thenReturn(sender);
 
-        try (var service = new TestSenderService(factory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
-            PlainActionFuture<Boolean> listener = new PlainActionFuture<>();
-            service.start(mock(Model.class), listener);
-
-            listener.actionGet(TIMEOUT);
-            verify(sender, times(1)).startAsynchronously(any());
+        try (var ignored = new TestSenderService(factory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
             verify(factory, times(1)).createSender();
         }
 
@@ -101,23 +95,22 @@ public class SenderServiceTests extends ESTestCase {
         verifyNoMoreInteractions(sender);
     }
 
-    public void testStart_CallingStartTwiceKeepsSameSenderReference() throws IOException {
+    public void testStart_ReturnsTrue() throws IOException {
         var sender = createMockSender();
 
         var factory = mock(HttpRequestSender.Factory.class);
         when(factory.createSender()).thenReturn(sender);
 
         try (var service = new TestSenderService(factory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
-            PlainActionFuture<Boolean> listener = new PlainActionFuture<>();
-            service.start(mock(Model.class), listener);
-            listener.actionGet(TIMEOUT);
-
-            PlainActionFuture<Boolean> listener2 = new PlainActionFuture<>();
-            service.start(mock(Model.class), listener2);
-            listener2.actionGet(TIMEOUT);
-
             verify(factory, times(1)).createSender();
-            verify(sender, times(2)).startAsynchronously(any());
+
+            var listener = new TestPlainActionFuture<Boolean>();
+            service.start(mock(Model.class), null, listener);
+            assertTrue(listener.actionGet(TIMEOUT));
+
+            var listener2 = new TestPlainActionFuture<Boolean>();
+            service.start(mock(Model.class), null, listener2);
+            assertTrue(listener2.actionGet(TIMEOUT));
         }
 
         verify(sender, times(1)).close();
@@ -355,14 +348,7 @@ public class SenderServiceTests extends ESTestCase {
     }
 
     public static Sender createMockSender() {
-        var sender = mock(Sender.class);
-        doAnswer(invocationOnMock -> {
-            ActionListener<Void> listener = invocationOnMock.getArgument(0);
-            listener.onResponse(null);
-            return Void.TYPE;
-        }).when(sender).startAsynchronously(any());
-
-        return sender;
+        return mock(Sender.class);
     }
 
     private static class TestSenderService extends SenderService<Model> {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ai21/action/Ai21ActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ai21/action/Ai21ActionCreatorTests.java
@@ -73,8 +73,6 @@ public class Ai21ActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "id": "chatcmpl-37a38daa-ffdc-44df-cade-49098f9def8a",
@@ -117,8 +115,6 @@ public class Ai21ActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "invalid_field": "unexpected"

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
@@ -94,7 +94,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -1104,7 +1103,6 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
         verify(sender, times(1)).close();
         verifyNoMoreInteractions(factory);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockMockRequestSender.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockMockRequestSender.java
@@ -66,16 +66,6 @@ public class AmazonBedrockMockRequestSender implements Sender {
     }
 
     @Override
-    public void startSynchronously() {
-        // do nothing
-    }
-
-    @Override
-    public void startAsynchronously(ActionListener<Void> listener) {
-        throw new UnsupportedOperationException("not supported");
-    }
-
-    @Override
     public void send(
         RequestManager requestCreator,
         InferenceInputs inferenceInputs,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockRequestSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockRequestSenderTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.inference.external.http.sender.ChatCompletionInput;
 import org.elasticsearch.xpack.inference.external.http.sender.EmbeddingsInput;
-import org.elasticsearch.xpack.inference.external.http.sender.Sender;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 import org.elasticsearch.xpack.inference.services.ServiceComponentsTests;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockCompletionRequestManager;
@@ -155,7 +154,7 @@ public class AmazonBedrockRequestSenderTests extends ESTestCase {
         );
     }
 
-    public static Sender createSender(AmazonBedrockRequestSender.Factory factory) {
-        return factory.createSender();
+    public static AmazonBedrockRequestSender createSender(AmazonBedrockRequestSender.Factory factory) {
+        return (AmazonBedrockRequestSender) factory.createSender();
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
@@ -74,7 +74,6 @@ import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.
 import static org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettingsTests.getSecretSettingsMap;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -488,7 +487,6 @@ public class AnthropicServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/action/AnthropicActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/action/AnthropicActionCreatorTests.java
@@ -72,8 +72,6 @@ public class AnthropicActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "id": "msg_01XzZQmG41BMGe5NZ5p2vEWb",
@@ -138,8 +136,6 @@ public class AnthropicActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "id": "msg_01XzZQmG41BMGe5NZ5p2vEWb",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/action/AnthropicChatCompletionActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/action/AnthropicChatCompletionActionTests.java
@@ -84,8 +84,6 @@ public class AnthropicChatCompletionActionTests extends ESTestCase {
         var senderFactory = new HttpRequestSender.Factory(createWithEmptySettings(threadPool), clientManager, mockClusterServiceEmpty());
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "id": "msg_01XzZQmG41BMGe5NZ5p2vEWb",
@@ -193,8 +191,6 @@ public class AnthropicChatCompletionActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "id": "msg_01XzZQmG41BMGe5NZ5p2vEWb",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioServiceTests.java
@@ -97,7 +97,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -1269,7 +1268,6 @@ public class AzureAiStudioServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -1308,7 +1306,6 @@ public class AzureAiStudioServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/action/AzureAiStudioActionAndCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/action/AzureAiStudioActionAndCreatorTests.java
@@ -90,8 +90,6 @@ public class AzureAiStudioActionAndCreatorTests extends ESTestCase {
         final var serviceComponents = getServiceComponents();
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(testEmbeddingsTokenResponseJson));
 
             final var model = AzureAiStudioEmbeddingsModelTests.createModel(
@@ -129,8 +127,6 @@ public class AzureAiStudioActionAndCreatorTests extends ESTestCase {
         final var serviceComponents = getServiceComponents();
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(testCompletionTokenResponseJson));
             final var webserverUrl = getUrl(webServer);
             final var model = AzureAiStudioChatCompletionModelTests.createModel(
@@ -166,8 +162,6 @@ public class AzureAiStudioActionAndCreatorTests extends ESTestCase {
         final var serviceComponents = getServiceComponents();
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(testRerankTokenResponseJson));
             final var webserverUrl = getUrl(webServer);
             final var model = AzureAiStudioRerankModelTests.createModel(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
@@ -109,7 +109,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.isA;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -1018,7 +1017,6 @@ public class AzureOpenAiServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/action/AzureOpenAiActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/action/AzureOpenAiActionCreatorTests.java
@@ -87,8 +87,6 @@ public class AzureOpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",
@@ -138,8 +136,6 @@ public class AzureOpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",
@@ -190,8 +186,6 @@ public class AzureOpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, ZERO_TIMEOUT_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",
@@ -246,8 +240,6 @@ public class AzureOpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             // note - there is no complete documentation on Azure's error messages
             // but this error and response has been verified manually via CURL
             var contentTooLargeErrorMessage =
@@ -323,8 +315,6 @@ public class AzureOpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             // note - there is no complete documentation on Azure's error messages
             // but this error and response has been verified manually via CURL
             var contentTooLargeErrorMessage =
@@ -400,8 +390,6 @@ public class AzureOpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",
@@ -452,8 +440,6 @@ public class AzureOpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "choices": [
@@ -510,8 +496,6 @@ public class AzureOpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "choices": [
@@ -566,8 +550,6 @@ public class AzureOpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, ZERO_TIMEOUT_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             // "choices" missing
             String responseJson = """
                 {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/action/AzureOpenAiCompletionActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/action/AzureOpenAiCompletionActionTests.java
@@ -81,8 +81,6 @@ public class AzureOpenAiCompletionActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "choices": [

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/action/AzureOpenAiEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/action/AzureOpenAiEmbeddingsActionTests.java
@@ -88,8 +88,6 @@ public class AzureOpenAiEmbeddingsActionTests extends ESTestCase {
         );
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
@@ -101,7 +101,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -857,7 +856,6 @@ public class CohereServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereActionCreatorTests.java
@@ -76,8 +76,6 @@ public class CohereActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "id": "de37399c-5df6-47cb-bc57-e3c5680c977b",
@@ -157,8 +155,6 @@ public class CohereActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                      "response_id": "some id",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereCompletionActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereCompletionActionTests.java
@@ -79,8 +79,6 @@ public class CohereCompletionActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = HttpRequestSenderTests.createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                      "response_id": "some id",
@@ -232,8 +230,6 @@ public class CohereCompletionActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = HttpRequestSenderTests.createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                      "response_id": "some id",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereEmbeddingsActionTests.java
@@ -84,8 +84,6 @@ public class CohereEmbeddingsActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = HttpRequestSenderTests.createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "id": "de37399c-5df6-47cb-bc57-e3c5680c977b",
@@ -168,8 +166,6 @@ public class CohereEmbeddingsActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = HttpRequestSenderTests.createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "id": "de37399c-5df6-47cb-bc57-e3c5680c977b",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -120,7 +120,6 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isA;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -580,7 +579,6 @@ public class ElasticInferenceServiceTests extends ESTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -650,7 +648,6 @@ public class ElasticInferenceServiceTests extends ESTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/action/ElasticInferenceServiceActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/action/ElasticInferenceServiceActionCreatorTests.java
@@ -90,8 +90,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "data": [
@@ -156,8 +154,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "data": [
@@ -236,8 +232,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             // This will fail because the expected output is {"data": [{...}]}
             String responseJson = """
                 {
@@ -283,8 +277,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "results": [
@@ -352,8 +344,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "results": [
@@ -420,8 +410,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "data": [
@@ -479,8 +467,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "data": [
@@ -539,8 +525,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "data": [
@@ -595,8 +579,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             // This will fail because the expected output is {"data": [[...]]}
             String responseJson = """
                 {
@@ -639,8 +621,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "data": []
@@ -673,8 +653,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJsonContentTooLarge = """
                 {
                     "error": "Input validation error: `input` must have less than 512 tokens. Given: 571",
@@ -743,8 +721,6 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "data": [

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
@@ -90,7 +90,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -724,7 +723,6 @@ public class GoogleAiStudioServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -763,7 +761,6 @@ public class GoogleAiStudioServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/action/GoogleAiStudioCompletionActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/action/GoogleAiStudioCompletionActionTests.java
@@ -78,8 +78,6 @@ public class GoogleAiStudioCompletionActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = HttpRequestSenderTests.createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "candidates": [
@@ -203,8 +201,6 @@ public class GoogleAiStudioCompletionActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = HttpRequestSenderTests.createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "candidates": [

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/action/GoogleAiStudioEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/action/GoogleAiStudioEmbeddingsActionTests.java
@@ -87,8 +87,6 @@ public class GoogleAiStudioEmbeddingsActionTests extends ESTestCase {
         var senderFactory = new HttpRequestSender.Factory(createWithEmptySettings(threadPool), clientManager, mockClusterServiceEmpty());
 
         try (var sender = senderFactory.createSender()) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "embeddings": [

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/groq/action/GroqActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/groq/action/GroqActionCreatorTests.java
@@ -85,8 +85,6 @@ public class GroqActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (Sender sender = HttpRequestSenderTests.createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "id": "chatcmpl-123",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceBaseServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceBaseServiceTests.java
@@ -32,7 +32,6 @@ import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.services.SenderServiceTests.createMockSender;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
 import static org.hamcrest.CoreMatchers.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -84,7 +83,6 @@ public class HuggingFaceBaseServiceTests extends ESTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
@@ -101,7 +101,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.isA;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -292,7 +291,6 @@ public class HuggingFaceServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/action/HuggingFaceActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/action/HuggingFaceActionCreatorTests.java
@@ -84,8 +84,6 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 [
                     {
@@ -144,8 +142,6 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 [
                   {
@@ -204,8 +200,6 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "embeddings": [
@@ -263,8 +257,6 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             // this will fail because the only valid formats are {"embeddings": [[...]]} or [[...]]
             String responseJson = """
                 [
@@ -325,8 +317,6 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "rerank": [
@@ -384,8 +374,6 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJsonContentTooLarge = """
                 {
                     "error": "Input validation error: `inputs` must have less than 512 tokens. Given: 571",
@@ -456,8 +444,6 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "embeddings": [
@@ -509,8 +495,6 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                      "object": "chat.completion",
@@ -557,8 +541,6 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "invalid_field": "unexpected"

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/action/HuggingFaceChatCompletionActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/action/HuggingFaceChatCompletionActionTests.java
@@ -86,8 +86,6 @@ public class HuggingFaceChatCompletionActionTests extends ESTestCase {
         var senderFactory = new HttpRequestSender.Factory(createWithEmptySettings(threadPool), clientManager, mockClusterServiceEmpty());
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "id": "chatcmpl-123",
@@ -186,8 +184,6 @@ public class HuggingFaceChatCompletionActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "id": "chatcmpl-123",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
@@ -98,7 +98,6 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -654,7 +653,6 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -700,7 +698,6 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/action/IbmWatsonxEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/action/IbmWatsonxEmbeddingsActionTests.java
@@ -92,8 +92,6 @@ public class IbmWatsonxEmbeddingsActionTests extends ESTestCase {
         var senderFactory = new HttpRequestSender.Factory(createWithEmptySettings(threadPool), clientManager, mockClusterServiceEmpty());
 
         try (var sender = senderFactory.createSender()) {
-            sender.startSynchronously();
-
             String responseJson = """
                     {
                         "results": [

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
@@ -120,7 +120,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -1018,7 +1017,6 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/llama/action/LlamaActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/llama/action/LlamaActionCreatorTests.java
@@ -80,8 +80,6 @@ public class LlamaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "embeddings": [
@@ -116,8 +114,6 @@ public class LlamaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 [
                     {
@@ -148,8 +144,6 @@ public class LlamaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "id": "chatcmpl-03e70a75-efb6-447d-b661-e5ed0bd59ce9",
@@ -204,8 +198,6 @@ public class LlamaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "invalid_field": "unexpected"

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
@@ -103,7 +103,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.isA;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -283,7 +282,6 @@ public class MistralServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -1042,7 +1040,6 @@ public class MistralServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -1081,7 +1078,6 @@ public class MistralServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/action/MistralActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/action/MistralActionCreatorTests.java
@@ -73,8 +73,6 @@ public class MistralActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                      "object": "chat.completion",
@@ -121,8 +119,6 @@ public class MistralActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "invalid_field": "unexpected"

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/action/MistralChatCompletionActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/action/MistralChatCompletionActionTests.java
@@ -48,8 +48,6 @@ public class MistralChatCompletionActionTests extends ChatCompletionActionTests 
         var senderFactory = new HttpRequestSender.Factory(createWithEmptySettings(threadPool), clientManager, mockClusterServiceEmpty());
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(getResponseJson()));
 
             var action = createAction(getUrl(webServer), sender);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/action/NvidiaActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/nvidia/action/NvidiaActionCreatorTests.java
@@ -190,8 +190,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EMBEDDING_RESPONSE_JSON));
 
             var model = NvidiaEmbeddingsModelTests.createEmbeddingsModel(
@@ -221,8 +219,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EMBEDDING_RESPONSE_JSON));
 
             var model = NvidiaEmbeddingsModelTests.createEmbeddingsModel(
@@ -252,8 +248,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EMBEDDING_RESPONSE_JSON));
 
             var model = NvidiaEmbeddingsModelTests.createEmbeddingsModel(
@@ -286,8 +280,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EMBEDDING_RESPONSE_JSON));
 
             var model = NvidiaEmbeddingsModelTests.createEmbeddingsModel(
@@ -321,8 +313,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EMBEDDING_RESPONSE_JSON));
 
             var model = NvidiaEmbeddingsModelTests.createEmbeddingsModel(
@@ -356,8 +346,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EMBEDDING_RESPONSE_JSON));
 
             var model = NvidiaEmbeddingsModelTests.createEmbeddingsModel(
@@ -413,8 +401,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "object": "list",
@@ -481,8 +467,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = Strings.format(CHAT_COMPLETION_RESPONSE_JSON, MODEL_VALUE, COMPLETION_RESULT_VALUE);
 
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
@@ -516,8 +500,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(413).setBody(INPUT_IS_TOO_LONG_ERROR_MESSAGE));
 
             var model = NvidiaChatCompletionModelTests.createCompletionModel(getUrl(webServer), API_KEY_VALUE, MODEL_VALUE);
@@ -539,8 +521,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJsonContentTooLarge = """
                     {
                         "error": "Please reduce your prompt; or completion length."
@@ -568,8 +548,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = Strings.format("""
                 {
                     "id": "cmpl-ef780b96e82d46ceb1e45ee4188913bc",
@@ -625,8 +603,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(413).setBody(INPUT_IS_TOO_LONG_ERROR_MESSAGE));
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EMBEDDING_RESPONSE_JSON));
 
@@ -677,8 +653,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJsonContentTooLarge = """
                     {
                         "error": "Input length 18432 exceeds maximum allowed token size 8192"
@@ -733,8 +707,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EMBEDDING_RESPONSE_JSON));
 
             // truncated to 1 token = 3 characters
@@ -774,8 +746,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "rankings": [
@@ -824,8 +794,6 @@ public class NvidiaActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "not_rankings": [

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
@@ -111,8 +111,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.isA;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -429,7 +427,6 @@ public class OpenAiServiceTests extends AbstractInferenceServiceTests {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -468,7 +465,6 @@ public class OpenAiServiceTests extends AbstractInferenceServiceTests {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -509,7 +505,6 @@ public class OpenAiServiceTests extends AbstractInferenceServiceTests {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -552,7 +547,6 @@ public class OpenAiServiceTests extends AbstractInferenceServiceTests {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -621,11 +615,6 @@ public class OpenAiServiceTests extends AbstractInferenceServiceTests {
 
     public void testInfer_ReturnsErrorWhenCallingInfer_WithChatCompletion() throws IOException {
         var sender = mock(HttpRequestSender.class);
-        doAnswer(invocation -> {
-            ActionListener<Void> listener = invocation.getArgument(0);
-            listener.onResponse(null);
-            return Void.TYPE;
-        }).when(sender).startAsynchronously(any());
 
         var s = mock(HttpRequestSender.Factory.class);
         when(s.createSender()).thenReturn(sender);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/action/OpenAiActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/action/OpenAiActionCreatorTests.java
@@ -78,8 +78,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",
@@ -135,8 +133,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",
@@ -191,8 +187,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",
@@ -254,8 +248,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",
@@ -316,8 +308,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "id": "chatcmpl-123",
@@ -380,8 +370,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "id": "chatcmpl-123",
@@ -443,8 +431,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "id": "chatcmpl-123",
@@ -513,8 +499,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, settings);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "id": "chatcmpl-123",
@@ -578,8 +562,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             var contentTooLargeErrorMessage =
                 "This model's maximum context length is 8192 tokens, however you requested 13531 tokens (13531 in your prompt;"
                     + "0 for the completion). Please reduce your prompt; or completion length.";
@@ -665,8 +647,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             var contentTooLargeErrorMessage =
                 "This model's maximum context length is 8192 tokens, however you requested 13531 tokens (13531 in your prompt;"
                     + "0 for the completion). Please reduce your prompt; or completion length.";
@@ -752,8 +732,6 @@ public class OpenAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/action/OpenAiChatCompletionActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/action/OpenAiChatCompletionActionTests.java
@@ -89,8 +89,6 @@ public class OpenAiChatCompletionActionTests extends ESTestCase {
         var senderFactory = new HttpRequestSender.Factory(createWithEmptySettings(threadPool), clientManager, mockClusterServiceEmpty());
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "id": "chatcmpl-123",
@@ -242,8 +240,6 @@ public class OpenAiChatCompletionActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "id": "chatcmpl-123",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/action/OpenAiEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/action/OpenAiEmbeddingsActionTests.java
@@ -86,8 +86,6 @@ public class OpenAiEmbeddingsActionTests extends ESTestCase {
         );
 
         try (var sender = senderFactory.createSender()) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                   "object": "list",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openshiftai/action/OpenShiftAiActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openshiftai/action/OpenShiftAiActionCreatorTests.java
@@ -133,8 +133,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "id": "embd-45e6d99b97a645c0af96653598069cd9",
@@ -197,7 +195,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             String responseJson = """
                 {
@@ -258,7 +255,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             String responseJson = """
                 {
@@ -322,7 +318,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             String responseJson = """
                 {
@@ -384,7 +379,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             var contentTooLargeErrorMessage = """
                 This model's maximum context length is 8192 tokens, however you requested 13531 tokens (13531 in your prompt;\
@@ -468,7 +462,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             var contentTooLargeErrorMessage = """
                 This model's maximum context length is 8192 tokens, however you requested 13531 tokens (13531 in your prompt;\
@@ -550,7 +543,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             var responseJson = """
                 {
@@ -609,7 +601,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             String responseJson = """
                 {
@@ -668,7 +659,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             String responseJson = """
                 {
@@ -727,7 +717,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             String responseJson = """
                 {
@@ -780,7 +769,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             String responseJson = """
                 {
@@ -833,7 +821,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             String responseJson = """
                 {
@@ -886,7 +873,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             String responseJson = """
                 {
@@ -935,7 +921,6 @@ public class OpenShiftAiActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager, NO_RETRY_SETTINGS);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
 
             String responseJson = """
                 {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIServiceTests.java
@@ -85,7 +85,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -849,7 +848,6 @@ public class VoyageAIServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();
@@ -895,7 +893,6 @@ public class VoyageAIServiceTests extends InferenceServiceTestCase {
             );
 
             verify(factory, times(1)).createSender();
-            verify(sender, times(1)).startAsynchronously(any());
         }
 
         verify(sender, times(1)).close();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/action/VoyageAIActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/action/VoyageAIActionCreatorTests.java
@@ -74,8 +74,6 @@ public class VoyageAIActionCreatorTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "object": "list",

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/action/VoyageAIEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/action/VoyageAIEmbeddingsActionTests.java
@@ -88,8 +88,6 @@ public class VoyageAIEmbeddingsActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = HttpRequestSenderTests.createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "object": "list",
@@ -185,8 +183,6 @@ public class VoyageAIEmbeddingsActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = HttpRequestSenderTests.createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "object": "list",
@@ -282,8 +278,6 @@ public class VoyageAIEmbeddingsActionTests extends ESTestCase {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var sender = HttpRequestSenderTests.createSender(senderFactory)) {
-            sender.startSynchronously();
-
             String responseJson = """
                 {
                     "object": "list",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[Inference API] Fix inference initialization thread exhaustion (#147063)](https://github.com/elastic/elasticsearch/pull/147063)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)