### PR TITLE
Missing ensureGreen() call in TSDBSyntheticIdsIT#testSyntheticId

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBSyntheticIdsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBSyntheticIdsIT.java
@@ -387,6 +387,7 @@ public class TSDBSyntheticIdsIT extends ESIntegTestCase {
         if (randomBoolean()) {
             logger.info("--> restarting the cluster");
             internalCluster().rollingRestart(new InternalTestCluster.RestartCallback());
+            ensureGreen(dataStreamName);
         } else {
             // Move all the shards to a new node to force relocations
             var newNodeName = internalCluster().startDataOnlyNode();


### PR DESCRIPTION
Fixes a rare failure in this test where no shards were available after a rolling restart due to slow or busy machines.  Calling ensureGreen() will wait for shards to be available before continuing the test.

Fixes #148235