### PR TITLE
ESQL: Cache parquet dictionary array across batches

### DIFF
--- a/docs/changelog/148349.yaml
+++ b/docs/changelog/148349.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148349
+summary: Cache parquet dictionary array across batches
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -469,6 +469,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     }
 
     private void initColumnReaders(RowRanges currentRowRanges) {
+        // Close any readers from the previous row group before discarding the array — each reader
+        // holds a ref-counted BytesRefArray (the cached dictionary) that must be released here.
+        // Pages already emitted are unaffected: they own their own BytesRefArrayVector wrappers,
+        // which hold independent refs to the underlying array.
+        closePageColumnReaders();
         pageColumnReaders = new PageColumnReader[columnInfos.length];
         columnReaders = null;
         for (int i = 0; i < columnInfos.length; i++) {
@@ -812,6 +817,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     public void close() throws IOException {
         cancelPendingPrefetch();
         try {
+            closePageColumnReaders();
             if (rowGroup != null) {
                 rowGroup.close();
                 rowGroup = null;
@@ -820,6 +826,19 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             releaseCurrentReservation();
             reader.close();
         }
+    }
+
+    /**
+     * Closes any non-null entries in {@link #pageColumnReaders}, releasing each reader's cached
+     * dictionary {@link org.elasticsearch.common.util.BytesRefArray}. Idempotent — null entries
+     * and a null array are both fine. The array is then discarded by the caller.
+     */
+    private void closePageColumnReaders() {
+        if (pageColumnReaders == null) {
+            return;
+        }
+        Releasables.close(pageColumnReaders);
+        pageColumnReaders = null;
     }
 
     /** Bundles an in-flight prefetch future with its breaker reservation for paired release. */

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -1136,9 +1136,11 @@ final class PageColumnReader implements Releasable {
 
     private BytesRefVector buildDictionaryVector(BytesRef[] entries, BlockFactory blockFactory) {
         BytesRefArray array = ensureCachedDictArray(entries, blockFactory);
-        // newBytesRefArrayVector takes ownership of one ref of the array (its closeInternal calls
-        // values.close() -> decRef()). To keep our cached ref alive across batches we incRef before
-        // handing the array to the wrapper.
+        // newBytesRefArrayVector takes ownership of one ref of the array: its closeInternal calls
+        // values.close() -> decRef(). The class Javadoc on BytesRefArrayVector that says it "does
+        // not take ownership" is misleading on the refcount side and applies only to the
+        // breaker accounting (which the factory adjusts here). To keep our cached ref alive
+        // across batches, incRef before handing the array to the wrapper.
         array.incRef();
         boolean success = false;
         try {
@@ -1156,8 +1158,11 @@ final class PageColumnReader implements Releasable {
         if (cachedDictArray != null && cachedDictArraySource == dictionary) {
             return cachedDictArray;
         }
-        // Either first call for this reader or the dictionary changed (defensive — shouldn't
-        // happen mid-chunk in practice). Drop any stale cache before rebuilding.
+        // First call for this reader, or — and this should never happen given parquet-mr keeps
+        // one Dictionary per chunk and a PageColumnReader reads exactly one chunk — the
+        // Dictionary identity changed mid-reader. Assert in dev/test builds so a violated
+        // invariant fails loudly; rebuild rather than reuse a stale cache in production.
+        assert cachedDictArray == null : "PageColumnReader saw a Dictionary identity change mid-chunk; reader should have been replaced";
         releaseCachedDictArray();
         BytesRefArray array = new BytesRefArray(entries.length, blockFactory.bigArrays());
         boolean success = false;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -27,6 +27,7 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 
@@ -59,19 +60,32 @@ import java.util.Arrays;
  * <p>For dictionary-encoded BINARY/UTF8 columns, {@code readBytesBatch} takes an ordinal
  * fast path that emits an {@link OrdinalBytesRefBlock} so downstream {@code BlockHash} can
  * hash only the {@code k} dictionary entries instead of the {@code N} row values. The
- * dictionary {@code BytesRefVector} is rebuilt per batch (deep-copying the bytes via
- * {@link BytesRefArray#append}) so each emitted block fully owns its memory and is safe to
- * outlive the {@link PageColumnReader} or its row group — pages can be buffered and
- * consumed asynchronously by a different driver thread without aliasing into Parquet-side
- * state. UUID-typed columns skip the ordinal path because their values need per-row byte
- * formatting that would have to be applied to dictionary entries instead.
+ * dictionary bytes are deep-copied into a {@link BytesRefArray} once per chunk and that
+ * array is shared across every batch in the chunk via its atomic ref-count
+ * ({@link BytesRefArray} extends {@code AbstractRefCounted}). Each emitted batch creates a
+ * fresh {@code BytesRefArrayVector} wrapper that holds one ref to the shared array; the
+ * wrapper itself is single-driver-owned (its non-thread-safe ref counter is never shared)
+ * and decRefs the shared array when the block is closed. This decoupling lets pages be
+ * buffered and consumed asynchronously by a different driver thread (see
+ * {@code AsyncExternalSourceOperatorFactory} which calls
+ * {@code page.allowPassingToDifferentDriver()}) without racing the producer's per-batch
+ * ref-count updates against the consumer's close. UUID-typed columns skip the ordinal path
+ * because their values need per-row byte formatting that would have to be applied to
+ * dictionary entries instead.
+ *
+ * <p>The cached {@link BytesRefArray} is released when this reader's chunk changes
+ * (currently never — chunk is fixed for the reader's lifetime, so this is defensive) or
+ * when the reader is {@link #close() closed}. Closing is driven by
+ * {@code OptimizedParquetColumnIterator}, which closes any previous readers when it
+ * advances row groups (in {@code initColumnReaders}) and when the iterator itself is
+ * closed.
  *
  * <p>If a non-dictionary page is encountered mid-batch (rare in practice — Parquet writers
  * keep encoding consistent across all data pages of a column chunk), the partial ordinal
  * batch is resolved through the dictionary and the remainder is read via the materialized
  * binary path.
  */
-final class PageColumnReader {
+final class PageColumnReader implements Releasable {
 
     private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0).asReadOnlyBuffer();
     private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
@@ -86,6 +100,16 @@ final class PageColumnReader {
 
     private Dictionary dictionary;
     private boolean dictionaryLoaded;
+
+    /**
+     * Cached deep-copy of the current dictionary's entries as a ref-counted {@link BytesRefArray}.
+     * Built lazily on the first ordinal batch of the chunk and reused (via {@code incRef}) for every
+     * subsequent batch. A defensive {@link #cachedDictArraySource} reference guards against the
+     * (currently impossible) case of the underlying {@link Dictionary} changing within a single
+     * reader's lifetime — if it does, the old cache is released and rebuilt.
+     */
+    private BytesRefArray cachedDictArray;
+    private Dictionary cachedDictArraySource;
 
     private final DefinitionLevelDecoder defDecoder = new DefinitionLevelDecoder();
     private final PlainValueDecoder plainDecoder = new PlainValueDecoder();
@@ -1111,20 +1135,58 @@ final class PageColumnReader {
     }
 
     private BytesRefVector buildDictionaryVector(BytesRef[] entries, BlockFactory blockFactory) {
+        BytesRefArray array = ensureCachedDictArray(entries, blockFactory);
+        // newBytesRefArrayVector takes ownership of one ref of the array (its closeInternal calls
+        // values.close() -> decRef()). To keep our cached ref alive across batches we incRef before
+        // handing the array to the wrapper.
+        array.incRef();
+        boolean success = false;
+        try {
+            BytesRefVector vector = blockFactory.newBytesRefArrayVector(array, entries.length);
+            success = true;
+            return vector;
+        } finally {
+            if (success == false) {
+                array.decRef();
+            }
+        }
+    }
+
+    private BytesRefArray ensureCachedDictArray(BytesRef[] entries, BlockFactory blockFactory) {
+        if (cachedDictArray != null && cachedDictArraySource == dictionary) {
+            return cachedDictArray;
+        }
+        // Either first call for this reader or the dictionary changed (defensive — shouldn't
+        // happen mid-chunk in practice). Drop any stale cache before rebuilding.
+        releaseCachedDictArray();
         BytesRefArray array = new BytesRefArray(entries.length, blockFactory.bigArrays());
         boolean success = false;
         try {
             for (BytesRef entry : entries) {
                 array.append(entry);
             }
-            BytesRefVector vector = blockFactory.newBytesRefArrayVector(array, entries.length);
+            cachedDictArray = array;
+            cachedDictArraySource = dictionary;
             success = true;
-            return vector;
+            return array;
         } finally {
             if (success == false) {
                 array.close();
             }
         }
+    }
+
+    private void releaseCachedDictArray() {
+        if (cachedDictArray != null) {
+            cachedDictArray.decRef();
+            cachedDictArray = null;
+            cachedDictArraySource = null;
+        }
+    }
+
+    @Override
+    public void close() {
+        releaseCachedDictArray();
     }
 
     private Block finishMaterializedFallback(int[] ordinals, WordMask nulls, int produced, int remaining, BlockFactory blockFactory) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderDictionaryCacheTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderDictionaryCacheTests.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntFunction;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+
+/**
+ * Verifies that {@link PageColumnReader} caches the dictionary
+ * {@link org.elasticsearch.common.util.BytesRefArray} once per chunk and shares it across
+ * emitted batches via atomic ref-count, while still being safe to drive across drivers
+ * (producer keeps decoding while a consumer thread closes already-emitted pages).
+ *
+ * <p>Sharing is verified indirectly via the breaker: with {@link MockBigArrays#withCircuitBreaking()}
+ * the underlying {@code BigArrays} bytes flow through the breaker. If the dictionary were
+ * deep-copied per batch (the bug the cache fixes), peak breaker usage while all batches are alive
+ * would scale with the batch count; with sharing it stays bounded near a single dictionary's
+ * footprint.
+ */
+public class PageColumnReaderDictionaryCacheTests extends ESTestCase {
+
+    /**
+     * Many small batches over a single dictionary-encoded chunk share one underlying
+     * {@code BytesRefArray}. We hold every emitted page alive simultaneously, then assert that
+     * peak breaker usage is far below what a per-batch deep-copy would have produced. Pages are
+     * then closed in random order to exercise the atomic ref-count.
+     */
+    public void testDictionaryArrayCachedAcrossBatches() throws IOException {
+        int numRows = 5_000;
+        int batchSize = 256;
+        int dictSize = 64;
+        IntFunction<String> valueFor = row -> "v_" + (row % dictSize);
+
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(256)).withCircuitBreaking();
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        BlockFactory blockFactory = BlockFactory.builder(bigArrays).breaker(breaker).build();
+
+        byte[] data = writeStringFile(numRows, false, valueFor);
+
+        List<Page> pages = new ArrayList<>();
+        long usedAfterFirstPage = -1;
+        try (CloseableIterator<Page> iter = openIterator(blockFactory, data, batchSize)) {
+            while (iter.hasNext()) {
+                pages.add(iter.next());
+                if (usedAfterFirstPage < 0) {
+                    usedAfterFirstPage = breaker.getUsed();
+                }
+            }
+        }
+        try {
+            assertTrue("expected many batches per chunk: got " + pages.size(), pages.size() >= 20);
+
+            int totalRows = 0;
+            int ordinalPagesSeen = 0;
+            for (Page page : pages) {
+                BytesRefBlock block = page.getBlock(0);
+                OrdinalBytesRefBlock ordinal = block.asOrdinals();
+                if (ordinal != null) {
+                    ordinalPagesSeen++;
+                }
+                BytesRef scratch = new BytesRef();
+                for (int p = 0; p < page.getPositionCount(); p++) {
+                    String expected = valueFor.apply(totalRows);
+                    assertEquals("row " + totalRows, new BytesRef(expected), block.getBytesRef(p, scratch));
+                    totalRows++;
+                }
+            }
+            assertEquals(numRows, totalRows);
+            assertEquals("every page should have hit the ordinal fast path", pages.size(), ordinalPagesSeen);
+
+            // Sharing-by-breaker check. The first-page mark captures one chunk's footprint
+            // (dict array + per-batch wrapper). With sharing, holding all pages alive only adds
+            // wrapper overhead per page (small) on top of that. Without sharing, each page would
+            // pay another full dict-array allocation, which would push usage well past 5x the
+            // first-page mark even at this small dict size. We pick 5x as a generous ceiling.
+            long peak = breaker.getUsed();
+            assertTrue(
+                "peak breaker usage ["
+                    + peak
+                    + "] should be bounded relative to first-page footprint ["
+                    + usedAfterFirstPage
+                    + "] given "
+                    + pages.size()
+                    + " pages — a per-batch deep copy would scale linearly",
+                peak < usedAfterFirstPage * 5
+            );
+        } finally {
+            List<Page> shuffled = new ArrayList<>(pages);
+            Collections.shuffle(shuffled, new Random(randomLong()));
+            for (Page page : shuffled) {
+                page.releaseBlocks();
+            }
+        }
+        assertEquals("breaker must return to zero after random-order release", 0, breaker.getUsed());
+    }
+
+    /**
+     * Reads a multi-row-group file with a tracking breaker wired through {@link MockBigArrays}.
+     * The breaker must return to zero — a leaked cached {@code BytesRefArray} would manifest as
+     * a positive remainder because its underlying {@code BigArrays} bytes are never released.
+     */
+    public void testCachedDictionaryArrayReleasedOnChunkBoundary() throws IOException {
+        int numRows = 6_000;
+        int batchSize = 256;
+        int dictSize = 50;
+        IntFunction<String> valueFor = row -> "term_" + (row % dictSize);
+        // Small row group → multiple chunks → exercises the close-and-rebuild path between
+        // chunks where the previous reader's cached array must be released.
+        byte[] data = writeStringFile(numRows, false, valueFor, /* rowGroupSize */ 8 * 1024L);
+
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(256)).withCircuitBreaking();
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        BlockFactory blockFactory = BlockFactory.builder(bigArrays).breaker(breaker).build();
+
+        int totalRows = 0;
+        try (CloseableIterator<Page> iter = openIterator(blockFactory, data, batchSize)) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                totalRows += page.getPositionCount();
+                page.releaseBlocks();
+            }
+        }
+        assertEquals(numRows, totalRows);
+        assertEquals("breaker must return to zero — a leaked cached BytesRefArray would show here", 0, breaker.getUsed());
+    }
+
+    /**
+     * Producer-thread keeps decoding pages while a separate consumer-thread closes already-emitted
+     * pages after a randomized small delay (and a {@code page.allowPassingToDifferentDriver()} hop
+     * to mirror {@code AsyncExternalSourceOperatorFactory}). Repeated for many iterations and
+     * iterator instances; the breaker must still return to zero. With a non-thread-safe shared
+     * refcount, this would race and either leak or trigger an assertion in {@code decRef}.
+     */
+    public void testCrossDriverCloseDuringDecode() throws Exception {
+        int iterations = 50;
+        int numRows = 1_500;
+        int batchSize = 64;
+        int dictSize = 32;
+        IntFunction<String> valueFor = row -> "v_" + (row % dictSize);
+        byte[] data = writeStringFile(numRows, false, valueFor);
+
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(256)).withCircuitBreaking();
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        BlockFactory blockFactory = BlockFactory.builder(bigArrays).breaker(breaker).build();
+
+        ExecutorService consumer = Executors.newSingleThreadExecutor();
+        AtomicReference<Throwable> consumerFailure = new AtomicReference<>();
+        try {
+            for (int i = 0; i < iterations; i++) {
+                CountDownLatch consumed = new CountDownLatch(1);
+                List<Page> emitted = new ArrayList<>();
+                int rowsRead = 0;
+                try (CloseableIterator<Page> iter = openIterator(blockFactory, data, batchSize)) {
+                    while (iter.hasNext()) {
+                        Page page = iter.next();
+                        rowsRead += page.getPositionCount();
+                        page.allowPassingToDifferentDriver();
+                        emitted.add(page);
+                    }
+                }
+                assertEquals(numRows, rowsRead);
+                final List<Page> toClose = emitted;
+                consumer.execute(() -> {
+                    try {
+                        for (Page page : toClose) {
+                            try {
+                                Thread.sleep(0, randomIntBetween(0, 200_000));
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                break;
+                            }
+                            page.releaseBlocks();
+                        }
+                    } catch (Throwable t) {
+                        consumerFailure.compareAndSet(null, t);
+                    } finally {
+                        consumed.countDown();
+                    }
+                });
+                if (consumed.await(30, TimeUnit.SECONDS) == false) {
+                    fail("consumer did not finish in time on iteration " + i);
+                }
+                if (consumerFailure.get() != null) {
+                    throw new AssertionError("consumer thread failed on iteration " + i, consumerFailure.get());
+                }
+            }
+        } finally {
+            consumer.shutdown();
+            assertTrue("consumer did not terminate", consumer.awaitTermination(10, TimeUnit.SECONDS));
+        }
+        assertEquals("breaker must return to zero across all cross-driver iterations", 0, breaker.getUsed());
+    }
+
+    // --- helpers ---
+
+    private CloseableIterator<Page> openIterator(BlockFactory blockFactory, byte[] data, int batchSize) throws IOException {
+        StorageObject so = storageObject(data);
+        // Force optimizedReader=true so we exercise the PageColumnReader / OptimizedParquetColumnIterator paths.
+        return new ParquetFormatReader(blockFactory, true).read(so, FormatReadContext.of(List.of("name"), batchSize));
+    }
+
+    private byte[] writeStringFile(int numRows, boolean optional, IntFunction<String> valueFor) throws IOException {
+        return writeStringFile(numRows, optional, valueFor, 64 * 1024L);
+    }
+
+    private byte[] writeStringFile(int numRows, boolean optional, IntFunction<String> valueFor, long rowGroupSize) throws IOException {
+        Types.MessageTypeBuilder schemaBuilder = Types.buildMessage();
+        var col = optional ? Types.optional(BINARY) : Types.required(BINARY);
+        col.as(LogicalTypeAnnotation.stringType());
+        schemaBuilder.addField(col.named("name"));
+        MessageType schema = schemaBuilder.named("dict_cache_test");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+        PlainParquetConfiguration conf = new PlainParquetConfiguration();
+        conf.set("parquet.enable.dictionary", "true");
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile(out))
+                .withConf(conf)
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(schema)
+                .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_1_0)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withDictionaryEncoding(true)
+                .withDictionaryPageSize(64 * 1024)
+                .withRowGroupSize(rowGroupSize)
+                .withPageSize(4 * 1024)
+                .build()
+        ) {
+            for (int i = 0; i < numRows; i++) {
+                Group g = factory.newGroup();
+                String v = valueFor.apply(i);
+                if (v != null) {
+                    g.append("name", v);
+                }
+                writer.write(g);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    @SuppressWarnings("unused")
+    private static StorageObject storageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                return new ByteArrayInputStream(data, (int) position, (int) Math.min(length, data.length - position));
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.EPOCH;
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://dict-cache-test.parquet");
+            }
+        };
+    }
+
+    private static OutputFile outputFile(ByteArrayOutputStream out) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long position = 0;
+
+                    @Override
+                    public long getPos() {
+                        return position;
+                    }
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        out.write(b);
+                        position++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        out.write(b, off, len);
+                        position += len;
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        out.close();
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+
+            @Override
+            public String getPath() {
+                return "memory://dict-cache-test.parquet";
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderDictionaryCacheTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReaderDictionaryCacheTests.java
@@ -116,21 +116,37 @@ public class PageColumnReaderDictionaryCacheTests extends ESTestCase {
             assertEquals(numRows, totalRows);
             assertEquals("every page should have hit the ordinal fast path", pages.size(), ordinalPagesSeen);
 
-            // Sharing-by-breaker check. The first-page mark captures one chunk's footprint
-            // (dict array + per-batch wrapper). With sharing, holding all pages alive only adds
-            // wrapper overhead per page (small) on top of that. Without sharing, each page would
-            // pay another full dict-array allocation, which would push usage well past 5x the
-            // first-page mark even at this small dict size. We pick 5x as a generous ceiling.
+            // Sharing-by-breaker check, expressed as the average bytes added per additional
+            // page rather than a multiplicative ratio. The first-page mark captures the full
+            // chunk footprint (dict array + first wrapper + ordinals + page bookkeeping).
+            // With sharing: each subsequent page adds only wrapper + ordinals + page overhead
+            // — observed locally at ~1 KB / page for a 64-entry dict, far below the first-page
+            // mark since the dict array dominates that baseline.
+            // Without sharing (the regression we want to detect): every page deep-copies the
+            // dict, so per-page growth approximates the *entire* first-page mark.
+            // Bounding per-page growth at 1/3 of the first-page mark cleanly separates the two
+            // regimes: shared sits around 0.15x; per-batch deep copy would land near 1.0x.
             long peak = breaker.getUsed();
+            long extraPages = pages.size() - 1;
+            long perPageGrowth = extraPages > 0 ? (peak - usedAfterFirstPage) / extraPages : 0;
+            long perPageCeiling = usedAfterFirstPage / 3;
+            logger.debug(
+                "dict cache test breaker stats: usedAfterFirstPage={}, peak={}, pages={}, perPageGrowth={}, perPageCeiling={}",
+                usedAfterFirstPage,
+                peak,
+                pages.size(),
+                perPageGrowth,
+                perPageCeiling
+            );
             assertTrue(
-                "peak breaker usage ["
-                    + peak
-                    + "] should be bounded relative to first-page footprint ["
-                    + usedAfterFirstPage
-                    + "] given "
+                "average per-page breaker growth ["
+                    + perPageGrowth
+                    + " bytes] should stay below 1/3 of first-page footprint ["
+                    + perPageCeiling
+                    + " bytes] across "
                     + pages.size()
-                    + " pages — a per-batch deep copy would scale linearly",
-                peak < usedAfterFirstPage * 5
+                    + " pages — a per-batch deep copy of the dictionary would push this near 1.0x",
+                perPageGrowth < perPageCeiling
             );
         } finally {
             List<Page> shuffled = new ArrayList<>(pages);


### PR DESCRIPTION
The optimized parquet reader rebuilt the dictionary BytesRefArray for
every emitted batch, deep-copying ~50K entries on each ClickBench URL
batch. Profiling showed buildDictionaryVector + BytesRefArray.append.

Cache the BytesRefArray once per chunk in PageColumnReader and share
it across batches via its atomic refcount; emit a fresh wrapper per
batch so the non-thread-safe vector refcount stays single-driver-owned
and remains safe under page-passing across drivers.

PageColumnReader now implements Releasable; OptimizedParquetColumnIterator
closes prior readers when advancing row groups and on its own close,
ensuring the cached array is released on chunk boundaries.

Developed with AI-assisted tooling