### PR TITLE
Add isEmpty() to ExponentialHistogram

### DIFF
--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogram.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogram.java
@@ -110,6 +110,16 @@ public interface ExponentialHistogram extends Accountable {
     long valueCount();
 
     /**
+     * Returns whether this histogram is empty, i.e. contains no values.
+     * Implementations may override this in case {@link #valueCount()} is expensive.
+     *
+     * @return true if this histogram contains no values
+     */
+    default boolean isEmpty() {
+        return valueCount() == 0;
+    }
+
+    /**
      * Returns minimum of all values represented by this histogram.
      *
      * @return the minimum, NaN for empty histograms

--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramMerger.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramMerger.java
@@ -197,6 +197,9 @@ public class ExponentialHistogramMerger implements Accountable, Releasable {
      * @param toAdd the histogram to merge
      */
     public void add(ExponentialHistogram toAdd) {
+        if (toAdd.isEmpty()) {
+            return;
+        }
         ExponentialHistogram a = result == null ? ExponentialHistogram.empty() : result;
         ExponentialHistogram b = toAdd;
 

--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/FixedCapacityExponentialHistogram.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/FixedCapacityExponentialHistogram.java
@@ -184,6 +184,11 @@ final class FixedCapacityExponentialHistogram extends AbstractExponentialHistogr
     }
 
     @Override
+    public boolean isEmpty() {
+        return negativeBuckets.numBuckets == 0 && positiveBuckets.numBuckets == 0 && zeroBucket.count() == 0;
+    }
+
+    @Override
     public int scale() {
         return bucketScale;
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExponentialHistogramStateTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExponentialHistogramStateTests.java
@@ -178,7 +178,7 @@ public class ExponentialHistogramStateTests extends ESTestCase {
             ExponentialHistogram sample;
             do {
                 sample = randomHistogram(randomIntBetween(4, 100));
-            } while (sample.valueCount() == 0);
+            } while (sample.isEmpty());
             state.add(sample);
 
             assertThat(state.size(), equalTo(sample.valueCount()));

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/bucket/histogram/ExponentialHistogramBackedHistogramAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/bucket/histogram/ExponentialHistogramBackedHistogramAggregatorTests.java
@@ -50,12 +50,12 @@ public class ExponentialHistogramBackedHistogramAggregatorTests extends Exponent
             histograms.clear();
             histograms.addAll(createRandomHistograms(randomIntBetween(1, 1000)));
             min = histograms.stream()
-                .filter(histogram -> histogram.valueCount() > 0)
+                .filter(histogram -> histogram.isEmpty() == false)
                 .mapToDouble(ExponentialHistogram::min)
                 .min()
                 .orElse(0.0);
             max = histograms.stream()
-                .filter(histogram -> histogram.valueCount() > 0)
+                .filter(histogram -> histogram.isEmpty() == false)
                 .mapToDouble(ExponentialHistogram::max)
                 .max()
                 .orElse(0.0);
@@ -140,8 +140,8 @@ public class ExponentialHistogramBackedHistogramAggregatorTests extends Exponent
             .map(Map.Entry::getKey)
             .toList();
 
-        double min = filteredHistograms.stream().filter(h -> h.valueCount() > 0).mapToDouble(ExponentialHistogram::min).min().orElse(0.0);
-        double max = filteredHistograms.stream().filter(h -> h.valueCount() > 0).mapToDouble(ExponentialHistogram::max).max().orElse(0.0);
+        double min = filteredHistograms.stream().filter(h -> h.isEmpty() == false).mapToDouble(ExponentialHistogram::min).min().orElse(0.0);
+        double max = filteredHistograms.stream().filter(h -> h.isEmpty() == false).mapToDouble(ExponentialHistogram::max).max().orElse(0.0);
         double interval = Math.max(1.0, (max - min) / 20);
         Map<Double, Long> expectedHistogram = computeExpectedHistogram(filteredHistograms, interval, 0.0);
 
@@ -158,7 +158,7 @@ public class ExponentialHistogramBackedHistogramAggregatorTests extends Exponent
             ),
             histogram -> {
                 assertThat(histogram.getBuckets().size(), equalTo(expectedHistogram.size()));
-                if (filteredHistograms.stream().anyMatch(h -> h.valueCount() > 0)) {
+                if (filteredHistograms.stream().anyMatch(h -> h.isEmpty() == false)) {
                     assertThat(AggregationInspectionHelper.hasValue(histogram), equalTo(true));
                 } else {
                     assertThat(AggregationInspectionHelper.hasValue(histogram), equalTo(false));

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/ExponentialHistogramMaxAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/ExponentialHistogramMaxAggregatorTests.java
@@ -41,7 +41,7 @@ public class ExponentialHistogramMaxAggregatorTests extends ExponentialHistogram
     public void testMatchesNumericDocValues() throws IOException {
 
         List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(1, 1000));
-        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.isEmpty() == false);
 
         double expectedMax = histograms.stream()
             .mapToDouble(ExponentialHistogram::max)
@@ -77,10 +77,10 @@ public class ExponentialHistogramMaxAggregatorTests extends ExponentialHistogram
             .map(histo -> Map.entry(histo, randomBoolean()))
             .toList();
 
-        boolean anyMatch = histogramsWithFilter.stream().filter(entry -> entry.getKey().valueCount() > 0).anyMatch(Map.Entry::getValue);
+        boolean anyMatch = histogramsWithFilter.stream().filter(entry -> entry.getKey().isEmpty() == false).anyMatch(Map.Entry::getValue);
         double filteredMax = histogramsWithFilter.stream()
             .filter(Map.Entry::getValue)
-            .filter(entry -> entry.getKey().valueCount() > 0)
+            .filter(entry -> entry.getKey().isEmpty() == false)
             .mapToDouble(entry -> entry.getKey().max())
             .max()
             .orElse(Double.NEGATIVE_INFINITY);

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/ExponentialHistogramMinAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/ExponentialHistogramMinAggregatorTests.java
@@ -41,7 +41,7 @@ public class ExponentialHistogramMinAggregatorTests extends ExponentialHistogram
     public void testMatchesNumericDocValues() throws IOException {
 
         List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(1, 1000));
-        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.isEmpty() == false);
 
         double expectedMin = histograms.stream()
             .mapToDouble(ExponentialHistogram::min)
@@ -77,10 +77,10 @@ public class ExponentialHistogramMinAggregatorTests extends ExponentialHistogram
             .map(histo -> Map.entry(histo, randomBoolean()))
             .toList();
 
-        boolean anyMatch = histogramsWithFilter.stream().filter(entry -> entry.getKey().valueCount() > 0).anyMatch(Map.Entry::getValue);
+        boolean anyMatch = histogramsWithFilter.stream().filter(entry -> entry.getKey().isEmpty() == false).anyMatch(Map.Entry::getValue);
         double filteredMin = histogramsWithFilter.stream()
             .filter(Map.Entry::getValue)
-            .filter(entry -> entry.getKey().valueCount() > 0)
+            .filter(entry -> entry.getKey().isEmpty() == false)
             .mapToDouble(entry -> entry.getKey().min())
             .min()
             .orElse(Double.POSITIVE_INFINITY);

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/ExponentialHistogramPercentileRanksAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/ExponentialHistogramPercentileRanksAggregatorTests.java
@@ -86,7 +86,7 @@ public class ExponentialHistogramPercentileRanksAggregatorTests extends Exponent
 
     public void testRandomHistograms() throws IOException {
         List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(1, 100));
-        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.isEmpty() == false);
 
         testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, FIELD_NAME, histo)), percentileRanks -> {
             assertThat(AggregationInspectionHelper.hasValue(percentileRanks), equalTo(anyNonEmpty));
@@ -104,7 +104,7 @@ public class ExponentialHistogramPercentileRanksAggregatorTests extends Exponent
             .map(Map.Entry::getKey)
             .toList();
 
-        boolean anyMatchingNonEmpty = filteredHistograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+        boolean anyMatchingNonEmpty = filteredHistograms.stream().anyMatch(histo -> histo.isEmpty() == false);
 
         testCase(
             new TermQuery(new Term("match", "yes")),
@@ -125,7 +125,7 @@ public class ExponentialHistogramPercentileRanksAggregatorTests extends Exponent
 
     public void testCustomValues() throws IOException {
         List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(10, 50));
-        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.isEmpty() == false);
 
         double[] customValues = new double[] { 0.1, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0 };
         testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, FIELD_NAME, histo)), percentileRanks -> {
@@ -162,7 +162,7 @@ public class ExponentialHistogramPercentileRanksAggregatorTests extends Exponent
         for (int i = 0; i <= 100; i++) {
 
             double value = 0;
-            if (reference.valueCount() > 0) {
+            if (reference.isEmpty() == false) {
                 value = ExponentialHistogramQuantile.getQuantile(reference, i / 100.0);
             }
 

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/ExponentialHistogramPercentilesAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/ExponentialHistogramPercentilesAggregatorTests.java
@@ -85,7 +85,7 @@ public class ExponentialHistogramPercentilesAggregatorTests extends ExponentialH
 
     public void testRandomHistograms() throws IOException {
         List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(1, 100));
-        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.isEmpty() == false);
 
         testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, FIELD_NAME, histo)), percentiles -> {
             assertThat(AggregationInspectionHelper.hasValue(percentiles), equalTo(anyNonEmpty));
@@ -103,7 +103,7 @@ public class ExponentialHistogramPercentilesAggregatorTests extends ExponentialH
             .map(Map.Entry::getKey)
             .toList();
 
-        boolean anyMatchingNonEmpty = filteredHistograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+        boolean anyMatchingNonEmpty = filteredHistograms.stream().anyMatch(histo -> histo.isEmpty() == false);
 
         testCase(
             new TermQuery(new Term("match", "yes")),
@@ -124,7 +124,7 @@ public class ExponentialHistogramPercentilesAggregatorTests extends ExponentialH
 
     public void testCustomPercentiles() throws IOException {
         List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(10, 50));
-        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.isEmpty() == false);
 
         double[] customPercents = new double[] { 1, 10, 25, 50, 75, 90, 99 };
         testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, FIELD_NAME, histo)), percentiles -> {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/ExponentialHistogramBoxplotAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/ExponentialHistogramBoxplotAggregatorTests.java
@@ -65,7 +65,7 @@ public class ExponentialHistogramBoxplotAggregatorTests extends ExponentialHisto
 
     public void testRandomHistograms() throws IOException {
         List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(1, 100));
-        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.isEmpty() == false);
 
         testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, FIELD_NAME, histo)), boxplot -> {
             assertThat(hasValue(boxplot), equalTo(anyNonEmpty));
@@ -83,7 +83,7 @@ public class ExponentialHistogramBoxplotAggregatorTests extends ExponentialHisto
             .map(Map.Entry::getKey)
             .toList();
 
-        boolean anyMatchingNonEmpty = filteredHistograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+        boolean anyMatchingNonEmpty = filteredHistograms.stream().anyMatch(histo -> histo.isEmpty() == false);
 
         testCase(
             new TermQuery(new Term("match", "yes")),
@@ -109,7 +109,7 @@ public class ExponentialHistogramBoxplotAggregatorTests extends ExponentialHisto
             referenceHistograms.iterator()
         );
 
-        if (reference.valueCount() == 0) {
+        if (reference.isEmpty()) {
             // Empty histogram should produce NaN for quartiles
             assertEquals(Double.POSITIVE_INFINITY, boxplot.getMin(), 0);
             assertEquals(Double.NEGATIVE_INFINITY, boxplot.getMax(), 0);

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramParserTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/ExponentialHistogramParserTests.java
@@ -56,7 +56,7 @@ public class ExponentialHistogramParserTests extends ESTestCase {
             assertThat(parsed.positiveBuckets(), equalTo(expectedPositiveBuckets));
             assertThat(parsed.negativeBuckets(), equalTo(expectedNegativeBuckets));
 
-            assertThat(parsed.sum(), equalTo(histogram.valueCount() == 0 ? null : histogram.sum()));
+            assertThat(parsed.sum(), equalTo(histogram.isEmpty() ? null : histogram.sum()));
             assertThat(parsed.min(), equalTo(Double.isNaN(histogram.min()) ? null : histogram.min()));
             assertThat(parsed.max(), equalTo(Double.isNaN(histogram.max()) ? null : histogram.max()));
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramArrayBlock.java
@@ -160,7 +160,7 @@ public final class ExponentialHistogramArrayBlock extends AbstractDelegatingComp
             throw new RuntimeException("Failed to encode histogram", e);
         }
         double sum;
-        if (histogram.valueCount() == 0) {
+        if (histogram.isEmpty()) {
             assert histogram.sum() == 0.0 : "Empty histogram should have sum 0.0 but was " + histogram.sum();
             sum = Double.NaN; // we store null/NaN for empty histograms to ensure avg is null/0.0 instead of 0.0/0.0
         } else {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/ExponentialHistogramBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/ExponentialHistogramBlockTests.java
@@ -133,7 +133,7 @@ public class ExponentialHistogramBlockTests extends ComputeTestCase {
                             }
                         }
                         case SUM -> {
-                            if (histo.valueCount() == 0) {
+                            if (histo.isEmpty()) {
                                 assertThat(componentBlock.isNull(i), equalTo(true));
                             } else {
                                 assertThat(componentBlock.getValueCount(i), equalTo(1));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigest.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigest.java
@@ -151,7 +151,7 @@ public class ToTDigest extends AbstractConvertFunction {
             in.zeroBucket(),
             in.positiveBuckets()
         );
-        double sum = in.valueCount() > 0 ? in.sum() : Double.NaN;
+        double sum = in.isEmpty() == false ? in.sum() : Double.NaN;
         scratch.set(convertedCentroids, sum, in.min(), in.max());
         return scratch.accessor();
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgTests.java
@@ -132,7 +132,7 @@ public class AvgTests extends AbstractAggregationTestCase {
                     }
                     case EXPONENTIAL_HISTOGRAM -> {
                         var expHisto = (ExponentialHistogram) fieldData.get(0);
-                        if (expHisto.valueCount() == 0) {
+                        if (expHisto.isEmpty()) {
                             yield null;
                         }
                         yield expHisto.sum() / expHisto.valueCount();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MaxTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MaxTests.java
@@ -241,7 +241,7 @@ public class MaxTests extends AbstractAggregationTestCase {
                 expected = fieldTypedData.multiRowData()
                     .stream()
                     .map(obj -> (ExponentialHistogram) obj)
-                    .filter(histo -> histo.valueCount() > 0) // only non-empty histograms have an influence
+                    .filter(histo -> histo.isEmpty() == false)
                     .map(ExponentialHistogram::max)
                     .max(Comparator.naturalOrder())
                     .orElse(null);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MinTests.java
@@ -241,7 +241,7 @@ public class MinTests extends AbstractAggregationTestCase {
                 expected = fieldTypedData.multiRowData()
                     .stream()
                     .map(obj -> (ExponentialHistogram) obj)
-                    .filter(histo -> histo.valueCount() > 0) // only non-empty histograms have an influence
+                    .filter(histo -> histo.isEmpty() == false)
                     .map(ExponentialHistogram::min)
                     .min(Comparator.naturalOrder())
                     .orElse(null);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumOverTimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumOverTimeTests.java
@@ -140,7 +140,7 @@ public class SumOverTimeTests extends AbstractAggregationTestCase {
                     case EXPONENTIAL_HISTOGRAM -> {
                         var sums = data.stream()
                             .map(obj -> (ExponentialHistogram) obj)
-                            .filter(obj -> obj.valueCount() > 0)
+                            .filter(obj -> obj.isEmpty() == false)
                             .mapToDouble(ExponentialHistogram::sum)
                             .toArray();
                         yield sums.length == 0 ? null : Arrays.stream(sums).sum();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumTests.java
@@ -147,7 +147,7 @@ public class SumTests extends AbstractAggregationTestCase {
                     case EXPONENTIAL_HISTOGRAM -> {
                         var sums = data.stream()
                             .map(obj -> (ExponentialHistogram) obj)
-                            .filter(obj -> obj.valueCount() > 0)
+                            .filter(obj -> obj.isEmpty() == false)
                             .mapToDouble(ExponentialHistogram::sum)
                             .toArray();
                         yield sums.length == 0 ? null : Arrays.stream(sums).sum();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTDigestTests.java
@@ -138,7 +138,7 @@ public class ToTDigestTests extends AbstractScalarFunctionTestCase {
         double min = Double.NaN;
         double max = Double.NaN;
         double sum = Double.NaN;
-        if (in.valueCount() > 0) {
+        if (in.isEmpty() == false) {
             min = in.min();
             max = in.max();
             sum = in.sum();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/ExtractHistogramComponentTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/ExtractHistogramComponentTests.java
@@ -90,7 +90,7 @@ public class ExtractHistogramComponentTests extends AbstractScalarFunctionTestCa
                         double max = value.max();
                         yield Double.isNaN(max) ? null : max;
                     }
-                    case SUM -> value.valueCount() > 0 ? value.sum() : null;
+                    case SUM -> value.isEmpty() == false ? value.sum() : null;
                     case COUNT -> (double) value.valueCount();
                 };
             }


### PR DESCRIPTION
Add a default `isEmpty()` method to `ExponentialHistogram` with an efficient override in `FixedCapacityExponentialHistogram` where `valueCount()` requires summing bucket counts. Use it to short-circuit `ExponentialHistogramMerger.add()` for empty histograms because with cumulative histograms we are likely to encounter this more often. Also replace `valueCount() == 0` checks across the codebase.


Disclaimer: This PR is AI-generated