### PR TITLE
Add DirectBytesRefVector

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/AbstractTSDBDocValuesProducer.java
@@ -387,13 +387,12 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
                             }
                         } else if (isDense(firstDocId, lastDocId, count)) {
                             try (var builder = factory.singletonBytesRefs(count)) {
-                                long[] offsets = new long[count + 1];
+                                int[] offsets = new int[count + 1];
 
                                 long startOffset = addresses.get(firstDocId);
                                 for (int i = offset, j = 1; i < docs.count(); i++, j++) {
                                     int docId = docs.get(i);
-                                    long nextOffset = addresses.get(docId + 1) - startOffset;
-                                    offsets[j] = nextOffset;
+                                    offsets[j] = Math.toIntExact(addresses.get(docId + 1) - startOffset);
                                 }
 
                                 int length = Math.toIntExact(addresses.get(lastDocId + 1L) - startOffset);
@@ -887,7 +886,7 @@ public abstract class AbstractTSDBDocValuesProducer extends DocValuesProducer {
             final int bufferSize = computeMultipleBlockBufferSize(firstBlockId, endBlockId);
 
             int offsetBufferIndex = 0;
-            final long[] offsetBuffer = new long[count + 1];
+            final int[] offsetBuffer = new int[count + 1];
             int valuesBufferIndex = 0;
             final byte[] valuesBuffer = new byte[bufferSize];
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
@@ -798,12 +798,12 @@ public interface BlockLoader {
          * Append multiple BytesRef. Offsets contains offsets of each BytesRef in the byte array.
          * The length of the offsets array is one more than the number of BytesRefs.
          */
-        SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, long[] offsets) throws IOException;
+        SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, int[] offsets) throws IOException;
 
         /**
          * Append multiple BytesRefs, all with the same length.
          */
-        SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, long bytesRefLengths) throws IOException;
+        SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, int bytesRefLengths) throws IOException;
     }
 
     interface FloatBuilder extends Builder {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
@@ -124,18 +124,18 @@ public class TestBlock implements BlockLoader.Block {
                     }
 
                     @Override
-                    public BlockLoader.SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, long[] offsets) throws IOException {
+                    public BlockLoader.SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, int[] offsets) {
                         for (int i = 0; i < offsets.length - 1; i++) {
-                            BytesRef ref = new BytesRef(bytes, (int) offsets[i], (int) (offsets[i + 1] - offsets[i]));
+                            BytesRef ref = new BytesRef(bytes, offsets[i], offsets[i + 1] - offsets[i]);
                             add(BytesRef.deepCopyOf(ref));
                         }
                         return this;
                     }
 
                     @Override
-                    public BlockLoader.SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, long bytesRefLengths) throws IOException {
+                    public BlockLoader.SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, int bytesRefLengths) {
                         for (int i = 0; i < count; i++) {
-                            BytesRef ref = new BytesRef(bytes, (int) (i * bytesRefLengths), (int) bytesRefLengths);
+                            BytesRef ref = new BytesRef(bytes, (int) (i * bytesRefLengths), bytesRefLengths);
                             add(BytesRef.deepCopyOf(ref));
                         }
                         return this;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -23,7 +23,7 @@ import java.io.IOException;
  * This class is generated. Edit {@code X-Vector.java.st} instead.
  */
 public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVector, BytesRefArrayVector, ConstantNullVector,
-    OrdinalBytesRefVector, org.elasticsearch.compute.data.arrow.BytesRefArrowBufVector {
+    OrdinalBytesRefVector, DirectBytesRefVector, org.elasticsearch.compute.data.arrow.BytesRefArrowBufVector {
     /**
      * Build a contiguous array of bytes for the value stored at the
      * given position. The underlying data is generally stored in pages

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -492,6 +492,12 @@ public class BlockFactory {
         return b;
     }
 
+    public BytesRefVector newDirectBytesRefVector(byte[] bytes, int[] startOffsets, int positionCount) {
+        var v = new DirectBytesRefVector(bytes, startOffsets, positionCount, this);
+        adjustBreaker(v.ramBytesUsed());
+        return v;
+    }
+
     public BytesRefBlock newConstantBytesRefBlockWith(BytesRef value, int positions) {
         return newConstantBytesRefVector(value, positions).asBlock();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DirectBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DirectBytesRefVector.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.bytes.PagedBytesCursor;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
+
+/**
+ * A {@link BytesRefVector} that wraps a flat bytes array and offsets directly
+ */
+public final class DirectBytesRefVector extends AbstractVector implements BytesRefVector {
+    static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DirectBytesRefVector.class)
+        // TODO: remove these extra bytes once `asBlock` returns a block with a separate reference to the vector.
+        + RamUsageEstimator.shallowSizeOfInstance(BytesRefVectorBlock.class)
+        // TODO: remove this if/when we account for memory used by Pages
+        + Block.PAGE_MEM_OVERHEAD_PER_BLOCK;
+
+    private final byte[] bytes;
+    private final int[] startOffsets;
+
+    DirectBytesRefVector(byte[] bytes, int[] startOffsets, int positionCount, BlockFactory blockFactory) {
+        super(positionCount, blockFactory);
+        this.bytes = bytes;
+        this.startOffsets = startOffsets;
+    }
+
+    @Override
+    public BytesRef getBytesRef(int position, BytesRef dest) {
+        dest.bytes = bytes;
+        dest.offset = startOffsets[position];
+        dest.length = startOffsets[position + 1] - dest.offset;
+        return dest;
+    }
+
+    @Override
+    public PagedBytesCursor get(int position, PagedBytesCursor scratch) {
+        final int startOffset = startOffsets[position];
+        scratch.init(bytes, startOffset, startOffsets[position + 1] - startOffset);
+        return scratch;
+    }
+
+    @Override
+    public BytesRefBlock asBlock() {
+        return new BytesRefVectorBlock(this);
+    }
+
+    @Override
+    public OrdinalBytesRefVector asOrdinals() {
+        return null;
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.BYTES_REF;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public BytesRefVector filter(boolean mayContainDuplicates, int... positions) {
+        var scratch = new BytesRef();
+        try (BytesRefVector.Builder builder = blockFactory().newBytesRefVectorBuilder(positions.length)) {
+            for (int p : positions) {
+                builder.appendBytesRef(getBytesRef(p, scratch));
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public BytesRefBlock keepMask(BooleanVector mask) {
+        if (getPositionCount() == 0) {
+            incRef();
+            return new BytesRefVectorBlock(this);
+        }
+        if (mask.isConstant()) {
+            if (mask.getBoolean(0)) {
+                incRef();
+                return new BytesRefVectorBlock(this);
+            }
+            return (BytesRefBlock) blockFactory().newConstantNullBlock(getPositionCount());
+        }
+        var scratch = new BytesRef();
+        try (BytesRefBlock.Builder builder = blockFactory().newBytesRefBlockBuilder(getPositionCount())) {
+            for (int p = 0; p < getPositionCount(); p++) {
+                if (mask.getBoolean(p)) {
+                    builder.appendBytesRef(getBytesRef(p, scratch));
+                } else {
+                    builder.appendNull();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public ReleasableIterator<BytesRefBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new BytesRefLookup(asBlock(), positions, targetBlockSize);
+    }
+
+    @Override
+    public BytesRefVector slice(int beginInclusive, int endExclusive) {
+        if (beginInclusive == 0 && endExclusive == getPositionCount()) {
+            incRef();
+            return this;
+        }
+        var scratch = new BytesRef();
+        try (BytesRefVector.Builder builder = blockFactory().newBytesRefVectorBuilder(endExclusive - beginInclusive)) {
+            for (int i = beginInclusive; i < endExclusive; i++) {
+                builder.appendBytesRef(getBytesRef(i, scratch));
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public int valueMaxByteSize() {
+        int max = 0;
+        for (int i = 0; i < getPositionCount(); i++) {
+            max = Math.max(max, startOffsets[i + 1] - startOffsets[i]);
+        }
+        return max;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(bytes) + RamUsageEstimator.sizeOf(startOffsets);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BytesRefVector that) {
+            return BytesRefVector.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return BytesRefVector.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[positions=" + getPositionCount() + ']';
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -26,7 +26,7 @@ import java.io.IOException;
  */
 $if(BytesRef)$
 public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVector, BytesRefArrayVector, ConstantNullVector,
-    OrdinalBytesRefVector, org.elasticsearch.compute.data.arrow.BytesRefArrowBufVector$extraArrowBufVectorPermits$ {
+    OrdinalBytesRefVector, DirectBytesRefVector, org.elasticsearch.compute.data.arrow.BytesRefArrowBufVector$extraArrowBufVectorPermits$ {
 $elseif(boolean)$
 public sealed interface $Type$Vector extends Vector permits Constant$Type$Vector, $Type$ArrayVector, $Type$BigArrayVector,
     ConstantNullVector, org.elasticsearch.compute.data.arrow.$Type$ArrowBufVector$extraArrowBufVectorPermits$ {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonBytesRefBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonBytesRefBuilder.java
@@ -7,22 +7,15 @@
 
 package org.elasticsearch.compute.lucene.read;
 
-import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.BytesRefArray;
-import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.index.mapper.BlockLoader;
 
-import java.io.IOException;
-
 public final class SingletonBytesRefBuilder implements BlockLoader.SingletonBytesRefBuilder {
-
     private final int count;
     private final BlockFactory blockFactory;
-
-    private BytesRefArray bytesRefArray;
+    private byte[] bytes;
+    private int[] startOffsets;
 
     public SingletonBytesRefBuilder(int count, BlockFactory blockFactory) {
         this.count = count;
@@ -30,27 +23,27 @@ public final class SingletonBytesRefBuilder implements BlockLoader.SingletonByte
     }
 
     @Override
-    public SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, long[] offsets) {
-        var values = blockFactory.bigArrays().newByteArrayWrapper(bytes);
-        bytesRefArray = new BytesRefArray(new LongArrayWrapper(offsets), values, count, blockFactory.bigArrays());
+    public SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, int[] offsets) {
+        this.bytes = bytes;
+        this.startOffsets = offsets;
         return this;
     }
 
     @Override
-    public SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, long bytesRefLengths) {
-        var values = blockFactory.bigArrays().newByteArrayWrapper(bytes);
-        bytesRefArray = new BytesRefArray(
-            new ConstantOffsetLongArrayWrapper(bytesRefLengths, count + 1),
-            values,
-            count,
-            blockFactory.bigArrays()
-        );
-        return this;
+    public SingletonBytesRefBuilder appendBytesRefs(byte[] bytes, int fixedLength) {
+        final int[] offsets = new int[count + 1];
+        for (int i = 0; i <= count; i++) {
+            offsets[i] = i * fixedLength;
+        }
+        return appendBytesRefs(bytes, offsets);
     }
 
     @Override
     public BlockLoader.Block build() {
-        return blockFactory.newBytesRefArrayVector(bytesRefArray, count).asBlock();
+        BytesRefBlock block = blockFactory.newDirectBytesRefVector(bytes, startOffsets, count).asBlock();
+        bytes = null;
+        startOffsets = null;
+        return block;
     }
 
     @Override
@@ -70,137 +63,4 @@ public final class SingletonBytesRefBuilder implements BlockLoader.SingletonByte
 
     @Override
     public void close() {}
-
-    /**
-     * An array wrapper that starts with 0 and has a constant offset between each pair of values.
-     * For an offset of n, the values are: [0, n, 2n, 3n, ..., Xn]
-     * This can be used to provide an "offsets" array for ByteRefs of constant length without the need to allocate an unnecessary array.
-     */
-    static final class ConstantOffsetLongArrayWrapper implements LongArray {
-
-        private final long offset;
-        private final long size;
-
-        ConstantOffsetLongArrayWrapper(long offset, long size) {
-            this.offset = offset;
-            this.size = size;
-        }
-
-        @Override
-        public long get(long index) {
-            assert index >= 0 && index < size;
-            return index * offset;
-        }
-
-        @Override
-        public long getAndSet(long index, long value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void set(long index, long value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long increment(long index, long inc) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void fill(long fromIndex, long toIndex, long value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void fillWith(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void set(long index, byte[] buf, int offset, int len) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long size() {
-            return size;
-        }
-
-        @Override
-        public long ramBytesUsed() {
-            return 2 * Long.BYTES; // offset + size
-        }
-
-        @Override
-        public void close() {}
-    }
-
-    static class LongArrayWrapper implements LongArray {
-
-        final long[] values;
-
-        LongArrayWrapper(long[] values) {
-            this.values = values;
-        }
-
-        @Override
-        public long get(long index) {
-            return values[(int) index];
-        }
-
-        @Override
-        public long getAndSet(long index, long value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void set(long index, long value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long increment(long index, long inc) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void fill(long fromIndex, long toIndex, long value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void fillWith(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void set(long index, byte[] buf, int offset, int len) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long size() {
-            return values.length;
-        }
-
-        @Override
-        public long ramBytesUsed() {
-            return RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) values.length * Long.BYTES;
-        }
-
-        @Override
-        public void close() {}
-    }
-
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -959,6 +959,30 @@ public class BasicBlockTests extends ESTestCase {
         }
     }
 
+    public void testDirectBytesRefVector() {
+        byte[] bytes = new byte[10 * 1024];
+        int positionCount = between(100, 500);
+        int[] offsets = new int[positionCount + 1];
+        int offset = 0;
+        try (var builder = blockFactory.newBytesRefVectorBuilder(positionCount)) {
+            offsets[0] = offset;
+            for (int p = 0; p < positionCount; p++) {
+                byte[] values = randomByteArrayOfLength(between(5, 10));
+                System.arraycopy(values, 0, bytes, offset, values.length);
+                builder.appendBytesRef(new BytesRef(values));
+                offset += values.length;
+                offsets[p + 1] = offset;
+            }
+            try (var vector1 = builder.build(); var vector2 = blockFactory.newDirectBytesRefVector(bytes, offsets, positionCount)) {
+                BytesRef scratch1 = new BytesRef();
+                BytesRef scratch2 = new BytesRef();
+                for (int p = 0; p < positionCount; p++) {
+                    assertThat(vector1.getBytesRef(p, scratch1), equalTo(vector2.getBytesRef(p, scratch2)));
+                }
+            }
+        }
+    }
+
     public void testBooleanBlock() {
         for (int i = 0; i < 1000; i++) {
             int positionCount = randomIntBetween(1, 16 * 1024);


### PR DESCRIPTION
The current BytesRefArray uses longs for offsets - this is needed to support more than 2GB, but most of the time we don't exceed 2GB; hence, we should use ints first and fall back to long offsets. The saved memory is not critical, but can be important in hash tables. We will try to make this change in #148168. However, we also have usages where we wrap bytes/offsets directly. So instead of supporting wrapping bytes/offsets into BytesRefArray, this change adds a DirectBytesRefVector for that specific purpose - to keep the BytesRefArray simple and the new PR focused.