### PR TITLE
ESQL: Use lat/lon ordering for DECAY geo_point origin

### DIFF
--- a/docs/changelog/148356.yaml
+++ b/docs/changelog/148356.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148356
+summary: Use lat/lon ordering for DECAY `geo_point` origin
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/decay.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/decay.csv-spec
@@ -277,6 +277,39 @@ decay_result:double
 0.606876005579706
 ;
 
+geoPointLinearSameOriginAndValue
+required_capability: decay_geo_point_origin_lat_lon_fix
+
+ROW value = TO_GEOPOINT("POINT(20 50)")
+| EVAL decay_result = decay(value, TO_GEOPOINT("POINT(20 50)"), "200km", {"offset": "0km", "decay": 0.5, "type": "linear"})
+| KEEP decay_result;
+
+decay_result:double
+1.0
+;
+
+geoPointExpSameOriginAndValue
+required_capability: decay_geo_point_origin_lat_lon_fix
+
+ROW value = TO_GEOPOINT("POINT(20 50)")
+| EVAL decay_result = decay(value, TO_GEOPOINT("POINT(20 50)"), "200km", {"offset": "0km", "decay": 0.5, "type": "exp"})
+| KEEP decay_result;
+
+decay_result:double
+1.0
+;
+
+geoPointGaussSameOriginAndValue
+required_capability: decay_geo_point_origin_lat_lon_fix
+
+ROW value = TO_GEOPOINT("POINT(20 50)")
+| EVAL decay_result = decay(value, TO_GEOPOINT("POINT(20 50)"), "200km", {"offset": "0km", "decay": 0.5, "type": "gauss"})
+| KEEP decay_result;
+
+decay_result:double
+1.0
+;
+
 datetimeLinear1
 required_capability: decay_function
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1595,6 +1595,14 @@ public class EsqlCapabilities {
         DECAY_FUNCTION_PARAMETER_CONVERSION,
 
         /**
+         * Fix latitude/longitude ordering of the in geo-point {@code DECAY}.
+         * Previously the origin was serialized as "lon,lat" before being parsed by
+         * {@code GeoUtils.parseGeoPoint}, which expects "lat,lon", effectively swapping the
+         * origin's coordinates and producing incorrect distances whenever {@code lat != lon}.
+         */
+        DECAY_GEO_POINT_ORIGIN_LAT_LON_FIX,
+
+        /**
          * Support correct counting of skipped shards.
          */
         CORRECT_SKIPPED_SHARDS_COUNT,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/Decay.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/Decay.java
@@ -511,7 +511,8 @@ public class Decay extends EsqlScalarFunction implements OptionalArgument, PostO
         Point originPoint = SpatialCoordinateTypes.UNSPECIFIED.wkbAsPoint(origin);
         GeoPoint originGeoPoint = new GeoPoint(originPoint.getY(), originPoint.getX());
 
-        String originStr = originGeoPoint.getX() + "," + originGeoPoint.getY();
+        // GeoUtils.parseGeoPoint expects coordinate strings in "lat,lon" order; use getY (lat) then getX (lon).
+        String originStr = originGeoPoint.getY() + "," + originGeoPoint.getX();
         String scaleStr = scale.utf8ToString();
         String offsetStr = offset.utf8ToString();
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayTests.java
@@ -954,7 +954,8 @@ public class DecayTests extends AbstractScalarFunctionTestCase {
         double decay,
         String type
     ) {
-        String originStr = origin.getX() + "," + origin.getY();
+        // GeoUtils.parseGeoPoint expects coordinate strings in "lat,lon" order; use getY (lat) then getX (lon).
+        String originStr = origin.getY() + "," + origin.getX();
 
         return switch (type) {
             case "linear" -> new ScoreScriptUtils.DecayGeoLinear(originStr, scale, offset, decay).decayGeoLinear(value);


### PR DESCRIPTION
Here's a suggested PR title and body. Both are neutral, focus on the change rather than blame, and follow common Elasticsearch PR conventions (release-note line, area labels you'll typically want, and a check-list).

Title
ESQL: Use lat/lon ordering for DECAY geo_point origin
Body

## Summary
Builds the origin string passed to `ScoreScriptUtils.DecayGeo*` as
`"lat,lon"` so it matches `GeoUtils.parseGeoPoint`, which is used to
parse the origin in `DecayGeoLinear` / `DecayGeoExp` / `DecayGeoGauss`.
`GeoPoint#getX` returns longitude and `#getY` returns latitude, so the
previous `getX() + "," + getY()` produced `"lon,lat"` and the parsed
origin's coordinates were swapped whenever `lat != lon`. With the
ordering aligned, geo-point `DECAY` returns correct distances for any
origin.

## Changes
- `Decay#process` (geo-point evaluator): emit `"lat,lon"` for the origin
  string.
- `DecayTests#geoPointDecayWithScoreScript`: same alignment so the
  expected values now reflect the corrected behavior (random geo-point
  test cases previously matched the implementation rather than verifying
  it).
- New csv-spec tests in `decay.csv-spec` using a non-symmetric origin
  (`POINT(20 50)`), covering linear, exp and gauss.
- New capability `DECAY_GEO_POINT_ORIGIN_LAT_LON_FIX` to gate the new
  behavior so mixed-version BWC tests don't regress.
