### PR TITLE
Fix file handle leak in Lucene90CompoundEntriesReaderTests on Windows

### DIFF
--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/Lucene90CompoundEntriesReaderTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/Lucene90CompoundEntriesReaderTests.java
@@ -42,7 +42,10 @@ public class Lucene90CompoundEntriesReaderTests extends ESTestCase {
             var infos = Lucene.readSegmentInfos(directory);
             var si = infos.info(0).info;
 
-            var actualSegmentEntries = Set.of(si.getCodec().compoundFormat().getCompoundReader(directory, si).listAll());
+            Set<String> actualSegmentEntries;
+            try (var compoundReader = si.getCodec().compoundFormat().getCompoundReader(directory, si)) {
+                actualSegmentEntries = Set.of(compoundReader.listAll());
+            }
             var parsedSegmentEntries = prependSegmentName(
                 si.name,
                 Lucene90CompoundEntriesReader.readEntries(directory.openInput(si.name + ".cfe", IOContext.DEFAULT)).keySet()


### PR DESCRIPTION
## Summary

- `getCompoundReader()` returns a `CompoundDirectory` that holds open file handles to the `.cfs`/`.cfe` Lucene compound segment files.
- The reader was previously used inline (chained `.listAll()` call) without ever being closed, leaking the file handle.
- On Linux/macOS this goes unnoticed — open files can be deleted. On Windows the OS locks open files, so the test framework's temp-dir cleanup threw `AccessDeniedException`.
- Fix: wrap the compound reader in a try-with-resources block so it is closed before temp-dir cleanup runs.

Fixes: https://gradle-enterprise.elastic.co/s/it3ete7tvg5rm