### PR TITLE
ESQL: Ordinal fast path for BytesRefTopNBlockHash

### DIFF
--- a/docs/changelog/148333.yaml
+++ b/docs/changelog/148333.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148333
+summary: Ordinal fast path for `BytesRefTopNBlockHash`
+type: enhancement

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefTopNBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefTopNBlockHash.java
@@ -18,6 +18,8 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.sort.BytesRefTopNSet;
 import org.elasticsearch.compute.operator.mvdedupe.TopNMultivalueDedupeBytesRef;
@@ -175,14 +177,18 @@ final class BytesRefTopNBlockHash extends BlockHash {
     /**
      * Adds the vector values to the hash, and returns a new vector with the group IDs for those positions.
      * <p>
-     *     TODO: when an {@code OrdinalBytesRefVector} reaches this method (e.g. once a Parquet reader emits
-     *     dictionary-encoded blocks), short-circuit by running the two-pass logic over the dictionary entries
-     *     and looking up rows via the ordinal index, mirroring {@code BytesRefBlockHash#addOrdinalsVector}.
-     *     The current implementation correctly resolves ordinals to bytes per row, but loses the dictionary
-     *     speed-up that the upstream block already paid for.
+     *     For {@link OrdinalBytesRefVector} inputs we short-circuit and run the two-pass logic over the
+     *     {@code k} dictionary entries instead of the {@code N} row positions, mirroring
+     *     {@code BytesRefBlockHash#addOrdinalsVector}. Non-competitive dictionary entries are rejected via a
+     *     simple {@code int[]} lookup at row time, so the dictionary speed-up that the upstream block already
+     *     paid for composes with the TopN pruning instead of being undone by per-row string resolution.
      * </p>
      */
     IntBlock add(BytesRefVector vector) {
+        OrdinalBytesRefVector ordinals = vector.asOrdinals();
+        if (ordinals != null) {
+            return addOrdinalsVector(ordinals);
+        }
         int positions = vector.getPositionCount();
         BytesRef scratch = new BytesRef();
 
@@ -206,12 +212,75 @@ final class BytesRefTopNBlockHash extends BlockHash {
     }
 
     /**
+     * Ordinal fast path for {@link #add(BytesRefVector)}. Walks the dictionary instead of every row, so the
+     * TopN comparator and the hash table only see each distinct value once per page. Unreferenced dictionary
+     * entries (which can appear after {@link OrdinalBytesRefVector#filter}) are skipped to avoid corrupting
+     * the TopN with values that don't actually appear in this page.
+     */
+    private IntBlock addOrdinalsVector(OrdinalBytesRefVector ordinals) {
+        IntVector ordinalIndices = ordinals.getOrdinalsVector();
+        BytesRefVector dict = ordinals.getDictionaryVector();
+        int positions = ordinalIndices.getPositionCount();
+        int dictSize = dict.getPositionCount();
+
+        // Mark dictionary entries actually referenced by this page; only those participate in the TopN.
+        boolean[] referenced = new boolean[dictSize];
+        for (int p = 0; p < positions; p++) {
+            referenced[ordinalIndices.getInt(p)] = true;
+        }
+
+        // Pass 1: feed each referenced dictionary entry to the TopN set. Pass 2 (below) hashes only
+        // the survivors, so transient winners that get evicted later in this loop never reach the hash.
+        BytesRef scratch = new BytesRef();
+        for (int d = 0; d < dictSize; d++) {
+            if (referenced[d]) {
+                acceptValue(dict.getBytesRef(d, scratch));
+            }
+        }
+
+        // Per-dictionary-entry mapping to the final group id; -1 means non-competitive (or not referenced).
+        // Built once and reused for every row, so the row-time work shrinks to two int loads + a branch.
+        int[] groupIds = new int[dictSize];
+        for (int d = 0; d < dictSize; d++) {
+            if (referenced[d]) {
+                BytesRef value = dict.getBytesRef(d, scratch);
+                groupIds[d] = isAcceptable(value) ? Math.toIntExact(hashOrdToGroupNullReserved(hash.add(value))) : -1;
+            } else {
+                groupIds[d] = -1;
+            }
+        }
+
+        try (var builder = blockFactory.newIntBlockBuilder(positions)) {
+            for (int p = 0; p < positions; p++) {
+                int g = groupIds[ordinalIndices.getInt(p)];
+                if (g < 0) {
+                    builder.appendNull();
+                } else {
+                    builder.appendInt(g);
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    /**
      * Adds the block values to the hash, and returns a new vector with the group IDs for those positions.
      * <p>
      *     For nulls, a 0 group ID is used. For multivalues, a multivalue is used with all the group IDs.
      * </p>
+     * <p>
+     *     {@link OrdinalBytesRefBlock} inputs without multivalues take the same dictionary fast path as
+     *     {@link #addOrdinalsVector(OrdinalBytesRefVector)}; multivalue ordinal blocks fall through to the
+     *     general path because the cross-row dedupe in {@link TopNMultivalueDedupeBytesRef} would have to be
+     *     re-implemented over ordinals, which is not worth the complexity for the parquet workloads we care
+     *     about today (single-valued KEYWORD columns).
+     * </p>
      */
     IntBlock add(BytesRefBlock block) {
+        OrdinalBytesRefBlock ordinals = block.asOrdinals();
+        if (ordinals != null && ordinals.mayHaveMultivaluedFields() == false) {
+            return addOrdinalsBlock(ordinals);
+        }
         BytesRef scratch = new BytesRef();
         // Add all the values to the top set first, so we don't end up sending invalid values later.
         for (int p = 0; p < block.getPositionCount(); p++) {
@@ -231,6 +300,77 @@ final class BytesRefTopNBlockHash extends BlockHash {
         return new TopNMultivalueDedupeBytesRef(block, hasNull, this::isAcceptable).hashAdd(blockFactory, hash).ords();
     }
 
+    /**
+     * Ordinal fast path for {@link #add(BytesRefBlock)} on single-valued blocks (with optional nulls). Mirrors
+     * {@link #addOrdinalsVector(OrdinalBytesRefVector)} but processes the per-position null markers from the
+     * ordinals {@link IntBlock}. Multivalue positions are not supported here — see the precondition in
+     * {@link #add(BytesRefBlock)}.
+     */
+    private IntBlock addOrdinalsBlock(OrdinalBytesRefBlock ordinals) {
+        IntBlock ordinalIndices = ordinals.getOrdinalsBlock();
+        BytesRefVector dict = ordinals.getDictionaryVector();
+        int positions = ordinalIndices.getPositionCount();
+        int dictSize = dict.getPositionCount();
+
+        // Single pass in row order: feed null positions into the TopN's null accounting (matching the
+        // interleaving the non-ordinal {@link #add(BytesRefBlock)} does) and mark which dictionary entries
+        // this page actually references so the dictionary sweep below ignores phantom entries.
+        boolean[] referenced = new boolean[dictSize];
+        for (int p = 0; p < positions; p++) {
+            if (ordinalIndices.isNull(p)) {
+                acceptNull();
+            } else {
+                // Single-valued precondition (mayHaveMultivaluedFields() == false) means each non-null
+                // position has exactly one value; we read it via getFirstValueIndex to be safe across
+                // block layouts where the value array is not 1:1 with positions (e.g. compacted nullable
+                // IntArrayBlock).
+                referenced[ordinalIndices.getInt(ordinalIndices.getFirstValueIndex(p))] = true;
+            }
+        }
+
+        // Pass over the dictionary: feed referenced entries to the TopN. As with the vector path, hashing is
+        // deferred so transient winners that get evicted later never enter the hash table.
+        BytesRef scratch = new BytesRef();
+        for (int d = 0; d < dictSize; d++) {
+            if (referenced[d]) {
+                acceptValue(dict.getBytesRef(d, scratch));
+            }
+        }
+
+        // Final mapping from dictionary ord to group id (or -1 for non-competitive / unreferenced).
+        int[] groupIds = new int[dictSize];
+        for (int d = 0; d < dictSize; d++) {
+            if (referenced[d]) {
+                BytesRef value = dict.getBytesRef(d, scratch);
+                groupIds[d] = isAcceptable(value) ? Math.toIntExact(hashOrdToGroupNullReserved(hash.add(value))) : -1;
+            } else {
+                groupIds[d] = -1;
+            }
+        }
+
+        try (var builder = blockFactory.newIntBlockBuilder(positions)) {
+            for (int p = 0; p < positions; p++) {
+                if (ordinalIndices.isNull(p)) {
+                    // Mirrors the non-ordinal block path: nulls land on group id 0 only when the TopN has
+                    // accepted at least one null; otherwise the position is excluded entirely.
+                    if (hasNull) {
+                        builder.appendInt(0);
+                    } else {
+                        builder.appendNull();
+                    }
+                } else {
+                    int g = groupIds[ordinalIndices.getInt(ordinalIndices.getFirstValueIndex(p))];
+                    if (g < 0) {
+                        builder.appendNull();
+                    } else {
+                        builder.appendInt(g);
+                    }
+                }
+            }
+            return builder.build();
+        }
+    }
+
     @Override
     public ReleasableIterator<IntBlock> lookup(Page page, ByteSizeValue targetBlockSize) {
         var block = page.getBlock(channel);
@@ -248,6 +388,10 @@ final class BytesRefTopNBlockHash extends BlockHash {
     }
 
     private IntBlock lookup(BytesRefVector vector) {
+        OrdinalBytesRefVector ordinals = vector.asOrdinals();
+        if (ordinals != null) {
+            return lookupOrdinalsVector(ordinals);
+        }
         int positions = vector.getPositionCount();
         BytesRef scratch = new BytesRef();
         try (var builder = blockFactory.newIntBlockBuilder(positions)) {
@@ -258,6 +402,44 @@ final class BytesRefTopNBlockHash extends BlockHash {
                     builder.appendNull();
                 } else {
                     builder.appendInt(Math.toIntExact(hashOrdToGroupNullReserved(found)));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    /**
+     * Ordinal fast path for {@link #lookup(BytesRefVector)}. Resolves the dictionary entries to group ids
+     * once per page and then services every row with two int loads. We do not build a {@code referenced[]}
+     * mask here: phantom dictionary entries are never actually used as a row index, so the at-most-extra
+     * {@code hash.find} per unreferenced entry is wasted work but cannot produce a wrong result for any
+     * row in this page.
+     */
+    private IntBlock lookupOrdinalsVector(OrdinalBytesRefVector ordinals) {
+        IntVector ordinalIndices = ordinals.getOrdinalsVector();
+        BytesRefVector dict = ordinals.getDictionaryVector();
+        int positions = ordinalIndices.getPositionCount();
+        int dictSize = dict.getPositionCount();
+
+        BytesRef scratch = new BytesRef();
+        int[] groupIds = new int[dictSize];
+        for (int d = 0; d < dictSize; d++) {
+            BytesRef v = dict.getBytesRef(d, scratch);
+            long found = hash.find(v);
+            if (found < 0 || isAcceptable(v) == false) {
+                groupIds[d] = -1;
+            } else {
+                groupIds[d] = Math.toIntExact(hashOrdToGroupNullReserved(found));
+            }
+        }
+
+        try (var builder = blockFactory.newIntBlockBuilder(positions)) {
+            for (int p = 0; p < positions; p++) {
+                int g = groupIds[ordinalIndices.getInt(p)];
+                if (g < 0) {
+                    builder.appendNull();
+                } else {
+                    builder.appendInt(g);
                 }
             }
             return builder.build();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/TopNBlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/TopNBlockHashTests.java
@@ -14,9 +14,13 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
@@ -464,6 +468,145 @@ public class TopNBlockHashTests extends BlockHashTestCase {
                     }
                 }
             }, builder);
+        }
+    }
+
+    public void testBytesRefOrdinalsHash() {
+        // Same logical input as testBytesRefHash ("b","a","d","b","d","a","c","d") but fed via an
+        // OrdinalBytesRefVector. The TopN groupings (which keys survive, which rows hit which group) match the
+        // plain path; the only observable difference is that group ids follow the *dictionary* order rather than
+        // the per-row first-encountered order — which is the same convention {@link BytesRefBlockHash} uses for
+        // its ordinal fast path (see {@code BlockHashTests.testBasicOrdinals}).
+        String[] dictionary = { "a", "b", "c", "d" };
+        int[] ordinals = { 1, 0, 3, 1, 3, 0, 2, 3 };
+
+        hash(ordsAndKeys -> {
+            if (forcePackedHash) {
+                // TODO: Not tested yet
+            } else {
+                assertThat(
+                    ordsAndKeys.description(),
+                    equalTo("BytesRefTopNBlockHash{channel=0, " + topNParametersString(4, 0) + ", hasNull=false}")
+                );
+                if (limit == LIMIT_HIGH) {
+                    // Dictionary order: a=1, b=2, c=3, d=4
+                    assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "a", "b", "c", "d" });
+                    assertOrds(ordsAndKeys.ords(), 2, 1, 4, 2, 4, 1, 3, 4);
+                    assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(1, 5)));
+                } else {
+                    if (asc) {
+                        // Top 2 ascending: a, b. Dictionary order assigns a=1, b=2.
+                        assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "a", "b" });
+                        assertOrds(ordsAndKeys.ords(), 2, 1, null, 2, null, 1, null, null);
+                        assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(1, 2)));
+                    } else {
+                        // Top 2 descending: c, d. Dictionary order assigns c=1, d=2.
+                        assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "c", "d" });
+                        assertOrds(ordsAndKeys.ords(), null, null, 2, null, 2, null, 1, 2);
+                        assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(1, 2)));
+                    }
+                }
+            }
+        }, ordinalVector(ordinals, dictionary).asBlock());
+    }
+
+    public void testBytesRefOrdinalsBlockWithNulls() {
+        // Mirrors testBytesRefHashWithNulls but the input is an OrdinalBytesRefBlock with nulls in the
+        // ordinals IntBlock (the dictionary itself is null-free and shared).
+        String[] dictionary = { "a", "c" };
+        // null positions are encoded as nulls in the ordinals IntBlock; non-null positions reference the dictionary.
+        try (
+            IntBlock.Builder ords = blockFactory.newIntBlockBuilder(4);
+            BytesRefVector.Builder bytes = blockFactory.newBytesRefVectorBuilder(dictionary.length)
+        ) {
+            ords.appendInt(0);
+            ords.appendNull();
+            ords.appendInt(1);
+            ords.appendNull();
+            for (String v : dictionary) {
+                bytes.appendBytesRef(new BytesRef(v));
+            }
+            OrdinalBytesRefBlock block = new OrdinalBytesRefBlock(ords.build(), bytes.build());
+
+            hash(ordsAndKeys -> {
+                if (forcePackedHash) {
+                    // TODO: Not tested yet
+                } else {
+                    boolean hasTwoNonNullValues = nullsFirst == false || limit == LIMIT_HIGH;
+                    boolean hasNull = nullsFirst || limit == LIMIT_HIGH;
+                    assertThat(
+                        ordsAndKeys.description(),
+                        equalTo(
+                            "BytesRefTopNBlockHash{channel=0, "
+                                + topNParametersString(hasTwoNonNullValues ? 2 : 1, 0)
+                                + ", hasNull="
+                                + hasNull
+                                + "}"
+                        )
+                    );
+                    if (limit == LIMIT_HIGH) {
+                        assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { null, "a", "c" });
+                        assertOrds(ordsAndKeys.ords(), 1, 0, 2, 0);
+                        assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(0, 1, 2)));
+                    } else {
+                        if (nullsFirst) {
+                            if (asc) {
+                                assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { null, "a" });
+                                assertOrds(ordsAndKeys.ords(), 1, 0, null, 0);
+                                assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(0, 1)));
+                            } else {
+                                assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { null, "c" });
+                                assertOrds(ordsAndKeys.ords(), null, 0, 1, 0);
+                                assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(0, 1)));
+                            }
+                        } else {
+                            assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "a", "c" });
+                            assertOrds(ordsAndKeys.ords(), 1, null, 2, null);
+                            assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(1, 2)));
+                        }
+                    }
+                }
+            }, block);
+        }
+    }
+
+    /**
+     * The dictionary contains entries that the ordinals never reference. A naive ordinal fast path that ranks the
+     * full dictionary would let those phantom values into the TopN and silently corrupt the result. We feed
+     * {@code "a", "a"} (the only referenced entry), keeping {@code "z"} in the dictionary as bait — the assertions
+     * are identical to feeding the same logical values through the plain path.
+     */
+    public void testBytesRefOrdinalsHashUnreferencedDictEntries() {
+        String[] dictionary = { "a", "z" };
+        int[] ordinals = { 0, 0 };
+
+        hash(ordsAndKeys -> {
+            if (forcePackedHash) {
+                // TODO: Not tested yet
+            } else {
+                assertThat(
+                    ordsAndKeys.description(),
+                    equalTo("BytesRefTopNBlockHash{channel=0, " + topNParametersString(1, 0) + ", hasNull=false}")
+                );
+                assertKeys(ordsAndKeys.keys(), (Object[]) new String[] { "a" });
+                assertOrds(ordsAndKeys.ords(), 1, 1);
+                assertThat(ordsAndKeys.nonEmpty(), equalTo(intVector(1)));
+            }
+        }, ordinalVector(ordinals, dictionary).asBlock());
+    }
+
+    private OrdinalBytesRefVector ordinalVector(int[] ordinals, String[] dictionary) {
+        try (
+            IntVector.Builder ords = blockFactory.newIntVectorFixedBuilder(ordinals.length);
+            BytesRefVector.Builder bytes = blockFactory.newBytesRefVectorBuilder(dictionary.length)
+        ) {
+            for (int o : ordinals) {
+                ords.appendInt(o);
+            }
+            for (String v : dictionary) {
+                bytes.appendBytesRef(new BytesRef(v));
+            }
+            return new OrdinalBytesRefVector(ords.build(), bytes.build());
         }
     }
 


### PR DESCRIPTION
OrdinalBytesRefBlock/Vector reaching BytesRefTopNBlockHash previously
fell back to per-row dictionary resolution, undoing the dictionary
speed-up the upstream block already paid for. Walk the dictionary
instead of every row, building a per-dictionary-entry group id mapping
so row-time work shrinks to two int loads and a branch. Unreferenced
dictionary entries (which can appear after filter) are masked out so
they cannot pollute the TopN.

Developed with AI-assisted tooling