### PR TITLE
[ESQL] Emit ordinal blocks for dictionary parquet strings

### DIFF
--- a/docs/changelog/148242.yaml
+++ b/docs/changelog/148242.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148242
+summary: Emit ordinal blocks for dictionary parquet strings
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoder.java
@@ -19,6 +19,20 @@ import java.util.Arrays;
  * Bulk decoder for RLE_DICTIONARY-encoded Parquet values. Reads a 1-byte bit width header,
  * then decodes RLE hybrid-encoded dictionary indices and gathers typed values from the
  * {@link Dictionary}.
+ *
+ * <p>In addition to the typed read methods that resolve indices through the dictionary,
+ * the decoder also exposes raw indices via {@code readIndices} and the decoded dictionary
+ * via {@code getDictionaryBytesRefs}, which together let callers emit an ordinal-backed
+ * {@code OrdinalBytesRefBlock} without materializing every value as a separate {@code BytesRef}.
+ *
+ * <p>Lifetime / threading: pages emitted by {@code PageColumnReader} can be consumed
+ * asynchronously by a different driver thread, possibly after the row group has been
+ * released. The cached {@code BytesRef[]} returned by {@code getDictionaryBytesRefs} is built
+ * by calling {@link org.apache.parquet.io.api.Binary#getBytes()}, whose contract in
+ * parquet-mr is to return a JVM-owned, freshly-allocated {@code byte[]} (it does not return a
+ * view into a shared buffer). Downstream consumers that intend to outlive the row group
+ * should still copy the bytes into ESQL-managed storage (e.g. via
+ * {@link org.elasticsearch.common.util.BytesRefArray#append}) before publishing.
  */
 final class DictionaryValueDecoder {
 
@@ -81,20 +95,32 @@ final class DictionaryValueDecoder {
     }
 
     void readBinaries(BytesRef[] values, int offset, int count, Dictionary dict) {
+        BytesRef[] entries = getDictionaryBytesRefs(dict);
+        for (int i = 0; i < count; i++) {
+            values[offset + i] = entries[nextIndex()];
+        }
+    }
+
+    void readIndices(int[] indices, int offset, int count) {
+        for (int i = 0; i < count; i++) {
+            indices[offset + i] = nextIndex();
+        }
+    }
+
+    BytesRef[] getDictionaryBytesRefs(Dictionary dict) {
         Check.notNull(dict, "dictionary");
         assert cachedDict == null || cachedDict == dict;
         if (cachedDictBytesRefs == null) {
             int size = dict.getMaxId() + 1;
-            cachedDictBytesRefs = new BytesRef[size];
+            BytesRef[] entries = new BytesRef[size];
             for (int i = 0; i < size; i++) {
                 byte[] bytes = dict.decodeToBinary(i).getBytes();
-                cachedDictBytesRefs[i] = new BytesRef(bytes, 0, bytes.length);
+                entries[i] = new BytesRef(bytes, 0, bytes.length);
             }
+            cachedDictBytesRefs = entries;
             cachedDict = dict;
         }
-        for (int i = 0; i < count; i++) {
-            values[offset + i] = cachedDictBytesRefs[nextIndex()];
-        }
+        return cachedDictBytesRefs;
     }
 
     void skip(int count) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -21,8 +21,13 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
+import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 
 import java.io.IOException;
@@ -51,6 +56,21 @@ import java.util.BitSet;
  * ranges are skipped entirely in {@link #loadNextPage()}. This is a safety net for the
  * sequential builder path (when prefetch is unavailable and the builder cannot pre-filter
  * pages) and a no-op for the filtered builder path.
+ *
+ * <p>For dictionary-encoded BINARY/UTF8 columns, {@code readBytesBatch} takes an ordinal
+ * fast path that emits an {@link OrdinalBytesRefBlock} so downstream {@code BlockHash} can
+ * hash only the {@code k} dictionary entries instead of the {@code N} row values. The
+ * dictionary {@code BytesRefVector} is rebuilt per batch (deep-copying the bytes via
+ * {@link BytesRefArray#append}) so each emitted block fully owns its memory and is safe to
+ * outlive the {@link PageColumnReader} or its row group — pages can be buffered and
+ * consumed asynchronously by a different driver thread without aliasing into Parquet-side
+ * state. UUID-typed columns skip the ordinal path because their values need per-row byte
+ * formatting that would have to be applied to dictionary entries instead.
+ *
+ * <p>If a non-dictionary page is encountered mid-batch (rare in practice — Parquet writers
+ * keep encoding consistent across all data pages of a column chunk), the partial ordinal
+ * batch is resolved through the dictionary and the remainder is read via the materialized
+ * binary path.
  */
 final class PageColumnReader {
 
@@ -919,6 +939,12 @@ final class PageColumnReader {
 
     private Block readBytesBatch(int maxRows, BlockFactory blockFactory) {
         boolean isUuid = info.logicalType() instanceof LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+        // Dictionary-encoded chunk: emit an OrdinalBytesRefBlock so downstream BlockHash can
+        // hash only k dictionary entries instead of N row values. Skip for UUID, where each
+        // value needs per-row byte formatting that the ordinal path does not perform.
+        if (dictionary != null && isUuid == false) {
+            return readBytesBatchAsOrdinals(maxRows, blockFactory);
+        }
         if (maxDefLevel == 0) {
             BytesRef[] allValues = new BytesRef[maxRows];
             int produced = 0;
@@ -992,6 +1018,166 @@ final class PageColumnReader {
         BytesRef[] values = new BytesRef[count];
         readBinariesDispatch(values, 0, count);
         return values;
+    }
+
+    private Block readBytesBatchAsOrdinals(int maxRows, BlockFactory blockFactory) {
+        int[] ordinals = new int[maxRows];
+        WordMask nulls = maxDefLevel > 0 ? buffers.nullsMask(maxRows) : null;
+        int produced = 0;
+        int remaining = maxRows;
+        boolean fallback = false;
+        while (remaining > 0 && ensurePage()) {
+            if (currentEncoding.usesDictionary() == false) {
+                fallback = true;
+                break;
+            }
+            int fromPage = Math.min(remaining, availableInPage());
+            if (nulls == null) {
+                dictDecoder.readIndices(ordinals, produced, fromPage);
+            } else {
+                int nonNull = defDecoder.readBatch(fromPage, nulls, produced);
+                if (nonNull == fromPage) {
+                    dictDecoder.readIndices(ordinals, produced, fromPage);
+                } else if (nonNull > 0) {
+                    int[] packed = new int[nonNull];
+                    dictDecoder.readIndices(packed, 0, nonNull);
+                    int pi = 0;
+                    for (int i = 0; i < fromPage; i++) {
+                        if (nulls.get(produced + i) == false) {
+                            ordinals[produced + i] = packed[pi++];
+                        }
+                    }
+                }
+            }
+            advancePosition(fromPage);
+            produced += fromPage;
+            remaining -= fromPage;
+        }
+        if (fallback) {
+            return finishMaterializedFallback(ordinals, nulls, produced, remaining, blockFactory);
+        }
+        return buildOrdinalResult(ordinals, nulls, produced, blockFactory);
+    }
+
+    private Block buildOrdinalResult(int[] ordinals, WordMask nulls, int produced, BlockFactory blockFactory) {
+        BytesRef[] dict = dictDecoder.getDictionaryBytesRefs(dictionary);
+        if (produced == 0) {
+            return blockFactory.newConstantNullBlock(0);
+        }
+        if (nulls != null && nulls.popCount() == produced) {
+            return blockFactory.newConstantNullBlock(produced);
+        }
+        // Non-null, all-equal indices: emit a constant block to skip the ordinal indirection.
+        if (nulls == null || nulls.isEmpty()) {
+            int constantOrdinal = detectConstantOrdinal(ordinals, produced);
+            if (constantOrdinal >= 0) {
+                return blockFactory.newConstantBytesRefBlockWith(dict[constantOrdinal], produced);
+            }
+        }
+        IntBlock ordinalsBlock = null;
+        BytesRefVector dictVector = null;
+        boolean success = false;
+        try {
+            ordinalsBlock = buildOrdinalsBlock(ordinals, nulls, produced, blockFactory);
+            dictVector = buildDictionaryVector(dict, blockFactory);
+            OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(ordinalsBlock, dictVector);
+            success = true;
+            return result;
+        } finally {
+            if (success == false) {
+                Releasables.closeExpectNoException(ordinalsBlock, dictVector);
+            }
+        }
+    }
+
+    private static int detectConstantOrdinal(int[] ordinals, int produced) {
+        if (produced == 0) {
+            return -1;
+        }
+        int first = ordinals[0];
+        for (int i = 1; i < produced; i++) {
+            if (ordinals[i] != first) {
+                return -1;
+            }
+        }
+        return first;
+    }
+
+    private IntBlock buildOrdinalsBlock(int[] ordinals, WordMask nulls, int produced, BlockFactory blockFactory) {
+        int[] sized = produced < ordinals.length ? Arrays.copyOf(ordinals, produced) : ordinals;
+        if (nulls == null || nulls.isEmpty()) {
+            return blockFactory.newIntArrayVector(sized, produced).asBlock();
+        }
+        return blockFactory.newIntArrayBlock(sized, produced, null, nulls.toBitSet(), Block.MvOrdering.UNORDERED);
+    }
+
+    private BytesRefVector buildDictionaryVector(BytesRef[] entries, BlockFactory blockFactory) {
+        BytesRefArray array = new BytesRefArray(entries.length, blockFactory.bigArrays());
+        boolean success = false;
+        try {
+            for (BytesRef entry : entries) {
+                array.append(entry);
+            }
+            BytesRefVector vector = blockFactory.newBytesRefArrayVector(array, entries.length);
+            success = true;
+            return vector;
+        } finally {
+            if (success == false) {
+                array.close();
+            }
+        }
+    }
+
+    private Block finishMaterializedFallback(int[] ordinals, WordMask nulls, int produced, int remaining, BlockFactory blockFactory) {
+        BytesRef[] dict = dictDecoder.getDictionaryBytesRefs(dictionary);
+        int total = produced + remaining;
+        BytesRef[] all = new BytesRef[total];
+        WordMask combinedNulls = nulls;
+        for (int i = 0; i < produced; i++) {
+            if (combinedNulls != null && combinedNulls.get(i)) {
+                continue;
+            }
+            all[i] = dict[ordinals[i]];
+        }
+        int filled = produced;
+        while (remaining > 0 && ensurePage()) {
+            int fromPage = Math.min(remaining, availableInPage());
+            if (combinedNulls == null) {
+                BytesRef[] vals = readBinaryValues(fromPage);
+                System.arraycopy(vals, 0, all, filled, fromPage);
+            } else {
+                WordMask pageNulls = buffers.valueSelection(fromPage);
+                int nonNull = defDecoder.readBatch(fromPage, pageNulls, 0);
+                BytesRef[] vals = nonNull > 0 ? readBinaryValues(nonNull) : null;
+                int valIdx = 0;
+                for (int i = 0; i < fromPage; i++) {
+                    if (pageNulls.get(i)) {
+                        combinedNulls.set(filled + i);
+                    } else {
+                        all[filled + i] = vals[valIdx++];
+                    }
+                }
+            }
+            advancePosition(fromPage);
+            filled += fromPage;
+            remaining -= fromPage;
+        }
+        if (combinedNulls != null && combinedNulls.isEmpty() == false) {
+            Block allNull = ConstantBlockDetection.tryAllNull(combinedNulls.toBitSet(), filled, blockFactory);
+            if (allNull != null) {
+                return allNull;
+            }
+        }
+        try (var builder = blockFactory.newBytesRefBlockBuilder(filled)) {
+            for (int i = 0; i < filled; i++) {
+                if (combinedNulls != null && combinedNulls.get(i)) {
+                    builder.appendNull();
+                } else {
+                    builder.appendBytesRef(all[i]);
+                }
+            }
+            return builder.build();
+        }
     }
 
     // --- Datetime ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DictionaryValueDecoderTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
+import org.apache.parquet.io.api.Binary;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+/**
+ * Unit tests for {@link DictionaryValueDecoder}, including the dictionary-index fast path
+ * used by {@link PageColumnReader} to emit {@link org.elasticsearch.compute.data.OrdinalBytesRefBlock}.
+ */
+public class DictionaryValueDecoderTests extends ESTestCase {
+
+    public void testReadIndicesShortRun() throws IOException {
+        int[] expected = { 0, 0, 0, 0, 0, 0, 0, 0 };
+        DictionaryValueDecoder decoder = decoderFor(expected, /* bitWidth= */ 4);
+
+        int[] indices = new int[expected.length];
+        decoder.readIndices(indices, 0, expected.length);
+
+        assertArrayEquals(expected, indices);
+    }
+
+    public void testReadIndicesMixedRunAndPacked() throws IOException {
+        int[] expected = { 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 0, 0, 1, 2, 3, 5 };
+        DictionaryValueDecoder decoder = decoderFor(expected, /* bitWidth= */ 3);
+
+        int[] indices = new int[expected.length];
+        decoder.readIndices(indices, 0, expected.length);
+
+        assertArrayEquals(expected, indices);
+    }
+
+    public void testReadIndicesWithOffset() throws IOException {
+        int[] expected = { 1, 2, 3, 4, 5, 6, 7, 0 };
+        DictionaryValueDecoder decoder = decoderFor(expected, /* bitWidth= */ 3);
+
+        int[] indices = new int[expected.length + 5];
+        Arrays.fill(indices, -1);
+        decoder.readIndices(indices, 5, expected.length);
+
+        for (int i = 0; i < 5; i++) {
+            assertEquals("slot before offset must be untouched", -1, indices[i]);
+        }
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals("slot at offset " + (5 + i), expected[i], indices[5 + i]);
+        }
+    }
+
+    public void testReadIndicesRandom() throws IOException {
+        int dictSize = randomIntBetween(2, 64);
+        int bitWidth = BytesUtils.getWidthFromMaxInt(dictSize - 1);
+        int count = randomIntBetween(50, 5000);
+        int[] expected = new int[count];
+        for (int i = 0; i < count; i++) {
+            expected[i] = randomIntBetween(0, dictSize - 1);
+        }
+        DictionaryValueDecoder decoder = decoderFor(expected, bitWidth);
+
+        int[] indices = new int[count];
+        decoder.readIndices(indices, 0, count);
+
+        assertArrayEquals(expected, indices);
+    }
+
+    public void testReadIndicesAndReadBinariesAgreeOnSameStream() throws IOException {
+        // For the same encoded index stream, both paths must produce equivalent results
+        // (readBinaries resolves indices through the dictionary; readIndices returns the indices).
+        String[] dict = { "alpha", "beta", "gamma", "delta" };
+        int[] expectedIndices = new int[200];
+        for (int i = 0; i < expectedIndices.length; i++) {
+            expectedIndices[i] = randomIntBetween(0, dict.length - 1);
+        }
+
+        DictionaryValueDecoder indexDecoder = decoderFor(expectedIndices, /* bitWidth= */ 2);
+        int[] indices = new int[expectedIndices.length];
+        indexDecoder.readIndices(indices, 0, expectedIndices.length);
+
+        DictionaryValueDecoder binaryDecoder = decoderFor(expectedIndices, /* bitWidth= */ 2);
+        BytesRef[] resolved = new BytesRef[expectedIndices.length];
+        Dictionary fakeDict = new BinaryDictionary(dict);
+        binaryDecoder.readBinaries(resolved, 0, expectedIndices.length, fakeDict);
+
+        for (int i = 0; i < expectedIndices.length; i++) {
+            assertEquals("index@" + i, expectedIndices[i], indices[i]);
+            BytesRef expected = new BytesRef(dict[expectedIndices[i]]);
+            assertEquals("resolved@" + i, expected, resolved[i]);
+        }
+    }
+
+    public void testGetDictionaryBytesRefsCachesAcrossCalls() {
+        String[] dict = { "one", "two", "three" };
+        Dictionary fakeDict = new BinaryDictionary(dict);
+        DictionaryValueDecoder decoder = new DictionaryValueDecoder();
+
+        BytesRef[] first = decoder.getDictionaryBytesRefs(fakeDict);
+        BytesRef[] second = decoder.getDictionaryBytesRefs(fakeDict);
+
+        assertSame("dictionary array should be cached and returned by reference", first, second);
+        assertEquals(dict.length, first.length);
+        for (int i = 0; i < dict.length; i++) {
+            assertEquals(new BytesRef(dict[i]), first[i]);
+        }
+    }
+
+    public void testGetDictionaryBytesRefsBeforeReadBinariesIsAvailable() {
+        // The dictionary array must be lazily initialized on first access without requiring
+        // readBinaries to have been called.
+        String[] dict = { "x", "y" };
+        Dictionary fakeDict = new BinaryDictionary(dict);
+        DictionaryValueDecoder decoder = new DictionaryValueDecoder();
+
+        BytesRef[] entries = decoder.getDictionaryBytesRefs(fakeDict);
+        assertEquals(2, entries.length);
+        assertEquals(new BytesRef("x"), entries[0]);
+        assertEquals(new BytesRef("y"), entries[1]);
+    }
+
+    public void testReadBinariesAndGetDictionaryBytesRefsShareCache() throws IOException {
+        // A subsequent readBinaries call must reuse the same cached dictionary array.
+        int[] expectedIndices = { 0, 1, 0, 1 };
+        String[] dict = { "left", "right" };
+        Dictionary fakeDict = new BinaryDictionary(dict);
+
+        DictionaryValueDecoder decoder = decoderFor(expectedIndices, /* bitWidth= */ 1);
+        BytesRef[] entries = decoder.getDictionaryBytesRefs(fakeDict);
+
+        BytesRef[] resolved = new BytesRef[expectedIndices.length];
+        decoder.readBinaries(resolved, 0, expectedIndices.length, fakeDict);
+
+        for (int i = 0; i < expectedIndices.length; i++) {
+            assertSame("readBinaries must return the cached entry", entries[expectedIndices[i]], resolved[i]);
+        }
+    }
+
+    // --- helpers ---
+
+    private static DictionaryValueDecoder decoderFor(int[] indices, int bitWidth) throws IOException {
+        ByteBuffer encoded = encodeRle(indices, bitWidth);
+        DictionaryValueDecoder decoder = new DictionaryValueDecoder();
+        decoder.init(encoded);
+        return decoder;
+    }
+
+    /**
+     * Encodes {@code indices} using Parquet's RLE/bit-packed hybrid encoding and prepends
+     * the 1-byte bit-width header that {@link DictionaryValueDecoder#init(ByteBuffer)} expects.
+     */
+    private static ByteBuffer encodeRle(int[] indices, int bitWidth) throws IOException {
+        RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(
+            bitWidth,
+            64,
+            1024,
+            HeapByteBufferAllocator.getInstance()
+        );
+        for (int v : indices) {
+            encoder.writeInt(v);
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(bitWidth & 0xFF);
+        encoder.toBytes().writeAllTo(out);
+        return ByteBuffer.wrap(out.toByteArray());
+    }
+
+    /**
+     * Minimal {@link Dictionary} implementation for testing. The real Parquet
+     * {@code Dictionary} subclasses (e.g. {@code PlainBinaryDictionary}) require an
+     * encoded {@code DictionaryPage} plus a {@code ColumnDescriptor} to be instantiated,
+     * which is far heavier than what these unit tests need. Here we extend
+     * {@link Dictionary} directly and only override the two methods exercised by
+     * {@link DictionaryValueDecoder}: {@code getMaxId} and {@code decodeToBinary}.
+     */
+    private static final class BinaryDictionary extends Dictionary {
+        private final Binary[] entries;
+
+        BinaryDictionary(String[] values) {
+            super(null);
+            this.entries = new Binary[values.length];
+            for (int i = 0; i < values.length; i++) {
+                this.entries[i] = Binary.fromString(values[i]);
+            }
+        }
+
+        @Override
+        public int getMaxId() {
+            return entries.length - 1;
+        }
+
+        @Override
+        public Binary decodeToBinary(int id) {
+            return entries[id];
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetOrdinalBytesRefTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetOrdinalBytesRefTests.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntArrayBlock;
+import org.elasticsearch.compute.data.IntBigArrayBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.IntFunction;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+
+/**
+ * End-to-end tests verifying that {@link PageColumnReader} emits an
+ * {@link OrdinalBytesRefBlock} for dictionary-encoded BINARY columns.
+ *
+ * <p>The ordinal block is the input shape that activates the
+ * {@code BytesRefBlockHash#addOrdinalsVector}/{@code addOrdinalsBlock} fast path in the
+ * compute engine: hash aggregation runs over the {@code k} dictionary entries instead of
+ * the {@code N} row values, which is the win we are after for high-cardinality string
+ * GROUP BY on Parquet.
+ */
+public class ParquetOrdinalBytesRefTests extends ESTestCase {
+
+    private static final int BATCH_SIZE = 1000;
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testDictionaryEncodedColumnEmitsOrdinalBlock() throws IOException {
+        int numRows = 5_000;
+        int dictSize = 64;
+        // Many repeats per dictionary entry — the writer keeps the column dictionary-encoded.
+        byte[] data = writeStringFile(numRows, false, row -> "v_" + (row % dictSize));
+
+        verifyDictionaryEncoded(data, numRows, false, row -> "v_" + (row % dictSize));
+    }
+
+    public void testNullableDictionaryEncodedColumnEmitsOrdinalBlock() throws IOException {
+        int numRows = 5_000;
+        int dictSize = 32;
+        byte[] data = writeStringFile(numRows, true, row -> row % 7 == 0 ? null : "color_" + (row % dictSize));
+
+        verifyDictionaryEncoded(data, numRows, true, row -> row % 7 == 0 ? null : "color_" + (row % dictSize));
+    }
+
+    /**
+     * End-to-end check that the ordinal block produced by the Parquet reader is consumable by
+     * {@link BlockHash}: the hash returns the same group ids and key set whether we feed it the
+     * {@link OrdinalBytesRefBlock} from the reader or a freshly-built equivalent
+     * {@code BytesRefBlock} populated with the same values. The dictionary size is a small
+     * fraction of the row count, so on a correct ordinal path the hash table ends up holding
+     * exactly the dictionary entries (k keys for N rows, k &lt;&lt; N).
+     *
+     * <p>This also exercises the asynchronous-consumer lifetime invariant: we deliberately
+     * release every parquet-sourced page and close the underlying iterator <strong>before</strong>
+     * extracting keys from the {@link BlockHash}. If the dictionary {@code BytesRefVector}
+     * still aliased Parquet-side memory (rather than its own deep copy in
+     * {@code BytesRefArray}-backed {@code BigArrays} storage), the keys we read out at the end
+     * would be corrupted.
+     */
+    public void testOrdinalBlockFlowsThroughBlockHashAfterSourceReleased() throws IOException {
+        int numRows = 4_000;
+        int distinctValues = 50;
+        IntFunction<String> valueFor = row -> "term_" + (row % distinctValues);
+        byte[] data = writeStringFile(numRows, false, valueFor);
+
+        int[] groupIdsFromOrdinal = new int[numRows];
+        BytesRef[] keysFromOrdinal;
+        int numKeysOrdinal;
+        boolean sawOrdinalBlock = false;
+        try (BlockHash hash = newBytesRefHash()) {
+            try (CloseableIterator<Page> iter = openIterator(data)) {
+                int row = 0;
+                while (iter.hasNext()) {
+                    Page page = iter.next();
+                    try {
+                        BytesRefBlock col = page.getBlock(0);
+                        if (col.asOrdinals() != null) {
+                            sawOrdinalBlock = true;
+                        }
+                        int rowAtPageStart = row;
+                        hash.add(page, new CapturingAddInput(groupIdsFromOrdinal, rowAtPageStart));
+                        row += page.getPositionCount();
+                    } finally {
+                        page.releaseBlocks();
+                    }
+                }
+                assertEquals(numRows, row);
+            }
+            // Source iterator and pages are now closed. Read keys out of the hash.
+            assertTrue("ordinal block should have been observed at least once", sawOrdinalBlock);
+            numKeysOrdinal = hash.numKeys();
+            keysFromOrdinal = readKeys(hash);
+        }
+
+        // Reference path: same data, plain BytesRefBlock.
+        int[] groupIdsFromPlain = new int[numRows];
+        BytesRef[] keysFromPlain;
+        int numKeysPlain;
+        try (BlockHash hash = newBytesRefHash()) {
+            try (Page page = new Page(buildPlainBytesRefBlock(numRows, valueFor))) {
+                hash.add(page, new CapturingAddInput(groupIdsFromPlain, 0));
+            }
+            numKeysPlain = hash.numKeys();
+            keysFromPlain = readKeys(hash);
+        }
+
+        // The hash sees one key per logically-distinct value. We deliberately do not pin the
+        // count to the writer's dictionary cardinality (which can include unused entries in
+        // some encodings) — the structural assertion is that ordinal and plain runs agree.
+        assertEquals("logical distinct value count", distinctValues, numKeysPlain);
+        assertEquals("plain and ordinal hashes must agree on key count", numKeysPlain, numKeysOrdinal);
+
+        // Group ids may not be byte-equal across runs (insertion order can differ), so compare
+        // by mapping each group id to the key it represents.
+        for (int i = 0; i < numRows; i++) {
+            BytesRef expected = new BytesRef(valueFor.apply(i));
+            assertEquals("row " + i + " (ordinal path)", expected, keysFromOrdinal[groupIdsFromOrdinal[i]]);
+            assertEquals("row " + i + " (plain path)", expected, keysFromPlain[groupIdsFromPlain[i]]);
+        }
+    }
+
+    public void testUniqueStringsRemainCorrectAcrossPages() throws IOException {
+        // High-cardinality input: every value distinct. Whether the writer keeps the column
+        // dictionary-encoded or falls back to PLAIN depends on parquet-mr's per-column
+        // heuristics, which we don't try to pin down here. The contract verified is that
+        // the reader returns the correct values regardless of the chosen encoding (i.e.
+        // both the ordinal and materialized paths agree on the values they emit).
+        int numRows = 2_000;
+        byte[] data = writeStringFile(numRows, false, row -> "unique_" + row);
+
+        List<Page> pages = readAll(data);
+        try {
+            int row = 0;
+            for (Page page : pages) {
+                BytesRefBlock block = page.getBlock(0);
+                assertNotNull("page should produce a block", block);
+                BytesRef scratch = new BytesRef();
+                for (int p = 0; p < page.getPositionCount(); p++) {
+                    assertFalse("required column", block.isNull(p));
+                    assertEquals(new BytesRef("unique_" + row), block.getBytesRef(p, scratch));
+                    row++;
+                }
+            }
+            assertEquals(numRows, row);
+        } finally {
+            pages.forEach(Page::releaseBlocks);
+        }
+    }
+
+    // --- helpers ---
+
+    private void verifyDictionaryEncoded(byte[] data, int numRows, boolean optional, IntFunction<String> valueFor) throws IOException {
+        List<Page> pages = readAll(data);
+        try {
+            int seenOrdinalPages = 0;
+            int totalRows = 0;
+            BytesRef scratch = new BytesRef();
+            for (Page page : pages) {
+                BytesRefBlock block = page.getBlock(0);
+                assertNotNull(block);
+                OrdinalBytesRefBlock ordinal = block.asOrdinals();
+                if (ordinal != null) {
+                    seenOrdinalPages++;
+                    assertTrue(
+                        "dictionary should be small relative to dataset cardinality",
+                        ordinal.getDictionaryVector().getPositionCount() < numRows
+                    );
+                }
+                for (int p = 0; p < page.getPositionCount(); p++) {
+                    String expected = valueFor.apply(totalRows);
+                    if (expected == null) {
+                        assertTrue("expected null at row " + totalRows, block.isNull(p));
+                    } else {
+                        assertFalse("unexpected null at row " + totalRows, block.isNull(p));
+                        assertEquals("row " + totalRows, new BytesRef(expected), block.getBytesRef(p, scratch));
+                    }
+                    totalRows++;
+                }
+            }
+            assertEquals(numRows, totalRows);
+            assertTrue("expected at least one ordinal-encoded page; got " + seenOrdinalPages + " of " + pages.size(), seenOrdinalPages > 0);
+        } finally {
+            pages.forEach(Page::releaseBlocks);
+        }
+    }
+
+    private List<Page> readAll(byte[] data) throws IOException {
+        List<Page> pages = new ArrayList<>();
+        try (CloseableIterator<Page> iter = openIterator(data)) {
+            while (iter.hasNext()) {
+                pages.add(iter.next());
+            }
+        }
+        return pages;
+    }
+
+    private CloseableIterator<Page> openIterator(byte[] data) throws IOException {
+        StorageObject so = storageObject(data);
+        return new ParquetFormatReader(blockFactory).read(so, FormatReadContext.of(List.of("name"), BATCH_SIZE));
+    }
+
+    private BlockHash newBytesRefHash() {
+        // allowBrokenOptimizations is irrelevant for a single BYTES_REF group (BlockHash.build
+        // routes that case directly to BytesRefBlockHash regardless of the flag), but keep it
+        // false so readers don't infer the test relies on optimizations with known caveats.
+        return BlockHash.build(List.of(new BlockHash.GroupSpec(0, ElementType.BYTES_REF)), blockFactory, randomIntBetween(1, 1000), false);
+    }
+
+    private BytesRefBlock buildPlainBytesRefBlock(int numRows, IntFunction<String> valueFor) {
+        try (var builder = blockFactory.newBytesRefBlockBuilder(numRows)) {
+            for (int i = 0; i < numRows; i++) {
+                builder.appendBytesRef(new BytesRef(valueFor.apply(i)));
+            }
+            return builder.build();
+        }
+    }
+
+    /**
+     * Reads the distinct keys held by a {@link BlockHash} into a {@link BytesRef} array indexed
+     * by group id (with index 0 reserved for the null group). Used to map captured group ids
+     * back to their original values when comparing two hash runs whose group-id assignment may
+     * differ in insertion order.
+     */
+    private BytesRef[] readKeys(BlockHash hash) {
+        try (IntVector selected = hash.nonEmpty()) {
+            Block[] keyBlocks = hash.getKeys(selected);
+            try {
+                BytesRefBlock keys = (BytesRefBlock) keyBlocks[0];
+                BytesRef[] out = new BytesRef[hash.numKeys() + 1];
+                BytesRef scratch = new BytesRef();
+                for (int p = 0; p < keys.getPositionCount(); p++) {
+                    int groupId = selected.getInt(p);
+                    if (keys.isNull(p)) {
+                        out[groupId] = null;
+                    } else {
+                        out[groupId] = BytesRef.deepCopyOf(keys.getBytesRef(p, scratch));
+                    }
+                }
+                return out;
+            } finally {
+                Releasables.closeExpectNoException(keyBlocks);
+            }
+        }
+    }
+
+    /**
+     * Captures the group ids emitted by {@link BlockHash#add(Page, GroupingAggregatorFunction.AddInput)}
+     * into a single shared array indexed by the row's position in the input dataset.
+     */
+    private static final class CapturingAddInput implements GroupingAggregatorFunction.AddInput {
+        private final int[] target;
+        private final int positionBase;
+
+        CapturingAddInput(int[] target, int positionBase) {
+            this.target = target;
+            this.positionBase = positionBase;
+        }
+
+        @Override
+        public void add(int positionOffset, IntVector groupIds) {
+            for (int i = 0; i < groupIds.getPositionCount(); i++) {
+                target[positionBase + positionOffset + i] = groupIds.getInt(i);
+            }
+        }
+
+        @Override
+        public void add(int positionOffset, IntArrayBlock groupIds) {
+            // No multivalues / nulls expected for this test (required column, no MV).
+            for (int p = 0; p < groupIds.getPositionCount(); p++) {
+                if (groupIds.isNull(p) || groupIds.getValueCount(p) != 1) {
+                    throw new AssertionError("unexpected null/multivalue group at " + p);
+                }
+                target[positionBase + positionOffset + p] = groupIds.getInt(groupIds.getFirstValueIndex(p));
+            }
+        }
+
+        @Override
+        public void add(int positionOffset, IntBigArrayBlock groupIds) {
+            for (int p = 0; p < groupIds.getPositionCount(); p++) {
+                if (groupIds.isNull(p) || groupIds.getValueCount(p) != 1) {
+                    throw new AssertionError("unexpected null/multivalue group at " + p);
+                }
+                target[positionBase + positionOffset + p] = groupIds.getInt(groupIds.getFirstValueIndex(p));
+            }
+        }
+
+        @Override
+        public void close() {
+            // BlockHash#add must not close its AddInput callback (per its Javadoc).
+            throw new AssertionError("BlockHash should not close the AddInput callback");
+        }
+    }
+
+    private byte[] writeStringFile(int numRows, boolean optional, IntFunction<String> valueFor) throws IOException {
+        Types.MessageTypeBuilder schemaBuilder = Types.buildMessage();
+        var col = optional ? Types.optional(BINARY) : Types.required(BINARY);
+        col.as(LogicalTypeAnnotation.stringType());
+        schemaBuilder.addField(col.named("name"));
+        MessageType schema = schemaBuilder.named("ordinal_test");
+
+        return writeFile(schema, numRows, (g, i) -> {
+            String v = valueFor.apply(i);
+            if (v != null) {
+                g.append("name", v);
+            }
+        });
+    }
+
+    private byte[] writeFile(MessageType schema, int numRows, BiConsumer<Group, Integer> populate) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        PlainParquetConfiguration conf = new PlainParquetConfiguration();
+        conf.set("parquet.enable.dictionary", "true");
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile(out))
+                .withConf(conf)
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withDictionaryEncoding(true)
+                .withDictionaryPageSize(64 * 1024)
+                .withRowGroupSize(64 * 1024L)
+                .withPageSize(4 * 1024)
+                .build()
+        ) {
+            for (int i = 0; i < numRows; i++) {
+                Group g = factory.newGroup();
+                populate.accept(g, i);
+                writer.write(g);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private static StorageObject storageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                return new ByteArrayInputStream(data, (int) position, (int) Math.min(length, data.length - position));
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.EPOCH;
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://ordinal_test.parquet");
+            }
+        };
+    }
+
+    private static OutputFile outputFile(ByteArrayOutputStream out) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position = 0;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        out.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        out.write(b, off, len);
+                        position += len;
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        out.close();
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+
+            @Override
+            public String getPath() {
+                return "memory://ordinal_test.parquet";
+            }
+        };
+    }
+}


### PR DESCRIPTION
Make the Parquet reader produce OrdinalBytesRefBlock for
dictionary-encoded BINARY/UTF8 columns so BytesRefBlockHash takes
its addOrdinalsVector / addOrdinalsBlock fast path on hash
aggregation. The hash now runs over the k dictionary entries
instead of the N row values, dropping the cost of GROUP BY on
low-cardinality string columns from O(N * len) to roughly
O(k * len) + O(N * 4) (one int per row).

DictionaryValueDecoder gains readIndices, which decodes raw
RLE/bit-packed ordinals into a caller-provided int[], and
getDictionaryBytesRefs, which lazily decodes and caches the
column-chunk dictionary as a BytesRef[]. Bytes are owned by the
JVM (Parquet's Binary#getBytes contract returns a freshly
allocated byte[]), so the cache is safe to outlive the row group.

PageColumnReader detects dictionary-encoded BINARY columns and
routes them through readBytesBatchAsOrdinals, which collects
ordinals plus a null mask, falls back gracefully if a page in
the chunk is plain-encoded, short-circuits all-null and
constant-ordinal cases, and otherwise wraps the result in an
OrdinalBytesRefBlock. The dictionary BytesRefVector is rebuilt
per batch via BytesRefArray.append (BigArrays-backed, breaker
accounted) so each emitted block fully owns its memory and is
safe for asynchronous consumption by a different driver thread.
UUID columns skip the ordinal path because their values need
per-row formatting that would have to be applied to dictionary
entries instead.

Tests cover the new low-level decoder methods, end-to-end
ordinal emission for required and nullable columns, and a
BlockHash integration that releases every parquet page (and
closes the iterator) before reading keys back from the hash, so
any aliasing into Parquet-side memory would surface as
corruption.

Developed with AI-assisted tooling