### PR TITLE
[9.4] Add external changelog source support for release notes (#145958)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/BundleChangelogsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/BundleChangelogsTask.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
@@ -24,6 +25,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
@@ -35,8 +37,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,6 +53,16 @@ import static java.util.stream.Collectors.toList;
 public class BundleChangelogsTask extends DefaultTask {
     private static final Logger LOGGER = Logging.getLogger(BundleChangelogsTask.class);
 
+    /**
+     * Configuration for an external repository whose changelog entries should be
+     * merged into the Elasticsearch release notes bundle.
+     *
+     * @param repoUrl       HTTPS clone URL, e.g. {@code https://github.com/elastic/ml-cpp.git}
+     * @param sourceRepo    GitHub owner/name used for PR links, e.g. {@code elastic/ml-cpp}
+     * @param changelogPath path inside the repo containing YAML entries, e.g. {@code docs/changelog}
+     */
+    public record ExternalChangelogSource(String repoUrl, String sourceRepo, String changelogPath) implements java.io.Serializable {}
+
     private final ConfigurableFileCollection changelogs;
 
     private final RegularFileProperty bundleFile;
@@ -56,6 +70,8 @@ public class BundleChangelogsTask extends DefaultTask {
     private final DirectoryProperty changelogBundlesDirectory;
 
     private final GitWrapper gitWrapper;
+
+    private List<ExternalChangelogSource> externalSources = List.of();
 
     @Nullable
     private String branch;
@@ -73,7 +89,7 @@ public class BundleChangelogsTask extends DefaultTask {
         option = "bc-ref",
         description = "A source ref, typically the sha of a BC, that should be used to source PRs for changelog entries. "
             + "The actual content of the changelogs will come from the 'branch' ref. "
-            + "You should generally always use bc-ref."
+            + "You should generally always use bc-ref. Blank or whitespace-only values are ignored."
     )
     public void setBcRef(String ref) {
         this.bcRef = ref;
@@ -124,11 +140,12 @@ public class BundleChangelogsTask extends DefaultTask {
         }
 
         final String upstreamRemote = gitWrapper.getUpstream();
+        final String esBcRefForGit = (bcRef != null && bcRef.isBlank() == false) ? resolveElasticsearchGitRef(bcRef, upstreamRemote) : null;
         Set<String> entriesFromBc = Set.of();
 
         var didCheckoutChangelogs = false;
         try {
-            var usingBcRef = bcRef != null && bcRef.isEmpty() == false;
+            var usingBcRef = bcRef != null && bcRef.isBlank() == false;
             if (usingBcRef) {
                 // Check out all the changelogs that existed at the time of the BC
                 checkoutChangelogs(gitWrapper, upstreamRemote, bcRef);
@@ -148,12 +165,7 @@ public class BundleChangelogsTask extends DefaultTask {
             // version file name.
             String versionRef;
             if (usingBcRef) {
-                versionRef = upstreamRemote + "/" + bcRef;
-                if (bcRef.contains("upstream/")) {
-                    versionRef = bcRef.replace("upstream/", upstreamRemote + "/");
-                } else if (bcRef.matches("^[0-9a-f]+$")) {
-                    versionRef = bcRef;
-                }
+                versionRef = Objects.requireNonNull(esBcRefForGit);
             } else {
                 versionRef = upstreamRemote + "/" + branch;
             }
@@ -179,9 +191,20 @@ public class BundleChangelogsTask extends DefaultTask {
                 // This specifically covers the case of a PR being merged into the BC with a missing changelog file, and the file added
                 // later.
                 var prNumber = f.getName().replace(".yaml", "");
-                var output = gitWrapper.runCommand("git", "log", bcRef, "--grep", "(#" + prNumber + ")");
+                var output = gitWrapper.runCommand("git", "log", esBcRefForGit, "--grep", "(#" + prNumber + ")");
                 return output.trim().isEmpty() == false;
-            }).map(ChangelogEntry::parse).sorted(Comparator.comparing(ChangelogEntry::getPr)).collect(toList());
+            }).map(ChangelogEntry::parse).sorted(changelogEntryComparator()).collect(toList());
+
+            // Fetch changelog entries from external repositories
+            for (ExternalChangelogSource source : externalSources) {
+                List<ChangelogEntry> externalEntries = fetchExternalChangelogs(source, branch, esBcRefForGit, upstreamRemote);
+                if (externalEntries.isEmpty() == false) {
+                    LOGGER.info("Adding {} entries from {}", externalEntries.size(), source.sourceRepo());
+                    entries.addAll(externalEntries);
+                }
+            }
+
+            entries.sort(changelogEntryComparator());
 
             ChangelogBundle bundle = new ChangelogBundle(version, finalize, Instant.now().toString(), entries);
 
@@ -223,6 +246,259 @@ public class BundleChangelogsTask extends DefaultTask {
         }
 
         gitWrapper.runCommand("git", "checkout", refSpec, "--", changelogDirectory.get() + "/*.yaml");
+    }
+
+    /**
+     * Fetch changelog entries from an external repository for the given branch.
+     * Fetches directly from the repo URL into FETCH_HEAD (no persistent remote),
+     * reads each YAML file via {@code git show}, and sets {@code sourceRepo} on
+     * the parsed entries.
+     * <p>
+     * When {@code bcRefForFilter} is non-null (Elasticsearch {@code --bc-ref} is in use),
+     * it must already be resolved for this repository (see {@link #resolveElasticsearchGitRef}).
+     * Entries with a {@code pr} are kept only when that PR appears in external history not newer
+     * than the BC ref's committer date (see {@link #gitLogHasGrepUntil}). Entries without a
+     * {@code pr} are kept when the changelog file already existed in the external tree at that
+     * cutoff (see {@link #externalChangelogFileExistedAtOrBeforeBc}).
+     * <p>
+     * {@code esUpstreamRemote} strips {@code <remote>/} from {@code branchRef} for {@code git fetch}
+     * (same remote name as {@link GitWrapper#getUpstream()}).
+     */
+    private List<ChangelogEntry> fetchExternalChangelogs(
+        ExternalChangelogSource source,
+        String branchRef,
+        @Nullable String bcRefForFilter,
+        String esUpstreamRemote
+    ) {
+        if (isShaRef(branchRef)) {
+            LOGGER.info("Skipping external changelog fetch for SHA-valued --branch: {}", branchRef);
+            return List.of();
+        }
+        String normalizedBranch = normalizeBranchForExternalFetch(branchRef, esUpstreamRemote);
+
+        try {
+            if (bcRefForFilter != null && bcRefForFilter.isBlank() == false) {
+                // Full history: shallow fetch can hide PR merges older than --depth from FETCH_HEAD,
+                // causing BC grep filtering to drop valid external changelog entries.
+                LOGGER.info(
+                    "Fetching full history from {}:{} for BC filtering (may be slower than shallow fetch)",
+                    source.sourceRepo(),
+                    normalizedBranch
+                );
+                gitWrapper.runCommand("git", "fetch", source.repoUrl(), normalizedBranch);
+            } else {
+                gitWrapper.runCommand("git", "fetch", "--depth=1", source.repoUrl(), normalizedBranch);
+            }
+        } catch (Exception e) {
+            throw new GradleException(
+                "Failed to fetch branch " + normalizedBranch + " from " + source.sourceRepo() + " for external changelogs",
+                e
+            );
+        }
+
+        String externalHead = gitWrapper.runCommand("git", "rev-parse", "FETCH_HEAD").trim();
+
+        String treePath = source.changelogPath();
+
+        List<String> files;
+        try {
+            files = gitWrapper.listFiles("FETCH_HEAD", treePath).filter(f -> f.endsWith(".yaml")).toList();
+        } catch (Exception e) {
+            LOGGER.warn("No changelog directory found at {} in {}:{}", treePath, source.sourceRepo(), normalizedBranch);
+            return List.of();
+        }
+
+        if (files.isEmpty()) {
+            LOGGER.info("No external changelog entries found in {}:{}", source.sourceRepo(), normalizedBranch);
+            return List.of();
+        }
+
+        LOGGER.info("Found {} changelog file(s) in {}:{}", files.size(), source.sourceRepo(), normalizedBranch);
+
+        List<ParsedExternalChangelog> parsed = new ArrayList<>();
+        for (String filePath : files) {
+            String content = gitWrapper.runCommand("git", "show", "FETCH_HEAD:" + filePath);
+            ChangelogEntry entry = ChangelogEntry.parse(content);
+            entry.setSourceRepo(source.sourceRepo());
+            applyExternalFilenamePrFallback(filePath, entry);
+            parsed.add(new ParsedExternalChangelog(filePath, entry));
+        }
+
+        if (bcRefForFilter != null && bcRefForFilter.isBlank() == false) {
+            String bcCommitterIso = committerIsoAtRef(bcRefForFilter);
+            int before = parsed.size();
+            parsed = parsed.stream()
+                .filter(p -> includeExternalChangelogForBuildCandidate(p.entry(), externalHead, bcCommitterIso, p.repoRelativePath()))
+                .collect(Collectors.toCollection(ArrayList::new));
+            if (before != parsed.size()) {
+                LOGGER.info(
+                    "Filtered {} external changelog(s) from {} for BC ref {} ({} remaining)",
+                    before - parsed.size(),
+                    source.sourceRepo(),
+                    bcRefForFilter,
+                    parsed.size()
+                );
+            }
+        }
+
+        return parsed.stream().map(ParsedExternalChangelog::entry).collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private record ParsedExternalChangelog(String repoRelativePath, ChangelogEntry entry) {}
+
+    /**
+     * For external changelog entries, the {@code pr} field refers to that external repository,
+     * not Elasticsearch; {@code git log} on the ES repo at {@code --bc-ref} could match an
+     * unrelated ES PR with the same number. We only consult the fetched external tip, capped
+     * by the BC ref's committer date (see {@link #gitLogHasGrepUntil}).
+     * <p>
+     * When {@code pr} is absent, we keep the entry only if {@code repoRelativePath} already
+     * existed in the external tree at or before the BC committer time (mirroring local
+     * {@code entriesFromBc} behavior).
+     */
+    private boolean includeExternalChangelogForBuildCandidate(
+        ChangelogEntry entry,
+        String externalTip,
+        String bcCommitterIso,
+        String repoRelativePath
+    ) {
+        Integer pr = entry.getPr();
+        if (pr == null) {
+            return externalChangelogFileExistedAtOrBeforeBc(externalTip, bcCommitterIso, repoRelativePath);
+        }
+        String grep = "(#" + pr + ")";
+        return gitLogHasGrepUntil(externalTip, grep, bcCommitterIso);
+    }
+
+    /**
+     * True if {@code pathInRepo} is present in the tree at the latest commit on {@code externalTip}'s
+     * history with committer time not newer than {@code bcCommitterIso}.
+     */
+    private boolean externalChangelogFileExistedAtOrBeforeBc(String externalTip, String bcCommitterIso, String pathInRepo) {
+        try {
+            String rev = gitWrapper.runCommand("git", "rev-list", "-n", "1", "--until", bcCommitterIso, externalTip).trim();
+            if (rev.isEmpty()) {
+                return false;
+            }
+            gitWrapper.runCommand("git", "cat-file", "-e", rev + ":" + pathInRepo);
+            return true;
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    /**
+     * If YAML omits {@code pr} but the changelog file is named like local ES entries
+     * ({@code N.yaml} with numeric {@code N}), set the PR so BC filtering matches
+     * {@code executeTask}'s local changelog behavior.
+     */
+    private static void applyExternalFilenamePrFallback(String repoRelativePath, ChangelogEntry entry) {
+        if (entry.getPr() != null) {
+            return;
+        }
+        int slash = repoRelativePath.lastIndexOf('/');
+        String baseName = slash >= 0 ? repoRelativePath.substring(slash + 1) : repoRelativePath;
+        if (baseName.endsWith(".yaml") == false) {
+            return;
+        }
+        String stem = baseName.substring(0, baseName.length() - ".yaml".length());
+        try {
+            entry.setPr(Integer.parseInt(stem));
+        } catch (NumberFormatException e) {
+            // leave unset; BC filtering uses tree-at-BC for inclusion when pr is absent
+        }
+    }
+
+    /**
+     * Resolves {@code --bc-ref} / branch-style refs the same way as {@link #checkoutChangelogs}
+     * so {@code git show} / {@code git log} run against the configured upstream remote name
+     * instead of a literal {@code upstream/} remote that may not exist.
+     */
+    static String resolveElasticsearchGitRef(String ref, String upstreamRemote) {
+        if (ref.contains("upstream/")) {
+            return ref.replace("upstream/", upstreamRemote + "/");
+        }
+        if (ref.matches("^[0-9a-f]+$")) {
+            return ref;
+        }
+        return upstreamRemote + "/" + ref;
+    }
+
+    /**
+     * True if {@code ref}'s history contains a commit matching {@code grep} with committer
+     * date not newer than {@code untilIsoInclusive} ({@code git show -s --format=%cI} form).
+     */
+    private boolean gitLogHasGrepUntil(String ref, String grep, String untilIsoInclusive) {
+        return gitWrapper.runCommand("git", "log", ref, "--grep", grep, "--until", untilIsoInclusive, "-n", "1").trim().isEmpty() == false;
+    }
+
+    private String committerIsoAtRef(String ref) {
+        return gitWrapper.runCommand("git", "show", "-s", "--format=%cI", ref).trim();
+    }
+
+    private static final Set<String> KNOWN_REMOTE_PREFIXES = Set.of("upstream/", "origin/");
+
+    /**
+     * Orders bundled changelog entries by PR number, then by {@code source_repo} so entries from
+     * different repositories that share a PR number sort deterministically.
+     */
+    static Comparator<ChangelogEntry> changelogEntryComparator() {
+        return Comparator.comparing(ChangelogEntry::getPr, Comparator.nullsLast(Comparator.naturalOrder()))
+            .thenComparing(ChangelogEntry::getSourceRepo, Comparator.nullsFirst(Comparator.naturalOrder()));
+    }
+
+    static boolean isShaRef(String ref) {
+        return ref.matches("(?i)^[0-9a-f]{7,40}$");
+    }
+
+    /**
+     * Normalizes a branch reference for use with external repos. Strips known
+     * remote prefixes ({@code upstream/}, {@code origin/}) which are ES-repo-specific,
+     * and when {@code esUpstreamRemote} is set, strips {@code <remote>/} for the
+     * Elasticsearch remote name returned by {@link GitWrapper#getUpstream()} (e.g.
+     * {@code elastic/main} → {@code main}) so {@code git fetch} targets a branch that
+     * exists on the external repository.
+     * <p>
+     * Raw commit SHAs are rejected since they are meaningless for external repositories.
+     * Other refs (including branch names with slashes like {@code feature/foo}) are passed
+     * through except for the prefixes above.
+     */
+    static String normalizeBranchForExternalFetch(String branchRef) {
+        return normalizeBranchForExternalFetch(branchRef, null);
+    }
+
+    static String normalizeBranchForExternalFetch(String branchRef, @Nullable String esUpstreamRemote) {
+        if (isShaRef(branchRef)) {
+            throw new IllegalArgumentException(
+                "Cannot use a commit SHA ("
+                    + branchRef
+                    + ") as --branch when fetching external changelog sources: "
+                    + "git fetch on the remote repository requires a branch or tag name. "
+                    + "Local Elasticsearch changelog YAML can still be checked out from a SHA; "
+                    + "pass a named branch for --branch (and use --bc-ref for the build candidate when applicable)."
+            );
+        }
+        for (String prefix : KNOWN_REMOTE_PREFIXES) {
+            if (branchRef.startsWith(prefix)) {
+                return branchRef.substring(prefix.length());
+            }
+        }
+        if (esUpstreamRemote != null && esUpstreamRemote.isBlank() == false) {
+            String remotePrefix = esUpstreamRemote + "/";
+            if (branchRef.startsWith(remotePrefix)) {
+                return branchRef.substring(remotePrefix.length());
+            }
+        }
+        return branchRef;
+    }
+
+    public void setExternalSources(List<ExternalChangelogSource> sources) {
+        this.externalSources = sources;
+    }
+
+    @Input
+    public List<ExternalChangelogSource> getExternalSources() {
+        return externalSources;
     }
 
     @InputDirectory

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ChangelogEntry.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ChangelogEntry.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.gradle.internal.release;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
@@ -44,7 +45,9 @@ public class ChangelogEntry {
     private Highlight highlight;
     private Deprecation deprecation;
     private String entryOverride;
+    private String sourceRepo;
 
+    private static final String DEFAULT_REPO = "elastic/elasticsearch";
     private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
     /**
@@ -57,6 +60,19 @@ public class ChangelogEntry {
             return yamlMapper.readValue(file, ChangelogEntry.class);
         } catch (IOException e) {
             LOGGER.error("Failed to parse changelog from " + file.getAbsolutePath(), e);
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Create a new instance by parsing YAML content from a string.
+     * @param yamlContent the YAML string to parse
+     * @return a new instance
+     */
+    public static ChangelogEntry parse(String yamlContent) {
+        try {
+            return yamlMapper.readValue(yamlContent, ChangelogEntry.class);
+        } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
@@ -134,6 +150,22 @@ public class ChangelogEntry {
         this.entryOverride = entryOverride;
     }
 
+    @JsonProperty("source_repo")
+    public String getSourceRepo() {
+        return sourceRepo;
+    }
+
+    @JsonProperty("source_repo")
+    public void setSourceRepo(String sourceRepo) {
+        this.sourceRepo = sourceRepo;
+    }
+
+    @JsonIgnore
+    public String getRepoUrl() {
+        String repo = sourceRepo != null ? sourceRepo : DEFAULT_REPO;
+        return "https://github.com/" + repo;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -150,19 +182,20 @@ public class ChangelogEntry {
             && Objects.equals(summary, that.summary)
             && Objects.equals(highlight, that.highlight)
             && Objects.equals(breaking, that.breaking)
-            && Objects.equals(entryOverride, that.entryOverride);
+            && Objects.equals(entryOverride, that.entryOverride)
+            && Objects.equals(sourceRepo, that.sourceRepo);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(pr, issues, area, type, summary, highlight, breaking, entryOverride);
+        return Objects.hash(pr, issues, area, type, summary, highlight, breaking, entryOverride, sourceRepo);
     }
 
     @Override
     public String toString() {
         return String.format(
             Locale.ROOT,
-            "ChangelogEntry{pr=%d, issues=%s, area='%s', type='%s', summary='%s', highlight=%s, breaking=%s, deprecation=%s}",
+            "ChangelogEntry{pr=%d, issues=%s, area='%s', type='%s', summary='%s', highlight=%s, breaking=%s, deprecation=%s, sourceRepo='%s'}",
             pr,
             issues,
             area,
@@ -170,7 +203,8 @@ public class ChangelogEntry {
             summary,
             highlight,
             breaking,
-            deprecation
+            deprecation,
+            sourceRepo
         );
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
@@ -9,6 +9,10 @@
 
 package org.elasticsearch.gradle.internal.release;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitTaskPlugin;
@@ -23,6 +27,10 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.util.PatternSet;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -32,6 +40,7 @@ import javax.inject.Inject;
 public class ReleaseToolsPlugin implements Plugin<Project> {
 
     private static final String RESOURCES = "build-tools-internal/src/main/resources/";
+    private static final String EXTERNAL_SOURCES_CONFIG = "external-changelog-sources.yml";
 
     private final ProjectLayout projectLayout;
 
@@ -69,11 +78,12 @@ public class ReleaseToolsPlugin implements Plugin<Project> {
 
         final Action<BundleChangelogsTask> configureBundleTask = task -> {
             task.setGroup("Documentation");
-            task.setDescription("Generates release notes from changelog files held in this checkout");
+            task.setDescription("Generates release notes from changelog files held in this checkout and external repos");
             task.setChangelogs(yamlFiles);
             task.setChangelogDirectory(changeLogDirectory);
             task.setChangelogBundlesDirectory(changeLogBundlesDirectory);
             task.setBundleFile(projectDirectory.file("docs/release-notes/changelogs-" + version.toString() + ".yml"));
+            task.setExternalSources(loadExternalSources());
             task.getOutputs().upToDateWhen(o -> false);
         };
 
@@ -110,5 +120,17 @@ public class ReleaseToolsPlugin implements Plugin<Project> {
         });
 
         project.getTasks().named("precommit").configure(task -> task.dependsOn(validateChangelogsTask));
+    }
+
+    private static List<BundleChangelogsTask.ExternalChangelogSource> loadExternalSources() {
+        try (InputStream is = ReleaseToolsPlugin.class.getClassLoader().getResourceAsStream(EXTERNAL_SOURCES_CONFIG)) {
+            if (is == null) {
+                return List.of();
+            }
+            ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+            return mapper.readValue(is, new TypeReference<>() {});
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load " + EXTERNAL_SOURCES_CONFIG, e);
+        }
     }
 }

--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -130,6 +130,10 @@
         },
         "deprecation": {
           "$ref": "#/definitions/CompatibilityChange"
+        },
+        "source_repo": {
+          "type": "string",
+          "description": "GitHub repository (owner/name) for entries from external repos, e.g. elastic/ml-cpp. Defaults to elastic/elasticsearch when absent."
         }
       },
       "required": [

--- a/build-tools-internal/src/main/resources/external-changelog-sources.yml
+++ b/build-tools-internal/src/main/resources/external-changelog-sources.yml
@@ -1,0 +1,13 @@
+# External repositories whose changelog entries should be merged into the
+# Elasticsearch release notes bundle at build time.
+#
+# Each entry specifies:
+#   repoUrl       - HTTPS clone URL for git fetch
+#   sourceRepo    - GitHub owner/name, used for PR/issue links in release notes
+#   changelogPath - path inside the repo containing YAML changelog entries
+#
+# To add a new external source, append an entry below.
+
+- repoUrl: https://github.com/elastic/ml-cpp.git
+  sourceRepo: elastic/ml-cpp
+  changelogPath: docs/changelog

--- a/build-tools-internal/src/main/resources/templates/breaking-changes.md
+++ b/build-tools-internal/src/main/resources/templates/breaking-changes.md
@@ -37,10 +37,10 @@ for(bundle in changelogBundles) {
 
             for (change in changelogsByTypeByArea['breaking'][team]) {
                 if (!change.entryOverride) {
-                    print "* ${change.summary} [#${change.pr}](https://github.com/elastic/elasticsearch/pull/${change.pr})"
+                    print "* ${change.summary} [#${change.pr}](${change.repoUrl}/pull/${change.pr})"
                     if (change.issues != null && change.issues.empty == false) {
                         print change.issues.size() == 1 ? " (issue: " : " (issues: "
-                        print change.issues.collect { "[#${it}](https://github.com/elastic/elasticsearch/issues/${it})" }.join(", ")
+                        print change.issues.collect { "[#${it}](${change.repoUrl}/issues/${it})" }.join(", ")
                         print ")"
                     }
                 } else {

--- a/build-tools-internal/src/main/resources/templates/deprecations.md
+++ b/build-tools-internal/src/main/resources/templates/deprecations.md
@@ -39,10 +39,10 @@ for(bundle in changelogBundles) {
             print "\n${team}:\n";
 
             for (change in changelogsByTypeByArea['deprecation'][team]) {
-                print "* ${change.summary} [#${change.pr}](https://github.com/elastic/elasticsearch/pull/${change.pr})"
+                print "* ${change.summary} [#${change.pr}](${change.repoUrl}/pull/${change.pr})"
                 if (change.issues != null && change.issues.empty == false) {
                     print change.issues.size() == 1 ? " (issue: " : " (issues: "
-                    print change.issues.collect { "[#${it}](https://github.com/elastic/elasticsearch/issues/${it})" }.join(", ")
+                    print change.issues.collect { "[#${it}](${change.repoUrl}/issues/${it})" }.join(", ")
                     print ")"
                 }
                 print "\n"

--- a/build-tools-internal/src/main/resources/templates/index.md
+++ b/build-tools-internal/src/main/resources/templates/index.md
@@ -65,10 +65,10 @@ for (changeType in ['features-enhancements', 'fixes', 'regression']) {
 
     for (change in changelogsByTypeByArea[changeType][team]) {
         if (!change.entryOverride) {
-            print "* ${change.summary} [#${change.pr}](https://github.com/elastic/elasticsearch/pull/${change.pr})"
+            print "* ${change.summary} [#${change.pr}](${change.repoUrl}/pull/${change.pr})"
             if (change.issues != null && change.issues.empty == false) {
                 print change.issues.size() == 1 ? " (issue: " : " (issues: "
-                print change.issues.collect { "[#${it}](https://github.com/elastic/elasticsearch/issues/${it})" }.join(", ")
+                print change.issues.collect { "[#${it}](${change.repoUrl}/issues/${it})" }.join(", ")
                 print ")"
             }
         } else {

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ExternalChangelogSourceTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ExternalChangelogSourceTests.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.release;
+
+import org.junit.Test;
+
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
+
+public class ExternalChangelogSourceTests {
+
+    @Test
+    public void testParseSourceRepoFromYaml() {
+        String yaml = """
+            pr: 3008
+            summary: "Harden pytorch_inference with TorchScript model graph validation"
+            area: Machine Learning
+            type: enhancement
+            issues:
+              - 2890
+            source_repo: elastic/ml-cpp
+            """;
+
+        ChangelogEntry entry = ChangelogEntry.parse(yaml);
+        assertThat(entry.getSourceRepo(), equalTo("elastic/ml-cpp"));
+        assertThat(entry.getRepoUrl(), equalTo("https://github.com/elastic/ml-cpp"));
+        assertThat(entry.getPr(), equalTo(3008));
+        assertThat(entry.getSummary(), equalTo("Harden pytorch_inference with TorchScript model graph validation"));
+    }
+
+    @Test
+    public void testDefaultRepoUrlWhenSourceRepoAbsent() {
+        String yaml = """
+            pr: 145000
+            summary: "Some ES change"
+            area: Search
+            type: enhancement
+            """;
+
+        ChangelogEntry entry = ChangelogEntry.parse(yaml);
+        assertThat(entry.getSourceRepo(), nullValue());
+        assertThat(entry.getRepoUrl(), equalTo("https://github.com/elastic/elasticsearch"));
+    }
+
+    @Test
+    public void testResolveElasticsearchGitRef() {
+        assertThat(BundleChangelogsTask.resolveElasticsearchGitRef("main", "origin"), equalTo("origin/main"));
+        assertThat(BundleChangelogsTask.resolveElasticsearchGitRef("upstream/9.1", "origin"), equalTo("origin/9.1"));
+        assertThat(BundleChangelogsTask.resolveElasticsearchGitRef("abc1234567890", "origin"), equalTo("abc1234567890"));
+        assertThat(BundleChangelogsTask.resolveElasticsearchGitRef("feature/foo", "myremote"), equalTo("myremote/feature/foo"));
+    }
+
+    @Test
+    public void testNormalizeBranchStripsPrefixes() {
+        assertThat(BundleChangelogsTask.normalizeBranchForExternalFetch("main"), equalTo("main"));
+        assertThat(BundleChangelogsTask.normalizeBranchForExternalFetch("9.3"), equalTo("9.3"));
+        assertThat(BundleChangelogsTask.normalizeBranchForExternalFetch("upstream/main"), equalTo("main"));
+        assertThat(BundleChangelogsTask.normalizeBranchForExternalFetch("origin/9.3"), equalTo("9.3"));
+    }
+
+    @Test
+    public void testNormalizeBranchStripsConfiguredElasticsearchRemote() {
+        assertThat(BundleChangelogsTask.normalizeBranchForExternalFetch("elastic/9.2", "elastic"), equalTo("9.2"));
+        assertThat(BundleChangelogsTask.normalizeBranchForExternalFetch("myfork/feature/x", "myfork"), equalTo("feature/x"));
+    }
+
+    @Test
+    public void testNormalizeBranchPreservesSlashesInBranchNames() {
+        assertThat(BundleChangelogsTask.normalizeBranchForExternalFetch("feature/foo"), equalTo("feature/foo"));
+        assertThat(BundleChangelogsTask.normalizeBranchForExternalFetch("refs/heads/main"), equalTo("refs/heads/main"));
+        assertThat(BundleChangelogsTask.normalizeBranchForExternalFetch("release/9.4.0"), equalTo("release/9.4.0"));
+    }
+
+    @Test
+    public void testNormalizeBranchRejectsSha() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> BundleChangelogsTask.normalizeBranchForExternalFetch("abc1234def5678")
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> BundleChangelogsTask.normalizeBranchForExternalFetch("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+        );
+    }
+
+    @Test
+    public void testIsShaRef() {
+        assertThat(BundleChangelogsTask.isShaRef("abc1234"), equalTo(true));
+        assertThat(BundleChangelogsTask.isShaRef("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"), equalTo(true));
+        assertThat(BundleChangelogsTask.isShaRef("ABC1234DEF5678"), equalTo(true));
+        assertThat(BundleChangelogsTask.isShaRef("aBc1234"), equalTo(true));
+        assertThat(BundleChangelogsTask.isShaRef("main"), equalTo(false));
+        assertThat(BundleChangelogsTask.isShaRef("9.3"), equalTo(false));
+        assertThat(BundleChangelogsTask.isShaRef("upstream/main"), equalTo(false));
+        assertThat(BundleChangelogsTask.isShaRef("feature/foo"), equalTo(false));
+    }
+
+    @Test
+    public void testParseStringSetSourceRepoManually() {
+        String yaml = """
+            pr: 100
+            summary: "A change"
+            area: Machine Learning
+            type: bug
+            """;
+
+        ChangelogEntry entry = ChangelogEntry.parse(yaml);
+        assertThat(entry.getSourceRepo(), nullValue());
+        assertThat(entry.getRepoUrl(), equalTo("https://github.com/elastic/elasticsearch"));
+
+        entry.setSourceRepo("elastic/ml-cpp");
+        assertThat(entry.getSourceRepo(), equalTo("elastic/ml-cpp"));
+        assertThat(entry.getRepoUrl(), equalTo("https://github.com/elastic/ml-cpp"));
+    }
+
+    @Test
+    public void testParseStringInvalidYamlThrows() {
+        assertThrows(UncheckedIOException.class, () -> ChangelogEntry.parse("not: [valid: yaml: for: changelog"));
+    }
+
+    @Test
+    public void testIsShaRefEdgeCases() {
+        assertThat("6 chars (too short)", BundleChangelogsTask.isShaRef("abc123"), equalTo(false));
+        assertThat("7 chars (minimum)", BundleChangelogsTask.isShaRef("abc1234"), equalTo(true));
+        assertThat("40 chars (full SHA)", BundleChangelogsTask.isShaRef("a".repeat(40)), equalTo(true));
+        assertThat("41 chars (too long)", BundleChangelogsTask.isShaRef("a".repeat(41)), equalTo(false));
+        assertThat("contains non-hex", BundleChangelogsTask.isShaRef("abc123g"), equalTo(false));
+        assertThat("empty string", BundleChangelogsTask.isShaRef(""), equalTo(false));
+    }
+
+    @Test
+    public void testExternalChangelogSourceAccessors() {
+        var source = new BundleChangelogsTask.ExternalChangelogSource(
+            "https://github.com/elastic/ml-cpp.git",
+            "elastic/ml-cpp",
+            "docs/changelog"
+        );
+
+        assertThat(source.repoUrl(), equalTo("https://github.com/elastic/ml-cpp.git"));
+        assertThat(source.sourceRepo(), equalTo("elastic/ml-cpp"));
+        assertThat(source.changelogPath(), equalTo("docs/changelog"));
+    }
+
+    @Test
+    public void testChangelogEntryComparatorUsesSourceRepoForDuplicatePrNumbers() {
+        var mlCpp = new ChangelogEntry();
+        mlCpp.setPr(100);
+        mlCpp.setSourceRepo("elastic/ml-cpp");
+        var es = new ChangelogEntry();
+        es.setPr(100);
+        es.setSourceRepo(null);
+        var other = new ChangelogEntry();
+        other.setPr(100);
+        other.setSourceRepo("elastic/other");
+
+        var entries = new ArrayList<>(List.of(mlCpp, es, other));
+        entries.sort(BundleChangelogsTask.changelogEntryComparator());
+        assertThat(entries.get(0).getSourceRepo(), nullValue());
+        assertThat(entries.get(1).getSourceRepo(), equalTo("elastic/ml-cpp"));
+        assertThat(entries.get(2).getSourceRepo(), equalTo("elastic/other"));
+    }
+}


### PR DESCRIPTION
Backport of #145958 to the `9.4` branch.

Cherry-picked squash merge commit `a2bea5c67f1` from `main`.

See original PR for motivation and test plan.