### PR TITLE
[ESQL] Report external source rows as documents_found

### DIFF
--- a/docs/changelog/148410.yaml
+++ b/docs/changelog/148410.yaml
@@ -1,0 +1,5 @@
+pr: 148410
+summary: Surface external source operator's emitted rows as `documents_found`
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperator.java
@@ -172,6 +172,17 @@ public class AsyncExternalSourceOperator extends SourceOperator {
             return failure;
         }
 
+        /**
+         * Projects the operator's existing {@code rowsEmitted} counter into the
+         * {@link Operator.Status#documentsFound()} contract so external-source-emitted
+         * rows aggregate into the top-level {@code documents_found} of the ES|QL response
+         * alongside Lucene-sourced operators, without introducing a new wire field.
+         */
+        @Override
+        public long documentsFound() {
+            return rowsEmitted;
+        }
+
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();


### PR DESCRIPTION
## Summary

Override `Operator.Status#documentsFound()` on the async external source operator
to project its existing `rowsEmitted` counter, so rows emitted by external
datasources (Parquet, ORC, CSV, NDJSON, …) aggregate into the top-level
`documents_found` field of the ES|QL response alongside Lucene-sourced
operators, instead of staying at the interface default of `0`.

This is a pure projection — no new state, no new wire field, no new transport
version, and no format-reader plumbing. `documents_found` already flows from
`Operator.Status` through `DriverCompletionInfo` into the REST response; this
PR simply makes the external-source operator opt into that contract by aliasing
its existing `rowsEmitted` field to it, the same way `LuceneOperator.Status`
does.

## Scope

- `AsyncExternalSourceOperator.Status.documentsFound()` returns `rowsEmitted`.

That's the whole change. 11 added lines in `AsyncExternalSourceOperator.java`
plus the changelog entry.

## What this PR intentionally does *not* do

The original scope of this PR included a separate `PushdownStats` accumulator
and a per-source-operator `pushdown` sub-object in the profile, plus a new
`values_loaded` wire field on the operator status. Both were dropped in favour
of the strict retrofit above:

- **`values_loaded`** required walking each emitted block's validity bitmap via
  `Block#getTotalValueCount()`, which trips a pre-existing latent bug in
  `AbstractArrowBufBlock#nullCount` (introduced in #142981) whose validity-buffer
  walk reads past the end when the producer ships a spec-minimum
  `ceil(valueCount/8)`-byte validity buffer rather than a long-aligned one.
  That manifested as `IndexOutOfBoundsException: index: 8, length: 8 (expected:
  range(0, 13))` in the parquet-rs QA suite. The Arrow buffer-size bug should
  be fixed separately; this PR no longer exercises the path.

- **`pushdown` sub-object** (block totals/skipped, row totals, files
  with/without pushdown) added five vLongs + a presence boolean to the
  `AsyncExternalSourceOperator.Status` wire format with no `TransportVersion`
  gate. Mixed-cluster BWC suites in the serverless pipeline read the stream
  with the older `Status` layout, drifted off by ~9 bytes, and surfaced as
  `unexpected byte [0x69]` while deserializing `TransportEsqlAsyncGetResultsAction`
  responses. Rather than introduce a new wire field plus the format-reader
  plumbing to populate it, the pushdown counters are deferred to a follow-up
  that can take its time with the wire-format gating and per-format
  accept/reject lists.

After this PR the `Status` wire layout is byte-identical to `main`'s — no new
fields, no `Writeable` contract change.

## Test plan

- [x] `./gradlew :x-pack:plugin:esql:compileJava :x-pack:plugin:esql:compileTestJava :x-pack:plugin:esql-datasource-parquet:compileJava :x-pack:plugin:esql-datasource-orc:compileJava`
- [x] `./gradlew :x-pack:plugin:esql:test --tests "*AsyncExternalSource*"`
- [x] `./gradlew :x-pack:plugin:esql:spotlessJavaCheck :x-pack:plugin:esql-datasource-parquet:spotlessJavaCheck :x-pack:plugin:esql-datasource-orc:spotlessJavaCheck`
- [ ] Full PR CI (this push)

Developed using AI-assisted tooling.
