### PR TITLE
[ESQL] Resilient CSV parsing and COUNT(*) fast path

### DIFF
--- a/docs/changelog/148162.yaml
+++ b/docs/changelog/148162.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148162
+summary: Resilient CSV parsing and COUNT(*) fast path
+type: enhancement

--- a/docs/changelog/148162.yaml
+++ b/docs/changelog/148162.yaml
@@ -1,5 +1,5 @@
 area: ES|QL
 issues: []
 pr: 148162
-summary: Resilient CSV parsing and COUNT(*) fast path
+summary: Resilient CSV parsing, COUNT(*) fast path, and 400-status malformed-data errors
 type: enhancement

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvErrorMessages.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvErrorMessages.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+/**
+ * Helpers for building short, user-facing CSV error messages.
+ *
+ * <p>CSV parsing errors must include enough context for the user to locate and fix the
+ * offending row in their input file, but rows or values can be megabyte-sized in
+ * pathological inputs. These helpers cap excerpts at small, fixed budgets so the
+ * resulting HTTP response stays small even when many warnings accumulate.
+ */
+final class CsvErrorMessages {
+
+    /** Per-value/row character cap. Picked to comfortably show typical URL-bearing rows
+     *  (median ~200 chars in ClickBench-style data) without spilling into KB territory. */
+    static final int MAX_EXCERPT_CHARS = 256;
+
+    /** Maximum total characters of free-form text appended to a single error message
+     *  (sum of the row excerpt plus any embedded cause excerpts). */
+    static final int MAX_MESSAGE_CHARS = 1024;
+
+    private CsvErrorMessages() {}
+
+    /**
+     * Returns {@code value} unchanged if it fits within {@link #MAX_EXCERPT_CHARS}, otherwise
+     * returns a head/tail summary of the form
+     * {@code "<first>… (truncated, N chars total) …<last>"} so both ends of the offending
+     * value remain visible. {@code null} maps to the literal string {@code "null"}.
+     */
+    static String summarize(String value) {
+        return summarize(value, MAX_EXCERPT_CHARS);
+    }
+
+    /** {@link #summarize(String)} with an explicit cap; visible for tests. */
+    static String summarize(String value, int maxChars) {
+        if (value == null) {
+            return "null";
+        }
+        if (value.length() <= maxChars) {
+            return value;
+        }
+        // Reserve room for the "(truncated, N chars total)" marker; split the rest evenly.
+        String marker = "… (truncated, " + value.length() + " chars total) …";
+        int remaining = Math.max(0, maxChars - marker.length());
+        int head = remaining / 2;
+        int tail = remaining - head;
+        return value.substring(0, head) + marker + value.substring(value.length() - tail);
+    }
+
+    /**
+     * Builds a short row excerpt of the form {@code col0=[…], col1=[…], …}. Empty rows
+     * (sentinel for rows that could not be tokenised) return the literal {@code "<unparsed>"}.
+     * The total excerpt is capped at {@link #MAX_EXCERPT_CHARS} characters.
+     */
+    static String summarizeRow(String[] row) {
+        if (row == null || row.length == 0) {
+            return "<unparsed>";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < row.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append("col").append(i).append("=[").append(row[i]).append("]");
+            if (sb.length() >= MAX_EXCERPT_CHARS) {
+                break;
+            }
+        }
+        return summarize(sb.toString());
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -163,17 +163,34 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private final List<String> extensions;
     private final List<Attribute> resolvedSchema;
     private final int schemaSampleSize;
+    /**
+     * ErrorPolicy used by the planning-time {@link #metadata} call (which has no per-query
+     * {@link FormatReadContext}). Resolved from the {@code WITH} options in {@link #withConfig}
+     * so a user request like {@code WITH {"error_mode": "skip_row"}} also applies to schema
+     * sampling — matching ClickHouse's {@code input_format_allow_errors_*} semantics.
+     * Defaults to {@link #defaultErrorPolicy()} (FAIL_FAST), so unset implies "fail at planning
+     * if the file cannot be sampled cleanly", consistent with the rest of the system.
+     */
+    private final ErrorPolicy effectivePolicy;
 
     public CsvFormatReader(BlockFactory blockFactory) {
-        this(blockFactory, CsvFormatOptions.DEFAULT, "csv", List.of(".csv", ".tsv"), null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE);
+        this(
+            blockFactory,
+            CsvFormatOptions.DEFAULT,
+            "csv",
+            List.of(".csv", ".tsv"),
+            null,
+            CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE,
+            ErrorPolicy.STRICT
+        );
     }
 
     public CsvFormatReader(BlockFactory blockFactory, String format, List<String> extensions) {
-        this(blockFactory, CsvFormatOptions.DEFAULT, format, extensions, null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE);
+        this(blockFactory, CsvFormatOptions.DEFAULT, format, extensions, null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE, ErrorPolicy.STRICT);
     }
 
     public CsvFormatReader(BlockFactory blockFactory, CsvFormatOptions options, String format, List<String> extensions) {
-        this(blockFactory, options, format, extensions, null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE);
+        this(blockFactory, options, format, extensions, null, CsvSchemaInferrer.DEFAULT_SAMPLE_SIZE, ErrorPolicy.STRICT);
     }
 
     private CsvFormatReader(
@@ -182,7 +199,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
         String format,
         List<String> extensions,
         List<Attribute> resolvedSchema,
-        int schemaSampleSize
+        int schemaSampleSize,
+        ErrorPolicy effectivePolicy
     ) {
         this.blockFactory = blockFactory;
         this.options = options;
@@ -190,6 +208,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         this.extensions = extensions;
         this.resolvedSchema = resolvedSchema;
         this.schemaSampleSize = schemaSampleSize;
+        this.effectivePolicy = effectivePolicy;
         this.sharedCsvMapper = createMapper(options);
     }
 
@@ -346,12 +365,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     public CsvFormatReader withOptions(CsvFormatOptions newOptions) {
-        return new CsvFormatReader(blockFactory, newOptions, format, extensions, resolvedSchema, schemaSampleSize);
+        return new CsvFormatReader(blockFactory, newOptions, format, extensions, resolvedSchema, schemaSampleSize, effectivePolicy);
     }
 
     @Override
     public CsvFormatReader withSchema(List<Attribute> schema) {
-        return new CsvFormatReader(blockFactory, options, format, extensions, schema, schemaSampleSize);
+        return new CsvFormatReader(blockFactory, options, format, extensions, schema, schemaSampleSize, effectivePolicy);
     }
 
     @Override
@@ -362,15 +381,17 @@ public class CsvFormatReader implements SegmentableFormatReader {
         CsvFormatOptions parsed = parseOptionsFromConfig(config);
         int newSampleSize = parseInt(config.get("schema_sample_size"), schemaSampleSize);
         Check.isTrue(newSampleSize > 0, "schema_sample_size must be positive, got: {}", newSampleSize);
+        ErrorPolicy resolvedPolicy = ErrorPolicy.fromConfig(config, effectivePolicy);
         CsvFormatReader result = parsed != null ? withOptions(parsed) : this;
-        if (newSampleSize != result.schemaSampleSize) {
+        if (newSampleSize != result.schemaSampleSize || resolvedPolicy != result.effectivePolicy) {
             result = new CsvFormatReader(
                 result.blockFactory,
                 result.options,
                 result.format,
                 result.extensions,
                 result.resolvedSchema,
-                newSampleSize
+                newSampleSize,
+                resolvedPolicy
             );
         }
         return result;
@@ -418,7 +439,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         String[] columnNames = headerLine.split(Pattern.quote(Character.toString(options.delimiter())));
         Iterator<List<?>> csvIterator = newCsvIterator(reader);
         CircuitBreaker breaker = blockFactory.breaker();
-        SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, breaker);
+        SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, breaker, effectivePolicy);
         try {
             return CsvSchemaInferrer.inferSchema(columnNames, sample.rows());
         } finally {
@@ -429,7 +450,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
     private List<Attribute> inferSchemaWithSyntheticNames(BufferedReader reader) throws IOException {
         Iterator<List<?>> csvIterator = newCsvIterator(reader);
         CircuitBreaker breaker = blockFactory.breaker();
-        SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, breaker);
+        SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, breaker, effectivePolicy);
         try {
             if (sample.rows().isEmpty()) {
                 throw new IOException("CSV file has no data rows");
@@ -496,53 +517,61 @@ public class CsvFormatReader implements SegmentableFormatReader {
      */
     record SchemaSample(List<String[]> rows, long reservedBytes) {}
 
-    /** Maximum number of consecutive parse failures tolerated during schema sampling before
-     *  giving up. Jackson's stream-based CSV parser cannot guarantee resync after a malformed
-     *  record (the tokeniser may have consumed bytes mid-field), so even when many rows have
-     *  already been sampled successfully we cap the back-to-back failures to avoid infinite
-     *  retries on a permanently confused parser state. Matches the ClickHouse / DuckDB
-     *  philosophy of bounding sampling work via {@code sample_size}. */
+    /** Hard cap on consecutive parse failures during schema sampling, applied INDEPENDENTLY of
+     *  the user's {@link ErrorPolicy}. Jackson's stream-based CSV parser cannot guarantee
+     *  resync after a malformed record (the tokeniser may have consumed bytes mid-field), so
+     *  even a generous {@code max_errors} budget cannot make progress past a permanently
+     *  confused parser state. ClickHouse / DuckDB don't need this guard because their C++
+     *  parsers can resync reliably. */
     static final int MAX_CONSECUTIVE_SAMPLING_FAILURES = 16;
 
-    /** Maximum number of distinct error excerpts captured for the "could not sample any row"
-     *  failure message. Keeps the eventual {@link ParsingException} small. */
+    /** Maximum number of distinct error excerpts captured for the failure message. Keeps the
+     *  eventual {@link ParsingException} small. */
     private static final int MAX_CAPTURED_SAMPLING_ERRORS = 3;
 
     /**
-     * Best-effort sampling for schema inference. Tolerates malformed rows so files that other
-     * engines (ClickHouse, DuckDB, Spark) accept also infer here. The contract is:
+     * Samples rows for schema inference, honouring the given {@link ErrorPolicy} the same way
+     * the data-row path does:
      * <ul>
-     *   <li>Try to sample up to {@code sampleSize} well-formed rows from {@code csvIterator}.</li>
-     *   <li>If a row throws (Jackson {@link RuntimeException} wrapping a parse error), skip it
-     *       and continue. Capture the first {@link #MAX_CAPTURED_SAMPLING_ERRORS} causes for
-     *       the failure message in case all rows are bad.</li>
-     *   <li>Bail after {@link #MAX_CONSECUTIVE_SAMPLING_FAILURES} consecutive failures — at
-     *       that point the parser state is almost certainly unrecoverable.</li>
-     *   <li>If at least one row was sampled, return it (callers infer types from the partial
-     *       sample). Only when ZERO rows could be sampled do we throw {@link ParsingException}
-     *       (HTTP 400) with a short, capped summary of what went wrong.</li>
+     *   <li>{@code FAIL_FAST}: throw {@link ParsingException} (HTTP 400) on the first malformed
+     *       row, with a capped row excerpt and a hint pointing at {@code skip_row}.</li>
+     *   <li>{@code SKIP_ROW} / {@code NULL_FIELD}: skip bad rows, continue sampling, throw if
+     *       the budget ({@code max_errors} / {@code max_error_ratio}) is exceeded.</li>
      * </ul>
-     * The {@link ErrorPolicy} configured for the query is intentionally <em>not</em> consulted
-     * here: schema inference is a best-effort planning step and runtime row-handling policy
-     * still applies once data starts flowing.
+     * Independent of the policy, sampling bails after
+     * {@link #MAX_CONSECUTIVE_SAMPLING_FAILURES} consecutive failures (Jackson resync guard),
+     * and throws if zero rows could be collected.
+     *
+     * <p>Aligning sampling with the runtime policy matches ClickHouse's
+     * {@code input_format_allow_errors_*} semantics (one budget covering both phases) and
+     * means a {@code WITH {"error_mode": "skip_row"}} request is honoured at planning time
+     * too — not just once data starts flowing.
      */
-    static SchemaSample collectSampleRows(Iterator<List<?>> csvIterator, String commentPrefix, int sampleSize, CircuitBreaker breaker) {
+    static SchemaSample collectSampleRows(
+        Iterator<List<?>> csvIterator,
+        String commentPrefix,
+        int sampleSize,
+        CircuitBreaker breaker,
+        ErrorPolicy policy
+    ) {
         List<String[]> sampleRows = new ArrayList<>();
         long reservedBytes = 0;
         boolean success = false;
         List<String> capturedErrors = null;
         Throwable firstCause = null;
+        long errorCount = 0;
+        long totalRowCount = 0;
         int consecutiveFailures = 0;
+        boolean failFast = policy.mode() == ErrorPolicy.Mode.FAIL_FAST;
         try {
             boolean hasCommentFilter = commentPrefix != null && commentPrefix.isEmpty() == false;
             while (sampleRows.size() < sampleSize) {
-                boolean advanced;
                 try {
                     if (csvIterator.hasNext() == false) {
                         break;
                     }
                     List<?> rowList = csvIterator.next();
-                    advanced = true;
+                    totalRowCount++;
                     String[] row = new String[rowList.size()];
                     for (int i = 0; i < rowList.size(); i++) {
                         Object val = rowList.get(i);
@@ -559,7 +588,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     sampleRows.add(row);
                     consecutiveFailures = 0;
                 } catch (RuntimeException e) {
-                    advanced = false;
+                    totalRowCount++;
+                    errorCount++;
+                    if (failFast) {
+                        // Single point of truth for FAIL_FAST: same exception type and hint as
+                        // the data-row path so users see consistent error messages whether
+                        // sampling or reading actually tripped the failure.
+                        throw failFastSamplingError(totalRowCount, e);
+                    }
                     consecutiveFailures++;
                     if (firstCause == null) {
                         firstCause = e;
@@ -570,18 +606,19 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     if (capturedErrors.size() < MAX_CAPTURED_SAMPLING_ERRORS) {
                         capturedErrors.add(CsvErrorMessages.summarize(e.getMessage()));
                     }
+                    if (policy.isBudgetExceeded(errorCount, totalRowCount)) {
+                        throw budgetExceededSamplingError(errorCount, totalRowCount, policy, capturedErrors, firstCause);
+                    }
                     if (consecutiveFailures >= MAX_CONSECUTIVE_SAMPLING_FAILURES) {
+                        // Jackson cannot resync; bail with whatever we have. If we have at least
+                        // one row this is a successful (partial) sample; otherwise the empty
+                        // check below converts it to a ParsingException.
                         break;
                     }
                 }
-                if (advanced == false) {
-                    // Defensive: if neither hasNext returned false nor next succeeded nor threw,
-                    // bail to avoid spinning. Should be unreachable in practice.
-                    break;
-                }
             }
             if (sampleRows.isEmpty() && capturedErrors != null) {
-                throw schemaSamplingFailure(capturedErrors, firstCause);
+                throw zeroRowsSamplingError(capturedErrors, firstCause);
             }
             success = true;
             return new SchemaSample(sampleRows, reservedBytes);
@@ -592,14 +629,48 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
     }
 
-    /**
-     * Builds a {@link ParsingException} (HTTP 400) for the case where schema sampling could
-     * not collect a single well-formed row. Includes capped excerpts of the underlying parse
-     * errors so the user can locate and fix the offending input without the response carrying
-     * megabytes of stack trace.
-     */
-    private static ParsingException schemaSamplingFailure(List<String> capturedErrors, Throwable firstCause) {
+    private static ParsingException failFastSamplingError(long row, Throwable cause) {
+        Exception e = cause instanceof Exception ex ? ex : null;
+        return new ParsingException(
+            e,
+            Source.EMPTY,
+            "{}",
+            "CSV schema sampling failed at row ["
+                + row
+                + "]: "
+                + CsvErrorMessages.summarize(cause != null ? cause.getMessage() : "(no message)")
+                + "; set error_mode to skip_row (or null_field) in WITH options to skip and warn instead of failing"
+        );
+    }
+
+    private static ParsingException budgetExceededSamplingError(
+        long errorCount,
+        long rowCount,
+        ErrorPolicy policy,
+        List<String> capturedErrors,
+        Throwable firstCause
+    ) {
+        Exception cause = firstCause instanceof Exception ex ? ex : null;
+        StringBuilder details = new StringBuilder("CSV schema sampling exceeded error budget: [").append(errorCount)
+            .append("] errors in [")
+            .append(rowCount)
+            .append("] sampled rows, maximum allowed is [")
+            .append(policy.maxErrors())
+            .append("] errors or [")
+            .append(policy.maxErrorRatio())
+            .append("] ratio; first errors: ");
+        appendCapturedErrors(details, capturedErrors);
+        return new ParsingException(cause, Source.EMPTY, "{}", details.toString());
+    }
+
+    private static ParsingException zeroRowsSamplingError(List<String> capturedErrors, Throwable firstCause) {
+        Exception cause = firstCause instanceof Exception ex ? ex : null;
         StringBuilder details = new StringBuilder("CSV schema inference failed: no rows could be parsed; first errors: ");
+        appendCapturedErrors(details, capturedErrors);
+        return new ParsingException(cause, Source.EMPTY, "{}", details.toString());
+    }
+
+    private static void appendCapturedErrors(StringBuilder details, List<String> capturedErrors) {
         for (int i = 0; i < capturedErrors.size(); i++) {
             if (i > 0) {
                 details.append("; ");
@@ -609,8 +680,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 break;
             }
         }
-        Exception cause = firstCause instanceof Exception ex ? ex : null;
-        return new ParsingException(cause, Source.EMPTY, "{}", details.toString());
     }
 
     /**
@@ -659,7 +728,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
             reader.readLine();
             effectiveSchema = resolvedSchema;
         }
-        ErrorPolicy effective = context.errorPolicy() != null ? context.errorPolicy() : defaultErrorPolicy();
+        // Falls back to effectivePolicy (resolved from WITH options in withConfig) so a user
+        // request like WITH {"error_mode": "skip_row"} also applies to the data path when no
+        // upstream caller has built a FormatReadContext with an explicit policy. The planner
+        // path always sets context.errorPolicy() explicitly.
+        ErrorPolicy effective = context.errorPolicy() != null ? context.errorPolicy() : effectivePolicy;
         return new CsvBatchIterator(
             reader,
             stream,
@@ -1008,7 +1081,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                             // onRowError. Jackson typically resynchronizes at the next record
                             // boundary so we keep going. Errors (OOM etc.) propagate.
                             totalRowCount++;
-                            onRowError("CSV parse error: " + CsvErrorMessages.summarize(e.getMessage()), e, EMPTY_ROW);
+                            onRowError("CSV parse error: " + CsvErrorMessages.summarize(e.getMessage()), e, EMPTY_ROW, true);
                         }
                     }
                 }
@@ -1052,9 +1125,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 try {
                     String[] row = splitLineBracketAware(logicalLine.toString());
                     rows.add(row);
-                } catch (EsqlIllegalArgumentException e) {
+                } catch (MalformedRowException e) {
                     totalRowCount++;
-                    onRowError("CSV bracket parse error: " + CsvErrorMessages.summarize(e.getMessage()), e, EMPTY_ROW);
+                    onRowError(e.getMessage(), e, EMPTY_ROW, true);
                 }
             }
         }
@@ -1143,10 +1216,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 }
             }
             if (inQuotes) {
-                throw new EsqlIllegalArgumentException("Unclosed quoted field in line [{}]", line);
+                throw new MalformedRowException("Unclosed quoted field in line [" + CsvErrorMessages.summarize(line) + "]");
             }
             if (inBrackets) {
-                throw new EsqlIllegalArgumentException("Unclosed bracket cell in line [{}]", line);
+                throw new MalformedRowException("Unclosed bracket cell in line [" + CsvErrorMessages.summarize(line) + "]");
             }
             if (current.length() > 0) {
                 entries.add(current.toString().trim());
@@ -1157,7 +1230,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
         private List<Attribute> inferSchemaFromBatchReader(String headerLine) throws IOException {
             String[] columnNames = headerLine.split(Pattern.quote(Character.toString(options.delimiter())));
             csvIterator = newCsvIterator(reader);
-            SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, blockFactory.breaker());
+            SchemaSample sample = collectSampleRows(
+                csvIterator,
+                options.commentPrefix(),
+                schemaSampleSize,
+                blockFactory.breaker(),
+                errorPolicy
+            );
             if (sample.rows().isEmpty()) {
                 blockFactory.breaker().addWithoutBreaking(-sample.reservedBytes());
                 return null;
@@ -1169,7 +1248,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         private List<Attribute> inferSchemaHeaderlessFromBatchReader() throws IOException {
             csvIterator = newCsvIterator(reader);
-            SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, blockFactory.breaker());
+            SchemaSample sample = collectSampleRows(
+                csvIterator,
+                options.commentPrefix(),
+                schemaSampleSize,
+                blockFactory.breaker(),
+                errorPolicy
+            );
             if (sample.rows().isEmpty()) {
                 blockFactory.breaker().addWithoutBreaking(-sample.reservedBytes());
                 return null;
@@ -1238,7 +1323,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 for (String[] row : rows) {
                     totalRowCount++;
                     if (row.length > schemaSize) {
-                        onRowError("CSV row has [" + row.length + "] columns but schema defines [" + schemaSize + "] columns", null, row);
+                        onRowError(
+                            "CSV row has [" + row.length + "] columns but schema defines [" + schemaSize + "] columns",
+                            null,
+                            row,
+                            true
+                        );
                         continue;
                     }
                     acceptedRows++;
@@ -1258,7 +1348,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 for (String[] row : rows) {
                     totalRowCount++;
                     if (row.length > schemaSize) {
-                        onRowError("CSV row has [" + row.length + "] columns but schema defines [" + schemaSize + "] columns", null, row);
+                        onRowError(
+                            "CSV row has [" + row.length + "] columns but schema defines [" + schemaSize + "] columns",
+                            null,
+                            row,
+                            true
+                        );
                         continue;
                     }
                     if (convertRowInPlace(row)) {
@@ -1298,7 +1393,10 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     } else {
                         String err = lastFieldError;
                         lastFieldError = null;
-                        onRowError(err, null, row);
+                        // Field-type error: skip_row drops the whole row when one field is bad;
+                        // null_field is usually the better escape hatch. structural=false so the
+                        // FAIL_FAST hint suggests null_field.
+                        onRowError(err, null, row, false);
                         return false;
                     }
                 } else {
@@ -1534,16 +1632,29 @@ public class CsvFormatReader implements SegmentableFormatReader {
             }
         }
 
-        private void onRowError(String message, Exception cause, String[] row) {
+        /**
+         * Single point of truth for what happens to a row that failed structural parsing or
+         * row-shape validation.
+         *
+         * @param structural {@code true} for tokeniser errors (Jackson, bracket parser) and
+         *                   row-shape mismatches (column count) where {@code skip_row} is the
+         *                   natural escape hatch; {@code false} for field-type errors where
+         *                   {@code null_field} is the better suggestion. Only affects the hint
+         *                   appended to the FAIL_FAST {@link ParsingException}.
+         */
+        private void onRowError(String message, Exception cause, String[] row, boolean structural) {
             if (modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) {
-                // Malformed user data → client error (HTTP 400), not a 500. Include the row index
-                // and a capped excerpt so the user can locate and fix the offending input
-                // without the response carrying megabytes of context.
+                // Malformed user data → client error (HTTP 400), not a 500. Include the row index,
+                // a capped row excerpt, and a hint pointing at the relaxed error modes so the
+                // user knows there is a way out without grepping the docs.
+                String hint = structural
+                    ? "; set error_mode to skip_row (or null_field) in WITH options to skip and warn instead of failing"
+                    : "; set error_mode to null_field in WITH options to null-fill the bad field instead of failing";
                 throw new ParsingException(
                     cause,
                     Source.EMPTY,
                     "{}",
-                    "CSV parse error at row [" + totalRowCount + "]: " + message + "; row: " + CsvErrorMessages.summarizeRow(row)
+                    "CSV parse error at row [" + totalRowCount + "]: " + message + "; row: " + CsvErrorMessages.summarizeRow(row) + hint
                 );
             }
             errorCount++;

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -703,12 +703,20 @@ public class CsvFormatReader implements SegmentableFormatReader {
         List<Attribute> effectiveSchema;
         if (context.firstSplit()) {
             // First split carries the file's leading bytes, including the header (if any).
-            // Two sub-cases:
-            // 1. resolvedSchema bound (upstream withSchema): use it; just consume the header line so
-            // Jackson does not see it as a data row. Avoids re-running schema inference on chunk 0
-            // bytes (which can crash on a single malformed row long before any data is emitted).
-            // 2. No bound schema: let the iterator parse the header / infer types itself.
-            if (resolvedSchema != null) {
+            // The chunk-0 bound-schema fast path only applies when an upstream coordinator has
+            // pre-bound the FULL file schema — signalled by recordAligned=true. The streaming
+            // parallel coordinator infers the schema from chunk 0 on its own thread and calls
+            // withSchema(...) before any chunk is dispatched; binding is observed here so the
+            // iterator can skip its own per-chunk inference (which would otherwise re-sample on
+            // potentially malformed bytes and crash before any data is emitted).
+            //
+            // For single-shot reads (firstSplit=true, recordAligned=false), resolvedSchema may
+            // still be non-null because the planner calls withSchema(projectedAttributes) at
+            // operator-factory time; that list is the projected output, not the file's column
+            // layout, and using it as the iterator's positional schema would mis-align column
+            // indices and trigger spurious row-shape errors. Treat the whole-file read like
+            // main: ignore resolvedSchema and let the iterator parse the header itself.
+            if (context.recordAligned() && resolvedSchema != null) {
                 if (options.headerRow()) {
                     skipHeaderLine(reader);
                 }

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -153,6 +153,9 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     private static final int READER_BUFFER_SIZE = 64 * 1024;
 
+    /** Sentinel passed to {@link CsvBatchIterator#onRowError} when the offending row could not be tokenised. */
+    private static final String[] EMPTY_ROW = new String[0];
+
     private final BlockFactory blockFactory;
     private final CsvMapper sharedCsvMapper;
     private final CsvFormatOptions options;
@@ -545,8 +548,20 @@ public class CsvFormatReader implements SegmentableFormatReader {
         BufferedReader reader = new BufferedReader(new InputStreamReader(stream, options.encoding()), READER_BUFFER_SIZE);
         List<Attribute> effectiveSchema;
         if (context.firstSplit()) {
+            // First split: the bytes start at the beginning of the file, so the header (if present)
+            // is still on the wire. Let the iterator parse it; resolvedSchema (if bound by an upstream
+            // withSchema call) is intentionally ignored so the header is consumed and not fed to Jackson
+            // as a data row.
             effectiveSchema = null;
+        } else if (context.recordAligned()) {
+            // Non-first split that the caller guarantees starts on a record boundary
+            // (e.g. streaming-parallel chunks sliced on \n). No partial line to drop, no header
+            // to parse — use the pre-bound schema directly.
+            effectiveSchema = resolvedSchema;
         } else {
+            // Non-first byte-range split (e.g. bzip2 / zstd-indexed macro-split). The leading
+            // bytes belong to the previous split's trailing record and have already been emitted
+            // there; drop them here.
             reader.readLine();
             effectiveSchema = resolvedSchema;
         }
@@ -854,22 +869,37 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     prefetchedRowsBytes = 0;
                 }
                 if (csvIterator == null && bracketMultiValues && options.delimiter() == ',') {
-                    rows.addAll(readRowsBracketAware(batchSize - rows.size()));
+                    readRowsBracketAware(rows, batchSize - rows.size());
                 } else {
-                    while (rows.size() < batchSize && csvIterator.hasNext()) {
-                        List<?> rowList = csvIterator.next();
-                        String[] row = new String[rowList.size()];
-                        for (int i = 0; i < rowList.size(); i++) {
-                            Object val = rowList.get(i);
-                            row[i] = val != null ? val.toString() : null;
-                        }
-                        if (hasCommentFilter && row.length > 0 && row[0] != null) {
-                            String trimmedFirstCell = row[0].trim();
-                            if (trimmedFirstCell.startsWith(options.commentPrefix())) {
-                                continue;
+                    while (rows.size() < batchSize) {
+                        try {
+                            if (csvIterator.hasNext() == false) {
+                                break;
                             }
+                            List<?> rowList = csvIterator.next();
+                            String[] row = new String[rowList.size()];
+                            for (int i = 0; i < rowList.size(); i++) {
+                                Object val = rowList.get(i);
+                                row[i] = val != null ? val.toString() : null;
+                            }
+                            if (hasCommentFilter && row.length > 0 && row[0] != null) {
+                                String trimmedFirstCell = row[0].trim();
+                                if (trimmedFirstCell.startsWith(options.commentPrefix())) {
+                                    continue;
+                                }
+                            }
+                            rows.add(row);
+                        } catch (RuntimeException e) {
+                            // Jackson's MappingIterator wraps both structural parse errors and any
+                            // underlying IOException as RuntimeException since hasNext()/next() do
+                            // not declare checked exceptions. Routing them through the error policy
+                            // lets SKIP_ROW/NULL_FIELD recover from malformed rows (e.g. unclosed
+                            // quote) without killing the query; FAIL_FAST re-throws inside
+                            // onRowError. Jackson typically resynchronizes at the next record
+                            // boundary so we keep going. Errors (OOM etc.) propagate.
+                            totalRowCount++;
+                            onRowError("CSV parse error: " + e.getMessage(), e, EMPTY_ROW);
                         }
-                        rows.add(row);
                     }
                 }
 
@@ -889,9 +919,12 @@ public class CsvFormatReader implements SegmentableFormatReader {
          * and ends with {@code ]} before a comma, commas inside are not column delimiters.
          * The cell value is kept as {@code [a,b,c]} so multi-value conversion can parse it.
          * Supports multi-line quoted fields.
+         * <p>
+         * Per-line {@code splitLineBracketAware} failures are routed through the error policy so a
+         * single malformed line does not abort the batch. {@link IOException}s from the underlying
+         * reader are propagated since they signal an unrecoverable I/O fault.
          */
-        private List<String[]> readRowsBracketAware(int batchSize) throws IOException {
-            List<String[]> rows = new ArrayList<>();
+        private void readRowsBracketAware(List<String[]> rows, int batchSize) throws IOException {
             String line;
             while (rows.size() < batchSize && (line = reader.readLine()) != null) {
                 line = line.trim();
@@ -906,10 +939,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     }
                     logicalLine.append('\n').append(next);
                 }
-                String[] row = splitLineBracketAware(logicalLine.toString());
-                rows.add(row);
+                try {
+                    String[] row = splitLineBracketAware(logicalLine.toString());
+                    rows.add(row);
+                } catch (EsqlIllegalArgumentException e) {
+                    totalRowCount++;
+                    onRowError("CSV bracket parse error: " + e.getMessage(), e, EMPTY_ROW);
+                }
             }
-            return rows;
         }
 
         private static boolean hasUnclosedQuote(String s, char quote) {
@@ -1041,12 +1078,18 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         private void initProjection() {
             int schemaSize = schema.size();
-            if (projectedColumns == null || projectedColumns.isEmpty()) {
+            if (projectedColumns == null) {
+                // null means "no projection info available" — fall back to all columns for backward compat.
                 columnCount = schemaSize;
                 projectedIdx = new int[schemaSize];
                 for (int i = 0; i < schemaSize; i++) {
                     projectedIdx[i] = i;
                 }
+            } else if (projectedColumns.isEmpty()) {
+                // Empty list means the optimizer pruned every column (e.g. COUNT(*)). Skip all type
+                // conversion and emit row-count-only Pages from convertRowsToPage.
+                columnCount = 0;
+                projectedIdx = new int[0];
             } else {
                 columnCount = projectedColumns.size();
                 projectedIdx = new int[columnCount];
@@ -1076,6 +1119,22 @@ public class CsvFormatReader implements SegmentableFormatReader {
         }
 
         private Page convertRowsToPage(List<String[]> rows) {
+            int schemaSize = schema.size();
+            // COUNT(*) fast path: no columns projected, so skip builder allocation and type conversion
+            // and emit a row-count-only Page. We still apply the column-count validation that the
+            // regular path uses so structural errors are routed through the policy consistently.
+            if (columnCount == 0) {
+                int acceptedRows = 0;
+                for (String[] row : rows) {
+                    totalRowCount++;
+                    if (row.length > schemaSize) {
+                        onRowError("CSV row has [" + row.length + "] columns but schema defines [" + schemaSize + "] columns", null, row);
+                        continue;
+                    }
+                    acceptedRows++;
+                }
+                return acceptedRows == 0 ? null : new Page(acceptedRows);
+            }
             BlockUtils.BuilderWrapper[] builders = new BlockUtils.BuilderWrapper[columnCount];
             try {
                 for (int i = 0; i < columnCount; i++) {
@@ -1085,7 +1144,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         rows.size()
                     );
                 }
-                int schemaSize = schema.size();
                 int acceptedRows = 0;
                 for (String[] row : rows) {
                     totalRowCount++;

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -496,28 +496,92 @@ public class CsvFormatReader implements SegmentableFormatReader {
      */
     record SchemaSample(List<String[]> rows, long reservedBytes) {}
 
+    /** Maximum number of consecutive parse failures tolerated during schema sampling before
+     *  giving up. Jackson's stream-based CSV parser cannot guarantee resync after a malformed
+     *  record (the tokeniser may have consumed bytes mid-field), so even when many rows have
+     *  already been sampled successfully we cap the back-to-back failures to avoid infinite
+     *  retries on a permanently confused parser state. Matches the ClickHouse / DuckDB
+     *  philosophy of bounding sampling work via {@code sample_size}. */
+    static final int MAX_CONSECUTIVE_SAMPLING_FAILURES = 16;
+
+    /** Maximum number of distinct error excerpts captured for the "could not sample any row"
+     *  failure message. Keeps the eventual {@link ParsingException} small. */
+    private static final int MAX_CAPTURED_SAMPLING_ERRORS = 3;
+
+    /**
+     * Best-effort sampling for schema inference. Tolerates malformed rows so files that other
+     * engines (ClickHouse, DuckDB, Spark) accept also infer here. The contract is:
+     * <ul>
+     *   <li>Try to sample up to {@code sampleSize} well-formed rows from {@code csvIterator}.</li>
+     *   <li>If a row throws (Jackson {@link RuntimeException} wrapping a parse error), skip it
+     *       and continue. Capture the first {@link #MAX_CAPTURED_SAMPLING_ERRORS} causes for
+     *       the failure message in case all rows are bad.</li>
+     *   <li>Bail after {@link #MAX_CONSECUTIVE_SAMPLING_FAILURES} consecutive failures — at
+     *       that point the parser state is almost certainly unrecoverable.</li>
+     *   <li>If at least one row was sampled, return it (callers infer types from the partial
+     *       sample). Only when ZERO rows could be sampled do we throw {@link ParsingException}
+     *       (HTTP 400) with a short, capped summary of what went wrong.</li>
+     * </ul>
+     * The {@link ErrorPolicy} configured for the query is intentionally <em>not</em> consulted
+     * here: schema inference is a best-effort planning step and runtime row-handling policy
+     * still applies once data starts flowing.
+     */
     static SchemaSample collectSampleRows(Iterator<List<?>> csvIterator, String commentPrefix, int sampleSize, CircuitBreaker breaker) {
         List<String[]> sampleRows = new ArrayList<>();
         long reservedBytes = 0;
         boolean success = false;
+        List<String> capturedErrors = null;
+        Throwable firstCause = null;
+        int consecutiveFailures = 0;
         try {
             boolean hasCommentFilter = commentPrefix != null && commentPrefix.isEmpty() == false;
-            while (sampleRows.size() < sampleSize && csvIterator.hasNext()) {
-                List<?> rowList = csvIterator.next();
-                String[] row = new String[rowList.size()];
-                for (int i = 0; i < rowList.size(); i++) {
-                    Object val = rowList.get(i);
-                    row[i] = val != null ? val.toString() : null;
-                }
-                if (hasCommentFilter && row.length > 0 && row[0] != null) {
-                    if (row[0].trim().startsWith(commentPrefix)) {
-                        continue;
+            while (sampleRows.size() < sampleSize) {
+                boolean advanced;
+                try {
+                    if (csvIterator.hasNext() == false) {
+                        break;
+                    }
+                    List<?> rowList = csvIterator.next();
+                    advanced = true;
+                    String[] row = new String[rowList.size()];
+                    for (int i = 0; i < rowList.size(); i++) {
+                        Object val = rowList.get(i);
+                        row[i] = val != null ? val.toString() : null;
+                    }
+                    if (hasCommentFilter && row.length > 0 && row[0] != null) {
+                        if (row[0].trim().startsWith(commentPrefix)) {
+                            continue;
+                        }
+                    }
+                    long rowBytes = estimateRowBytes(row);
+                    breaker.addEstimateBytesAndMaybeBreak(rowBytes, "csv_schema_inference");
+                    reservedBytes += rowBytes;
+                    sampleRows.add(row);
+                    consecutiveFailures = 0;
+                } catch (RuntimeException e) {
+                    advanced = false;
+                    consecutiveFailures++;
+                    if (firstCause == null) {
+                        firstCause = e;
+                    }
+                    if (capturedErrors == null) {
+                        capturedErrors = new ArrayList<>(MAX_CAPTURED_SAMPLING_ERRORS);
+                    }
+                    if (capturedErrors.size() < MAX_CAPTURED_SAMPLING_ERRORS) {
+                        capturedErrors.add(CsvErrorMessages.summarize(e.getMessage()));
+                    }
+                    if (consecutiveFailures >= MAX_CONSECUTIVE_SAMPLING_FAILURES) {
+                        break;
                     }
                 }
-                long rowBytes = estimateRowBytes(row);
-                breaker.addEstimateBytesAndMaybeBreak(rowBytes, "csv_schema_inference");
-                reservedBytes += rowBytes;
-                sampleRows.add(row);
+                if (advanced == false) {
+                    // Defensive: if neither hasNext returned false nor next succeeded nor threw,
+                    // bail to avoid spinning. Should be unreachable in practice.
+                    break;
+                }
+            }
+            if (sampleRows.isEmpty() && capturedErrors != null) {
+                throw schemaSamplingFailure(capturedErrors, firstCause);
             }
             success = true;
             return new SchemaSample(sampleRows, reservedBytes);
@@ -526,6 +590,27 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 breaker.addWithoutBreaking(-reservedBytes);
             }
         }
+    }
+
+    /**
+     * Builds a {@link ParsingException} (HTTP 400) for the case where schema sampling could
+     * not collect a single well-formed row. Includes capped excerpts of the underlying parse
+     * errors so the user can locate and fix the offending input without the response carrying
+     * megabytes of stack trace.
+     */
+    private static ParsingException schemaSamplingFailure(List<String> capturedErrors, Throwable firstCause) {
+        StringBuilder details = new StringBuilder("CSV schema inference failed: no rows could be parsed; first errors: ");
+        for (int i = 0; i < capturedErrors.size(); i++) {
+            if (i > 0) {
+                details.append("; ");
+            }
+            details.append('[').append(capturedErrors.get(i)).append(']');
+            if (details.length() >= CsvErrorMessages.MAX_MESSAGE_CHARS) {
+                break;
+            }
+        }
+        Exception cause = firstCause instanceof Exception ex ? ex : null;
+        return new ParsingException(cause, Source.EMPTY, "{}", details.toString());
     }
 
     /**
@@ -548,11 +633,20 @@ public class CsvFormatReader implements SegmentableFormatReader {
         BufferedReader reader = new BufferedReader(new InputStreamReader(stream, options.encoding()), READER_BUFFER_SIZE);
         List<Attribute> effectiveSchema;
         if (context.firstSplit()) {
-            // First split: the bytes start at the beginning of the file, so the header (if present)
-            // is still on the wire. Let the iterator parse it; resolvedSchema (if bound by an upstream
-            // withSchema call) is intentionally ignored so the header is consumed and not fed to Jackson
-            // as a data row.
-            effectiveSchema = null;
+            // First split carries the file's leading bytes, including the header (if any).
+            // Two sub-cases:
+            // 1. resolvedSchema bound (upstream withSchema): use it; just consume the header line so
+            // Jackson does not see it as a data row. Avoids re-running schema inference on chunk 0
+            // bytes (which can crash on a single malformed row long before any data is emitted).
+            // 2. No bound schema: let the iterator parse the header / infer types itself.
+            if (resolvedSchema != null) {
+                if (options.headerRow()) {
+                    skipHeaderLine(reader);
+                }
+                effectiveSchema = resolvedSchema;
+            } else {
+                effectiveSchema = null;
+            }
         } else if (context.recordAligned()) {
             // Non-first split that the caller guarantees starts on a record boundary
             // (e.g. streaming-parallel chunks sliced on \n). No partial line to drop, no header
@@ -639,6 +733,22 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     @Override
     public void close() throws IOException {}
+
+    /**
+     * Consumes one header line from {@code reader}, skipping over leading empty lines and
+     * comment lines. Used by {@link #read} when a schema is already bound but the input split
+     * still starts with the file header.
+     */
+    private void skipHeaderLine(BufferedReader reader) throws IOException {
+        String line;
+        while ((line = reader.readLine()) != null) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || (options.commentPrefix().isEmpty() == false && trimmed.startsWith(options.commentPrefix()))) {
+                continue;
+            }
+            return;
+        }
+    }
 
     private List<Attribute> parseSchema(String schemaLine) {
         String[] columns = schemaLine.split(Pattern.quote(Character.toString(options.delimiter())));
@@ -898,7 +1008,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                             // onRowError. Jackson typically resynchronizes at the next record
                             // boundary so we keep going. Errors (OOM etc.) propagate.
                             totalRowCount++;
-                            onRowError("CSV parse error: " + e.getMessage(), e, EMPTY_ROW);
+                            onRowError("CSV parse error: " + CsvErrorMessages.summarize(e.getMessage()), e, EMPTY_ROW);
                         }
                     }
                 }
@@ -944,7 +1054,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     rows.add(row);
                 } catch (EsqlIllegalArgumentException e) {
                     totalRowCount++;
-                    onRowError("CSV bracket parse error: " + e.getMessage(), e, EMPTY_ROW);
+                    onRowError("CSV bracket parse error: " + CsvErrorMessages.summarize(e.getMessage()), e, EMPTY_ROW);
                 }
             }
         }
@@ -1426,7 +1536,15 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         private void onRowError(String message, Exception cause, String[] row) {
             if (modeOrdinal == ErrorPolicy.Mode.FAIL_FAST.ordinal()) {
-                throw new EsqlIllegalArgumentException(cause, message);
+                // Malformed user data → client error (HTTP 400), not a 500. Include the row index
+                // and a capped excerpt so the user can locate and fix the offending input
+                // without the response carrying megabytes of context.
+                throw new ParsingException(
+                    cause,
+                    Source.EMPTY,
+                    "{}",
+                    "CSV parse error at row [" + totalRowCount + "]: " + message + "; row: " + CsvErrorMessages.summarizeRow(row)
+                );
             }
             errorCount++;
             skipWarnings.add("Row [" + totalRowCount + "] error: " + message);
@@ -1444,12 +1562,13 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         private void onFieldError(String message, String value, Attribute attr) {
             errorCount++;
-            skipWarnings.add("Row [" + totalRowCount + "] field [" + attr.name() + "] value [" + value + "]: " + message);
+            String summarizedValue = CsvErrorMessages.summarize(value);
+            skipWarnings.add("Row [" + totalRowCount + "] field [" + attr.name() + "] value [" + summarizedValue + "]: " + message);
             if (logErrors) {
                 logger.warn(
                     "Null-filling unparseable field [{}] value [{}] in row [{}] (error {}/{}): {}",
                     attr.name(),
-                    value,
+                    summarizedValue,
                     totalRowCount,
                     errorCount,
                     errorPolicy.maxErrors(),
@@ -1474,8 +1593,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
                         + errorPolicy.maxErrorRatio()
                         + "]"
                 );
-                throw new EsqlIllegalArgumentException(
+                // Budget exceeded is a client-data problem (the file has too many bad rows for the
+                // user-configured tolerance), not a server bug — surface as HTTP 400.
+                throw new ParsingException(
                     cause,
+                    Source.EMPTY,
                     "CSV error budget exceeded: [{}] errors in [{}] rows, maximum allowed is [{}] errors or [{}] ratio",
                     errorCount,
                     totalRowCount,

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/MalformedRowException.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/MalformedRowException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.csv;
+
+/**
+ * Marker thrown by the CSV tokenisers (Jackson and the bracket-aware path) when a single
+ * row cannot be parsed. The single point of truth for what to do with it lives in
+ * {@code CsvFormatReader.CsvBatchIterator.onRowError}, which decides between mapping it to
+ * a client {@code ParsingException} (FAIL_FAST) and recording it against the error budget
+ * (SKIP_ROW / NULL_FIELD).
+ *
+ * <p>Kept package-private and unchecked on purpose: it is purely a control-flow signal
+ * between the tokeniser and the row-level error policy, never propagated to callers
+ * outside this package.
+ */
+final class MalformedRowException extends RuntimeException {
+
+    MalformedRowException(String message) {
+        super(message);
+    }
+
+    MalformedRowException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -626,7 +626,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         StorageObject object = createStorageObject(csv);
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
 
-        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+        ParsingException e = expectThrows(ParsingException.class, () -> {
             try (
                 CloseableIterator<Page> iterator = reader.read(
                     object,
@@ -639,6 +639,11 @@ public class CsvFormatReaderTests extends ESTestCase {
             }
         });
         assertTrue(e.getMessage().contains("Failed to parse CSV value"));
+        // Malformed user data must surface as HTTP 400, not a 500 server error.
+        assertEquals(org.elasticsearch.rest.RestStatus.BAD_REQUEST, e.status());
+        // Row index and a capped row excerpt must be present so the user can locate the offending input.
+        assertTrue("expected row index, got: " + e.getMessage(), e.getMessage().contains("row [2]"));
+        assertTrue("expected row excerpt, got: " + e.getMessage(), e.getMessage().contains("col0=[not_a_number]"));
     }
 
     public void testLenientPolicySkipsMalformedRows() throws IOException {
@@ -681,7 +686,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
         ErrorPolicy limited = new ErrorPolicy(2, false);
 
-        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+        ParsingException e = expectThrows(ParsingException.class, () -> {
             try (
                 CloseableIterator<Page> iterator = reader.read(
                     object,
@@ -694,6 +699,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             }
         });
         assertTrue(e.getMessage().contains("error budget exceeded"));
+        assertEquals(org.elasticsearch.rest.RestStatus.BAD_REQUEST, e.status());
     }
 
     public void testLenientPolicyWithExtraColumns() throws IOException {
@@ -780,7 +786,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
         ErrorPolicy ratioPolicy = new ErrorPolicy(Long.MAX_VALUE, 0.3, true);
 
-        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+        ParsingException e = expectThrows(ParsingException.class, () -> {
             try (
                 CloseableIterator<Page> iterator = reader.read(
                     object,
@@ -793,6 +799,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             }
         });
         assertTrue(e.getMessage().contains("error budget exceeded"));
+        assertEquals(org.elasticsearch.rest.RestStatus.BAD_REQUEST, e.status());
     }
 
     public void testErrorRatioWithinBudget() throws IOException {
@@ -1484,7 +1491,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
         ErrorPolicy permissive = new ErrorPolicy(ErrorPolicy.Mode.NULL_FIELD, 1, 0.0, false);
 
-        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+        ParsingException e = expectThrows(ParsingException.class, () -> {
             try (
                 CloseableIterator<Page> iterator = reader.read(
                     object,
@@ -1497,6 +1504,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             }
         });
         assertTrue(e.getMessage().contains("error budget exceeded"));
+        assertEquals(org.elasticsearch.rest.RestStatus.BAD_REQUEST, e.status());
     }
 
     public void testPermissiveModeMultipleBadFieldsInSameRow() throws IOException {
@@ -1632,7 +1640,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         CsvFormatReader baseReader = new CsvFormatReader(blockFactory);
         FormatReader configured = baseReader.withConfig(Map.of("multi_value_syntax", "none"));
 
-        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+        ParsingException e = expectThrows(ParsingException.class, () -> {
             try (CloseableIterator<Page> iterator = configured.read(object, null, 10)) {
                 while (iterator.hasNext()) {
                     iterator.next();
@@ -2012,7 +2020,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         );
         CsvFormatReader reader = new CsvFormatReader(blockFactory).withOptions(options);
 
-        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+        ParsingException e = expectThrows(ParsingException.class, () -> {
             try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
                 while (iterator.hasNext()) {
                     iterator.next();
@@ -3122,7 +3130,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         Map<String, Object> config = Map.of("multi_value_syntax", "NONE");
         CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(config);
 
-        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+        ParsingException e = expectThrows(ParsingException.class, () -> {
             try (
                 CloseableIterator<Page> iterator = reader.read(
                     object,
@@ -3135,6 +3143,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             }
         });
         assertTrue("expected CSV parse error, got: " + e.getMessage(), e.getMessage().contains("CSV parse error"));
+        assertEquals(org.elasticsearch.rest.RestStatus.BAD_REQUEST, e.status());
     }
 
     public void testSkipRowOnBracketParseError() throws IOException {
@@ -3176,7 +3185,7 @@ public class CsvFormatReaderTests extends ESTestCase {
         CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(config);
         ErrorPolicy budgetOf2 = new ErrorPolicy(2, false);
 
-        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+        ParsingException e = expectThrows(ParsingException.class, () -> {
             try (
                 CloseableIterator<Page> iterator = reader.read(
                     object,
@@ -3189,6 +3198,7 @@ public class CsvFormatReaderTests extends ESTestCase {
             }
         });
         assertTrue("expected budget message, got: " + e.getMessage(), e.getMessage().contains("error budget exceeded"));
+        assertEquals(org.elasticsearch.rest.RestStatus.BAD_REQUEST, e.status());
     }
 
     // -- Stage 2: empty projection (COUNT(*)) fast path --
@@ -3364,5 +3374,203 @@ public class CsvFormatReaderTests extends ESTestCase {
             assertEquals(new BytesRef("Charlie"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
             page.releaseBlocks();
         }
+    }
+
+    // -- Stage 4: schema-sampling resilience and chunk-0 use of pre-bound schema --
+
+    /**
+     * The streaming-parallel coordinator pre-binds the schema via {@code withSchema} before
+     * dispatching chunk 0. Chunk 0 still carries the file header (with {@code header_row=true})
+     * or starts at the first data row (with {@code header_row=false}). In both cases the parser
+     * must use the bound schema rather than re-running schema inference on chunk-0 bytes —
+     * doing so would re-read the entire {@code schema_sample_size} window of rows just to
+     * rediscover the same schema, and any malformed row in that window would crash the query.
+     */
+    public void testFirstSplitWithBoundSchemaSkipsHeaderInsteadOfReinferring() throws IOException {
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            2,Bob
+            """;
+        StorageObject object = createStorageObject(csv);
+
+        List<Attribute> bound = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "id", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD)
+        );
+        FormatReader baseReader = new CsvFormatReader(blockFactory);
+        FormatReader boundReader = baseReader.withSchema(bound);
+
+        try (
+            CloseableIterator<Page> iterator = boundReader.read(
+                object,
+                FormatReadContext.builder().firstSplit(true).recordAligned(true).batchSize(10).build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(2L, ((LongBlock) page.getBlock(0)).getLong(1));
+            assertEquals(new BytesRef("Bob"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+            page.releaseBlocks();
+        }
+    }
+
+    public void testFirstSplitWithBoundSchemaHeaderlessSkipsNoLine() throws IOException {
+        // No header in the file; bound schema names the columns. The header-skip path must
+        // be a no-op and the first line "1,Alice" must be returned as data.
+        String csv = "1,Alice\n2,Bob\n";
+        StorageObject object = createStorageObject(csv);
+
+        List<Attribute> bound = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "col0", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "col1", DataType.KEYWORD)
+        );
+        FormatReader headerless = new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false));
+        FormatReader bound2 = headerless.withSchema(bound);
+
+        try (
+            CloseableIterator<Page> iterator = bound2.read(
+                object,
+                FormatReadContext.builder().firstSplit(true).recordAligned(true).batchSize(10).build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            page.releaseBlocks();
+        }
+    }
+
+    /**
+     * Schema sampling must skip malformed rows (the bracket-aware path is disabled here so the
+     * Jackson {@code RuntimeException}-wrapping path is exercised) and still infer the schema
+     * from the well-formed rows around them. Files that other engines (ClickHouse, DuckDB,
+     * Spark) accept must also infer here.
+     */
+    public void testCollectSampleRowsTolerantOfMalformedRows() throws IOException {
+        // Row 2 has an unclosed quote — Jackson will throw on it.
+        String csv = "1,Alice\n2,\"Bob\n3,Charlie\n4,Dave\n";
+        StorageObject object = createStorageObject(csv);
+        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false, "multi_value_syntax", "NONE"));
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            // Schema must be inferred from the rows that did parse — query must not 500.
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            // The row with the unclosed quote and any rows Jackson swallows during recovery
+            // are dropped under FAIL_FAST during sampling, but at least one row must come out.
+            assertTrue("expected at least one row to survive sampling, got " + page.getPositionCount(), page.getPositionCount() >= 1);
+            page.releaseBlocks();
+        }
+    }
+
+    /**
+     * If schema sampling cannot collect a single well-formed row, surface a capped client
+     * error (HTTP 400) rather than letting Jackson's {@code RuntimeException} escape as a 500.
+     */
+    public void testCollectSampleRowsAllBadRowsThrowsClientError() {
+        // Every line is malformed (unclosed quote at end). After {@link
+        // CsvFormatReader#MAX_CONSECUTIVE_SAMPLING_FAILURES} consecutive failures we bail.
+        StringBuilder csv = new StringBuilder();
+        for (int i = 0; i < CsvFormatReader.MAX_CONSECUTIVE_SAMPLING_FAILURES + 4; i++) {
+            csv.append(i).append(",\"unterminated\n");
+        }
+        StorageObject object = createStorageObject(csv.toString());
+        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false, "multi_value_syntax", "NONE"));
+
+        ParsingException e = expectThrows(ParsingException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        assertTrue("expected schema inference message, got: " + e.getMessage(), e.getMessage().contains("schema inference failed"));
+        assertEquals(org.elasticsearch.rest.RestStatus.BAD_REQUEST, e.status());
+        // Message must be capped, not megabytes of stack trace.
+        assertTrue("expected capped message, got " + e.getMessage().length() + " chars", e.getMessage().length() <= 4096);
+    }
+
+    public void testCsvErrorMessagesSummarizeShortValuePassesThrough() {
+        assertEquals("hello", CsvErrorMessages.summarize("hello"));
+        assertEquals("null", CsvErrorMessages.summarize((String) null));
+    }
+
+    public void testCsvErrorMessagesSummarizeLongValueIsCapped() {
+        StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 5_000; i++) {
+            huge.append('x');
+        }
+        String summarized = CsvErrorMessages.summarize(huge.toString());
+        assertTrue(
+            "expected length <= MAX_EXCERPT_CHARS, got " + summarized.length(),
+            summarized.length() <= CsvErrorMessages.MAX_EXCERPT_CHARS
+        );
+        assertTrue("expected truncation marker, got: " + summarized, summarized.contains("truncated"));
+        assertTrue("expected total-length marker, got: " + summarized, summarized.contains("5000"));
+    }
+
+    public void testCsvErrorMessagesSummarizeRowEmptyIsSentinel() {
+        assertEquals("<unparsed>", CsvErrorMessages.summarizeRow(new String[0]));
+        assertEquals("<unparsed>", CsvErrorMessages.summarizeRow(null));
+    }
+
+    /**
+     * The end-to-end repro for the ClickBench failure: a chunk-0 split with a malformed row
+     * deep inside the schema sample window. With the previous code, the parser thread would
+     * call {@code inferSchemaHeaderlessFromBatchReader} on chunk 0 even though
+     * {@link FormatReader#withSchema} had already bound the schema upstream, hit the bad row,
+     * and crash the query with a 500. With the fix, chunk-0 uses the bound schema and emits
+     * pages even when sampling on the same bytes would fail.
+     */
+    public void testStreamingChunkZeroWithBoundSchemaSurvivesMidFileMalformedRow() throws IOException {
+        StringBuilder csv = new StringBuilder();
+        for (int i = 0; i < 1300; i++) {
+            // Inject one malformed row well past 1000 to mimic ClickBench's "line 1246" case.
+            if (i == 1246) {
+                csv.append(i).append(",\"unterminated row that crashes Jackson\n");
+            } else {
+                csv.append(i).append(",\"row").append(i).append("\"\n");
+            }
+        }
+        StorageObject object = createStorageObject(csv.toString());
+
+        List<Attribute> bound = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "col0", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "col1", DataType.KEYWORD)
+        );
+        FormatReader headerless = new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false, "multi_value_syntax", "NONE"));
+        FormatReader bound2 = headerless.withSchema(bound);
+
+        // SKIP_ROW so the malformed row is dropped and the rest of the file flows through.
+        ErrorPolicy lenient = new ErrorPolicy(100, true);
+        try (
+            CloseableIterator<Page> iterator = bound2.read(
+                object,
+                FormatReadContext.builder().firstSplit(true).recordAligned(true).batchSize(2048).errorPolicy(lenient).build()
+            )
+        ) {
+            int totalRows = 0;
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                totalRows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+            // Most of the 1300 rows must come out; we only lose the malformed one (and possibly a
+            // small handful Jackson swallows during recovery). Pre-fix this would throw a 500.
+            assertTrue("expected most rows to survive, got " + totalRows, totalRows >= 1295);
+        }
+    }
+
+    public void testCsvErrorMessagesSummarizeRowFormatsColumns() {
+        String summary = CsvErrorMessages.summarizeRow(new String[] { "1", "Alice", null });
+        assertTrue("expected col0, got: " + summary, summary.contains("col0=[1]"));
+        assertTrue("expected col1, got: " + summary, summary.contains("col1=[Alice]"));
+        assertTrue("expected col2, got: " + summary, summary.contains("col2=[null]"));
     }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -3447,6 +3447,60 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     /**
+     * Regression for elastic#148162: a single-shot whole-file read (firstSplit=true,
+     * recordAligned=false) must NOT use {@code resolvedSchema} as the iterator's positional
+     * schema. The planner calls {@code withSchema(context.attributes())} at operator-factory
+     * time with the projected output attributes, not the file's column layout. Treating that
+     * list as the file schema would mis-align column indices and trigger spurious
+     * "row has [N] columns but schema defines [M] columns" errors on every data row.
+     *
+     * <p>The bound-schema fast path is reserved for streaming-coordinator dispatch where
+     * {@code recordAligned=true} signals that the upstream caller has bound the FULL file
+     * schema. For non-streaming reads, the iterator must re-parse the header itself, exactly
+     * like the legacy non-bound path.
+     */
+    public void testFirstSplitWithoutRecordAlignedIgnoresProjectedBoundSchema() throws IOException {
+        // 4 columns in the file, projection asks for 2 of them. The planner-bound schema
+        // mirrors the projected output; if read() used it as the file schema, every data row
+        // (4 cols) would trip the row-shape check against schemaSize=2.
+        String csv = """
+            id:long,name:keyword,score:double,city:keyword
+            1,Alice,10.5,NYC
+            2,Bob,20.5,LON
+            """;
+        StorageObject object = createStorageObject(csv);
+
+        List<Attribute> projectedAttrs = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "id", DataType.LONG),
+            new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD)
+        );
+        FormatReader boundReader = new CsvFormatReader(blockFactory).withSchema(projectedAttrs);
+
+        try (
+            CloseableIterator<Page> iterator = boundReader.read(
+                object,
+                // firstSplit=true, recordAligned=false: matches AsyncExternalSourceOperatorFactory's
+                // single-shot whole-file read context.
+                FormatReadContext.builder()
+                    .projectedColumns(List.of("id", "name"))
+                    .firstSplit(true)
+                    .recordAligned(false)
+                    .batchSize(10)
+                    .build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(2L, ((LongBlock) page.getBlock(0)).getLong(1));
+            assertEquals(new BytesRef("Bob"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+            page.releaseBlocks();
+        }
+    }
+
+    /**
      * Schema sampling honours skip_row the same way the data path does. The malformed row in
      * the middle is dropped, sampling continues, schema is inferred from the surrounding good
      * rows. This exercises the Jackson {@code RuntimeException}-wrapping path (multi_value

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -26,6 +26,9 @@ import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Nullability;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.ErrorPolicy;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
@@ -42,6 +45,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -3063,5 +3067,302 @@ public class CsvFormatReaderTests extends ESTestCase {
                 return StoragePath.of("memory://test.csv");
             }
         };
+    }
+
+    // -- Stage 1: structural parse error resilience --
+    //
+    // Jackson CSV throws on malformed rows (e.g. unclosed quotes). Before, the exception
+    // propagated and killed the query. The error policy now intercepts those failures so
+    // SKIP_ROW / NULL_FIELD recover and FAIL_FAST surfaces a clear error.
+
+    public void testSkipRowOnUnclosedQuoteJacksonPath() throws IOException {
+        // Trailing quote with no closing pair triggers Jackson's "Missing closing quote" error.
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            2,"Bob is broken
+            3,Charlie
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        // Jackson path requires bracketMultiValues=false: use NONE multi-value syntax.
+        Map<String, Object> config = Map.of("multi_value_syntax", "NONE");
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(config);
+        ErrorPolicy lenient = new ErrorPolicy(10, true);
+
+        List<Long> ids = new ArrayList<>();
+        try (
+            CloseableIterator<Page> iterator = reader.read(object, FormatReadContext.builder().batchSize(10).errorPolicy(lenient).build())
+        ) {
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                LongBlock idBlock = (LongBlock) page.getBlock(0);
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    ids.add(idBlock.getLong(i));
+                }
+                page.releaseBlocks();
+            }
+        }
+        // The good row 1,Alice must survive; behaviour for rows after the malformed line is
+        // defined by Jackson's resync — pin the row that precedes the malformed input so a
+        // regression that drops it (e.g. removing the try/catch around csvIterator.next) fails
+        // loudly. The tail behaviour is intentionally left untested as it depends on Jackson.
+        assertTrue("expected id 1 (Alice) to survive the unclosed-quote row, got " + ids, ids.contains(1L));
+    }
+
+    public void testFailFastOnUnclosedQuoteJacksonPath() {
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            2,"Bob is broken
+            3,Charlie
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        Map<String, Object> config = Map.of("multi_value_syntax", "NONE");
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(config);
+
+        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            try (
+                CloseableIterator<Page> iterator = reader.read(
+                    object,
+                    FormatReadContext.builder().batchSize(10).errorPolicy(ErrorPolicy.STRICT).build()
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        assertTrue("expected CSV parse error, got: " + e.getMessage(), e.getMessage().contains("CSV parse error"));
+    }
+
+    public void testSkipRowOnBracketParseError() throws IOException {
+        // Unclosed bracket in last cell is detected by splitLineBracketAware which throws
+        // EsqlIllegalArgumentException; the policy must intercept it.
+        String csv = """
+            id:long,tags:keyword
+            1,[a,b,c]
+            2,[broken
+            3,[x,y]
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(10, true);
+
+        try (
+            CloseableIterator<Page> iterator = reader.read(object, FormatReadContext.builder().batchSize(10).errorPolicy(lenient).build())
+        ) {
+            int totalRows = 0;
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                totalRows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+            // Rows 1 and 3 must survive the malformed bracketed row in the middle.
+            assertEquals(2, totalRows);
+        }
+    }
+
+    public void testStructuralErrorBudgetEnforced() {
+        StringBuilder csv = new StringBuilder("id:long,name:keyword\n");
+        for (int i = 0; i < 10; i++) {
+            csv.append("1,\"unterminated\n");
+        }
+
+        StorageObject object = createStorageObject(csv.toString());
+        Map<String, Object> config = Map.of("multi_value_syntax", "NONE");
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(config);
+        ErrorPolicy budgetOf2 = new ErrorPolicy(2, false);
+
+        EsqlIllegalArgumentException e = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            try (
+                CloseableIterator<Page> iterator = reader.read(
+                    object,
+                    FormatReadContext.builder().batchSize(10).errorPolicy(budgetOf2).build()
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        assertTrue("expected budget message, got: " + e.getMessage(), e.getMessage().contains("error budget exceeded"));
+    }
+
+    // -- Stage 2: empty projection (COUNT(*)) fast path --
+    //
+    // When the optimizer prunes every column (projectedColumns=[]), the reader must emit
+    // row-count-only Pages without allocating any blocks or running type conversion.
+
+    public void testEmptyProjectionEmitsRowCountOnlyPages() throws IOException {
+        String csv = """
+            id:long,name:keyword,score:double
+            1,Alice,1.5
+            2,Bob,2.5
+            3,Charlie,3.5
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (
+            CloseableIterator<Page> iterator = reader.read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of()).batchSize(10).build()
+            )
+        ) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(3, page.getPositionCount());
+            assertEquals("COUNT(*) fast path must emit zero blocks", 0, page.getBlockCount());
+            page.releaseBlocks();
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    public void testEmptyProjectionAcrossBatches() throws IOException {
+        StringBuilder csv = new StringBuilder("id:long,name:keyword\n");
+        int rowCount = 250;
+        for (int i = 0; i < rowCount; i++) {
+            csv.append(i).append(",Name").append(i).append('\n');
+        }
+
+        StorageObject object = createStorageObject(csv.toString());
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (
+            CloseableIterator<Page> iterator = reader.read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of()).batchSize(50).build()
+            )
+        ) {
+            int totalRows = 0;
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                assertEquals("COUNT(*) fast path must emit zero blocks", 0, page.getBlockCount());
+                totalRows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+            assertEquals(rowCount, totalRows);
+        }
+    }
+
+    public void testEmptyProjectionAppliesColumnCountValidation() throws IOException {
+        // Even on the COUNT(*) fast path, structural row errors (extra columns) must still
+        // be routed through the error policy.
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            2,Bob,extra_column
+            3,Charlie
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        ErrorPolicy lenient = new ErrorPolicy(10, true);
+
+        try (
+            CloseableIterator<Page> iterator = reader.read(
+                object,
+                FormatReadContext.builder().projectedColumns(List.of()).batchSize(10).errorPolicy(lenient).build()
+            )
+        ) {
+            int totalRows = 0;
+            while (iterator.hasNext()) {
+                Page page = iterator.next();
+                assertEquals(0, page.getBlockCount());
+                totalRows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+            // The malformed extra-column row must be skipped, leaving 2 valid rows.
+            assertEquals(2, totalRows);
+        }
+    }
+
+    public void testNullProjectionStillReadsAllColumns() throws IOException {
+        // Backward compatibility: projectedColumns=null means "no projection info available",
+        // which historically meant "read everything". Stage 2 must not regress this.
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            2,Bob
+            """;
+
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, FormatReadContext.builder().batchSize(10).build())) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals("null projection must still produce all columns", 2, page.getBlockCount());
+            // Verify column ordering and types are preserved (id:long first, name:keyword second).
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(2L, ((LongBlock) page.getBlock(0)).getLong(1));
+            assertEquals(new BytesRef("Bob"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+            page.releaseBlocks();
+        }
+    }
+
+    // -- Stage 3: recordAligned signal and split semantics --
+    //
+    // For non-first splits, the CSV reader needs to know whether the leading bytes are a
+    // partial record (byte-range macro-split — drop them) or a complete record (streaming
+    // chunk — keep them). The recordAligned flag carries that signal.
+
+    public void testRecordAlignedNonFirstSplitDoesNotDropFirstLine() throws IOException {
+        // Simulate a streaming-parallel chunk 1..N: bytes start exactly at a record boundary,
+        // schema is pre-bound via withSchema(), and the read context is firstSplit=false +
+        // recordAligned=true. The reader must NOT skip the first line.
+        String csv = "1,Alice\n2,Bob\n3,Charlie\n";
+        StorageObject object = createStorageObject(csv);
+        List<Attribute> schema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "id", DataType.LONG, Nullability.TRUE, null, false),
+            new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD, Nullability.TRUE, null, false)
+        );
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withSchema(schema);
+
+        FormatReadContext ctx = FormatReadContext.builder().batchSize(10).firstSplit(false).recordAligned(true).build();
+        try (CloseableIterator<Page> iterator = reader.read(object, ctx)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals("recordAligned=true must preserve all 3 rows", 3, page.getPositionCount());
+            // Pin the leading row so a regression that re-introduces the line skip on this path
+            // (which would surface as id=2 here) fails loudly.
+            assertEquals(1L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Alice"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(2L, ((LongBlock) page.getBlock(0)).getLong(1));
+            assertEquals(3L, ((LongBlock) page.getBlock(0)).getLong(2));
+            page.releaseBlocks();
+        }
+    }
+
+    public void testNonRecordAlignedNonFirstSplitDropsFirstLine() throws IOException {
+        // Simulate a bzip2/zstd byte-range macro-split: bytes start mid-record. The leading
+        // partial line was already emitted by the previous split, so the reader must drop it.
+        String csv = "partial-line-from-previous-split\n2,Bob\n3,Charlie\n";
+        StorageObject object = createStorageObject(csv);
+        List<Attribute> schema = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "id", DataType.LONG, Nullability.TRUE, null, false),
+            new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD, Nullability.TRUE, null, false)
+        );
+        CsvFormatReader reader = new CsvFormatReader(blockFactory).withSchema(schema);
+
+        // recordAligned defaults to false, matching legacy macro-split semantics.
+        FormatReadContext ctx = FormatReadContext.builder().batchSize(10).firstSplit(false).build();
+        try (CloseableIterator<Page> iterator = reader.read(object, ctx)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals("non-record-aligned non-first split must drop leading partial line", 2, page.getPositionCount());
+            // Pin the rows we kept: the partial leading line is gone; 2,Bob and 3,Charlie remain.
+            assertEquals(2L, ((LongBlock) page.getBlock(0)).getLong(0));
+            assertEquals(new BytesRef("Bob"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(0, new BytesRef()));
+            assertEquals(3L, ((LongBlock) page.getBlock(0)).getLong(1));
+            assertEquals(new BytesRef("Charlie"), ((BytesRefBlock) page.getBlock(1)).getBytesRef(1, new BytesRef()));
+            page.releaseBlocks();
+        }
     }
 }

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -3447,35 +3447,35 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     /**
-     * Schema sampling must skip malformed rows (the bracket-aware path is disabled here so the
-     * Jackson {@code RuntimeException}-wrapping path is exercised) and still infer the schema
-     * from the well-formed rows around them. Files that other engines (ClickHouse, DuckDB,
-     * Spark) accept must also infer here.
+     * Schema sampling honours skip_row the same way the data path does. The malformed row in
+     * the middle is dropped, sampling continues, schema is inferred from the surrounding good
+     * rows. This exercises the Jackson {@code RuntimeException}-wrapping path (multi_value
+     * syntax is set to NONE so the bracket-aware path is bypassed).
      */
-    public void testCollectSampleRowsTolerantOfMalformedRows() throws IOException {
-        // Row 2 has an unclosed quote — Jackson will throw on it.
+    public void testSamplingHonoursSkipRowPolicy() throws IOException {
+        // Row 2 has an unclosed quote — Jackson throws on it.
         String csv = "1,Alice\n2,\"Bob\n3,Charlie\n4,Dave\n";
         StorageObject object = createStorageObject(csv);
-        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("header_row", false, "multi_value_syntax", "NONE"));
+        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(
+            Map.of("header_row", false, "multi_value_syntax", "NONE", "error_mode", "skip_row", "max_errors", 100)
+        );
 
         try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
             // Schema must be inferred from the rows that did parse — query must not 500.
             assertTrue(iterator.hasNext());
             Page page = iterator.next();
-            // The row with the unclosed quote and any rows Jackson swallows during recovery
-            // are dropped under FAIL_FAST during sampling, but at least one row must come out.
             assertTrue("expected at least one row to survive sampling, got " + page.getPositionCount(), page.getPositionCount() >= 1);
             page.releaseBlocks();
         }
     }
 
     /**
-     * If schema sampling cannot collect a single well-formed row, surface a capped client
-     * error (HTTP 400) rather than letting Jackson's {@code RuntimeException} escape as a 500.
+     * Sampling under FAIL_FAST (the default) surfaces the very first malformed row as a
+     * client error (HTTP 400), with the row index, capped excerpt, and the hint pointing at
+     * skip_row. Same exception type and message shape the data-row path uses.
      */
-    public void testCollectSampleRowsAllBadRowsThrowsClientError() {
-        // Every line is malformed (unclosed quote at end). After {@link
-        // CsvFormatReader#MAX_CONSECUTIVE_SAMPLING_FAILURES} consecutive failures we bail.
+    public void testSamplingFailFastThrowsClientErrorWithHint() {
+        // Every line is malformed (unclosed quote at end). FAIL_FAST throws on row 1.
         StringBuilder csv = new StringBuilder();
         for (int i = 0; i < CsvFormatReader.MAX_CONSECUTIVE_SAMPLING_FAILURES + 4; i++) {
             csv.append(i).append(",\"unterminated\n");
@@ -3490,10 +3490,123 @@ public class CsvFormatReaderTests extends ESTestCase {
                 }
             }
         });
-        assertTrue("expected schema inference message, got: " + e.getMessage(), e.getMessage().contains("schema inference failed"));
+        assertTrue("expected sampling error message, got: " + e.getMessage(), e.getMessage().contains("CSV schema sampling failed"));
+        assertTrue("expected row index, got: " + e.getMessage(), e.getMessage().contains("row [1]"));
+        assertTrue("expected skip_row hint, got: " + e.getMessage(), e.getMessage().contains("skip_row"));
         assertEquals(org.elasticsearch.rest.RestStatus.BAD_REQUEST, e.status());
-        // Message must be capped, not megabytes of stack trace.
         assertTrue("expected capped message, got " + e.getMessage().length() + " chars", e.getMessage().length() <= 4096);
+    }
+
+    /**
+     * Sampling under SKIP_ROW with a tight budget exhausts and surfaces a capped budget error.
+     * Sampling errors count against the SAME max_errors budget the data path uses, matching
+     * ClickHouse's input_format_allow_errors_num semantics.
+     */
+    public void testSamplingSkipRowExceedsBudget() {
+        StringBuilder csv = new StringBuilder();
+        // 30 malformed rows, budget of 5 errors → throws after 6th error.
+        for (int i = 0; i < 30; i++) {
+            csv.append(i).append(",\"unterminated\n");
+        }
+        StorageObject object = createStorageObject(csv.toString());
+        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(
+            Map.of("header_row", false, "multi_value_syntax", "NONE", "error_mode", "skip_row", "max_errors", 5)
+        );
+
+        ParsingException e = expectThrows(ParsingException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        assertTrue("expected budget message, got: " + e.getMessage(), e.getMessage().contains("schema sampling exceeded error budget"));
+        assertEquals(org.elasticsearch.rest.RestStatus.BAD_REQUEST, e.status());
+    }
+
+    /**
+     * Sampling under SKIP_ROW with a generous budget but a permanently malformed file bails
+     * after MAX_CONSECUTIVE_SAMPLING_FAILURES (the Jackson-resync safety net), surfacing a
+     * "no rows could be parsed" error.
+     */
+    public void testSamplingSkipRowConsecutiveFailureSafetyNet() {
+        StringBuilder csv = new StringBuilder();
+        for (int i = 0; i < CsvFormatReader.MAX_CONSECUTIVE_SAMPLING_FAILURES + 4; i++) {
+            csv.append(i).append(",\"unterminated\n");
+        }
+        StorageObject object = createStorageObject(csv.toString());
+        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(
+            Map.of("header_row", false, "multi_value_syntax", "NONE", "error_mode", "skip_row", "max_errors", Long.MAX_VALUE)
+        );
+
+        ParsingException e = expectThrows(ParsingException.class, () -> {
+            try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        assertTrue("expected zero-rows message, got: " + e.getMessage(), e.getMessage().contains("schema inference failed"));
+        assertEquals(org.elasticsearch.rest.RestStatus.BAD_REQUEST, e.status());
+    }
+
+    /**
+     * Sanity check: the FAIL_FAST hint distinguishes structural errors (suggest skip_row) from
+     * field-type errors (suggest null_field). Field-type error: skip_row drops the whole row
+     * when one field is bad; null_field is the better escape hatch.
+     */
+    public void testFailFastHintForFieldTypeErrorMentionsNullField() {
+        String csv = """
+            id:long,name:keyword
+            1,Alice
+            not_a_number,Bob
+            """;
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        ParsingException e = expectThrows(ParsingException.class, () -> {
+            try (
+                CloseableIterator<Page> iterator = reader.read(
+                    object,
+                    FormatReadContext.builder().batchSize(10).errorPolicy(ErrorPolicy.STRICT).build()
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        });
+        // Field-type error → the hint should point at null_field specifically.
+        assertTrue("expected null_field hint, got: " + e.getMessage(), e.getMessage().contains("null_field"));
+        // structural=false should NOT mention skip_row in the recommendation.
+        assertFalse("did not expect skip_row hint for field error, got: " + e.getMessage(), e.getMessage().contains("skip_row"));
+    }
+
+    /**
+     * Sanity check: the FAIL_FAST hint for a structural (tokeniser) error mentions skip_row.
+     */
+    public void testFailFastHintForStructuralErrorMentionsSkipRow() {
+        String csv = """
+            id:long,name:keyword
+            1,"unterminated row
+            """;
+        StorageObject object = createStorageObject(csv);
+        // Bracket parsing disabled so the Jackson tokeniser fires the structural error.
+        FormatReader reader = new CsvFormatReader(blockFactory).withConfig(Map.of("multi_value_syntax", "NONE"));
+
+        ParsingException e = expectThrows(ParsingException.class, () -> {
+            try (
+                CloseableIterator<Page> iterator = reader.read(
+                    object,
+                    FormatReadContext.builder().batchSize(10).errorPolicy(ErrorPolicy.STRICT).build()
+                )
+            ) {
+                while (iterator.hasNext()) {
+                    iterator.next().releaseBlocks();
+                }
+            }
+        });
+        assertTrue("expected skip_row hint, got: " + e.getMessage(), e.getMessage().contains("skip_row"));
     }
 
     public void testCsvErrorMessagesSummarizeShortValuePassesThrough() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSourceFactory.java
@@ -207,76 +207,11 @@ final class FileSourceFactory implements ExternalSourceFactory {
     }
 
     static final String CONFIG_FORMAT = "format";
-    static final String CONFIG_MAX_ERRORS = "max_errors";
-    static final String CONFIG_MAX_ERROR_RATIO = "max_error_ratio";
-    static final String CONFIG_ERROR_MODE = "error_mode";
 
+    /** Delegates to {@link ErrorPolicy#fromConfig(Map, ErrorPolicy)} with the format's default
+     *  policy as the fallback. Kept here so existing call sites and tests do not have to change. */
     static ErrorPolicy resolveErrorPolicy(Map<String, Object> config, FormatReader format) {
-        if (config == null) {
-            return format.defaultErrorPolicy();
-        }
-        Object maxErrorsValue = config.get(CONFIG_MAX_ERRORS);
-        Object maxErrorRatioValue = config.get(CONFIG_MAX_ERROR_RATIO);
-        Object errorModeValue = config.get(CONFIG_ERROR_MODE);
-        if (maxErrorsValue == null && maxErrorRatioValue == null && errorModeValue == null) {
-            return format.defaultErrorPolicy();
-        }
-
-        // When only budget keys are set (no explicit mode), default to SKIP_ROW.
-        // When only mode is set, budget defaults depend on the mode.
-        ErrorPolicy.Mode mode = ErrorPolicy.Mode.SKIP_ROW;
-        if (errorModeValue != null) {
-            String modeStr = errorModeValue.toString();
-            try {
-                mode = ErrorPolicy.Mode.parse(modeStr);
-            } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Invalid value for [" + CONFIG_ERROR_MODE + "]: [" + errorModeValue + "]", e);
-            }
-            if (mode == null) {
-                throw new IllegalArgumentException("Invalid value for [" + CONFIG_ERROR_MODE + "]: [" + errorModeValue + "]");
-            }
-        }
-
-        // FAIL_FAST is incompatible with budget settings — it always aborts on the first error.
-        if (mode == ErrorPolicy.Mode.FAIL_FAST) {
-            if (maxErrorsValue != null || maxErrorRatioValue != null) {
-                throw new IllegalArgumentException(
-                    "["
-                        + CONFIG_MAX_ERRORS
-                        + "] and ["
-                        + CONFIG_MAX_ERROR_RATIO
-                        + "] cannot be used with ["
-                        + CONFIG_ERROR_MODE
-                        + "="
-                        + mode
-                        + "]; fail_fast always aborts on the first error"
-                );
-            }
-            return ErrorPolicy.STRICT;
-        }
-
-        long maxErrors;
-        if (maxErrorsValue != null) {
-            try {
-                maxErrors = Long.parseLong(maxErrorsValue.toString());
-            } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("Invalid value for [" + CONFIG_MAX_ERRORS + "]: [" + maxErrorsValue + "]", e);
-            }
-        } else {
-            maxErrors = Long.MAX_VALUE;
-        }
-
-        double maxErrorRatio = 0.0;
-        if (maxErrorRatioValue != null) {
-            try {
-                maxErrorRatio = Double.parseDouble(maxErrorRatioValue.toString());
-            } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("Invalid value for [" + CONFIG_MAX_ERROR_RATIO + "]: [" + maxErrorRatioValue + "]", e);
-            }
-        }
-
-        boolean logErrors = maxErrors < Long.MAX_VALUE || maxErrorRatio > 0.0;
-        return new ErrorPolicy(mode, maxErrors, maxErrorRatio, logErrors);
+        return ErrorPolicy.fromConfig(config, format.defaultErrorPolicy());
     }
 
     private FormatReader resolveFormatReader(String objectName, Map<String, Object> config) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -231,24 +231,32 @@ public final class ParallelParsingCoordinator {
         private void parseSegment(int segmentIndex, long offset, long length) {
             BlockingQueue<Page> queue = segmentQueues.get(segmentIndex);
             try {
+                boolean lastSplit = segmentIndex == segmentQueues.size() - 1;
                 StorageObject segObj = new RangeStorageObject(storageObject, offset, length);
 
-                // Both record-boundary flags are true for every segment:
-                // - firstSplit: computeSegments probes the next record boundary, so each segment
-                // starts on a complete record; no leading partial line to skip.
-                // - lastSplit: each non-final segment's length runs through the full record
-                // terminator that the next segment starts after (LF, CRLF, or lone CR for formats
-                // that handle it), so the segment's final byte is the last byte of a terminator.
-                // The final segment runs to fileLength; behavior there is unchanged from the
-                // previous code which also marked it lastSplit=true. Setting this everywhere lets
-                // line-oriented readers (e.g. NDJSON) skip the byte-by-byte trailing-partial-line
+                // Per-flag semantics:
+                // - firstSplit: only segment 0 owns the file's leading bytes (and any header).
+                // computeSegments probes the next record boundary so segments 1..N start on a
+                // complete record, but for header-bearing formats (CSV) "first split" still means
+                // "the segment that contains the header"; otherwise non-first segments would re-run
+                // header inference on data rows.
+                // - lastSplit: only the trailing segment runs to fileLength; non-final segments
+                // end on a record-terminator byte and must NOT be marked lastSplit, so the
+                // codec/reader can correctly handle the segment-boundary tail (see
+                // ParallelParsingCoordinator's segmentation contract).
+                // - recordAligned: every segment is guaranteed to start at a record boundary
+                // (computeSegments probes the next record boundary), so line-oriented readers
+                // can skip the "drop leading partial line" workaround used for byte-range
+                // macro-splits where the leading bytes belong to a previous split. Setting this
+                // also lets readers (e.g. NDJSON) skip the byte-by-byte trailing-partial-line
                 // scan that the format would otherwise apply per chunk.
                 FormatReadContext ctx = FormatReadContext.builder()
                     .projectedColumns(projectedColumns)
                     .batchSize(batchSize)
                     .errorPolicy(errorPolicy)
-                    .firstSplit(true)
-                    .lastSplit(true)
+                    .firstSplit(segmentIndex == 0)
+                    .lastSplit(lastSplit)
+                    .recordAligned(true)
                     .build();
                 CloseableIterator<Page> pages = reader.read(segObj, ctx);
                 try (pages) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -420,9 +420,11 @@ public final class StreamingParallelParsingCoordinator {
                             chunk.length
                         );
 
-                        // Both record-boundary flags are true for every chunk:
-                        // - firstSplit: the segmentator slices on \n carry-over, so each chunk
-                        // starts on a complete record; no leading partial line to skip.
+                        // - firstSplit: only the very first chunk carries the file's leading bytes
+                        // (which for header-bearing formats like CSV include the header row).
+                        // Subsequent chunks start on data records and must not be treated as the
+                        // first split; otherwise CSV-style readers re-run header inference on data
+                        // rows. NDJSON does not have a header, so the readers ignore firstSplit.
                         // - lastSplit: the segmentator only dispatches a chunk after locating its
                         // trailing \n via findLastNewline (or grows the buffer until one is found),
                         // so the chunk's final byte is always a record terminator. The original
@@ -430,12 +432,16 @@ public final class StreamingParallelParsingCoordinator {
                         // chunk wrapped in TrimLastPartialLineInputStream's per-byte tail scan —
                         // pure overhead on already-aligned data. Setting lastSplit=true everywhere
                         // lets line-oriented readers (NDJSON) skip that scan.
+                        // - recordAligned: the segmentator slices on \n carry-over so each chunk
+                        // starts exactly on a record boundary; readers can skip the "drop leading
+                        // partial line" workaround used for byte-range macro-splits.
                         FormatReadContext ctx = FormatReadContext.builder()
                             .projectedColumns(projectedColumns)
                             .batchSize(batchSize)
                             .errorPolicy(errorPolicy)
-                            .firstSplit(true)
+                            .firstSplit(chunk.index == 0)
                             .lastSplit(true)
+                            .recordAligned(true)
                             .build();
 
                         try (CloseableIterator<Page> pages = reader.read(chunkObj, ctx)) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/ErrorPolicy.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.datasources.spi;
 
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Configures how format readers handle malformed or unparseable rows.
@@ -152,5 +153,86 @@ public record ErrorPolicy(Mode mode, long maxErrors, double maxErrorRatio, boole
             return (double) errorsSoFar > maxErrorRatio * rowsSoFar;
         }
         return false;
+    }
+
+    /** Config keys recognised by {@link #fromConfig}. Mirrored as constants so format
+     *  plugins do not have to hard-code the strings. */
+    public static final String CONFIG_MAX_ERRORS = "max_errors";
+
+    public static final String CONFIG_MAX_ERROR_RATIO = "max_error_ratio";
+    public static final String CONFIG_ERROR_MODE = "error_mode";
+
+    /**
+     * Resolves an {@link ErrorPolicy} from the user's {@code WITH} options. Returns
+     * {@code defaultPolicy} when none of {@link #CONFIG_ERROR_MODE},
+     * {@link #CONFIG_MAX_ERRORS}, or {@link #CONFIG_MAX_ERROR_RATIO} are set.
+     *
+     * <p>Validation matches what {@code FileSourceFactory} applied historically: invalid
+     * mode strings, non-numeric budgets, and {@code FAIL_FAST} combined with budget keys
+     * are all rejected with {@link IllegalArgumentException}.
+     */
+    public static ErrorPolicy fromConfig(Map<String, Object> config, ErrorPolicy defaultPolicy) {
+        if (config == null) {
+            return defaultPolicy;
+        }
+        Object maxErrorsValue = config.get(CONFIG_MAX_ERRORS);
+        Object maxErrorRatioValue = config.get(CONFIG_MAX_ERROR_RATIO);
+        Object errorModeValue = config.get(CONFIG_ERROR_MODE);
+        if (maxErrorsValue == null && maxErrorRatioValue == null && errorModeValue == null) {
+            return defaultPolicy;
+        }
+
+        Mode mode = Mode.SKIP_ROW;
+        if (errorModeValue != null) {
+            String modeStr = errorModeValue.toString();
+            try {
+                mode = Mode.parse(modeStr);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid value for [" + CONFIG_ERROR_MODE + "]: [" + errorModeValue + "]", e);
+            }
+            if (mode == null) {
+                throw new IllegalArgumentException("Invalid value for [" + CONFIG_ERROR_MODE + "]: [" + errorModeValue + "]");
+            }
+        }
+
+        if (mode == Mode.FAIL_FAST) {
+            if (maxErrorsValue != null || maxErrorRatioValue != null) {
+                throw new IllegalArgumentException(
+                    "["
+                        + CONFIG_MAX_ERRORS
+                        + "] and ["
+                        + CONFIG_MAX_ERROR_RATIO
+                        + "] cannot be used with ["
+                        + CONFIG_ERROR_MODE
+                        + "="
+                        + mode
+                        + "]; fail_fast always aborts on the first error"
+                );
+            }
+            return STRICT;
+        }
+
+        long maxErrors;
+        if (maxErrorsValue != null) {
+            try {
+                maxErrors = Long.parseLong(maxErrorsValue.toString());
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid value for [" + CONFIG_MAX_ERRORS + "]: [" + maxErrorsValue + "]", e);
+            }
+        } else {
+            maxErrors = Long.MAX_VALUE;
+        }
+
+        double maxErrorRatio = 0.0;
+        if (maxErrorRatioValue != null) {
+            try {
+                maxErrorRatio = Double.parseDouble(maxErrorRatioValue.toString());
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid value for [" + CONFIG_MAX_ERROR_RATIO + "]: [" + maxErrorRatioValue + "]", e);
+            }
+        }
+
+        boolean logErrors = maxErrors < Long.MAX_VALUE || maxErrorRatio > 0.0;
+        return new ErrorPolicy(mode, maxErrors, maxErrorRatio, logErrors);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
@@ -46,10 +46,14 @@ public record FormatReadContext(
 ) {
 
     /**
-     * Creates a minimal context for the common non-split case.
+     * Creates a minimal context for the common non-split case. Leaves {@code errorPolicy} as
+     * {@code null} so the reader falls back to its own default — typically the policy resolved
+     * from the user's {@code WITH} options via {@link FormatReader#withConfig}, or the
+     * {@link FormatReader#defaultErrorPolicy()} when no user options are set. Callers that need
+     * to override the policy should use {@link #builder()} or {@link #withErrorPolicy(ErrorPolicy)}.
      */
     public static FormatReadContext of(List<String> projectedColumns, int batchSize) {
-        return new FormatReadContext(projectedColumns, batchSize, FormatReader.NO_LIMIT, ErrorPolicy.STRICT, true, true, false);
+        return new FormatReadContext(projectedColumns, batchSize, FormatReader.NO_LIMIT, null, true, true, false);
     }
 
     /**
@@ -81,7 +85,10 @@ public record FormatReadContext(
         private List<String> projectedColumns;
         private int batchSize;
         private int rowLimit = FormatReader.NO_LIMIT;
-        private ErrorPolicy errorPolicy = ErrorPolicy.STRICT;
+        // Defaults to null so the reader falls back to its own resolved policy
+        // (typically the WITH-options policy from withConfig). Callers that want to override
+        // explicitly should call errorPolicy(...).
+        private ErrorPolicy errorPolicy = null;
         private boolean firstSplit = true;
         private boolean lastSplit = true;
         private boolean recordAligned = false;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/FormatReadContext.java
@@ -18,13 +18,22 @@ import java.util.List;
  * instance via {@link FormatReader#withPushedFilter}. This context carries only the parameters
  * that may vary per file or per split within a single query execution.
  *
- * @param projectedColumns columns to read (null or empty means all columns)
+ * @param projectedColumns columns to read. {@code null} means "no projection info available — read
+ *                         every column" (backward compatibility default). An <em>empty</em> list
+ *                         means "the optimizer pruned every column" (e.g. {@code COUNT(*)}); format
+ *                         readers may take a fast path that skips type conversion and emits row-
+ *                         count-only {@link org.elasticsearch.compute.data.Page Page}s.
  * @param batchSize        target number of rows per page
  * @param rowLimit         maximum total rows to return ({@link FormatReader#NO_LIMIT} for unlimited)
  * @param errorPolicy      how to handle malformed rows
  * @param firstSplit       whether this is the first split for the file (consistent with {@code lastSplit};
  *                         format-agnostic replacement for the legacy {@code skipFirstLine} parameter)
  * @param lastSplit        whether this is the last split for the file (affects trailing-record handling)
+ * @param recordAligned    whether the split starts at a record boundary (no leading partial record).
+ *                         When {@code false}, line-oriented readers may need to skip a leading partial line
+ *                         (e.g. bzip2 / zstd-indexed macro-splits). When {@code true}, the split is known
+ *                         to start exactly on a record boundary (e.g. streaming-parallel chunks sliced on
+ *                         {@code \n}). Has no effect on the first split.
  */
 public record FormatReadContext(
     List<String> projectedColumns,
@@ -32,35 +41,36 @@ public record FormatReadContext(
     int rowLimit,
     ErrorPolicy errorPolicy,
     boolean firstSplit,
-    boolean lastSplit
+    boolean lastSplit,
+    boolean recordAligned
 ) {
 
     /**
      * Creates a minimal context for the common non-split case.
      */
     public static FormatReadContext of(List<String> projectedColumns, int batchSize) {
-        return new FormatReadContext(projectedColumns, batchSize, FormatReader.NO_LIMIT, ErrorPolicy.STRICT, true, true);
+        return new FormatReadContext(projectedColumns, batchSize, FormatReader.NO_LIMIT, ErrorPolicy.STRICT, true, true, false);
     }
 
     /**
      * Returns a copy with a different row limit.
      */
     public FormatReadContext withRowLimit(int limit) {
-        return new FormatReadContext(projectedColumns, batchSize, limit, errorPolicy, firstSplit, lastSplit);
+        return new FormatReadContext(projectedColumns, batchSize, limit, errorPolicy, firstSplit, lastSplit, recordAligned);
     }
 
     /**
      * Returns a copy with a different error policy.
      */
     public FormatReadContext withErrorPolicy(ErrorPolicy policy) {
-        return new FormatReadContext(projectedColumns, batchSize, rowLimit, policy, firstSplit, lastSplit);
+        return new FormatReadContext(projectedColumns, batchSize, rowLimit, policy, firstSplit, lastSplit, recordAligned);
     }
 
     /**
      * Returns a copy configured for a split-based read.
      */
     public FormatReadContext withSplit(boolean first, boolean last) {
-        return new FormatReadContext(projectedColumns, batchSize, rowLimit, errorPolicy, first, last);
+        return new FormatReadContext(projectedColumns, batchSize, rowLimit, errorPolicy, first, last, recordAligned);
     }
 
     public static Builder builder() {
@@ -74,6 +84,7 @@ public record FormatReadContext(
         private ErrorPolicy errorPolicy = ErrorPolicy.STRICT;
         private boolean firstSplit = true;
         private boolean lastSplit = true;
+        private boolean recordAligned = false;
 
         private Builder() {}
 
@@ -107,11 +118,20 @@ public record FormatReadContext(
             return this;
         }
 
+        /**
+         * Marks the split as starting at a record boundary so line-oriented readers can skip the
+         * "trim leading partial record" workaround used for byte-range macro-splits.
+         */
+        public Builder recordAligned(boolean recordAligned) {
+            this.recordAligned = recordAligned;
+            return this;
+        }
+
         public FormatReadContext build() {
             if (batchSize <= 0) {
                 throw new IllegalArgumentException("batchSize must be positive, got: " + batchSize);
             }
-            return new FormatReadContext(projectedColumns, batchSize, rowLimit, errorPolicy, firstSplit, lastSplit);
+            return new FormatReadContext(projectedColumns, batchSize, rowLimit, errorPolicy, firstSplit, lastSplit, recordAligned);
         }
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -271,12 +272,16 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
     }
 
     /**
-     * Each segment ends at a record boundary by construction: non-final segments stop at the byte
-     * after the next segment's leading newline, and the final segment runs to {@code fileLength}.
-     * The coordinator therefore must mark every segment as {@code lastSplit=true} so the NDJSON
-     * reader can skip its byte-by-byte {@code TrimLastPartialLineInputStream} scan over the chunk.
+     * Verifies the per-segment context flags set by {@link ParallelParsingCoordinator}:
+     * <ul>
+     *   <li>Exactly one segment owns the file's leading bytes ({@code firstSplit=true}).</li>
+     *   <li>Exactly one segment runs to file end ({@code lastSplit=true}); non-final segments must
+     *       not be marked lastSplit so codecs/readers correctly handle the segment-boundary tail.</li>
+     *   <li>Every segment is {@code recordAligned=true} so line-oriented readers can skip the
+     *       leading-partial-line trim that byte-range macro-splits otherwise need.</li>
+     * </ul>
      */
-    public void testParseSegmentMarksAllChunksAsLastSplit() throws Exception {
+    public void testParseSegmentSetsExpectedSplitFlags() throws Exception {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < 200; i++) {
             sb.append("line-").append(String.format(java.util.Locale.ROOT, "%04d", i)).append("\n");
@@ -284,10 +289,8 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
         byte[] content = sb.toString().getBytes(StandardCharsets.UTF_8);
         StorageObject obj = new InMemoryStorageObject(content);
         BlockFactory blockFactory = blockFactory();
-        ContextRecordingFormatReader reader = new ContextRecordingFormatReader(blockFactory);
+        ContextCapturingLineReader reader = new ContextCapturingLineReader(blockFactory);
 
-        // Force several segments by setting parallelism > 1 with a small minimum segment size on
-        // the recording reader (1 byte) so computeSegments produces multiple chunks.
         ExecutorService exec = Executors.newFixedThreadPool(4);
         try {
             CloseableIterator<Page> iter = ParallelParsingCoordinator.parallelRead(reader, obj, List.of("line"), 50, 4, exec);
@@ -300,13 +303,25 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
             exec.shutdown();
         }
 
-        List<FormatReadContext> seen = reader.contexts();
+        List<FormatReadContext> seen;
+        synchronized (reader.contexts) {
+            seen = new ArrayList<>(reader.contexts);
+        }
         assertTrue("Expected at least 2 segments, recorded " + seen.size(), seen.size() >= 2);
+        int firstSplitCount = 0;
+        int lastSplitCount = 0;
         for (int i = 0; i < seen.size(); i++) {
             FormatReadContext ctx = seen.get(i);
-            assertTrue("segment[" + i + "] must have firstSplit=true", ctx.firstSplit());
-            assertTrue("segment[" + i + "] must have lastSplit=true (record-boundary aligned)", ctx.lastSplit());
+            if (ctx.firstSplit()) {
+                firstSplitCount++;
+            }
+            if (ctx.lastSplit()) {
+                lastSplitCount++;
+            }
+            assertTrue("segment[" + i + "] must have recordAligned=true", ctx.recordAligned());
         }
+        assertEquals("exactly one segment must own the file's leading bytes", 1, firstSplitCount);
+        assertEquals("exactly one segment must run to file end", 1, lastSplitCount);
     }
 
     /**
@@ -342,6 +357,25 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
         FormatReadContext only = seen.get(0);
         assertTrue("Whole-file fallback path must mark firstSplit=true", only.firstSplit());
         assertTrue("Whole-file fallback path must mark lastSplit=true", only.lastSplit());
+    }
+
+    /**
+     * Records the {@link FormatReadContext} of every {@code read} call so tests can assert the
+     * coordinator's per-segment split-flag dispatch behavior. Otherwise behaves like the parent
+     * {@link LineFormatReader}.
+     */
+    private static class ContextCapturingLineReader extends LineFormatReader {
+        final List<FormatReadContext> contexts = Collections.synchronizedList(new ArrayList<>());
+
+        ContextCapturingLineReader(BlockFactory blockFactory) {
+            super(blockFactory);
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+            contexts.add(context);
+            return super.read(object, context);
+        }
     }
 
     private static final BlockFactory TEST_BLOCK_FACTORY = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE)
@@ -451,7 +485,10 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
 
         @Override
         public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
-            boolean skipFirstLine = context.firstSplit() == false;
+            // Mirror production semantics: drop a leading partial record only when the caller has
+            // not guaranteed record-alignment. `ParallelParsingCoordinator` now sets
+            // `recordAligned=true` for every segment, so `skipFirstLine` is effectively false here.
+            boolean skipFirstLine = context.firstSplit() == false && context.recordAligned() == false;
             int batchSize = context.batchSize();
             InputStream stream = object.newStream();
             java.io.BufferedReader br = new java.io.BufferedReader(new java.io.InputStreamReader(stream, StandardCharsets.UTF_8));
@@ -659,7 +696,9 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
 
         @Override
         public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
-            boolean skipFirstLine = context.firstSplit() == false;
+            // See note in the other test fixture: drop a leading partial record only when the caller
+            // has not guaranteed record-alignment.
+            boolean skipFirstLine = context.firstSplit() == false && context.recordAligned() == false;
             int batchSize = context.batchSize();
             InputStream stream = object.newStream();
             java.io.BufferedReader br = new java.io.BufferedReader(new java.io.InputStreamReader(stream, StandardCharsets.UTF_8));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -203,11 +203,20 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
                 seen = new ArrayList<>(reader.seenContexts);
             }
             assertTrue("Expected at least 2 chunks, recorded " + seen.size(), seen.size() >= 2);
+            // Contexts may not arrive in chunk-index order across parser threads. Count rather
+            // than positional-assert: exactly one chunk owns the file's leading bytes (firstSplit),
+            // every chunk is record-aligned, and every chunk is marked lastSplit so line-oriented
+            // readers can skip the trailing-partial-line scan.
+            int firstSplitCount = 0;
             for (int i = 0; i < seen.size(); i++) {
                 FormatReadContext ctx = seen.get(i);
-                assertTrue("chunk[" + i + "] must have firstSplit=true", ctx.firstSplit());
+                if (ctx.firstSplit()) {
+                    firstSplitCount++;
+                }
                 assertTrue("chunk[" + i + "] must have lastSplit=true (record-boundary aligned)", ctx.lastSplit());
+                assertTrue("chunk[" + i + "] must have recordAligned=true (sliced on \\n)", ctx.recordAligned());
             }
+            assertEquals("exactly one chunk must own the file's leading bytes", 1, firstSplitCount);
         } finally {
             executor.shutdownNow();
         }
@@ -428,7 +437,11 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             List<String> lines = new ArrayList<>();
             StringBuilder current = new StringBuilder();
 
-            boolean skipFirst = context.firstSplit() == false;
+            // Mirror the production behavior: skip a leading partial record only when the caller
+            // has not guaranteed record-alignment (e.g. byte-range macro-splits). Streaming chunks
+            // and segment-aligned splits set recordAligned=true, in which case the leading bytes
+            // are a complete record.
+            boolean skipFirst = context.firstSplit() == false && context.recordAligned() == false;
 
             int b;
             while ((b = stream.read()) != -1) {


### PR DESCRIPTION
Three independent improvements to the CSV format reader and the parsing coordinators that drive it.

## Why

- **Structural CSV parse errors used to kill the query.** Jackson's `MissingClosingQuoteException` and the bracket-aware path's structural failures bypassed the existing error policy. Real datasets contain malformed rows; users want the same `SKIP_ROW` / `NULL_FIELD` / `FAIL_FAST` semantics that already cover field-level conversion errors.
- **`COUNT(*)` over CSV did 100% of the type-conversion work it didn't need.** When the optimizer prunes every column, the reader still parsed and converted every cell. The new fast path emits row-count-only `Page`s and skips builder allocation entirely, mirroring the same optimization recently added to NDJSON.
- **Parallel CSV parsing mis-handled headers.** Streaming-parallel chunks 1..N (and byte-range segments 1..N) were dispatched with `firstSplit=true`, which made the reader re-run header inference on data rows; alternatively `firstSplit=false` would skip a valid record. A new `recordAligned` context flag lets coordinators tell the reader "this split starts on a record boundary" so the pre-bound schema is used directly. Legacy bzip2/zstd byte-range macro-splits keep their leading-partial-line trim by leaving `recordAligned` at the default `false`.

## Notes for review

- The PR is currently based on `esql/streaming-parallel-gzip` and will be rebased on `main` once that PR lands; the diff against `main` will look right then.
- Tests use value-level assertions (column values, not just row counts) so future regressions surface loudly.
- Backward compatibility: `projectedColumns == null` keeps reading every column; only `projectedColumns.isEmpty()` triggers the COUNT(*) fast path.

Developed with AI-assisted tooling