### PR TITLE
Close metric instruments after changing provider

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/AbstractInstrument.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/AbstractInstrument.java
@@ -47,7 +47,15 @@ public abstract class AbstractInstrument<T> implements Instrument {
     }
 
     void setProvider(@Nullable Meter meter) {
-        delegate.set(instrumentBuilder.apply(Objects.requireNonNull(meter)));
+        var oldInstrument = delegate.getAndSet(instrumentBuilder.apply(Objects.requireNonNull(meter)));
+        if (oldInstrument instanceof AutoCloseable closeableOldInstrument) {
+            try {
+                closeableOldInstrument.close();
+            } catch (Exception e) {
+                assert true : "OTel metrics must not throw on close()";
+                throw new IllegalStateException("OTel metrics must not throw on close()", e);
+            }
+        }
     }
 
     protected abstract static class Builder<T> {

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/GaugeAdapterTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/GaugeAdapterTests.java
@@ -138,4 +138,29 @@ public class GaugeAdapterTests extends ESTestCase {
         AssertionError error = assertThrows(AssertionError.class, otelMeter::collectMetrics);
         assertThat(error.getMessage(), containsString("Attribute [es_has_timestamp] of [es.test.name.total] is forbidden"));
     }
+
+    public void testGaugeDoesNotReportOldValuesAnymoreAfterChangingProvider() {
+        var anotherMeter = new RecordingOtelMeter();
+        var value = new AtomicReference<>(42L);
+
+        var gauge = registry.registerLongGauge("es.test.name.total", "desc", "thingies", () -> new LongWithAttributes(value.get()));
+
+        otelMeter.collectMetrics();
+        var metrics = otelMeter.getRecorder().getMeasurements(gauge);
+        assertThat(metrics, hasSize(1));
+        assertThat(metrics.get(0).getLong(), equalTo(42L));
+
+        registry.setProvider(anotherMeter);
+        value.set(12L);
+
+        anotherMeter.collectMetrics();
+        metrics = anotherMeter.getRecorder().getMeasurements(gauge);
+        assertThat(metrics, hasSize(1));
+        assertThat("New meter records the updated value", metrics.get(0).getLong(), equalTo(12L));
+
+        otelMeter.getRecorder().resetCalls();
+        otelMeter.collectMetrics();
+        metrics = otelMeter.getRecorder().getMeasurements(gauge);
+        assertThat("Old meter does not record anything anymore after being overriden", metrics, hasSize(0));
+    }
 }


### PR DESCRIPTION
This PR solves a subtle bug: async instruments continued to observe measurements on the old OTel `Meter` even after calling `APMMeterRegistry#setProvider()`.
