### PR TITLE
[9.4] Fix field name length limit tests (#148161)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/100_field_name_length_limit.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/100_field_name_length_limit.yml
@@ -37,6 +37,10 @@ setup:
   - match: { result: created }
 
   - do:
+      cluster.health:
+        wait_for_events: languid
+
+  - do:
       indices.get_mapping:
         index: test_index
 
@@ -88,6 +92,10 @@ setup:
             field_name_not_ignored: [ 10, 20, 30 ]
 
   - match: { result: created }
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
 
   - do:
       indices.get_mapping:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix field name length limit tests (#148161)](https://github.com/elastic/elasticsearch/pull/148161)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)