### PR TITLE
Renamed doc values MultiValue options to TRUE|FALSE|PRESERVE_ORDER

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -106,12 +106,6 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "match_only_text";
 
-    private static final FieldMapper.DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new FieldMapper.DocValuesParameter.Values(
-        false,
-        FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
-        FieldMapper.DocValuesParameter.Values.MultiValue.ARRAYS
-    );
-
     public static class Defaults {
         public static final FieldType FIELD_TYPE;
 
@@ -130,10 +124,13 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
     public static class Builder extends TextFamilyBuilder {
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
-        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.arraysWithCardinality(
-            DEFAULT_DOC_VALUES_PARAMS,
+        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.builder(
             m -> ((MatchOnlyTextFieldMapper) m).docValuesParameters
-        );
+        )
+            .enabled(false)  // doc_values are disabled on match only text fields by default
+            .multiValue(FieldMapper.DocValuesParameter.Values.MultiValue.TRUE)
+            .cardinality(FieldMapper.DocValuesParameter.Values.Cardinality.HIGH)
+            .build();
 
         private final TextParams.Analyzers analyzers;
         private final boolean storedFieldInBinaryFormat;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -89,19 +89,12 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         return (ScaledFloatFieldMapper) in;
     }
 
-    public static final FieldMapper.DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new FieldMapper.DocValuesParameter.Values(
-        true,
-        FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-        FieldMapper.DocValuesParameter.Values.MultiValue.SORTED
-    );
-
     public static class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> indexed;
-        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.sorted(
-            DEFAULT_DOC_VALUES_PARAMS,
+        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.builder(
             m -> toType(m).docValuesParameters()
-        );
+        ).enabled(true).multiValue(FieldMapper.DocValuesParameter.Values.MultiValue.TRUE).build();
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
 
         private final Parameter<Explicit<Boolean>> ignoreMalformed;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -44,19 +44,12 @@ public class TokenCountFieldMapper extends FieldMapper {
         return (TokenCountFieldMapper) in;
     }
 
-    public static final FieldMapper.DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new FieldMapper.DocValuesParameter.Values(
-        true,
-        FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-        FieldMapper.DocValuesParameter.Values.MultiValue.SORTED
-    );
-
     public static class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> index = Parameter.indexParam(m -> toType(m).index, true);
-        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.sorted(
-            DEFAULT_DOC_VALUES_PARAMS,
+        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.builder(
             m -> toType(m).docValuesParameters()
-        );
+        ).enabled(true).multiValue(FieldMapper.DocValuesParameter.Values.MultiValue.TRUE).build();
         private final Parameter<Boolean> store = Parameter.storeParam(m -> toType(m).store, false);
 
         private final Parameter<NamedAnalyzer> analyzer = Parameter.analyzerParam("analyzer", true, m -> toType(m).analyzer, () -> null);

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
@@ -818,18 +818,18 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
         }
     }
 
-    public void testSingleValueIsAcceptedWhenMultiValueNo() throws IOException {
+    public void testSingleValueIsAcceptedWhenMultiValueFalse() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "match_only_text").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "match_only_text").startObject("doc_values").field("multi_value", "false").endObject())
         );
         mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(5))));
     }
 
-    public void testSecondValueIsRejectedWhenMultiValueNo() throws IOException {
+    public void testSecondValueIsRejectedWhenMultiValueFalse() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "match_only_text").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "match_only_text").startObject("doc_values").field("multi_value", "false").endObject())
         );
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -837,7 +837,7 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapperTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -122,11 +121,11 @@ public class TokenCountFieldMapperTests extends MapperTestCase {
         assertThat(TokenCountFieldMapper.countPositions(analyzer, "", "", false), equalTo(2));
     }
 
-    public void testMultiValueSorted() throws IOException {
+    public void testMultiValueTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "sorted").endObject();
+            b.startObject("doc_values").field("multi_value", "true").endObject();
         }));
         TokenCountFieldMapper mapper = (TokenCountFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertThat(
@@ -135,45 +134,33 @@ public class TokenCountFieldMapperTests extends MapperTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
     }
 
-    public void testMultiValueSortedSetNotAllowed() throws IOException {
-        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
-        var e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
-            minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "sorted_set").endObject();
-        })));
-        assertThat(
-            e.getMessage(),
-            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, arrays]")
-        );
-    }
-
-    public void testMultiValueDefaultIsSorted() throws IOException {
+    public void testMultiValueDefaultIsTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
         TokenCountFieldMapper mapper = (TokenCountFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED));
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.TRUE));
     }
 
-    public void testMultiValueNoAcceptsSingleValue() throws IOException {
+    public void testMultiValueFalseAcceptsSingleValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(8))));
     }
 
-    public void testMultiValueNoRejectsArray() throws IOException {
+    public void testMultiValueFalseRejectsArray() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         String first = randomAlphanumericOfLength(8);
         String second = randomAlphanumericOfLength(8);
@@ -183,15 +170,15 @@ public class TokenCountFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
-    public void testMultiValueNoUsesNumericDocValues() throws IOException {
+    public void testMultiValueFalseUsesNumericDocValues() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(8))));
         List<IndexableField> fields = doc.rootDoc().getFields("field");
@@ -201,7 +188,7 @@ public class TokenCountFieldMapperTests extends MapperTestCase {
             DocValuesType dvType = f.fieldType().docValuesType();
             if (dvType != DocValuesType.NONE) {
                 hasDocValuesField = true;
-                assertEquals("multi_value=no must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
+                assertEquals("multi_value=false must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
             }
         }
         assertTrue("expected a doc values field for [field]", hasDocValuesField);

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
@@ -58,12 +58,6 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "icu_collation_keyword";
 
-    private static final DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new DocValuesParameter.Values(
-        true,
-        DocValuesParameter.Values.Cardinality.LOW,
-        DocValuesParameter.Values.MultiValue.SORTED_SET
-    );
-
     public static final class CollationFieldType extends StringFieldType {
         private final Collator collator;
         private final String nullValue;
@@ -247,10 +241,11 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
     public static class Builder extends FieldMapper.Builder {
 
         final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
-        final DocValuesParameter docValuesPameters = DocValuesParameter.sortedSetWithCardinality(
-            DEFAULT_DOC_VALUES_PARAMS,
-            m -> toType(m).docValuesParams()
-        );
+        final DocValuesParameter docValuesPameters = DocValuesParameter.builder(m -> toType(m).docValuesParams())
+            .enabled(true)
+            .multiValue(DocValuesParameter.Values.MultiValue.TRUE)
+            .cardinality(DocValuesParameter.Values.Cardinality.LOW)
+            .build();
         final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).fieldType.stored(), false);
 
         final Parameter<String> indexOptions = TextParams.keywordIndexOptions(m -> toType(m).indexOptions);

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
@@ -1,8 +1,8 @@
 ---
-"multi_value=no is enforced per document not per segment":
+"multi_value=false is enforced per document not per segment":
   - requires:
-      cluster_features: ["mapper.doc_values.multi_value"]
-      reason: "multi_value doc values parameter support"
+      cluster_features: ["mapper.doc_values.multi_value_rename"]
+      reason: "multi_value doc values parameter support with renamed options"
 
   - do:
       indices.create:
@@ -15,7 +15,7 @@
               kw:
                 type: keyword
                 doc_values:
-                  multi_value: "no"
+                  multi_value: false
 
   - do:
       index:
@@ -45,10 +45,10 @@
   - match: { hits.total.value: 2 }
 
 ---
-"multi_value=no mapping serialization roundtrip":
+"multi_value=false mapping serialization roundtrip":
   - requires:
-      cluster_features: ["mapper.doc_values.multi_value"]
-      reason: "multi_value doc values parameter support"
+      cluster_features: ["mapper.doc_values.multi_value_rename"]
+      reason: "multi_value doc values parameter support with renamed options"
 
   - do:
       indices.create:
@@ -61,19 +61,99 @@
               kw:
                 type: keyword
                 doc_values:
-                  multi_value: "no"
+                  multi_value: false
 
   - do:
       indices.get_mapping:
         index: test_roundtrip
 
-  - match: { test_roundtrip.mappings.properties.kw.doc_values.multi_value: "no" }
+  - match: { test_roundtrip.mappings.properties.kw.doc_values.multi_value: "false" }
 
 ---
-"multi_value=no on multi-field sub rejects parent array":
+"multi_value=false accepts both boolean and string forms":
   - requires:
-      cluster_features: ["mapper.doc_values.multi_value_enforcement"]
-      reason: "multi_value=no enforcement on indexing"
+      cluster_features: ["mapper.doc_values.multi_value_rename"]
+      reason: "multi_value doc values parameter support with renamed options"
+
+  # Boolean form: multi_value: false
+  - do:
+      indices.create:
+        index: test_boolean_form
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: false
+
+  # String form: multi_value: "false"
+  - do:
+      indices.create:
+        index: test_string_form
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: "false"
+
+  - do:
+      indices.get_mapping:
+        index: test_boolean_form
+
+  - match: { test_boolean_form.mappings.properties.kw.doc_values.multi_value: "false" }
+
+  - do:
+      indices.get_mapping:
+        index: test_string_form
+
+  - match: { test_string_form.mappings.properties.kw.doc_values.multi_value: "false" }
+
+---
+"multi_value=true accepts both boolean and string forms":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value_rename"]
+      reason: "multi_value doc values parameter support with renamed options"
+
+  # Boolean form: multi_value: true
+  - do:
+      indices.create:
+        index: test_true_boolean_form
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: true
+
+  # String form: multi_value: "true"
+  - do:
+      indices.create:
+        index: test_true_string_form
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: "true"
+
+---
+"multi_value=false on multi-field sub rejects parent array":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value_enforcement", "mapper.doc_values.multi_value_rename"]
+      reason: "multi_value=false enforcement on indexing with renamed options"
 
   - do:
       indices.create:
@@ -89,7 +169,7 @@
                   child:
                     type: keyword
                     doc_values:
-                      multi_value: "no"
+                      multi_value: false
 
   # The first value is accepted by both the parent and child fields.
   - do:
@@ -102,7 +182,7 @@
 
   # The second value is rejected by the child field.
   - do:
-      catch: /configured with \[multi_value=no\] but encountered multiple values in the same document/
+      catch: /configured with \[multi_value=false\] but encountered multiple values in the same document/
       index:
         index: test_multifield_sub
         id: "2"
@@ -111,10 +191,10 @@
           parent: ["a", "b"]
 
 ---
-"multi_value=no on multi-field parent rejects parent array":
+"multi_value=false on multi-field parent rejects parent array":
   - requires:
-      cluster_features: ["mapper.doc_values.multi_value_enforcement"]
-      reason: "multi_value=no enforcement on indexing"
+      cluster_features: ["mapper.doc_values.multi_value_enforcement", "mapper.doc_values.multi_value_rename"]
+      reason: "multi_value=false enforcement on indexing with renamed options"
 
   - do:
       indices.create:
@@ -127,14 +207,14 @@
               parent:
                 type: keyword
                 doc_values:
-                  multi_value: "no"
+                  multi_value: false
                 fields:
                   child:
                     type: keyword
 
   # The second value is rejected by the parent field.
   - do:
-      catch: /configured with \[multi_value=no\] but encountered multiple values in the same document/
+      catch: /configured with \[multi_value=false\] but encountered multiple values in the same document/
       index:
         index: test_multifield_parent
         id: "1"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mapping/40_doc_values_multi_value.yml
@@ -1,5 +1,5 @@
 ---
-"multi_value=no is enforced per document not per segment":
+"multi_value=false is enforced per document not per segment":
   - requires:
       cluster_features: ["mapper.doc_values.multi_value"]
       reason: "multi_value doc values parameter support"
@@ -15,7 +15,7 @@
               kw:
                 type: keyword
                 doc_values:
-                  multi_value: "no"
+                  multi_value: false
 
   - do:
       index:
@@ -45,7 +45,7 @@
   - match: { hits.total.value: 2 }
 
 ---
-"multi_value=no mapping serialization roundtrip":
+"multi_value=false mapping serialization roundtrip":
   - requires:
       cluster_features: ["mapper.doc_values.multi_value"]
       reason: "multi_value doc values parameter support"
@@ -61,19 +61,99 @@
               kw:
                 type: keyword
                 doc_values:
-                  multi_value: "no"
+                  multi_value: false
 
   - do:
       indices.get_mapping:
         index: test_roundtrip
 
-  - match: { test_roundtrip.mappings.properties.kw.doc_values.multi_value: "no" }
+  - match: { test_roundtrip.mappings.properties.kw.doc_values.multi_value: "false" }
 
 ---
-"multi_value=no on multi-field sub rejects parent array":
+"multi_value=false accepts both boolean and string forms":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value"]
+      reason: "multi_value doc values parameter support"
+
+  # Boolean form: multi_value: false
+  - do:
+      indices.create:
+        index: test_boolean_form
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: false
+
+  # String form: multi_value: "false"
+  - do:
+      indices.create:
+        index: test_string_form
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: "false"
+
+  - do:
+      indices.get_mapping:
+        index: test_boolean_form
+
+  - match: { test_boolean_form.mappings.properties.kw.doc_values.multi_value: "false" }
+
+  - do:
+      indices.get_mapping:
+        index: test_string_form
+
+  - match: { test_string_form.mappings.properties.kw.doc_values.multi_value: "false" }
+
+---
+"multi_value=true accepts both boolean and string forms":
+  - requires:
+      cluster_features: ["mapper.doc_values.multi_value"]
+      reason: "multi_value doc values parameter support"
+
+  # Boolean form: multi_value: true
+  - do:
+      indices.create:
+        index: test_true_boolean_form
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: true
+
+  # String form: multi_value: "true"
+  - do:
+      indices.create:
+        index: test_true_string_form
+        body:
+          settings:
+            index.mode: logsdb
+          mappings:
+            properties:
+              kw:
+                type: keyword
+                doc_values:
+                  multi_value: "true"
+
+---
+"multi_value=false on multi-field sub rejects parent array":
   - requires:
       cluster_features: ["mapper.doc_values.multi_value_enforcement"]
-      reason: "multi_value=no enforcement on indexing"
+      reason: "multi_value=false enforcement on indexing"
 
   - do:
       indices.create:
@@ -89,7 +169,7 @@
                   child:
                     type: keyword
                     doc_values:
-                      multi_value: "no"
+                      multi_value: false
 
   # The first value is accepted by both the parent and child fields.
   - do:
@@ -102,7 +182,7 @@
 
   # The second value is rejected by the child field.
   - do:
-      catch: /configured with \[multi_value=no\] but encountered multiple values in the same document/
+      catch: /configured with \[multi_value=false\] but encountered multiple values in the same document/
       index:
         index: test_multifield_sub
         id: "2"
@@ -111,10 +191,10 @@
           parent: ["a", "b"]
 
 ---
-"multi_value=no on multi-field parent rejects parent array":
+"multi_value=false on multi-field parent rejects parent array":
   - requires:
       cluster_features: ["mapper.doc_values.multi_value_enforcement"]
-      reason: "multi_value=no enforcement on indexing"
+      reason: "multi_value=false enforcement on indexing"
 
   - do:
       indices.create:
@@ -127,14 +207,14 @@
               parent:
                 type: keyword
                 doc_values:
-                  multi_value: "no"
+                  multi_value: false
                 fields:
                   child:
                     type: keyword
 
   # The second value is rejected by the parent field.
   - do:
-      catch: /configured with \[multi_value=no\] but encountered multiple values in the same document/
+      catch: /configured with \[multi_value=false\] but encountered multiple values in the same document/
       index:
         index: test_multifield_parent
         id: "1"

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -78,18 +78,12 @@ public class BooleanFieldMapper extends FieldMapper {
         return (BooleanFieldMapper) in;
     }
 
-    public static final DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new DocValuesParameter.Values(
-        true,
-        DocValuesParameter.Values.Cardinality.LOW,
-        DocValuesParameter.Values.MultiValue.SORTED
-    );
-
     public static final class Builder extends FieldMapper.DimensionBuilder {
 
-        private final DocValuesParameter docValuesParameters = DocValuesParameter.sorted(
-            DEFAULT_DOC_VALUES_PARAMS,
-            m -> toType(m).docValuesParameters()
-        );
+        private final DocValuesParameter docValuesParameters = DocValuesParameter.builder(m -> toType(m).docValuesParameters())
+            .enabled(true)
+            .multiValue(DocValuesParameter.Values.MultiValue.TRUE)
+            .build();
         private final Parameter<Boolean> indexed;
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
         private final Parameter<Explicit<Boolean>> ignoreMalformed;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -257,19 +257,13 @@ public final class DateFieldMapper extends FieldMapper {
         return (DateFieldMapper) in;
     }
 
-    public static final DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new DocValuesParameter.Values(
-        true,
-        DocValuesParameter.Values.Cardinality.LOW,
-        DocValuesParameter.Values.MultiValue.SORTED
-    );
-
     public static final class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> index = Parameter.indexParam(m -> toType(m).indexed, true);
-        private final DocValuesParameter docValuesParameters = DocValuesParameter.sorted(
-            DEFAULT_DOC_VALUES_PARAMS,
-            m -> toType(m).docValuesParameters()
-        );
+        private final DocValuesParameter docValuesParameters = DocValuesParameter.builder(m -> toType(m).docValuesParameters())
+            .enabled(true)
+            .multiValue(DocValuesParameter.Values.MultiValue.TRUE)
+            .build();
         private final Parameter<Boolean> store = Parameter.storeParam(m -> toType(m).store, false);
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocValuesFieldFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocValuesFieldFactory.java
@@ -20,9 +20,9 @@ import org.elasticsearch.index.mapper.FieldMapper.DocValuesParameter.Values.Mult
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField.ValueOrdering;
 
 /**
- * Centralizes doc values field creation, branching between single-valued (multi_value=no) and multi-valued Lucene types.
+ * Centralizes doc values field creation, branching between single-valued (multi_value=false) and multi-valued Lucene types.
  * <p>
- * For {@link MultiValue#NO}, uses single-valued Lucene types ({@link NumericDocValuesField}, {@link SortedDocValuesField},
+ * For {@link MultiValue#FALSE}, uses single-valued Lucene types ({@link NumericDocValuesField}, {@link SortedDocValuesField},
  * {@link BinaryDocValuesField}) which enforce single-valuedness natively and enable storage optimizations.
  * For other multi-value modes, uses multi-valued types ({@link SortedNumericDocValuesField}, {@link SortedSetDocValuesField},
  * {@link MultiValuedBinaryDocValuesField}).
@@ -48,7 +48,7 @@ public class DocValuesFieldFactory {
     }
 
     /**
-     * Adds a numeric doc values field. For {@code multi_value=no}, creates a {@link NumericDocValuesField} (single-valued).
+     * Adds a numeric doc values field. For {@code multi_value=false}, creates a {@link NumericDocValuesField} (single-valued).
      * Otherwise, creates a {@link SortedNumericDocValuesField} (multi-valued).
      */
     public void addNumericField(LuceneDocument doc, String name, long value) {
@@ -60,7 +60,7 @@ public class DocValuesFieldFactory {
     }
 
     /**
-     * Adds a sorted (bytes) doc values field. For {@code multi_value=no}, creates a {@link SortedDocValuesField} (single-valued).
+     * Adds a sorted (bytes) doc values field. For {@code multi_value=false}, creates a {@link SortedDocValuesField} (single-valued).
      * Otherwise, creates a {@link SortedSetDocValuesField} (multi-valued).
      */
     public void addSortedField(LuceneDocument doc, String name, BytesRef value) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -359,14 +359,14 @@ public abstract class DocumentParserContext {
     }
 
     /**
-     * Enforces that a field configured with {@code multi_value=no} receives at most one value per document. The first call for a given
+     * Enforces that a field configured with {@code multi_value=false} receives at most one value per document. The first call for a given
      * field name succeeds; a subsequent call for the same name throws {@link IllegalArgumentException}. Shared across all child contexts
      * so the constraint is respected regardless of which context sub-tree the duplicate value comes from.
      */
     public final void enforceSingleValue(String fieldName) {
         if (singleValuedFields.add(fieldName) == false) {
             throw new IllegalArgumentException(
-                "Field [" + fieldName + "] is configured with [multi_value=no] but encountered multiple values in the same document"
+                "Field [" + fieldName + "] is configured with [multi_value=false] but encountered multiple values in the same document."
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -282,7 +283,7 @@ public abstract class FieldMapper extends Mapper {
     protected abstract void parseCreateField(DocumentParserContext context) throws IOException;
 
     /**
-     * Whether this mapper enforces single-valued semantics (ie. {@code multi_value=no}). When {@code true}, a second value for the same
+     * Whether this mapper enforces single-valued semantics (ie. {@code multi_value=false}). When {@code true}, a second value for the same
      * document throws. Override on mappers that expose the {@code multi_value} doc values mapping parameter.
      */
     protected boolean isSingleValueEnforced() {
@@ -1486,23 +1487,22 @@ public abstract class FieldMapper extends Mapper {
             /**
              * Controls how multiple values per document are handled in doc values.
              * <p>
-             * {@code NO} restricts the field to a single value per document.
-             * {@code SORTED} stores multiple values sorted per document (numeric types).
-             * {@code SORTED_SET} stores multiple values sorted and deduplicated per document (keyword/IP types).
-             * {@code ARRAYS} allows multiple values, keeps original ordering, and supports null values.
+             * {@code FALSE} restricts the field to a single value per document.
+             * {@code TRUE} stores multiple values per document; ordering and dedup behavior is determined by the field type's underlying
+             * backing doc values field.
+             * {@code PRESERVE_ORDER} stores multiple values, keeps original ordering, and supports nulls.
              */
             public enum MultiValue {
-                NO,
-                SORTED,
-                SORTED_SET,
-                ARRAYS;
+                FALSE,
+                TRUE,
+                PRESERVE_ORDER;
 
                 /**
                  * Whether this mode restricts the field to a single value per document. Callers use this to branch between single-valued
                  * and multi-valued code paths (e.g. Lucene field selection, block loaders, doc-values-fallback queries).
                  */
                 public boolean isSingleValued() {
-                    return this == NO;
+                    return this == FALSE;
                 }
 
                 @Override
@@ -1510,62 +1510,69 @@ public abstract class FieldMapper extends Mapper {
                     return name().toLowerCase(Locale.ROOT);
                 }
             }
-
-            public static Values DISABLED = new Values(false, Cardinality.LOW, MultiValue.SORTED);
         }
 
         public final Optional<Parameter<Values.Cardinality>> cardinalityParameter;
-        public final Parameter<Values.MultiValue> multiValueParameter;
+        public final Optional<Parameter<Values.MultiValue>> multiValueParameter;
 
-        /**
-         * Factory for field types that do not support cardinality. Use for numeric types that use {@code SortedNumericDocValuesField}.
-         */
-        public static DocValuesParameter sorted(Values defaultValue, Function<FieldMapper, Values> initializer) {
-            return new DocValuesParameter(
-                defaultValue,
-                initializer,
-                false,
-                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED, Values.MultiValue.ARRAYS)
-            );
+        public static DefaultBuilder builder(Function<FieldMapper, Values> initializer) {
+            return new DefaultBuilder(initializer);
         }
 
         /**
-         * Factory for field types that do not support cardinality. Use for types that use {@code SortedSetDocValuesField}
-         * (e.g. IP, flattened).
+         * Builder for default values for each option in the doc values config map.
          */
-        public static DocValuesParameter sortedSet(Values defaultValue, Function<FieldMapper, Values> initializer) {
-            return new DocValuesParameter(
-                defaultValue,
-                initializer,
-                false,
-                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED_SET, Values.MultiValue.ARRAYS)
-            );
-        }
+        public static final class DefaultBuilder {
 
-        /**
-         * Factory for field types that support cardinality. Use for keyword fields.
-         */
-        public static DocValuesParameter sortedSetWithCardinality(Values defaultValue, Function<FieldMapper, Values> initializer) {
-            return new DocValuesParameter(
-                defaultValue,
-                initializer,
-                true,
-                EnumSet.of(Values.MultiValue.NO, Values.MultiValue.SORTED_SET, Values.MultiValue.ARRAYS)
-            );
-        }
+            private final Function<FieldMapper, Values> initializer;
+            private Boolean enabledDefault;
+            private Values.MultiValue multiValueDefault;
+            private Values.Cardinality cardinalityDefault;
 
-        /**
-         * Factory for field types that support cardinality. Use for text-family fields (text, match_only_text).
-         */
-        public static DocValuesParameter arraysWithCardinality(Values defaultValue, Function<FieldMapper, Values> initializer) {
-            return new DocValuesParameter(defaultValue, initializer, true, EnumSet.of(Values.MultiValue.NO, Values.MultiValue.ARRAYS));
+            private DefaultBuilder(Function<FieldMapper, Values> initializer) {
+                this.initializer = Objects.requireNonNull(initializer);
+            }
+
+            public DefaultBuilder enabled(boolean defaultValue) {
+                if (this.enabledDefault != null) {
+                    throw new IllegalStateException("enabled() already set");
+                }
+                this.enabledDefault = defaultValue;
+                return this;
+            }
+
+            public DefaultBuilder multiValue(Values.MultiValue defaultValue) {
+                if (this.multiValueDefault != null) {
+                    throw new IllegalStateException("multiValue() already set");
+                }
+                this.multiValueDefault = Objects.requireNonNull(defaultValue);
+                return this;
+            }
+
+            public DefaultBuilder cardinality(Values.Cardinality defaultValue) {
+                if (this.cardinalityDefault != null) {
+                    throw new IllegalStateException("cardinality() already set");
+                }
+                this.cardinalityDefault = Objects.requireNonNull(defaultValue);
+                return this;
+            }
+
+            public DocValuesParameter build() {
+                if (enabledDefault == null) {
+                    throw new IllegalStateException("enabled() not set");
+                }
+                Values.Cardinality effectiveCardinality = cardinalityDefault != null ? cardinalityDefault : Values.Cardinality.LOW;
+                Values.MultiValue effectiveMultiValue = multiValueDefault != null ? multiValueDefault : Values.MultiValue.TRUE;
+                Values defaults = new Values(enabledDefault, effectiveCardinality, effectiveMultiValue);
+                return new DocValuesParameter(defaults, initializer, cardinalityDefault != null, multiValueDefault != null);
+            }
         }
 
         private DocValuesParameter(
             Values defaultValue,
             Function<FieldMapper, Values> initializer,
             boolean supportsCardinality,
-            Set<Values.MultiValue> allowedMultiValues
+            boolean supportsMultiValue
         ) {
             super(PARAMETER_NAME, false, () -> defaultValue, null, initializer, null, Values::toString);
 
@@ -1583,14 +1590,20 @@ public abstract class FieldMapper extends Mapper {
                 cardinalityParameter = Optional.empty();
             }
 
-            multiValueParameter = Parameter.restrictedEnumParam(
-                "multi_value",
-                false,
-                m -> initializer.apply(m).multiValue,
-                defaultValue.multiValue,
-                Values.MultiValue.class,
-                allowedMultiValues
-            );
+            if (supportsMultiValue) {
+                multiValueParameter = Optional.of(
+                    Parameter.restrictedEnumParam(
+                        "multi_value",
+                        false,
+                        m -> initializer.apply(m).multiValue,
+                        defaultValue.multiValue,
+                        Values.MultiValue.class,
+                        EnumSet.allOf(Values.MultiValue.class)
+                    )
+                );
+            } else {
+                multiValueParameter = Optional.empty();
+            }
         }
 
         /**
@@ -1602,13 +1615,12 @@ public abstract class FieldMapper extends Mapper {
          *   <li>{@code "doc_values": true} - doc_values enabled with defaults</li>
          *   <li>{@code "doc_values": { "cardinality": "low" }} - doc_values enabled with LOW cardinality</li>
          *   <li>{@code "doc_values": { "cardinality": "high" }} - doc_values enabled with HIGH cardinality</li>
-         *   <li>{@code "doc_values": { "multi_value": "no" }} - single value enforced per document</li>
-         *   <li>{@code "doc_values": { "multi_value": "sorted" }} - multiple values sorted per document</li>
-         *   <li>{@code "doc_values": { "multi_value": "sorted_set" }} - multiple values sorted and deduplicated per document</li>
-         *   <li>{@code "doc_values": { "multi_value": "arrays" }} - multiple values stored as-is (no sorting or deduplication)</li>
+         *   <li>{@code "doc_values": { "multi_value": "false" }} - single value enforced per document</li>
+         *   <li>{@code "doc_values": { "multi_value": "true" }} - multiple values per document</li>
+         *   <li>{@code "doc_values": { "multi_value": "preserve_order" }} - multiple values stored with original ordering preserved</li>
          * </ul>
          * <p>
-         * Not all {@code multi_value} options are supported by every field type; unsupported options are rejected at mapping parse time.
+         * Sub-parameters that the field type does not expose (e.g. {@code cardinality} on numeric fields) are rejected at parse time.
          * <p>
          * The presence of {@code doc_values} as a map indicates the user wants doc_values enabled. The map format allows specifying
          * additional cardinality and multi_value settings.
@@ -1616,21 +1628,36 @@ public abstract class FieldMapper extends Mapper {
         @Override
         public void parse(String field, MappingParserContext context, Object value) {
             if (value instanceof Map<?, ?> valueMap && EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled()) {
-                cardinalityParameter.ifPresent(p -> p.parse(field, context, valueMap.get(p.name)));
-                multiValueParameter.parse(field, context, valueMap.get(multiValueParameter.name));
+                // Verify that the mapping only contains support parameters. For example, numeric fields don't support cardinality.
+                Set<String> knownKeys = new HashSet<>();
+                cardinalityParameter.ifPresent(p -> knownKeys.add(p.name));
+                multiValueParameter.ifPresent(p -> knownKeys.add(p.name));
+                for (Object key : valueMap.keySet()) {
+                    if (knownKeys.contains(Objects.toString(key)) == false) {
+                        throw new MapperParsingException("Unknown subkey [" + key + "] for [" + name + "] on field [" + field + "]");
+                    }
+                }
 
+                // Parse the actual parameters.
+                cardinalityParameter.ifPresent(p -> p.parse(field, context, valueMap.get(p.name)));
+                multiValueParameter.ifPresent(p -> p.parse(field, context, valueMap.get(p.name)));
+
+                // Finally, assign values.
+                Values defaults = getDefaultValue();
                 setValue(
                     new Values(
                         true,
-                        cardinalityParameter.map(Parameter::getValue).orElse(getDefaultValue().cardinality()),
-                        multiValueParameter.getValue()
+                        cardinalityParameter.map(Parameter::getValue).orElse(defaults.cardinality()),
+                        multiValueParameter.map(Parameter::getValue).orElse(defaults.multiValue())
                     )
                 );
             } else {
+                // The mapping doesn't use the extended doc values parameters, so parse doc values as a basic boolean.
+                Values defaults = getDefaultValue();
                 if (XContentMapValues.nodeBooleanValue(value, name)) {
-                    setValue(new Values(true, getDefaultValue().cardinality(), getDefaultValue().multiValue()));
+                    setValue(new Values(true, defaults.cardinality(), defaults.multiValue()));
                 } else {
-                    setValue(Values.DISABLED);
+                    setValue(new Values(false, defaults.cardinality(), defaults.multiValue()));
                 }
             }
         }
@@ -1639,7 +1666,7 @@ public abstract class FieldMapper extends Mapper {
         public void setValue(Values value) {
             super.setValue(value);
             cardinalityParameter.ifPresent(p -> p.setValue(value.cardinality));
-            multiValueParameter.setValue(value.multiValue);
+            multiValueParameter.ifPresent(p -> p.setValue(value.multiValue));
         }
 
         protected void toXContent(XContentBuilder builder, boolean includeDefaults) throws IOException {
@@ -1651,7 +1678,7 @@ public abstract class FieldMapper extends Mapper {
                     builder.field(name, true);
                 } else {
                     boolean cardinalityConfigured = cardinalityParameter.map(Parameter::isConfigured).orElse(false);
-                    boolean multiValueConfigured = multiValueParameter.isConfigured();
+                    boolean multiValueConfigured = multiValueParameter.map(Parameter::isConfigured).orElse(false);
                     if (includeDefaults == false && cardinalityConfigured == false && multiValueConfigured == false) {
                         // no sub-parameters were explicitly set; use the boolean shorthand to match the original source
                         builder.field(name, true);
@@ -1666,9 +1693,15 @@ public abstract class FieldMapper extends Mapper {
                                 }
                             }
                         });
-                        if (includeDefaults || multiValueConfigured) {
-                            builder.field(multiValueParameter.name, value.multiValue);
-                        }
+                        multiValueParameter.ifPresent(p -> {
+                            if (includeDefaults || p.isConfigured()) {
+                                try {
+                                    builder.field(p.name, value.multiValue);
+                                } catch (IOException e) {
+                                    throw new UncheckedIOException(e);
+                                }
+                            }
+                        });
                         builder.endObject();
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -82,19 +82,14 @@ public class IpFieldMapper extends FieldMapper {
         return (IpFieldMapper) in;
     }
 
-    public static final DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new DocValuesParameter.Values(
-        true,
-        DocValuesParameter.Values.Cardinality.LOW,
-        DocValuesParameter.Values.MultiValue.SORTED_SET
-    );
-
     public static final class Builder extends FieldMapper.DimensionBuilder {
 
         private final Parameter<Boolean> indexed;
-        private final DocValuesParameter docValuesParameters = DocValuesParameter.sortedSetWithCardinality(
-            DEFAULT_DOC_VALUES_PARAMS,
-            m -> toType(m).docValuesParameters()
-        );
+        private final DocValuesParameter docValuesParameters = DocValuesParameter.builder(m -> toType(m).docValuesParameters())
+            .enabled(true)
+            .multiValue(DocValuesParameter.Values.MultiValue.TRUE)
+            .cardinality(DocValuesParameter.Values.Cardinality.LOW)
+            .build();
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
 
         private final Parameter<Boolean> ignoreMalformed;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -128,12 +128,6 @@ public final class KeywordFieldMapper extends FieldMapper {
     public static final String CONTENT_TYPE = "keyword";
     private static final String HOST_NAME = "host.name";
 
-    public static final DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new DocValuesParameter.Values(
-        true,
-        DocValuesParameter.Values.Cardinality.LOW,
-        DocValuesParameter.Values.MultiValue.SORTED_SET
-    );
-
     public static class Defaults {
         public static final FieldType FIELD_TYPE;
         public static final FieldType FIELD_TYPE_WITH_SKIP_DOC_VALUES;
@@ -197,10 +191,11 @@ public final class KeywordFieldMapper extends FieldMapper {
     public static final class Builder extends FieldMapper.DimensionBuilder {
 
         private final Parameter<Boolean> indexed;
-        private final DocValuesParameter docValuesParameters = DocValuesParameter.sortedSetWithCardinality(
-            DEFAULT_DOC_VALUES_PARAMS,
-            m -> toType(m).docValuesParameters()
-        );
+        private final DocValuesParameter docValuesParameters = DocValuesParameter.builder(m -> toType(m).docValuesParameters())
+            .enabled(true)
+            .multiValue(DocValuesParameter.Values.MultiValue.TRUE)
+            .cardinality(DocValuesParameter.Values.Cardinality.LOW)
+            .build();
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).fieldType.stored(), false);
 
         private final Parameter<String> nullValue = Parameter.stringParam("null_value", false, m -> toType(m).fieldType().nullValue, null)
@@ -347,12 +342,15 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         @Deprecated()
         public Builder docValues(boolean hasDocValues) {
-            this.docValuesParameters.setValue(hasDocValues ? DEFAULT_DOC_VALUES_PARAMS : DocValuesParameter.Values.DISABLED);
+            DocValuesParameter.Values defaults = this.docValuesParameters.getDefaultValue();
+            this.docValuesParameters.setValue(new DocValuesParameter.Values(hasDocValues, defaults.cardinality(), defaults.multiValue()));
             return this;
         }
 
         public Builder docValues(DocValuesParameter.Values.Cardinality cardinality) {
-            this.docValuesParameters.setValue(new DocValuesParameter.Values(true, cardinality, DEFAULT_DOC_VALUES_PARAMS.multiValue()));
+            this.docValuesParameters.setValue(
+                new DocValuesParameter.Values(true, cardinality, this.docValuesParameters.getDefaultValue().multiValue())
+            );
             return this;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -81,8 +81,8 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX = new NodeFeature(
         "mapper.dense_vector.dynamic_template_dotted_field_fix"
     );
-    public static final NodeFeature DOC_VALUES_MULTI_VALUE = new NodeFeature("mapper.doc_values.multi_value");
     public static final NodeFeature DOC_VALUES_MULTI_VALUE_ENFORCEMENT = new NodeFeature("mapper.doc_values.multi_value_enforcement");
+    public static final NodeFeature DOC_VALUES_MULTI_VALUE_RENAME = new NodeFeature("mapper.doc_values.multi_value_rename");
     static final NodeFeature DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX = new NodeFeature(
         "mapper.dense_vector.dynamic_template_nested_object_fix"
     );
@@ -150,8 +150,8 @@ public class MapperFeatures implements FeatureSpecification {
             TDIGEST_TYPE,
             TEXT_FIELD_DOC_VALUES,
             DENSE_VECTOR_DYNAMIC_TEMPLATE_DOTTED_FIELD_FIX,
-            DOC_VALUES_MULTI_VALUE,
             DOC_VALUES_MULTI_VALUE_ENFORCEMENT,
+            DOC_VALUES_MULTI_VALUE_RENAME,
             DENSE_VECTOR_DYNAMIC_TEMPLATE_NESTED_OBJECT_FIX,
             FLATTENED_MAPPED_SUBFIELDS_FEATURE,
             ES940_DISK_BBQ,

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -106,19 +106,13 @@ public class NumberFieldMapper extends FieldMapper {
         return (NumberFieldMapper) in;
     }
 
-    public static final DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new DocValuesParameter.Values(
-        true,
-        DocValuesParameter.Values.Cardinality.LOW,
-        DocValuesParameter.Values.MultiValue.SORTED
-    );
-
     public static final class Builder extends FieldMapper.DimensionBuilder {
 
         private final Parameter<Boolean> indexed;
-        private final DocValuesParameter docValuesParameters = DocValuesParameter.sorted(
-            DEFAULT_DOC_VALUES_PARAMS,
-            m -> toType(m).docValuesParameters()
-        );
+        private final DocValuesParameter docValuesParameters = DocValuesParameter.builder(m -> toType(m).docValuesParameters())
+            .enabled(true)
+            .multiValue(DocValuesParameter.Values.MultiValue.TRUE)
+            .build();
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
 
         private final Parameter<Explicit<Boolean>> ignoreMalformed;
@@ -237,7 +231,8 @@ public class NumberFieldMapper extends FieldMapper {
 
         @Deprecated
         public Builder docValues(boolean hasDocValues) {
-            this.docValuesParameters.setValue(hasDocValues ? DEFAULT_DOC_VALUES_PARAMS : DocValuesParameter.Values.DISABLED);
+            DocValuesParameter.Values defaults = this.docValuesParameters.getDefaultValue();
+            this.docValuesParameters.setValue(new DocValuesParameter.Values(hasDocValues, defaults.cardinality(), defaults.multiValue()));
             return this;
         }
 
@@ -1745,7 +1740,7 @@ public class NumberFieldMapper extends FieldMapper {
         /**
          * Maps the given {@code value} to one or more Lucene field values ands them to the given {@code document} under the given
          * {@code name}. Delegates to {@link #addFields(LuceneDocument, String, Number, IndexType, boolean, DocValuesFieldFactory)}
-         * with a {@link DocValuesParameter.Values.MultiValue#SORTED}-configured factory — kept so test callers and other non-mapper
+         * with a {@link DocValuesParameter.Values.MultiValue#TRUE}-configured factory — kept so test callers and other non-mapper
          * callers don't need to thread a {@code DocValuesFieldFactory} through when they only care about the default multi-valued behavior.
          */
         public final void addFields(LuceneDocument document, String name, Number value, IndexType indexType, boolean stored) {
@@ -1756,7 +1751,7 @@ public class NumberFieldMapper extends FieldMapper {
                 indexType,
                 stored,
                 new DocValuesFieldFactory(
-                    DocValuesParameter.Values.MultiValue.SORTED,
+                    DocValuesParameter.Values.MultiValue.TRUE,
                     indexType.hasDocValuesSkipper(),
                     IndexVersion.current()
                 )

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -112,12 +112,6 @@ public final class TextFieldMapper extends FieldMapper {
     private static final String FAST_PHRASE_SUFFIX = "._index_phrase";
     private static final String FAST_PREFIX_SUFFIX = "._index_prefix";
 
-    public static final DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new DocValuesParameter.Values(
-        false,
-        DocValuesParameter.Values.Cardinality.HIGH,
-        DocValuesParameter.Values.MultiValue.ARRAYS
-    );
-
     public static class Defaults {
         public static final double FIELDDATA_MIN_FREQUENCY = 0;
         public static final double FIELDDATA_MAX_FREQUENCY = Integer.MAX_VALUE;
@@ -267,10 +261,11 @@ public final class TextFieldMapper extends FieldMapper {
 
         private final Parameter<Boolean> index = Parameter.indexParam(m -> ((TextFieldMapper) m).index, true);
 
-        final DocValuesParameter docValuesParameters = DocValuesParameter.arraysWithCardinality(
-            DEFAULT_DOC_VALUES_PARAMS,
-            m -> ((TextFieldMapper) m).docValuesParameters
-        );
+        final DocValuesParameter docValuesParameters = DocValuesParameter.builder(m -> ((TextFieldMapper) m).docValuesParameters)
+            .enabled(false)  // doc_values are disabled on text fields by default
+            .multiValue(DocValuesParameter.Values.MultiValue.TRUE)
+            .cardinality(DocValuesParameter.Values.Cardinality.HIGH)
+            .build();
 
         final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> ((TextFieldMapper) m).similarity);
 
@@ -2046,7 +2041,7 @@ public final class TextFieldMapper extends FieldMapper {
                     // text fields with doc_values may have all values stored in fallback fields; if every value exceeds MAX_TERM_LENGTH.
                     // In that case, there will be no doc values at all, but the "main" field is still going to be indexed. As a result,
                     // we can't use SortedSetDocValuesSyntheticFieldLoaderLayer since it uses DocValues.getSortedSet(), which will throw.
-                    // Check for both SORTED_SET (multi-valued) and SORTED (multi_value=no) doc values types.
+                    // Check for both SORTED_SET (multi-valued) and SORTED (multi_value=false) doc values types.
                     if (reader.getSortedSetDocValues(fieldName()) == null && reader.getSortedDocValues(fieldName()) == null) {
                         return null;
                     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -91,11 +91,11 @@ public class BooleanFieldMapperTests extends MapperTestCase {
         });
     }
 
-    public void testMultiValueSorted() throws IOException {
+    public void testMultiValueTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "sorted").endObject();
+            b.startObject("doc_values").field("multi_value", "true").endObject();
         }));
         BooleanFieldMapper mapper = (BooleanFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertThat(
@@ -104,45 +104,33 @@ public class BooleanFieldMapperTests extends MapperTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
     }
 
-    public void testMultiValueSortedSetNotAllowed() throws IOException {
-        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
-        var e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
-            minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "sorted_set").endObject();
-        })));
-        assertThat(
-            e.getMessage(),
-            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, arrays]")
-        );
-    }
-
-    public void testMultiValueDefaultIsSorted() throws IOException {
+    public void testMultiValueDefaultIsTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
         BooleanFieldMapper mapper = (BooleanFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED));
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.TRUE));
     }
 
-    public void testMultiValueNoAcceptsSingleValue() throws IOException {
+    public void testMultiValueFalseAcceptsSingleValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         mapper.parse(source(b -> b.field("field", randomBoolean())));
     }
 
-    public void testMultiValueNoRejectsArray() throws IOException {
+    public void testMultiValueFalseRejectsArray() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -150,15 +138,15 @@ public class BooleanFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
-    public void testMultiValueNoUsesNumericDocValues() throws IOException {
+    public void testMultiValueFalseUsesNumericDocValues() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", randomBoolean())));
         List<IndexableField> fields = doc.rootDoc().getFields("field");
@@ -168,7 +156,7 @@ public class BooleanFieldMapperTests extends MapperTestCase {
             DocValuesType dvType = f.fieldType().docValuesType();
             if (dvType != DocValuesType.NONE) {
                 hasDocValuesField = true;
-                assertEquals("multi_value=no must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
+                assertEquals("multi_value=false must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
             }
         }
         assertTrue("expected a doc values field for [field]", hasDocValuesField);

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -122,11 +122,11 @@ public class DateFieldMapperTests extends MapperTestCase {
         assertFalse(field.fieldType().stored());
     }
 
-    public void testMultiValueSorted() throws IOException {
+    public void testMultiValueTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "sorted").endObject();
+            b.startObject("doc_values").field("multi_value", "true").endObject();
         }));
         DateFieldMapper mapper = (DateFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertThat(
@@ -135,45 +135,33 @@ public class DateFieldMapperTests extends MapperTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
     }
 
-    public void testMultiValueSortedSetNotAllowed() throws IOException {
-        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
-        var e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
-            minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "sorted_set").endObject();
-        })));
-        assertThat(
-            e.getMessage(),
-            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, arrays]")
-        );
-    }
-
-    public void testMultiValueDefaultIsSorted() throws IOException {
+    public void testMultiValueDefaultIsTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
         DateFieldMapper mapper = (DateFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED));
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.TRUE));
     }
 
-    public void testMultiValueNoAcceptsSingleValue() throws IOException {
+    public void testMultiValueFalseAcceptsSingleValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         mapper.parse(source(b -> b.field("field", "2016-03-11")));
     }
 
-    public void testMultiValueNoRejectsArray() throws IOException {
+    public void testMultiValueFalseRejectsArray() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -181,15 +169,15 @@ public class DateFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
-    public void testMultiValueNoUsesNumericDocValues() throws IOException {
+    public void testMultiValueFalseUsesNumericDocValues() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "2016-03-11")));
         List<IndexableField> fields = doc.rootDoc().getFields("field");
@@ -199,7 +187,7 @@ public class DateFieldMapperTests extends MapperTestCase {
             DocValuesType dvType = f.fieldType().docValuesType();
             if (dvType != DocValuesType.NONE) {
                 hasDocValuesField = true;
-                assertEquals("multi_value=no must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
+                assertEquals("multi_value=false must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
             }
         }
         assertTrue("expected a doc values field for [field]", hasDocValuesField);

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
@@ -9,19 +9,37 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.util.Map;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class DocValuesParameterTests extends MapperServiceTestCase {
 
     // -----------------------------------------------------------------------
-    // Null-fallback: omitting one sub-parameter falls back to the field-type default
+    // Parsing - accepted forms
     // -----------------------------------------------------------------------
+
+    public void testDocValuesFalseShorthand() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("doc_values", false)));
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters().enabled(), equalTo(false));
+    }
 
     public void testMultiValueWithoutCardinalityUsesDefault() throws Exception {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(
-            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "sorted_set").endObject())
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "true").endObject())
         );
         KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertThat(
@@ -30,7 +48,7 @@ public class DocValuesParameterTests extends MapperServiceTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
@@ -48,14 +66,56 @@ public class DocValuesParameterTests extends MapperServiceTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
     }
 
+    public void testBothSubParametersConfigured() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(
+                b -> b.field("type", "keyword")
+                    .startObject("doc_values")
+                    .field("cardinality", "high")
+                    .field("multi_value", "preserve_order")
+                    .endObject()
+            )
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(
+            mapper.docValuesParameters(),
+            equalTo(
+                new FieldMapper.DocValuesParameter.Values(
+                    true,
+                    FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+                    FieldMapper.DocValuesParameter.Values.MultiValue.PRESERVE_ORDER
+                )
+            )
+        );
+    }
+
+    public void testMultiValuePreserveOrderParses() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "preserve_order").endObject())
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.PRESERVE_ORDER));
+    }
+
+    public void testMultiValueBooleanFalse() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", false).endObject())
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.FALSE));
+    }
+
     // -----------------------------------------------------------------------
-    // Unknown-value rejection
+    // Parsing - rejected forms
     // -----------------------------------------------------------------------
 
     public void testInvalidCardinality() throws Exception {
@@ -79,25 +139,109 @@ public class DocValuesParameterTests extends MapperServiceTestCase {
         );
         assertThat(
             e.getMessage(),
-            containsString("Unknown value [invalid] for field [multi_value] - accepted values are [no, sorted_set, arrays]")
+            containsString("Unknown value [invalid] for field [multi_value] - accepted values are [false, true, preserve_order]")
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Boolean shorthand: doc_values: true / false still works alongside map form
-    // -----------------------------------------------------------------------
-
-    public void testDocValuesTrueShorthand() throws Exception {
+    public void testUnknownSubkeyRejected() throws Exception {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
-        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("doc_values", true)));
-        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        assertThat(mapper.docValuesParameters().enabled(), equalTo(true));
+        var e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(
+                fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("foo", "bar").endObject())
+            )
+        );
+        assertThat(e.getMessage(), containsString("Unknown subkey [foo] for [doc_values] on field [field]"));
     }
 
-    public void testDocValuesFalseShorthand() throws Exception {
+    public void testCardinalityRejectedOnNumericField() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        var e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(
+                fieldMapping(b -> b.field("type", "long").startObject("doc_values").field("cardinality", "high").endObject())
+            )
+        );
+        assertThat(e.getMessage(), containsString("Unknown subkey [cardinality] for [doc_values] on field [field]"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Serialization (toXContent)
+    // -----------------------------------------------------------------------
+
+    public void testToXContentBooleanShorthandPreserved() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        // Text fields default doc_values to disabled, so an explicit `doc_values: true` here is non-default and exercises
+        // the boolean-shorthand serialization branch (no sub-parameters configured -> emit boolean).
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "text").field("doc_values", true)));
+        Map<String, Object> serialized = serializeFieldMapper(mapperService.documentMapper().mappers().getMapper("field"), false);
+        assertThat(serialized.get("doc_values"), is(true));
+    }
+
+    public void testToXContentDocValuesFalseEmitsBoolean() throws Exception {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("doc_values", false)));
-        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        assertThat(mapper.docValuesParameters().enabled(), equalTo(false));
+        Map<String, Object> serialized = serializeFieldMapper(mapperService.documentMapper().mappers().getMapper("field"), false);
+        assertThat(serialized.get("doc_values"), is(false));
     }
+
+    public void testToXContentEmitsOnlyConfiguredSubparameter() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject())
+        );
+        Map<String, Object> serialized = serializeFieldMapper(mapperService.documentMapper().mappers().getMapper("field"), false);
+        assertThat(serialized.get("doc_values"), instanceOf(Map.class));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> dv = (Map<String, Object>) serialized.get("doc_values");
+        assertThat(dv.get("multi_value").toString(), equalTo("false"));
+        assertThat("cardinality must not be emitted when not configured", dv.get("cardinality"), nullValue());
+    }
+
+    public void testToXContentIncludeDefaultsEmitsAllSubparameters() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject())
+        );
+        Map<String, Object> serialized = serializeFieldMapper(mapperService.documentMapper().mappers().getMapper("field"), true);
+        assertThat(serialized.get("doc_values"), instanceOf(Map.class));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> dv = (Map<String, Object>) serialized.get("doc_values");
+        assertThat(dv.get("multi_value").toString(), equalTo("false"));
+        assertThat(dv.get("cardinality").toString(), equalTo("low"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Builder validation
+    // -----------------------------------------------------------------------
+
+    public void testBuilderRequiresEnabled() {
+        var e = expectThrows(IllegalStateException.class, () -> FieldMapper.DocValuesParameter.builder(m -> {
+            throw new AssertionError("initializer should not be invoked");
+        }).build());
+        assertThat(e.getMessage(), containsString("enabled() not set"));
+    }
+
+    public void testBuilderEnabledCalledTwiceThrows() {
+        var b = FieldMapper.DocValuesParameter.builder(m -> { throw new AssertionError("initializer should not be invoked"); })
+            .enabled(true);
+        var e = expectThrows(IllegalStateException.class, () -> b.enabled(false));
+        assertThat(e.getMessage(), containsString("enabled() already set"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> serializeFieldMapper(Mapper mapper, boolean includeDefaults) throws Exception {
+        ToXContent.Params params = includeDefaults ? new ToXContent.MapParams(Map.of("include_defaults", "true")) : ToXContent.EMPTY_PARAMS;
+        XContentBuilder builder = jsonBuilder().startObject();
+        mapper.toXContent(builder, params).endObject();
+        builder.close();
+        try (var parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            return (Map<String, Object>) parser.map().get("field");
+        }
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocValuesParameterTests.java
@@ -9,19 +9,37 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.util.Map;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class DocValuesParameterTests extends MapperServiceTestCase {
 
     // -----------------------------------------------------------------------
-    // Null-fallback: omitting one sub-parameter falls back to the field-type default
+    // Parsing - accepted forms
     // -----------------------------------------------------------------------
+
+    public void testDocValuesFalseShorthand() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("doc_values", false)));
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters().enabled(), equalTo(false));
+    }
 
     public void testMultiValueWithoutCardinalityUsesDefault() throws Exception {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(
-            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "sorted_set").endObject())
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "true").endObject())
         );
         KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertThat(
@@ -30,7 +48,7 @@ public class DocValuesParameterTests extends MapperServiceTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
@@ -48,14 +66,59 @@ public class DocValuesParameterTests extends MapperServiceTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
     }
 
+    public void testBothSubParametersConfigured() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(
+                b -> b.field("type", "keyword")
+                    .startObject("doc_values")
+                    .field("cardinality", "high")
+                    .field("multi_value", "preserve_order")
+                    .endObject()
+            )
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(
+            mapper.docValuesParameters(),
+            equalTo(
+                new FieldMapper.DocValuesParameter.Values(
+                    true,
+                    FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+                    FieldMapper.DocValuesParameter.Values.MultiValue.PRESERVE_ORDER
+                )
+            )
+        );
+    }
+
+    public void testMultiValuePreserveOrderParses() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "preserve_order").endObject())
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(
+            mapper.docValuesParameters().multiValue(),
+            equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.PRESERVE_ORDER)
+        );
+    }
+
+    public void testMultiValueBooleanFalse() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", false).endObject())
+        );
+        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.FALSE));
+    }
+
     // -----------------------------------------------------------------------
-    // Unknown-value rejection
+    // Parsing - rejected forms
     // -----------------------------------------------------------------------
 
     public void testInvalidCardinality() throws Exception {
@@ -79,25 +142,109 @@ public class DocValuesParameterTests extends MapperServiceTestCase {
         );
         assertThat(
             e.getMessage(),
-            containsString("Unknown value [invalid] for field [multi_value] - accepted values are [no, sorted_set, arrays]")
+            containsString("Unknown value [invalid] for field [multi_value] - accepted values are [false, true, preserve_order]")
         );
     }
 
-    // -----------------------------------------------------------------------
-    // Boolean shorthand: doc_values: true / false still works alongside map form
-    // -----------------------------------------------------------------------
-
-    public void testDocValuesTrueShorthand() throws Exception {
+    public void testUnknownSubkeyRejected() throws Exception {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
-        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("doc_values", true)));
-        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        assertThat(mapper.docValuesParameters().enabled(), equalTo(true));
+        var e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(
+                fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("foo", "bar").endObject())
+            )
+        );
+        assertThat(e.getMessage(), containsString("Unknown subkey [foo] for [doc_values] on field [field]"));
     }
 
-    public void testDocValuesFalseShorthand() throws Exception {
+    public void testCardinalityRejectedOnNumericField() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        var e = expectThrows(
+            MapperParsingException.class,
+            () -> createMapperService(
+                fieldMapping(b -> b.field("type", "long").startObject("doc_values").field("cardinality", "high").endObject())
+            )
+        );
+        assertThat(e.getMessage(), containsString("Unknown subkey [cardinality] for [doc_values] on field [field]"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Serialization (toXContent)
+    // -----------------------------------------------------------------------
+
+    public void testToXContentBooleanShorthandPreserved() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        // Text fields default doc_values to disabled, so an explicit `doc_values: true` here is non-default and exercises
+        // the boolean-shorthand serialization branch (no sub-parameters configured -> emit boolean).
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "text").field("doc_values", true)));
+        Map<String, Object> serialized = serializeFieldMapper(mapperService.documentMapper().mappers().getMapper("field"), false);
+        assertThat(serialized.get("doc_values"), is(true));
+    }
+
+    public void testToXContentDocValuesFalseEmitsBoolean() throws Exception {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword").field("doc_values", false)));
-        KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        assertThat(mapper.docValuesParameters().enabled(), equalTo(false));
+        Map<String, Object> serialized = serializeFieldMapper(mapperService.documentMapper().mappers().getMapper("field"), false);
+        assertThat(serialized.get("doc_values"), is(false));
     }
+
+    public void testToXContentEmitsOnlyConfiguredSubparameter() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject())
+        );
+        Map<String, Object> serialized = serializeFieldMapper(mapperService.documentMapper().mappers().getMapper("field"), false);
+        assertThat(serialized.get("doc_values"), instanceOf(Map.class));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> dv = (Map<String, Object>) serialized.get("doc_values");
+        assertThat(dv.get("multi_value").toString(), equalTo("false"));
+        assertThat("cardinality must not be emitted when not configured", dv.get("cardinality"), nullValue());
+    }
+
+    public void testToXContentIncludeDefaultsEmitsAllSubparameters() throws Exception {
+        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
+        MapperService mapperService = createMapperService(
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject())
+        );
+        Map<String, Object> serialized = serializeFieldMapper(mapperService.documentMapper().mappers().getMapper("field"), true);
+        assertThat(serialized.get("doc_values"), instanceOf(Map.class));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> dv = (Map<String, Object>) serialized.get("doc_values");
+        assertThat(dv.get("multi_value").toString(), equalTo("false"));
+        assertThat(dv.get("cardinality").toString(), equalTo("low"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Builder validation
+    // -----------------------------------------------------------------------
+
+    public void testBuilderRequiresEnabled() {
+        var e = expectThrows(IllegalStateException.class, () -> FieldMapper.DocValuesParameter.builder(m -> {
+            throw new AssertionError("initializer should not be invoked");
+        }).build());
+        assertThat(e.getMessage(), containsString("enabled() not set"));
+    }
+
+    public void testBuilderEnabledCalledTwiceThrows() {
+        var b = FieldMapper.DocValuesParameter.builder(m -> { throw new AssertionError("initializer should not be invoked"); })
+            .enabled(true);
+        var e = expectThrows(IllegalStateException.class, () -> b.enabled(false));
+        assertThat(e.getMessage(), containsString("enabled() already set"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> serializeFieldMapper(Mapper mapper, boolean includeDefaults) throws Exception {
+        ToXContent.Params params = includeDefaults ? new ToXContent.MapParams(Map.of("include_defaults", "true")) : ToXContent.EMPTY_PARAMS;
+        XContentBuilder builder = jsonBuilder().startObject();
+        mapper.toXContent(builder, params).endObject();
+        builder.close();
+        try (var parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            return (Map<String, Object>) parser.map().get("field");
+        }
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
@@ -455,10 +455,10 @@ public class IpFieldMapperTests extends MapperTestCase {
         };
     }
 
-    public void testMultiValueSortedSet() throws IOException {
+    public void testMultiValueTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createSytheticSourceMapperService(
-            fieldMapping(b -> b.field("type", "ip").startObject("doc_values").field("multi_value", "sorted_set").endObject())
+            fieldMapping(b -> b.field("type", "ip").startObject("doc_values").field("multi_value", "true").endObject())
         );
         IpFieldMapper mapper = (IpFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
         assertThat(
@@ -467,7 +467,7 @@ public class IpFieldMapperTests extends MapperTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
@@ -514,39 +514,25 @@ public class IpFieldMapperTests extends MapperTestCase {
         );
     }
 
-    public void testMultiValueDefaultIsSortedSet() throws IOException {
+    public void testMultiValueDefaultIsTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "ip")));
         IpFieldMapper mapper = (IpFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET));
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.TRUE));
     }
 
-    public void testMultiValueSortedNotAllowed() throws IOException {
-        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
-        var e = expectThrows(
-            MapperParsingException.class,
-            () -> createMapperService(
-                fieldMapping(b -> b.field("type", "ip").startObject("doc_values").field("multi_value", "sorted").endObject())
-            )
-        );
-        assertThat(
-            e.getMessage(),
-            containsString("Unknown value [sorted] for field [multi_value] - accepted values are [no, sorted_set, arrays]")
-        );
-    }
-
-    public void testMultiValueNoAcceptsSingleValue() throws IOException {
+    public void testMultiValueFalseAcceptsSingleValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "ip").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "ip").startObject("doc_values").field("multi_value", "false").endObject())
         );
         mapper.parse(source(b -> b.field("field", "::1")));
     }
 
-    public void testMultiValueNoRejectsArray() throws IOException {
+    public void testMultiValueFalseRejectsArray() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "ip").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "ip").startObject("doc_values").field("multi_value", "false").endObject())
         );
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -554,7 +540,7 @@ public class IpFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
@@ -562,11 +548,11 @@ public class IpFieldMapperTests extends MapperTestCase {
      * Single malformed value routes to the {@code _ignored} fallback. Only one {@link FieldMapper#parse(DocumentParserContext)} call
      * fires, so enforcement does not trip.
      */
-    public void testMultiValueNoAcceptsSingleIgnoreMalformedValue() throws IOException {
+    public void testMultiValueFalseAcceptsSingleIgnoreMalformedValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             b.field("type", "ip").field("ignore_malformed", true);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         mapper.parse(source(b -> b.field("field", "not-an-ip")));
     }
@@ -575,11 +561,11 @@ public class IpFieldMapperTests extends MapperTestCase {
      * Both values are malformed and would route to the {@code _ignored} fallback. Enforcement still throws on the second
      * {@link FieldMapper#parse(DocumentParserContext)} call before either is handled.
      */
-    public void testMultiValueNoRejectsTwoIgnoreMalformedFallbacks() throws IOException {
+    public void testMultiValueFalseRejectsTwoIgnoreMalformedFallbacks() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             b.field("type", "ip").field("ignore_malformed", true);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -587,15 +573,15 @@ public class IpFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
-    public void testMultiValueNoRejectsNormalPlusIgnoreMalformedFallback() throws IOException {
+    public void testMultiValueFalseRejectsNormalPlusIgnoreMalformedFallback() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             b.field("type", "ip").field("ignore_malformed", true);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -603,19 +589,19 @@ public class IpFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
     /**
-     * Mirror of {@link #testMultiValueNoRejectsNormalPlusIgnoreMalformedFallback} with the order reversed: first value is malformed
+     * Mirror of {@link #testMultiValueFalseRejectsNormalPlusIgnoreMalformedFallback} with the order reversed: first value is malformed
      * and would route to the {@code _ignored} fallback, second is a valid IP. Enforcement still fires on the second parse call.
      */
-    public void testMultiValueNoRejectsIgnoreMalformedFallbackPlusNormal() throws IOException {
+    public void testMultiValueFalseRejectsIgnoreMalformedFallbackPlusNormal() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             b.field("type", "ip").field("ignore_malformed", true);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -623,7 +609,7 @@ public class IpFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -1004,7 +1004,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
@@ -1023,7 +1023,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
@@ -1071,13 +1071,13 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
     }
 
-    public void testMultiValueSortedSet() throws IOException {
+    public void testMultiValueTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createSytheticSourceMapperService(
             fieldMapping(
                 b -> b.field("type", "keyword")
                     .startObject("doc_values")
-                    .field("multi_value", "sorted_set")
+                    .field("multi_value", "true")
                     .field("cardinality", "low")
                     .endObject()
             )
@@ -1089,38 +1089,24 @@ public class KeywordFieldMapperTests extends MapperTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
         assertScriptDocValues(mapperService, List.of("foo", "bar", "foo"), equalTo(List.of("bar", "foo")));
     }
 
-    public void testMultiValueDefaultIsSortedSet() throws IOException {
+    public void testMultiValueDefaultIsTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));
         KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("field");
-        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET));
+        assertThat(mapper.docValuesParameters().multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.TRUE));
     }
 
-    public void testMultiValueSortedNotAllowed() throws IOException {
-        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
-        var e = expectThrows(
-            MapperParsingException.class,
-            () -> createMapperService(
-                fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "sorted").endObject())
-            )
-        );
-        assertThat(
-            e.getMessage(),
-            containsString("Unknown value [sorted] for field [multi_value] - accepted values are [no, sorted_set, arrays]")
-        );
-    }
-
-    public void testSingleValueIsAcceptedWhenMultiValueNo() throws IOException {
+    public void testSingleValueIsAcceptedWhenMultiValueFalse() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject())
         );
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(5))));
         assertEquals(1, doc.rootDoc().getFields("field").stream().filter(f -> f.fieldType().docValuesType() != DocValuesType.NONE).count());
@@ -1129,7 +1115,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     public void testSecondValueIsRejectedWhenMultiValueNo() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject())
         );
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -1137,7 +1123,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
@@ -1146,11 +1132,11 @@ public class KeywordFieldMapperTests extends MapperTestCase {
      * to the {@code field._original} fallback field. Enforcement fires at the document-level, so the multi-valued input is rejected
      * regardless of which suffix the second write would have targeted.
      */
-    public void testMultiValueNoRejectsNormalPlusIgnoreAboveFallback() throws IOException {
+    public void testMultiValueFalseRejectsNormalPlusIgnoreAboveFallback() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createSytheticSourceMapperService(
             fieldMapping(
-                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "no").endObject()
+                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "false").endObject()
             )
         ).documentMapper();
         DocumentParsingException e = expectThrows(
@@ -1159,19 +1145,19 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
     /**
-     * Mirror of {@link #testMultiValueNoRejectsNormalPlusIgnoreAboveFallback} with the order reversed: first value routes to the
+     * Mirror of {@link #testMultiValueFalseRejectsNormalPlusIgnoreAboveFallback} with the order reversed: first value routes to the
      * {@code field._original} fallback and the second indexes normally.
      */
-    public void testMultiValueNoRejectsIgnoreAboveFallbackPlusNormal() throws IOException {
+    public void testMultiValueFalseRejectsIgnoreAboveFallbackPlusNormal() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createSytheticSourceMapperService(
             fieldMapping(
-                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "no").endObject()
+                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "false").endObject()
             )
         ).documentMapper();
         DocumentParsingException e = expectThrows(
@@ -1180,18 +1166,18 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
     /**
      * Both values exceed {@code ignore_above}, so both would route to {@code field._original}. Enforcement throws on the second value.
      */
-    public void testMultiValueNoRejectsTwoIgnoreAboveFallbacks() throws IOException {
+    public void testMultiValueFalseRejectsTwoIgnoreAboveFallbacks() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createSytheticSourceMapperService(
             fieldMapping(
-                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "no").endObject()
+                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "false").endObject()
             )
         ).documentMapper();
         DocumentParsingException e = expectThrows(
@@ -1200,15 +1186,15 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
-    public void testMultiValueNoAcceptsSingleIgnoreAboveValue() throws IOException {
+    public void testMultiValueFalseAcceptsSingleIgnoreAboveValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createSytheticSourceMapperService(
             fieldMapping(
-                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "no").endObject()
+                b -> b.field("type", "keyword").field("ignore_above", 5).startObject("doc_values").field("multi_value", "false").endObject()
             )
         ).documentMapper();
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(20))));
@@ -1216,14 +1202,19 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     }
 
     /**
-     * The {@code copy_to} target is configured with {@code multi_value=no}. The source field writes one value, then the destination field
-     * receives a direct value - giving the destination two values and tripping enforcement.
+     * The {@code copy_to} target is configured with {@code multi_value=false}. The source field writes one value, then the destination
+     * field receives a direct value - giving the destination two values and tripping enforcement.
      */
-    public void testMultiValueNoRejectsCopyToTargetWithDirectValue() throws IOException {
+    public void testMultiValueFalseRejectsCopyToTargetWithDirectValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("source").field("type", "keyword").field("copy_to", "target").endObject();
-            b.startObject("target").field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject().endObject();
+            b.startObject("target")
+                .field("type", "keyword")
+                .startObject("doc_values")
+                .field("multi_value", "false")
+                .endObject()
+                .endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -1231,18 +1222,24 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
     /**
-     * Every source element is copied to the target, so the target receives two values and its own {@code multi_value=no} enforcement fires.
+     * Every source element is copied to the target, so the target receives two values and its own {@code multi_value=false} enforcement
+     * fires.
      */
-    public void testMultiValueNoRejectsCopyToTargetFromSourceArray() throws IOException {
+    public void testMultiValueFalseRejectsCopyToTargetFromSourceArray() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("source").field("type", "keyword").field("copy_to", "target").endObject();
-            b.startObject("target").field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject().endObject();
+            b.startObject("target")
+                .field("type", "keyword")
+                .startObject("doc_values")
+                .field("multi_value", "false")
+                .endObject()
+                .endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -1250,22 +1247,22 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
     /**
-     * Source field itself has {@code multi_value=no}. A multi-valued array on the source is rejected before {@code copy_to} runs, so
+     * Source field itself has {@code multi_value=false}. A multi-valued array on the source is rejected before {@code copy_to} runs, so
      * the target never sees the values.
      */
-    public void testMultiValueNoRejectsCopyToSourceWithMultipleValues() throws IOException {
+    public void testMultiValueFalseRejectsCopyToSourceWithMultipleValues() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("source")
                 .field("type", "keyword")
                 .field("copy_to", "target")
                 .startObject("doc_values")
-                .field("multi_value", "no")
+                .field("multi_value", "false")
                 .endObject()
                 .endObject();
             b.startObject("target").field("type", "keyword").endObject();
@@ -1276,62 +1273,62 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
     /**
      * null still counts as a value, so the second value is rejected.
      */
-    public void testMultiValueNoRejectsNullThenValue() throws IOException {
+    public void testMultiValueFalseRejectsNullThenValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject())
         );
         DocumentParsingException e = expectThrows(DocumentParsingException.class, () -> mapper.parse(source(b -> {
             b.startArray("field").nullValue().value(randomAlphanumericOfLength(5)).endArray();
         })));
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
     /**
-     * Mirror of {@link #testMultiValueNoRejectsNullThenValue} with the order reversed: first value is non-null, second is null.
+     * Mirror of {@link #testMultiValueFalseRejectsNullThenValue} with the order reversed: first value is non-null, second is null.
      */
-    public void testMultiValueNoRejectsValueThenNull() throws IOException {
+    public void testMultiValueFalseRejectsValueThenNull() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject())
         );
         DocumentParsingException e = expectThrows(DocumentParsingException.class, () -> mapper.parse(source(b -> {
             b.startArray("field").value(randomAlphanumericOfLength(5)).nullValue().endArray();
         })));
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
-    public void testMultiValueNoAcceptsSingleNull() throws IOException {
+    public void testMultiValueFalseAcceptsSingleNull() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject())
         );
         mapper.parse(source(b -> b.nullField("field")));
     }
 
     /**
-     * A sub-field configures {@code multi_value=no}. Parent field has two values, each of which triggers a sub-field parse so enforcement
-     * on the sub-field fires twice and throws, rejecting the second value.
+     * A sub-field configures {@code multi_value=false}. Parent field has two values, each of which triggers a sub-field parse so
+     * enforcement on the sub-field fires twice and throws, rejecting the second value.
      */
-    public void testMultiValueNoOnMultiFieldRejectsParentSecondValue() throws IOException {
+    public void testMultiValueFalseOnMultiFieldRejectsParentSecondValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("parent").field("type", "keyword");
             b.startObject("fields");
-            b.startObject("child").field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject().endObject();
+            b.startObject("child").field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject().endObject();
             b.endObject();
             b.endObject();
         }));
@@ -1341,16 +1338,16 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
-    public void testMultiValueNoOnMultiFieldAcceptsParentSingleValue() throws IOException {
+    public void testMultiValueFalseOnMultiFieldAcceptsParentSingleValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("parent").field("type", "keyword");
             b.startObject("fields");
-            b.startObject("child").field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject().endObject();
+            b.startObject("child").field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject().endObject();
             b.endObject();
             b.endObject();
         }));
@@ -1358,13 +1355,13 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     }
 
     /**
-     * Parent has {@code multi_value=no}. Enforcement on the parent's slot fires before multi-fields are processed, so the second value
+     * Parent has {@code multi_value=false}. Enforcement on the parent's slot fires before multi-fields are processed, so the second value
      * throws on the parent's path.
      */
-    public void testMultiValueNoOnParentWithMultiFieldRejectsParentArray() throws IOException {
+    public void testMultiValueFalseOnParentWithMultiFieldRejectsParentArray() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
-            b.startObject("parent").field("type", "keyword").startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("parent").field("type", "keyword").startObject("doc_values").field("multi_value", "false").endObject();
             b.startObject("fields");
             b.startObject("child").field("type", "keyword").endObject();
             b.endObject();
@@ -1376,7 +1373,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesFieldTests.java
@@ -370,16 +370,16 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
     }
 
     // =====================================================================================================================================
-    // multi_value=no tests
+    // multi_value=false tests
     // =====================================================================================================================================
 
-    public void testMultiValueNoUsesBinaryDocValuesFieldWithRawBytes() {
+    public void testMultiValueFalseUsesBinaryDocValuesFieldWithRawBytes() {
         // given
         LuceneDocument doc = new LuceneDocument();
         BytesRef value = new BytesRef(randomAlphanumericOfLength(10));
 
-        // when — use DocValuesFieldFactory which handles multi_value=no branching
-        DocValuesFieldFactory factory = new DocValuesFieldFactory(MultiValue.NO, false, IndexVersion.current());
+        // when — use DocValuesFieldFactory which handles multi_value=false branching
+        DocValuesFieldFactory factory = new DocValuesFieldFactory(MultiValue.FALSE, false, IndexVersion.current());
         factory.addBinaryField(doc, "field", value, ValueOrdering.SORTED_UNIQUE);
 
         // then — field is stored as a plain BinaryDocValuesField with the raw value
@@ -393,12 +393,12 @@ public class MultiValuedBinaryDocValuesFieldTests extends ESTestCase {
      * This test verifies that we're not double storing field names in keyedFields ({@link LuceneDocument}) and singleValuedFields
      * ({@link DocumentParserContext}). This ensures that we're not double storing.
      */
-    public void testMultiValueNoDoesNotStoreInKeyedFields() {
+    public void testMultiValueFalseDoesNotStoreInKeyedFields() {
         // given
         LuceneDocument doc = new LuceneDocument();
 
         // when
-        DocValuesFieldFactory factory = new DocValuesFieldFactory(MultiValue.NO, false, IndexVersion.current());
+        DocValuesFieldFactory factory = new DocValuesFieldFactory(MultiValue.FALSE, false, IndexVersion.current());
         factory.addBinaryField(doc, "field", new BytesRef(randomAlphanumericOfLength(10)), ValueOrdering.SORTED_UNIQUE);
 
         // then — field is NOT registered in keyedFields; only in the Lucene fields list. Single-value enforcement is handled at the

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -2773,18 +2773,18 @@ public class TextFieldMapperTests extends MapperTestCase {
         assertThat(syntheticSource, containsString(longValue));
     }
 
-    public void testSingleValueIsAcceptedWhenMultiValueNo() throws IOException {
+    public void testSingleValueIsAcceptedWhenMultiValueFalse() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "false").endObject())
         );
         mapper.parse(source(b -> b.field("field", randomAlphanumericOfLength(5))));
     }
 
-    public void testSecondValueIsRejectedWhenMultiValueNo() throws IOException {
+    public void testSecondValueIsRejectedWhenMultiValueFalse() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "false").endObject())
         );
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -2792,14 +2792,14 @@ public class TextFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
-    public void testSingleFallbackValueIsAcceptedWhenMultiValueNo() throws IOException {
+    public void testSingleFallbackValueIsAcceptedWhenMultiValueFalse() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "false").endObject())
         );
         String longValue = randomAlphanumericOfLength(IndexWriter.MAX_TERM_LENGTH + 1);
         mapper.parse(source(b -> b.field("field", longValue)));
@@ -2811,10 +2811,10 @@ public class TextFieldMapperTests extends MapperTestCase {
      * First value routes to SortedSet doc values; second exceeds MAX_TERM_LENGTH and would route to the {@code ._original} fallback field.
      * While these are technically two separate fields, single values are enforced on a document-level, so the second value is rejected.
      */
-    public void testSecondValueInFallbackFieldIsRejectedWhenMultiValueNoAndFirstValueInRegularField() throws IOException {
+    public void testSecondValueInFallbackFieldIsRejectedWhenMultiValueFalseAndFirstValueInRegularField() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "false").endObject())
         );
         String shortValue = randomAlphanumericOfLength(5);
         String longValue = randomAlphanumericOfLength(IndexWriter.MAX_TERM_LENGTH + 1);
@@ -2824,17 +2824,17 @@ public class TextFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
     /**
-     * Mirror of {@link #testSecondValueInFallbackFieldIsRejectedWhenMultiValueNoAndFirstValueInRegularField} with the order reversed.
+     * Mirror of {@link #testSecondValueInFallbackFieldIsRejectedWhenMultiValueFalseAndFirstValueInRegularField} with the order reversed.
      */
-    public void testSecondValueInRegularFieldIsRejectedWhenMultiValueNoAndFirstValueInFallbackField() throws IOException {
+    public void testSecondValueInRegularFieldIsRejectedWhenMultiValueFalseAndFirstValueInFallbackField() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "false").endObject())
         );
         String longValue = randomAlphanumericOfLength(IndexWriter.MAX_TERM_LENGTH + 1);
         String shortValue = randomAlphanumericOfLength(5);
@@ -2844,17 +2844,17 @@ public class TextFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
     /**
      * We have two values for a field, both of which exceed MAX_TERM_LENGTH and would route to the {@code ._original} fallback field.
      */
-    public void testSecondValueInFallbackFieldIsRejectedWhenMultiValueNo() throws IOException {
+    public void testSecondValueInFallbackFieldIsRejectedWhenMultiValueFalse() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(
-            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "no").endObject())
+            fieldMapping(b -> b.field("type", "text").startObject("doc_values").field("multi_value", "false").endObject())
         );
         String longValue1 = randomAlphanumericOfLength(IndexWriter.MAX_TERM_LENGTH + 1);
         String longValue2 = randomAlphanumericOfLength(IndexWriter.MAX_TERM_LENGTH + 1);
@@ -2864,7 +2864,7 @@ public class TextFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -322,8 +322,8 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
             case 1 -> Map.of("cardinality", "low");
             case 2 -> Map.of("cardinality", "high");
             case 3 -> true;
-            case 4 -> Map.of("cardinality", "low", "multi_value", "arrays");
-            case 5 -> Map.of("cardinality", "high", "multi_value", "arrays");
+            case 4 -> Map.of("cardinality", "low", "multi_value", "true");
+            case 5 -> Map.of("cardinality", "high", "multi_value", "true");
             default -> throw new IllegalStateException();
         };
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/KeywordFieldSyntheticSourceSupport.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/KeywordFieldSyntheticSourceSupport.java
@@ -48,12 +48,16 @@ public class KeywordFieldSyntheticSourceSupport implements MapperTestCase.Synthe
         // TODO: Remove this case when FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF is removed.
         if (Build.current().isSnapshot() == false) {
             if (allowIgnoredSource && ESTestCase.randomBoolean()) {
-                return FieldMapper.DocValuesParameter.Values.DISABLED;
+                return new FieldMapper.DocValuesParameter.Values(
+                    false,
+                    FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
+                );
             } else {
                 return new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 );
             }
         }
@@ -62,14 +66,18 @@ public class KeywordFieldSyntheticSourceSupport implements MapperTestCase.Synthe
             case 0 -> new FieldMapper.DocValuesParameter.Values(
                 true,
                 FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
             );
             case 1 -> new FieldMapper.DocValuesParameter.Values(
                 true,
                 FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
-                FieldMapper.DocValuesParameter.Values.MultiValue.SORTED_SET
+                FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
             );
-            case 2 -> FieldMapper.DocValuesParameter.Values.DISABLED;
+            case 2 -> new FieldMapper.DocValuesParameter.Values(
+                false,
+                FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
+                FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
+            );
             default -> throw new IllegalStateException();
         };
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -372,7 +372,7 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
@@ -517,11 +517,11 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         return mapper.docValuesParameters();
     }
 
-    public void testMultiValueSorted() throws IOException {
+    public void testMultiValueTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "sorted").endObject();
+            b.startObject("doc_values").field("multi_value", "true").endObject();
         }));
         assertThat(
             getDocValuesParameters(mapperService),
@@ -529,44 +529,32 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
                 new FieldMapper.DocValuesParameter.Values(
                     true,
                     FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                    FieldMapper.DocValuesParameter.Values.MultiValue.SORTED
+                    FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
                 )
             )
         );
     }
 
-    public void testMultiValueDefaultIsSorted() throws IOException {
+    public void testMultiValueDefaultIsTrue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
-        assertThat(getDocValuesParameters(mapperService).multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.SORTED));
+        assertThat(getDocValuesParameters(mapperService).multiValue(), equalTo(FieldMapper.DocValuesParameter.Values.MultiValue.TRUE));
     }
 
-    public void testMultiValueSortedSetNotAllowed() throws IOException {
-        assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
-        var e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
-            minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "sorted_set").endObject();
-        })));
-        assertThat(
-            e.getMessage(),
-            containsString("Unknown value [sorted_set] for field [multi_value] - accepted values are [no, sorted, arrays]")
-        );
-    }
-
-    public void testMultiValueNoAcceptsSingleValue() throws IOException {
+    public void testMultiValueFalseAcceptsSingleValue() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         mapper.parse(source(b -> b.field("field", getSampleValueForDocument())));
     }
 
-    public void testMultiValueNoRejectsArray() throws IOException {
+    public void testMultiValueFalseRejectsArray() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -574,7 +562,7 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
@@ -582,12 +570,12 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
      * Both values are malformed and would route to the {@code _ignored} fallback. Enforcement still throws on the second
      * {@link FieldMapper#parse(DocumentParserContext)} call before either is handled.
      */
-    public void testMultiValueNoRejectsTwoIgnoreMalformedFallbacks() throws IOException {
+    public void testMultiValueFalseRejectsTwoIgnoreMalformedFallbacks() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
             b.field("ignore_malformed", true);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -595,7 +583,7 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
@@ -603,12 +591,12 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
      * One regular value and one malformed value (routed to {@code _ignored} fallback). Single value enforcement throws on the
      * second (malformed) value.
      */
-    public void testMultiValueNoRejectsRegularPlusMalformed() throws IOException {
+    public void testMultiValueFalseRejectsRegularPlusMalformed() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
             b.field("ignore_malformed", true);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -616,7 +604,7 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
@@ -624,12 +612,12 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
      * One malformed value (routed to {@code _ignored} fallback) followed by one regular value. Single value enforcement throws on the
      * second (regular) value.
      */
-    public void testMultiValueNoRejectsMalformedPlusRegular() throws IOException {
+    public void testMultiValueFalseRejectsMalformedPlusRegular() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
             b.field("ignore_malformed", true);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
@@ -637,15 +625,15 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         );
         assertThat(
             e.getCause().getMessage(),
-            containsString("configured with [multi_value=no] but encountered multiple values in the same document")
+            containsString("configured with [multi_value=false] but encountered multiple values in the same document")
         );
     }
 
-    public void testMultiValueNoUsesNumericDocValues() throws IOException {
+    public void testMultiValueFalseUsesNumericDocValues() throws IOException {
         assumeTrue("feature under test must be enabled", FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled());
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
-            b.startObject("doc_values").field("multi_value", "no").endObject();
+            b.startObject("doc_values").field("multi_value", "false").endObject();
         }));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", getSampleValueForDocument())));
         List<IndexableField> fields = doc.rootDoc().getFields("field");
@@ -655,7 +643,7 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
             DocValuesType dvType = f.fieldType().docValuesType();
             if (dvType != DocValuesType.NONE) {
                 hasDocValuesField = true;
-                assertEquals("multi_value=no must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
+                assertEquals("multi_value=false must use NUMERIC doc values, not SORTED_NUMERIC", DocValuesType.NUMERIC, dvType);
             }
         }
         assertTrue("expected a doc values field for [field]", hasDocValuesField);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TextFieldFamilySyntheticSourceTestSetup.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TextFieldFamilySyntheticSourceTestSetup.java
@@ -22,7 +22,7 @@ import static org.elasticsearch.test.ESTestCase.between;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
-import static org.elasticsearch.test.ESTestCase.randomInt;
+import static org.elasticsearch.test.ESTestCase.randomFrom;
 
 /**
  * Provides functionality needed to test synthetic source support in text and text-like fields (e.g. "text", "annotated_text").
@@ -58,28 +58,32 @@ public final class TextFieldFamilySyntheticSourceTestSetup {
     private static FieldMapper.DocValuesParameter.Values docValuesParams(boolean supportsDocValues) {
         // currently, only text fields support doc values, so if doc_values aren't supported, then there is no reason to generate them
         if (supportsDocValues == false) {
-            return FieldMapper.DocValuesParameter.Values.DISABLED;
+            return new FieldMapper.DocValuesParameter.Values(
+                false,
+                FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+                FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
+            );
         }
 
         // text field doc_values support is behind a feature flag
         if (FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF.isEnabled() == false) {
-            return FieldMapper.DocValuesParameter.Values.DISABLED;
+            return new FieldMapper.DocValuesParameter.Values(
+                false,
+                FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
+                FieldMapper.DocValuesParameter.Values.MultiValue.TRUE
+            );
         }
 
-        return switch (randomInt(2)) {
-            case 0 -> new FieldMapper.DocValuesParameter.Values(
-                true,
-                FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-                FieldMapper.DocValuesParameter.Values.MultiValue.ARRAYS
-            );
-            case 1 -> new FieldMapper.DocValuesParameter.Values(
-                true,
-                FieldMapper.DocValuesParameter.Values.Cardinality.HIGH,
-                FieldMapper.DocValuesParameter.Values.MultiValue.ARRAYS
-            );
-            case 2 -> FieldMapper.DocValuesParameter.Values.DISABLED;
-            default -> throw new IllegalStateException();
-        };
+        // Randomize each axis independently. MultiValue.FALSE is intentionally excluded: text fields' synthetic-source path
+        // would require constraining inputs to a single value per document, which the example generator below does not do.
+        return new FieldMapper.DocValuesParameter.Values(
+            randomBoolean(),
+            randomFrom(FieldMapper.DocValuesParameter.Values.Cardinality.values()),
+            randomFrom(
+                FieldMapper.DocValuesParameter.Values.MultiValue.TRUE,
+                FieldMapper.DocValuesParameter.Values.MultiValue.PRESERVE_ORDER
+            )
+        );
     }
 
     public static void validateRoundTripReader(String syntheticSource, DirectoryReader reader, DirectoryReader roundTripReader) {
@@ -190,6 +194,9 @@ public final class TextFieldFamilySyntheticSourceTestSetup {
                 } else {
                     b.startObject("doc_values");
                     b.field("cardinality", docValues.cardinality().toString());
+                    if (docValues.multiValue() != FieldMapper.DocValuesParameter.Values.MultiValue.TRUE) {
+                        b.field("multi_value", docValues.multiValue().toString());
+                    }
                     b.endObject();
                 }
             };

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
@@ -102,7 +102,7 @@ public class RandomizedRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTest
             .withDataSourceHandlers(List.of(new DefaultMappingParametersHandler() {
                 @Override
                 protected Object extendedDocValuesParams() {
-                    if (oldClusterHasFeature(MapperFeatures.DOC_VALUES_MULTI_VALUE)) {
+                    if (oldClusterHasFeature(MapperFeatures.DOC_VALUES_MULTI_VALUE_RENAME)) {
                         return super.extendedDocValuesParams();
                     }
 

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -84,22 +84,15 @@ public class UnsignedLongFieldMapper extends FieldMapper {
     static final BigInteger BIGINTEGER_2_64_MINUS_ONE = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE); // 2^64 -1
     private static final BigDecimal BIGDECIMAL_2_64_MINUS_ONE = new BigDecimal(BIGINTEGER_2_64_MINUS_ONE);
 
-    public static final FieldMapper.DocValuesParameter.Values DEFAULT_DOC_VALUES_PARAMS = new FieldMapper.DocValuesParameter.Values(
-        true,
-        FieldMapper.DocValuesParameter.Values.Cardinality.LOW,
-        FieldMapper.DocValuesParameter.Values.MultiValue.SORTED
-    );
-
     private static UnsignedLongFieldMapper toType(FieldMapper in) {
         return (UnsignedLongFieldMapper) in;
     }
 
     public static final class Builder extends FieldMapper.DimensionBuilder {
         private final Parameter<Boolean> indexed;
-        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.sorted(
-            DEFAULT_DOC_VALUES_PARAMS,
+        private final FieldMapper.DocValuesParameter docValuesParameters = FieldMapper.DocValuesParameter.builder(
             m -> toType(m).docValuesParameters()
-        );
+        ).enabled(true).multiValue(FieldMapper.DocValuesParameter.Values.MultiValue.TRUE).build();
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
         private final Parameter<Explicit<Boolean>> ignoreMalformed;
         private final Parameter<String> nullValue;


### PR DESCRIPTION
Follow up on the discussion we had. I figured we better merge this change first, before `array` is supported and a bunch of our BWC tests fail.

This PR renames the options for `multi_value` from `no|sorted|sorted_set|array` to `false|true|preserve_order`.

As part of this PR, I've also dropped the factory interface for `DocValuesParameters` in favor of a builder. A builder works better here since its future-proof - adding new options for `DocValuesParameters` will be easier with a builder than with a factory. The factory also loses value now that `multi_value` has been simplified to a simple boolean, which means all fields now support all `multi_value` options as opposed to only some (`sorted` vs `sorted_set`).
 