### PR TITLE
ES|QL Support dynamic time_zone in DATE_PARSE

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -1940,3 +1940,46 @@ from employees
 emp_no:integer | hire_date:date             | monthName:keyword
 10004          | 1986-12-01T00:00:00.000Z   | November
 ;
+
+evalDateParseWithDynamicTimezone
+required_capability: date_parse_options
+
+row timestamp = "2023-05-06T10:00:00", tz = "US/Eastern"
+| eval parsed = date_parse("yyyy-MM-dd'T'HH:mm:ss", timestamp, {"time_zone": tz})
+| keep timestamp, tz, parsed;
+
+timestamp:keyword   | tz:keyword     | parsed:datetime
+2023-05-06T10:00:00 | US/Eastern     | 2023-05-06T14:00:00.000Z
+;
+
+evalDateParseWithDynamicTimezoneTokyо
+required_capability: date_parse_options
+
+row timestamp = "2023-05-06T08:15:00", tz = "Asia/Tokyo"
+| eval parsed = date_parse("yyyy-MM-dd'T'HH:mm:ss", timestamp, {"time_zone": tz})
+| keep timestamp, tz, parsed;
+
+timestamp:keyword   | tz:keyword  | parsed:datetime
+2023-05-06T08:15:00 | Asia/Tokyo  | 2023-05-05T23:15:00.000Z
+;
+
+evalDateParseDynamicTimezoneFromEmployees
+required_capability: date_parse_options
+
+FROM employees 
+| WHERE emp_no >= 10001 AND emp_no <= 10003
+| SORT emp_no
+| EVAL tz = CASE(
+    emp_no == 10001, "US/Eastern",
+    emp_no == 10002, "Europe/Paris",
+    emp_no == 10003, "Asia/Tokyo"
+  )
+| EVAL birth_str = DATE_FORMAT("yyyy-MM-dd'T'HH:mm:ss", birth_date)
+| EVAL parsed = DATE_PARSE("yyyy-MM-dd'T'HH:mm:ss", birth_str, {"time_zone": tz})
+| KEEP emp_no, birth_date, tz, parsed;
+
+emp_no:integer | birth_date:datetime          | tz:keyword     | parsed:datetime
+10001          | 1953-09-02T00:00:00.000Z     | US/Eastern     | 1953-09-02T04:00:00.000Z
+10002          | 1964-06-02T00:00:00.000Z     | Europe/Paris   | 1964-06-01T23:00:00.000Z
+10003          | 1959-12-03T00:00:00.000Z     | Asia/Tokyo     | 1959-12-02T15:00:00.000Z
+;

--- a/x-pack/plugin/esql/src/main/antlr/parser/Expression.g4
+++ b/x-pack/plugin/esql/src/main/antlr/parser/Expression.g4
@@ -69,6 +69,7 @@ entryExpression
 mapValue
     : constant
     | mapExpression
+    | qualifiedName
     ;
 
 constant

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -98,9 +98,9 @@ public class DateParse extends EsqlConfigurationFunction implements TwoOptionalA
                     name = TIME_ZONE_PARAM_NAME,
                     type = "keyword",
                     valueHint = { "standard" },
-                    description = "Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values 
-                    in the query string to UTC. Can be a literal string (e.g. "US/Eastern") or a field reference containing 
-                    the timezone per document."
+                    description = "Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values "
+                        + "in the query string to UTC. Can be a literal string (e.g. \"US/Eastern\") or a field reference "
+                        + "containing the timezone per document."
                 ),
                 @MapParam.MapParamEntry(
                     name = LOCALE_PARAM_NAME,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -70,6 +70,7 @@ public class DateParse extends EsqlConfigurationFunction implements TwoOptionalA
 
     private static final String TIME_ZONE_PARAM_NAME = "time_zone";
     private static final String LOCALE_PARAM_NAME = "locale";
+    public static final String FuNCTION_NAME = "date_parse";
 
     private final Expression first;
     private final Expression second;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.util.LocaleUtils;
@@ -18,7 +19,9 @@ import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.EntryExpression;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MapExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -236,12 +239,31 @@ public class DateParse extends EsqlConfigurationFunction implements TwoOptionalA
         return parse(val.utf8ToString(), toFormatter(formatter, locale), zoneId, locale);
     }
 
+    @Evaluator(extraName = "ConstantRuntimeZoneId", warnExceptions = { IllegalArgumentException.class, ZoneRulesException.class, NullPointerException.class })
+    static long process(BytesRef val, @Fixed DateFormatter formatter, BytesRef zoneId, @Fixed Locale locale)
+        throws IllegalArgumentException, ZoneRulesException {
+        return parse(val.utf8ToString(), formatter, parseZoneId(zoneId), locale);
+    }
+
+    @Evaluator(extraName = "RuntimeZoneId", warnExceptions = { IllegalArgumentException.class, ZoneRulesException.class, NullPointerException.class })
+    static long process(BytesRef val, BytesRef formatter, BytesRef zoneId, @Fixed Locale locale) throws IllegalArgumentException,
+        ZoneRulesException {
+        return parse(val.utf8ToString(), toFormatter(formatter, locale), parseZoneId(zoneId), locale);
+    }
+
     private static long parse(String date, DateFormatter formatter, ZoneId zoneId, Locale locale) {
         try {
             return DateFormatters.from(formatter.parse(date), locale, zoneId).toInstant().toEpochMilli();
         } catch (DateTimeException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
+    }
+
+    private static ZoneId parseZoneId(BytesRef zoneIdStr) {
+        if (zoneIdStr == null || zoneIdStr.length == 0) {
+            return null;
+        }
+        return ZoneId.of(zoneIdStr.utf8ToString());
     }
 
     public static final Map<String, DataType> ALLOWED_OPTIONS = Map.ofEntries(
@@ -262,47 +284,157 @@ public class DateParse extends EsqlConfigurationFunction implements TwoOptionalA
 
     @Override
     public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
-        Expression field = field();
-        Expression format = format();
-        ExpressionEvaluator.Factory fieldEvaluator = toEvaluator.apply(field);
+        ExpressionEvaluator.Factory fieldEvaluator = toEvaluator.apply(field());
 
-        var parsedOptions = this.parseOptions();
-        String localeAsString = (String) parsedOptions.get(LOCALE_PARAM_NAME);
-        Locale locale = localeAsString == null ? Locale.ROOT : LocaleUtils.parse(localeAsString);
+        Expression options = options();
 
-        String timezoneAsString = (String) parsedOptions.get(TIME_ZONE_PARAM_NAME);
-        ZoneId timezone = configuration().zoneId();
-        try {
-            if (timezoneAsString != null) {
-                timezone = ZoneId.of(timezoneAsString);
-            }
-        } catch (ZoneRulesException e) {
-            throw new IllegalArgumentException("unsupported timezone [" + timezoneAsString + "]");
+        Locale locale = extractLocale(options);
+        Expression timezoneExpr = extractTimezoneExpr(options);
+
+        ZoneId constantTimezone = resolveConstantTimezone(timezoneExpr, toEvaluator);
+        ExpressionEvaluator.Factory timezoneEvaluator = resolveTimezoneEvaluator(timezoneExpr, toEvaluator);
+
+        return resolveFormatterAndBuildEvaluator(
+            format(),
+            locale,
+            toEvaluator,
+            fieldEvaluator,
+            constantTimezone,
+            timezoneEvaluator
+        );
+    }
+
+    private Locale extractLocale(Expression options) {
+        if (options == null) {
+            return Locale.ROOT;
         }
+
+        for (EntryExpression entry : ((MapExpression) options).entryExpressions()) {
+            if (!(entry.key() instanceof Literal keyLit)) {
+                throw new InvalidArgumentException("Option keys must be literal values");
+            }
+
+            if (LOCALE_PARAM_NAME.equals(BytesRefs.toString(keyLit.value()))) {
+                if (!(entry.value() instanceof Literal valLit)) {
+                    throw new InvalidArgumentException(
+                        "Invalid option [" + LOCALE_PARAM_NAME + "] in [" + sourceText() + "], expected a [keyword] value");
+                }
+                return LocaleUtils.parse(BytesRefs.toString(valLit.value()));
+            }
+        }
+
+        return Locale.ROOT;
+    }
+
+    private Expression extractTimezoneExpr(Expression options) {
+        if (options == null) {
+            return null;
+        }
+
+        for (EntryExpression entry : ((MapExpression) options).entryExpressions()) {
+            if (!(entry.key() instanceof Literal keyLit)) {
+                throw new InvalidArgumentException("Option keys must be literal values");
+            }
+
+            String optionKey = BytesRefs.toString(keyLit.value());
+
+            if (!ALLOWED_OPTIONS.containsKey(optionKey)) {
+                throw new InvalidArgumentException(
+                    "Invalid option [" + optionKey + "] in [" + sourceText() + "], expected one of " + ALLOWED_OPTIONS.keySet());
+            }
+
+            if (TIME_ZONE_PARAM_NAME.equals(optionKey)) {
+                if (!DataType.isString(entry.value().dataType())) {
+                    throw new InvalidArgumentException(
+                        "Invalid option [" + optionKey + "] in [" + sourceText() + "], expected a [keyword] value");
+                }
+                return entry.value();
+            }
+        }
+
+        return null;
+    }
+
+    private ZoneId resolveConstantTimezone(Expression timezoneExpr, ToEvaluator toEvaluator) {
+        if (timezoneExpr == null) {
+            return configuration().zoneId();
+        }
+
+        if (!timezoneExpr.foldable()) {
+            return null;
+        }
+
+        try {
+            String tzString = BytesRefs.toString((BytesRef) timezoneExpr.fold(toEvaluator.foldCtx()));
+            return ZoneId.of(tzString);
+        } catch (ZoneRulesException e) {
+            throw new IllegalArgumentException("unsupported timezone [" + timezoneExpr + "]: " + e.getMessage());
+        }
+    }
+
+    private ExpressionEvaluator.Factory resolveTimezoneEvaluator(Expression timezoneExpr, ToEvaluator toEvaluator) {
+        if (timezoneExpr == null || timezoneExpr.foldable()) {
+            return null;
+        }
+        return toEvaluator.apply(timezoneExpr);
+    }
+
+    private ExpressionEvaluator.Factory resolveFormatterAndBuildEvaluator(
+        Expression format,
+        Locale locale,
+        ToEvaluator toEvaluator,
+        ExpressionEvaluator.Factory fieldEvaluator,
+        ZoneId constantTimezone,
+        ExpressionEvaluator.Factory timezoneEvaluator) {
 
         if (format == null) {
-            return new DateParseConstantEvaluator.Factory(
-                source(),
-                fieldEvaluator,
-                DEFAULT_DATE_TIME_FORMATTER.withLocale(locale),
-                timezone,
-                locale
-            );
+            DateFormatter formatter = DEFAULT_DATE_TIME_FORMATTER.withLocale(locale);
+            return selectEvaluator(fieldEvaluator, formatter, null, constantTimezone, timezoneEvaluator, locale);
         }
-        if (DataType.isString(format.dataType()) == false) {
+
+        if (!DataType.isString(format.dataType())) {
             throw new IllegalArgumentException("unsupported data type for date_parse [" + format.dataType() + "]");
         }
 
         if (format.foldable()) {
             try {
                 DateFormatter formatter = toFormatter(format.fold(toEvaluator.foldCtx()), locale);
-                return new DateParseConstantEvaluator.Factory(source(), fieldEvaluator, formatter, timezone, locale);
+                return selectEvaluator(fieldEvaluator, formatter, null, constantTimezone, timezoneEvaluator, locale);
             } catch (IllegalArgumentException e) {
                 throw new InvalidArgumentException(e, "invalid date pattern for [{}]: {}", sourceText(), e.getMessage());
             }
         }
+
+        // Format is runtime
         ExpressionEvaluator.Factory formatEvaluator = toEvaluator.apply(format);
-        return new DateParseEvaluator.Factory(source(), fieldEvaluator, formatEvaluator, timezone, locale);
+        return selectEvaluator(fieldEvaluator, null, formatEvaluator, constantTimezone, timezoneEvaluator, locale);
+    }
+
+    private ExpressionEvaluator.Factory selectEvaluator(
+        ExpressionEvaluator.Factory fieldEvaluator,
+        DateFormatter formatter,
+        ExpressionEvaluator.Factory formatEvaluator,
+        ZoneId constantTimezone,
+        ExpressionEvaluator.Factory timezoneEvaluator,
+        Locale locale) {
+
+        if (formatEvaluator != null && timezoneEvaluator != null) {
+            return new DateParseRuntimeZoneIdEvaluator.Factory(
+                source(), fieldEvaluator, formatEvaluator, timezoneEvaluator, locale);
+        }
+
+        if (formatEvaluator != null) {
+            return new DateParseEvaluator.Factory(
+                source(), fieldEvaluator, formatEvaluator, constantTimezone, locale);
+        }
+
+        if (timezoneEvaluator != null) {
+            return new DateParseConstantRuntimeZoneIdEvaluator.Factory(
+                source(), fieldEvaluator, formatter, timezoneEvaluator, locale);
+        }
+
+        return new DateParseConstantEvaluator.Factory(
+            source(), fieldEvaluator, formatter, constantTimezone, locale);
     }
 
     private static DateFormatter toFormatter(Object format, Locale locale) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -98,8 +98,9 @@ public class DateParse extends EsqlConfigurationFunction implements TwoOptionalA
                     name = TIME_ZONE_PARAM_NAME,
                     type = "keyword",
                     valueHint = { "standard" },
-                    description = "Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values in the "
-                        + "query string to UTC."
+                    description = "Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values 
+                    in the query string to UTC. Can be a literal string (e.g. "US/Eastern") or a field reference containing 
+                    the timezone per document."
                 ),
                 @MapParam.MapParamEntry(
                     name = LOCALE_PARAM_NAME,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -70,7 +70,7 @@ public class DateParse extends EsqlConfigurationFunction implements TwoOptionalA
 
     private static final String TIME_ZONE_PARAM_NAME = "time_zone";
     private static final String LOCALE_PARAM_NAME = "locale";
-    public static final String FuNCTION_NAME = "date_parse";
+    public static final String FUNCTION_NAME = "date_parse";
 
     private final Expression first;
     private final Expression second;
@@ -227,7 +227,9 @@ public class DateParse extends EsqlConfigurationFunction implements TwoOptionalA
     public boolean foldable() {
         Expression field = field();
         Expression format = format();
-        return field.foldable() && (format == null || format.foldable());
+        Expression options = options();
+        Expression timezoneExpr = extractTimezoneExpr(options);
+        return field.foldable() && (format == null || format.foldable())&& (timezoneExpr == null || timezoneExpr.foldable());
     }
 
     @Evaluator(extraName = "Constant", warnExceptions = { IllegalArgumentException.class })
@@ -370,7 +372,7 @@ public class DateParse extends EsqlConfigurationFunction implements TwoOptionalA
             String tzString = BytesRefs.toString((BytesRef) timezoneExpr.fold(toEvaluator.foldCtx()));
             return ZoneId.of(tzString);
         } catch (ZoneRulesException e) {
-            throw new IllegalArgumentException("unsupported timezone [" + timezoneExpr + "]: " + e.getMessage());
+            throw new IllegalArgumentException("unsupported timezone [" + timezoneExpr + "]");
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -45,6 +45,7 @@ import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.UnresolvedFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.FilteredExpression;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.MatchOperator;
+import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateParse;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.RLike;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.RLikeList;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -737,44 +737,43 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
         }
         return visitIdentifierOrParameter(ctx.identifierOrParameter());
     }
+    @Override
+    public MapExpression visitMapExpression(EsqlBaseParser.MapExpressionContext ctx) {
+        List<Expression> namedArgs = new ArrayList<>(ctx.entryExpression().size());
+        List<String> names = new ArrayList<>(ctx.entryExpression().size());
+        List<EsqlBaseParser.EntryExpressionContext> kvCtx = ctx.entryExpression();
 
- @Override
-public MapExpression visitMapExpression(EsqlBaseParser.MapExpressionContext ctx) {
-    List<Expression> namedArgs = new ArrayList<>(ctx.entryExpression().size());
-    List<String> names = new ArrayList<>(ctx.entryExpression().size());
-    List<EsqlBaseParser.EntryExpressionContext> kvCtx = ctx.entryExpression();
+        for (EsqlBaseParser.EntryExpressionContext entry : kvCtx) {
+            EsqlBaseParser.StringContext stringCtx = entry.string();
+            String key = unquote(stringCtx.QUOTED_STRING().getText()); // key is case-sensitive
 
-    for (EsqlBaseParser.EntryExpressionContext entry : kvCtx) {
-        EsqlBaseParser.StringContext stringCtx = entry.string();
-        String key = unquote(stringCtx.QUOTED_STRING().getText()); // key is case-sensitive
+            if (key.isBlank()) {
+                throw new ParsingException(source(ctx), "Invalid named parameter [{}], empty key is not supported", entry.getText());
+            }
+            if (names.contains(key)) {
+                throw new ParsingException(source(ctx), "Duplicated named parameters with the same name [{}] is not supported", key);
+            }
 
-        if (key.isBlank()) {
-            throw new ParsingException(source(ctx), "Invalid named parameter [{}], empty key is not supported", entry.getText());
+            // Support: literals, nested maps, and field references/expressions
+            Expression value;
+            if (entry.value.constant() != null) {
+                value = expression(entry.value.constant());
+            } else if (entry.value.mapExpression() != null) {
+                value = expression(entry.value.mapExpression());
+            } else if (entry.value.qualifiedName() != null) {
+                // NEW: Support field references like {"time_zone": timezone_field}
+                value = visitQualifiedName(entry.value.qualifiedName());
+            } else {
+                throw new ParsingException(source(entry), "Invalid map value in [{}]", entry.getText());
+            }
+
+            namedArgs.add(Literal.keyword(source(stringCtx), key));
+            namedArgs.add(value);
+            names.add(key);
         }
-        if (names.contains(key)) {
-            throw new ParsingException(source(ctx), "Duplicated named parameters with the same name [{}] is not supported", key);
-        }
 
-        // Support: literals, nested maps, and field references/expressions
-        Expression value;
-        if (entry.value.constant() != null) {
-            value = expression(entry.value.constant());
-        } else if (entry.value.mapExpression() != null) {
-            value = expression(entry.value.mapExpression());
-        } else if (entry.value.qualifiedName() != null) {
-            // NEW: Support field references like {"time_zone": timezone_field}
-            value = visitQualifiedName(entry.value.qualifiedName());
-        } else {
-            throw new ParsingException(source(entry), "Invalid map value in [{}]", entry.getText());
-        }
-
-        namedArgs.add(Literal.keyword(source(stringCtx), key));
-        namedArgs.add(value);
-        names.add(key);
+        return new MapExpression(source(ctx), namedArgs);
     }
-
-    return new MapExpression(source(ctx), namedArgs);
-}
 
     @Override
     public MapExpression visitCommandNamedParameters(EsqlBaseParser.CommandNamedParametersContext ctx) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -699,7 +699,9 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
         String name = visitFunctionName(ctx.functionName());
         List<Expression> args = new ArrayList<>(expressions(ctx.booleanExpression()));
         if (ctx.mapExpression() != null) {
-            MapExpression mapArg = visitMapExpression(ctx.mapExpression());
+            MapExpression mapArg = DateParse.FUNCTION_NAME.equals(EsqlFunctionRegistry.normalizeName(name))
+                ? visitMapExpressionWithFieldRefs(ctx.mapExpression())
+                : visitMapExpression(ctx.mapExpression());
             args.add(mapArg);
         }
         if ("is_null".equals(EsqlFunctionRegistry.normalizeName(name))) {
@@ -737,15 +739,44 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
         }
         return visitIdentifierOrParameter(ctx.identifierOrParameter());
     }
+    
     @Override
     public MapExpression visitMapExpression(EsqlBaseParser.MapExpressionContext ctx) {
         List<Expression> namedArgs = new ArrayList<>(ctx.entryExpression().size());
         List<String> names = new ArrayList<>(ctx.entryExpression().size());
         List<EsqlBaseParser.EntryExpressionContext> kvCtx = ctx.entryExpression();
-
         for (EsqlBaseParser.EntryExpressionContext entry : kvCtx) {
             EsqlBaseParser.StringContext stringCtx = entry.string();
             String key = unquote(stringCtx.QUOTED_STRING().getText()); // key is case-sensitive
+            if (key.isBlank()) {
+                throw new ParsingException(source(ctx), "Invalid named parameter [{}], empty key is not supported", entry.getText());
+            }
+            if (names.contains(key)) {
+                throw new ParsingException(source(ctx), "Duplicated named parameters with the same name [{}] is not supported", key);
+            }
+            Expression value = expression(entry.value.constant() != null ? entry.value.constant() : entry.value.mapExpression());
+            String entryText = entry.getText();
+            if (value instanceof Literal l) {
+                namedArgs.add(Literal.keyword(source(stringCtx), key));
+                namedArgs.add(l);
+                names.add(key);
+            } else if (value instanceof MapExpression) {
+                namedArgs.add(Literal.keyword(source(stringCtx), key));
+                namedArgs.add(value);
+            } else {
+                throw new ParsingException(source(ctx), "Invalid named parameter [{}], only constant value is supported", entryText);
+            }
+        }
+        return new MapExpression(source(ctx), namedArgs);
+    }
+
+    private MapExpression visitMapExpressionWithFieldRefs(EsqlBaseParser.MapExpressionContext ctx) {
+        List<Expression> namedArgs = new ArrayList<>(ctx.entryExpression().size());
+        List<String> names = new ArrayList<>(ctx.entryExpression().size());
+
+        for (EsqlBaseParser.EntryExpressionContext entry : ctx.entryExpression()) {
+            EsqlBaseParser.StringContext stringCtx = entry.string();
+            String key = unquote(stringCtx.QUOTED_STRING().getText());
 
             if (key.isBlank()) {
                 throw new ParsingException(source(ctx), "Invalid named parameter [{}], empty key is not supported", entry.getText());
@@ -754,14 +785,12 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
                 throw new ParsingException(source(ctx), "Duplicated named parameters with the same name [{}] is not supported", key);
             }
 
-            // Support: literals, nested maps, and field references/expressions
             Expression value;
             if (entry.value.constant() != null) {
                 value = expression(entry.value.constant());
             } else if (entry.value.mapExpression() != null) {
                 value = expression(entry.value.mapExpression());
             } else if (entry.value.qualifiedName() != null) {
-                // NEW: Support field references like {"time_zone": timezone_field}
                 value = visitQualifiedName(entry.value.qualifiedName());
             } else {
                 throw new ParsingException(source(entry), "Invalid map value in [{}]", entry.getText());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -738,35 +738,43 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
         return visitIdentifierOrParameter(ctx.identifierOrParameter());
     }
 
-    @Override
-    public MapExpression visitMapExpression(EsqlBaseParser.MapExpressionContext ctx) {
-        List<Expression> namedArgs = new ArrayList<>(ctx.entryExpression().size());
-        List<String> names = new ArrayList<>(ctx.entryExpression().size());
-        List<EsqlBaseParser.EntryExpressionContext> kvCtx = ctx.entryExpression();
-        for (EsqlBaseParser.EntryExpressionContext entry : kvCtx) {
-            EsqlBaseParser.StringContext stringCtx = entry.string();
-            String key = unquote(stringCtx.QUOTED_STRING().getText()); // key is case-sensitive
-            if (key.isBlank()) {
-                throw new ParsingException(source(ctx), "Invalid named parameter [{}], empty key is not supported", entry.getText());
-            }
-            if (names.contains(key)) {
-                throw new ParsingException(source(ctx), "Duplicated named parameters with the same name [{}] is not supported", key);
-            }
-            Expression value = expression(entry.value.constant() != null ? entry.value.constant() : entry.value.mapExpression());
-            String entryText = entry.getText();
-            if (value instanceof Literal l) {
-                namedArgs.add(Literal.keyword(source(stringCtx), key));
-                namedArgs.add(l);
-                names.add(key);
-            } else if (value instanceof MapExpression) {
-                namedArgs.add(Literal.keyword(source(stringCtx), key));
-                namedArgs.add(value);
-            } else {
-                throw new ParsingException(source(ctx), "Invalid named parameter [{}], only constant value is supported", entryText);
-            }
+ @Override
+public MapExpression visitMapExpression(EsqlBaseParser.MapExpressionContext ctx) {
+    List<Expression> namedArgs = new ArrayList<>(ctx.entryExpression().size());
+    List<String> names = new ArrayList<>(ctx.entryExpression().size());
+    List<EsqlBaseParser.EntryExpressionContext> kvCtx = ctx.entryExpression();
+
+    for (EsqlBaseParser.EntryExpressionContext entry : kvCtx) {
+        EsqlBaseParser.StringContext stringCtx = entry.string();
+        String key = unquote(stringCtx.QUOTED_STRING().getText()); // key is case-sensitive
+
+        if (key.isBlank()) {
+            throw new ParsingException(source(ctx), "Invalid named parameter [{}], empty key is not supported", entry.getText());
         }
-        return new MapExpression(source(ctx), namedArgs);
+        if (names.contains(key)) {
+            throw new ParsingException(source(ctx), "Duplicated named parameters with the same name [{}] is not supported", key);
+        }
+
+        // Support: literals, nested maps, and field references/expressions
+        Expression value;
+        if (entry.value.constant() != null) {
+            value = expression(entry.value.constant());
+        } else if (entry.value.mapExpression() != null) {
+            value = expression(entry.value.mapExpression());
+        } else if (entry.value.qualifiedName() != null) {
+            // NEW: Support field references like {"time_zone": timezone_field}
+            value = visitQualifiedName(entry.value.qualifiedName());
+        } else {
+            throw new ParsingException(source(entry), "Invalid map value in [{}]", entry.getText());
+        }
+
+        namedArgs.add(Literal.keyword(source(stringCtx), key));
+        namedArgs.add(value);
+        names.add(key);
     }
+
+    return new MapExpression(source(ctx), namedArgs);
+}
 
     @Override
     public MapExpression visitCommandNamedParameters(EsqlBaseParser.CommandNamedParametersContext ctx) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
@@ -484,6 +484,211 @@ public class DateParseTests extends AbstractConfigurationFunctionTestCase {
         assertThat(e.getMessage(), startsWith("unsupported timezone [" + timezone + "]"));
     }
 
+    /**
+     * Test runtime timezone with constant formatter - DateParseConstantRuntimeZoneIdEvaluator
+     */
+    public void testRuntimeTimezoneWithConstantFormat() {
+        String pattern = "yyyy-MM-dd";
+        String date = "2023-05-05";
+        DriverContext driverContext = driverContext();
+        
+        DateParse dateParse = new DateParse(
+            Source.EMPTY,
+            new Literal(Source.EMPTY, new BytesRef(pattern), DataType.KEYWORD),
+            field("date", DataType.KEYWORD),
+            new MapExpression(
+                Source.EMPTY,
+                List.of(
+                    new Literal(Source.EMPTY, new BytesRef("time_zone"), DataType.KEYWORD),
+                    field("tz", DataType.KEYWORD),  // Runtime timezone reference
+                    new Literal(Source.EMPTY, new BytesRef("locale"), DataType.KEYWORD),
+                    new Literal(Source.EMPTY, new BytesRef("en-us"), DataType.KEYWORD)
+                )
+            ),
+            randomConfiguration()
+        );
+        
+        var evaluator = evaluator(dateParse);
+        assertThat(evaluator.toString(), startsWith("DateParseConstantRuntimeZoneIdEvaluator"));
+    }
+
+    /**
+     * Test runtime timezone with runtime formatter - DateParseRuntimeZoneIdEvaluator
+     */
+    public void testRuntimeTimezoneWithRuntimeFormat() {
+        DriverContext driverContext = driverContext();
+        
+        DateParse dateParse = new DateParse(
+            Source.EMPTY,
+            field("format", DataType.KEYWORD),
+            field("date", DataType.KEYWORD),
+            new MapExpression(
+                Source.EMPTY,
+                List.of(
+                    new Literal(Source.EMPTY, new BytesRef("time_zone"), DataType.KEYWORD),
+                    field("tz", DataType.KEYWORD),  // Runtime timezone reference
+                    new Literal(Source.EMPTY, new BytesRef("locale"), DataType.KEYWORD),
+                    new Literal(Source.EMPTY, new BytesRef("en-us"), DataType.KEYWORD)
+                )
+            ),
+            randomConfiguration()
+        );
+        
+        var evaluator = evaluator(dateParse);
+        assertThat(evaluator.toString(), startsWith("DateParseRuntimeZoneIdEvaluator"));
+    }
+
+    /**
+     * Test that runtime timezone evaluator is selected when timezone is from field
+     */
+    public void testRuntimeTimezoneEvaluatorSelection() {
+        String pattern = "yyyy-MM-dd";
+        DriverContext driverContext = driverContext();
+        
+        // Both format and timezone are fields - should use RuntimeZoneId evaluator
+        DateParse dateParse = new DateParse(
+            Source.EMPTY,
+            field("format", DataType.KEYWORD),
+            field("date", DataType.KEYWORD),
+            new MapExpression(
+                Source.EMPTY,
+                List.of(
+                    new Literal(Source.EMPTY, new BytesRef("time_zone"), DataType.KEYWORD),
+                    field("tz", DataType.KEYWORD),  // Runtime timezone
+                    new Literal(Source.EMPTY, new BytesRef("locale"), DataType.KEYWORD),
+                    new Literal(Source.EMPTY, new BytesRef("en-us"), DataType.KEYWORD)
+                )
+            ),
+            randomConfiguration()
+        );
+        
+        var evaluator = evaluator(dateParse);
+        // Should select RuntimeZoneId evaluator when both formatter and timezone are runtime
+        assertThat(evaluator.toString(), startsWith("DateParseRuntimeZoneIdEvaluator"));
+    }
+
+    /**
+     * Test that NullPointerException is in warn exceptions for runtime timezone evaluators
+     * This ensures null/empty timezone values don't fail the entire query
+     */
+    public void testNullTimezoneHandling() {
+        // Verify that the @Evaluator annotations include NullPointerException in warnExceptions
+        // by checking that the evaluator factory exists and handles null timezone gracefully
+        String pattern = "yyyy-MM-dd";
+        
+        DateParse dateParse = new DateParse(
+            Source.EMPTY,
+            new Literal(Source.EMPTY, new BytesRef(pattern), DataType.KEYWORD),
+            field("date", DataType.KEYWORD),
+            new MapExpression(
+                Source.EMPTY,
+                List.of(
+                    new Literal(Source.EMPTY, new BytesRef("time_zone"), DataType.KEYWORD),
+                    field("tz", DataType.KEYWORD),  // Field that could be null
+                    new Literal(Source.EMPTY, new BytesRef("locale"), DataType.KEYWORD),
+                    new Literal(Source.EMPTY, new BytesRef("en-us"), DataType.KEYWORD)
+                )
+            ),
+            randomConfiguration()
+        );
+        
+        var evaluator = evaluator(dateParse);
+        // Verify the ConstantRuntimeZoneId evaluator is selected
+        assertThat(evaluator.toString(), startsWith("DateParseConstantRuntimeZoneIdEvaluator"));
+    }
+
+    /**
+     * Test invalid timezone literal value caught at compile time
+     */
+    public void testInvalidRuntimeTimezoneWithLiteral() {
+        String pattern = "yyyy-MM-dd";
+        String invalidTz = "Invalid/TimeZone";
+        DriverContext driverContext = driverContext();
+        
+        // Invalid timezone in options map literal should throw at compile time
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> evaluator(
+                new DateParse(
+                    Source.EMPTY,
+                    new Literal(Source.EMPTY, new BytesRef(pattern), DataType.KEYWORD),
+                    field("date", DataType.KEYWORD),
+                    new MapExpression(
+                        Source.EMPTY,
+                        List.of(
+                            new Literal(Source.EMPTY, new BytesRef("time_zone"), DataType.KEYWORD),
+                            new Literal(Source.EMPTY, new BytesRef(invalidTz), DataType.KEYWORD),
+                            new Literal(Source.EMPTY, new BytesRef("locale"), DataType.KEYWORD),
+                            new Literal(Source.EMPTY, new BytesRef("en-us"), DataType.KEYWORD)
+                        )
+                    ),
+                    randomConfiguration()
+                )
+            ).get(driverContext)
+        );
+        assertThat(e.getMessage(), startsWith("unsupported timezone"));
+    }
+
+    /**
+     * Test runtime timezone with literal locale - mixed constant and runtime options
+     */
+    public void testRuntimeTimezoneWithConstantLocale() {
+        String pattern = "yyyy-MM-dd";
+        String localeString = "en-us";
+        DriverContext driverContext = driverContext();
+        
+        // Format constant, timezone runtime, locale constant
+        DateParse dateParse = new DateParse(
+            Source.EMPTY,
+            new Literal(Source.EMPTY, new BytesRef(pattern), DataType.KEYWORD),
+            field("date", DataType.KEYWORD),
+            new MapExpression(
+                Source.EMPTY,
+                List.of(
+                    new Literal(Source.EMPTY, new BytesRef("time_zone"), DataType.KEYWORD),
+                    field("tz", DataType.KEYWORD),  // Runtime timezone
+                    new Literal(Source.EMPTY, new BytesRef("locale"), DataType.KEYWORD),
+                    new Literal(Source.EMPTY, new BytesRef(localeString), DataType.KEYWORD)  // Constant locale
+                )
+            ),
+            randomConfiguration()
+        );
+        
+        var evaluator = evaluator(dateParse);
+        assertThat(evaluator.toString(), startsWith("DateParseConstantRuntimeZoneIdEvaluator"));
+    }
+
+    /**
+     * Test runtime timezone option overrides session configuration timezone
+     */
+    public void testRuntimeTimezoneOverridesSessionConfig() {
+        String pattern = "yyyy-MM-dd";
+        ZoneId sessionTz = ZoneOffset.UTC;
+        ZoneId runtimeTz = ZoneId.of("Europe/Paris");
+        DriverContext driverContext = driverContext();
+        
+        // Even if session config has a timezone, runtime timezone from options takes precedence
+        DateParse dateParse = new DateParse(
+            Source.EMPTY,
+            new Literal(Source.EMPTY, new BytesRef(pattern), DataType.KEYWORD),
+            field("date", DataType.KEYWORD),
+            new MapExpression(
+                Source.EMPTY,
+                List.of(
+                    new Literal(Source.EMPTY, new BytesRef("time_zone"), DataType.KEYWORD),
+                    field("tz", DataType.KEYWORD),  // Runtime timezone - overrides session TZ
+                    new Literal(Source.EMPTY, new BytesRef("locale"), DataType.KEYWORD),
+                    new Literal(Source.EMPTY, new BytesRef("en-us"), DataType.KEYWORD)
+                )
+            ),
+            configurationForTimezone(sessionTz)
+        );
+        
+        var evaluator = evaluator(dateParse);
+        // Should create ConstantRuntimeZoneId evaluator with runtime timezone
+        assertThat(evaluator.toString(), startsWith("DateParseConstantRuntimeZoneIdEvaluator"));
+    }
+
     @Override
     protected Expression buildWithConfiguration(Source source, List<Expression> args, Configuration configuration) {
         return new DateParse(


### PR DESCRIPTION
Fixes #147505

### Description

This PR enhances the `DATE_PARSE` function to support **dynamic `time_zone`** values from document fields, while fully maintaining the existing behavior for constant (literal) timezones.

**Examples**

**Constant timezone** (existing behavior - still fully supported):
```esql
ROW date_string = "2022-05-06T15:30:00" | EVAL date = DATE_PARSE("yyyy-MM-dd'T'HH:mm:ss", date_string, {"time_zone": "US/Eastern"})
```

**Dynamic timezone** (new behavior)
```esql 
ROW date_string = "2022-05-06T15:30:00", zone = "US/Eastern" | EVAL date = DATE_PARSE("yyyy-MM-dd'T'HH:mm:ss", date_string, {"time_zone": zone})
```