### PR TITLE
Add Remote Reindexing Test for 8.12

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -129,6 +129,7 @@ if (OS.current() == OS.WINDOWS) {
     systemProperty "tests.fromRemote7x", "false"
     systemProperty "tests.fromRemote7xEs79", "false"
     systemProperty "tests.fromRemote7xEs710", "false"
+    systemProperty "tests.fromRemoteEs812", "false"
   }
 } else if (rootProject.rootDir.toString().contains(" ")) {
   logger.warn("Disabling reindex-from-old tests because Elasticsearch 1.7 won't start with spaces in the path")
@@ -137,6 +138,7 @@ if (OS.current() == OS.WINDOWS) {
     systemProperty "tests.fromRemote7x", "false"
     systemProperty "tests.fromRemote7xEs79", "false"
     systemProperty "tests.fromRemote7xEs710", "false"
+    systemProperty "tests.fromRemoteEs812", "false"
   }
 } else {
   /* Register a gradle artifact transformation to unpack resolved elasticsearch distributions. We only resolve
@@ -257,6 +259,15 @@ if (OS.current() == OS.WINDOWS) {
     remoteEs710Fixture = registerRemoteReindex7xFixture("remoteEs710Fixture", remoteEs710Dist)
   }
 
+  ElasticsearchDistribution remoteEs812Dist = distributions.findByName("remote_reindex_es812")
+  if (remoteEs812Dist == null) {
+    remoteEs812Dist = distributions.create("remote_reindex_es812") { ElasticsearchDistribution d ->
+      d.version = "8.12.2"
+      d.architecture = Architecture.current()
+    }
+  }
+  def remoteEs812Fixture = registerRemoteReindex7xFixture("remoteEs812Fixture", remoteEs812Dist)
+
   tasks.named("javaRestTest").configure {
     if (remoteEs710Fixture != null) {
       dependsOn remoteEs710Fixture
@@ -264,15 +275,18 @@ if (OS.current() == OS.WINDOWS) {
     if (remoteEs79Fixture != null) {
       dependsOn remoteEs79Fixture
     }
+    dependsOn remoteEs812Fixture
     systemProperty "tests.fromRemote7x", "true"
     systemProperty "tests.fromRemote7xEs79", macOsAarch64 ? "false" : "true"
     systemProperty "tests.fromRemote7xEs710", macOsAarch64 ? "false" : "true"
+    systemProperty "tests.fromRemoteEs812", "true"
     if (remoteEs79Fixture != null) {
       nonInputProperties.systemProperty "es79.port", remoteEs79Fixture.map(f -> f.addressAndPort)
     }
     if (remoteEs710Fixture != null) {
       nonInputProperties.systemProperty "es710.port", remoteEs710Fixture.map(f -> f.addressAndPort)
     }
+    nonInputProperties.systemProperty "es812.port", remoteEs812Fixture.map(f -> f.addressAndPort)
   }
 }
 

--- a/modules/reindex/src/javaRestTest/java/org/elasticsearch/index/reindex/remote/ReindexFromRemoteIT.java
+++ b/modules/reindex/src/javaRestTest/java/org/elasticsearch/index/reindex/remote/ReindexFromRemoteIT.java
@@ -50,13 +50,7 @@ public class ReindexFromRemoteIT extends ESRestTestCase {
                 for (int i = 0; i < DOCS; i++) {
                     String id = "doc" + i;
                     bulkBody.append(
-                        String.format(
-                            Locale.ROOT,
-                            "{\"index\":{\"_index\":\"%s\",\"_id\":\"%s\"}}\n{\"id\":\"%s\"}\n",
-                            remoteIndex,
-                            id,
-                            id
-                        )
+                        String.format(Locale.ROOT, "{\"index\":{\"_index\":\"%s\",\"_id\":\"%s\"}}\n{\"id\":\"%s\"}\n", remoteIndex, id, id)
                     );
                 }
                 Request bulk = new Request("POST", "/_bulk");

--- a/modules/reindex/src/javaRestTest/java/org/elasticsearch/index/reindex/remote/ReindexFromRemoteIT.java
+++ b/modules/reindex/src/javaRestTest/java/org/elasticsearch/index/reindex/remote/ReindexFromRemoteIT.java
@@ -18,20 +18,18 @@ import org.elasticsearch.core.Booleans;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
 import java.io.IOException;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.containsString;
 
 /**
- * Reindex-from-remote against Elasticsearch 7.9.x (remote scroll) and 7.10.0 (remote PIT when supported).
+ * Reindex-from-remote against external Elasticsearch clusters (see {@code modules/reindex/build.gradle}).
  */
-public class ReindexFromRemote7xIT extends ESRestTestCase {
+public class ReindexFromRemoteIT extends ESRestTestCase {
 
     private static final int DOCS = 10;
 
-    private void reindexFromRemote7x(String portProperty, String remoteIndex, String destIndex) throws IOException {
-        boolean enabled = Booleans.parseBoolean(System.getProperty("tests.fromRemote7x"));
-        assumeTrue("test is disabled (windows, path with spaces, or fixtures not wired)", enabled);
-
+    private void reindexFromRemoteCluster(String portProperty, String remoteIndex, String destIndex) throws IOException {
         int remotePort = Integer.parseInt(System.getProperty(portProperty));
         boolean success = false;
         try (RestClient remote = RestClient.builder(new HttpHost("127.0.0.1", remotePort)).build()) {
@@ -53,7 +51,7 @@ public class ReindexFromRemote7xIT extends ESRestTestCase {
                     String id = "doc" + i;
                     bulkBody.append(
                         String.format(
-                            java.util.Locale.ROOT,
+                            Locale.ROOT,
                             "{\"index\":{\"_index\":\"%s\",\"_id\":\"%s\"}}\n{\"id\":\"%s\"}\n",
                             remoteIndex,
                             id,
@@ -69,7 +67,7 @@ public class ReindexFromRemote7xIT extends ESRestTestCase {
                 Request reindex = new Request("POST", "/_reindex");
                 reindex.addParameter("refresh", "true");
                 reindex.addParameter("pretty", "true");
-                reindex.setJsonEntity(String.format(java.util.Locale.ROOT, """
+                reindex.setJsonEntity(String.format(Locale.ROOT, """
                     {
                       "source": {
                         "index": "%s",
@@ -108,21 +106,40 @@ public class ReindexFromRemote7xIT extends ESRestTestCase {
         }
     }
 
-    /** Remote is 7.9.0, so the reindex client uses scroll search */
+    /** Remote is 7.9.x; the reindex client uses scroll search. */
     public void testReindexFromRemote79() throws IOException {
+        assumeTrue(
+            "test is disabled (windows, path with spaces, or fixtures not wired)",
+            Booleans.parseBoolean(System.getProperty("tests.fromRemote7x"))
+        );
         assumeTrue(
             "remote 7.9 fixture not run on this platform (e.g. darwin-aarch64 has no 7.9 archive)",
             Booleans.parseBoolean(System.getProperty("tests.fromRemote7xEs79", "true"))
         );
-        reindexFromRemote7x("es79.port", "reindex_remote_79_src", "reindex_remote_79_dest");
+        reindexFromRemoteCluster("es79.port", "reindex_remote_79_src", "reindex_remote_79_dest");
     }
 
-    /** Remote is 7.10.0, so the reindex client uses PIT search */
+    /** Remote is 7.10.0; the reindex client uses PIT search. */
     public void testReindexFromRemote710() throws IOException {
+        assumeTrue(
+            "test is disabled (windows, path with spaces, or fixtures not wired)",
+            Booleans.parseBoolean(System.getProperty("tests.fromRemote7x"))
+        );
         assumeTrue(
             "remote 7.10.0 fixture not run on this platform (e.g. darwin-aarch64 has no 7.10 archive)",
             Booleans.parseBoolean(System.getProperty("tests.fromRemote7xEs710", "true"))
         );
-        reindexFromRemote7x("es710.port", "reindex_remote_710_src", "reindex_remote_710_dest");
+        reindexFromRemoteCluster("es710.port", "reindex_remote_710_src", "reindex_remote_710_dest");
+    }
+
+    /**
+     * Remote is 8.12.x; the reindex client uses PIT search. Open PIT may include {@code index_filter} when applicable.
+     */
+    public void testReindexFromRemote812() throws IOException {
+        assumeTrue(
+            "test is disabled (windows, path with spaces, or fixture not wired)",
+            Booleans.parseBoolean(System.getProperty("tests.fromRemoteEs812"))
+        );
+        reindexFromRemoteCluster("es812.port", "reindex_remote_812_src", "reindex_remote_812_dest");
     }
 }

--- a/modules/reindex/src/javaRestTest/java/org/elasticsearch/index/reindex/remote/ReindexFromRemoteIT.java
+++ b/modules/reindex/src/javaRestTest/java/org/elasticsearch/index/reindex/remote/ReindexFromRemoteIT.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 import static org.hamcrest.Matchers.containsString;
 
 /**
- * Reindex-from-remote against external Elasticsearch clusters (see {@code modules/reindex/build.gradle}).
+ * Reindex-from-remote against external Elasticsearch clusters
  */
 public class ReindexFromRemoteIT extends ESRestTestCase {
 

--- a/modules/reindex/src/javaRestTest/java/org/elasticsearch/index/reindex/remote/ReindexFromRemoteIT.java
+++ b/modules/reindex/src/javaRestTest/java/org/elasticsearch/index/reindex/remote/ReindexFromRemoteIT.java
@@ -106,7 +106,7 @@ public class ReindexFromRemoteIT extends ESRestTestCase {
         }
     }
 
-    /** Remote is 7.9.x; the reindex client uses scroll search. */
+    /** Remote is 7.9.x, so the reindex client uses scroll search. */
     public void testReindexFromRemote79() throws IOException {
         assumeTrue(
             "test is disabled (windows, path with spaces, or fixtures not wired)",
@@ -119,7 +119,7 @@ public class ReindexFromRemoteIT extends ESRestTestCase {
         reindexFromRemoteCluster("es79.port", "reindex_remote_79_src", "reindex_remote_79_dest");
     }
 
-    /** Remote is 7.10.0; the reindex client uses PIT search. */
+    /** Remote is 7.10.0, so the reindex client uses PIT search. */
     public void testReindexFromRemote710() throws IOException {
         assumeTrue(
             "test is disabled (windows, path with spaces, or fixtures not wired)",
@@ -133,7 +133,7 @@ public class ReindexFromRemoteIT extends ESRestTestCase {
     }
 
     /**
-     * Remote is 8.12.x; the reindex client uses PIT search. Open PIT may include {@code index_filter} when applicable.
+     * Remote is 8.12.x. The reindex client uses PIT search. Open PIT may include {@code index_filter} when applicable.
      */
     public void testReindexFromRemote812() throws IOException {
         assumeTrue(

--- a/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
+++ b/test/fixtures/old-elasticsearch/src/main/java/oldes/OldElasticsearch.java
@@ -34,6 +34,26 @@ import java.util.regex.Pattern;
  * writing a "ports" file.
  */
 public class OldElasticsearch {
+
+    private static final Pattern ELASTICSEARCH_DIR_MAJOR = Pattern.compile("elasticsearch-(\\d+)");
+
+    /**
+     * {@code transport.tcp.port} was removed in Elasticsearch 8.0 in favor of {@code transport.port}.
+     */
+    private static String bindRandomTransportPortLine(Path esInstallDir) {
+        Matcher m = ELASTICSEARCH_DIR_MAJOR.matcher(esInstallDir.getFileName().toString());
+        if (m.find()) {
+            try {
+                if (Integer.parseInt(m.group(1)) >= 8) {
+                    return "transport.port: 0";
+                }
+            } catch (NumberFormatException e) {
+                // use legacy setting
+            }
+        }
+        return "transport.tcp.port: 0";
+    }
+
     public static void main(String[] args) throws IOException {
         Path baseDir = Paths.get(args[0]);
         Path unzipDir = Paths.get(args[1]);
@@ -75,7 +95,7 @@ public class OldElasticsearch {
         Path config = esDir.resolve("config").resolve("elasticsearch.yml");
 
         List<String> configOptions = new ArrayList<>();
-        configOptions.addAll(Arrays.asList("http.port: 0", "transport.tcp.port: 0", "network.host: 127.0.0.1"));
+        configOptions.addAll(Arrays.asList("http.port: 0", bindRandomTransportPortLine(esDir), "network.host: 127.0.0.1"));
         if (args.length > 3) {
             for (int i = 3; i < args.length; i++) {
                 configOptions.add(args[i]);
@@ -93,6 +113,12 @@ public class OldElasticsearch {
         Path pidPath = baseDir.relativize(baseDir.resolve("pid"));
         command.add(pidPath.toString().replace("&", "\\&"));
         ProcessBuilder subprocess = new ProcessBuilder(command);
+        /*
+         * The Gradle fixture sets CLASSPATH to run this launcher (often including lucene-core from this
+         * subproject). That environment is inherited here; Elasticsearch 8+ configures JVM security policies
+         * per Lucene codebase and crashes if CLASSPATH duplicates another lucene-core (different version).
+         */
+        subprocess.environment().remove("CLASSPATH");
         Process process = subprocess.start();
         System.out.println("Running " + command);
 


### PR DESCRIPTION
Adds a reindexing integration test that spins up a cluster on version 8.12.X and reindexes into it. Version 8.12 gates whether we use an `index_filter` parameter when opening a pit

Relates: https://github.com/elastic/elasticsearch-team/issues/2101
