### PR TITLE
[9.3] Fix field name length limit tests (#148161)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/100_field_name_length_limit.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/100_field_name_length_limit.yml
@@ -30,6 +30,10 @@ setup:
             field_name_not_ignored: 10
 
   - do:
+      cluster.health:
+        wait_for_events: languid
+
+  - do:
       indices.get_mapping:
         index: test_index
 
@@ -74,6 +78,10 @@ setup:
           foo:
             test_really_long_field_name_that_will_be_ignored: [ foo, bar, baz ]
             field_name_not_ignored: [ 10, 20, 30 ]
+
+  - do:
+      cluster.health:
+        wait_for_events: languid
 
   - do:
       indices.get_mapping:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix field name length limit tests (#148161)](https://github.com/elastic/elasticsearch/pull/148161)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)