### PR TITLE
[ESQL] Fix ExternalParquetCountPushdownIT on Windows

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -527,18 +527,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.datasources.StreamingParallelParsingCoordinatorTests
   method: testCloseWhileSegmentatorParkedOnDispatchPermit
   issue: https://github.com/elastic/elasticsearch/issues/148229
-- class: org.elasticsearch.xpack.esql.action.ExternalParquetCountPushdownIT
-  method: testCountStarPushdownCoordinatorOnly
-  issue: https://github.com/elastic/elasticsearch/issues/148116
-- class: org.elasticsearch.xpack.esql.action.ExternalParquetCountPushdownIT
-  method: testCountStarPushdown
-  issue: https://github.com/elastic/elasticsearch/issues/148118
-- class: org.elasticsearch.xpack.esql.action.ExternalParquetCountPushdownIT
-  method: testCountStarPushdownSingleRowGroup
-  issue: https://github.com/elastic/elasticsearch/issues/148119
-- class: org.elasticsearch.xpack.esql.action.ExternalParquetCountPushdownIT
-  method: testCountStarPushdownManyRowGroups
-  issue: https://github.com/elastic/elasticsearch/issues/148117
 - class: org.elasticsearch.xpack.stateless.commits.StatelessCommitServiceTests
   method: testCommitsTrackingTakesIntoAccountSearchNodeUsage
   issue: https://github.com/elastic/elasticsearch/issues/148300

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetCountPushdownIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ExternalParquetCountPushdownIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.datasource.http.HttpDataSourcePlugin;
 import org.elasticsearch.xpack.esql.datasource.parquet.ParquetDataSourcePlugin;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.ByteArrayOutputStream;
@@ -76,7 +77,7 @@ public class ExternalParquetCountPushdownIT extends AbstractEsqlIntegTestCase {
         int totalRows = 300;
         Path parquetFile = writeParquetFile(totalRows, 100);
         try {
-            String query = "EXTERNAL \"file://" + parquetFile.toAbsolutePath() + "\" | STATS c = COUNT(*)";
+            String query = "EXTERNAL \"" + StoragePath.fileUri(parquetFile) + "\" | STATS c = COUNT(*)";
 
             var request = syncEsqlQueryRequest(query);
             request.profile(true);
@@ -103,7 +104,7 @@ public class ExternalParquetCountPushdownIT extends AbstractEsqlIntegTestCase {
         int totalRows = 50;
         Path parquetFile = writeParquetFile(totalRows, totalRows + 1);
         try {
-            String query = "EXTERNAL \"file://" + parquetFile.toAbsolutePath() + "\" | STATS c = COUNT(*)";
+            String query = "EXTERNAL \"" + StoragePath.fileUri(parquetFile) + "\" | STATS c = COUNT(*)";
 
             var request = syncEsqlQueryRequest(query);
             request.profile(true);
@@ -126,7 +127,7 @@ public class ExternalParquetCountPushdownIT extends AbstractEsqlIntegTestCase {
         // rowGroupSize=50 bytes forces ~20 row groups for 1000 rows
         Path parquetFile = writeParquetFile(totalRows, 50);
         try {
-            String query = "EXTERNAL \"file://" + parquetFile.toAbsolutePath() + "\" | STATS c = COUNT(*)";
+            String query = "EXTERNAL \"" + StoragePath.fileUri(parquetFile) + "\" | STATS c = COUNT(*)";
 
             var request = syncEsqlQueryRequest(query);
             request.profile(true);
@@ -149,8 +150,8 @@ public class ExternalParquetCountPushdownIT extends AbstractEsqlIntegTestCase {
         int totalRows = 500;
         Path parquetFile = writeParquetFile(totalRows, 80);
         try {
-            String query = "EXTERNAL \"file://"
-                + parquetFile.toAbsolutePath()
+            String query = "EXTERNAL \""
+                + StoragePath.fileUri(parquetFile)
                 + "\" WITH { \"external_distribution\": \"coordinator_only\" } | STATS c = COUNT(*)";
 
             var request = syncEsqlQueryRequest(query);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/IcebergParsingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/IcebergParsingTests.java
@@ -131,4 +131,35 @@ public class IcebergParsingTests extends AbstractStatementParserTests {
 
         assertNotNull(iceberg.tablePath());
     }
+
+    /**
+     * A naive Windows local path embedded as {@code "file://C:\\dir\\file"} fails to parse because
+     * the QUOTED_STRING grammar treats {@code \\} as an escape introducer (see
+     * x-pack/plugin/esql/src/main/antlr/lexer/Expression.g4: ESCAPE_SEQUENCE only allows
+     * {@code \\t \\n \\r \\" \\\\}). Tests must produce {@code file:///C:/...} URIs, e.g. via
+     * {@code StoragePath.fileUri(Path)}, so EXTERNAL queries are parser-safe across OSes.
+     */
+    public void testExternalCommandRejectsBackslashesInUri() {
+        assumeTrue("requires snapshot builds", Build.current().isSnapshot());
+
+        ParsingException pe = expectThrows(ParsingException.class, () -> query("EXTERNAL \"file://C:\\build\\data.parquet\""));
+        assertThat(pe.getMessage(), containsString("token recognition error"));
+    }
+
+    /**
+     * Forward-slash {@code file:///C:/...} URIs (the form {@code StoragePath.fileUri(Path)} produces
+     * on Windows) parse cleanly, ensuring the EXTERNAL command works on Windows when callers use the
+     * helper instead of {@code Path.toAbsolutePath().toString()}.
+     */
+    public void testExternalCommandAcceptsWindowsFileUri() {
+        assumeTrue("requires snapshot builds", Build.current().isSnapshot());
+
+        String uri = "file:///C:/build/data.parquet";
+        var plan = query("EXTERNAL \"" + uri + "\"");
+
+        assertThat(plan, instanceOf(UnresolvedExternalRelation.class));
+        UnresolvedExternalRelation external = as(plan, UnresolvedExternalRelation.class);
+        Literal pathLiteral = as(external.tablePath(), Literal.class);
+        assertThat(BytesRefs.toString(pathLiteral.value()), equalTo(uri));
+    }
 }


### PR DESCRIPTION
The IT built EXTERNAL queries as

    "EXTERNAL \"file://" + path.toAbsolutePath() + "\" | ..."

which on Windows yields

    EXTERNAL "file://C:\build\..."

The `QUOTED_STRING` grammar in
`x-pack/plugin/esql/src/main/antlr/lexer/Expression.g4` only accepts
`\t \n \r \" \\` as escape sequences, so any backslash followed by other
characters (e.g. `\b`) raises `token recognition error` and the parser
rejects the query before it ever reaches the planner.

Switch the four query builders to `StoragePath.fileUri(Path)`, the existing
helper that normalizes Windows backslashes to `/` and emits the canonical
`file:///C:/...` URI. Also unmute the four affected tests.

Two parser regression tests in `IcebergParsingTests` pin the lexer
behaviour:
- one asserts that an `"file://C:\\..."` URI still throws, so future
  callers know not to embed raw Windows paths,
- the other asserts that `"file:///C:/..."` parses cleanly, which is the
  output of the helper.

Closes #148116
Closes #148117
Closes #148118
Closes #148119

Developed with AI-assisted tooling
