### PR TITLE
ESQL: Support TO_STRING and COUNT of flattened

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/FlattenedCases.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/FlattenedCases.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
+import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+
+/**
+ * Shared suppliers for {@link DataType#FLATTENED} test cases,
+ * used by both {@link TestCaseSupplier} and {@link MultiRowTestCaseSupplier}.
+ */
+class FlattenedCases {
+    static final Supplier<BytesRef> EMPTY = json(b -> {});
+    static final Supplier<BytesRef> SINGLE_KEY = json(b -> b.field(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20)));
+    static final Supplier<BytesRef> MULTI_KEY = json(b -> {
+        int keys = randomIntBetween(2, 10);
+        for (int i = 0; i < keys; i++) {
+            b.field(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
+        }
+    });
+    static final Supplier<BytesRef> OBJECT = json(b -> {
+        int keys = randomIntBetween(1, 5);
+        for (int i = 0; i < keys; i++) {
+            b.startObject(randomAlphaOfLengthBetween(1, 10));
+            int objectKeys = randomIntBetween(1, 5);
+            for (int j = 0; j < objectKeys; j++) {
+                b.field(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10));
+            }
+            b.endObject();
+        }
+    });
+    static final Supplier<BytesRef> RANDOM = () -> randomFrom(EMPTY, SINGLE_KEY, MULTI_KEY, OBJECT).get();
+
+    private static Supplier<BytesRef> json(CheckedConsumer<XContentBuilder, IOException> body) {
+        return () -> {
+            try {
+                XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+                body.accept(builder);
+                return new BytesRef(builder.endObject().toString());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
@@ -577,6 +577,16 @@ public final class MultiRowTestCaseSupplier {
         return cases;
     }
 
+    public static List<TypedDataSupplier> flattenedCases(int minRows, int maxRows) {
+        List<TypedDataSupplier> cases = new ArrayList<>();
+        addSuppliers(cases, minRows, maxRows, "empty", DataType.FLATTENED, FlattenedCases.EMPTY);
+        addSuppliers(cases, minRows, maxRows, "single key", DataType.FLATTENED, FlattenedCases.SINGLE_KEY);
+        addSuppliers(cases, minRows, maxRows, "multi key", DataType.FLATTENED, FlattenedCases.MULTI_KEY);
+        addSuppliers(cases, minRows, maxRows, "object", DataType.FLATTENED, FlattenedCases.OBJECT);
+        addSuppliers(cases, minRows, maxRows, "random", DataType.FLATTENED, FlattenedCases.RANDOM);
+        return cases;
+    }
+
     public static List<TypedDataSupplier> tsidCases(int minRows, int maxRows) {
         List<TypedDataSupplier> cases = new ArrayList<>();
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -1601,6 +1601,35 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
     }
 
     /**
+     * Supplier test case data for {@link DataType#FLATTENED} fields.
+     * <p>
+     * For multi-row parameters, see {@link MultiRowTestCaseSupplier#flattenedCases}.
+     * </p>
+     */
+    public static List<TypedDataSupplier> flattenedCases() {
+        return List.of(
+            new TypedDataSupplier("<empty flattened>", FlattenedCases.EMPTY::get, DataType.FLATTENED),
+            new TypedDataSupplier("<single key flattened>", FlattenedCases.SINGLE_KEY::get, DataType.FLATTENED),
+            new TypedDataSupplier("<multi key flattened>", FlattenedCases.MULTI_KEY::get, DataType.FLATTENED),
+            new TypedDataSupplier("<object flattened>", FlattenedCases.OBJECT::get, DataType.FLATTENED),
+            new TypedDataSupplier("<random flattened>", FlattenedCases.RANDOM::get, DataType.FLATTENED)
+        );
+    }
+
+    /**
+     * Generate positive test cases for a unary function operating on a {@link DataType#FLATTENED} field.
+     */
+    public static void forUnaryFlattened(
+        List<TestCaseSupplier> suppliers,
+        String expectedEvaluatorToString,
+        DataType expectedType,
+        Function<BytesRef, Object> expectedValue,
+        List<String> warnings
+    ) {
+        unary(suppliers, expectedEvaluatorToString, flattenedCases(), expectedType, v -> expectedValue.apply((BytesRef) v), warnings);
+    }
+
+    /**
      * Supplier test case data for {@link Version} fields.
      * <p>
      * For multi-row parameters, see {@link MultiRowTestCaseSupplier#versionCases}.

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/flattened.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/flattened.csv-spec
@@ -49,6 +49,7 @@ FROM flattened_otel_logs
 
 count
 required_capability: flattened_datatype
+required_capability: fn_count_flattened
 
 FROM flattened_otel_logs
 | STATS count = COUNT(attributes)
@@ -60,7 +61,7 @@ count:long
 
 to_string
 required_capability: flattened_datatype
-required_capability: fn_to_string_from_flattened
+required_capability: fn_to_string_flattened
 
 FROM flattened_otel_logs
 | WHERE @timestamp == "2020-01-01T00:02:48.461Z"

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/flattened.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/flattened.csv-spec
@@ -46,3 +46,28 @@ FROM flattened_otel_logs
 @timestamp:date          | resource.attributes:flattened
 2020-01-01T00:02:48.461Z | "{""agent.id"":""c92cc400-fe39-4252-bc0f-4b024e742f25"",""agent.type"":""filebeat"",""host.name"":""infra-filebeat-6vjxr""}"
 ;
+
+count
+required_capability: flattened_datatype
+
+FROM flattened_otel_logs
+| STATS count = COUNT(attributes)
+;
+
+count:long
+10
+;
+
+to_string
+required_capability: flattened_datatype
+required_capability: fn_to_string_from_flattened
+
+FROM flattened_otel_logs
+| WHERE @timestamp == "2020-01-01T00:02:48.461Z"
+| EVAL first_part = MV_FIRST(SPLIT(TO_STRING(attributes), ","))
+| KEEP @timestamp, first_part
+;
+
+@timestamp:date          | first_part:keyword
+2020-01-01T00:02:48.461Z | "{""rally.message_size"":""192"""
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
@@ -118,6 +118,7 @@ public class Count extends AggregateFunction implements ToAggregator, SurrogateE
                 "integer",
                 "ip",
                 "keyword",
+                "flattened",
                 "long",
                 "tdigest",
                 "text",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
@@ -48,7 +48,10 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.EXPONENTIAL_HISTOG
 
 public class Count extends AggregateFunction implements ToAggregator, SurrogateExpression, AggregateMetricDoubleNativeSupport {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Count", Count::new);
-    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Count.class).unary(Count::new).name("count");
+    public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Count.class)
+        .unary(Count::new)
+        .capabilities("flattened")
+        .name("count");
     public static final PromqlFunctionDefinition PROMQL_DEFINITION = PromqlFunctionDefinition.def()
         .acrossSeries(Count::new)
         .description("Counts the number of elements in the input vector.")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
@@ -74,7 +74,7 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToString", ToString::new);
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(ToString.class)
         .unaryConfig(ToString::new)
-        .capabilities("from_flattened")
+        .capabilities("flattened")
         .name("to_string", "to_str");
 
     private static final Map<DataType, BuildFactory> STATIC_EVALUATORS = Map.ofEntries(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
@@ -44,6 +44,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_RANGE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DENSE_VECTOR;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.EXPONENTIAL_HISTOGRAM;
+import static org.elasticsearch.xpack.esql.core.type.DataType.FLATTENED;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEOHASH;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEOHEX;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEOTILE;
@@ -73,6 +74,7 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToString", ToString::new);
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(ToString.class)
         .unaryConfig(ToString::new)
+        .capabilities("from_flattened")
         .name("to_string", "to_str");
 
     private static final Map<DataType, BuildFactory> STATIC_EVALUATORS = Map.ofEntries(
@@ -84,6 +86,7 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
         Map.entry(LONG, ToStringFromLongEvaluator.Factory::new),
         Map.entry(INTEGER, ToStringFromIntEvaluator.Factory::new),
         Map.entry(TEXT, (source, fieldEval) -> fieldEval),
+        Map.entry(FLATTENED, (source, fieldEval) -> fieldEval),
         Map.entry(VERSION, ToStringFromVersionEvaluator.Factory::new),
         Map.entry(UNSIGNED_LONG, ToStringFromUnsignedLongEvaluator.Factory::new),
         Map.entry(GEO_POINT, ToStringFromGeoPointEvaluator.Factory::new),
@@ -141,7 +144,8 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
                 "unsigned_long",
                 "version",
                 "date_range",
-                "exponential_histogram" },
+                "exponential_histogram",
+                "flattened" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
         ) Expression v,
         Configuration configuration

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -1865,7 +1865,7 @@ public class AnalyzerTests extends ESTestCase {
         // DATE_PERIOD and TIME_DURATION types have been added, but not really patched through the engine; i.e. supported.
         final String supportedTypes =
             "aggregate_metric_double or boolean or cartesian_point or cartesian_shape or date_nanos or date_range or datetime "
-                + "or dense_vector or exponential_histogram or geo_point "
+                + "or dense_vector or exponential_histogram or flattened or geo_point "
                 + "or geo_shape or geohash or geohex or geotile or histogram or ip or numeric or string or version";
         analyzer().error(
             "row period = 1 year | eval to_string(period)",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
@@ -66,6 +66,7 @@ public class CountTests extends AbstractAggregationTestCase {
             MultiRowTestCaseSupplier.geohexCases(1, 1000),
             MultiRowTestCaseSupplier.stringCases(1, 1000, DataType.KEYWORD),
             MultiRowTestCaseSupplier.stringCases(1, 1000, DataType.TEXT),
+            MultiRowTestCaseSupplier.flattenedCases(1, 1000),
             MultiRowTestCaseSupplier.tdigestCases(1, 1000)
                 .stream()
                 .map(s -> s.withAppliesTo(histogramPreviewAppliesTo).withAppliesTo(histogramGaAppliesTo))
@@ -90,6 +91,7 @@ public class CountTests extends AbstractAggregationTestCase {
             DataType.IP,
             DataType.VERSION,
             DataType.KEYWORD,
+            DataType.FLATTENED,
             DataType.TDIGEST,
             DataType.TEXT,
             DataType.GEO_POINT,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
@@ -165,6 +165,7 @@ public class ToStringTests extends AbstractConfigurationFunctionTestCase {
             List.of()
         );
         TestCaseSupplier.forUnaryStrings(suppliers, read, DataType.KEYWORD, bytesRef -> bytesRef, List.of());
+        TestCaseSupplier.forUnaryFlattened(suppliers, read, DataType.KEYWORD, bytesRef -> bytesRef, List.of());
         TestCaseSupplier.forUnaryVersion(
             suppliers,
             "ToStringFromVersionEvaluator[version=" + read + "]",


### PR DESCRIPTION
Adds support for `TO_STRING(flattened)` and `COUNT(flattened)`.
