### PR TITLE
ESQL: Bulk-decode Parquet definition levels

### DIFF
--- a/docs/changelog/148255.yaml
+++ b/docs/changelog/148255.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148255
+summary: Bulk-decode Parquet definition levels
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
@@ -179,6 +179,24 @@ final class DefinitionLevelDecoder {
                 remaining--;
                 packedRemaining--;
             }
+            // Bulk path: read 8 bytes (= 64 def levels) at a time and OR the inverted bits
+            // straight into the WordMask's underlying long[]. Parquet packs def levels LSB-first
+            // within each byte, and reading 8 bytes as little-endian gives a long whose bit i
+            // matches def level i in the 64-level group — same convention as WordMask.set, so
+            // the inverted long can be OR-ed at any bit position via WordMask.orLongAt.
+            while (remaining >= 64) {
+                long packedLong = readLittleEndianLong(packedBytes, packedByteOffset);
+                packedByteOffset += 8;
+                long nullLong = ~packedLong;
+                if (nullLong != 0) {
+                    nullCount += 64 - Long.bitCount(packedLong);
+                    mask.orLongAt(outOffset, nullLong);
+                }
+                outOffset += 64;
+                remaining -= 64;
+                packedRemaining -= 64;
+            }
+            // Per-byte path: drains the [0, 64) byte tail of the bulk loop above.
             while (remaining >= 8) {
                 int packed = packedBytes[packedByteOffset++] & 0xFF;
                 int nullByte = ~packed & 0xFF;
@@ -247,6 +265,14 @@ final class DefinitionLevelDecoder {
                 groupNext++;
                 remaining--;
                 packedRemaining--;
+            }
+            // Bulk path: pop 64 def levels per iteration (popcount on the inverted long).
+            while (remaining >= 64) {
+                long packedLong = readLittleEndianLong(packedBytes, packedByteOffset);
+                packedByteOffset += 8;
+                nullCount += 64 - Long.bitCount(packedLong);
+                remaining -= 64;
+                packedRemaining -= 64;
             }
             while (remaining >= 8) {
                 int packed = packedBytes[packedByteOffset++] & 0xFF;
@@ -329,6 +355,16 @@ final class DefinitionLevelDecoder {
             shift += 7;
             Check.isTrue(shift <= 35, "Varint overflow in definition level stream");
         }
+    }
+
+    /**
+     * Reads 8 bytes from {@code data} starting at {@code offset} as a little-endian {@code long}.
+     * The caller must ensure {@code offset + 8 <= data.length}.
+     */
+    private static long readLittleEndianLong(byte[] data, int offset) {
+        return (data[offset] & 0xFFL) | ((data[offset + 1] & 0xFFL) << 8) | ((data[offset + 2] & 0xFFL) << 16) | ((data[offset + 3] & 0xFFL)
+            << 24) | ((data[offset + 4] & 0xFFL) << 32) | ((data[offset + 5] & 0xFFL) << 40) | ((data[offset + 6] & 0xFFL) << 48)
+            | ((data[offset + 7] & 0xFFL) << 56);
     }
 
     private int readIntLittleEndianPadded() {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoder.java
@@ -7,80 +7,76 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
-import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.util.Check;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.BitSet;
 
 /**
- * Bulk decoder for Parquet definition levels, producing a {@link BitSet} of null positions
- * for nullable flat columns. Delegates to parquet-java's {@link RunLengthBitPackingHybridDecoder}
- * for the actual RLE hybrid stream decoding.
+ * Bulk decoder for Parquet definition levels, producing a {@link WordMask} of null positions
+ * for nullable flat columns. Implements the Parquet RLE/BitPacked hybrid format directly so
+ * runs of all-null or all-present values can be applied to the output bitmask in O(1) per run
+ * instead of O(N) per value.
  *
  * <p>For non-nullable columns ({@code maxDefLevel == 0}), no def-level section exists in the
  * page and all operations are no-ops.
+ *
+ * <p>The decoder is specialized for the overwhelmingly common case of {@code maxDefLevel == 1}
+ * (a nullable flat column), where each def level is a single bit (0 = null, 1 = present) and
+ * a bit-packed group of 8 def levels is exactly one byte. The general path handles
+ * {@code maxDefLevel > 1} (e.g. nested types reaching this code via the flat-column read path).
  */
 final class DefinitionLevelDecoder {
 
     private boolean nonNullable;
     private int maxDefLevel;
-    private RunLengthBitPackingHybridDecoder rleDecoder;
+    private int bitWidth;
+    private ByteBuffer in;
+
+    // RLE/BitPacked hybrid state across calls (a run can span several readBatch invocations).
+    private boolean rleMode;
+    private int rleLeft;
+    private int rleValue;
+    private byte[] packedBytes;
+    private int packedByteOffset;
+    private int packedRemaining;
+    // Decoded values for the currently-loaded bit-packed group (only used when bitWidth > 1).
+    private final int[] groupValues = new int[8];
+    private int groupNext = 8;
 
     DefinitionLevelDecoder() {}
 
-    void init(ByteBuffer defLevelBytes, int valueCount, int maxDefLevel, boolean hasLengthPrefix) {
+    void init(ByteBuffer defLevelBytes, int maxDefLevel, boolean hasLengthPrefix) {
         this.maxDefLevel = maxDefLevel;
         if (maxDefLevel <= 0) {
             this.nonNullable = true;
-            this.rleDecoder = null;
+            this.in = null;
             return;
         }
         this.nonNullable = false;
-        int bitWidth = 32 - Integer.numberOfLeadingZeros(maxDefLevel);
+        this.bitWidth = 32 - Integer.numberOfLeadingZeros(maxDefLevel);
         ByteBuffer source = defLevelBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
         if (hasLengthPrefix) {
             int payloadLen = source.getInt();
-            byte[] payload = new byte[payloadLen];
-            source.get(payload);
-            this.rleDecoder = new RunLengthBitPackingHybridDecoder(bitWidth, new ByteArrayInputStream(payload));
+            Check.isTrue(source.remaining() >= payloadLen, "Truncated definition level payload");
+            ByteBuffer payload = source.slice().order(ByteOrder.LITTLE_ENDIAN);
+            payload.limit(payloadLen);
+            this.in = payload;
         } else {
-            byte[] data = new byte[source.remaining()];
-            source.get(data);
-            this.rleDecoder = new RunLengthBitPackingHybridDecoder(bitWidth, new ByteArrayInputStream(data));
+            this.in = source.slice().order(ByteOrder.LITTLE_ENDIAN);
         }
+        this.rleMode = true;
+        this.rleLeft = 0;
+        this.rleValue = 0;
+        this.packedRemaining = 0;
+        this.packedByteOffset = 0;
+        this.groupNext = 8;
     }
 
     /**
      * Decodes the next {@code count} definition levels, setting null positions in {@code nulls}
      * starting at {@code offset}. Returns the number of non-null values.
      */
-    int readBatch(int count, BitSet nulls, int offset) {
-        if (nonNullable) {
-            return count;
-        }
-        if (count == 0) {
-            return 0;
-        }
-        int nonNull = 0;
-        try {
-            for (int i = 0; i < count; i++) {
-                int def = rleDecoder.readInt();
-                if (def < maxDefLevel) {
-                    nulls.set(offset + i);
-                } else {
-                    nonNull++;
-                }
-            }
-        } catch (IOException e) {
-            throw new QlIllegalArgumentException("Failed to read definition levels: " + e.getMessage(), e);
-        }
-        return nonNull;
-    }
-
     int readBatch(int count, WordMask nulls, int offset) {
         if (nonNullable) {
             return count;
@@ -88,20 +84,32 @@ final class DefinitionLevelDecoder {
         if (count == 0) {
             return 0;
         }
-        int nonNull = 0;
-        try {
-            for (int i = 0; i < count; i++) {
-                int def = rleDecoder.readInt();
-                if (def < maxDefLevel) {
-                    nulls.set(offset + i);
-                } else {
-                    nonNull++;
+        int produced = 0;
+        int nullCount = 0;
+        while (produced < count) {
+            if (rleMode) {
+                if (rleLeft == 0) {
+                    startNextRun();
+                    continue;
                 }
+                int take = Math.min(rleLeft, count - produced);
+                if (rleValue < maxDefLevel) {
+                    nulls.setRange(offset + produced, offset + produced + take);
+                    nullCount += take;
+                }
+                produced += take;
+                rleLeft -= take;
+            } else {
+                if (packedRemaining == 0) {
+                    startNextRun();
+                    continue;
+                }
+                int take = Math.min(packedRemaining, count - produced);
+                nullCount += unpackInto(nulls, offset + produced, take);
+                produced += take;
             }
-        } catch (IOException e) {
-            throw new QlIllegalArgumentException("Failed to read definition levels: " + e.getMessage(), e);
         }
-        return nonNull;
+        return count - nullCount;
     }
 
     /**
@@ -112,17 +120,272 @@ final class DefinitionLevelDecoder {
         if (nonNullable || count == 0) {
             return count;
         }
-        int nonNull = 0;
-        try {
-            for (int i = 0; i < count; i++) {
-                int def = rleDecoder.readInt();
-                if (def >= maxDefLevel) {
-                    nonNull++;
+        int skipped = 0;
+        int nullCount = 0;
+        while (skipped < count) {
+            if (rleMode) {
+                if (rleLeft == 0) {
+                    startNextRun();
+                    continue;
+                }
+                int take = Math.min(rleLeft, count - skipped);
+                if (rleValue < maxDefLevel) {
+                    nullCount += take;
+                }
+                skipped += take;
+                rleLeft -= take;
+            } else {
+                if (packedRemaining == 0) {
+                    startNextRun();
+                    continue;
+                }
+                int take = Math.min(packedRemaining, count - skipped);
+                nullCount += skipPackedNulls(take);
+                skipped += take;
+            }
+        }
+        return count - nullCount;
+    }
+
+    /**
+     * Consumes {@code count} bit-packed def levels (which must already be loaded into the
+     * current group) and writes nulls into {@code mask} starting at {@code outOffset}.
+     * Returns the number of nulls written.
+     *
+     * <p>For {@code bitWidth == 1} this consumes raw bytes 8 levels at a time without
+     * staging a {@code groupValues[]} array; each bit in the packed byte directly maps
+     * to a not-null bit, so the null bits are obtained by inverting the packed byte.
+     */
+    private int unpackInto(WordMask mask, int outOffset, int count) {
+        int nullCount = 0;
+        int remaining = count;
+        if (bitWidth == 1) {
+            // Fast path: drain in-flight partial group bit-by-bit (rare: only when readBatch
+            // finished mid-group on a prior call), then process whole bytes (8 levels each),
+            // and finally a tail byte for the last <8 levels.
+            //
+            // Invariant: when groupNext < 8, the in-flight byte is packedBytes[packedByteOffset - 1].
+            // groupNext drops below 8 only after a tail-byte read below (which incremented
+            // packedByteOffset before setting groupNext = remaining), so packedByteOffset >= 1
+            // is guaranteed in this branch.
+            while (groupNext < 8 && remaining > 0) {
+                int packed = packedBytes[packedByteOffset - 1] & 0xFF;
+                if (((packed >>> groupNext) & 1) == 0) {
+                    mask.set(outOffset);
+                    nullCount++;
+                }
+                groupNext++;
+                outOffset++;
+                remaining--;
+                packedRemaining--;
+            }
+            while (remaining >= 8) {
+                int packed = packedBytes[packedByteOffset++] & 0xFF;
+                int nullByte = ~packed & 0xFF;
+                // Single popcount + iterate-set-bits is faster than testing 8 bits unconditionally
+                // because realistic flat-column null patterns produce mostly-empty inverted bytes
+                // (nulls are sparse) — Integer.bitCount maps to a single CPU popcnt instruction.
+                if (nullByte != 0) {
+                    nullCount += Integer.bitCount(nullByte);
+                    int b = nullByte;
+                    do {
+                        int bit = Integer.numberOfTrailingZeros(b);
+                        mask.set(outOffset + bit);
+                        b &= b - 1;
+                    } while (b != 0);
+                }
+                outOffset += 8;
+                remaining -= 8;
+                packedRemaining -= 8;
+            }
+            if (remaining > 0) {
+                int packed = packedBytes[packedByteOffset++] & 0xFF;
+                for (int i = 0; i < remaining; i++) {
+                    if (((packed >>> i) & 1) == 0) {
+                        mask.set(outOffset + i);
+                        nullCount++;
+                    }
+                }
+                groupNext = remaining;
+                packedRemaining -= remaining;
+            }
+            return nullCount;
+        }
+        // General path (bitWidth > 1): unpack 8 values at a time into groupValues[].
+        while (remaining > 0) {
+            if (groupNext >= 8) {
+                loadPackedGroup();
+            }
+            int inGroup = Math.min(8 - groupNext, remaining);
+            for (int i = 0; i < inGroup; i++) {
+                if (groupValues[groupNext + i] < maxDefLevel) {
+                    mask.set(outOffset + i);
+                    nullCount++;
                 }
             }
-        } catch (IOException e) {
-            throw new QlIllegalArgumentException("Failed to skip definition levels: " + e.getMessage(), e);
+            groupNext += inGroup;
+            outOffset += inGroup;
+            remaining -= inGroup;
+            packedRemaining -= inGroup;
         }
-        return nonNull;
+        return nullCount;
+    }
+
+    /**
+     * Skip variant of {@link #unpackInto}: consumes {@code count} bit-packed def levels
+     * without writing to a mask, returning the number of nulls encountered.
+     */
+    private int skipPackedNulls(int count) {
+        int nullCount = 0;
+        int remaining = count;
+        if (bitWidth == 1) {
+            while (groupNext < 8 && remaining > 0) {
+                int packed = packedBytes[packedByteOffset - 1] & 0xFF;
+                if (((packed >>> groupNext) & 1) == 0) {
+                    nullCount++;
+                }
+                groupNext++;
+                remaining--;
+                packedRemaining--;
+            }
+            while (remaining >= 8) {
+                int packed = packedBytes[packedByteOffset++] & 0xFF;
+                nullCount += Integer.bitCount(~packed & 0xFF);
+                remaining -= 8;
+                packedRemaining -= 8;
+            }
+            if (remaining > 0) {
+                int packed = packedBytes[packedByteOffset++] & 0xFF;
+                for (int i = 0; i < remaining; i++) {
+                    if (((packed >>> i) & 1) == 0) {
+                        nullCount++;
+                    }
+                }
+                groupNext = remaining;
+                packedRemaining -= remaining;
+            }
+            return nullCount;
+        }
+        while (remaining > 0) {
+            if (groupNext >= 8) {
+                loadPackedGroup();
+            }
+            int inGroup = Math.min(8 - groupNext, remaining);
+            for (int i = 0; i < inGroup; i++) {
+                if (groupValues[groupNext + i] < maxDefLevel) {
+                    nullCount++;
+                }
+            }
+            groupNext += inGroup;
+            remaining -= inGroup;
+            packedRemaining -= inGroup;
+        }
+        return nullCount;
+    }
+
+    private void startNextRun() {
+        Check.isTrue(in.hasRemaining(), "Truncated definition level stream");
+        int header = readUnsignedVarInt();
+        if ((header & 1) == 0) {
+            rleMode = true;
+            rleLeft = header >>> 1;
+            rleValue = readIntLittleEndianPadded();
+            packedRemaining = 0;
+            groupNext = 8;
+        } else {
+            rleMode = false;
+            int numGroups = header >>> 1;
+            packedRemaining = numGroups * 8;
+            int byteLen = numGroups * bitWidth;
+            Check.isTrue(in.remaining() >= byteLen, "Truncated bit-packed definition level data");
+            if (packedBytes == null || packedBytes.length < byteLen) {
+                packedBytes = new byte[byteLen];
+            }
+            in.get(packedBytes, 0, byteLen);
+            packedByteOffset = 0;
+            groupNext = 8;
+            rleLeft = 0;
+        }
+    }
+
+    private void loadPackedGroup() {
+        // bitWidth is always >= 1 here: init short-circuits to nonNullable=true when maxDefLevel<=0,
+        // and unpackInto / skipPackedNulls use a bitWidth==1 fast path that never enters this method.
+        unpack8Values(packedBytes, packedByteOffset, groupValues, bitWidth);
+        packedByteOffset += bitWidth;
+        groupNext = 0;
+    }
+
+    private int readUnsignedVarInt() {
+        int shift = 0;
+        int result = 0;
+        while (true) {
+            Check.isTrue(in.hasRemaining(), "Truncated varint in definition level stream");
+            int b = in.get() & 0xFF;
+            result |= (b & 0x7F) << shift;
+            if ((b & 0x80) == 0) {
+                return result;
+            }
+            shift += 7;
+            Check.isTrue(shift <= 35, "Varint overflow in definition level stream");
+        }
+    }
+
+    private int readIntLittleEndianPadded() {
+        int n = (bitWidth + 7) >>> 3;
+        if (n == 0) {
+            return 0;
+        }
+        Check.isTrue(in.remaining() >= n, "Truncated padded definition level value");
+        int v = 0;
+        for (int i = 0; i < n; i++) {
+            v |= (in.get() & 0xFF) << (8 * i);
+        }
+        return v;
+    }
+
+    /**
+     * Unpacks 8 def-level values from the bit-packed stream. Called only from
+     * {@link #loadPackedGroup}, which is itself only reachable for {@code bitWidth >= 2}
+     * (the {@code bitWidth == 1} fast path bypasses {@code groupValues[]} entirely).
+     */
+    private static void unpack8Values(byte[] packed, int byteOffset, int[] out, int bitWidth) {
+        switch (bitWidth) {
+            case 2 -> {
+                int word = (packed[byteOffset] & 0xFF) | ((packed[byteOffset + 1] & 0xFF) << 8);
+                for (int i = 0; i < 8; i++) {
+                    out[i] = (word >>> (i * 2)) & 0x3;
+                }
+            }
+            case 4 -> {
+                int word = (packed[byteOffset] & 0xFF) | ((packed[byteOffset + 1] & 0xFF) << 8) | ((packed[byteOffset + 2] & 0xFF) << 16)
+                    | ((packed[byteOffset + 3] & 0xFF) << 24);
+                for (int i = 0; i < 8; i++) {
+                    out[i] = (word >>> (i * 4)) & 0xF;
+                }
+            }
+            case 8 -> {
+                for (int i = 0; i < 8; i++) {
+                    out[i] = packed[byteOffset + i] & 0xFF;
+                }
+            }
+            default -> {
+                int bitBase = byteOffset * 8;
+                for (int i = 0; i < 8; i++) {
+                    out[i] = readBitsLE(packed, bitBase + i * bitWidth, bitWidth);
+                }
+            }
+        }
+    }
+
+    private static int readBitsLE(byte[] data, int bitOffset, int width) {
+        int byteIdx = bitOffset >>> 3;
+        int bitInByte = bitOffset & 7;
+        long word = 0;
+        int bytesNeeded = ((bitInByte + width) + 7) >>> 3;
+        for (int i = 0; i < bytesNeeded && (byteIdx + i) < data.length; i++) {
+            word |= (long) (data[byteIdx + i] & 0xFF) << (i * 8);
+        }
+        return (int) ((word >>> bitInByte) & (width == 32 ? 0xFFFFFFFFL : ((1L << width) - 1)));
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -32,7 +32,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.BitSet;
 
 /**
  * Page-level batch column reader that bypasses {@code ColumnReadStoreImpl} and works directly
@@ -40,7 +39,7 @@ import java.util.BitSet;
  * <ol>
  *   <li>Reads data pages from the {@link PageReader}</li>
  *   <li>Splits V1/V2 pages into def-level and value streams</li>
- *   <li>Bulk-decodes def levels via {@link DefinitionLevelDecoder} → null {@link BitSet}</li>
+ *   <li>Bulk-decodes def levels via {@link DefinitionLevelDecoder} → null {@link WordMask}</li>
  *   <li>Bulk-decodes values via {@link PlainValueDecoder} or {@link DictionaryValueDecoder}</li>
  *   <li>Assembles into ESQL {@link Block}s</li>
  * </ol>
@@ -278,9 +277,9 @@ final class PageColumnReader {
 
     private void initDecoders() {
         if (maxDefLevel > 0 && currentDefLevelBytes != null) {
-            defDecoder.init(currentDefLevelBytes, currentPageValueCount, maxDefLevel, currentPageIsV1);
+            defDecoder.init(currentDefLevelBytes, maxDefLevel, currentPageIsV1);
         } else {
-            defDecoder.init(EMPTY_BYTE_BUFFER.duplicate(), currentPageValueCount, 0, false);
+            defDecoder.init(EMPTY_BYTE_BUFFER.duplicate(), 0, false);
         }
 
         if (currentEncoding.usesDictionary()) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
@@ -57,6 +57,27 @@ final class WordMask {
     }
 
     /**
+     * Bitwise-ORs a 64-bit chunk of bits into the mask starting at bit position {@code bitOffset}.
+     * Bit {@code i} of {@code bits} (i.e. {@code (bits >>> i) & 1}) is OR-ed into bit
+     * {@code bitOffset + i} of the mask. The chunk may straddle a word boundary, in which case
+     * both adjacent words are updated.
+     *
+     * <p>The caller must ensure {@code bitOffset + 64 <= numBits}; this is the bulk-write companion
+     * to {@link #set(int)} for hot decode loops that produce 64 bits at a time (e.g. Parquet
+     * def-level decoding, where 8 packed bytes give 64 def levels in one read).
+     */
+    void orLongAt(int bitOffset, long bits) {
+        int wordIdx = bitOffset >>> 6;
+        int shift = bitOffset & 63;
+        if (shift == 0) {
+            words[wordIdx] |= bits;
+        } else {
+            words[wordIdx] |= bits << shift;
+            words[wordIdx + 1] |= bits >>> (64 - shift);
+        }
+    }
+
+    /**
      * Sets all bits in the half-open range {@code [from, to)} using word-level operations.
      * This is significantly faster than calling {@link #set(int)} in a loop for long runs,
      * which is the common case when bulk-decoding RLE def-level streams of all-null rows.

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
@@ -57,6 +57,30 @@ final class WordMask {
     }
 
     /**
+     * Sets all bits in the half-open range {@code [from, to)} using word-level operations.
+     * This is significantly faster than calling {@link #set(int)} in a loop for long runs,
+     * which is the common case when bulk-decoding RLE def-level streams of all-null rows.
+     */
+    void setRange(int from, int to) {
+        if (from >= to) {
+            return;
+        }
+        int firstWord = from >>> 6;
+        int lastWord = (to - 1) >>> 6;
+        long firstMask = ~0L << from;
+        long lastMask = ~0L >>> -to;
+        if (firstWord == lastWord) {
+            words[firstWord] |= firstMask & lastMask;
+        } else {
+            words[firstWord] |= firstMask;
+            for (int i = firstWord + 1; i < lastWord; i++) {
+                words[i] = ~0L;
+            }
+            words[lastWord] |= lastMask;
+        }
+    }
+
+    /**
      * Resets the mask to the given size and sets all {@code numBits} bits to 1.
      * Trailing bits in the last word beyond {@code numBits} are left as 0.
      */

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
@@ -81,6 +81,10 @@ final class WordMask {
      * Sets all bits in the half-open range {@code [from, to)} using word-level operations.
      * This is significantly faster than calling {@link #set(int)} in a loop for long runs,
      * which is the common case when bulk-decoding RLE def-level streams of all-null rows.
+     *
+     * <p>The caller must ensure {@code 0 <= from <= to <= numBits}; out-of-range indices
+     * silently set bits beyond the logical mask size, since (like {@link #set(int)}) this
+     * helper does no bounds validation against {@code numBits}.
      */
     void setRange(int from, int to) {
         if (from >= to) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoderBulkPathTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoderBulkPathTests.java
@@ -21,15 +21,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 /**
- * Targeted tests for the bulk 64-bits-at-a-time fast path in {@link DefinitionLevelDecoder}.
+ * Tests that decode {@link DefinitionLevelDecoder} output and parquet-mr's
+ * {@link RunLengthBitPackingHybridDecoder} from the same encoded byte stream and assert
+ * bit-by-bit equivalence — i.e. parquet-mr's decoder is the ground truth, not the original
+ * {@code int[]} of def levels. This guards against any drift between our format reading and
+ * parquet-mr's wire-format interpretation, even in cases where the def-level array round-trips
+ * correctly through both encoder and decoder by coincidence.
  *
- * <p>The general {@link DefinitionLevelDecoderTests} suite asserts against an expected
- * {@code int[]} of def levels. This suite goes one step further and decodes the exact same
- * bytes with parquet-mr's {@link RunLengthBitPackingHybridDecoder} as ground truth, then
- * asserts the bit-mask produced by our bulk path is identical at every position. That way, if
- * our notion of the format ever drifts from parquet-mr's, the test catches it.
- *
- * <p>These tests deliberately:
+ * <p>The bulk of this suite targets the bulk 64-bits-at-a-time fast path for {@code bitWidth==1}:
  * <ul>
  *   <li>Force runs long enough ({@code >= 64}) that the bulk path is exercised.</li>
  *   <li>Vary the alignment of the destination offset within the {@link WordMask} to cover
@@ -38,6 +37,10 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
  *       gets entered/exited at varying state-machine points.</li>
  *   <li>Cover all-null, all-present, sparse-null, dense-null and random patterns.</li>
  * </ul>
+ *
+ * <p>An additional case covers the {@code unpack8Values} {@code default} branch (bit widths
+ * other than 1, 2, 4, 8) by driving {@code bitWidth==3}, so the general bit-shifted readout
+ * path is also tied to parquet-mr's wire format.
  */
 public class DefinitionLevelDecoderBulkPathTests extends ESTestCase {
 
@@ -160,10 +163,11 @@ public class DefinitionLevelDecoderBulkPathTests extends ESTestCase {
     }
 
     public void testBulkPathInterleavedRleAndBitPacked() throws IOException {
-        // Mixed scenario: long all-present RLE (handled by setRange) interleaved with long
-        // bit-packed runs (where the bulk path should dominate).
+        // Mixed scenario: long all-present RLE (no-op for the mask; readBatch only touches
+        // it for null runs via setRange) interleaved with long bit-packed runs (where the
+        // bulk path should dominate) and long all-null RLE runs (which exercise setRange).
         int[] defs = new int[2048];
-        // 0..199: all present (RLE)
+        // 0..199: all present (RLE; mask is not touched here)
         for (int i = 0; i < 200; i++) {
             defs[i] = 1;
         }
@@ -171,7 +175,7 @@ public class DefinitionLevelDecoderBulkPathTests extends ESTestCase {
         for (int i = 200; i < 600; i++) {
             defs[i] = i & 1;
         }
-        // 600..899: all null (RLE)
+        // 600..899: all null (RLE; setRange path)
         for (int i = 600; i < 900; i++) {
             defs[i] = 0;
         }
@@ -294,6 +298,21 @@ public class DefinitionLevelDecoderBulkPathTests extends ESTestCase {
                 assertEquals("trial=" + trial + " offset=" + offset + " bit=" + j, expectedNulls[j], mask.get(offset + j));
             }
         }
+    }
+
+    public void testParityWithParquetMrForBitWidth3DefaultUnpackBranch() throws IOException {
+        // bitWidth=3 (maxDefLevel=7) hits unpack8Values' `default` branch, which routes through
+        // the generic readBitsLE bit-shifted readout. Bit widths 4 and 8 are covered by dedicated
+        // switch cases (and in DefinitionLevelDecoderTests). This test ties the default branch
+        // directly to parquet-mr's wire format by decoding the same bytes with both decoders.
+        int[] defs = new int[1024];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = randomIntBetween(0, 7);
+        }
+        assertParityWithParquetMrDecoder(defs, 7);
+        // Guard-rail: random 0..7 values are entropy-rich enough that the encoder will emit
+        // at least one bit-packed run, ensuring readBitsLE actually ran.
+        assertHasBitPackedRunOfAtLeast(defs, 7, 8);
     }
 
     public void testBulkPathExercisesSanityForceLongBitPackedRun() throws IOException {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoderBulkPathTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoderBulkPathTests.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+/**
+ * Targeted tests for the bulk 64-bits-at-a-time fast path in {@link DefinitionLevelDecoder}.
+ *
+ * <p>The general {@link DefinitionLevelDecoderTests} suite asserts against an expected
+ * {@code int[]} of def levels. This suite goes one step further and decodes the exact same
+ * bytes with parquet-mr's {@link RunLengthBitPackingHybridDecoder} as ground truth, then
+ * asserts the bit-mask produced by our bulk path is identical at every position. That way, if
+ * our notion of the format ever drifts from parquet-mr's, the test catches it.
+ *
+ * <p>These tests deliberately:
+ * <ul>
+ *   <li>Force runs long enough ({@code >= 64}) that the bulk path is exercised.</li>
+ *   <li>Vary the alignment of the destination offset within the {@link WordMask} to cover
+ *       both word-aligned and misaligned long writes.</li>
+ *   <li>Mix RLE + bit-packed + bit-packed-spanning-multiple-readBatch-calls so the bulk path
+ *       gets entered/exited at varying state-machine points.</li>
+ *   <li>Cover all-null, all-present, sparse-null, dense-null and random patterns.</li>
+ * </ul>
+ */
+public class DefinitionLevelDecoderBulkPathTests extends ESTestCase {
+
+    /** Long enough to comfortably exceed 64 def levels in a single bit-packed run. */
+    private static final int LARGE_LENGTH = 1024;
+
+    public void testBulkPathWordAlignedAllNullsBitPacked() throws IOException {
+        // Force a bit-packed run with all zeros (= all null). After encoding, parquet-mr will
+        // typically choose RLE for long all-zero runs — so we use a known anti-RLE pattern (a
+        // few sparse non-zero values) to push the encoder toward bit-packed and isolate the
+        // bulk path. We then assert against parquet-mr.
+        int[] defs = new int[LARGE_LENGTH];
+        // Sprinkle one non-null every 64 levels: this prevents long RLE runs of zeros and
+        // forces bit-packed encoding for stretches >= 64.
+        for (int i = 0; i < defs.length; i += 64) {
+            defs[i] = 1;
+        }
+        assertParityWithParquetMrDecoder(defs, 1);
+    }
+
+    public void testBulkPathDenseNullsBitPacked() throws IOException {
+        int[] defs = new int[LARGE_LENGTH];
+        // Random pattern with ~50% nulls (high-entropy → bit-packed runs).
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = randomBoolean() ? 1 : 0;
+        }
+        assertParityWithParquetMrDecoder(defs, 1);
+    }
+
+    public void testBulkPathSparseNullsBitPacked() throws IOException {
+        int[] defs = new int[LARGE_LENGTH];
+        // Mostly-present with rare nulls — exercises the `if (nullLong != 0)` short-circuit
+        // when the inverted long happens to be zero (no nulls in this 64-level chunk).
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = randomIntBetween(0, 99) < 95 ? 1 : 0;
+        }
+        // Drop a small bit-packed seed to discourage the encoder from emitting one giant RLE run.
+        defs[37] = 0;
+        defs[83] = 0;
+        defs[140] = 0;
+        assertParityWithParquetMrDecoder(defs, 1);
+    }
+
+    public void testBulkPathAlternatingPattern() throws IOException {
+        // Alternating 0/1 → maximum entropy → guaranteed bit-packed encoding.
+        int[] defs = new int[LARGE_LENGTH];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = i & 1;
+        }
+        assertParityWithParquetMrDecoder(defs, 1);
+    }
+
+    public void testBulkPathMisalignedOffsets() throws IOException {
+        // Verify the bulk path handles every word-internal alignment. We do this by reading
+        // the same encoded stream multiple times into a WordMask, but starting at different
+        // offsets within the destination mask. Parquet-mr ground truth is computed once.
+        int[] defs = new int[LARGE_LENGTH];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = randomBoolean() ? 1 : 0;
+        }
+        boolean[] expectedNulls = referenceNulls(defs, 1);
+
+        for (int alignment = 0; alignment < 64; alignment++) {
+            DefinitionLevelDecoder decoder = newDecoder(defs, 1);
+            int totalBits = alignment + defs.length;
+            WordMask mask = new WordMask();
+            mask.reset(totalBits);
+            int nonNull = decoder.readBatch(defs.length, mask, alignment);
+
+            int expectedNonNull = 0;
+            for (boolean isNull : expectedNulls) {
+                if (isNull == false) {
+                    expectedNonNull++;
+                }
+            }
+            assertEquals("alignment=" + alignment, expectedNonNull, nonNull);
+            for (int i = 0; i < defs.length; i++) {
+                assertEquals("alignment=" + alignment + " bit=" + (alignment + i), expectedNulls[i], mask.get(alignment + i));
+            }
+            // bits below the offset must remain zero (we did not touch them)
+            for (int i = 0; i < alignment; i++) {
+                assertFalse("alignment=" + alignment + " pre-offset bit=" + i, mask.get(i));
+            }
+        }
+    }
+
+    public void testBulkPathSpansMultipleReadBatchCalls() throws IOException {
+        // Decode the same large stream in random-sized chunks. The bulk path may be entered
+        // multiple times across separate readBatch invocations, with the per-call partial-drain
+        // loop kicking in when a previous call ended mid-byte.
+        int[] defs = new int[LARGE_LENGTH * 2];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = randomBoolean() ? 1 : 0;
+        }
+        boolean[] expectedNulls = referenceNulls(defs, 1);
+
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1);
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+
+        int produced = 0;
+        int totalNonNull = 0;
+        while (produced < defs.length) {
+            // Use chunk sizes that often land mid-byte and mid-long to stress all paths.
+            int chunk = Math.min(defs.length - produced, randomIntBetween(1, 197));
+            totalNonNull += decoder.readBatch(chunk, mask, produced);
+            produced += chunk;
+        }
+
+        int expectedNonNull = 0;
+        for (boolean isNull : expectedNulls) {
+            if (isNull == false) {
+                expectedNonNull++;
+            }
+        }
+        assertThat(totalNonNull, equalTo(expectedNonNull));
+        for (int i = 0; i < defs.length; i++) {
+            assertEquals("bit " + i, expectedNulls[i], mask.get(i));
+        }
+    }
+
+    public void testBulkPathInterleavedRleAndBitPacked() throws IOException {
+        // Mixed scenario: long all-present RLE (handled by setRange) interleaved with long
+        // bit-packed runs (where the bulk path should dominate).
+        int[] defs = new int[2048];
+        // 0..199: all present (RLE)
+        for (int i = 0; i < 200; i++) {
+            defs[i] = 1;
+        }
+        // 200..599: alternating (bit-packed)
+        for (int i = 200; i < 600; i++) {
+            defs[i] = i & 1;
+        }
+        // 600..899: all null (RLE)
+        for (int i = 600; i < 900; i++) {
+            defs[i] = 0;
+        }
+        // 900..1499: random (probably bit-packed, definitely entering bulk path)
+        for (int i = 900; i < 1500; i++) {
+            defs[i] = randomBoolean() ? 1 : 0;
+        }
+        // 1500..end: all present
+        for (int i = 1500; i < defs.length; i++) {
+            defs[i] = 1;
+        }
+        assertParityWithParquetMrDecoder(defs, 1);
+    }
+
+    public void testBulkPathSkipMatchesReadBatch() throws IOException {
+        // The skip variant of the bulk path uses a popcount-only branch (no mask write). Ensure
+        // it returns the same non-null count as the read path on the same byte stream.
+        int[] defs = new int[LARGE_LENGTH * 3];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = randomBoolean() ? 1 : 0;
+        }
+
+        DefinitionLevelDecoder readDecoder = newDecoder(defs, 1);
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int readNonNull = readDecoder.readBatch(defs.length, mask, 0);
+
+        DefinitionLevelDecoder skipDecoder = newDecoder(defs, 1);
+        int skipNonNull = skipDecoder.skip(defs.length);
+
+        assertThat(skipNonNull, equalTo(readNonNull));
+    }
+
+    public void testBulkPathSkipInChunksLargeStream() throws IOException {
+        // Stress the skip-bulk path across multiple skip calls so the per-call partial-drain
+        // path is also exercised in skip().
+        int[] defs = new int[LARGE_LENGTH * 4];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = randomBoolean() ? 1 : 0;
+        }
+
+        DefinitionLevelDecoder readDecoder = newDecoder(defs, 1);
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int readNonNull = readDecoder.readBatch(defs.length, mask, 0);
+
+        DefinitionLevelDecoder skipDecoder = newDecoder(defs, 1);
+        int totalNonNull = 0;
+        int skipped = 0;
+        while (skipped < defs.length) {
+            int chunk = Math.min(defs.length - skipped, randomIntBetween(1, 251));
+            totalNonNull += skipDecoder.skip(chunk);
+            skipped += chunk;
+        }
+        assertThat(totalNonNull, equalTo(readNonNull));
+    }
+
+    public void testBulkPathParityWithParquetMrLargeRandom() throws IOException {
+        // Heavyweight randomized test: build a large stream with a mix of regimes and decode
+        // it with both our decoder and parquet-mr's reference. They must agree bit-by-bit and
+        // value-by-value (non-null count).
+        int length = randomIntBetween(2000, 8000);
+        int[] defs = new int[length];
+        int i = 0;
+        while (i < length) {
+            int span = Math.min(length - i, randomIntBetween(1, 400));
+            int mode = randomIntBetween(0, 3);
+            switch (mode) {
+                case 0 -> {
+                    int v = randomBoolean() ? 1 : 0;
+                    for (int j = 0; j < span; j++) {
+                        defs[i + j] = v;
+                    }
+                }
+                case 1 -> {
+                    for (int j = 0; j < span; j++) {
+                        defs[i + j] = (i + j) & 1;
+                    }
+                }
+                default -> {
+                    for (int j = 0; j < span; j++) {
+                        defs[i + j] = randomBoolean() ? 1 : 0;
+                    }
+                }
+            }
+            i += span;
+        }
+        assertParityWithParquetMrDecoder(defs, 1);
+        // Belt-and-braces: also verify the encoded stream actually contains a long-enough
+        // bit-packed run, so this test cannot silently degrade into "RLE + per-byte loop only"
+        // if a future parquet-mr encoder version changes its run-shape choices.
+        assertHasBitPackedRunOfAtLeast(defs, 1, 64);
+    }
+
+    public void testBulkPathParityAtArbitraryOffsetsRandomized() throws IOException {
+        // Combine large random data + non-trivial output offset (not word-aligned) to exercise
+        // the misaligned orLongAt path under realistic data.
+        for (int trial = 0; trial < 10; trial++) {
+            int length = randomIntBetween(LARGE_LENGTH, LARGE_LENGTH * 2);
+            int[] defs = new int[length];
+            for (int j = 0; j < length; j++) {
+                defs[j] = randomBoolean() ? 1 : 0;
+            }
+            int offset = randomIntBetween(1, 63);
+
+            boolean[] expectedNulls = referenceNulls(defs, 1);
+            DefinitionLevelDecoder decoder = newDecoder(defs, 1);
+            WordMask mask = new WordMask();
+            mask.reset(offset + length);
+            int nonNull = decoder.readBatch(length, mask, offset);
+
+            int expectedNonNull = 0;
+            for (boolean isNull : expectedNulls) {
+                if (isNull == false) {
+                    expectedNonNull++;
+                }
+            }
+            assertEquals("trial=" + trial + " offset=" + offset, expectedNonNull, nonNull);
+            for (int j = 0; j < length; j++) {
+                assertEquals("trial=" + trial + " offset=" + offset + " bit=" + j, expectedNulls[j], mask.get(offset + j));
+            }
+        }
+    }
+
+    public void testBulkPathExercisesSanityForceLongBitPackedRun() throws IOException {
+        // Sanity check: confirm the encoder actually emits a bit-packed run >= 64 levels
+        // for our high-entropy test data. Otherwise, "bulk path" tests would silently degrade
+        // into "RLE path" tests and not exercise what they claim to.
+        int[] defs = new int[256];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = i & 1;
+        }
+        assertHasBitPackedRunOfAtLeast(defs, 1, 64);
+    }
+
+    // --- helpers ---
+
+    /**
+     * Encode {@code defs} with parquet-mr's encoder, decode the same bytes with both
+     * {@link DefinitionLevelDecoder} (our impl) and {@link RunLengthBitPackingHybridDecoder}
+     * (parquet-mr reference decoder), and assert the resulting null bitmasks agree at every
+     * position. Parquet-mr's decoder is the ground truth — this gives stronger format-fidelity
+     * coverage than asserting against the original {@code int[]} alone.
+     */
+    private void assertParityWithParquetMrDecoder(int[] defs, int maxDefLevel) throws IOException {
+        boolean[] expectedNulls = referenceNulls(defs, maxDefLevel);
+
+        DefinitionLevelDecoder ourDecoder = newDecoder(defs, maxDefLevel);
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int nonNull = ourDecoder.readBatch(defs.length, mask, 0);
+
+        int expectedNonNull = 0;
+        for (boolean isNull : expectedNulls) {
+            if (isNull == false) {
+                expectedNonNull++;
+            }
+        }
+        assertEquals("non-null count must match parquet-mr", expectedNonNull, nonNull);
+        for (int i = 0; i < defs.length; i++) {
+            assertEquals("bit " + i + " (def=" + defs[i] + ")", expectedNulls[i], mask.get(i));
+        }
+    }
+
+    /**
+     * Walks the encoded RLE/BitPacked-hybrid byte stream produced by parquet-mr for {@code defs}
+     * and asserts that at least one bit-packed run is at least {@code minLevels} def levels long.
+     *
+     * <p>Used as a guard-rail: tests that claim to exercise the bulk path (which only triggers
+     * for bit-packed runs of {@literal >=} 64 levels) rely on the encoder choosing a bit-packed
+     * encoding for the input. If a future parquet-mr release changes its run-shape heuristics
+     * such that our test inputs only produce RLE runs, this assertion fails loudly instead of
+     * the bulk path silently going untested.
+     */
+    private static void assertHasBitPackedRunOfAtLeast(int[] defs, int maxDefLevel, int minLevels) throws IOException {
+        int bitWidth = 32 - Integer.numberOfLeadingZeros(maxDefLevel);
+        byte[] payload = encode(defs, maxDefLevel);
+        ByteBuffer buf = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN);
+        int paddedValueBytes = (bitWidth + 7) >>> 3;
+        int maxBitPackedLevels = 0;
+        while (buf.hasRemaining()) {
+            int header = readVarInt(buf);
+            if ((header & 1) == 0) {
+                int runLen = header >>> 1;
+                if (runLen == 0) {
+                    break;
+                }
+                buf.position(buf.position() + paddedValueBytes);
+            } else {
+                int numGroups = header >>> 1;
+                int levels = numGroups * 8;
+                maxBitPackedLevels = Math.max(maxBitPackedLevels, levels);
+                buf.position(buf.position() + numGroups * bitWidth);
+            }
+        }
+        assertThat(
+            "encoded stream must contain a bit-packed run of >= " + minLevels + " levels to exercise the bulk path",
+            maxBitPackedLevels,
+            greaterThanOrEqualTo(minLevels)
+        );
+    }
+
+    /**
+     * Decode the encoded byte stream with parquet-mr's reference decoder and return a boolean[]
+     * where {@code true} means "null" (def {@literal <} maxDefLevel). This is the ground truth.
+     */
+    private static boolean[] referenceNulls(int[] defs, int maxDefLevel) throws IOException {
+        byte[] payload = encode(defs, maxDefLevel);
+        int bitWidth = 32 - Integer.numberOfLeadingZeros(maxDefLevel);
+        RunLengthBitPackingHybridDecoder ref = new RunLengthBitPackingHybridDecoder(bitWidth, new ByteArrayInputStream(payload));
+        boolean[] nulls = new boolean[defs.length];
+        for (int i = 0; i < defs.length; i++) {
+            int v = ref.readInt();
+            nulls[i] = v < maxDefLevel;
+        }
+        return nulls;
+    }
+
+    private static byte[] encode(int[] defs, int maxDefLevel) throws IOException {
+        int bitWidth = 32 - Integer.numberOfLeadingZeros(maxDefLevel);
+        try (
+            RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(
+                bitWidth,
+                64,
+                1024,
+                new HeapByteBufferAllocator()
+            )
+        ) {
+            for (int d : defs) {
+                encoder.writeInt(d);
+            }
+            return encoder.toBytes().toByteArray();
+        }
+    }
+
+    private static DefinitionLevelDecoder newDecoder(int[] defs, int maxDefLevel) throws IOException {
+        byte[] payload = encode(defs, maxDefLevel);
+        ByteBuffer buf = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN);
+        DefinitionLevelDecoder decoder = new DefinitionLevelDecoder();
+        decoder.init(buf, maxDefLevel, false);
+        return decoder;
+    }
+
+    private static int readVarInt(ByteBuffer buf) {
+        int shift = 0;
+        int result = 0;
+        while (true) {
+            int b = buf.get() & 0xFF;
+            result |= (b & 0x7F) << shift;
+            if ((b & 0x80) == 0) {
+                return result;
+            }
+            shift += 7;
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/DefinitionLevelDecoderTests.java
@@ -1,0 +1,545 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies that {@link DefinitionLevelDecoder} produces the correct null bitmask
+ * for a variety of RLE-hybrid encoded def-level streams. Inputs are produced by
+ * parquet-mr's {@link RunLengthBitPackingHybridEncoder} (the same encoder Parquet
+ * writers use), so this test asserts byte-level format compatibility.
+ */
+public class DefinitionLevelDecoderTests extends ESTestCase {
+
+    public void testNonNullableShortCircuit() {
+        DefinitionLevelDecoder decoder = new DefinitionLevelDecoder();
+        decoder.init(ByteBuffer.allocate(0), 0, false);
+
+        WordMask mask = new WordMask();
+        mask.reset(100);
+        int nonNull = decoder.readBatch(100, mask, 0);
+        assertThat(nonNull, equalTo(100));
+        assertTrue("mask should be empty (no nulls)", mask.isEmpty());
+
+        // skip is also a no-op-ish (returns count as nonNull)
+        DefinitionLevelDecoder skipDecoder = new DefinitionLevelDecoder();
+        skipDecoder.init(ByteBuffer.allocate(0), 0, false);
+        assertThat(skipDecoder.skip(50), equalTo(50));
+    }
+
+    public void testEmptyBatch() throws IOException {
+        int[] defs = new int[] { 1, 0, 1, 1, 0 };
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, false);
+        WordMask mask = new WordMask();
+        mask.reset(8);
+        assertThat(decoder.readBatch(0, mask, 0), equalTo(0));
+        assertTrue(mask.isEmpty());
+    }
+
+    public void testAllPresentRleRun() throws IOException {
+        int[] defs = new int[1024];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = 1;
+        }
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, false);
+
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int nonNull = decoder.readBatch(defs.length, mask, 0);
+        assertThat(nonNull, equalTo(defs.length));
+        assertTrue("no nulls expected", mask.isEmpty());
+    }
+
+    public void testAllNullRleRun() throws IOException {
+        int[] defs = new int[1024];
+        // all zeros: all-null run
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, false);
+
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int nonNull = decoder.readBatch(defs.length, mask, 0);
+        assertThat(nonNull, equalTo(0));
+        assertThat(mask.popCount(), equalTo(defs.length));
+        for (int i = 0; i < defs.length; i++) {
+            assertTrue("bit " + i, mask.get(i));
+        }
+    }
+
+    public void testAlternatingPattern() throws IOException {
+        // alternating 0/1 forces bit-packed encoding (no long runs)
+        int[] defs = new int[256];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = i & 1;
+        }
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, false);
+
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int nonNull = decoder.readBatch(defs.length, mask, 0);
+        assertThat(nonNull, equalTo(defs.length / 2));
+        for (int i = 0; i < defs.length; i++) {
+            assertEquals("bit " + i, defs[i] == 0, mask.get(i));
+        }
+    }
+
+    public void testMixedRunsAndBitPacked() throws IOException {
+        // 64 ones, then 64 alternating, then 64 zeros, then 64 alternating
+        int[] defs = new int[256];
+        for (int i = 0; i < 64; i++) {
+            defs[i] = 1;
+        }
+        for (int i = 64; i < 128; i++) {
+            defs[i] = i & 1;
+        }
+        for (int i = 128; i < 192; i++) {
+            defs[i] = 0;
+        }
+        for (int i = 192; i < 256; i++) {
+            defs[i] = (i + 1) & 1;
+        }
+
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, false);
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int nonNull = decoder.readBatch(defs.length, mask, 0);
+
+        int expectedNulls = 0;
+        for (int d : defs) {
+            if (d == 0) {
+                expectedNulls++;
+            }
+        }
+        assertThat(nonNull, equalTo(defs.length - expectedNulls));
+        for (int i = 0; i < defs.length; i++) {
+            assertEquals("bit " + i, defs[i] == 0, mask.get(i));
+        }
+    }
+
+    public void testSplitAcrossMultipleReadBatchCalls() throws IOException {
+        int[] defs = randomDefLevels(500, 1);
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, false);
+
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+
+        // Drain in random-sized chunks to exercise cross-call state for both RLE runs and bit-packed groups
+        int totalNonNull = 0;
+        int produced = 0;
+        while (produced < defs.length) {
+            int chunk = Math.min(defs.length - produced, randomIntBetween(1, 73));
+            totalNonNull += decoder.readBatch(chunk, mask, produced);
+            produced += chunk;
+        }
+
+        int expectedNulls = 0;
+        for (int d : defs) {
+            if (d == 0) {
+                expectedNulls++;
+            }
+        }
+        assertThat(totalNonNull, equalTo(defs.length - expectedNulls));
+        for (int i = 0; i < defs.length; i++) {
+            assertEquals("bit " + i + " (def=" + defs[i] + ")", defs[i] == 0, mask.get(i));
+        }
+    }
+
+    public void testReadBatchWithNonZeroOffset() throws IOException {
+        int[] defs = new int[] { 1, 0, 0, 1, 1, 0, 1, 1, 0, 0 };
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, false);
+
+        WordMask mask = new WordMask();
+        mask.reset(20);
+        // pre-set a bit before the offset to ensure we don't accidentally clobber unrelated bits
+        mask.set(0);
+        int nonNull = decoder.readBatch(defs.length, mask, 5);
+        int expectedNulls = 0;
+        for (int d : defs) {
+            if (d == 0) {
+                expectedNulls++;
+            }
+        }
+        assertThat(nonNull, equalTo(defs.length - expectedNulls));
+        assertTrue("pre-existing bit at 0 must be preserved", mask.get(0));
+        for (int i = 0; i < defs.length; i++) {
+            assertEquals("bit " + (5 + i), defs[i] == 0, mask.get(5 + i));
+        }
+    }
+
+    public void testMaxDefLevelGreaterThanOne() throws IOException {
+        // Simulate a column with maxDefLevel=3: any value < 3 is null, value 3 is present.
+        int[] defs = new int[200];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = randomIntBetween(0, 3);
+        }
+        DefinitionLevelDecoder decoder = newDecoder(defs, 3, false);
+
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int nonNull = decoder.readBatch(defs.length, mask, 0);
+
+        int expectedNulls = 0;
+        for (int d : defs) {
+            if (d < 3) {
+                expectedNulls++;
+            }
+        }
+        assertThat(nonNull, equalTo(defs.length - expectedNulls));
+        for (int i = 0; i < defs.length; i++) {
+            assertEquals("bit " + i + " (def=" + defs[i] + ")", defs[i] < 3, mask.get(i));
+        }
+    }
+
+    public void testWithLengthPrefix() throws IOException {
+        // V1 pages prefix the def-level payload with a 4-byte little-endian length.
+        int[] defs = randomDefLevels(300, 1);
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, true);
+
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int nonNull = decoder.readBatch(defs.length, mask, 0);
+
+        int expectedNulls = 0;
+        for (int d : defs) {
+            if (d == 0) {
+                expectedNulls++;
+            }
+        }
+        assertThat(nonNull, equalTo(defs.length - expectedNulls));
+        for (int i = 0; i < defs.length; i++) {
+            assertEquals("bit " + i + " (def=" + defs[i] + ")", defs[i] == 0, mask.get(i));
+        }
+    }
+
+    public void testWideBitWidthsExerciseUnpackPaths() throws IOException {
+        // Drive bitWidth=4 (maxDefLevel=15) and bitWidth=8 (maxDefLevel=255) so the dedicated
+        // case branches of unpack8Values are exercised end-to-end.
+        for (int maxDefLevel : new int[] { 15, 255 }) {
+            int[] defs = randomDefLevels(513, maxDefLevel);
+            DefinitionLevelDecoder decoder = newDecoder(defs, maxDefLevel, false);
+            WordMask mask = new WordMask();
+            mask.reset(defs.length);
+
+            int produced = 0;
+            int totalNonNull = 0;
+            while (produced < defs.length) {
+                int chunk = Math.min(defs.length - produced, randomIntBetween(1, 67));
+                totalNonNull += decoder.readBatch(chunk, mask, produced);
+                produced += chunk;
+            }
+
+            int expectedNulls = 0;
+            for (int d : defs) {
+                if (d < maxDefLevel) {
+                    expectedNulls++;
+                }
+            }
+            assertEquals("maxDefLevel=" + maxDefLevel, defs.length - expectedNulls, totalNonNull);
+            for (int i = 0; i < defs.length; i++) {
+                assertEquals("maxDefLevel=" + maxDefLevel + " bit=" + i + " def=" + defs[i], defs[i] < maxDefLevel, mask.get(i));
+            }
+        }
+    }
+
+    public void testSkipWithLengthPrefix() throws IOException {
+        int[] defs = randomDefLevels(400, 1);
+
+        DefinitionLevelDecoder readDecoder = newDecoder(defs, 1, true);
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int nonNullFromRead = readDecoder.readBatch(defs.length, mask, 0);
+
+        DefinitionLevelDecoder skipDecoder = newDecoder(defs, 1, true);
+        int nonNullFromSkip = 0;
+        int skipped = 0;
+        while (skipped < defs.length) {
+            int chunk = Math.min(defs.length - skipped, randomIntBetween(1, 89));
+            nonNullFromSkip += skipDecoder.skip(chunk);
+            skipped += chunk;
+        }
+        assertThat(nonNullFromSkip, equalTo(nonNullFromRead));
+    }
+
+    public void testSkipMatchesReadBatchNullCount() throws IOException {
+        int[] defs = randomDefLevels(700, 1);
+
+        // First decoder: full readBatch
+        DefinitionLevelDecoder readDecoder = newDecoder(defs, 1, false);
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int nonNullFromRead = readDecoder.readBatch(defs.length, mask, 0);
+
+        // Second decoder: skip everything
+        DefinitionLevelDecoder skipDecoder = newDecoder(defs, 1, false);
+        int nonNullFromSkip = skipDecoder.skip(defs.length);
+
+        assertThat(nonNullFromSkip, equalTo(nonNullFromRead));
+    }
+
+    public void testSkipInChunks() throws IOException {
+        int[] defs = randomDefLevels(500, 1);
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, false);
+
+        int expectedNonNull = 0;
+        for (int d : defs) {
+            if (d == 1) {
+                expectedNonNull++;
+            }
+        }
+
+        int totalNonNull = 0;
+        int skipped = 0;
+        while (skipped < defs.length) {
+            int chunk = Math.min(defs.length - skipped, randomIntBetween(1, 91));
+            totalNonNull += decoder.skip(chunk);
+            skipped += chunk;
+        }
+        assertThat(totalNonNull, equalTo(expectedNonNull));
+    }
+
+    public void testInterleavedReadAndSkip() throws IOException {
+        int[] defs = randomDefLevels(400, 1);
+
+        // Generate a deterministic chunk plan ahead of time so we can reuse it for the verifier.
+        record Chunk(int size, boolean read) {}
+        List<Chunk> plan = new ArrayList<>();
+        int planned = 0;
+        boolean readMode = true;
+        while (planned < defs.length) {
+            int chunk = Math.min(defs.length - planned, randomIntBetween(1, 47));
+            plan.add(new Chunk(chunk, readMode));
+            planned += chunk;
+            readMode = readMode == false;
+        }
+
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, false);
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+
+        int position = 0;
+        for (Chunk chunk : plan) {
+            if (chunk.read()) {
+                decoder.readBatch(chunk.size(), mask, position);
+            } else {
+                decoder.skip(chunk.size());
+            }
+            position += chunk.size();
+        }
+
+        // Verify each region: read regions match defs[]; skip regions remain 0 in the mask.
+        position = 0;
+        for (Chunk chunk : plan) {
+            if (chunk.read()) {
+                for (int j = 0; j < chunk.size(); j++) {
+                    int idx = position + j;
+                    assertEquals("bit " + idx, defs[idx] == 0, mask.get(idx));
+                }
+            } else {
+                for (int j = 0; j < chunk.size(); j++) {
+                    int idx = position + j;
+                    assertFalse("skipped bit " + idx + " must remain 0", mask.get(idx));
+                }
+            }
+            position += chunk.size();
+        }
+    }
+
+    public void testAllPresentSkipsBitmask() throws IOException {
+        // Scenario: every value present (def=1). The decoder should set NO bits in the mask
+        // even after multiple readBatch calls.
+        int[] defs = new int[400];
+        for (int i = 0; i < defs.length; i++) {
+            defs[i] = 1;
+        }
+        DefinitionLevelDecoder decoder = newDecoder(defs, 1, false);
+
+        WordMask mask = new WordMask();
+        mask.reset(defs.length);
+        int produced = 0;
+        while (produced < defs.length) {
+            int chunk = Math.min(defs.length - produced, randomIntBetween(1, 97));
+            int nonNull = decoder.readBatch(chunk, mask, produced);
+            assertThat(nonNull, equalTo(chunk));
+            produced += chunk;
+        }
+        assertTrue("no nulls expected", mask.isEmpty());
+    }
+
+    public void testReinitOnSameInstance() throws IOException {
+        // First page: maxDefLevel=1, fully present
+        int[] firstDefs = new int[100];
+        for (int i = 0; i < firstDefs.length; i++) {
+            firstDefs[i] = 1;
+        }
+        DefinitionLevelDecoder decoder = newDecoder(firstDefs, 1, false);
+        WordMask firstMask = new WordMask();
+        firstMask.reset(firstDefs.length);
+        int firstNonNull = decoder.readBatch(firstDefs.length, firstMask, 0);
+        assertThat(firstNonNull, equalTo(firstDefs.length));
+        assertTrue("first page: no nulls expected", firstMask.isEmpty());
+
+        // Re-init the same instance with a brand new buffer + different maxDefLevel,
+        // BEFORE draining the first stream. State must be fully replaced.
+        int[] secondDefs = randomDefLevels(150, 3);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (
+            RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(
+                32 - Integer.numberOfLeadingZeros(3),
+                64,
+                1024,
+                new HeapByteBufferAllocator()
+            )
+        ) {
+            for (int d : secondDefs) {
+                encoder.writeInt(d);
+            }
+            byte[] payload = encoder.toBytes().toByteArray();
+            ByteBuffer buf = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN);
+            decoder.init(buf, 3, false);
+        }
+
+        WordMask secondMask = new WordMask();
+        secondMask.reset(secondDefs.length);
+        int secondNonNull = decoder.readBatch(secondDefs.length, secondMask, 0);
+        int expectedNulls = 0;
+        for (int d : secondDefs) {
+            if (d < 3) {
+                expectedNulls++;
+            }
+        }
+        assertThat(secondNonNull, equalTo(secondDefs.length - expectedNulls));
+        for (int i = 0; i < secondDefs.length; i++) {
+            assertEquals("bit " + i + " (def=" + secondDefs[i] + ")", secondDefs[i] < 3, secondMask.get(i));
+        }
+
+        // Re-init again, this time switching to nonNullable (maxDefLevel=0). All ops must be no-ops.
+        decoder.init(ByteBuffer.allocate(0), 0, false);
+        WordMask thirdMask = new WordMask();
+        thirdMask.reset(50);
+        int thirdNonNull = decoder.readBatch(50, thirdMask, 0);
+        assertThat(thirdNonNull, equalTo(50));
+        assertTrue("nonNullable re-init: no nulls expected", thirdMask.isEmpty());
+    }
+
+    public void testRandomizedManyConfigurations() throws IOException {
+        for (int trial = 0; trial < 25; trial++) {
+            int maxDefLevel = randomFrom(1, 1, 1, 1, 2, 3, 7); // bias to bitWidth=1 (the common case)
+            int length = randomIntBetween(1, 4096);
+            int[] defs = randomDefLevels(length, maxDefLevel);
+            boolean withLengthPrefix = randomBoolean();
+
+            DefinitionLevelDecoder decoder = newDecoder(defs, maxDefLevel, withLengthPrefix);
+            WordMask mask = new WordMask();
+            mask.reset(length);
+
+            int totalNonNull = 0;
+            int produced = 0;
+            while (produced < length) {
+                int chunk = Math.min(length - produced, randomIntBetween(1, 257));
+                totalNonNull += decoder.readBatch(chunk, mask, produced);
+                produced += chunk;
+            }
+
+            int expectedNulls = 0;
+            for (int d : defs) {
+                if (d < maxDefLevel) {
+                    expectedNulls++;
+                }
+            }
+            assertEquals("trial=" + trial + " maxDefLevel=" + maxDefLevel + " length=" + length, length - expectedNulls, totalNonNull);
+            for (int i = 0; i < length; i++) {
+                assertEquals(
+                    "trial=" + trial + " bit=" + i + " def=" + defs[i] + " maxDefLevel=" + maxDefLevel,
+                    defs[i] < maxDefLevel,
+                    mask.get(i)
+                );
+            }
+        }
+    }
+
+    // --- helpers ---
+
+    /**
+     * Builds a {@link DefinitionLevelDecoder} initialized over the encoded form of {@code defs},
+     * mimicking what a parquet-mr writer would emit for a page with this set of def levels.
+     */
+    private static DefinitionLevelDecoder newDecoder(int[] defs, int maxDefLevel, boolean withLengthPrefix) throws IOException {
+        int bitWidth = 32 - Integer.numberOfLeadingZeros(maxDefLevel);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (
+            RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(
+                bitWidth,
+                64,
+                1024,
+                new HeapByteBufferAllocator()
+            )
+        ) {
+            for (int d : defs) {
+                encoder.writeInt(d);
+            }
+            BytesInput bytes = encoder.toBytes();
+            byte[] payload = bytes.toByteArray();
+
+            ByteBuffer buf;
+            if (withLengthPrefix) {
+                buf = ByteBuffer.allocate(4 + payload.length).order(ByteOrder.LITTLE_ENDIAN);
+                buf.putInt(payload.length);
+                buf.put(payload);
+                buf.flip();
+            } else {
+                buf = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN);
+            }
+
+            DefinitionLevelDecoder decoder = new DefinitionLevelDecoder();
+            decoder.init(buf, maxDefLevel, withLengthPrefix);
+            return decoder;
+        }
+    }
+
+    private int[] randomDefLevels(int length, int maxDefLevel) {
+        int[] defs = new int[length];
+        // Mix of run-friendly stretches and noisy stretches to stress both RLE and bit-packed paths
+        int i = 0;
+        while (i < length) {
+            int span = Math.min(length - i, randomIntBetween(1, 200));
+            int mode = randomIntBetween(0, 3);
+            switch (mode) {
+                case 0 -> {
+                    int v = randomIntBetween(0, maxDefLevel);
+                    for (int j = 0; j < span; j++) {
+                        defs[i + j] = v;
+                    }
+                }
+                case 1 -> {
+                    for (int j = 0; j < span; j++) {
+                        defs[i + j] = (i + j) & 1;
+                    }
+                }
+                default -> {
+                    for (int j = 0; j < span; j++) {
+                        defs[i + j] = randomIntBetween(0, maxDefLevel);
+                    }
+                }
+            }
+            i += span;
+        }
+        return defs;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskTests.java
@@ -55,6 +55,103 @@ public class WordMaskTests extends ESTestCase {
         assertThat(full.popCount(), equalTo(256));
     }
 
+    public void testSetRangeWithinSingleWord() {
+        WordMask mask = new WordMask();
+        mask.reset(128);
+        mask.setRange(3, 17);
+        for (int i = 0; i < 128; i++) {
+            assertEquals("bit " + i, i >= 3 && i < 17, mask.get(i));
+        }
+        assertThat(mask.popCount(), equalTo(14));
+    }
+
+    public void testSetRangeAcrossMultipleWords() {
+        WordMask mask = new WordMask();
+        mask.reset(256);
+        // [40, 200) spans words 0, 1, 2 with misaligned ends
+        mask.setRange(40, 200);
+        for (int i = 0; i < 256; i++) {
+            assertEquals("bit " + i, i >= 40 && i < 200, mask.get(i));
+        }
+        assertThat(mask.popCount(), equalTo(160));
+    }
+
+    public void testSetRangeAlignedToWordBoundaries() {
+        WordMask mask = new WordMask();
+        mask.reset(256);
+        mask.setRange(64, 192);
+        for (int i = 0; i < 256; i++) {
+            assertEquals("bit " + i, i >= 64 && i < 192, mask.get(i));
+        }
+        assertThat(mask.popCount(), equalTo(128));
+    }
+
+    public void testSetRangeFromZero() {
+        WordMask mask = new WordMask();
+        mask.reset(128);
+        mask.setRange(0, 64);
+        for (int i = 0; i < 128; i++) {
+            assertEquals("bit " + i, i < 64, mask.get(i));
+        }
+    }
+
+    public void testSetRangeToEnd() {
+        WordMask mask = new WordMask();
+        mask.reset(128);
+        mask.setRange(70, 128);
+        for (int i = 0; i < 128; i++) {
+            assertEquals("bit " + i, i >= 70, mask.get(i));
+        }
+        assertThat(mask.popCount(), equalTo(58));
+    }
+
+    public void testSetRangeFullMask() {
+        WordMask mask = new WordMask();
+        mask.reset(200);
+        mask.setRange(0, 200);
+        for (int i = 0; i < 200; i++) {
+            assertTrue("bit " + i, mask.get(i));
+        }
+        assertThat(mask.popCount(), equalTo(200));
+    }
+
+    public void testSetRangeEmpty() {
+        WordMask mask = new WordMask();
+        mask.reset(128);
+        mask.set(50);
+        mask.setRange(10, 10);
+        // empty range is a no-op; only the pre-set bit should be set
+        assertThat(mask.popCount(), equalTo(1));
+        assertTrue(mask.get(50));
+    }
+
+    public void testSetRangeIsIdempotentWithExistingBits() {
+        WordMask mask = new WordMask();
+        mask.reset(128);
+        mask.set(20);
+        mask.set(80);
+        mask.setRange(10, 100);
+        for (int i = 0; i < 128; i++) {
+            assertEquals("bit " + i, i >= 10 && i < 100, mask.get(i));
+        }
+        assertThat(mask.popCount(), equalTo(90));
+    }
+
+    public void testSetRangeRandomized() {
+        for (int trial = 0; trial < 50; trial++) {
+            int numBits = randomIntBetween(1, 1024);
+            int from = randomIntBetween(0, numBits);
+            int to = randomIntBetween(from, numBits);
+            WordMask mask = new WordMask();
+            mask.reset(numBits);
+            mask.setRange(from, to);
+            for (int i = 0; i < numBits; i++) {
+                assertEquals("trial=" + trial + " bit=" + i + " range=[" + from + "," + to + ")", i >= from && i < to, mask.get(i));
+            }
+            assertThat(mask.popCount(), equalTo(to - from));
+        }
+    }
+
     public void testIsAll() {
         WordMask mask = new WordMask();
         mask.setAll(128);

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskTests.java
@@ -55,6 +55,84 @@ public class WordMaskTests extends ESTestCase {
         assertThat(full.popCount(), equalTo(256));
     }
 
+    public void testOrLongAtWordAligned() {
+        WordMask mask = new WordMask();
+        mask.reset(192);
+        long bits = 0xCAFEBABEDEADBEEFL;
+        mask.orLongAt(64, bits);
+        for (int i = 0; i < 192; i++) {
+            boolean expected = i >= 64 && i < 128 && ((bits >>> (i - 64)) & 1L) != 0;
+            assertEquals("bit " + i, expected, mask.get(i));
+        }
+    }
+
+    public void testOrLongAtMisaligned() {
+        WordMask mask = new WordMask();
+        mask.reset(256);
+        long bits = 0xF0F0F0F0F0F0F0F0L;
+        int offset = 17;
+        mask.orLongAt(offset, bits);
+        for (int i = 0; i < 256; i++) {
+            boolean expected = i >= offset && i < offset + 64 && ((bits >>> (i - offset)) & 1L) != 0;
+            assertEquals("bit " + i, expected, mask.get(i));
+        }
+    }
+
+    public void testOrLongAtPreservesExistingBits() {
+        WordMask mask = new WordMask();
+        mask.reset(192);
+        mask.set(5);
+        mask.set(70);
+        mask.set(150);
+        long bits = 0x00000000FFFFFFFFL; // low 32 bits set
+        int offset = 60; // straddles word boundary at bit 64
+        mask.orLongAt(offset, bits);
+        // expected: bits 60..91 set (from the OR), plus pre-existing 5, 70, 150
+        for (int i = 0; i < 192; i++) {
+            boolean fromOr = i >= offset && i < offset + 64 && ((bits >>> (i - offset)) & 1L) != 0;
+            boolean preexisting = i == 5 || i == 70 || i == 150;
+            assertEquals("bit " + i, fromOr || preexisting, mask.get(i));
+        }
+    }
+
+    public void testOrLongAtAllOnesStraddling() {
+        WordMask mask = new WordMask();
+        mask.reset(256);
+        // 64 bits set at offset 30 → covers bits 30..93
+        mask.orLongAt(30, ~0L);
+        for (int i = 0; i < 256; i++) {
+            assertEquals("bit " + i, i >= 30 && i < 94, mask.get(i));
+        }
+    }
+
+    public void testOrLongAtRandomized() {
+        for (int trial = 0; trial < 50; trial++) {
+            int numBits = randomIntBetween(64, 512);
+            int offset = randomIntBetween(0, numBits - 64);
+            long bits = randomLong();
+            WordMask mask = new WordMask();
+            mask.reset(numBits);
+            // pre-set a few random bits to verify OR semantics
+            int[] preset = new int[randomIntBetween(0, 5)];
+            for (int i = 0; i < preset.length; i++) {
+                preset[i] = randomIntBetween(0, numBits - 1);
+                mask.set(preset[i]);
+            }
+            mask.orLongAt(offset, bits);
+            for (int i = 0; i < numBits; i++) {
+                boolean fromOr = i >= offset && i < offset + 64 && ((bits >>> (i - offset)) & 1L) != 0;
+                boolean wasPreset = false;
+                for (int p : preset) {
+                    if (p == i) {
+                        wasPreset = true;
+                        break;
+                    }
+                }
+                assertEquals("trial=" + trial + " bit=" + i, fromOr || wasPreset, mask.get(i));
+            }
+        }
+    }
+
     public void testSetRangeWithinSingleWord() {
         WordMask mask = new WordMask();
         mask.reset(128);


### PR DESCRIPTION
Replace the per-value `RunLengthBitPackingHybridDecoder.readInt()` loop in `DefinitionLevelDecoder` with a custom RLE/BitPacked hybrid decoder that writes directly into the output `WordMask`. The previous implementation called parquet-mr per def level for every nullable column on every batch, adding virtual dispatch and `IOException` handling to a tight inner loop.

The new decoder applies RLE runs of all-null def levels via a new `WordMask.setRange` helper (word-level OR) and processes bit-packed groups 8 levels per byte for the dominant `bitWidth == 1` case. All-present runs become a no-op on the output bitmask. The decoder state machine handles runs that span multiple `readBatch` invocations, mirroring the existing `DictionaryValueDecoder` pattern.

Developed with AI-assisted tooling