### PR TITLE
Unmute RandomizedRollingUpgradeIT#testIndexingSyntheticSource

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -255,9 +255,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_byte_quantized_bfloat16/KNN Vector similarity search only}
   issue: https://github.com/elastic/elasticsearch/issues/147251
-- class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
-  method: testIndexingSyntheticSource
-  issue: https://github.com/elastic/elasticsearch/issues/147298
 - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
   method: testDeploymentSurvivesRestart {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/145728


### PR DESCRIPTION
The test was failing and muted by CI, tracked in #147298.
Unfortunately, due to #147772, I was unable to reproduce the issue.
I'll re-enable the test. Now that the non-reproducibility issue is fixed, if it fails again, I should be able to reproduce locally and debug.