### PR TITLE
Fix field name length limit tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -253,9 +253,6 @@ tests:
   method: testMultipleEntriesForSameMetricAcrossStreams
   issue: https://github.com/elastic/elasticsearch/issues/147170
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=index/100_field_name_length_limit/Test field name length limit array}
-  issue: https://github.com/elastic/elasticsearch/issues/147205
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/KNN Vector similarity search only}
   issue: https://github.com/elastic/elasticsearch/issues/147251
 - class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
@@ -273,9 +270,6 @@ tests:
 - class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
   method: testReindexTaskRelocatesOnNodeShutdown
   issue: https://github.com/elastic/elasticsearch/issues/147449
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=index/100_field_name_length_limit/Test field name length limit}
-  issue: https://github.com/elastic/elasticsearch/issues/147494
 - class: org.elasticsearch.xpack.core.transform.transforms.pivot.ScriptConfigTests
   method: testFromXContent
   issue: https://github.com/elastic/elasticsearch/issues/147543

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/100_field_name_length_limit.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/100_field_name_length_limit.yml
@@ -37,6 +37,10 @@ setup:
   - match: { result: created }
 
   - do:
+      cluster.health:
+        wait_for_events: languid
+
+  - do:
       indices.get_mapping:
         index: test_index
 
@@ -88,6 +92,10 @@ setup:
             field_name_not_ignored: [ 10, 20, 30 ]
 
   - match: { result: created }
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
 
   - do:
       indices.get_mapping:


### PR DESCRIPTION
These tests were very rarely failing due to the dynamically-mapped field `field_name_not_ignored` missing in the reported mappings.

I believe this was caused by a race condition, where the `indices.get_mapping` call was rarely being executed by a node that had not yet received the cluster state update with the updated mappings.

This test fixes this issue by waiting for all pending cluster state updates to complete before calling `indices.get_mapping`.

Fixes #147205
Fixes #147494