### PR TITLE
Enable multiple items per content object for Elastic service (#148340)

### DIFF
--- a/docs/changelog/148340.yaml
+++ b/docs/changelog/148340.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 148340
+summary: Enable multiple items per content object for Elastic service
+type: enhancement

--- a/docs/changelog/148348.yaml
+++ b/docs/changelog/148348.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 148348
+summary: Enable multiple items per content object for Elastic service
+type: enhancement

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/SenderService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/SenderService.java
@@ -292,7 +292,7 @@ public abstract class SenderService<M extends Model> implements InferenceService
     public void embeddingInfer(Model model, EmbeddingRequest request, TimeValue timeout, ActionListener<InferenceServiceResults> listener) {
         try {
             var resolvedInferenceTimeout = resolveInferenceTimeout(timeout, request.inputType(), clusterService, model.getTaskType());
-            if (supportsImageEmbeddingContent() == false && containsNonTextEntry(request.inputs())) {
+            if (supportsNonTextEmbeddingContent() == false && containsNonTextEntry(request.inputs())) {
                 listener.onFailure(
                     new ElasticsearchStatusException(
                         Strings.format("The %s service does not support embedding with non-text inputs", name()),
@@ -340,7 +340,7 @@ public abstract class SenderService<M extends Model> implements InferenceService
      * Override as necessary for services which support images in embedding inputs
      * @return true if the service supports images in embedding inputs
      */
-    protected boolean supportsImageEmbeddingContent() {
+    protected boolean supportsNonTextEmbeddingContent() {
         return false;
     }
 
@@ -396,7 +396,7 @@ public abstract class SenderService<M extends Model> implements InferenceService
                 if (input.isEmpty()) {
                     listener.onResponse(List.of());
                 } else {
-                    if (supportsImageEmbeddingContent() == false
+                    if (supportsNonTextEmbeddingContent() == false
                         && containsNonTextEntry(input.stream().map(ChunkInferenceInput::input).toList())) {
                         listener.onFailure(
                             new ElasticsearchStatusException(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -266,7 +266,12 @@ public class ElasticInferenceService extends SenderService<ElasticInferenceServi
     }
 
     @Override
-    protected boolean supportsImageEmbeddingContent() {
+    protected boolean supportsNonTextEmbeddingContent() {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsMultipleItemsPerContent() {
         return true;
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIService.java
@@ -210,7 +210,7 @@ public class JinaAIService extends SenderService<JinaAIModel> implements Reranki
     }
 
     @Override
-    protected boolean supportsImageEmbeddingContent() {
+    protected boolean supportsNonTextEmbeddingContent() {
         return true;
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.inference.ChunkInferenceInput;
 import org.elasticsearch.inference.ChunkedInference;
+import org.elasticsearch.inference.DataType;
 import org.elasticsearch.inference.EmbeddingRequest;
 import org.elasticsearch.inference.EmptySecretSettings;
 import org.elasticsearch.inference.EmptyTaskSettings;
@@ -1487,9 +1488,12 @@ public class ElasticInferenceServiceTests extends ESTestCase {
                 """, Arrays.toString(firstEmbedding), Arrays.toString(secondEmbedding));
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
+            // Inputs containing non-text, and multiple items per content object
             var inputs = List.of(
-                new InferenceStringGroup("first_input"),
-                new InferenceStringGroup(new InferenceString(IMAGE, BASE64, TEST_DATA_URI))
+                new InferenceStringGroup("first_text_input"),
+                new InferenceStringGroup(
+                    List.of(new InferenceString(IMAGE, BASE64, TEST_DATA_URI), new InferenceString(DataType.TEXT, "second_text_input"))
+                )
             );
 
             var inputType = randomFrom(InputType.INGEST, InputType.SEARCH);


### PR DESCRIPTION
Also rename supportsImageEmbeddingContent() to
supportsNonTextEmbeddingContent() since content may be audio, video or PDF, not just image.