### PR TITLE
Skip stateless plugin tests on Windows

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -228,6 +228,10 @@ gradlePlugin {
       id = 'elasticsearch.internal-yaml-rest-test'
       implementationClass = 'org.elasticsearch.gradle.internal.test.rest.InternalYamlRestTestPlugin'
     }
+    skipTestsOnWindows {
+      id = 'elasticsearch.skip-tests-on-windows'
+      implementationClass = 'org.elasticsearch.gradle.internal.test.SkipTestsOnWindowsPlugin'
+    }
     transportVersionReferencesPlugin {
       id = 'elasticsearch.transport-version-references'
       implementationClass = 'org.elasticsearch.gradle.internal.transport.TransportVersionReferencesPlugin'

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/SkipTestsOnWindowsPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/SkipTestsOnWindowsPluginFuncTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.test
+
+import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.gradle.testkit.runner.TaskOutcome
+
+class SkipTestsOnWindowsPluginFuncTest extends AbstractGradleFuncTest {
+    def setup() {
+        configurationCacheCompatible = false
+        file("src/test/java/org/acme/Dummy.java") << """
+            package org.acme;
+            public class Dummy {}
+        """
+    }
+
+    def "test task is skipped when simulating windows"() {
+        given:
+        buildFile.text = """
+            plugins {
+              id 'java'
+              id 'elasticsearch.skip-tests-on-windows'
+            }
+
+            tasks.register("otherTest", Test) {
+              testClassesDirs = tasks.named("test").get().testClassesDirs
+              classpath = tasks.named("test").get().classpath
+            }
+
+            tasks.withType(Test).configureEach {
+              failOnNoDiscoveredTests = false
+            }
+        """
+
+        when:
+        def result = gradleRunner(
+            "test",
+            "otherTest",
+            "-Dos.name=Windows 11",
+            "--rerun-tasks",
+        ).build()
+
+        then:
+        result.task(":test").outcome == TaskOutcome.SKIPPED
+        result.task(":otherTest").outcome == TaskOutcome.SKIPPED
+    }
+
+    def "test task runs on non-windows"() {
+        given:
+        buildFile.text = """
+            plugins {
+              id 'java'
+              id 'elasticsearch.skip-tests-on-windows'
+            }
+
+            tasks.register("otherTest", Test) {
+              testClassesDirs = tasks.named("test").get().testClassesDirs
+              classpath = tasks.named("test").get().classpath
+            }
+
+            tasks.withType(Test).configureEach {
+              failOnNoDiscoveredTests = false
+            }
+        """
+
+        when:
+        def result = gradleRunner("test", "otherTest", "--rerun-tasks").build()
+
+        then:
+        result.task(":test").outcome == TaskOutcome.SUCCESS
+        result.task(":otherTest").outcome == TaskOutcome.SUCCESS
+    }
+}
+

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/SkipTestsOnWindowsPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/SkipTestsOnWindowsPlugin.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.test;
+
+import org.elasticsearch.gradle.OS;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.testing.Test;
+
+public class SkipTestsOnWindowsPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getTasks()
+            .withType(Test.class)
+            .configureEach(test -> test.onlyIf("Not running on windows", task -> OS.current() != OS.WINDOWS));
+    }
+}

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/test/SkipTestsOnWindowsPluginTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/test/SkipTestsOnWindowsPluginTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.test;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class SkipTestsOnWindowsPluginTests {
+
+    @Test
+    public void testDisablesTestTasksOnWindows() {
+        withOsName("Windows 11", () -> {
+            Project project = ProjectBuilder.builder().build();
+            project.getPlugins().apply("java");
+            project.getPlugins().apply("elasticsearch.skip-tests-on-windows");
+
+            org.gradle.api.tasks.testing.Test test = (org.gradle.api.tasks.testing.Test) project.getTasks().getByName("test");
+            assertThat(test.getOnlyIf().isSatisfiedBy(test), is(false));
+        });
+    }
+
+    @Test
+    public void testAllowsTestTasksOnNonWindows() {
+        withOsName("Linux", () -> {
+            Project project = ProjectBuilder.builder().build();
+            project.getPlugins().apply("java");
+            project.getPlugins().apply("elasticsearch.skip-tests-on-windows");
+
+            org.gradle.api.tasks.testing.Test test = (org.gradle.api.tasks.testing.Test) project.getTasks().getByName("test");
+            assertThat(test.getOnlyIf().isSatisfiedBy(test), is(true));
+        });
+    }
+
+    private static void withOsName(String osName, Runnable runnable) {
+        String previous = System.getProperty("os.name");
+        try {
+            System.setProperty("os.name", osName);
+            runnable.run();
+        } finally {
+            if (previous == null) {
+                System.clearProperty("os.name");
+            } else {
+                System.setProperty("os.name", previous);
+            }
+        }
+    }
+}
+

--- a/x-pack/plugin/stateless-health-shards-availability/build.gradle
+++ b/x-pack/plugin/stateless-health-shards-availability/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.skip-tests-on-windows'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-test-artifact'

--- a/x-pack/plugin/stateless-master-failover/build.gradle
+++ b/x-pack/plugin/stateless-master-failover/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.skip-tests-on-windows'
 
 esplugin {
     name = 'stateless-master-failover'

--- a/x-pack/plugin/stateless-no-wait-for-active-shards/build.gradle
+++ b/x-pack/plugin/stateless-no-wait-for-active-shards/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.skip-tests-on-windows'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 

--- a/x-pack/plugin/stateless-sigterm/build.gradle
+++ b/x-pack/plugin/stateless-sigterm/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.skip-tests-on-windows'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 

--- a/x-pack/plugin/stateless/build.gradle
+++ b/x-pack/plugin/stateless/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.skip-tests-on-windows'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'


### PR DESCRIPTION
## Summary

Skip stateless x-pack plugin module tests on Windows to avoid known Windows-only CI failures.

## Changes

- Add an `elasticsearch.skip-tests-on-windows` Gradle plugin (build-tools-internal) that disables `Test` tasks on Windows.
- Apply the plugin to the stateless x-pack plugin modules so their test tasks are skipped on Windows.
- Add unit + functional tests for the build logic.

#147959

