### PR TITLE
ESQL: Skip filter eval when row group stats prove all rows pass

### DIFF
--- a/docs/changelog/148261.yaml
+++ b/docs/changelog/148261.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148261
+summary: Skip filter eval when row group stats prove all rows pass
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -12,6 +12,7 @@ import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.compression.CompressionCodecFactory;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -62,6 +63,13 @@ import java.util.concurrent.CompletableFuture;
  * {@link BlockFactory#breaker()}) before async I/O starts. The reservation is released
  * when prefetched data is consumed and cleared. If the breaker would trip, prefetch is
  * skipped and the query falls back to synchronous I/O for that row group.
+ *
+ * <p><b>Trivially-passes guard:</b> when late materialization is enabled and row-group
+ * statistics prove every row satisfies the pushed filter ({@link TriviallyPassesChecker}),
+ * the iterator routes that row group through {@code nextStandard} for the remainder of the
+ * row group, skipping per-row filter evaluation and survivor compaction. This benefits queries
+ * that mix selective and non-selective row groups (e.g., time-bucketed data with skewed
+ * filter selectivity).
  */
 final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
 
@@ -111,8 +119,22 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final boolean lateMaterialization;
     private final boolean[] isPredicateColumn;
     private final ParquetPushedExpressions pushedExpressions;
+    /**
+     * Cached parquet-mr {@link FilterPredicate} translated from {@link #pushedExpressions} once at
+     * construction. Reused per row group by the trivially-passes check so we don't re-translate
+     * the predicate tree for every row group.
+     */
+    private final FilterPredicate cachedFilterPredicate;
     private final WordMask survivorMask;
     private long rowsEliminatedByLateMaterialization;
+    /**
+     * When {@code true}, row-group statistics prove every row in the current row group satisfies
+     * the pushed filter, so late materialization is bypassed for this row group: filter
+     * evaluation and survivor compaction are skipped, and the standard read path is used.
+     */
+    private boolean currentRowGroupTriviallyPasses;
+    /** Diagnostic counter: number of row groups for which the filter was proven to trivially pass. */
+    private long rowGroupsWithTrivialFilter;
 
     OptimizedParquetColumnIterator(
         ParquetFileReader reader,
@@ -151,6 +173,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.isPredicateColumn = classifyPredicateColumns(attributes, columnInfos, pushedExpressions);
         this.lateMaterialization = pushedExpressions != null && hasProjectionOnlyColumns(isPredicateColumn, columnInfos);
         this.survivorMask = lateMaterialization ? new WordMask() : null;
+        this.cachedFilterPredicate = lateMaterialization
+            ? translateFilterPredicate(pushedExpressions, projectedSchema, fileLocation)
+            : null;
 
         this.projectedColumnPaths = buildProjectedColumnPaths(columnInfos);
         this.prefetchDepth = computePrefetchDepth(reader.getRowGroups(), this.projectedColumnPaths);
@@ -291,6 +316,28 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         return false;
     }
 
+    /**
+     * Translates the pushed expressions to a parquet-mr {@link FilterPredicate} once for the
+     * lifetime of this iterator. Returns {@code null} when translation fails or yields no
+     * predicate; the iterator gracefully degrades to non-trivial late-materialization in that
+     * case.
+     */
+    private static FilterPredicate translateFilterPredicate(
+        ParquetPushedExpressions pushed,
+        MessageType projectedSchema,
+        String fileLocation
+    ) {
+        if (pushed == null) {
+            return null;
+        }
+        try {
+            return pushed.toFilterPredicate(projectedSchema);
+        } catch (RuntimeException e) {
+            logger.debug("Disabling trivially-passes guard for [{}]: predicate translation failed: {}", fileLocation, e.getMessage());
+            return null;
+        }
+    }
+
     @Override
     public boolean hasNext() {
         if (exhausted) {
@@ -333,18 +380,36 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             if (rowsEliminatedByLateMaterialization > 0) {
                 logger.debug("Late materialization eliminated [{}] rows in [{}]", rowsEliminatedByLateMaterialization, fileLocation);
             }
+            if (rowGroupsWithTrivialFilter > 0) {
+                logger.debug(
+                    "Trivially-passes guard skipped late-materialization for [{}] row groups in [{}]",
+                    rowGroupsWithTrivialFilter,
+                    fileLocation
+                );
+            }
             return false;
         }
         rowGroupOrdinal = nextOrdinal;
         pageBatchIndexInRowGroup = 0;
 
         BlockMetaData block = reader.getRowGroups().get(rowGroupOrdinal);
+        // Per-row-group trivially-passes check: when stats prove every row matches the filter,
+        // the late-materialization machinery (decode predicate columns → evaluate filter → compact
+        // survivors) is pure overhead. Switching to the standard path eliminates filter evaluation.
+        currentRowGroupTriviallyPasses = lateMaterialization
+            && cachedFilterPredicate != null
+            && TriviallyPassesChecker.check(cachedFilterPredicate, block);
+        if (currentRowGroupTriviallyPasses) {
+            rowGroupsWithTrivialFilter++;
+        }
         NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = takePendingPrefetch(rowGroupOrdinal);
         try {
             RowRanges currentRowRanges = resolveCurrentRowRanges(block);
             // When late materialization is active, skip ColumnIndex page filtering — late-mat handles
             // row-level filtering itself via the survivor mask. Applying both ColumnIndex RowRanges
             // AND late-mat evaluation causes double-filtering that drops rows incorrectly.
+            // The trivially-passes case is handled the same way: we already know all rows match,
+            // so leaving page filtering off is consistent and safe (RowRanges would be all() anyway).
             RowRanges buildRowRanges = lateMaterialization ? null : currentRowRanges;
             rowGroup = PrefetchedRowGroupBuilder.build(
                 block,
@@ -551,12 +616,13 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         }
         int rowsToRead = (int) Math.min(effectiveBatch, rowsRemainingInGroup);
 
-        Page result = lateMaterialization ? nextWithLateMaterialization(rowsToRead) : nextStandard(rowsToRead);
+        boolean useLateMaterialization = lateMaterialization && currentRowGroupTriviallyPasses == false;
+        Page result = useLateMaterialization ? nextWithLateMaterialization(rowsToRead) : nextStandard(rowsToRead);
 
         pageBatchIndexInRowGroup++;
         rowsRemainingInGroup -= rowsToRead;
         if (rowBudget != FormatReader.NO_LIMIT) {
-            rowBudget -= lateMaterialization ? result.getPositionCount() : rowsToRead;
+            rowBudget -= useLateMaterialization ? result.getPositionCount() : rowsToRead;
         }
         return result;
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -120,11 +120,17 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final boolean[] isPredicateColumn;
     private final ParquetPushedExpressions pushedExpressions;
     /**
-     * Cached parquet-mr {@link FilterPredicate} translated from {@link #pushedExpressions} once at
-     * construction. Reused per row group by the trivially-passes check so we don't re-translate
-     * the predicate tree for every row group.
+     * The parquet-mr {@link FilterPredicate} resolved by {@code ParquetFormatReader} for this scan,
+     * passed through unchanged so the trivially-passes check sees the same predicate that drove
+     * row-group pruning and ColumnIndex {@link RowRanges} computation. Translating again here
+     * would be wasted work and could subtly diverge if the caller's schema differs from
+     * {@link #projectedSchema}.
+     *
+     * <p>{@code null} when the trivially-passes guard is inactive: late materialization is off,
+     * the reader did not resolve a file-level predicate, or predicate resolution failed earlier
+     * (in which case the reader logged a warning and passed {@code null} through).
      */
-    private final FilterPredicate cachedFilterPredicate;
+    private final FilterPredicate triviallyPassesPredicate;
     private final WordMask survivorMask;
     private long rowsEliminatedByLateMaterialization;
     /**
@@ -151,7 +157,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         RowRanges[] allRowRanges,
         boolean[] survivingRowGroups,
         CompressionCodecFactory codecFactory,
-        ParquetPushedExpressions pushedExpressions
+        ParquetPushedExpressions pushedExpressions,
+        FilterPredicate triviallyPassesPredicate
     ) {
         this.reader = reader;
         this.projectedSchema = projectedSchema;
@@ -173,9 +180,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.isPredicateColumn = classifyPredicateColumns(attributes, columnInfos, pushedExpressions);
         this.lateMaterialization = pushedExpressions != null && hasProjectionOnlyColumns(isPredicateColumn, columnInfos);
         this.survivorMask = lateMaterialization ? new WordMask() : null;
-        this.cachedFilterPredicate = lateMaterialization
-            ? translateFilterPredicate(pushedExpressions, projectedSchema, fileLocation)
-            : null;
+        // Caller supplies null when late materialization is off; defensively also drop it here so
+        // the trivially-passes check is gated by a single condition below.
+        this.triviallyPassesPredicate = lateMaterialization ? triviallyPassesPredicate : null;
 
         this.projectedColumnPaths = buildProjectedColumnPaths(columnInfos);
         this.prefetchDepth = computePrefetchDepth(reader.getRowGroups(), this.projectedColumnPaths);
@@ -316,28 +323,6 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         return false;
     }
 
-    /**
-     * Translates the pushed expressions to a parquet-mr {@link FilterPredicate} once for the
-     * lifetime of this iterator. Returns {@code null} when translation fails or yields no
-     * predicate; the iterator gracefully degrades to non-trivial late-materialization in that
-     * case.
-     */
-    private static FilterPredicate translateFilterPredicate(
-        ParquetPushedExpressions pushed,
-        MessageType projectedSchema,
-        String fileLocation
-    ) {
-        if (pushed == null) {
-            return null;
-        }
-        try {
-            return pushed.toFilterPredicate(projectedSchema);
-        } catch (RuntimeException e) {
-            logger.debug("Disabling trivially-passes guard for [{}]: predicate translation failed: {}", fileLocation, e.getMessage());
-            return null;
-        }
-    }
-
     @Override
     public boolean hasNext() {
         if (exhausted) {
@@ -396,9 +381,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         // Per-row-group trivially-passes check: when stats prove every row matches the filter,
         // the late-materialization machinery (decode predicate columns → evaluate filter → compact
         // survivors) is pure overhead. Switching to the standard path eliminates filter evaluation.
-        currentRowGroupTriviallyPasses = lateMaterialization
-            && cachedFilterPredicate != null
-            && TriviallyPassesChecker.check(cachedFilterPredicate, block);
+        currentRowGroupTriviallyPasses = triviallyPassesPredicate != null && TriviallyPassesChecker.check(triviallyPassesPredicate, block);
         if (currentRowGroupTriviallyPasses) {
             rowGroupsWithTrivialFilter++;
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -813,6 +813,12 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             }
         }
 
+        // Reuse the FilterPredicate already resolved at the file level so the trivially-passes
+        // guard sees the same predicate that drove row-group pruning and column-index RowRanges.
+        // Only pass it through when late materialization is actually active; otherwise the
+        // iterator has no use for it.
+        FilterPredicate triviallyPassesPredicate = effectivePushed != null ? filterPredicate : null;
+
         return new OptimizedParquetColumnIterator(
             reader,
             projectedSchema,
@@ -828,7 +834,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             allRowRanges,
             survivingRowGroups,
             codecFactory,
-            effectivePushed
+            effectivePushed,
+            triviallyPassesPredicate
         );
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/TriviallyPassesChecker.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/TriviallyPassesChecker.java
@@ -77,16 +77,30 @@ final class TriviallyPassesChecker {
         }
 
         /**
-         * Returns the statistics for the column when they are usable for trivial-pass reasoning:
-         * non-null, non-empty, with min/max present and number-of-nulls populated. Returns
-         * {@code null} otherwise.
+         * Returns column statistics suitable for reasoning about a comparison whose semantics
+         * fail on null rows (Eq, NotEq, Lt, LtEq, Gt, GtEq, In, NotIn with non-null literals).
+         * The result is non-null only when:
+         * <ul>
+         *   <li>the column exists and stats are populated ({@code !isEmpty} and {@code isNumNullsSet}),</li>
+         *   <li>the stats observed at least one non-null value ({@code hasNonNullValue}),</li>
+         *   <li>the column has no nulls ({@code getNumNulls() == 0}) — a single null row would make
+         *       the predicate return false for that row, breaking the trivial-pass guarantee.</li>
+         * </ul>
+         * The single rawtype suppression here keeps the per-{@code visit} methods clean: callers
+         * use the returned reference to invoke {@link Statistics#compareMinToValue}/{@code compareMaxToValue}
+         * with the operator's typed value.
          */
-        private static Statistics<?> usableStats(ColumnChunkMetaData col) {
-            if (col == null) {
+        @SuppressWarnings("rawtypes")
+        private Statistics nonNullableStats(Operators.Column<?> col) {
+            ColumnChunkMetaData chunk = column(col);
+            if (chunk == null) {
                 return null;
             }
-            Statistics<?> stats = col.getStatistics();
+            Statistics<?> stats = chunk.getStatistics();
             if (stats == null || stats.isEmpty() || stats.isNumNullsSet() == false) {
+                return null;
+            }
+            if (stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
                 return null;
             }
             return stats;
@@ -98,13 +112,13 @@ final class TriviallyPassesChecker {
         @SuppressWarnings({ "unchecked", "rawtypes" })
         public <T extends Comparable<T>> Boolean visit(Operators.Eq<T> eq) {
             T value = eq.getValue();
-            ColumnChunkMetaData col = column(eq.getColumn());
-            Statistics stats = usableStats(col);
             if (value == null) {
                 // Eq(col, null) == IsNull(col): trivially passes iff every row is null.
-                return col != null && col.getValueCount() == numNulls(col);
+                ColumnChunkMetaData chunk = column(eq.getColumn());
+                return chunk != null && chunk.getValueCount() == numNulls(chunk);
             }
-            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+            Statistics stats = nonNullableStats(eq.getColumn());
+            if (stats == null) {
                 return false;
             }
             // min == max == value
@@ -115,14 +129,15 @@ final class TriviallyPassesChecker {
         @SuppressWarnings({ "unchecked", "rawtypes" })
         public <T extends Comparable<T>> Boolean visit(Operators.NotEq<T> notEq) {
             T value = notEq.getValue();
-            ColumnChunkMetaData col = column(notEq.getColumn());
             if (value == null) {
                 // NotEq(col, null) == IsNotNull(col): trivially passes iff no nulls.
-                Statistics<?> stats = usableStats(col);
-                return stats != null && stats.getNumNulls() == 0;
+                // Intentionally goes through nonNullableStats (which also requires hasNonNullValue)
+                // so this branch is consistent with the comparison branches: stats with numNulls == 0
+                // but no observed non-null value are too weak to prove "every row is non-null".
+                return nonNullableStats(notEq.getColumn()) != null;
             }
-            Statistics stats = usableStats(col);
-            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+            Statistics stats = nonNullableStats(notEq.getColumn());
+            if (stats == null) {
                 return false;
             }
             // value is strictly outside [min, max]
@@ -132,42 +147,30 @@ final class TriviallyPassesChecker {
         @Override
         @SuppressWarnings({ "unchecked", "rawtypes" })
         public <T extends Comparable<T>> Boolean visit(Operators.Lt<T> lt) {
-            Statistics stats = usableStats(column(lt.getColumn()));
-            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
-                return false;
-            }
+            Statistics stats = nonNullableStats(lt.getColumn());
             // max < value
-            return stats.compareMaxToValue(lt.getValue()) < 0;
+            return stats != null && stats.compareMaxToValue(lt.getValue()) < 0;
         }
 
         @Override
         @SuppressWarnings({ "unchecked", "rawtypes" })
         public <T extends Comparable<T>> Boolean visit(Operators.LtEq<T> ltEq) {
-            Statistics stats = usableStats(column(ltEq.getColumn()));
-            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
-                return false;
-            }
-            return stats.compareMaxToValue(ltEq.getValue()) <= 0;
+            Statistics stats = nonNullableStats(ltEq.getColumn());
+            return stats != null && stats.compareMaxToValue(ltEq.getValue()) <= 0;
         }
 
         @Override
         @SuppressWarnings({ "unchecked", "rawtypes" })
         public <T extends Comparable<T>> Boolean visit(Operators.Gt<T> gt) {
-            Statistics stats = usableStats(column(gt.getColumn()));
-            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
-                return false;
-            }
-            return stats.compareMinToValue(gt.getValue()) > 0;
+            Statistics stats = nonNullableStats(gt.getColumn());
+            return stats != null && stats.compareMinToValue(gt.getValue()) > 0;
         }
 
         @Override
         @SuppressWarnings({ "unchecked", "rawtypes" })
         public <T extends Comparable<T>> Boolean visit(Operators.GtEq<T> gtEq) {
-            Statistics stats = usableStats(column(gtEq.getColumn()));
-            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
-                return false;
-            }
-            return stats.compareMinToValue(gtEq.getValue()) >= 0;
+            Statistics stats = nonNullableStats(gtEq.getColumn());
+            return stats != null && stats.compareMinToValue(gtEq.getValue()) >= 0;
         }
 
         @Override
@@ -179,9 +182,8 @@ final class TriviallyPassesChecker {
             }
             // In(col, set) where the set already includes null is treated like
             // Eq(col, null) || In(col, set\{null}) — handled conservatively here.
-            ColumnChunkMetaData col = column(in.getColumn());
-            Statistics stats = usableStats(col);
-            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+            Statistics stats = nonNullableStats(in.getColumn());
+            if (stats == null) {
                 return false;
             }
             // Conservative: trivially passes only if the column has a single distinct value
@@ -206,9 +208,8 @@ final class TriviallyPassesChecker {
                 // NotIn(col, {}) is trivially true; but parquet-mr doesn't generate this.
                 return false;
             }
-            ColumnChunkMetaData col = column(notIn.getColumn());
-            Statistics stats = usableStats(col);
-            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+            Statistics stats = nonNullableStats(notIn.getColumn());
+            if (stats == null) {
                 return false;
             }
             // Trivially passes when every set value is strictly outside [min, max]: no value in

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/TriviallyPassesChecker.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/TriviallyPassesChecker.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.filter2.predicate.Operators;
+import org.apache.parquet.filter2.predicate.UserDefinedPredicate;
+import org.apache.parquet.filter2.statisticslevel.StatisticsFilter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Determines whether a row group's statistics guarantee that ALL rows satisfy a
+ * {@link FilterPredicate}. This is the logical complement of parquet-mr's
+ * {@link StatisticsFilter}, which proves that NO rows match (so the row group can be skipped).
+ *
+ * <p>When this check returns {@code true} for a row group, the iterator can route that row
+ * group through the standard read path: filter evaluation, survivor mask construction, and
+ * compaction are all skipped. Decoding of predicate columns themselves is unchanged when those
+ * columns are also part of the projection (the common case in this iterator).
+ *
+ * <p><b>Correctness invariants:</b>
+ * <ul>
+ *   <li>The check is conservative: any uncertainty (missing stats, unknown predicate forms,
+ *       null counts that could affect the predicate) yields {@code false}.</li>
+ *   <li>For comparison predicates the column must have NO nulls — a single null row would make
+ *       the predicate return {@code false} for that row, so the filter cannot trivially pass.</li>
+ *   <li>Row groups for which {@link Statistics#hasNonNullValue()} is {@code false} or
+ *       {@link Statistics#isEmpty()} is {@code true} cannot be reasoned about.</li>
+ * </ul>
+ */
+final class TriviallyPassesChecker {
+
+    private TriviallyPassesChecker() {}
+
+    /**
+     * Returns {@code true} when row-group statistics prove every row satisfies {@code predicate}.
+     *
+     * @param predicate     the filter predicate (must be non-null)
+     * @param rowGroup      the row group whose statistics are consulted
+     * @return {@code true} if every row in the row group is guaranteed to pass the filter
+     */
+    static boolean check(FilterPredicate predicate, BlockMetaData rowGroup) {
+        if (predicate == null || rowGroup == null) {
+            return false;
+        }
+        return predicate.accept(new Visitor(rowGroup));
+    }
+
+    private static final class Visitor implements FilterPredicate.Visitor<Boolean> {
+
+        private final BlockMetaData rowGroup;
+        private final Map<ColumnPath, ColumnChunkMetaData> columns;
+
+        Visitor(BlockMetaData rowGroup) {
+            this.rowGroup = rowGroup;
+            this.columns = new HashMap<>();
+            for (ColumnChunkMetaData c : rowGroup.getColumns()) {
+                columns.put(c.getPath(), c);
+            }
+        }
+
+        private ColumnChunkMetaData column(Operators.Column<?> col) {
+            return columns.get(col.getColumnPath());
+        }
+
+        /**
+         * Returns the statistics for the column when they are usable for trivial-pass reasoning:
+         * non-null, non-empty, with min/max present and number-of-nulls populated. Returns
+         * {@code null} otherwise.
+         */
+        private static Statistics<?> usableStats(ColumnChunkMetaData col) {
+            if (col == null) {
+                return null;
+            }
+            Statistics<?> stats = col.getStatistics();
+            if (stats == null || stats.isEmpty() || stats.isNumNullsSet() == false) {
+                return null;
+            }
+            return stats;
+        }
+
+        // ---------- comparison predicates ----------
+
+        @Override
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public <T extends Comparable<T>> Boolean visit(Operators.Eq<T> eq) {
+            T value = eq.getValue();
+            ColumnChunkMetaData col = column(eq.getColumn());
+            Statistics stats = usableStats(col);
+            if (value == null) {
+                // Eq(col, null) == IsNull(col): trivially passes iff every row is null.
+                return col != null && col.getValueCount() == numNulls(col);
+            }
+            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+                return false;
+            }
+            // min == max == value
+            return stats.compareMinToValue(value) == 0 && stats.compareMaxToValue(value) == 0;
+        }
+
+        @Override
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public <T extends Comparable<T>> Boolean visit(Operators.NotEq<T> notEq) {
+            T value = notEq.getValue();
+            ColumnChunkMetaData col = column(notEq.getColumn());
+            if (value == null) {
+                // NotEq(col, null) == IsNotNull(col): trivially passes iff no nulls.
+                Statistics<?> stats = usableStats(col);
+                return stats != null && stats.getNumNulls() == 0;
+            }
+            Statistics stats = usableStats(col);
+            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+                return false;
+            }
+            // value is strictly outside [min, max]
+            return stats.compareMinToValue(value) > 0 || stats.compareMaxToValue(value) < 0;
+        }
+
+        @Override
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public <T extends Comparable<T>> Boolean visit(Operators.Lt<T> lt) {
+            Statistics stats = usableStats(column(lt.getColumn()));
+            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+                return false;
+            }
+            // max < value
+            return stats.compareMaxToValue(lt.getValue()) < 0;
+        }
+
+        @Override
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public <T extends Comparable<T>> Boolean visit(Operators.LtEq<T> ltEq) {
+            Statistics stats = usableStats(column(ltEq.getColumn()));
+            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+                return false;
+            }
+            return stats.compareMaxToValue(ltEq.getValue()) <= 0;
+        }
+
+        @Override
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public <T extends Comparable<T>> Boolean visit(Operators.Gt<T> gt) {
+            Statistics stats = usableStats(column(gt.getColumn()));
+            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+                return false;
+            }
+            return stats.compareMinToValue(gt.getValue()) > 0;
+        }
+
+        @Override
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public <T extends Comparable<T>> Boolean visit(Operators.GtEq<T> gtEq) {
+            Statistics stats = usableStats(column(gtEq.getColumn()));
+            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+                return false;
+            }
+            return stats.compareMinToValue(gtEq.getValue()) >= 0;
+        }
+
+        @Override
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public <T extends Comparable<T>> Boolean visit(Operators.In<T> in) {
+            Set<T> values = in.getValues();
+            if (values == null || values.isEmpty()) {
+                return false;
+            }
+            // In(col, set) where the set already includes null is treated like
+            // Eq(col, null) || In(col, set\{null}) — handled conservatively here.
+            ColumnChunkMetaData col = column(in.getColumn());
+            Statistics stats = usableStats(col);
+            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+                return false;
+            }
+            // Conservative: trivially passes only if the column has a single distinct value
+            // (min == max) and that value is in the set. Stronger conditions exist in theory
+            // but are rare in practice and add complexity.
+            for (T candidate : values) {
+                if (candidate == null) {
+                    continue;
+                }
+                if (stats.compareMinToValue(candidate) == 0 && stats.compareMaxToValue(candidate) == 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public <T extends Comparable<T>> Boolean visit(Operators.NotIn<T> notIn) {
+            Set<T> values = notIn.getValues();
+            if (values == null || values.isEmpty()) {
+                // NotIn(col, {}) is trivially true; but parquet-mr doesn't generate this.
+                return false;
+            }
+            ColumnChunkMetaData col = column(notIn.getColumn());
+            Statistics stats = usableStats(col);
+            if (stats == null || stats.hasNonNullValue() == false || stats.getNumNulls() > 0) {
+                return false;
+            }
+            // Trivially passes when every set value is strictly outside [min, max]: no value in
+            // the column can equal any value in the set.
+            for (T candidate : values) {
+                if (candidate == null) {
+                    return false;
+                }
+                if (stats.compareMinToValue(candidate) <= 0 && stats.compareMaxToValue(candidate) >= 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public <T extends Comparable<T>> Boolean visit(Operators.Contains<T> contains) {
+            // Contains is for repeated columns; we don't reason about it.
+            return false;
+        }
+
+        // ---------- logical predicates ----------
+
+        @Override
+        public Boolean visit(Operators.And and) {
+            return and.getLeft().accept(this) && and.getRight().accept(this);
+        }
+
+        @Override
+        public Boolean visit(Operators.Or or) {
+            return or.getLeft().accept(this) || or.getRight().accept(this);
+        }
+
+        @Override
+        public Boolean visit(Operators.Not not) {
+            // Not(p) trivially passes iff p is provably empty for this row group — i.e., no row
+            // matches p. Delegate to parquet-mr's StatisticsFilter for that direction so the
+            // inversion is consistent with row-group pruning.
+            //
+            // parquet-mr's StatisticsFilter rejects nested Not nodes (its visit(Not) throws
+            // IllegalArgumentException recommending LogicalInverseRewriter). Any other RuntimeException
+            // thrown by parquet on malformed input is also degraded to "no optimization" so a
+            // best-effort guard never breaks an otherwise-valid scan.
+            FilterPredicate inner = not.getPredicate();
+            List<ColumnChunkMetaData> cols = rowGroup.getColumns();
+            try {
+                return StatisticsFilter.canDrop(inner, cols);
+            } catch (RuntimeException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public <T extends Comparable<T>, U extends UserDefinedPredicate<T>> Boolean visit(Operators.UserDefined<T, U> ud) {
+            return false;
+        }
+
+        @Override
+        public <T extends Comparable<T>, U extends UserDefinedPredicate<T>> Boolean visit(Operators.LogicalNotUserDefined<T, U> ud) {
+            return false;
+        }
+
+        // ---------- helpers ----------
+
+        private static long numNulls(ColumnChunkMetaData col) {
+            Statistics<?> stats = col.getStatistics();
+            return stats != null && stats.isNumNullsSet() ? stats.getNumNulls() : -1L;
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedFilteredReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedFilteredReaderTests.java
@@ -315,6 +315,48 @@ public class OptimizedFilteredReaderTests extends ESTestCase {
     }
 
     /**
+     * Trivially-passes guard: a multi-column projection with a filter that the row-group stats
+     * prove every row satisfies. The optimized reader should bypass late-materialization filter
+     * evaluation entirely for every row group and still produce results identical to the
+     * baseline. Exercises the {@link TriviallyPassesChecker} integration.
+     */
+    public void testPushedExpressionsTriviallyPassingFilterParity() throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(INT32)
+            .named("id")
+            .required(BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("name")
+            .named("trivial_pass_test");
+
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < TOTAL_ROWS; i++) {
+                groups.add(factory.newGroup().append("id", i).append("name", "row_" + i));
+            }
+            return groups;
+        });
+
+        // id ranges [0, TOTAL_ROWS): the filter `id >= 0 AND id < TOTAL_ROWS` is trivially
+        // satisfied by every row group's stats. With `name` also in the projection (a non-predicate
+        // column), late materialization is enabled; the trivially-passes guard should kick in and
+        // bypass per-row filter evaluation.
+        FilterPredicate filterCompat = FilterApi.and(
+            FilterApi.gtEq(FilterApi.intColumn("id"), 0),
+            FilterApi.lt(FilterApi.intColumn("id"), TOTAL_ROWS)
+        );
+        Expression esqlFilter = new org.elasticsearch.xpack.esql.expression.predicate.logical.And(
+            Source.EMPTY,
+            new GreaterThanOrEqual(Source.EMPTY, intAttr("id"), intLit(0), null),
+            new LessThan(Source.EMPTY, intAttr("id"), intLit(TOTAL_ROWS), null)
+        );
+
+        List<Page> baselinePages = readWithFilter(parquetData, filterCompat, false);
+        List<Page> pushedPages = readWithPushedExpressions(parquetData, esqlFilter);
+        assertPagesEqual(baselinePages, pushedPages);
+    }
+
+    /**
      * NOT(Eq) via PushedExpressions: verifies the RowRanges path returns all rows that
      * the baseline returns — i.e. NOT does not drop rows from mixed pages.
      */

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TriviallyPassesCheckerTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TriviallyPassesCheckerTests.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.statistics.IntStatistics;
+import org.apache.parquet.column.statistics.LongStatistics;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.filter2.predicate.FilterApi;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Unit tests for {@link TriviallyPassesChecker}. These tests construct {@link BlockMetaData}
+ * directly with synthetic {@link Statistics} so that each predicate / stats combination can be
+ * exercised in isolation without writing real Parquet files.
+ */
+public class TriviallyPassesCheckerTests extends ESTestCase {
+
+    private static final String COL = "id";
+
+    // ----- Eq -----
+
+    public void testEqTriviallyPassesWhenMinEqualsMaxEqualsValue() {
+        BlockMetaData block = blockWithIntStats(5, 5, 0L, 100L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.eq(FilterApi.intColumn(COL), 5), block));
+    }
+
+    public void testEqDoesNotTriviallyPassWhenRangeStraddlesValue() {
+        BlockMetaData block = blockWithIntStats(3, 7, 0L, 100L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.eq(FilterApi.intColumn(COL), 5), block));
+    }
+
+    public void testEqDoesNotTriviallyPassWhenColumnHasNulls() {
+        BlockMetaData block = blockWithIntStats(5, 5, 1L, 100L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.eq(FilterApi.intColumn(COL), 5), block));
+    }
+
+    public void testEqWithNullLiteralTriviallyPassesWhenAllRowsNull() {
+        BlockMetaData block = blockWithAllNullIntStats(50L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.eq(FilterApi.intColumn(COL), null), block));
+    }
+
+    public void testEqWithNullLiteralDoesNotTriviallyPassWhenSomeRowsNonNull() {
+        BlockMetaData block = blockWithIntStats(1, 1, 5L, 50L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.eq(FilterApi.intColumn(COL), null), block));
+    }
+
+    // ----- NotEq -----
+
+    public void testNotEqTriviallyPassesWhenValueAboveMax() {
+        BlockMetaData block = blockWithIntStats(1, 5, 0L, 100L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.notEq(FilterApi.intColumn(COL), 6), block));
+    }
+
+    public void testNotEqTriviallyPassesWhenValueBelowMin() {
+        BlockMetaData block = blockWithIntStats(10, 20, 0L, 100L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.notEq(FilterApi.intColumn(COL), 9), block));
+    }
+
+    public void testNotEqDoesNotTriviallyPassWhenValueWithinRange() {
+        BlockMetaData block = blockWithIntStats(1, 10, 0L, 100L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.notEq(FilterApi.intColumn(COL), 5), block));
+    }
+
+    public void testNotEqDoesNotTriviallyPassWhenColumnHasNulls() {
+        BlockMetaData block = blockWithIntStats(1, 5, 1L, 100L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.notEq(FilterApi.intColumn(COL), 100), block));
+    }
+
+    public void testNotEqWithNullLiteralTriviallyPassesWhenNoNulls() {
+        BlockMetaData block = blockWithIntStats(1, 5, 0L, 100L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.notEq(FilterApi.intColumn(COL), null), block));
+    }
+
+    public void testNotEqWithNullLiteralDoesNotTriviallyPassWhenAnyNulls() {
+        BlockMetaData block = blockWithIntStats(1, 5, 1L, 100L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.notEq(FilterApi.intColumn(COL), null), block));
+    }
+
+    // ----- Lt / LtEq / Gt / GtEq -----
+
+    public void testLtTriviallyPasses() {
+        BlockMetaData block = blockWithIntStats(0, 9, 0L, 100L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.lt(FilterApi.intColumn(COL), 10), block));
+    }
+
+    public void testLtBoundaryDoesNotTriviallyPass() {
+        // max == value, so Lt fails for max
+        BlockMetaData block = blockWithIntStats(0, 10, 0L, 100L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.lt(FilterApi.intColumn(COL), 10), block));
+    }
+
+    public void testLtEqTriviallyPassesAtBoundary() {
+        BlockMetaData block = blockWithIntStats(0, 10, 0L, 100L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.ltEq(FilterApi.intColumn(COL), 10), block));
+    }
+
+    public void testGtEqTriviallyPasses() {
+        BlockMetaData block = blockWithIntStats(15, 20, 0L, 100L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.gtEq(FilterApi.intColumn(COL), 10), block));
+    }
+
+    public void testGtEqDoesNotTriviallyPassWhenStatsStraddleThreshold() {
+        BlockMetaData block = blockWithIntStats(5, 20, 0L, 100L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.gtEq(FilterApi.intColumn(COL), 10), block));
+    }
+
+    public void testGtTriviallyPassesAtBoundary() {
+        // min == 11, value == 10, so min > 10 holds for every row
+        BlockMetaData block = blockWithIntStats(11, 20, 0L, 100L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.gt(FilterApi.intColumn(COL), 10), block));
+    }
+
+    public void testGtEqualBoundaryDoesNotTriviallyPass() {
+        BlockMetaData block = blockWithIntStats(10, 20, 0L, 100L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.gt(FilterApi.intColumn(COL), 10), block));
+    }
+
+    public void testRangePredicateAndTriviallyPasses() {
+        // x BETWEEN 10 AND 20 (inclusive both ends)
+        FilterPredicate pred = FilterApi.and(FilterApi.gtEq(FilterApi.intColumn(COL), 10), FilterApi.ltEq(FilterApi.intColumn(COL), 20));
+        BlockMetaData block = blockWithIntStats(12, 18, 0L, 100L);
+        assertTrue(TriviallyPassesChecker.check(pred, block));
+    }
+
+    public void testRangePredicateAndDoesNotTriviallyPassWhenOneSideFails() {
+        FilterPredicate pred = FilterApi.and(FilterApi.gtEq(FilterApi.intColumn(COL), 10), FilterApi.ltEq(FilterApi.intColumn(COL), 20));
+        BlockMetaData block = blockWithIntStats(12, 25, 0L, 100L);
+        assertFalse(TriviallyPassesChecker.check(pred, block));
+    }
+
+    // ----- In / NotIn -----
+
+    public void testInWithSingletonValueRangeTriviallyPasses() {
+        // min == max == 5, set contains 5
+        BlockMetaData block = blockWithIntStats(5, 5, 0L, 50L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.in(FilterApi.intColumn(COL), Set.of(5, 10)), block));
+    }
+
+    public void testInWithMultiValueRangeDoesNotTriviallyPass() {
+        BlockMetaData block = blockWithIntStats(5, 7, 0L, 50L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.in(FilterApi.intColumn(COL), Set.of(5, 10)), block));
+    }
+
+    public void testInDoesNotTriviallyPassWhenColumnHasNulls() {
+        BlockMetaData block = blockWithIntStats(5, 5, 1L, 50L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.in(FilterApi.intColumn(COL), Set.of(5, 10)), block));
+    }
+
+    public void testNotInTriviallyPassesWhenSetEntirelyOutsideRange() {
+        BlockMetaData block = blockWithIntStats(50, 60, 0L, 100L);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.notIn(FilterApi.intColumn(COL), Set.of(5, 10)), block));
+    }
+
+    public void testNotInDoesNotTriviallyPassWhenSetIntersectsRange() {
+        BlockMetaData block = blockWithIntStats(5, 60, 0L, 100L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.notIn(FilterApi.intColumn(COL), Set.of(50, 70)), block));
+    }
+
+    // ----- Or -----
+
+    public void testOrTriviallyPassesWhenEitherSideTriviallyPasses() {
+        // x == 5 (min=max=5, no nulls) OR x > 100 (min=20, max=30 → false)
+        BlockMetaData block = blockWithIntStats(5, 5, 0L, 50L);
+        FilterPredicate pred = FilterApi.or(FilterApi.eq(FilterApi.intColumn(COL), 5), FilterApi.gt(FilterApi.intColumn(COL), 100));
+        assertTrue(TriviallyPassesChecker.check(pred, block));
+    }
+
+    public void testOrDoesNotTriviallyPassWhenNeitherSideTriviallyPasses() {
+        BlockMetaData block = blockWithIntStats(0, 50, 0L, 100L);
+        FilterPredicate pred = FilterApi.or(FilterApi.eq(FilterApi.intColumn(COL), 5), FilterApi.gt(FilterApi.intColumn(COL), 100));
+        assertFalse(TriviallyPassesChecker.check(pred, block));
+    }
+
+    // ----- Not -----
+
+    public void testNotTriviallyPassesWhenInnerProvablyEmpty() {
+        // Stats: id ∈ [50, 60]. Inner predicate id == 5 cannot match any row → Not trivially passes.
+        BlockMetaData block = blockWithIntStats(50, 60, 0L, 100L);
+        FilterPredicate pred = FilterApi.not(FilterApi.eq(FilterApi.intColumn(COL), 5));
+        assertTrue(TriviallyPassesChecker.check(pred, block));
+    }
+
+    public void testNotDoesNotTriviallyPassWhenInnerCanMatch() {
+        BlockMetaData block = blockWithIntStats(0, 100, 0L, 100L);
+        FilterPredicate pred = FilterApi.not(FilterApi.eq(FilterApi.intColumn(COL), 5));
+        assertFalse(TriviallyPassesChecker.check(pred, block));
+    }
+
+    public void testNestedNotReturnsFalseGracefully() {
+        // parquet-mr's StatisticsFilter throws IllegalArgumentException on nested Not (asks
+        // for LogicalInverseRewriter). The checker must degrade to false, not throw.
+        BlockMetaData block = blockWithIntStats(50, 60, 0L, 100L);
+        FilterPredicate inner = FilterApi.not(FilterApi.eq(FilterApi.intColumn(COL), 5));
+        FilterPredicate nestedNot = FilterApi.not(inner);
+        assertFalse(TriviallyPassesChecker.check(nestedNot, block));
+    }
+
+    // ----- Stats absent / missing column -----
+
+    public void testReturnsFalseWhenStatsAreEmpty() {
+        IntStatistics stats = new IntStatistics();
+        // do not set min/max → empty
+        BlockMetaData block = blockWithStats(stats, 100L);
+        assertFalse(TriviallyPassesChecker.check(FilterApi.eq(FilterApi.intColumn(COL), 5), block));
+    }
+
+    public void testReturnsFalseWhenColumnMissingFromBlock() {
+        BlockMetaData block = blockWithIntStats(5, 5, 0L, 100L);
+        FilterPredicate predOnOtherCol = FilterApi.eq(FilterApi.intColumn("other"), 5);
+        assertFalse(TriviallyPassesChecker.check(predOnOtherCol, block));
+    }
+
+    public void testNullsArguments() {
+        BlockMetaData block = blockWithIntStats(5, 5, 0L, 100L);
+        assertFalse(TriviallyPassesChecker.check(null, block));
+        assertFalse(TriviallyPassesChecker.check(FilterApi.eq(FilterApi.intColumn(COL), 5), null));
+    }
+
+    // ----- Long type smoke test -----
+
+    public void testLongComparisonTriviallyPasses() {
+        LongStatistics stats = new LongStatistics();
+        stats.setMinMax(100L, 200L);
+        stats.setNumNulls(0L);
+        PrimitiveType type = Types.required(PrimitiveType.PrimitiveTypeName.INT64).named(COL);
+        ColumnChunkMetaData ccm = ColumnChunkMetaData.get(
+            ColumnPath.get(COL),
+            type,
+            CompressionCodecName.UNCOMPRESSED,
+            null,
+            EnumSet.of(Encoding.PLAIN),
+            stats,
+            0L,
+            0L,
+            500L,
+            0L,
+            0L
+        );
+        BlockMetaData block = new BlockMetaData();
+        block.setRowCount(500L);
+        block.addColumn(ccm);
+        assertTrue(TriviallyPassesChecker.check(FilterApi.gtEq(FilterApi.longColumn(COL), 50L), block));
+        assertFalse(TriviallyPassesChecker.check(FilterApi.gtEq(FilterApi.longColumn(COL), 150L), block));
+    }
+
+    // ----- helpers -----
+
+    private static BlockMetaData blockWithIntStats(int min, int max, long numNulls, long valueCount) {
+        IntStatistics stats = new IntStatistics();
+        stats.setMinMax(min, max);
+        stats.setNumNulls(numNulls);
+        return blockWithStats(stats, valueCount);
+    }
+
+    private static BlockMetaData blockWithAllNullIntStats(long valueCount) {
+        IntStatistics stats = new IntStatistics();
+        // no setMinMax: column is all-null, no observed values
+        stats.setNumNulls(valueCount);
+        return blockWithStats(stats, valueCount);
+    }
+
+    private static BlockMetaData blockWithStats(Statistics<?> stats, long valueCount) {
+        PrimitiveType type = Types.required(stats.type().getPrimitiveTypeName()).named(COL);
+        ColumnChunkMetaData ccm = ColumnChunkMetaData.get(
+            ColumnPath.get(COL),
+            type,
+            CompressionCodecName.UNCOMPRESSED,
+            null,
+            EnumSet.of(Encoding.PLAIN),
+            stats,
+            0L,
+            0L,
+            valueCount,
+            0L,
+            0L
+        );
+        BlockMetaData block = new BlockMetaData();
+        block.setRowCount(valueCount);
+        block.addColumn(ccm);
+        return block;
+    }
+}


### PR DESCRIPTION
Late materialization decodes predicate columns, evaluates the filter
to build a survivor mask, then decodes projection columns selectively.
When row group statistics guarantee that every row satisfies the filter,
this work is pure overhead.

Add a per-row-group trivially-passes guard: it inverts the logic of the
existing row-group pruning (which proves no rows match) to prove all
rows match. When it fires, the iterator switches to the standard read
path for that row group, skipping per-row filter evaluation and
survivor compaction. The check is conservative: any uncertainty in
the stats yields false, so a missed optimization is the worst case.

Developed with AI-assisted tooling