### PR TITLE
[DO NOT MERGE] Trigger repeat-changed-tests CI for #148200

### DIFF
--- a/.buildkite/scripts/repeat-changed-tests.test.ts
+++ b/.buildkite/scripts/repeat-changed-tests.test.ts
@@ -417,7 +417,7 @@ describe("generateBatchCommand", () => {
       },
     ];
     expect(generateBatchCommand(batch)).toBe(
-      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --rerun -Dtests.rest.suite=ml/anomaly_detectors_get"
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --rerun -Dtests.rest.suite.:x-pack:plugin:ml:yamlRestTest=ml/anomaly_detectors_get"
     );
   });
 
@@ -437,7 +437,7 @@ describe("generateBatchCommand", () => {
       },
     ];
     expect(generateBatchCommand(batch)).toBe(
-      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --rerun -Dtests.rest.suite=ml/test1,ml/test2"
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --rerun -Dtests.rest.suite.:x-pack:plugin:ml:yamlRestTest=ml/test1,ml/test2"
     );
   });
 
@@ -457,7 +457,7 @@ describe("generateBatchCommand", () => {
       },
     ];
     expect(generateBatchCommand(batch)).toBe(
-      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --rerun :x-pack:plugin:security:yamlRestTest --rerun -Dtests.rest.suite=ml/test1,security/test1"
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --rerun :x-pack:plugin:security:yamlRestTest --rerun -Dtests.rest.suite.:x-pack:plugin:ml:yamlRestTest=ml/test1 -Dtests.rest.suite.:x-pack:plugin:security:yamlRestTest=security/test1"
     );
   });
 });

--- a/.buildkite/scripts/repeat-changed-tests.test.ts
+++ b/.buildkite/scripts/repeat-changed-tests.test.ts
@@ -346,7 +346,7 @@ describe("generateBatchCommand", () => {
       { gradleProject: ":libs:core", kind: "test", sourceSet: "test", fqcn: "org.elasticsearch.core.BarTests" },
     ];
     expect(generateBatchCommand(batch)).toBe(
-      ".ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! :server:test :libs:core:test --tests org.elasticsearch.index.FooTests --tests org.elasticsearch.core.BarTests"
+      ".ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! :server:test --tests org.elasticsearch.index.FooTests :libs:core:test --tests org.elasticsearch.core.BarTests"
     );
   });
 
@@ -394,7 +394,7 @@ describe("generateBatchCommand", () => {
       { gradleProject: ":mod:b", kind: "javaRestTest", sourceSet: "javaRestTest", fqcn: "org.es.BarIT" },
     ];
     expect(generateBatchCommand(batch)).toBe(
-      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :mod:a:javaRestTest :mod:b:javaRestTest --tests org.es.FooIT --tests org.es.BarIT --rerun"
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :mod:a:javaRestTest --tests org.es.FooIT --rerun :mod:b:javaRestTest --tests org.es.BarIT --rerun"
     );
   });
 
@@ -417,7 +417,7 @@ describe("generateBatchCommand", () => {
       },
     ];
     expect(generateBatchCommand(batch)).toBe(
-      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest -Dtests.rest.suite=ml/anomaly_detectors_get --rerun"
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --rerun -Dtests.rest.suite=ml/anomaly_detectors_get"
     );
   });
 
@@ -437,7 +437,27 @@ describe("generateBatchCommand", () => {
       },
     ];
     expect(generateBatchCommand(batch)).toBe(
-      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest -Dtests.rest.suite=ml/test1,ml/test2 --rerun"
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --rerun -Dtests.rest.suite=ml/test1,ml/test2"
+    );
+  });
+
+  test("YAML REST test suites across projects", () => {
+    const batch: ClassifiedTest[] = [
+      {
+        gradleProject: ":x-pack:plugin:ml",
+        kind: "yamlRestTestSuite",
+        sourceSet: "yamlRestTest",
+        suitePath: "ml/test1",
+      },
+      {
+        gradleProject: ":x-pack:plugin:security",
+        kind: "yamlRestTestSuite",
+        sourceSet: "yamlRestTest",
+        suitePath: "security/test1",
+      },
+    ];
+    expect(generateBatchCommand(batch)).toBe(
+      ".ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh :x-pack:plugin:ml:yamlRestTest --rerun :x-pack:plugin:security:yamlRestTest --rerun -Dtests.rest.suite=ml/test1,security/test1"
     );
   });
 });

--- a/.buildkite/scripts/repeat-changed-tests.ts
+++ b/.buildkite/scripts/repeat-changed-tests.ts
@@ -233,11 +233,26 @@ export function generateBatchCommand(batch: ClassifiedTest[]): string {
       return `.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh ${batch[0].gradleProject}:yamlRestTest --rerun`;
     }
     case "yamlRestTestSuite": {
-      const tasks = [...new Set(batch.map((t) => `${t.gradleProject}:yamlRestTest`))]
-        .map((task) => `${task} --rerun`)
+      // `tests.rest.suite` is a JVM system property, not a Gradle task option,
+      // so a single value would apply to every yamlRestTest task in the
+      // invocation. ESClientYamlSuiteTestCase recognises a per-task scoped
+      // variant `tests.rest.suite.<task path>` so each task can receive only
+      // the suites that exist on its classpath.
+      const byTask = new Map<string, string[]>();
+      for (const t of batch) {
+        const task = `${t.gradleProject}:yamlRestTest`;
+        const paths = byTask.get(task);
+        if (paths) {
+          paths.push(t.suitePath!);
+        } else {
+          byTask.set(task, [t.suitePath!]);
+        }
+      }
+      const tasks = [...byTask.keys()].map((task) => `${task} --rerun`).join(" ");
+      const suiteProps = [...byTask.entries()]
+        .map(([task, paths]) => `-Dtests.rest.suite.${task}=${paths.join(",")}`)
         .join(" ");
-      const suitePaths = batch.map((t) => t.suitePath).join(",");
-      return `.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh ${tasks} -Dtests.rest.suite=${suitePaths}`;
+      return `.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh ${tasks} ${suiteProps}`;
     }
   }
 }

--- a/.buildkite/scripts/repeat-changed-tests.ts
+++ b/.buildkite/scripts/repeat-changed-tests.ts
@@ -187,32 +187,57 @@ const KIND_KEYS: Record<TestKind, string> = {
   yamlRestTestSuite: "repeat-changed-tests:yaml-suite",
 };
 
+// Gradle task-level options (`--tests`, `--rerun`, ...) bind to the most
+// recently named task on the command line; they don't fan out to all listed
+// test tasks. So per-task options must be emitted directly after each
+// `:project:taskName` they apply to. See
+// https://docs.gradle.org/current/userguide/command_line_interface.html#sec:task_options
+function tasksWithFilters(
+  batch: ClassifiedTest[],
+  taskName: string,
+  toFilter: (t: ClassifiedTest) => string,
+  perTaskSuffix?: string
+): string {
+  const byTask = new Map<string, string[]>();
+  for (const t of batch) {
+    const task = `${t.gradleProject}:${taskName}`;
+    const filters = byTask.get(task);
+    if (filters) {
+      filters.push(toFilter(t));
+    } else {
+      byTask.set(task, [toFilter(t)]);
+    }
+  }
+  return [...byTask.entries()]
+    .map(([task, filters]) => [task, ...filters, ...(perTaskSuffix ? [perTaskSuffix] : [])].join(" "))
+    .join(" ");
+}
+
 export function generateBatchCommand(batch: ClassifiedTest[]): string {
   const kind = batch[0].kind;
 
   switch (kind) {
     case "test": {
-      const projects = [...new Set(batch.map((t) => `${t.gradleProject}:test`))];
-      const testFilters = batch.map((t) => `--tests ${t.fqcn}`).join(" ");
-      return `.ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! ${projects.join(" ")} ${testFilters}`;
+      const tasks = tasksWithFilters(batch, "test", (t) => `--tests ${t.fqcn}`);
+      return `.ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! ${tasks}`;
     }
     case "internalClusterTest": {
-      const projects = [...new Set(batch.map((t) => `${t.gradleProject}:internalClusterTest`))];
-      const testFilters = batch.map((t) => `--tests ${t.fqcn}`).join(" ");
-      return `.ci/scripts/run-gradle.sh -Dtests.iters=20 -Dtests.timeoutSuite=3600000! ${projects.join(" ")} ${testFilters}`;
+      const tasks = tasksWithFilters(batch, "internalClusterTest", (t) => `--tests ${t.fqcn}`);
+      return `.ci/scripts/run-gradle.sh -Dtests.iters=20 -Dtests.timeoutSuite=3600000! ${tasks}`;
     }
     case "javaRestTest": {
-      const projects = [...new Set(batch.map((t) => `${t.gradleProject}:javaRestTest`))];
-      const testFilters = batch.map((t) => `--tests ${t.fqcn}`).join(" ");
-      return `.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh ${projects.join(" ")} ${testFilters} --rerun`;
+      const tasks = tasksWithFilters(batch, "javaRestTest", (t) => `--tests ${t.fqcn}`, "--rerun");
+      return `.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh ${tasks}`;
     }
     case "yamlRestTestRunner": {
       return `.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh ${batch[0].gradleProject}:yamlRestTest --rerun`;
     }
     case "yamlRestTestSuite": {
-      const projects = [...new Set(batch.map((t) => `${t.gradleProject}:yamlRestTest`))];
+      const tasks = [...new Set(batch.map((t) => `${t.gradleProject}:yamlRestTest`))]
+        .map((task) => `${task} --rerun`)
+        .join(" ");
       const suitePaths = batch.map((t) => t.suitePath).join(",");
-      return `.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh ${projects.join(" ")} -Dtests.rest.suite=${suitePaths} --rerun`;
+      return `.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh ${tasks} -Dtests.rest.suite=${suitePaths}`;
     }
   }
 }

--- a/libs/cli-terminal/src/test/java/org/elasticsearch/cli/terminal/TerminalTests.java
+++ b/libs/cli-terminal/src/test/java/org/elasticsearch/cli/terminal/TerminalTests.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+// repeat-changed-tests trigger
 @WithoutEntitlements // CLI tools don't run with entitlements enforced
 public class TerminalTests extends ESTestCase {
 

--- a/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectKeyTests.java
+++ b/libs/dissect/src/test/java/org/elasticsearch/dissect/DissectKeyTests.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+// repeat-changed-tests trigger
 public class DissectKeyTests extends ESTestCase {
 
     public void testNoModifier() {

--- a/modules/apm/src/javaRestTest/java/org/elasticsearch/telemetry/apm/ApmAgentSettingsIT.java
+++ b/modules/apm/src/javaRestTest/java/org/elasticsearch/telemetry/apm/ApmAgentSettingsIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.ClassRule;
 
+// repeat-changed-tests trigger
 public class ApmAgentSettingsIT extends ESRestTestCase {
 
     @ClassRule

--- a/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/StoredExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/StoredExpressionIT.java
@@ -25,6 +25,7 @@ import static org.elasticsearch.action.admin.cluster.storedscripts.StoredScriptI
 import static org.hamcrest.Matchers.containsString;
 
 //TODO: please convert to unit tests!
+// repeat-changed-tests trigger
 public class StoredExpressionIT extends ESIntegTestCase {
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {

--- a/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MustacheSettingsIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MustacheSettingsIT.java
@@ -23,6 +23,7 @@ import java.util.List;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
+// repeat-changed-tests trigger
 public class MustacheSettingsIT extends ESSingleNodeTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/51_routing.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/51_routing.yml
@@ -1,3 +1,4 @@
+# repeat-changed-tests trigger
 ---
 "Set routing":
   - requires:

--- a/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4BadRequestIT.java
+++ b/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4BadRequestIT.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.matchesRegex;
 
+// repeat-changed-tests trigger
 public class Netty4BadRequestIT extends AbstractNetty4IT {
 
     public Netty4BadRequestIT(@Name("pooled") boolean pooledAllocator) {

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/41_routing_doc_values.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/41_routing_doc_values.yml
@@ -1,3 +1,4 @@
+# repeat-changed-tests trigger
 ---
 "Routing with doc_values enabled":
  - requires:

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -69,6 +69,14 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
     /**
      * Property that allows to control which REST tests get run. Supports comma separated list of tests
      * or directories that contain tests e.g. -Dtests.rest.suite=index,get,create/10_with_id
+     * <p>
+     * A per-task variant {@code tests.rest.suite.<task path>} is also recognised and takes precedence
+     * over the unscoped property when set; this lets a single Gradle invocation supply different suite
+     * lists to different {@code yamlRestTest} tasks via the {@code tests.task} system property each task
+     * already exposes (see {@code GradleTestPolicySetupPlugin}). For example, running
+     * {@code :modules:reindex:yamlRestTest :rest-api-spec:yamlRestTest} in one invocation can use:
+     * {@code -Dtests.rest.suite.:modules:reindex:yamlRestTest=reindex/51_routing}
+     * {@code -Dtests.rest.suite.:rest-api-spec:yamlRestTest=get/41_routing_doc_values}.
      */
     public static final String REST_TESTS_SUITE = "tests.rest.suite";
     /**
@@ -227,7 +235,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      * Create parameters for this parameterized test.
      */
     public static Iterable<Object[]> createParameters(NamedXContentRegistry executeableSectionRegistry) throws Exception {
-        return createParameters(executeableSectionRegistry, Map.of(), resolvePathsProperty(REST_TESTS_SUITE, ""));
+        return createParameters(executeableSectionRegistry, Map.of(), resolveRestTestsSuitePaths());
     }
 
     /**
@@ -235,7 +243,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      * @param yamlParameters map or parameters used within the yaml specs to be replaced at parsing time.
      */
     public static Iterable<Object[]> createParameters(Map<String, Object> yamlParameters) throws Exception {
-        return createParameters(ExecutableSection.XCONTENT_REGISTRY, yamlParameters, resolvePathsProperty(REST_TESTS_SUITE, ""));
+        return createParameters(ExecutableSection.XCONTENT_REGISTRY, yamlParameters, resolveRestTestsSuitePaths());
     }
 
     /**
@@ -244,7 +252,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      * @param testPaths      list of paths to explicitly search for tests.
      */
     public static Iterable<Object[]> createParameters(Map<String, Object> yamlParameters, String... testPaths) throws Exception {
-        if (System.getProperty(REST_TESTS_SUITE) != null) {
+        if (resolveRestTestsSuiteProperty() != null) {
             throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
         }
         return createParameters(ExecutableSection.XCONTENT_REGISTRY, yamlParameters, testPaths);
@@ -255,7 +263,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      * @param testPaths list of paths to explicitly search for tests.
      */
     public static Iterable<Object[]> createParameters(String... testPaths) throws Exception {
-        if (System.getProperty(REST_TESTS_SUITE) != null) {
+        if (resolveRestTestsSuiteProperty() != null) {
             throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
         }
         return createParameters(ExecutableSection.XCONTENT_REGISTRY, Map.of(), testPaths);
@@ -270,7 +278,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
      */
     public static Iterable<Object[]> createParameters(NamedXContentRegistry executeableSectionRegistry, String... testPaths)
         throws Exception {
-        if (System.getProperty(REST_TESTS_SUITE) != null) {
+        if (resolveRestTestsSuiteProperty() != null) {
             throw new IllegalArgumentException("The '" + REST_TESTS_SUITE + "' system property is not supported with explicit test paths.");
         }
         return createParameters(executeableSectionRegistry, Map.of(), testPaths);
@@ -398,6 +406,30 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
         } else {
             return property.split(PATHS_SEPARATOR);
         }
+    }
+
+    /**
+     * Resolves the value of {@link #REST_TESTS_SUITE}, preferring the per-task scoped form
+     * {@code tests.rest.suite.<task path>} when {@code tests.task} is set and a matching property
+     * exists. Returns {@code null} if neither form is set.
+     */
+    private static String resolveRestTestsSuiteProperty() {
+        String task = System.getProperty("tests.task");
+        if (task != null) {
+            String scoped = System.getProperty(REST_TESTS_SUITE + "." + task);
+            if (scoped != null) {
+                return scoped;
+            }
+        }
+        return System.getProperty(REST_TESTS_SUITE);
+    }
+
+    private static String[] resolveRestTestsSuitePaths() {
+        String value = resolveRestTestsSuiteProperty();
+        if (Strings.hasLength(value) == false) {
+            return new String[] { "" };
+        }
+        return value.split(PATHS_SEPARATOR);
     }
 
     protected ClientYamlTestExecutionContext getAdminExecutionContext() {


### PR DESCRIPTION
## What this is

A throwaway PR to make the `repeat-changed-tests` pipeline exercise every cross-project command shape fixed by #148200 against real CI. The diff includes both #148200's fix commits and a single trigger commit on top — the trigger commit modifies 8 test files (one comment line each) so the pipeline detects them as changed and routes them through the fixed `generateBatchCommand`. **This branch will be closed without merging** once CI is observed; the actual fix lives in #148200.

## Triggered jobs and what each one tests

### `test` (unit tests, cross-project)

**Files:** `DissectKeyTests` (`:libs:dissect`), `TerminalTests` (`:libs:cli-terminal`)

**Generated command:**
```
.ci/scripts/run-gradle.sh -Dtests.iters=100 -Dtests.timeoutSuite=3600000! \
  :libs:dissect:test --tests org.elasticsearch.dissect.DissectKeyTests \
  :libs:cli-terminal:test --tests org.elasticsearch.cli.terminal.TerminalTests
```

**Fix exercised:** Per-task `--tests` binding for `Test` tasks. Pre-fix, both filters bound to the last listed task only, so `:libs:dissect:test` ran its entire test source set 100×.

**Expected:** Each project runs only its filtered class, 100 iterations. Step finishes well under 1h.

### `internalClusterTest` (cross-project)

**Files:** `MustacheSettingsIT` (`:modules:lang-mustache`), `StoredExpressionIT` (`:modules:lang-expression`)

**Generated command:**
```
.ci/scripts/run-gradle.sh -Dtests.iters=20 -Dtests.timeoutSuite=3600000! \
  :modules:lang-mustache:internalClusterTest --tests org.elasticsearch.script.mustache.MustacheSettingsIT \
  :modules:lang-expression:internalClusterTest --tests org.elasticsearch.script.expression.StoredExpressionIT
```

**Fix exercised:** Same per-task `--tests` binding, applied to the `internalClusterTest` task class (also a `Test` subclass).

**Expected:** Each project runs only its filtered IT class, 20 iterations. Step finishes within 1h.

### `javaRestTest` (cross-project)

**Files:** `Netty4BadRequestIT` (`:modules:transport-netty4`), `ApmAgentSettingsIT` (`:modules:apm`)

**Generated command:**
```
.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh \
  :modules:transport-netty4:javaRestTest --tests org.elasticsearch.rest.Netty4BadRequestIT --rerun \
  :modules:apm:javaRestTest --tests org.elasticsearch.telemetry.apm.ApmAgentSettingsIT --rerun
```

**Fix exercised:** Both per-task `--tests` AND per-task `--rerun` binding for `RestIntegTestTask` (also a `Test` subclass). `repeat-rest-test.sh 10` re-invokes Gradle 10×; pre-fix `--rerun` bound only to the last task, so iterations 2–10 would have skipped earlier tasks as UP-TO-DATE.

**Expected:** Both projects run only their filtered IT classes, freshly on each of 10 iterations.

### `yamlRestTestSuite` (cross-project)

**Files:** `reindex/51_routing.yml` (`:modules:reindex`), `get/41_routing_doc_values.yml` (`:rest-api-spec`)

**Generated command:**
```
.ci/scripts/repeat-rest-test.sh 10 .ci/scripts/run-gradle.sh \
  :modules:reindex:yamlRestTest --rerun \
  :rest-api-spec:yamlRestTest --rerun \
  -Dtests.rest.suite.:modules:reindex:yamlRestTest=reindex/51_routing \
  -Dtests.rest.suite.:rest-api-spec:yamlRestTest=get/41_routing_doc_values
```

**Fix exercised:** Per-task `--rerun` binding, AND the new scoped `tests.rest.suite.<task path>` system property added in the second commit of #148200. Without scoping, `tests.rest.suite` is global so each task tries to load every suite path from the union and fails `loadSuites` on paths that exist only in a sibling project.

**Expected:** Each task loads only its scoped suite — `:modules:reindex:yamlRestTest` runs `reindex/51_routing` (2 cases: `Set routing`, `Discard routing`); `:rest-api-spec:yamlRestTest` runs `get/41_routing_doc_values` (1 case: `Routing with doc_values enabled`). No `loadSuites` "expected file does not exist" failures. 10 iterations.

## After CI

This PR will be closed without merging once the four `repeat-changed-tests` jobs are observed to behave as expected. The fix is in #148200.