### PR TITLE
[Test] Fix CreateIndexLimitIT.testCreateIndexLimit

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -515,9 +515,6 @@ tests:
 - class: org.elasticsearch.xpack.searchablesnapshots.store.input.CachedBlobContainerIndexInputTests
   method: testRandomReads
   issue: https://github.com/elastic/elasticsearch/issues/148163
-- class: org.elasticsearch.xpack.stateless.cluster.metadata.CreateIndexLimitIT
-  method: testCreateIndexLimit
-  issue: https://github.com/elastic/elasticsearch/issues/147956
 - class: org.elasticsearch.xpack.stateless.recovery.SearchShardRelocationIT
   method: testUnpromotableRelocationHandoffFailsIfTargetAllocationIdChanges
   issue: https://github.com/elastic/elasticsearch/issues/147957

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cluster/metadata/CreateIndexLimitIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cluster/metadata/CreateIndexLimitIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -244,13 +245,7 @@ public class CreateIndexLimitIT extends AbstractStatelessPluginIntegTestCase {
                 IndexLimitExceededException.class,
                 prepareCreate(indexPattern + suffix)
             );
-            assertThat(
-                e.getMessage(),
-                containsString(
-                    "see https://www.elastic.co/docs/deploy-manage/deploy/"
-                        + "elastic-cloud/differences-from-other-elasticsearch-offerings.md?version=master#index-and-resource-limits"
-                )
-            );
+            assertThat(e.getMessage(), containsString("see " + ReferenceDocs.MAX_INDICES_PER_PROJECT));
         }
     }
 


### PR DESCRIPTION
The test was hardcoding `?version=master` in the expected URL, but in release tests that are run with 
`-Dbuild.snapshot=false`, the version becomes 9.5 instead of master.

This PR fixes the test by asserting using the constant `ReferenceDocs .MAX_INDICES_PER_PROJECT` directly, which generates the correct URL for snapshot and non-snapshot builds.

Closes #147956