### PR TITLE
[DO NOT MERGE] Diagnose Windows-2025 keystore CNF (#147204)

### DIFF
--- a/.buildkite/pipelines/pull-request/repro-windows-2025-keystore.yml
+++ b/.buildkite/pipelines/pull-request/repro-windows-2025-keystore.yml
@@ -1,0 +1,18 @@
+config:
+  auto-retry: false
+steps:
+  - label: "windows-2025 / repro keystore CNF (#147204)"
+    command: |
+      .\.buildkite\scripts\run-script.ps1 bash .buildkite/scripts/windows-run-gradle.sh
+    timeout_in_minutes: 60
+    agents:
+      provider: gcp
+      image: family/elasticsearch-windows-2025
+      machineType: n1-standard-16
+      diskType: pd-ssd
+      diskSizeGb: 350
+    env:
+      GRADLE_TASK: >-
+        :x-pack:qa:reindex-tests-with-security:yamlRestTest
+        :x-pack:qa:core-rest-tests-with-security:yamlRestTest
+        --continue

--- a/distribution/src/bin/elasticsearch-env.bat
+++ b/distribution/src/bin/elasticsearch-env.bat
@@ -50,6 +50,13 @@ if defined ES_JAVA_HOME (
   )
 
   rem check the user supplied jdk version
+  rem === REPRO diagnostic for Windows-2025 keystore CNF (#147204, #145264) - DO NOT MERGE ===
+  echo REPRO ES_HOME=!ES_HOME! 1>&2
+  echo REPRO JAVA=!JAVA! 1>&2
+  echo REPRO CP=!ES_HOME!\lib\java-version-checker\* 1>&2
+  for /f "delims=" %%A in ('!JAVA! -version 2^>^&1') do echo REPRO JVER=%%A 1>&2
+  dir "!ES_HOME!\lib\java-version-checker" 1>&2
+  rem === end REPRO ===
   !JAVA! -cp "%ES_HOME%\lib\java-version-checker\*" "org.elasticsearch.tools.java_version_checker.JavaVersionChecker" || exit /b 1
 ) else (
   rem use the bundled JDK (default)


### PR DESCRIPTION
**Diagnostic only — DO NOT MERGE / DO NOT BACKPORT.**

Local reproduction of the JavaVersionChecker `ClassNotFoundException` from #145264 / #147204 / #147309 has not triggered on a Windows-2025 GCP VM provisioned via `elastic/elasticsearch-infra/buildkite-tools/agent-instance.sh`, even at the exact CI path lengths (228-char install dir, 329-char path to JAR), with `LongPathsEnabled=1`, with 4-way concurrency, and on the same Adoptium 21 image. CI fails reliably; the VM does not. The remaining variables we cannot observe locally are the actual JDK invoked at the keystore call site, the literal command line, and whether Windows can enumerate `lib/java-version-checker` at the CI path.

This PR adds a few `echo` lines and a `dir` listing in `distribution/src/bin/elasticsearch-env.bat` immediately before the `JavaVersionChecker` invocation, so the failing CI job captures:

- `REPRO ES_HOME=…` — the real CI install dir
- `REPRO JAVA=…` — the JDK actually being invoked (Adoptium 21 vs Oracle 26)
- `REPRO CP=…` — the literal classpath path passed to java
- `REPRO JVER=…` — the JDK version string
- `dir lib\java-version-checker` — definitive proof of whether Windows can see the JAR at that path

It also adds a PR-only Buildkite pipeline file that runs three security suites known to fail in #147204 on a Windows-2025 agent so the diagnostic fires on every push, rather than waiting for the next `elasticsearch-periodic-platform-support` run.

If `dir` shows the JAR but Java still says `ClassNotFoundException` → the bug is in the JVM's wildcard-classpath enumeration on Windows-2025. Workaround would be a classpath jar / `@argfile`.

If `dir` shows "File Not Found" → the bug is at the Win32 path-handling layer. Fix is at the agent image (manifest-level long-path opt-in / shorter `BUILDKITE_BUILD_PATH`).

Will close once we have one failing run with the diagnostic output captured.

Made with [Cursor](https://cursor.com)