### PR TITLE
[ESQL] Prune non-top-N groups during aggregation

### DIFF
--- a/docs/changelog/148256.yaml
+++ b/docs/changelog/148256.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148256
+summary: Prune non-top-N groups during aggregation
+type: enhancement

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
@@ -165,9 +165,14 @@ public abstract class BlockHash implements Releasable, SeenGroupIds {
     public static BlockHash build(List<GroupSpec> groups, BlockFactory blockFactory, int emitBatchSize, boolean allowBrokenOptimizations) {
         if (groups.size() == 1) {
             GroupSpec group = groups.get(0);
-            if (group.topNDef() != null && group.elementType() == ElementType.LONG) {
+            if (group.topNDef() != null) {
                 TopNDef topNDef = group.topNDef();
-                return new LongTopNBlockHash(group.channel(), topNDef.asc(), topNDef.nullsFirst(), topNDef.limit(), blockFactory);
+                if (group.elementType() == ElementType.LONG) {
+                    return new LongTopNBlockHash(group.channel(), topNDef.asc(), topNDef.nullsFirst(), topNDef.limit(), blockFactory);
+                }
+                if (group.elementType() == ElementType.BYTES_REF) {
+                    return new BytesRefTopNBlockHash(group.channel(), topNDef.asc(), topNDef.nullsFirst(), topNDef.limit(), blockFactory);
+                }
             }
             return newForElementType(group.channel(), group.elementType(), blockFactory);
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefTopNBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefTopNBlockHash.java
@@ -32,6 +32,12 @@ import org.elasticsearch.search.sort.SortOrder;
  *     in the hash table; their aggregator state is therefore never allocated. {@link #nonEmpty()} filters
  *     out group ids whose key has been evicted while the hash was being filled.
  * </p>
+ * <p>
+ *     <b>Sort collation:</b> ordering uses {@link BytesRef#compareTo}, i.e. unsigned lexicographic byte
+ *     comparison. For {@code KEYWORD} fields encoded as valid UTF-8 this is equivalent to Unicode
+ *     codepoint order, matching how Lucene sorts these values. ICU/locale-aware collations are not honored
+ *     here; if a query needs them, the caller must perform the sort outside of this hash.
+ * </p>
  */
 final class BytesRefTopNBlockHash extends BlockHash {
     private final int channel;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefTopNBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefTopNBlockHash.java
@@ -168,6 +168,13 @@ final class BytesRefTopNBlockHash extends BlockHash {
 
     /**
      * Adds the vector values to the hash, and returns a new vector with the group IDs for those positions.
+     * <p>
+     *     TODO: when an {@code OrdinalBytesRefVector} reaches this method (e.g. once a Parquet reader emits
+     *     dictionary-encoded blocks), short-circuit by running the two-pass logic over the dictionary entries
+     *     and looking up rows via the ordinal index, mirroring {@code BytesRefBlockHash#addOrdinalsVector}.
+     *     The current implementation correctly resolves ordinals to bytes per row, but loses the dictionary
+     *     speed-up that the upstream block already paid for.
+     * </p>
      */
     IntBlock add(BytesRefVector vector) {
         int positions = vector.getPositionCount();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefTopNBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefTopNBlockHash.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.blockhash;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.BytesRefHashTable;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.sort.BytesRefTopNSet;
+import org.elasticsearch.compute.operator.mvdedupe.TopNMultivalueDedupeBytesRef;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+
+/**
+ * Maps a {@link BytesRefBlock} column to group ids, keeping only the top N values.
+ * <p>
+ *     Values that are not in the top-N at insertion time produce {@code null} group ids and are not stored
+ *     in the hash table; their aggregator state is therefore never allocated. {@link #nonEmpty()} filters
+ *     out group ids whose key has been evicted while the hash was being filled.
+ * </p>
+ */
+final class BytesRefTopNBlockHash extends BlockHash {
+    private final int channel;
+    private final boolean asc;
+    private final boolean nullsFirst;
+    private final int limit;
+    final BytesRefHashTable hash;
+    private final BytesRefTopNSet topValues;
+
+    /**
+     * Have we seen any {@code null} values?
+     * <p>
+     *     We reserve the 0 ordinal for the {@code null} key so methods like
+     *     {@link #nonEmpty} need to skip 0 if we haven't seen any null values.
+     * </p>
+     */
+    private boolean hasNull;
+
+    BytesRefTopNBlockHash(int channel, boolean asc, boolean nullsFirst, int limit, BlockFactory blockFactory) {
+        super(blockFactory);
+        assert limit > 0 : "BytesRefTopNBlockHash requires a limit greater than 0";
+        this.channel = channel;
+        this.asc = asc;
+        this.nullsFirst = nullsFirst;
+        this.limit = limit;
+
+        boolean success = false;
+        try {
+            this.hash = HashImplFactory.newBytesRefHash(blockFactory);
+            this.topValues = new BytesRefTopNSet(blockFactory.bigArrays(), asc ? SortOrder.ASC : SortOrder.DESC, limit);
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    @Override
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+        var block = page.getBlock(channel);
+
+        if (block.areAllValuesNull() && acceptNull()) {
+            hasNull = true;
+            try (IntVector groupIds = blockFactory.newConstantIntVector(0, block.getPositionCount())) {
+                addInput.add(0, groupIds);
+            }
+            return;
+        }
+        BytesRefBlock castBlock = (BytesRefBlock) block;
+        BytesRefVector vector = castBlock.asVector();
+        if (vector == null) {
+            try (IntBlock groupIds = add(castBlock)) {
+                addInput.add(0, groupIds);
+            }
+            return;
+        }
+        try (IntBlock groupIds = add(vector)) {
+            addInput.add(0, groupIds);
+        }
+    }
+
+    /**
+     * Tries to add null to the top values, and returns true if it was successful.
+     */
+    private boolean acceptNull() {
+        if (hasNull) {
+            return true;
+        }
+
+        if (nullsFirst) {
+            hasNull = true;
+            // Reduce the limit of the sort by one, as it's not filled with a null.
+            assert topValues.getLimit() == limit : "The top values can't be reduced twice";
+            topValues.reduceLimitByOne();
+            return true;
+        }
+
+        if (topValues.getCount() < limit) {
+            hasNull = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Tries to add the value to the top values, and returns true if it was successful.
+     */
+    private boolean acceptValue(BytesRef value) {
+        if (topValues.collect(value) == false) {
+            return false;
+        }
+
+        // Full top and null, there's an extra value/null we must remove.
+        if (topValues.getCount() == limit && hasNull && nullsFirst == false) {
+            hasNull = false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if the value is in, or can be added to the top; false otherwise.
+     */
+    private boolean isAcceptable(BytesRef value) {
+        return isTopComplete() == false || (hasNull && nullsFirst == false) || isInTop(value);
+    }
+
+    /**
+     * Returns true if the value is in the top; false otherwise.
+     * <p>
+     *     This method does not check if the value is currently part of the top; only if it's better or equal
+     *     than the current worst value.
+     * </p>
+     */
+    private boolean isInTop(BytesRef value) {
+        // Safe to use the view here: callers of isInTop never mutate topValues in-between.
+        // When the set is empty (e.g. limit was reduced to 0 by nullsFirst on a limit-1 hash) no real value
+        // can be in the top; the null slot is handled separately by isAcceptable/nonEmpty.
+        if (topValues.getCount() == 0) {
+            return false;
+        }
+        BytesRef worst = topValues.getWorstValueView();
+        return asc ? value.compareTo(worst) <= 0 : value.compareTo(worst) >= 0;
+    }
+
+    /**
+     * Returns true if there are {@code limit} values in the blockhash; false otherwise.
+     */
+    private boolean isTopComplete() {
+        return topValues.getCount() >= limit - (hasNull ? 1 : 0);
+    }
+
+    /**
+     * Adds the vector values to the hash, and returns a new vector with the group IDs for those positions.
+     */
+    IntBlock add(BytesRefVector vector) {
+        int positions = vector.getPositionCount();
+        BytesRef scratch = new BytesRef();
+
+        // Add all values to the top set, so we don't end up sending invalid values later.
+        for (int i = 0; i < positions; i++) {
+            BytesRef v = vector.getBytesRef(i, scratch);
+            acceptValue(v);
+        }
+
+        try (var builder = blockFactory.newIntBlockBuilder(positions)) {
+            for (int i = 0; i < positions; i++) {
+                BytesRef v = vector.getBytesRef(i, scratch);
+                if (isAcceptable(v)) {
+                    builder.appendInt(Math.toIntExact(hashOrdToGroupNullReserved(hash.add(v))));
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    /**
+     * Adds the block values to the hash, and returns a new vector with the group IDs for those positions.
+     * <p>
+     *     For nulls, a 0 group ID is used. For multivalues, a multivalue is used with all the group IDs.
+     * </p>
+     */
+    IntBlock add(BytesRefBlock block) {
+        BytesRef scratch = new BytesRef();
+        // Add all the values to the top set first, so we don't end up sending invalid values later.
+        for (int p = 0; p < block.getPositionCount(); p++) {
+            int count = block.getValueCount(p);
+            if (count == 0) {
+                acceptNull();
+                continue;
+            }
+            int first = block.getFirstValueIndex(p);
+
+            for (int i = 0; i < count; i++) {
+                BytesRef value = block.getBytesRef(first + i, scratch);
+                acceptValue(value);
+            }
+        }
+
+        return new TopNMultivalueDedupeBytesRef(block, hasNull, this::isAcceptable).hashAdd(blockFactory, hash).ords();
+    }
+
+    @Override
+    public ReleasableIterator<IntBlock> lookup(Page page, ByteSizeValue targetBlockSize) {
+        var block = page.getBlock(channel);
+        if (block.areAllValuesNull()) {
+            return ReleasableIterator.single(blockFactory.newConstantIntVector(0, block.getPositionCount()).asBlock());
+        }
+
+        BytesRefBlock castBlock = (BytesRefBlock) block;
+        BytesRefVector vector = castBlock.asVector();
+        // TODO honor targetBlockSize and chunk the pages if requested.
+        if (vector == null) {
+            return ReleasableIterator.single(lookup(castBlock));
+        }
+        return ReleasableIterator.single(lookup(vector));
+    }
+
+    private IntBlock lookup(BytesRefVector vector) {
+        int positions = vector.getPositionCount();
+        BytesRef scratch = new BytesRef();
+        try (var builder = blockFactory.newIntBlockBuilder(positions)) {
+            for (int i = 0; i < positions; i++) {
+                BytesRef v = vector.getBytesRef(i, scratch);
+                long found = hash.find(v);
+                if (found < 0 || isAcceptable(v) == false) {
+                    builder.appendNull();
+                } else {
+                    builder.appendInt(Math.toIntExact(hashOrdToGroupNullReserved(found)));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private IntBlock lookup(BytesRefBlock block) {
+        return new TopNMultivalueDedupeBytesRef(block, hasNull, this::isAcceptable).hashLookup(blockFactory, hash);
+    }
+
+    @Override
+    public BytesRefBlock[] getKeys(IntVector selected) {
+        int positions = selected.getPositionCount();
+        BytesRef spare = new BytesRef();
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(positions)) {
+            for (int i = 0; i < positions; i++) {
+                int groupId = selected.getInt(i);
+                if (groupId == 0) {
+                    builder.appendNull();
+                } else {
+                    builder.appendBytesRef(hash.get(groupId - 1, spare));
+                }
+            }
+            return new BytesRefBlock[] { builder.build() };
+        }
+    }
+
+    @Override
+    public IntVector nonEmpty() {
+        BytesRef spare = new BytesRef();
+        int nullOffset = hasNull ? 1 : 0;
+        // Every entry in topValues was inserted into hash, and any hash entry not currently in topValues
+        // has been evicted. So the number of "in top" hash entries equals topValues.getCount().
+        final int[] ids = new int[topValues.getCount() + nullOffset];
+        int idsIndex = nullOffset;
+        long hashSize = hash.size();
+        for (int i = 1; i <= hashSize; i++) {
+            BytesRef value = hash.get(i - 1, spare);
+            if (isInTop(value)) {
+                ids[idsIndex++] = i;
+            }
+        }
+        return blockFactory.newIntArrayVector(ids, ids.length);
+    }
+
+    @Override
+    public int numKeys() {
+        if (hasNull) {
+            return Math.toIntExact(hash.size()) + 1;
+        } else {
+            return Math.toIntExact(hash.size());
+        }
+    }
+
+    @Override
+    public BitArray seenGroupIds(BigArrays bigArrays) {
+        BitArray seenGroups = new BitArray(1, bigArrays);
+        if (hasNull) {
+            seenGroups.set(0);
+        }
+        BytesRef spare = new BytesRef();
+        long hashSize = hash.size();
+        for (int i = 1; i <= hashSize; i++) {
+            BytesRef value = hash.get(i - 1, spare);
+            if (isInTop(value)) {
+                seenGroups.set(i);
+            }
+        }
+        return seenGroups;
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(hash, topValues);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder();
+        b.append("BytesRefTopNBlockHash{channel=").append(channel);
+        b.append(", asc=").append(asc);
+        b.append(", nullsFirst=").append(nullsFirst);
+        b.append(", limit=").append(limit);
+        b.append(", entries=").append(hash.size());
+        b.append(", hasNull=").append(hasNull);
+        return b.append('}').toString();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/BytesRefTopNSet.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/BytesRefTopNSet.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BinarySearcher;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.sort.SortOrder;
+
+/**
+ * Aggregates the top N collected {@link BytesRef} values, kept sorted.
+ * <p>
+ *     Collection is O(1) for values out of the current top N. For values better than the worst value, it's O(log(n))
+ *     for the binary search plus O(n) for the shift on insertion (n is bounded by {@code limit}).
+ * </p>
+ * <p>
+ *     Backing storage is an array of {@link BreakingBytesRefBuilder}, one per slot, sized at most {@code limit}.
+ *     Each slot owns its bytes; on insertion, references are shifted right and the displaced (worst) slot is
+ *     reused as the destination for the new value.
+ * </p>
+ */
+public class BytesRefTopNSet implements Releasable {
+
+    private static final String BREAKER_LABEL = "BytesRefTopNSet";
+
+    private final CircuitBreaker breaker;
+    private final SortOrder order;
+    private int limit;
+
+    /**
+     * One builder per slot. Created lazily as values are collected, up to {@code limit} entries.
+     * Index {@code 0} is the best value, index {@code count - 1} is the worst.
+     */
+    private final BreakingBytesRefBuilder[] values;
+    private final BytesRefBinarySearcher searcher;
+
+    private int count;
+
+    public BytesRefTopNSet(BigArrays bigArrays, SortOrder order, int limit) {
+        this.breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        this.order = order;
+        this.limit = limit;
+        this.count = 0;
+        this.values = new BreakingBytesRefBuilder[limit];
+        this.searcher = new BytesRefBinarySearcher();
+    }
+
+    /**
+     * Adds the value to the top N, as long as it is "better" than the worst value, or the top isn't full yet.
+     */
+    public boolean collect(BytesRef value) {
+        if (limit == 0) {
+            return false;
+        }
+
+        // Short-circuit if the value is worse than the worst value on the top.
+        // This avoids a O(log(n)) check in the binary search.
+        if (count == limit && betterThan(getWorstValueView(), value)) {
+            return false;
+        }
+
+        if (count == 0) {
+            BreakingBytesRefBuilder slot = newSlotWithBytes(value);
+            values[0] = slot;
+            count++;
+            return true;
+        }
+
+        int insertionIndex = searcher.search(0, count - 1, value);
+
+        if (insertionIndex == count - 1) {
+            if (betterThan(getWorstValueView(), value)) {
+                BreakingBytesRefBuilder slot = newSlotWithBytes(value);
+                values[count] = slot;
+                count++;
+                return true;
+            }
+        }
+
+        // Only unique values are stored here.
+        if (values[insertionIndex].bytesRefView().bytesEquals(value)) {
+            return true;
+        }
+
+        // Allocate the new slot (with its bytes already populated) BEFORE mutating values[]. If allocation or copying
+        // throws (e.g. circuit breaker exception), the array stays in a valid state.
+        BreakingBytesRefBuilder newEntry = newSlotWithBytes(value);
+
+        // The searcher returns the upper bound, so we move right the elements from there.
+        // When the array is full, the displaced worst slot is closed; otherwise it grows by one.
+        BreakingBytesRefBuilder displaced = (count == limit) ? values[count - 1] : null;
+        int lastIndex = Math.min(count, limit - 1);
+        for (int i = lastIndex; i > insertionIndex; i--) {
+            values[i] = values[i - 1];
+        }
+        values[insertionIndex] = newEntry;
+        count = Math.min(count + 1, limit);
+
+        if (displaced != null) {
+            displaced.close();
+        }
+
+        return true;
+    }
+
+    /**
+     * Allocate a fresh slot already populated with {@code value}. If allocation or copying throws, any partially
+     * acquired breaker memory is released before propagating the exception.
+     */
+    private BreakingBytesRefBuilder newSlotWithBytes(BytesRef value) {
+        BreakingBytesRefBuilder slot = new BreakingBytesRefBuilder(breaker, BREAKER_LABEL, value.length);
+        boolean success = false;
+        try {
+            slot.copyBytes(value);
+            success = true;
+            return slot;
+        } finally {
+            if (success == false) {
+                slot.close();
+            }
+        }
+    }
+
+    /**
+     * Reduces the limit of the top N by 1.
+     * <p>
+     *     This method is specifically used to count for the null value, and ignore the extra element here without extra cost.
+     * </p>
+     */
+    public void reduceLimitByOne() {
+        if (limit == 0) {
+            return;
+        }
+        limit--;
+        if (count > limit) {
+            // Free the displaced slot: it won't fit anymore.
+            assert count == limit + 1 : "expected exactly one extra slot, got count=" + count + " limit=" + limit;
+            Releasables.close(values[count - 1]);
+            values[count - 1] = null;
+            count = limit;
+        }
+    }
+
+    /**
+     * Returns a deep copy of the worst value in the top.
+     * <p>
+     *     The worst is the greatest value for {@link SortOrder#ASC}, and the lowest value for {@link SortOrder#DESC}.
+     * </p>
+     * <p>
+     *     This always allocates. Hot callers that only need to compare against the worst value should prefer
+     *     {@link #getWorstValueView()} — which returns a view that is invalidated by the next mutation of this set.
+     * </p>
+     */
+    public BytesRef getWorstValue() {
+        assert count > 0;
+        return BytesRef.deepCopyOf(values[count - 1].bytesRefView());
+    }
+
+    /**
+     * Returns a non-owning {@link BytesRef} view of the worst value in the top.
+     * <p>
+     *     The returned reference is only valid until the next mutating call on this set
+     *     ({@link #collect(BytesRef)}, {@link #reduceLimitByOne()}, {@link #close()}). Callers that need to
+     *     keep the bytes across mutations must use {@link #getWorstValue()} instead.
+     * </p>
+     */
+    public BytesRef getWorstValueView() {
+        assert count > 0;
+        return values[count - 1].bytesRefView();
+    }
+
+    /**
+     * The order of the sort.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    /**
+     * {@code true} if {@code lhs} is "better" than {@code rhs}.
+     * "Better" in this means "lower" for {@link SortOrder#ASC} and "higher" for {@link SortOrder#DESC}.
+     */
+    private boolean betterThan(BytesRef lhs, BytesRef rhs) {
+        return order.reverseMul() * lhs.compareTo(rhs) < 0;
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(values);
+    }
+
+    private final class BytesRefBinarySearcher extends BinarySearcher {
+
+        private BytesRef searchFor;
+
+        @Override
+        protected int compare(int index) {
+            assert searchFor != null;
+            return order.reverseMul() * values[index].bytesRefView().compareTo(searchFor);
+        }
+
+        @Override
+        protected int getClosestIndex(int index1, int index2) {
+            return Math.max(index1, index2);
+        }
+
+        @Override
+        protected double distance(int index) {
+            throw new UnsupportedOperationException("getClosestIndex() is overridden and doesn't depend on this");
+        }
+
+        int search(int from, int to, BytesRef value) {
+            this.searchFor = value;
+            try {
+                return super.search(from, to);
+            } finally {
+                this.searchFor = null;
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/mvdedupe/TopNMultivalueDedupeBytesRef.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/mvdedupe/TopNMultivalueDedupeBytesRef.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.mvdedupe;
+
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.util.BytesRefHashTable;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+/**
+ * Removes duplicate values from multivalued positions, and keeps only the ones that pass the predicate.
+ * <p>
+ *     Clone of {@link MultivalueDedupeBytesRef}, but it accepts a predicate and nulls flag to filter the values
+ *     in a top-N aggregation context. Values not in the top-N produce {@code null} group ids so the corresponding
+ *     aggregator state is never allocated.
+ * </p>
+ */
+public class TopNMultivalueDedupeBytesRef {
+    /**
+     * The number of entries before we switch from an {@code n^2} strategy
+     * with low overhead to an {@code n*log(n)} strategy with higher overhead.
+     * The choice of number has been experimentally derived.
+     */
+    static final int ALWAYS_COPY_MISSING = 20;
+
+    /**
+     * The {@link Block} being deduplicated.
+     */
+    final BytesRefBlock block;
+    /**
+     * Whether the hash expects nulls or not.
+     */
+    final boolean acceptNulls;
+    /**
+     * A predicate to test if a value is part of the top N or not.
+     */
+    final Predicate<BytesRef> isAcceptable;
+    /**
+     * Oversized array of values that contains deduplicated values after running {@link #copyMissing} and
+     * sorted values after calling {@link #copyAndSort}.
+     */
+    BytesRef[] work = new BytesRef[ArrayUtil.oversize(2, RamUsageEstimator.NUM_BYTES_OBJECT_REF)];
+    /**
+     * After calling {@link #copyMissing} or {@link #copyAndSort} this is the number of values in {@link #work}
+     * for the current position.
+     */
+    int w;
+
+    public TopNMultivalueDedupeBytesRef(BytesRefBlock block, boolean acceptNulls, Predicate<BytesRef> isAcceptable) {
+        this.block = block;
+        this.acceptNulls = acceptNulls;
+        this.isAcceptable = isAcceptable;
+        fillWork(0, work.length);
+    }
+
+    /**
+     * Dedupe values, add them to the hash, and build an {@link IntBlock} of their hashes. This block is
+     * suitable for passing as the grouping block to a {@link GroupingAggregatorFunction}.
+     */
+    public MultivalueDedupe.HashResult hashAdd(BlockFactory blockFactory, BytesRefHashTable hash) {
+        try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
+            boolean sawNull = false;
+            for (int p = 0; p < block.getPositionCount(); p++) {
+                int count = block.getValueCount(p);
+                int first = block.getFirstValueIndex(p);
+                switch (count) {
+                    case 0 -> {
+                        if (acceptNulls) {
+                            sawNull = true;
+                            builder.appendInt(0);
+                        } else {
+                            builder.appendNull();
+                        }
+                    }
+                    case 1 -> {
+                        BytesRef v = block.getBytesRef(first, work[0]);
+                        hashAdd(builder, hash, v);
+                    }
+                    default -> {
+                        if (count < ALWAYS_COPY_MISSING) {
+                            copyMissing(first, count);
+                            hashAddUniquedWork(hash, builder);
+                        } else {
+                            copyAndSort(first, count);
+                            hashAddSortedWork(hash, builder);
+                        }
+                    }
+                }
+            }
+            return new MultivalueDedupe.HashResult(builder.build(), sawNull);
+        }
+    }
+
+    /**
+     * Dedupe values and build an {@link IntBlock} of their hashes. This block is suitable for passing as the
+     * grouping block to a {@link GroupingAggregatorFunction}.
+     */
+    public IntBlock hashLookup(BlockFactory blockFactory, BytesRefHashTable hash) {
+        try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
+            for (int p = 0; p < block.getPositionCount(); p++) {
+                int count = block.getValueCount(p);
+                int first = block.getFirstValueIndex(p);
+                switch (count) {
+                    case 0 -> {
+                        if (acceptNulls) {
+                            builder.appendInt(0);
+                        } else {
+                            builder.appendNull();
+                        }
+                    }
+                    case 1 -> {
+                        BytesRef v = block.getBytesRef(first, work[0]);
+                        hashLookupSingle(builder, hash, v);
+                    }
+                    default -> {
+                        if (count < ALWAYS_COPY_MISSING) {
+                            copyMissing(first, count);
+                            hashLookupUniquedWork(hash, builder);
+                        } else {
+                            copyAndSort(first, count);
+                            hashLookupSortedWork(hash, builder);
+                        }
+                    }
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    /**
+     * Copy all values from the position into {@link #work} and then sort them in {@code n * log(n)}.
+     * Only values passing {@link #isAcceptable} are kept.
+     */
+    void copyAndSort(int first, int count) {
+        grow(count);
+        int end = first + count;
+
+        w = 0;
+        for (int i = first; i < end; i++) {
+            BytesRef candidate = block.getBytesRef(i, work[w]);
+            if (isAcceptable.test(candidate)) {
+                work[w] = candidate;
+                w++;
+            }
+        }
+
+        Arrays.sort(work, 0, w);
+    }
+
+    /**
+     * Fill {@link #work} with the unique acceptable values in the position by scanning all fields already
+     * copied {@code n^2}.
+     */
+    void copyMissing(int first, int count) {
+        grow(count);
+        int end = first + count;
+
+        // Find the first acceptable value.
+        int probe = first;
+        for (; probe < end; probe++) {
+            BytesRef candidate = block.getBytesRef(probe, work[0]);
+            if (isAcceptable.test(candidate)) {
+                work[0] = candidate;
+                break;
+            }
+        }
+        if (probe == end) {
+            w = 0;
+            return;
+        }
+
+        w = 1;
+        i: for (int i = probe + 1; i < end; i++) {
+            BytesRef v = block.getBytesRef(i, work[w]);
+            if (isAcceptable.test(v)) {
+                for (int j = 0; j < w; j++) {
+                    if (v.equals(work[j])) {
+                        continue i;
+                    }
+                }
+                work[w++] = v;
+            }
+        }
+    }
+
+    /**
+     * Writes an already deduplicated {@link #work} to a hash.
+     */
+    private void hashAddUniquedWork(BytesRefHashTable hash, IntBlock.Builder builder) {
+        if (w == 0) {
+            builder.appendNull();
+            return;
+        }
+
+        if (w == 1) {
+            hashAddNoCheck(builder, hash, work[0]);
+            return;
+        }
+
+        builder.beginPositionEntry();
+        for (int i = 0; i < w; i++) {
+            hashAddNoCheck(builder, hash, work[i]);
+        }
+        builder.endPositionEntry();
+    }
+
+    /**
+     * Writes a sorted {@link #work} to a hash, skipping duplicates.
+     */
+    private void hashAddSortedWork(BytesRefHashTable hash, IntBlock.Builder builder) {
+        if (w == 0) {
+            builder.appendNull();
+            return;
+        }
+
+        if (w == 1) {
+            hashAddNoCheck(builder, hash, work[0]);
+            return;
+        }
+
+        builder.beginPositionEntry();
+        BytesRef prev = work[0];
+        hashAddNoCheck(builder, hash, prev);
+        for (int i = 1; i < w; i++) {
+            if (false == valuesEqual(prev, work[i])) {
+                prev = work[i];
+                hashAddNoCheck(builder, hash, prev);
+            }
+        }
+        builder.endPositionEntry();
+    }
+
+    /**
+     * Looks up an already deduplicated {@link #work} into a hash.
+     */
+    private void hashLookupUniquedWork(BytesRefHashTable hash, IntBlock.Builder builder) {
+        if (w == 0) {
+            builder.appendNull();
+            return;
+        }
+        if (w == 1) {
+            hashLookupSingle(builder, hash, work[0]);
+            return;
+        }
+
+        int i = 1;
+        long firstLookup = hashLookup(hash, work[0]);
+        while (firstLookup < 0) {
+            if (i >= w) {
+                builder.appendNull();
+                return;
+            }
+            firstLookup = hashLookup(hash, work[i]);
+            i++;
+        }
+
+        boolean foundSecond = false;
+        while (i < w) {
+            long nextLookup = hashLookup(hash, work[i]);
+            if (nextLookup >= 0) {
+                builder.beginPositionEntry();
+                appendFound(builder, firstLookup);
+                appendFound(builder, nextLookup);
+                i++;
+                foundSecond = true;
+                break;
+            }
+            i++;
+        }
+
+        if (false == foundSecond) {
+            appendFound(builder, firstLookup);
+            return;
+        }
+
+        while (i < w) {
+            long nextLookup = hashLookup(hash, work[i]);
+            if (nextLookup >= 0) {
+                appendFound(builder, nextLookup);
+            }
+            i++;
+        }
+        builder.endPositionEntry();
+    }
+
+    /**
+     * Looks up a sorted {@link #work} into a hash, skipping duplicates.
+     */
+    private void hashLookupSortedWork(BytesRefHashTable hash, IntBlock.Builder builder) {
+        if (w == 0) {
+            builder.appendNull();
+            return;
+        }
+        if (w == 1) {
+            hashLookupSingle(builder, hash, work[0]);
+            return;
+        }
+
+        int i = 1;
+        BytesRef prev = work[0];
+        long firstLookup = hashLookup(hash, prev);
+        while (firstLookup < 0) {
+            if (i >= w) {
+                builder.appendNull();
+                return;
+            }
+            prev = work[i];
+            firstLookup = hashLookup(hash, prev);
+            i++;
+        }
+
+        boolean foundSecond = false;
+        while (i < w) {
+            if (false == valuesEqual(prev, work[i])) {
+                long nextLookup = hashLookup(hash, work[i]);
+                if (nextLookup >= 0) {
+                    prev = work[i];
+                    builder.beginPositionEntry();
+                    appendFound(builder, firstLookup);
+                    appendFound(builder, nextLookup);
+                    i++;
+                    foundSecond = true;
+                    break;
+                }
+            }
+            i++;
+        }
+
+        if (false == foundSecond) {
+            appendFound(builder, firstLookup);
+            return;
+        }
+
+        while (i < w) {
+            if (false == valuesEqual(prev, work[i])) {
+                long nextLookup = hashLookup(hash, work[i]);
+                if (nextLookup >= 0) {
+                    prev = work[i];
+                    appendFound(builder, nextLookup);
+                }
+            }
+            i++;
+        }
+        builder.endPositionEntry();
+    }
+
+    private void grow(int size) {
+        int prev = work.length;
+        work = ArrayUtil.grow(work, size);
+        fillWork(prev, work.length);
+    }
+
+    private void fillWork(int from, int to) {
+        for (int i = from; i < to; i++) {
+            work[i] = new BytesRef();
+        }
+    }
+
+    private void hashAdd(IntBlock.Builder builder, BytesRefHashTable hash, BytesRef v) {
+        if (isAcceptable.test(v)) {
+            hashAddNoCheck(builder, hash, v);
+        } else {
+            builder.appendNull();
+        }
+    }
+
+    private void hashAddNoCheck(IntBlock.Builder builder, BytesRefHashTable hash, BytesRef v) {
+        appendFound(builder, hash.add(v));
+    }
+
+    private long hashLookup(BytesRefHashTable hash, BytesRef v) {
+        return isAcceptable.test(v) ? hash.find(v) : -1;
+    }
+
+    private void hashLookupSingle(IntBlock.Builder builder, BytesRefHashTable hash, BytesRef v) {
+        long found = hashLookup(hash, v);
+        if (found >= 0) {
+            appendFound(builder, found);
+        } else {
+            builder.appendNull();
+        }
+    }
+
+    private void appendFound(IntBlock.Builder builder, long found) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(found)));
+    }
+
+    private static boolean valuesEqual(BytesRef lhs, BytesRef rhs) {
+        return lhs.equals(rhs);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/TopNBlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/TopNBlockHashTests.java
@@ -10,8 +10,11 @@ package org.elasticsearch.compute.aggregation.blockhash;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -282,6 +285,201 @@ public class TopNBlockHashTests extends BlockHashTestCase {
         }
     }
 
+    public void testBytesRefHash() {
+        String[] values = { "b", "a", "d", "b", "d", "a", "c", "d" };
+
+        hash(ordsAndKeys -> {
+            if (forcePackedHash) {
+                // TODO: Not tested yet
+            } else {
+                assertThat(
+                    ordsAndKeys.description(),
+                    equalTo("BytesRefTopNBlockHash{channel=0, " + topNParametersString(4, 0) + ", hasNull=false}")
+                );
+                if (limit == LIMIT_HIGH) {
+                    assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "b", "a", "d", "c" });
+                    assertOrds(ordsAndKeys.ords(), 1, 2, 3, 1, 3, 2, 4, 3);
+                    assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(1, 5)));
+                } else {
+                    if (asc) {
+                        assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "b", "a" });
+                        assertOrds(ordsAndKeys.ords(), 1, 2, null, 1, null, 2, null, null);
+                        assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(1, 2)));
+                    } else {
+                        assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "d", "c" });
+                        assertOrds(ordsAndKeys.ords(), null, null, 1, null, 1, null, 2, 1);
+                        assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(1, 2)));
+                    }
+                }
+            }
+        }, bytesRefBlock(values));
+    }
+
+    public void testBytesRefHashWithNulls() {
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("a"));
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("c"));
+            builder.appendNull();
+
+            hash(ordsAndKeys -> {
+                if (forcePackedHash) {
+                    // TODO: Not tested yet
+                } else {
+                    boolean hasTwoNonNullValues = nullsFirst == false || limit == LIMIT_HIGH;
+                    boolean hasNull = nullsFirst || limit == LIMIT_HIGH;
+                    assertThat(
+                        ordsAndKeys.description(),
+                        equalTo(
+                            "BytesRefTopNBlockHash{channel=0, "
+                                + topNParametersString(hasTwoNonNullValues ? 2 : 1, 0)
+                                + ", hasNull="
+                                + hasNull
+                                + "}"
+                        )
+                    );
+                    if (limit == LIMIT_HIGH) {
+                        assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { null, "a", "c" });
+                        assertOrds(ordsAndKeys.ords(), 1, 0, 2, 0);
+                        assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(0, 1, 2)));
+                    } else {
+                        if (nullsFirst) {
+                            if (asc) {
+                                assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { null, "a" });
+                                assertOrds(ordsAndKeys.ords(), 1, 0, null, 0);
+                                assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(0, 1)));
+                            } else {
+                                assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { null, "c" });
+                                assertOrds(ordsAndKeys.ords(), null, 0, 1, 0);
+                                assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(0, 1)));
+                            }
+                        } else {
+                            assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "a", "c" });
+                            assertOrds(ordsAndKeys.ords(), 1, null, 2, null);
+                            assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(1, 2)));
+                        }
+                    }
+                }
+            }, builder);
+        }
+    }
+
+    public void testBytesRefHashWithMultiValuedFields() {
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(8)) {
+            builder.appendBytesRef(new BytesRef("a"));
+            builder.beginPositionEntry();
+            builder.appendBytesRef(new BytesRef("a"));
+            builder.appendBytesRef(new BytesRef("b"));
+            builder.appendBytesRef(new BytesRef("c"));
+            builder.endPositionEntry();
+            builder.beginPositionEntry();
+            builder.appendBytesRef(new BytesRef("a"));
+            builder.appendBytesRef(new BytesRef("a"));
+            builder.endPositionEntry();
+            builder.beginPositionEntry();
+            builder.appendBytesRef(new BytesRef("c"));
+            builder.endPositionEntry();
+            builder.appendNull();
+            builder.beginPositionEntry();
+            builder.appendBytesRef(new BytesRef("c"));
+            builder.appendBytesRef(new BytesRef("b"));
+            builder.appendBytesRef(new BytesRef("a"));
+            builder.endPositionEntry();
+
+            hash(ordsAndKeys -> {
+                if (forcePackedHash) {
+                    // TODO: Not tested yet
+                } else {
+                    if (limit == LIMIT_HIGH) {
+                        assertThat(
+                            ordsAndKeys.description(),
+                            equalTo("BytesRefTopNBlockHash{channel=0, " + topNParametersString(3, 0) + ", hasNull=true}")
+                        );
+                        assertOrds(
+                            ordsAndKeys.ords(),
+                            new int[] { 1 },
+                            new int[] { 1, 2, 3 },
+                            new int[] { 1 },
+                            new int[] { 3 },
+                            new int[] { 0 },
+                            new int[] { 3, 2, 1 }
+                        );
+                        assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { null, "a", "b", "c" });
+                    } else {
+                        assertThat(
+                            ordsAndKeys.description(),
+                            equalTo(
+                                "BytesRefTopNBlockHash{channel=0, "
+                                    + topNParametersString(nullsFirst ? 1 : 2, 0)
+                                    + ", hasNull="
+                                    + nullsFirst
+                                    + "}"
+                            )
+                        );
+                        if (nullsFirst) {
+                            if (asc) {
+                                assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { null, "a" });
+                                assertOrds(
+                                    ordsAndKeys.ords(),
+                                    new int[] { 1 },
+                                    new int[] { 1 },
+                                    new int[] { 1 },
+                                    null,
+                                    new int[] { 0 },
+                                    new int[] { 1 }
+                                );
+                                assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(0, 1)));
+                            } else {
+                                assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { null, "c" });
+                                assertOrds(
+                                    ordsAndKeys.ords(),
+                                    null,
+                                    new int[] { 1 },
+                                    null,
+                                    new int[] { 1 },
+                                    new int[] { 0 },
+                                    new int[] { 1 }
+                                );
+                                assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(0, 1)));
+                            }
+                        } else {
+                            if (asc) {
+                                assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "a", "b" });
+                                assertOrds(
+                                    ordsAndKeys.ords(),
+                                    new int[] { 1 },
+                                    new int[] { 1, 2 },
+                                    new int[] { 1 },
+                                    null,
+                                    null,
+                                    new int[] { 2, 1 }
+                                );
+                                assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(1, 2)));
+                            } else {
+                                assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "b", "c" });
+                                assertOrds(ordsAndKeys.ords(), null, new int[] { 1, 2 }, null, new int[] { 2 }, null, new int[] { 2, 1 });
+                                assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(1, 2)));
+                            }
+                        }
+                    }
+                }
+            }, builder);
+        }
+    }
+
+    private BytesRefBlock bytesRefBlock(String[] values) {
+        try (BytesRefBlock.Builder b = blockFactory.newBytesRefBlockBuilder(values.length)) {
+            for (String v : values) {
+                if (v == null) {
+                    b.appendNull();
+                } else {
+                    b.appendBytesRef(new BytesRef(v));
+                }
+            }
+            return b.build();
+        }
+    }
+
     // TODO: Test adding multiple blocks, as it triggers different logics like:
     // - Keeping older unused ords
     // - Returning nonEmpty ords greater than 1
@@ -370,7 +568,11 @@ public class TopNBlockHashTests extends BlockHashTestCase {
             ? new PackedValuesBlockHash(specs, blockFactory, emitBatchSize)
             : BlockHash.build(specs, blockFactory, emitBatchSize, true);*/
 
-        return new LongTopNBlockHash(specs.get(0).channel(), asc, nullsFirst, limit, blockFactory);
+        BlockHash.GroupSpec spec = specs.get(0);
+        if (spec.elementType() == ElementType.BYTES_REF) {
+            return new BytesRefTopNBlockHash(spec.channel(), asc, nullsFirst, limit, blockFactory);
+        }
+        return new LongTopNBlockHash(spec.channel(), asc, nullsFirst, limit, blockFactory);
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/sort/BytesRefTopNSetTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/sort/BytesRefTopNSetTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data.sort;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.List;
+
+public class BytesRefTopNSetTests extends TopNSetTestCase<BytesRefTopNSet, BytesRef> {
+
+    @Override
+    protected BytesRefTopNSet build(BigArrays bigArrays, SortOrder sortOrder, int limit) {
+        return new BytesRefTopNSet(bigArrays, sortOrder, limit);
+    }
+
+    @Override
+    protected BytesRef randomValue() {
+        return new BytesRef(randomAlphaOfLengthBetween(1, 16));
+    }
+
+    @Override
+    protected List<BytesRef> threeSortedValues() {
+        return List.of(new BytesRef("aaa"), new BytesRef("mmm"), new BytesRef("zzz"));
+    }
+
+    @Override
+    protected void collect(BytesRefTopNSet sort, BytesRef value) {
+        sort.collect(value);
+    }
+
+    @Override
+    protected void reduceLimitByOne(BytesRefTopNSet sort) {
+        sort.reduceLimitByOne();
+    }
+
+    @Override
+    protected BytesRef getWorstValue(BytesRefTopNSet sort) {
+        return sort.getWorstValue();
+    }
+
+    @Override
+    protected int getCount(BytesRefTopNSet sort) {
+        return sort.getCount();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushLimitToSo
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushSampleToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushStatsToExternalSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushStatsToSource;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushTopNIntoExternalSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.PushTopNToSource;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ReplaceRoundToWithQueryAndTags;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ReplaceSampledStatsByExactStats;
@@ -87,6 +88,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             esSourceRules.add(new PushStatsToSource());
             esSourceRules.add(new PushStatsToExternalSource());
             esSourceRules.add(new PushAggregatesToExternalSource());
+            esSourceRules.add(new PushTopNIntoExternalSource());
             esSourceRules.add(new EnableSpatialDistancePushdown());
         }
         esSourceRules.add(new ReplaceSampledStatsBySampleAndStats());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdown.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExternalSourceAggregatePushdown.java
@@ -28,7 +28,7 @@ import java.util.List;
  * {@link PushAggregatesToExternalSource}) that extract an {@link ExternalSourceExec}
  * from the plan tree and resolve filtered metadata using {@link SplitFilterClassifier}.
  */
-final class ExternalSourceAggregatePushdown {
+public final class ExternalSourceAggregatePushdown {
 
     private ExternalSourceAggregatePushdown() {}
 
@@ -38,6 +38,17 @@ final class ExternalSourceAggregatePushdown {
      * the filter condition from any intermediate {@code FilterExec}.
      */
     record ExternalSourceInfo(ExternalSourceExec externalExec, AttributeMap<Attribute> aliasReplacedBy, Expression filterCondition) {}
+
+    /**
+     * Light-weight projection of {@link #extractExternalSource(PhysicalPlan)} that returns just the
+     * {@link ExternalSourceExec} (or {@code null}) for callers that don't need the alias map or filter
+     * condition. Cross-package callers (the planner, other optimizer rules) use this so they share the
+     * same set of recognized wrapper shapes — adding a new shape here automatically propagates.
+     */
+    public static ExternalSourceExec findExternalSource(PhysicalPlan child) {
+        ExternalSourceInfo info = extractExternalSource(child);
+        return info == null ? null : info.externalExec();
+    }
 
     /**
      * Extracts the ExternalSourceExec and optional filter/alias information from the plan

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNIntoExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNIntoExternalSource.java
@@ -17,11 +17,8 @@ import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
-import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
-import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
-import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 
@@ -53,15 +50,23 @@ public class PushTopNIntoExternalSource extends PhysicalOptimizerRules.Parameter
     @Override
     protected PhysicalPlan rule(TopNExec topNExec, LocalPhysicalOptimizerContext ctx) {
         if (topNExec.child() instanceof AggregateExec aggregate && aggregate.getClass() == AggregateExec.class) {
+            // Use the shared helper to validate the wrapper-shape contract — anything outside the small set of
+            // recognized wrappers (Eval/Project/Filter, possibly nested) is rejected here, so the rebuild below
+            // only needs to swap the leaf source within an already-accepted subtree.
+            ExternalSourceExec ext = ExternalSourceAggregatePushdown.findExternalSource(aggregate.child());
+            if (ext == null || ext.pushedTopN() != null) {
+                return topNExec;
+            }
             BlockHash.TopNDef topNDef = buildTopNDef(topNExec, aggregate, ctx);
             if (topNDef == null) {
                 return topNExec;
             }
-            PhysicalPlan annotatedAggregateChild = annotateExternalSource(aggregate.child(), topNDef);
-            if (annotatedAggregateChild == aggregate.child()) {
-                return topNExec;
-            }
-            return topNExec.replaceChild(aggregate.replaceChild(annotatedAggregateChild));
+            ExternalSourceExec annotated = ext.withPushedTopN(topNDef);
+            // Rebuild the aggregate-child subtree by retargeting the original ext leaf at the annotated copy.
+            // findExternalSource has already validated the wrapper shape, so we know exactly one ExternalSourceExec
+            // sits below; transformDown on the leaf class is the simplest faithful rebuild.
+            PhysicalPlan rebuiltAggregateChild = aggregate.child().transformDown(ExternalSourceExec.class, e -> e == ext ? annotated : e);
+            return topNExec.replaceChild(aggregate.replaceChild(rebuiltAggregateChild));
         }
         return topNExec;
     }
@@ -100,7 +105,15 @@ public class PushTopNIntoExternalSource extends PhysicalOptimizerRules.Parameter
         }
         Object folded = limitExpr.fold(ctx.foldCtx());
         if (folded instanceof Number n) {
-            int limit = n.intValue();
+            // Defensive: the analyzer normally constrains LIMIT to a non-negative int literal, but folding can
+            // widen to Long. Math.toIntExact rejects values outside int range with an explicit ArithmeticException
+            // rather than silently truncating; we still validate positivity ourselves so callers never see 0.
+            int limit;
+            try {
+                limit = Math.toIntExact(n.longValue());
+            } catch (ArithmeticException ignored) {
+                return null;
+            }
             if (limit <= 0) {
                 return null;
             }
@@ -112,34 +125,4 @@ public class PushTopNIntoExternalSource extends PhysicalOptimizerRules.Parameter
         return null;
     }
 
-    /**
-     * Walks the AggregateExec child subtree and returns a copy where the (single) {@link ExternalSourceExec}
-     * has its {@code pushedTopN} hint set. Mirrors the small set of intermediate-node shapes recognized by
-     * {@code ExternalSourceAggregatePushdown.extractExternalSource}. Returns the original plan unchanged when
-     * no external source is found or its hint is already set.
-     */
-    private static PhysicalPlan annotateExternalSource(PhysicalPlan plan, BlockHash.TopNDef topNDef) {
-        if (plan instanceof ExternalSourceExec ext) {
-            return ext.pushedTopN() != null ? ext : ext.withPushedTopN(topNDef);
-        }
-        if (plan instanceof EvalExec eval && eval.child() instanceof ExternalSourceExec ext) {
-            return ext.pushedTopN() != null ? eval : eval.replaceChild(ext.withPushedTopN(topNDef));
-        }
-        if (plan instanceof ProjectExec project && project.child() instanceof ExternalSourceExec ext) {
-            return ext.pushedTopN() != null ? project : project.replaceChild(ext.withPushedTopN(topNDef));
-        }
-        if (plan instanceof FilterExec filter) {
-            PhysicalPlan filterChild = filter.child();
-            if (filterChild instanceof ExternalSourceExec ext) {
-                return ext.pushedTopN() != null ? filter : filter.replaceChild(ext.withPushedTopN(topNDef));
-            }
-            if (filterChild instanceof EvalExec eval && eval.child() instanceof ExternalSourceExec ext) {
-                return ext.pushedTopN() != null ? filter : filter.replaceChild(eval.replaceChild(ext.withPushedTopN(topNDef)));
-            }
-            if (filterChild instanceof ProjectExec project && project.child() instanceof ExternalSourceExec ext) {
-                return ext.pushedTopN() != null ? filter : filter.replaceChild(project.replaceChild(ext.withPushedTopN(topNDef)));
-            }
-        }
-        return plan;
-    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNIntoExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNIntoExternalSource.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+
+import java.util.List;
+
+/**
+ * Annotates an {@link ExternalSourceExec} with a Top-N grouping hint when the local plan tree has the shape
+ * {@code TopNExec → AggregateExec → ... → ExternalSourceExec} and the sort is on a single grouping key
+ * (not on an aggregation result). The hint flows through the planner into the {@code BlockHash}, which prunes
+ * non-competitive groups during aggregation, eliminating the need to materialize the full hash table.
+ *
+ * <p>Conditions for the rule to fire:
+ * <ul>
+ *   <li>The sort has exactly one {@link Order}.</li>
+ *   <li>The sort key references one of the aggregate's grouping attributes (not an aggregation output).</li>
+ *   <li>The aggregate has exactly one grouping (multi-key Top-N is deferred).</li>
+ *   <li>The limit is a non-negative integer literal.</li>
+ *   <li>The aggregate's child subtree contains an {@link ExternalSourceExec}.</li>
+ * </ul>
+ *
+ * <p>The {@link TopNExec} and {@link AggregateExec} nodes are <em>not</em> removed: they remain as the
+ * correctness safety net (necessary for distributed execution where each node prunes independently and the
+ * coordinator merges partial results). Only the {@link ExternalSourceExec#pushedTopN()} field is set.
+ */
+public class PushTopNIntoExternalSource extends PhysicalOptimizerRules.ParameterizedOptimizerRule<TopNExec, LocalPhysicalOptimizerContext> {
+
+    @Override
+    protected PhysicalPlan rule(TopNExec topNExec, LocalPhysicalOptimizerContext ctx) {
+        if (topNExec.child() instanceof AggregateExec aggregate && aggregate.getClass() == AggregateExec.class) {
+            BlockHash.TopNDef topNDef = buildTopNDef(topNExec, aggregate, ctx);
+            if (topNDef == null) {
+                return topNExec;
+            }
+            PhysicalPlan annotatedAggregateChild = annotateExternalSource(aggregate.child(), topNDef);
+            if (annotatedAggregateChild == aggregate.child()) {
+                return topNExec;
+            }
+            return topNExec.replaceChild(aggregate.replaceChild(annotatedAggregateChild));
+        }
+        return topNExec;
+    }
+
+    /**
+     * Builds a {@link BlockHash.TopNDef} hint when the input pattern matches the rule's preconditions. Returns
+     * {@code null} when any check fails so the caller can leave the plan untouched.
+     */
+    private static BlockHash.TopNDef buildTopNDef(TopNExec topNExec, AggregateExec aggregate, LocalPhysicalOptimizerContext ctx) {
+        List<Order> orders = topNExec.order();
+        if (orders.size() != 1) {
+            return null;
+        }
+        if (aggregate.groupings().size() != 1) {
+            return null;
+        }
+        Attribute groupAttr = Expressions.attribute(aggregate.groupings().get(0));
+        if (groupAttr == null) {
+            return null;
+        }
+        Order order = orders.get(0);
+        Attribute sortAttr = Expressions.attribute(order.child());
+        if (sortAttr == null || sortAttr.semanticEquals(groupAttr) == false) {
+            return null;
+        }
+        Expression limitExpr = topNExec.limit();
+        if (limitExpr instanceof Literal == false || limitExpr.foldable() == false) {
+            return null;
+        }
+        Object folded = limitExpr.fold(ctx.foldCtx());
+        if (folded instanceof Number n) {
+            int limit = n.intValue();
+            if (limit <= 0) {
+                return null;
+            }
+            boolean asc = order.direction() == Order.OrderDirection.ASC;
+            boolean nullsFirst = order.nullsPosition() == Order.NullsPosition.FIRST;
+            // Order index 0 because we only allow a single grouping/sort key.
+            return new BlockHash.TopNDef(0, asc, nullsFirst, limit);
+        }
+        return null;
+    }
+
+    /**
+     * Walks the AggregateExec child subtree and returns a copy where the (single) {@link ExternalSourceExec}
+     * has its {@code pushedTopN} hint set. Mirrors the small set of intermediate-node shapes recognized by
+     * {@code ExternalSourceAggregatePushdown.extractExternalSource}. Returns the original plan unchanged when
+     * no external source is found or its hint is already set.
+     */
+    private static PhysicalPlan annotateExternalSource(PhysicalPlan plan, BlockHash.TopNDef topNDef) {
+        if (plan instanceof ExternalSourceExec ext) {
+            return ext.pushedTopN() != null ? ext : ext.withPushedTopN(topNDef);
+        }
+        if (plan instanceof EvalExec eval && eval.child() instanceof ExternalSourceExec ext) {
+            return ext.pushedTopN() != null ? eval : eval.replaceChild(ext.withPushedTopN(topNDef));
+        }
+        if (plan instanceof ProjectExec project && project.child() instanceof ExternalSourceExec ext) {
+            return ext.pushedTopN() != null ? project : project.replaceChild(ext.withPushedTopN(topNDef));
+        }
+        if (plan instanceof FilterExec filter) {
+            PhysicalPlan filterChild = filter.child();
+            if (filterChild instanceof ExternalSourceExec ext) {
+                return ext.pushedTopN() != null ? filter : filter.replaceChild(ext.withPushedTopN(topNDef));
+            }
+            if (filterChild instanceof EvalExec eval && eval.child() instanceof ExternalSourceExec ext) {
+                return ext.pushedTopN() != null ? filter : filter.replaceChild(eval.replaceChild(ext.withPushedTopN(topNDef)));
+            }
+            if (filterChild instanceof ProjectExec project && project.child() instanceof ExternalSourceExec ext) {
+                return ext.pushedTopN() != null ? filter : filter.replaceChild(project.replaceChild(ext.withPushedTopN(topNDef)));
+            }
+        }
+        return plan;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNIntoExternalSource.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNIntoExternalSource.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
@@ -22,6 +23,7 @@ import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 
 import java.util.List;
 
@@ -36,6 +38,8 @@ import java.util.List;
  *   <li>The sort has exactly one {@link Order}.</li>
  *   <li>The sort key references one of the aggregate's grouping attributes (not an aggregation output).</li>
  *   <li>The aggregate has exactly one grouping (multi-key Top-N is deferred).</li>
+ *   <li>The grouping element type is supported by a Top-N {@link BlockHash} implementation
+ *       (currently {@link ElementType#LONG} and {@link ElementType#BYTES_REF}).</li>
  *   <li>The limit is a non-negative integer literal.</li>
  *   <li>The aggregate's child subtree contains an {@link ExternalSourceExec}.</li>
  * </ul>
@@ -76,6 +80,13 @@ public class PushTopNIntoExternalSource extends PhysicalOptimizerRules.Parameter
         }
         Attribute groupAttr = Expressions.attribute(aggregate.groupings().get(0));
         if (groupAttr == null) {
+            return null;
+        }
+        // Skip the annotation when the grouping type is not yet handled by a Top-N BlockHash. This keeps the
+        // hint as a strict promise that BlockHash#build will honor it; downstream code can rely on a non-null
+        // pushedTopN to mean "Top-N pruning is wired in".
+        ElementType groupingElementType = PlannerUtils.toElementType(groupAttr.dataType());
+        if (groupingElementType != ElementType.LONG && groupingElementType != ElementType.BYTES_REF) {
             return null;
         }
         Order order = orders.get(0);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExec.java
@@ -11,6 +11,8 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -64,6 +66,13 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
     private final Object pushedFilter; // Opaque filter - NOT serialized, created locally on data nodes
     private final List<Expression> pushedExpressions; // NOT serialized - ESQL expressions for per-file re-translation
     private final int pushedLimit; // NOT serialized, set locally on data nodes
+    /**
+     * Transient hint that the data above this source is a STATS aggregation followed by a TopN over a single
+     * grouping key. When present, the {@link BlockHash} can prune non-competitive groups during aggregation.
+     * NOT serialized; set locally on each node by {@code PushTopNIntoExternalSource}.
+     */
+    @Nullable
+    private final BlockHash.TopNDef pushedTopN;
     private final Integer estimatedRowSize;
     private final FileList fileList; // NOT serialized - resolved on coordinator, null on data nodes
     private final List<ExternalSplit> splits;
@@ -137,6 +146,43 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
         FileList fileList,
         List<ExternalSplit> splits
     ) {
+        this(
+            source,
+            sourcePath,
+            sourceType,
+            attributes,
+            config,
+            sourceMetadata,
+            pushedFilter,
+            pushedExpressions,
+            pushedLimit,
+            null,
+            estimatedRowSize,
+            fileList,
+            splits
+        );
+    }
+
+    /**
+     * Primary constructor that also accepts a transient {@link BlockHash.TopNDef} hint for in-hash TopN pruning.
+     * Package-private on purpose so the public, longest constructor (used by tooling and tree tests) remains
+     * the twelve-arg one above. Use {@link #withPushedTopN(BlockHash.TopNDef)} from optimizer rules.
+     */
+    ExternalSourceExec(
+        Source source,
+        String sourcePath,
+        String sourceType,
+        List<Attribute> attributes,
+        Map<String, Object> config,
+        Map<String, Object> sourceMetadata,
+        Object pushedFilter,
+        List<Expression> pushedExpressions,
+        int pushedLimit,
+        @Nullable BlockHash.TopNDef pushedTopN,
+        Integer estimatedRowSize,
+        FileList fileList,
+        List<ExternalSplit> splits
+    ) {
         super(source);
         if (sourcePath == null) {
             throw new IllegalArgumentException("sourcePath must not be null");
@@ -155,6 +201,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
         this.pushedFilter = pushedFilter;
         this.pushedExpressions = pushedExpressions != null ? List.copyOf(pushedExpressions) : List.of();
         this.pushedLimit = pushedLimit;
+        this.pushedTopN = pushedTopN;
         this.estimatedRowSize = estimatedRowSize;
         this.fileList = fileList;
         this.splits = splits != null ? List.copyOf(splits) : List.of();
@@ -313,6 +360,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             pushedFilter,
             pushedExpressions,
             pushedLimit,
+            pushedTopN,
             estimatedRowSize,
             fileList,
             newSplits
@@ -330,6 +378,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             newFilter,
             pushedExpressions,
             pushedLimit,
+            pushedTopN,
             estimatedRowSize,
             fileList,
             splits
@@ -347,6 +396,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             newFilter,
             newPushedExpressions,
             pushedLimit,
+            pushedTopN,
             estimatedRowSize,
             fileList,
             splits
@@ -364,10 +414,42 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             pushedFilter,
             pushedExpressions,
             newLimit,
+            pushedTopN,
             estimatedRowSize,
             fileList,
             splits
         );
+    }
+
+    /**
+     * Returns a copy of this source annotated with the given Top-N grouping hint. See {@link #pushedTopN()}.
+     */
+    public ExternalSourceExec withPushedTopN(@Nullable BlockHash.TopNDef newPushedTopN) {
+        return new ExternalSourceExec(
+            source(),
+            sourcePath,
+            sourceType,
+            attributes,
+            config,
+            sourceMetadata,
+            pushedFilter,
+            pushedExpressions,
+            pushedLimit,
+            newPushedTopN,
+            estimatedRowSize,
+            fileList,
+            splits
+        );
+    }
+
+    /**
+     * The Top-N grouping hint set by {@code PushTopNIntoExternalSource}, or {@code null} if no Top-N pruning
+     * should be performed during hash aggregation. This is a transient local-execution hint; it is never
+     * serialized and is re-derived independently on each node.
+     */
+    @Nullable
+    public BlockHash.TopNDef pushedTopN() {
+        return pushedTopN;
     }
 
     @Override
@@ -388,6 +470,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             pushedFilter,
             pushedExpressions,
             pushedLimit,
+            pushedTopN,
             newEstimatedRowSize,
             fileList,
             splits
@@ -396,6 +479,9 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
 
     @Override
     protected NodeInfo<? extends PhysicalPlan> info() {
+        // pushedTopN is intentionally excluded — it is a transient local-execution hint, set on each node
+        // independently. Including it would cause golden tests for external-source plans to diff whenever the
+        // local optimizer chooses to (or not to) annotate.
         return NodeInfo.create(
             this,
             ExternalSourceExec::new,
@@ -424,6 +510,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             pushedFilter,
             pushedExpressions,
             pushedLimit,
+            pushedTopN,
             estimatedRowSize,
             fileList,
             splits
@@ -449,6 +536,7 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
             && Objects.equals(pushedFilter, other.pushedFilter)
             && Objects.equals(pushedExpressions, other.pushedExpressions)
             && pushedLimit == other.pushedLimit
+            && Objects.equals(pushedTopN, other.pushedTopN)
             && Objects.equals(estimatedRowSize, other.estimatedRowSize)
             && Objects.equals(fileList, other.fileList)
             && Objects.equals(splits, other.splits);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ExternalSourceExec.java
@@ -479,9 +479,11 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
 
     @Override
     protected NodeInfo<? extends PhysicalPlan> info() {
-        // pushedTopN is intentionally excluded — it is a transient local-execution hint, set on each node
-        // independently. Including it would cause golden tests for external-source plans to diff whenever the
-        // local optimizer chooses to (or not to) annotate.
+        // pushedTopN is intentionally excluded from info(): it is a transient local-execution hint set after the
+        // plan has been distributed, and including it here would (a) require a public 13-arg ctor that breaks the
+        // node-reflection invariant in EsqlNodeSubclassTests#testInfoParameters and (b) leak the hint into any
+        // generic transform-based plan rewrite. The hint is preserved by the explicit with* methods that need it
+        // and is rendered in nodeString() for debuggability.
         return NodeInfo.create(
             this,
             ExternalSourceExec::new,
@@ -550,6 +552,17 @@ public class ExternalSourceExec extends LeafExec implements EstimatesRowSize, Da
         }
         if (pushedLimit != FormatReader.NO_LIMIT) {
             sb.append("[limit=").append(pushedLimit).append("]");
+        }
+        if (pushedTopN != null) {
+            sb.append("[topN=order:")
+                .append(pushedTopN.order())
+                .append(",asc:")
+                .append(pushedTopN.asc())
+                .append(",nullsFirst:")
+                .append(pushedTopN.nullsFirst())
+                .append(",limit:")
+                .append(pushedTopN.limit())
+                .append("]");
         }
         if (splits.isEmpty() == false) {
             sb.append("[splits=").append(splits.size()).append("]");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -19,6 +19,7 @@ import org.elasticsearch.compute.expression.ExpressionEvaluator;
 import org.elasticsearch.compute.operator.AggregationOperator;
 import org.elasticsearch.compute.operator.HashAggregationOperator;
 import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
@@ -35,6 +36,11 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountApproximate;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Categorize;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecutionPlannerContext;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperation;
@@ -99,6 +105,10 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
             // grouping
             List<GroupingAggregator.Factory> aggregatorFactories = new ArrayList<>();
             List<GroupSpec> groupSpecs = new ArrayList<>(aggregateExec.groupings().size());
+            // Look once for a transient Top-N grouping hint pushed onto an ExternalSourceExec by
+            // PushTopNIntoExternalSource. The rule only fires when there is a single grouping key, so we only
+            // forward the hint in that case.
+            BlockHash.TopNDef pushedTopN = aggregateExec.groupings().size() == 1 ? extractPushedTopN(aggregateExec.child()) : null;
             for (Expression group : aggregateExec.groupings()) {
                 Attribute groupAttribute = Expressions.attribute(group);
                 // In case of `... BY groupAttribute = CATEGORIZE(sourceGroupAttribute)` the actual source attribute is different.
@@ -144,7 +154,7 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
                 }
                 layout.append(groupAttributeLayout);
                 Layout.ChannelAndType groupInput = source.layout.get(sourceGroupAttribute.id());
-                groupSpecs.add(new GroupSpec(groupInput == null ? null : groupInput.channel(), sourceGroupAttribute, group));
+                groupSpecs.add(new GroupSpec(groupInput == null ? null : groupInput.channel(), sourceGroupAttribute, group, pushedTopN));
             }
 
             if (aggregatorMode.isOutputPartial()) {
@@ -355,7 +365,7 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
      * @param attribute The attribute, source of this group
      * @param expression The expression being used to group
      */
-    private record GroupSpec(Integer channel, Attribute attribute, Expression expression) {
+    private record GroupSpec(Integer channel, Attribute attribute, Expression expression, @Nullable BlockHash.TopNDef topNDef) {
         BlockHash.GroupSpec toHashGroupSpec() {
             if (channel == null) {
                 throw new EsqlIllegalArgumentException("planned to use ordinals but tried to use the hash instead");
@@ -364,13 +374,52 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
                 channel,
                 elementType(),
                 Alias.unwrap(expression) instanceof Categorize categorize ? categorize.categorizeDef() : null,
-                null
+                topNDef
             );
         }
 
         ElementType elementType() {
             return PlannerUtils.toElementType(attribute.dataType());
         }
+    }
+
+    /**
+     * Walks down the child subtree of an {@link AggregateExec} looking for an {@link ExternalSourceExec}
+     * whose transient {@link ExternalSourceExec#pushedTopN()} hint is set. Mirrors the small set of
+     * intermediate-node shapes recognized by {@code ExternalSourceAggregatePushdown.extractExternalSource}
+     * so the local execution plan honours the same rewrites the optimizer already validated against.
+     * Returns {@code null} when no external source (or no Top-N hint) is found.
+     */
+    @Nullable
+    private static BlockHash.TopNDef extractPushedTopN(PhysicalPlan child) {
+        ExternalSourceExec ext = findExternalSource(child);
+        return ext == null ? null : ext.pushedTopN();
+    }
+
+    @Nullable
+    private static ExternalSourceExec findExternalSource(PhysicalPlan child) {
+        if (child instanceof ExternalSourceExec ext) {
+            return ext;
+        }
+        if (child instanceof EvalExec eval && eval.child() instanceof ExternalSourceExec ext) {
+            return ext;
+        }
+        if (child instanceof ProjectExec project && project.child() instanceof ExternalSourceExec ext) {
+            return ext;
+        }
+        if (child instanceof FilterExec filter) {
+            PhysicalPlan filterChild = filter.child();
+            if (filterChild instanceof ExternalSourceExec ext) {
+                return ext;
+            }
+            if (filterChild instanceof EvalExec eval && eval.child() instanceof ExternalSourceExec ext) {
+                return ext;
+            }
+            if (filterChild instanceof ProjectExec project && project.child() instanceof ExternalSourceExec ext) {
+                return ext;
+            }
+        }
+        return null;
     }
 
     public abstract Operator.OperatorFactory timeSeriesAggregatorOperatorFactory(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -35,12 +35,10 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunct
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountApproximate;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Categorize;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ExternalSourceAggregatePushdown;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
-import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
-import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
-import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.TimeSeriesAggregateExec;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecutionPlannerContext;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperation;
@@ -385,41 +383,15 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
 
     /**
      * Walks down the child subtree of an {@link AggregateExec} looking for an {@link ExternalSourceExec}
-     * whose transient {@link ExternalSourceExec#pushedTopN()} hint is set. Mirrors the small set of
-     * intermediate-node shapes recognized by {@code ExternalSourceAggregatePushdown.extractExternalSource}
-     * so the local execution plan honours the same rewrites the optimizer already validated against.
+     * whose transient {@link ExternalSourceExec#pushedTopN()} hint is set. Delegates the wrapper-shape
+     * traversal to {@link ExternalSourceAggregatePushdown#findExternalSource(PhysicalPlan)} so the local
+     * execution plan honours the same rewrites the optimizer already validated against.
      * Returns {@code null} when no external source (or no Top-N hint) is found.
      */
     @Nullable
     private static BlockHash.TopNDef extractPushedTopN(PhysicalPlan child) {
-        ExternalSourceExec ext = findExternalSource(child);
+        ExternalSourceExec ext = ExternalSourceAggregatePushdown.findExternalSource(child);
         return ext == null ? null : ext.pushedTopN();
-    }
-
-    @Nullable
-    private static ExternalSourceExec findExternalSource(PhysicalPlan child) {
-        if (child instanceof ExternalSourceExec ext) {
-            return ext;
-        }
-        if (child instanceof EvalExec eval && eval.child() instanceof ExternalSourceExec ext) {
-            return ext;
-        }
-        if (child instanceof ProjectExec project && project.child() instanceof ExternalSourceExec ext) {
-            return ext;
-        }
-        if (child instanceof FilterExec filter) {
-            PhysicalPlan filterChild = filter.child();
-            if (filterChild instanceof ExternalSourceExec ext) {
-                return ext;
-            }
-            if (filterChild instanceof EvalExec eval && eval.child() instanceof ExternalSourceExec ext) {
-                return ext;
-            }
-            if (filterChild instanceof ProjectExec project && project.child() instanceof ExternalSourceExec ext) {
-                return ext;
-            }
-        }
-        return null;
     }
 
     public abstract Operator.OperatorFactory timeSeriesAggregatorOperatorFactory(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNIntoExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNIntoExternalSourceTests.java
@@ -39,6 +39,7 @@ public class PushTopNIntoExternalSourceTests extends ESTestCase {
 
     private static final ReferenceAttribute USER_ID = new ReferenceAttribute(Source.EMPTY, "user_id", DataType.KEYWORD);
     private static final ReferenceAttribute REGION = new ReferenceAttribute(Source.EMPTY, "region", DataType.KEYWORD);
+    private static final ReferenceAttribute COUNTER = new ReferenceAttribute(Source.EMPTY, "counter", DataType.INTEGER);
 
     public void testTopNPushedAscLimit10() {
         TopNExec topN = topN(USER_ID, Order.OrderDirection.ASC, 10, externalAggregate());
@@ -91,6 +92,19 @@ public class PushTopNIntoExternalSourceTests extends ESTestCase {
         Order primary = new Order(Source.EMPTY, USER_ID, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
         Order secondary = new Order(Source.EMPTY, REGION, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
         TopNExec topN = new TopNExec(Source.EMPTY, aggregate, List.of(primary, secondary), literal(10), null);
+
+        TopNExec result = (TopNExec) applyRule(topN);
+        assertNull(unwrap(result).pushedTopN());
+    }
+
+    /**
+     * Only LONG and BYTES_REF groupings have a Top-N {@link BlockHash} implementation today. Other element
+     * types (e.g. INT) must not receive the hint, otherwise it would be silently dropped at runtime by
+     * {@code BlockHash#build}, masking the absence of the optimization.
+     */
+    public void testTopNNotPushedForUnsupportedGroupingType() {
+        AggregateExec aggregate = aggregateExec(COUNTER, externalSource(), countStarAlias());
+        TopNExec topN = topN(COUNTER, Order.OrderDirection.ASC, 10, aggregate);
 
         TopNExec result = (TopNExec) applyRule(topN);
         assertNull(unwrap(result).pushedTopN());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNIntoExternalSourceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/PushTopNIntoExternalSourceTests.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExternalSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.alias;
+
+public class PushTopNIntoExternalSourceTests extends ESTestCase {
+
+    private static final ReferenceAttribute USER_ID = new ReferenceAttribute(Source.EMPTY, "user_id", DataType.KEYWORD);
+    private static final ReferenceAttribute REGION = new ReferenceAttribute(Source.EMPTY, "region", DataType.KEYWORD);
+
+    public void testTopNPushedAscLimit10() {
+        TopNExec topN = topN(USER_ID, Order.OrderDirection.ASC, 10, externalAggregate());
+
+        TopNExec result = (TopNExec) applyRule(topN);
+
+        ExternalSourceExec ext = unwrap(result);
+        BlockHash.TopNDef def = ext.pushedTopN();
+        assertNotNull(def);
+        assertEquals(0, def.order());
+        assertTrue(def.asc());
+        assertFalse(def.nullsFirst());
+        assertEquals(10, def.limit());
+    }
+
+    public void testTopNPushedDescLimit5() {
+        TopNExec topN = topN(USER_ID, Order.OrderDirection.DESC, 5, externalAggregate());
+
+        TopNExec result = (TopNExec) applyRule(topN);
+        BlockHash.TopNDef def = unwrap(result).pushedTopN();
+        assertNotNull(def);
+        assertFalse(def.asc());
+        assertEquals(5, def.limit());
+    }
+
+    /**
+     * Sort key must reference a grouping attribute. Sorting on the aggregation result must NOT push the hint
+     * because the rank of a key depends on data that is only known after the aggregation completes.
+     */
+    public void testTopNNotPushedWhenSortIsOnAggregateResult() {
+        Alias countAlias = countStarAlias();
+        AggregateExec aggregate = aggregateExec(USER_ID, externalSource(), countAlias);
+        // Sort on the aggregate's output reference (the count alias), not the grouping key.
+        TopNExec topN = topN(countAlias.toAttribute(), Order.OrderDirection.DESC, 10, aggregate);
+
+        TopNExec result = (TopNExec) applyRule(topN);
+        assertNull(unwrap(result).pushedTopN());
+    }
+
+    public void testTopNNotPushedWithMultipleGroupings() {
+        AggregateExec aggregate = aggregateExec(List.of(USER_ID, REGION), externalSource(), countStarAlias());
+        TopNExec topN = topN(USER_ID, Order.OrderDirection.ASC, 10, aggregate);
+
+        TopNExec result = (TopNExec) applyRule(topN);
+        assertNull(unwrap(result).pushedTopN());
+    }
+
+    public void testTopNNotPushedWithMultipleSortKeys() {
+        AggregateExec aggregate = aggregateExec(USER_ID, externalSource(), countStarAlias());
+        Order primary = new Order(Source.EMPTY, USER_ID, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
+        Order secondary = new Order(Source.EMPTY, REGION, Order.OrderDirection.ASC, Order.NullsPosition.LAST);
+        TopNExec topN = new TopNExec(Source.EMPTY, aggregate, List.of(primary, secondary), literal(10), null);
+
+        TopNExec result = (TopNExec) applyRule(topN);
+        assertNull(unwrap(result).pushedTopN());
+    }
+
+    public void testRuleIsNoOpWithoutAggregateChild() {
+        // TopN directly above ExternalSourceExec (no aggregate) — the rule must not fire.
+        ExternalSourceExec ext = externalSource();
+        TopNExec topN = topN(USER_ID, Order.OrderDirection.ASC, 10, ext);
+
+        PhysicalPlan result = applyRule(topN);
+
+        TopNExec resultTopN = (TopNExec) result;
+        assertSame(ext, resultTopN.child());
+        assertNull(((ExternalSourceExec) resultTopN.child()).pushedTopN());
+    }
+
+    public void testWithPushedTopNReturnsNewInstance() {
+        ExternalSourceExec ext = externalSource();
+        BlockHash.TopNDef def = new BlockHash.TopNDef(0, true, false, 7);
+        ExternalSourceExec annotated = ext.withPushedTopN(def);
+
+        assertNotSame(ext, annotated);
+        assertNull(ext.pushedTopN());
+        assertEquals(def, annotated.pushedTopN());
+        // Other fields untouched
+        assertEquals(ext.sourcePath(), annotated.sourcePath());
+        assertEquals(ext.sourceType(), annotated.sourceType());
+        assertEquals(ext.output(), annotated.output());
+    }
+
+    // --- helpers ---
+
+    private static TopNExec topN(Attribute sortAttr, Order.OrderDirection direction, int limit, PhysicalPlan child) {
+        Order order = new Order(Source.EMPTY, sortAttr, direction, Order.NullsPosition.LAST);
+        return new TopNExec(Source.EMPTY, child, List.of(order), literal(limit), null);
+    }
+
+    private static AggregateExec externalAggregate() {
+        return aggregateExec(USER_ID, externalSource(), countStarAlias());
+    }
+
+    private static AggregateExec aggregateExec(Attribute groupingAttr, PhysicalPlan child, NamedExpression... aggregates) {
+        return aggregateExec(List.of(groupingAttr), child, aggregates);
+    }
+
+    private static AggregateExec aggregateExec(List<Attribute> groupingAttrs, PhysicalPlan child, NamedExpression... aggregates) {
+        // The grouping is the attribute itself (no Alias wrapper) so that Expressions.attribute(group) returns it.
+        List<Expression> groupings = groupingAttrs.stream().<Expression>map(a -> a).toList();
+        List<NamedExpression> aggList = List.of(aggregates);
+        List<Attribute> intermediateAttrs = AbstractPhysicalOperationProviders.intermediateAttributes(aggList, groupings);
+        return new AggregateExec(Source.EMPTY, child, groupings, aggList, AggregatorMode.SINGLE, intermediateAttrs, null);
+    }
+
+    private static Alias countStarAlias() {
+        return alias("c", new Count(Source.EMPTY, Literal.keyword(Source.EMPTY, "*")));
+    }
+
+    private static ExternalSourceExec externalSource() {
+        return new ExternalSourceExec(Source.EMPTY, "file:///test.parquet", "parquet", List.of(USER_ID, REGION), Map.of(), Map.of(), null);
+    }
+
+    private static ExternalSourceExec unwrap(TopNExec topN) {
+        AggregateExec agg = (AggregateExec) topN.child();
+        return (ExternalSourceExec) agg.child();
+    }
+
+    private static Literal literal(int value) {
+        return new Literal(Source.EMPTY, value, DataType.INTEGER);
+    }
+
+    private static PhysicalPlan applyRule(TopNExec topNExec) {
+        PushTopNIntoExternalSource rule = new PushTopNIntoExternalSource();
+        LocalPhysicalOptimizerContext ctx = new LocalPhysicalOptimizerContext(
+            PlannerSettings.DEFAULTS,
+            new EsqlFlags(true),
+            null,
+            FoldContext.small(),
+            null
+        );
+        return rule.apply(topNExec, ctx);
+    }
+}


### PR DESCRIPTION
Queries shaped as STATS ... BY key | SORT key | LIMIT N over
external sources currently materialize the full grouping hash
table even when only a small ordered slice of the result is
needed. The hash now carries an optional Top-N hint so that
non-competitive groups are rejected at insertion time, leaving
the post-aggregation TopN nearly free.

A new local physical optimizer rule annotates the underlying
ExternalSourceExec with a transient Top-N grouping hint when
the sort is on a single grouping key. The hint flows through
the planner into BlockHash, which dispatches to a Top-N aware
implementation. Indexed-source queries are not affected as
they have no ExternalSourceExec in their subtree.

Adds the BytesRef variant of the Top-N aware BlockHash plus its
supporting set and multi-value deduper, mirroring the existing
LONG implementation. The TopNExec and AggregateExec nodes are
preserved as the correctness safety net for distributed runs.

Developed with AI-assisted tooling