### PR TITLE
ESQL: Cache FilterOperator/EvalOperator toString

### DIFF
--- a/docs/changelog/148354.yaml
+++ b/docs/changelog/148354.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148354
+summary: Cache `FilterOperator/EvalOperator` `toString`
+type: enhancement

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/EvalOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/EvalOperator.java
@@ -35,10 +35,17 @@ public class EvalOperator extends AbstractPageMappingOperator {
 
     private final DriverContext ctx;
     private final ExpressionEvaluator evaluator;
+    /**
+     * Cached {@link #toString()} representation. The evaluator tree is immutable after construction,
+     * so its string form is deterministic. {@link Driver} reads this on every status update; caching
+     * avoids walking the evaluator tree per call.
+     */
+    private final String description;
 
     public EvalOperator(DriverContext ctx, ExpressionEvaluator evaluator) {
         this.ctx = ctx;
         this.evaluator = evaluator;
+        this.description = getClass().getSimpleName() + "[evaluator=" + evaluator + "]";
         ctx.breaker().addEstimateBytesAndMaybeBreak(BASE_RAM_BYTES_USED + evaluator.baseRamBytesUsed(), "ESQL");
     }
 
@@ -50,7 +57,7 @@ public class EvalOperator extends AbstractPageMappingOperator {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "[evaluator=" + evaluator + "]";
+        return description;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/FilterOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/FilterOperator.java
@@ -17,6 +17,13 @@ import java.util.Arrays;
 public class FilterOperator extends AbstractPageMappingOperator {
 
     private final ExpressionEvaluator evaluator;
+    /**
+     * Cached {@link #toString()} representation. The evaluator tree is immutable after construction,
+     * so its string form is deterministic. {@link Driver} reads this on every status update; for
+     * deep predicates (e.g. nested {@code LIKE} / boolean logic chains) recomputing it walks the
+     * whole evaluator tree and can dominate CPU.
+     */
+    private final String description;
 
     public record FilterOperatorFactory(ExpressionEvaluator.Factory evaluatorSupplier) implements OperatorFactory {
 
@@ -33,6 +40,7 @@ public class FilterOperator extends AbstractPageMappingOperator {
 
     public FilterOperator(ExpressionEvaluator evaluator) {
         this.evaluator = evaluator;
+        this.description = "FilterOperator[evaluator=" + evaluator + ']';
     }
 
     @Override
@@ -74,7 +82,7 @@ public class FilterOperator extends AbstractPageMappingOperator {
 
     @Override
     public String toString() {
-        return "FilterOperator[" + "evaluator=" + evaluator + ']';
+        return description;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/EvalOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/EvalOperatorTests.java
@@ -28,6 +28,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class EvalOperatorTests extends OperatorTestCase {
     @Override
@@ -113,6 +114,22 @@ public class EvalOperatorTests extends OperatorTestCase {
             LongBlock lb = page.getBlock(resultChannel);
             IntStream.range(0, lb.getPositionCount()).forEach(pos -> assertEquals(expectedValue, lb.getLong(pos)));
         }
+    }
+
+    /**
+     * {@link EvalOperator#toString()} is read by the {@link Driver} on every status update. Verify
+     * that the same {@code String} instance is returned across calls so the evaluator-tree
+     * description is computed at most once per operator.
+     */
+    public void testToStringIsCached() {
+        DriverContext ctx = driverContext();
+        try (EvalOperator op = new EvalOperator(ctx, new Addition(ctx, 4, 9))) {
+            String first = op.toString();
+            String second = op.toString();
+            assertThat(first, equalTo("EvalOperator[evaluator=Addition[lhs=4, rhs=9]]"));
+            assertThat(second, sameInstance(first));
+        }
+        assertThat(ctx.breaker().getUsed(), equalTo(0L));
     }
 
     public void testReadFromBlock() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FilterOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FilterOperatorTests.java
@@ -28,6 +28,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class FilterOperatorTests extends OperatorTestCase {
     @Override
@@ -113,6 +114,22 @@ public class FilterOperatorTests extends OperatorTestCase {
 
     public void testNoResults() {
         assertSimple(driverContext(), 3);
+    }
+
+    /**
+     * {@link FilterOperator#toString()} is read by the {@link Driver} on every status update.
+     * Recomputing the (often deep) evaluator-tree string each time can dominate CPU. Verify that
+     * the same {@code String} instance is returned across calls so the description is computed
+     * at most once per operator.
+     */
+    public void testToStringIsCached() {
+        DriverContext ctx = driverContext();
+        try (FilterOperator op = new FilterOperator(new SameLastDigit(ctx, 3, 7))) {
+            String first = op.toString();
+            String second = op.toString();
+            assertThat(first, equalTo("FilterOperator[evaluator=SameLastDigit[lhs=3, rhs=7]]"));
+            assertThat(second, sameInstance(first));
+        }
     }
 
     public void testReadFromBlock() {


### PR DESCRIPTION
Driver.updateStatus rebuilds the operator status list on every status
update, calling op.toString() each time. For FilterOperator and
EvalOperator, toString delegates to the (immutable) ExpressionEvaluator
tree and walks every node, allocating intermediate strings.

For deep predicates (e.g. nested LIKE / boolean logic chains), this
diagnostic bookkeeping can consumes 8-10% of total query CPU.The evaluator tree is fixed at
construction, so cache the rendered description in a final field and
return it from toString.

Adds testToStringIsCached on both operators asserting the returned
String instance is reused across calls.

Developed using AI-assisted tooling