### PR TITLE
Clarifies Jina model EIS-only support

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
@@ -51,7 +51,7 @@ The default {{infer}} endpoint varies by deployment type and version:
 
 - {applies_to}`stack: ga 9.4` {applies_to}`serverless: ga` On {{ech}} deployments running {{stack}} 9.4+ and on {{serverless-short}}, the `inference_id` parameter defaults to `.jina-embeddings-v5-text-small` and runs on [EIS](docs-content://explore-analyze/elastic-inference/eis.md). 
 
-  Jina models are not supported for deployment on [{{ml}} nodes](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles.md#ml-node-role). Using these models requires connectivity to EIS and is therefore not compatible with fully air-gapped environments.
+  Jina models are not supported for deployment on [{{ml}} nodes](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles.md#ml-node-role). Using these models requires connectivity to EIS and is therefore not currently compatible with fully air-gapped environments.
 
 - {applies_to}`stack: ga 9.3` On {{ech}} deployments running {{stack}} 9.3, the `inference_id` parameter defaults to `.elser-2-elastic` and runs on [EIS](docs-content://explore-analyze/elastic-inference/eis.md#elser-on-eis).
 

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-setup-configuration.md
@@ -49,7 +49,9 @@ PUT my-index-000001
 
 The default {{infer}} endpoint varies by deployment type and version:
 
-- {applies_to}`stack: ga 9.4` {applies_to}`serverless: ga` On {{ech}} deployments running {{stack}} 9.4+ and on {{serverless-short}}, the `inference_id` parameter defaults to `.jina-embeddings-v5-text-small` and runs on [EIS](docs-content://explore-analyze/elastic-inference/eis.md)..
+- {applies_to}`stack: ga 9.4` {applies_to}`serverless: ga` On {{ech}} deployments running {{stack}} 9.4+ and on {{serverless-short}}, the `inference_id` parameter defaults to `.jina-embeddings-v5-text-small` and runs on [EIS](docs-content://explore-analyze/elastic-inference/eis.md). 
+
+  Jina models are not supported for deployment on [{{ml}} nodes](docs-content://deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles.md#ml-node-role). Using these models requires connectivity to EIS and is therefore not compatible with fully air-gapped environments.
 
 - {applies_to}`stack: ga 9.3` On {{ech}} deployments running {{stack}} 9.3, the `inference_id` parameter defaults to `.elser-2-elastic` and runs on [EIS](docs-content://explore-analyze/elastic-inference/eis.md#elser-on-eis).
 


### PR DESCRIPTION
This PR adds a note in the semantic_text docs clarifying that Jina models are only supported through Elastic Inference Service (EIS), are not supported on ML nodes, and require connectivity to EIS.

Related issue: https://github.com/elastic/docs-content/issues/6312
Related PR: https://github.com/elastic/docs-content/pull/6316
