### PR TITLE
ESQL: DS: Fix Azure URI handling

### DIFF
--- a/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageProvider.java
+++ b/x-pack/plugin/esql-datasource-azure/src/main/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageProvider.java
@@ -36,12 +36,16 @@ import java.util.NoSuchElementException;
 /**
  * StorageProvider implementation for Azure Blob Storage.
  * <p>
- * Supports the {@code wasbs://} and {@code wasb://} URI schemes.
- * URI format: {@code wasbs://account.blob.core.windows.net/container/path/to/blob}
+ * Supports the {@code wasbs://} and {@code wasb://} URI schemes in two equivalent forms:
  * <ul>
- *   <li>host: account.blob.core.windows.net (account name is first segment)</li>
- *   <li>path: /container/path/to/blob (first segment = container, remainder = blob name)</li>
+ *   <li><b>Path-style</b>: {@code wasbs://<account>.blob.core.windows.net/<container>/<blob>}
+ *       — host carries the account; the first path segment is the container.</li>
+ *   <li><b>Hadoop/Spark form</b>: {@code wasbs://<container>@<account>.blob.core.windows.net/<blob>}
+ *       — userInfo carries the container; the path is the blob name. This is the canonical
+ *       form documented at https://hadoop.apache.org/docs/stable/hadoop-azure/index.html
+ *       and emitted by Azure Open Datasets.</li>
  * </ul>
+ * In both forms the account name is extracted as the first dot-segment of the host.
  * <p>
  * Maintains both a sync {@link BlobServiceClient} and an async {@link BlobServiceAsyncClient},
  * built from the same {@link BlobServiceClientBuilder} (same pattern as {@code repository-azure}'s
@@ -302,15 +306,24 @@ public final class AzureStorageProvider implements StorageProvider {
     }
 
     /**
-     * Parse path for object access: wasbs://account.blob.core.windows.net/container/path/to/blob
-     * host = account.blob.core.windows.net -> account is first segment
-     * path = /container/path/to/blob -> container = first segment, blob name = path/to/blob
+     * Parse path for object access. Accepts two equivalent forms:
+     * <ul>
+     *   <li>Path-style {@code wasbs://account.blob.core.windows.net/container/blob} — host is
+     *       {@code account.blob.core.windows.net}, container is the first path segment.</li>
+     *   <li>Hadoop form {@code wasbs://container@account.blob.core.windows.net/blob} — userInfo
+     *       carries the container; the entire path is the blob name.</li>
+     * </ul>
      */
-    private static ParsedPath parsePath(StoragePath path) {
+    static ParsedPath parsePath(StoragePath path) {
         String host = path.host();
         String pathStr = path.path();
         if (pathStr.startsWith(StoragePath.PATH_SEPARATOR)) {
             pathStr = pathStr.substring(1);
+        }
+        String userInfo = path.userInfo();
+        if (userInfo != null) {
+            // Hadoop form: container is in userInfo, blob name is the entire path (may be empty for root listing).
+            return new ParsedPath(host, userInfo, pathStr);
         }
         if (pathStr.isEmpty()) {
             throw new IllegalArgumentException("Invalid Azure path: container and blob name required: " + path);
@@ -343,13 +356,17 @@ public final class AzureStorageProvider implements StorageProvider {
         return new ParsedPath(parsed.host, parsed.container, prefix);
     }
 
-    private record ParsedPath(String host, String container, String blobName) {}
+    record ParsedPath(String host, String container, String blobName) {}
 
-    private static final class AzureStorageIterator implements StorageIterator {
+    // Package-private (rather than private) so AzureStorageProviderTests can construct one
+    // directly from a synthetic Iterable<BlobItem> and verify URI-form preservation without
+    // standing up a real BlobServiceClient.
+    static final class AzureStorageIterator implements StorageIterator {
         private final Iterable<BlobItem> blobItems;
         private final StoragePath basePath;
         private final String container;
         private final String scheme;
+        private final String userInfo;
 
         private Iterator<BlobItem> iterator;
         private BlobItem current;
@@ -359,6 +376,7 @@ public final class AzureStorageProvider implements StorageProvider {
             this.basePath = basePath;
             this.container = container;
             this.scheme = basePath.scheme();
+            this.userInfo = basePath.userInfo();
         }
 
         @Override
@@ -401,9 +419,17 @@ public final class AzureStorageProvider implements StorageProvider {
             }
             BlobItem item = current;
             current = null;
-            String fullPath = scheme + StoragePath.SCHEME_SEPARATOR + basePath.host() + StoragePath.PATH_SEPARATOR + container
-                + StoragePath.PATH_SEPARATOR + item.getName();
-            StoragePath objectPath = StoragePath.of(fullPath);
+            // Preserve the input URI form: Hadoop form (container@host) emits
+            // scheme://container@host/blob; path-style emits scheme://host/container/blob.
+            String name = item.getName();
+            StringBuilder fullPath = new StringBuilder().append(scheme).append(StoragePath.SCHEME_SEPARATOR);
+            if (userInfo != null) {
+                fullPath.append(userInfo).append('@').append(basePath.host()).append(StoragePath.PATH_SEPARATOR);
+            } else {
+                fullPath.append(basePath.host()).append(StoragePath.PATH_SEPARATOR).append(container).append(StoragePath.PATH_SEPARATOR);
+            }
+            fullPath.append(name);
+            StoragePath objectPath = StoragePath.of(fullPath.toString());
             Instant lastModified = item.getProperties() != null && item.getProperties().getLastModified() != null
                 ? item.getProperties().getLastModified().toInstant()
                 : null;

--- a/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageProviderTests.java
+++ b/x-pack/plugin/esql-datasource-azure/src/test/java/org/elasticsearch/xpack/esql/datasource/azure/AzureStorageProviderTests.java
@@ -7,9 +7,15 @@
 
 package org.elasticsearch.xpack.esql.datasource.azure;
 
+import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.models.BlobItemProperties;
+
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.StorageEntry;
+import org.elasticsearch.xpack.esql.datasources.StorageIterator;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -66,5 +72,110 @@ public class AzureStorageProviderTests extends ESTestCase {
         StoragePath path = StoragePath.of("wasbs://account.blob.core.windows.net/container/data/2024/*.parquet");
         StoragePath prefix = path.patternPrefix();
         assertEquals("wasbs://account.blob.core.windows.net/container/data/2024/", prefix.toString());
+    }
+
+    // -- Hadoop/Spark canonical WASB(S) form: wasbs://<container>@<account>.host/<blob> --
+
+    public void testParsePathHadoopForm() {
+        StoragePath path = StoragePath.of("wasbs://nyctlc@azureopendatastorage.blob.core.windows.net/yellow/puYear=2019/file.parquet");
+        AzureStorageProvider.ParsedPath parsed = AzureStorageProvider.parsePath(path);
+        assertEquals("azureopendatastorage.blob.core.windows.net", parsed.host());
+        assertEquals("nyctlc", parsed.container());
+        assertEquals("yellow/puYear=2019/file.parquet", parsed.blobName());
+    }
+
+    public void testParsePathHadoopFormRootListing() {
+        // Hadoop form with empty path is a valid root-of-container reference for listing.
+        StoragePath path = StoragePath.of("wasbs://my-container@account.blob.core.windows.net/");
+        AzureStorageProvider.ParsedPath parsed = AzureStorageProvider.parsePath(path);
+        assertEquals("my-container", parsed.container());
+        assertEquals("", parsed.blobName());
+    }
+
+    public void testParsePathPathStyleUnchanged() {
+        StoragePath path = StoragePath.of("wasbs://account.blob.core.windows.net/my-container/data/file.parquet");
+        AzureStorageProvider.ParsedPath parsed = AzureStorageProvider.parsePath(path);
+        assertEquals("account.blob.core.windows.net", parsed.host());
+        assertEquals("my-container", parsed.container());
+        assertEquals("data/file.parquet", parsed.blobName());
+    }
+
+    public void testParsePathPathStyleEmptyRejected() {
+        StoragePath path = StoragePath.of("wasbs://account.blob.core.windows.net/");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> AzureStorageProvider.parsePath(path));
+        assertTrue(e.getMessage().contains("container and blob name required"));
+    }
+
+    // -- AzureStorageIterator URI-form preservation: emitted entries match input form --
+
+    public void testIteratorEmitsPathStyleWhenInputIsPathStyle() throws Exception {
+        StoragePath base = StoragePath.of("wasbs://account.blob.core.windows.net/c/data/");
+        List<StoragePath> emitted = drain(base, "c", "data/file1.parquet", "data/sub/file2.parquet");
+        assertEquals(
+            List.of(
+                StoragePath.of("wasbs://account.blob.core.windows.net/c/data/file1.parquet"),
+                StoragePath.of("wasbs://account.blob.core.windows.net/c/data/sub/file2.parquet")
+            ),
+            emitted
+        );
+        for (StoragePath p : emitted) {
+            assertNull("path-style entries must not carry userInfo", p.userInfo());
+        }
+    }
+
+    public void testIteratorEmitsHadoopFormWhenInputIsHadoopForm() throws Exception {
+        StoragePath base = StoragePath.of("wasbs://c@account.blob.core.windows.net/data/");
+        List<StoragePath> emitted = drain(base, "c", "data/file1.parquet", "data/sub/file2.parquet");
+        assertEquals(
+            List.of(
+                StoragePath.of("wasbs://c@account.blob.core.windows.net/data/file1.parquet"),
+                StoragePath.of("wasbs://c@account.blob.core.windows.net/data/sub/file2.parquet")
+            ),
+            emitted
+        );
+        for (StoragePath p : emitted) {
+            assertEquals("Hadoop-form entries must carry container in userInfo", "c", p.userInfo());
+        }
+    }
+
+    public void testIteratorSkipsPrefixesAndDirectoryEntries() throws Exception {
+        BlobItem prefix = new BlobItem().setName("data/sub/").setIsPrefix(Boolean.TRUE);
+        BlobItem dir = new BlobItem().setName("data/dir/").setProperties(properties(0L));
+        BlobItem file = new BlobItem().setName("data/file.parquet").setProperties(properties(123L));
+
+        StoragePath base = StoragePath.of("wasbs://c@account.blob.core.windows.net/data/");
+        AzureStorageProvider.AzureStorageIterator it = new AzureStorageProvider.AzureStorageIterator(List.of(prefix, dir, file), base, "c");
+
+        List<StorageEntry> entries = drainEntries(it);
+        assertEquals(1, entries.size());
+        assertEquals(StoragePath.of("wasbs://c@account.blob.core.windows.net/data/file.parquet"), entries.get(0).path());
+        assertEquals(123L, entries.get(0).length());
+    }
+
+    private static List<StoragePath> drain(StoragePath base, String container, String... blobNames) throws Exception {
+        List<BlobItem> items = new ArrayList<>(blobNames.length);
+        for (String name : blobNames) {
+            items.add(new BlobItem().setName(name).setProperties(properties(0L)));
+        }
+        AzureStorageProvider.AzureStorageIterator it = new AzureStorageProvider.AzureStorageIterator(items, base, container);
+        List<StoragePath> paths = new ArrayList<>();
+        for (StorageEntry entry : drainEntries(it)) {
+            paths.add(entry.path());
+        }
+        return paths;
+    }
+
+    private static List<StorageEntry> drainEntries(StorageIterator it) throws Exception {
+        List<StorageEntry> entries = new ArrayList<>();
+        try (it) {
+            while (it.hasNext()) {
+                entries.add(it.next());
+            }
+        }
+        return entries;
+    }
+
+    private static BlobItemProperties properties(long contentLength) {
+        return new BlobItemProperties().setContentLength(contentLength);
     }
 }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -396,7 +396,7 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
             case AZURE:
                 // Azure has two equivalent URI forms; the choice is made once per test in doTest().
                 // Path-style: wasbs://account.blob.core.windows.net/container/warehouse/.../employees.parquet
-                // Hadoop:     wasbs://container@account.blob.core.windows.net/warehouse/.../employees.parquet
+                // Hadoop: wasbs://container@account.blob.core.windows.net/warehouse/.../employees.parquet
                 if (useAzureHadoopForm) {
                     return "wasbs://" + CONTAINER + "@" + ACCOUNT + ".blob.core.windows.net/" + WAREHOUSE + "/" + relativePath;
                 }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -258,6 +258,12 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
 
     private final StorageBackend storageBackend;
     private final String format;
+    /**
+     * Per-test choice of Azure URI form, set once in {@link #doTest()} so that all template
+     * substitutions within a single test (including wildcard expansions returning multiple files)
+     * see a consistent form. Both forms are equivalent; randomising per test exercises both.
+     */
+    private boolean useAzureHadoopForm;
 
     protected AbstractExternalSourceSpecTestCase(
         String fileName,
@@ -294,6 +300,9 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
             assumeTrue("CSV format does not support multi-file glob patterns", "csv".equals(format) == false);
 
         }
+
+        // Pick the Azure URI form once per test so wildcard expansion sees a single, consistent form.
+        useAzureHadoopForm = storageBackend == StorageBackend.AZURE && randomBoolean();
 
         // Transform templates like {{employees}} to actual paths
         query = transformTemplates(query);
@@ -385,7 +394,12 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
                 return "gs://" + GcsFixtureUtils.BUCKET + "/" + WAREHOUSE + "/" + relativePath;
 
             case AZURE:
-                // Azure path: wasbs://account.blob.core.windows.net/container/warehouse/standalone/employees.parquet
+                // Azure has two equivalent URI forms; the choice is made once per test in doTest().
+                // Path-style: wasbs://account.blob.core.windows.net/container/warehouse/.../employees.parquet
+                // Hadoop:     wasbs://container@account.blob.core.windows.net/warehouse/.../employees.parquet
+                if (useAzureHadoopForm) {
+                    return "wasbs://" + CONTAINER + "@" + ACCOUNT + ".blob.core.windows.net/" + WAREHOUSE + "/" + relativePath;
+                }
                 return "wasbs://" + ACCOUNT + ".blob.core.windows.net/" + CONTAINER + "/" + WAREHOUSE + "/" + relativePath;
 
             default:

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StoragePath.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/StoragePath.java
@@ -18,6 +18,12 @@ import java.nio.file.Path;
  * - Has simpler parsing rules suitable for blob storage keys
  * - Provides convenient methods for path manipulation
  *
+ * The userInfo component is preserved verbatim and exposed via {@link #userInfo()}.
+ * Its meaning is provider-defined: for Azure WASB(S) URIs in the canonical
+ * Hadoop/Spark form ({@code wasbs://<container>@<account>.blob.core.windows.net/<blob>}),
+ * the userInfo is the container name. The boundary between userInfo and host is the
+ * last {@code '@'} in the authority, per RFC 3986.
+ *
  * Note: glob pattern detection ({@link #isPattern()}) only inspects the path component.
  * Glob characters in the scheme or authority (e.g. {@code s3://bucket-*&#47;data/}) are
  * not detected as patterns and will be treated as literal text.
@@ -32,13 +38,15 @@ public final class StoragePath {
 
     private final String location;
     private final String scheme;      // "s3", "https", "file", etc.
+    private final String userInfo;    // null if absent; provider-defined (e.g. WASB container)
     private final String host;        // bucket name, hostname
     private final int port;           // -1 if not specified
     private final String path;        // path within the storage
 
-    private StoragePath(String location, String scheme, String host, int port, String path) {
+    private StoragePath(String location, String scheme, String userInfo, String host, int port, String path) {
         this.location = location;
         this.scheme = scheme;
+        this.userInfo = userInfo;
         this.host = host;
         this.port = port;
         this.path = path;
@@ -101,9 +109,16 @@ public final class StoragePath {
         String host;
         int port = -1;
 
-        // Skip userInfo if present (not commonly used in storage URLs)
-        int atIndex = authority.indexOf('@');
+        // Extract userInfo if present. Per RFC 3986, the userInfo extends to the last '@'
+        // in the authority, so values containing ':' or '@' (e.g. "user:pa@ss") are preserved.
+        // The userInfo is provider-defined: for Azure WASB(S), it carries the container name
+        // (canonical Hadoop form: wasbs://<container>@<account>.blob.core.windows.net/<blob>).
+        String userInfo = null;
+        int atIndex = authority.lastIndexOf('@');
         if (atIndex >= 0) {
+            if (atIndex > 0) {
+                userInfo = authority.substring(0, atIndex);
+            }
             authority = authority.substring(atIndex + 1);
         }
 
@@ -140,11 +155,21 @@ public final class StoragePath {
             }
         }
 
-        return new StoragePath(location, scheme, host, port, path);
+        return new StoragePath(location, scheme, userInfo, host, port, path);
     }
 
     public String scheme() {
         return scheme;
+    }
+
+    /**
+     * Returns the userInfo component of the URI authority, or {@code null} when absent.
+     * Empty userInfo (e.g. {@code "scheme://@host/x"}) is normalized to {@code null}.
+     * The value is preserved verbatim (no URL decoding) and is provider-defined: Azure
+     * WASB(S) URIs in canonical Hadoop form carry the container name here.
+     */
+    public String userInfo() {
+        return userInfo;
     }
 
     public String host() {
@@ -263,11 +288,15 @@ public final class StoragePath {
     }
 
     private String authorityPrefix() {
-        String prefix = scheme + SCHEME_SEPARATOR + host;
-        if (port > 0) {
-            prefix += PORT_SEPARATOR + port;
+        StringBuilder prefix = new StringBuilder().append(scheme).append(SCHEME_SEPARATOR);
+        if (userInfo != null) {
+            prefix.append(userInfo).append('@');
         }
-        return prefix;
+        prefix.append(host);
+        if (port > 0) {
+            prefix.append(PORT_SEPARATOR).append(port);
+        }
+        return prefix.toString();
     }
 
     private int firstGlobMetacharacter() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/StoragePathTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/spi/StoragePathTests.java
@@ -131,4 +131,83 @@ public class StoragePathTests extends ESTestCase {
         StoragePath sp = StoragePath.of(uri);
         assertEquals(absPath, sp.path());
     }
+
+    // -- userInfo handling --
+
+    public void testUserInfoAbsent() {
+        StoragePath path = StoragePath.of("wasbs://account.blob.core.windows.net/container/file.parquet");
+        assertNull(path.userInfo());
+        assertEquals("account.blob.core.windows.net", path.host());
+        assertEquals("/container/file.parquet", path.path());
+    }
+
+    public void testUserInfoHadoopWasbForm() {
+        StoragePath path = StoragePath.of("wasbs://nyctlc@azureopendatastorage.blob.core.windows.net/yellow/puYear=2019/file.parquet");
+        assertEquals("wasbs", path.scheme());
+        assertEquals("nyctlc", path.userInfo());
+        assertEquals("azureopendatastorage.blob.core.windows.net", path.host());
+        assertEquals("/yellow/puYear=2019/file.parquet", path.path());
+    }
+
+    public void testUserInfoEmptyNormalizedToNull() {
+        StoragePath path = StoragePath.of("wasbs://@account.blob.core.windows.net/c/x");
+        assertNull(path.userInfo());
+        assertEquals("account.blob.core.windows.net", path.host());
+    }
+
+    public void testUserInfoToStringRoundTrip() {
+        String uri = "wasbs://nyctlc@azureopendatastorage.blob.core.windows.net/yellow/file.parquet";
+        StoragePath path = StoragePath.of(uri);
+        assertEquals(uri, path.toString());
+    }
+
+    public void testUserInfoLastAtIsBoundary() {
+        // Per RFC 3986 the userInfo extends to the last '@' so values containing '@' (e.g. SAS tokens) survive.
+        StoragePath path = StoragePath.of("s3://a@b@host/p");
+        assertEquals("a@b", path.userInfo());
+        assertEquals("host", path.host());
+    }
+
+    public void testUserInfoWithColonPreserved() {
+        StoragePath path = StoragePath.of("https://user:pass@example.com/x");
+        assertEquals("user:pass", path.userInfo());
+        assertEquals("example.com", path.host());
+        assertEquals("/x", path.path());
+    }
+
+    public void testUserInfoWithPort() {
+        StoragePath path = StoragePath.of("https://u@host:8443/x");
+        assertEquals("u", path.userInfo());
+        assertEquals("host", path.host());
+        assertEquals(8443, path.port());
+    }
+
+    public void testUserInfoWithIpv6() {
+        StoragePath path = StoragePath.of("https://u@[::1]:8080/x");
+        assertEquals("u", path.userInfo());
+        assertEquals("[::1]", path.host());
+        assertEquals(8080, path.port());
+        assertEquals("/x", path.path());
+    }
+
+    public void testParentDirectoryPreservesUserInfo() {
+        StoragePath path = StoragePath.of("wasbs://c@a.host/data/2024/file.parquet");
+        StoragePath parent = path.parentDirectory();
+        assertEquals("wasbs://c@a.host/data/2024", parent.toString());
+        assertEquals("c", parent.userInfo());
+    }
+
+    public void testAppendPathPreservesUserInfo() {
+        StoragePath path = StoragePath.of("wasbs://c@a.host/data");
+        StoragePath child = path.appendPath("file.parquet");
+        assertEquals("wasbs://c@a.host/data/file.parquet", child.toString());
+        assertEquals("c", child.userInfo());
+    }
+
+    public void testPatternPrefixPreservesUserInfo() {
+        StoragePath path = StoragePath.of("wasbs://c@a.host/data/*.parquet");
+        StoragePath prefix = path.patternPrefix();
+        assertEquals("wasbs://c@a.host/data/", prefix.toString());
+        assertEquals("c", prefix.userInfo());
+    }
 }


### PR DESCRIPTION
* `spi.StoragePath`  silently strips the userinfo from the authority (with the comment "Skip userInfo if present (not commonly used in storage URLs)". After this, `host()` returns the endpoint and `path()` returns a sub-path only — the container is gone.
* `AzureStorageProvider#parsePath` mistakes a first path segment for the container and treats a sub-path as the blob name.
