### PR TITLE
Add a primary attribute to the relocation metrics

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardChangesObserver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardChangesObserver.java
@@ -39,18 +39,23 @@ class ShardChangesObserver implements RoutingChangesObserver {
     private static final Map<UnassignedInfo.Reason, Map<String, Object>> PRIMARY_ATTRIBUTES = buildAttributesByReason(true);
     private static final Map<UnassignedInfo.Reason, Map<String, Object>> REPLICA_ATTRIBUTES = buildAttributesByReason(false);
     // Pre-calculate attributes for the most common move reasons
-    static final Map<String, Map<String, Object>> RELOCATION_ATTRIBUTES = Map.of(
-        REBALANCE_REASON,
-        Map.of("es_relocation_reason", REBALANCE_REASON),
-        MOVE_CANNOT_REMAIN_REASON,
-        Map.of("es_relocation_reason", MOVE_CANNOT_REMAIN_REASON),
-        MOVE_NOT_PREFERRED_REASON,
-        Map.of("es_relocation_reason", MOVE_NOT_PREFERRED_REASON)
-    );
+    static final Map<String, Map<String, Object>> PRIMARY_RELOCATION_ATTRIBUTES = buildRelocationAttributes(true);
+    static final Map<String, Map<String, Object>> REPLICA_RELOCATION_ATTRIBUTES = buildRelocationAttributes(false);
 
     private static Map<UnassignedInfo.Reason, Map<String, Object>> buildAttributesByReason(boolean primary) {
         return Arrays.stream(UnassignedInfo.Reason.values())
             .collect(Collectors.toUnmodifiableMap(r -> r, r -> Map.of("es_shard_primary", primary, "es_shard_reason", r.name())));
+    }
+
+    private static Map<String, Map<String, Object>> buildRelocationAttributes(boolean primary) {
+        return Map.of(
+            REBALANCE_REASON,
+            Map.of("es_relocation_reason", REBALANCE_REASON, "es_shard_primary", primary),
+            MOVE_CANNOT_REMAIN_REASON,
+            Map.of("es_relocation_reason", MOVE_CANNOT_REMAIN_REASON, "es_shard_primary", primary),
+            MOVE_NOT_PREFERRED_REASON,
+            Map.of("es_relocation_reason", MOVE_NOT_PREFERRED_REASON, "es_shard_primary", primary)
+        );
     }
 
     private final LongHistogram unassignedToInitializingDuration;
@@ -129,15 +134,15 @@ class ShardChangesObserver implements RoutingChangesObserver {
             startedShard.currentNodeId(),
             targetRelocatingShard.currentNodeId()
         );
-        relocationStartedCounter.incrementBy(1, relocationAttributes(reason));
+        relocationStartedCounter.incrementBy(1, relocationAttributes(reason, startedShard.primary()));
     }
 
-    private static Map<String, Object> relocationAttributes(String reason) {
-        final var attrs = RELOCATION_ATTRIBUTES.get(reason);
+    private static Map<String, Object> relocationAttributes(String reason, boolean primary) {
+        final var attrs = (primary ? PRIMARY_RELOCATION_ATTRIBUTES : REPLICA_RELOCATION_ATTRIBUTES).get(reason);
         if (attrs != null) {
             return attrs;
         }
-        return Map.of("es_relocation_reason", reason);
+        return Map.of("es_relocation_reason", reason, "es_shard_primary", primary);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardChangesObserverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardChangesObserverTests.java
@@ -44,6 +44,7 @@ import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBui
 import static org.elasticsearch.test.MockLog.assertThatLogger;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
@@ -250,14 +251,18 @@ public class ShardChangesObserverTests extends ESAllocationTestCase {
         final var recorder = meterRegistry.getRecorder();
 
         final var shardId = new ShardId("test-index", "_na_", 0);
-        final var startedShard = shardRoutingBuilder(shardId, "node-1", true, ShardRoutingState.STARTED).build();
-        final var targetShard = shardRoutingBuilder(shardId, "node-2", true, ShardRoutingState.INITIALIZING).build();
+        final var primary = randomBoolean();
+        final var startedShard = shardRoutingBuilder(shardId, "node-1", primary, ShardRoutingState.STARTED).build();
+        final var targetShard = shardRoutingBuilder(shardId, "node-2", primary, ShardRoutingState.INITIALIZING).build();
+        final var cachedAttributes = primary
+            ? ShardChangesObserver.PRIMARY_RELOCATION_ATTRIBUTES
+            : ShardChangesObserver.REPLICA_RELOCATION_ATTRIBUTES;
 
         assertThat(recorder.getMeasurements(InstrumentType.LONG_COUNTER, ShardChangesObserver.RELOCATION_STARTED_METRIC), hasSize(0));
 
         // known reasons
         final var moveCounts = new HashMap<String, Integer>();
-        for (final var reason : ShardChangesObserver.RELOCATION_ATTRIBUTES.keySet()) {
+        for (final var reason : cachedAttributes.keySet()) {
             final int moveCount = randomIntBetween(0, 10);
             moveCounts.put(reason, moveCount);
             for (int i = 0; i < moveCount; i++) {
@@ -270,13 +275,12 @@ public class ShardChangesObserverTests extends ESAllocationTestCase {
         );
         for (final var entry : moveCounts.entrySet()) {
             assertMovementCountForReason(measurements, entry.getKey(), entry.getValue());
-            assertThat(
-                measurements.stream()
-                    .map(Measurement::attributes)
-                    .filter(attributes -> attributes.get("es_relocation_reason").equals(entry.getKey()))
-                    .toList(),
-                everyItem(sameInstance(ShardChangesObserver.RELOCATION_ATTRIBUTES.get(entry.getKey())))
-            );
+            final var matchingAttributes = measurements.stream()
+                .map(Measurement::attributes)
+                .filter(attributes -> attributes.get("es_relocation_reason").equals(entry.getKey()))
+                .toList();
+            assertThat(matchingAttributes, everyItem(sameInstance(cachedAttributes.get(entry.getKey()))));
+            assertThat(matchingAttributes, everyItem(hasEntry("es_shard_primary", primary)));
         }
 
         // unknown reason: falls back to dynamic Map.of
@@ -287,6 +291,13 @@ public class ShardChangesObserverTests extends ESAllocationTestCase {
         }
         measurements = recorder.getMeasurements(InstrumentType.LONG_COUNTER, ShardChangesObserver.RELOCATION_STARTED_METRIC);
         assertMovementCountForReason(measurements, unknownReason, movements);
+        assertThat(
+            measurements.stream()
+                .map(Measurement::attributes)
+                .filter(attributes -> attributes.get("es_relocation_reason").equals(unknownReason))
+                .toList(),
+            everyItem(hasEntry("es_shard_primary", primary))
+        );
     }
 
     private void assertMovementCountForReason(List<Measurement> measurements, String reason, long expectedCount) {


### PR DESCRIPTION
I actually had intended to include this attribute in the original PR, but somehow forgot.

Given how different our balancing configurations are between indexing and search tier, this is very important.