### PR TITLE
[Test] Suppress ExtrasFs for MetadataSnapshotBlobStoreDirectoryTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -554,9 +554,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/148339
-- class: org.elasticsearch.xpack.stateless.snapshots.MetadataSnapshotBlobStoreDirectoryTests
-  method: testMetadataSnapshotWithBlobOffset
-  issue: https://github.com/elastic/elasticsearch/issues/148342
 - class: org.elasticsearch.xpack.security.ReindexRelocationWithSecurityIT
   method: testReindexRelocatesWhenCoordinatorShutsDown
   issue: https://github.com/elastic/elasticsearch/issues/148373

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/MetadataSnapshotBlobStoreDirectoryTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/snapshots/MetadataSnapshotBlobStoreDirectoryTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.blobstore.fs.FsBlobContainer;
@@ -40,6 +41,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 
+@LuceneTestCase.SuppressFileSystems("ExtrasFS")
 public class MetadataSnapshotBlobStoreDirectoryTests extends ESTestCase {
 
     public void testMetadataSnapshotMatchesLocalDirectory() throws IOException {


### PR DESCRIPTION
Extra files are not interesting for the tests. In addition, they cause spurious failures because they can be deleted or a directory instead of file. This PR suppress its usage.

Resolves #148342
