### PR TITLE
Fix warming logic related to skipping region 0

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -406,9 +406,6 @@ tests:
 - class: "org.elasticsearch.xpack.stateless.reshard.StatelessReshardMixedOperationsIT"
   issue: "https://github.com/elastic/elasticsearch/issues/147842"
   method: "testMixedOperationsDuringSplitWithDisruption"
-- class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceIT
-  method: testCacheIsWarmedBeforeSearchShardRecovery
-  issue: https://github.com/elastic/elasticsearch/issues/147843
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testStressWithRelocationOrObjectStoreFailures
   issue: https://github.com/elastic/elasticsearch/issues/147844

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingService.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingService.java
@@ -98,7 +98,9 @@ public class SharedBlobCacheWarmingService {
         INDEXING_EARLY(true),
         INDEXING(true),
         INDEXING_MERGE(false),
-        SEARCH(true),
+        // search shard recovery doesn't guarantee that all of region 0 has been cached, because header reads served from
+        // index shards are served at page rather than region granularity.
+        SEARCH(false),
         HOLLOWING(true),
         UNHOLLOWING(true);
 
@@ -1045,22 +1047,22 @@ public class SharedBlobCacheWarmingService {
         }
 
         private void addLocation(BlobLocation location, String fileName, long position, long length, ActionListener<Void> listener) {
-            final long start = position;
-            final long end = position + length;
+            final long start = length <= Integer.MAX_VALUE ? directory.getPosition(fileName, position, (int) length) : position;
+            final long end = start + length;
             final int regionSize = cacheService.getRegionSize();
             final int startRegion = cacheService.getRegion(start);
             final int endRegion = cacheService.getEndingRegion(end);
 
             if (startRegion == endRegion) {
                 BlobRegion blobRegion = new BlobRegion(location.blobFile(), startRegion);
-                enqueueLocation(blobRegion, fileName, location, position, length, listener);
+                enqueueLocation(blobRegion, location, start, length, listener);
             } else {
                 try (var listeners = new RefCountingListener(listener)) {
                     for (int r = startRegion; r <= endRegion; r++) {
                         // adjust the position & length to the region
                         var range = ByteRange.of(Math.max(start, (long) r * regionSize), Math.min(end, (r + 1L) * regionSize));
                         BlobRegion blobRegion = new BlobRegion(location.blobFile(), r);
-                        enqueueLocation(blobRegion, fileName, location, range.start(), range.length(), listeners.acquire());
+                        enqueueLocation(blobRegion, location, range.start(), range.length(), listeners.acquire());
                     }
                 }
             }
@@ -1108,29 +1110,25 @@ public class SharedBlobCacheWarmingService {
             }));
         }
 
-        private boolean shouldSkipLocationWarming(String fileName, long position, long length) {
+        private boolean shouldSkipLocationWarming(long position) {
             if (warmingRun.type.skipsWarmingForRegion0Locations == false) {
                 return false;
             }
-            if (length > Short.MAX_VALUE) {
-                // length is too long to be contained in replicated section
-                return false;
-            }
-            int region = (int) (directory.getPosition(fileName, position, (int) length) / cacheService.getRegionSize());
             // region 0 is already loaded by this point while resolving full set of commit files and safe to skip.
             // See org.elasticsearch.xpack.stateless.objectstore.ObjectStoreService#readIndexingShardState
-            return region == 0;
+            // reads that span regions will be split into separate tasks, so checking the starting position suffices.
+            return position / cacheService.getRegionSize() == 0;
         }
 
+        // When using replicated ranges, the location should already be translated to its replicated counterpart
         private void enqueueLocation(
             BlobRegion blobRegion,
-            String fileName,
             BlobLocation blobLocation,
             long position,
             long length,
             ActionListener<Void> listener
         ) {
-            if (shouldSkipLocationWarming(fileName, position, length)) {
+            if (shouldSkipLocationWarming(position)) {
                 skippedTasksCount.incrementAndGet();
                 listener.onResponse(null);
                 return;

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java
@@ -895,9 +895,8 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
             node.indexingDirectory.getBlobStoreCacheDirectory().updateMetadata(blobFileRanges, randomNonNegativeLong());
 
             final PlainActionFuture<Void> future = new PlainActionFuture<>();
-            var type = randomFrom(INDEXING, SEARCH);
             node.warmingService.warmCache(
-                type,
+                INDEXING,
                 mockIndexShard(node),
                 commit,
                 node.indexingDirectory.getBlobStoreCacheDirectory(),

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java
@@ -29,7 +29,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
@@ -89,12 +91,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -852,21 +852,31 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
     }
 
     public void testOnlyTheFirstRegionIsLoadedWhenReplicatedContentIsPresent() throws IOException {
+        var primaryTerm = 1;
         var cacheSize = ByteSizeValue.ofMb(10L);
         var regionSize = ByteSizeValue.ofBytes((long) randomIntBetween(1, 3) * 2 * SharedBytes.PAGE_SIZE);
-        try (var node = new FakeStatelessNodeWithFakeObjectStore() {
-            @Override
-            protected Settings nodeSettings() {
-                return Settings.builder()
-                    .put(super.nodeSettings())
-                    .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), cacheSize)
-                    .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), regionSize)
-                    .put(SharedBlobCacheService.SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), regionSize)
-                    .put(SharedBlobCacheWarmingService.PREWARMING_RANGE_MINIMIZATION_STEP.getKey(), regionSize)
-                    .put(StatelessCommitService.STATELESS_COMMIT_USE_INTERNAL_FILES_REPLICATED_CONTENT.getKey(), true)
-                    .build();
+        try (
+            var node = new FakeStatelessNode(
+                TestEnvironment::newEnvironment,
+                settings -> new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings)),
+                xContentRegistry(),
+                primaryTerm
+            ) {
+                @Override
+                protected Settings nodeSettings() {
+                    return Settings.builder()
+                        .put(super.nodeSettings())
+                        .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+                        .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
+                        .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), cacheSize)
+                        .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), regionSize)
+                        .put(SharedBlobCacheService.SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), regionSize)
+                        .put(SharedBlobCacheWarmingService.PREWARMING_RANGE_MINIMIZATION_STEP.getKey(), regionSize)
+                        .put(StatelessCommitService.STATELESS_COMMIT_USE_INTERNAL_FILES_REPLICATED_CONTENT.getKey(), true)
+                        .build();
+                }
             }
-        }) {
+        ) {
             final var primaryTermAndGeneration = new PrimaryTermAndGeneration(randomNonNegativeLong(), randomLongBetween(3, 42));
             final var blobFile = new BlobFile(
                 StatelessCompoundCommit.blobNameFromGeneration(primaryTermAndGeneration.generation()),
@@ -896,15 +906,10 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
                 future
             );
             safeGet(future);
-            verify(node.sharedCacheService, never()).maybeFetchRange(
-                any(),
-                not(eq(0)),
-                any(),
-                anyLong(),
-                any(),
-                any(),
-                anyActionListener()
-            );
+
+            SharedBlobCacheService.Stats stats = node.sharedCacheService.getStats();
+            assertThat(stats.writeCount(), equalTo(0L));
+            assertThat(stats.missCount(), equalTo(0L));
         }
     }
 
@@ -1170,7 +1175,7 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
         boolean preWarmForIdLookupEnabled,
         double idLookupPreWarmRatio
     ) throws IOException {
-        return new FakeStatelessNodeWithFakeObjectStore() {
+        return new FakeStatelessNode(this::newEnvironment, this::newNodeEnvironment, xContentRegistry()) {
             @Override
             protected Settings nodeSettings() {
                 Settings settings = super.nodeSettings();
@@ -1187,6 +1192,43 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
                     .put(SharedBlobCacheWarmingService.PREWARM_INDEX_SHARD_FOR_ID_LOOKUPS_SETTING.getKey(), preWarmForIdLookupEnabled)
                     .put(SharedBlobCacheWarmingService.ID_LOOKUP_PREWARM_RATIO_SETTING.getKey(), idLookupPreWarmRatio)
                     .build();
+            }
+
+            @Override
+            protected StatelessSharedBlobCacheService createCacheService(
+                NodeEnvironment nodeEnvironment,
+                Settings settings,
+                ThreadPool threadPool,
+                MeterRegistry meterRegistry
+            ) {
+                return spy(super.createCacheService(nodeEnvironment, settings, threadPool, meterRegistry));
+            }
+
+            @Override
+            public BlobContainer wrapBlobContainer(BlobPath path, BlobContainer innerContainer) {
+                return new FilterBlobContainer(innerContainer) {
+                    @Override
+                    protected BlobContainer wrapChild(BlobContainer child) {
+                        return child;
+                    }
+
+                    @Override
+                    public InputStream readBlob(OperationPurpose purpose, String blobName, long position, long length) throws IOException {
+                        return new InputStream() {
+                            private long remaining = length;
+
+                            @Override
+                            public int read() throws IOException {
+                                if (remaining == 0) {
+                                    return -1;
+                                } else {
+                                    remaining -= 1;
+                                    return 1;
+                                }
+                            }
+                        };
+                    }
+                };
             }
         };
     }
@@ -1229,58 +1271,6 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
                     .build();
             }
         };
-    }
-
-    class FakeStatelessNodeWithFakeObjectStore extends FakeStatelessNode {
-        FakeStatelessNodeWithFakeObjectStore() throws IOException {
-            this(1);
-        }
-
-        FakeStatelessNodeWithFakeObjectStore(int primaryTerm) throws IOException {
-            super(
-                SharedBlobCacheWarmingServiceTests.this::newEnvironment,
-                SharedBlobCacheWarmingServiceTests.this::newNodeEnvironment,
-                xContentRegistry(),
-                primaryTerm
-            );
-        }
-
-        @Override
-        protected StatelessSharedBlobCacheService createCacheService(
-            NodeEnvironment nodeEnvironment,
-            Settings settings,
-            ThreadPool threadPool,
-            MeterRegistry meterRegistry
-        ) {
-            return spy(super.createCacheService(nodeEnvironment, settings, threadPool, meterRegistry));
-        }
-
-        @Override
-        public BlobContainer wrapBlobContainer(BlobPath path, BlobContainer innerContainer) {
-            return new FilterBlobContainer(innerContainer) {
-                @Override
-                protected BlobContainer wrapChild(BlobContainer child) {
-                    return child;
-                }
-
-                @Override
-                public InputStream readBlob(OperationPurpose purpose, String blobName, long position, long length) throws IOException {
-                    return new InputStream() {
-                        private long remaining = length;
-
-                        @Override
-                        public int read() throws IOException {
-                            if (remaining == 0) {
-                                return -1;
-                            } else {
-                                remaining -= 1;
-                                return 1;
-                            }
-                        }
-                    };
-                }
-            };
-        }
     }
 
     private void appendCommitsToVbcc(

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java
@@ -29,9 +29,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Releasable;
-import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
@@ -91,10 +89,12 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -852,31 +852,21 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
     }
 
     public void testOnlyTheFirstRegionIsLoadedWhenReplicatedContentIsPresent() throws IOException {
-        var primaryTerm = 1;
         var cacheSize = ByteSizeValue.ofMb(10L);
         var regionSize = ByteSizeValue.ofBytes((long) randomIntBetween(1, 3) * 2 * SharedBytes.PAGE_SIZE);
-        try (
-            var node = new FakeStatelessNode(
-                TestEnvironment::newEnvironment,
-                settings -> new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings)),
-                xContentRegistry(),
-                primaryTerm
-            ) {
-                @Override
-                protected Settings nodeSettings() {
-                    return Settings.builder()
-                        .put(super.nodeSettings())
-                        .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
-                        .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toAbsolutePath().toString())
-                        .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), cacheSize)
-                        .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), regionSize)
-                        .put(SharedBlobCacheService.SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), regionSize)
-                        .put(SharedBlobCacheWarmingService.PREWARMING_RANGE_MINIMIZATION_STEP.getKey(), regionSize)
-                        .put(StatelessCommitService.STATELESS_COMMIT_USE_INTERNAL_FILES_REPLICATED_CONTENT.getKey(), true)
-                        .build();
-                }
+        try (var node = new FakeStatelessNodeWithFakeObjectStore() {
+            @Override
+            protected Settings nodeSettings() {
+                return Settings.builder()
+                    .put(super.nodeSettings())
+                    .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), cacheSize)
+                    .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), regionSize)
+                    .put(SharedBlobCacheService.SHARED_CACHE_RANGE_SIZE_SETTING.getKey(), regionSize)
+                    .put(SharedBlobCacheWarmingService.PREWARMING_RANGE_MINIMIZATION_STEP.getKey(), regionSize)
+                    .put(StatelessCommitService.STATELESS_COMMIT_USE_INTERNAL_FILES_REPLICATED_CONTENT.getKey(), true)
+                    .build();
             }
-        ) {
+        }) {
             final var primaryTermAndGeneration = new PrimaryTermAndGeneration(randomNonNegativeLong(), randomLongBetween(3, 42));
             final var blobFile = new BlobFile(
                 StatelessCompoundCommit.blobNameFromGeneration(primaryTermAndGeneration.generation()),
@@ -906,10 +896,15 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
                 future
             );
             safeGet(future);
-
-            SharedBlobCacheService.Stats stats = node.sharedCacheService.getStats();
-            assertThat(stats.writeCount(), equalTo(0L));
-            assertThat(stats.missCount(), equalTo(0L));
+            verify(node.sharedCacheService, never()).maybeFetchRange(
+                any(),
+                not(eq(0)),
+                any(),
+                anyLong(),
+                any(),
+                any(),
+                anyActionListener()
+            );
         }
     }
 
@@ -1175,7 +1170,7 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
         boolean preWarmForIdLookupEnabled,
         double idLookupPreWarmRatio
     ) throws IOException {
-        return new FakeStatelessNode(this::newEnvironment, this::newNodeEnvironment, xContentRegistry()) {
+        return new FakeStatelessNodeWithFakeObjectStore() {
             @Override
             protected Settings nodeSettings() {
                 Settings settings = super.nodeSettings();
@@ -1192,43 +1187,6 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
                     .put(SharedBlobCacheWarmingService.PREWARM_INDEX_SHARD_FOR_ID_LOOKUPS_SETTING.getKey(), preWarmForIdLookupEnabled)
                     .put(SharedBlobCacheWarmingService.ID_LOOKUP_PREWARM_RATIO_SETTING.getKey(), idLookupPreWarmRatio)
                     .build();
-            }
-
-            @Override
-            protected StatelessSharedBlobCacheService createCacheService(
-                NodeEnvironment nodeEnvironment,
-                Settings settings,
-                ThreadPool threadPool,
-                MeterRegistry meterRegistry
-            ) {
-                return spy(super.createCacheService(nodeEnvironment, settings, threadPool, meterRegistry));
-            }
-
-            @Override
-            public BlobContainer wrapBlobContainer(BlobPath path, BlobContainer innerContainer) {
-                return new FilterBlobContainer(innerContainer) {
-                    @Override
-                    protected BlobContainer wrapChild(BlobContainer child) {
-                        return child;
-                    }
-
-                    @Override
-                    public InputStream readBlob(OperationPurpose purpose, String blobName, long position, long length) throws IOException {
-                        return new InputStream() {
-                            private long remaining = length;
-
-                            @Override
-                            public int read() throws IOException {
-                                if (remaining == 0) {
-                                    return -1;
-                                } else {
-                                    remaining -= 1;
-                                    return 1;
-                                }
-                            }
-                        };
-                    }
-                };
             }
         };
     }
@@ -1271,6 +1229,58 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
                     .build();
             }
         };
+    }
+
+    class FakeStatelessNodeWithFakeObjectStore extends FakeStatelessNode {
+        FakeStatelessNodeWithFakeObjectStore() throws IOException {
+            this(1);
+        }
+
+        FakeStatelessNodeWithFakeObjectStore(int primaryTerm) throws IOException {
+            super(
+                SharedBlobCacheWarmingServiceTests.this::newEnvironment,
+                SharedBlobCacheWarmingServiceTests.this::newNodeEnvironment,
+                xContentRegistry(),
+                primaryTerm
+            );
+        }
+
+        @Override
+        protected StatelessSharedBlobCacheService createCacheService(
+            NodeEnvironment nodeEnvironment,
+            Settings settings,
+            ThreadPool threadPool,
+            MeterRegistry meterRegistry
+        ) {
+            return spy(super.createCacheService(nodeEnvironment, settings, threadPool, meterRegistry));
+        }
+
+        @Override
+        public BlobContainer wrapBlobContainer(BlobPath path, BlobContainer innerContainer) {
+            return new FilterBlobContainer(innerContainer) {
+                @Override
+                protected BlobContainer wrapChild(BlobContainer child) {
+                    return child;
+                }
+
+                @Override
+                public InputStream readBlob(OperationPurpose purpose, String blobName, long position, long length) throws IOException {
+                    return new InputStream() {
+                        private long remaining = length;
+
+                        @Override
+                        public int read() throws IOException {
+                            if (remaining == 0) {
+                                return -1;
+                            } else {
+                                remaining -= 1;
+                                return 1;
+                            }
+                        }
+                    };
+                }
+            };
+        }
     }
 
     private void appendCommitsToVbcc(


### PR DESCRIPTION
The warming code skips warming a range if it is found to be replicated and the replicated range is in region 0. There were two errors here:

1. Region 0 isn't guaranteed to be fully cached when warming runs, at least on search search shards. When search shards open, they read headers from the start of the file, which can trigger a cache fill. But search shards can fill the cache by reading commits from their corresponding index shards, and when they do they carefully only read to the page-aligned end of headers rather than fetching a full cache region as they would from the object store.

2. If a replicated range starts in region 0 but spans regions, then the warming code would skip the front part of the range, and then warm the back part from the actual file rather than the replicated range. That part isn't necessarily contiguous, so when Lucene tries to read the replicated range and does do a contiguous read, it may generate a cache miss on the back part of the range.

Problem 1 is addressed by disabling the region 0 skip for search shards.
Problem 2 is fixed by moving the replicated range translation before region calculation in the warming code.

Fixes #147843