### PR TITLE
Split search.vectors into its own CCS test suite.

### DIFF
--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/CcsSearchYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/CcsSearchYamlTestSuiteIT.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.rest.yaml;
+
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+
+import org.apache.lucene.tests.util.TimeUnits;
+
+import java.io.IOException;
+
+/**
+ * Runs the search and msearch API tests only. See {@link TestSuiteApiCheck}
+ */
+@TimeoutSuite(millis = 30 * TimeUnits.MINUTE) // to account for slow encryption at rest tests
+public class CcsSearchYamlTestSuiteIT extends CcsCommonYamlTestSuiteIT {
+    public CcsSearchYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) throws IOException {
+        super(testCandidate);
+    }
+}

--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/CcsVectorsYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/CcsVectorsYamlTestSuiteIT.java
@@ -16,11 +16,11 @@ import org.apache.lucene.tests.util.TimeUnits;
 import java.io.IOException;
 
 /**
- * Runs the search and msearch API tests only. See {@link TestSuiteApiCheck}
+ * Runs the search.vectors API tests only. See {@link TestSuiteApiCheck}
  */
 @TimeoutSuite(millis = 30 * TimeUnits.MINUTE) // to account for slow encryption at rest tests
-public class CssSearchYamlTestSuiteIT extends CcsCommonYamlTestSuiteIT {
-    public CssSearchYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) throws IOException {
+public class CcsVectorsYamlTestSuiteIT extends CcsCommonYamlTestSuiteIT {
+    public CcsVectorsYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) throws IOException {
         super(testCandidate);
     }
 }

--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsVectorsYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsVectorsYamlTestSuiteIT.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.rest.yaml;
+
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+
+import org.apache.lucene.tests.util.TimeUnits;
+
+import java.io.IOException;
+
+/**
+ * Runs the search.vectors API tests only. See {@link TestSuiteApiCheck}
+ */
+@TimeoutSuite(millis = 30 * TimeUnits.MINUTE) // to account for slow encryption at rest tests
+public class RcsCcsVectorsYamlTestSuiteIT extends RcsCcsCommonYamlTestSuiteIT {
+    public RcsCcsVectorsYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) throws IOException {
+        super(testCandidate);
+    }
+}

--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/TestSuiteApiCheck.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/TestSuiteApiCheck.java
@@ -29,17 +29,23 @@ class TestSuiteApiCheck {
      */
     public static boolean shouldExecuteTest(ESClientYamlSuiteTestCase testSuite, String apiName) {
         return switch (testSuite) {
-            case CssSearchYamlTestSuiteIT cssSearch -> isSearchApi(apiName);
-            case RcsCcsSearchYamlTestSuiteIT rssSearch -> isSearchApi(apiName);
+            case CcsSearchYamlTestSuiteIT ccsSearch -> isSearchApi(apiName) && isVectorsApi(apiName) == false;
+            case RcsCcsSearchYamlTestSuiteIT rcsSearch -> isSearchApi(apiName) && isVectorsApi(apiName) == false;
+            case CcsVectorsYamlTestSuiteIT ccsVectors -> isVectorsApi(apiName);
+            case RcsCcsVectorsYamlTestSuiteIT rcsVectors -> isVectorsApi(apiName);
             // Search tests are not executed in the common suite.
-            case CcsCommonYamlTestSuiteIT cssCommon -> isSearchApi(apiName) == false;
-            case RcsCcsCommonYamlTestSuiteIT rssCommon -> isSearchApi(apiName) == false;
+            case CcsCommonYamlTestSuiteIT ccsCommon -> isSearchApi(apiName) == false;
+            case RcsCcsCommonYamlTestSuiteIT rcsCommon -> isSearchApi(apiName) == false;
             default -> throw new IllegalArgumentException("unexpected test suite [" + testSuite.getClass().getSimpleName() + "]");
         };
     }
 
     private static boolean isSearchApi(String apiName) {
         return apiName.startsWith("search") || apiName.startsWith("msearch");
+    }
+
+    private static boolean isVectorsApi(String apiName) {
+        return apiName.equals("search.vectors");
     }
 
     private TestSuiteApiCheck() {}


### PR DESCRIPTION
The `encryption-at-rest periodic` step keeps hitting suite timeouts on `RcsCcsSearchYamlTestSuiteIT` (6 of 9 recent timeouts). Peel search.vectors tests, the largest subgroup (~44% of search-suite test sections), into its own IT class per CCS variant. Each new suite gets its own `@TimeoutSuite` budget.

Also rename `CssSearchYamlTestSuiteIT` to `CcsSearchYamlTestSuiteIT` to match the parent class name (Ccs prefix).

Should address these:
- #145956 (`RcsCcsSearchYamlTestSuiteIT`)
- #145848 (`RcsCcsCommonYamlTestSuiteIT`)
- #145849 (`CcsCommonYamlTestSuiteIT`)