### PR TITLE
Fix testConfiguredReservedRolesAfterClosingAndOpeningIndex - Take 2

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -440,9 +440,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.single_node.RestSqlIT
   method: testNextPageText
   issue: https://github.com/elastic/elasticsearch/issues/147950
-- class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
-  method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
-  issue: https://github.com/elastic/elasticsearch/issues/147972
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testDataStreamStatsActionBroadcastedToSearchNodesOnly
   issue: https://github.com/elastic/elasticsearch/issues/147973

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryableReservedRolesIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryableReservedRolesIT.java
@@ -295,6 +295,15 @@ public class QueryableReservedRolesIT extends ESRestTestCase {
         );
         Response response = adminClient().performRequest(request);
         assertOK(response);
+        // The close API can return acknowledged with the close-block applied but before IndexMetadata.state has
+        // been flipped to CLOSE.
+        assertBusy(() -> {
+            final Request stateRequest = new Request("GET", "_cluster/state/metadata/" + INTERNAL_SECURITY_MAIN_INDEX_7);
+            final Response stateResponse = adminClient().performRequest(stateRequest);
+            assertOK(stateResponse);
+            final String indexState = ObjectPath.createFromResponse(stateResponse).evaluate("metadata.indices.\\.security-7.state");
+            assertThat(indexState, equalTo("close"));
+        }, 30, TimeUnit.SECONDS);
     }
 
     private void openSecurityIndex() throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizer.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizer.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.SimpleBatchedExecutor;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.MetadataIndexStateService;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
@@ -487,7 +488,24 @@ public final class QueryableBuiltInRolesSynchronizer implements ClusterStateList
 
     private boolean isSecurityIndexClosed(final ClusterState state) {
         final IndexMetadata indexMetadata = resolveSecurityIndexMetadata(state.metadata());
-        return indexMetadata != null && indexMetadata.getState() == IndexMetadata.State.CLOSE;
+        return indexMetadata != null && isClosedOrClosing(state, indexMetadata);
+    }
+
+    /**
+     * Returns true if the given index is closed or is in the process of being closed. The close API installs
+     * {@link MetadataIndexStateService#INDEX_CLOSED_BLOCK} before flipping {@link IndexMetadata#getState()} to
+     * {@link IndexMetadata.State#CLOSE}, so checking the state field alone misses the in-progress window.
+     */
+    private static boolean isClosedOrClosing(final ClusterState state, final IndexMetadata indexMetadata) {
+        if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
+            return true;
+        }
+        return state.blocks()
+            .hasIndexBlockWithId(
+                state.metadata().projectFor(indexMetadata.getIndex()).id(),
+                indexMetadata.getIndex().getName(),
+                MetadataIndexStateService.INDEX_CLOSED_BLOCK_ID
+            );
     }
 
     /**
@@ -504,12 +522,13 @@ public final class QueryableBuiltInRolesSynchronizer implements ClusterStateList
         final Map<String, String> newRolesDigests,
         final ActionListener<Void> listener
     ) {
-        final IndexMetadata securityIndexMetadata = resolveSecurityIndexMetadata(clusterService.state().metadata());
+        final ClusterState currentState = clusterService.state();
+        final IndexMetadata securityIndexMetadata = resolveSecurityIndexMetadata(currentState.metadata());
         if (securityIndexMetadata == null) {
             listener.onFailure(new IndexNotFoundException(SECURITY_MAIN_ALIAS));
             return;
         }
-        if (securityIndexMetadata.getState() == IndexMetadata.State.CLOSE) {
+        if (isClosedOrClosing(currentState, securityIndexMetadata)) {
             listener.onFailure(new IndexClosedException(securityIndexMetadata.getIndex()));
             return;
         }
@@ -580,11 +599,9 @@ public final class QueryableBuiltInRolesSynchronizer implements ClusterStateList
             if (indexMetadata == null) {
                 throw new IndexNotFoundException(concreteSecurityIndexName);
             }
-            if (indexMetadata.getState() == IndexMetadata.State.CLOSE) {
-                // Index was closed between when the sync started and when this task runs. Do not update the
-                // synced-roles digest in metadata, since the actual role documents could not have been
-                // updated/deleted in a closed index. IndexClosedException is treated as an expected failure
-                // and does not count toward failedSyncAttempts.
+            if (isClosedOrClosing(state, indexMetadata)) {
+                // Bail if the index closed (or began closing) since the sync started. IndexClosedException is
+                // in isExpectedFailure, so this does not count against failedSyncAttempts.
                 throw new IndexClosedException(indexMetadata.getIndex());
             }
             Map<String, String> existingRoleDigests = indexMetadata.getCustomData(METADATA_QUERYABLE_BUILT_IN_ROLES_DIGEST_KEY);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizerTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.MetadataIndexStateService;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
@@ -406,6 +407,29 @@ public class QueryableBuiltInRolesSynchronizerTests extends ESTestCase {
         // could not have been updated.
         final ClusterState clusterState = markShardsAvailable(createClusterStateWithClosedSecurityIndex()).nodes(localNodeMaster())
             .blocks(emptyClusterBlocks())
+            .build();
+        final Map<String, String> newRoleDigests = Map.of("superuser", "digest-1", "viewer", "digest-2");
+        final MarkRolesAsSyncedTask task = new MarkRolesAsSyncedTask(
+            ActionListener.noop(),
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7,
+            null,
+            newRoleDigests
+        );
+        expectThrows(IndexClosedException.class, () -> task.execute(clusterState));
+    }
+
+    public void testMarkRolesAsSyncedTaskRejectsClosingInProgressIndex() {
+        // INDEX_CLOSED_BLOCK is added before IndexMetadata.state flips to CLOSE; the task must reject
+        // both, not just state == CLOSE.
+        final ClusterBlocks closingInProgressBlocks = ClusterBlocks.builder()
+            .addIndexBlock(
+                ProjectId.DEFAULT,
+                TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7,
+                MetadataIndexStateService.INDEX_CLOSED_BLOCK
+            )
+            .build();
+        final ClusterState clusterState = markShardsAvailable(createClusterStateWithOpenSecurityIndex()).nodes(localNodeMaster())
+            .blocks(closingInProgressBlocks)
             .build();
         final Map<String, String> newRoleDigests = Map.of("superuser", "digest-1", "viewer", "digest-2");
         final MarkRolesAsSyncedTask task = new MarkRolesAsSyncedTask(


### PR DESCRIPTION
Resolves: #147972
Follow-up to: #147710

#147710 added a closed-index check to MarkRolesAsSyncedTask.execute to stop a sync that started against an open index from writing the new digest after the index was closed. The test still flakes at ~1.5%, with the same symptom: after `closeSecurityIndex()` + `cluster.restart()`, the metadata digest contains the new (small) reserved-roles set instead of the previous (large) set — i.e. a sync ran end-to-end on what should have been a closed index.

### Hypothesis for the remaining race
The close API performs three observable steps:
1. Add `INDEX_CLOSED_BLOCK` (a temporary write-only block)
2. `TransportVerifyShardBeforeCloseAction` against each shard.
3. Replace the temp block with the final `INDEX_CLOSED_BLOCK` (read+write) and flip `IndexMetadata.state` to CLOSE.

Between steps 1 and 3, the index has the close block but state is still OPEN. A sync that already passed `shouldSyncBuiltInRoles` can race through that window:
- `nativeRolesStore.deleteRoles` checks `IndexState.isAvailable(PRIMARY_SHARDS)`, which only checks `state == CLOSE`  so it returns true during the transition.
- The bulk delete is submitted; if it cleared the bulk action's block check before the block was applied, it can complete.
- `MarkRolesAsSyncedTask.execute` then runs and only checks `state == CLOSE` sees `OPEN`, writes the new digest into the metadata of an effectively-closed index.

The same window is reachable across cluster restart if the close API ack is observed before `state == CLOSE` is fully published/persisted.

Fix
`QueryableBuiltInRolesSynchronizer.java`:
- Replace the `state == CLOSE` check with `isClosedOrClosing(state, indexMetadata)`, which returns true if either `state == CLOSE` or `INDEX_CLOSED_BLOCK_ID` is present on the index.
- Apply this in all three guard points: `isSecurityIndexClosed` (used by `shouldSyncBuiltInRoles`), `markRolesAsSynced` (pre-submit guard), and `MarkRolesAsSyncedTask.execute` (task-execution guard).

`QueryableBuiltInRolesSynchronizerTests.java`:
- Added `testMarkRolesAsSyncedTaskRejectsClosingInProgressIndex` exercising the new transition case (state=OPEN with INDEX_CLOSED_BLOCK) directly against `MarkRolesAsSyncedTask.execute`.

`QueryableReservedRolesIT.java`:
- After `closeSecurityIndex()`, `assertBusy` until `metadata.indices['.security-7'].state == "close"` so that `cluster.restart()` always sees a fully-closed index in persisted cluster state.