### PR TITLE
[9.4] [CI] Move Ubuntu 20.04 jobs to 24.04 (#148258)

### DIFF
--- a/.buildkite/pipelines/intake.template.yml
+++ b/.buildkite/pipelines/intake.template.yml
@@ -53,7 +53,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
-      image: family/elasticsearch-ubuntu-2004
+      image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
 

--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -54,7 +54,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
-      image: family/elasticsearch-ubuntu-2004
+      image: family/elasticsearch-ubuntu-2404
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
 

--- a/.buildkite/pipelines/lucene-snapshot/run-tests.yml
+++ b/.buildkite/pipelines/lucene-snapshot/run-tests.yml
@@ -53,7 +53,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
-      image: family/elasticsearch-ubuntu-2004
+      image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
   - group: bwc-snapshots

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -28,7 +28,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2004
+          image: family/elasticsearch-ubuntu-2404
           machineType: n4-standard-32
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
@@ -41,7 +41,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2004
+          image: family/elasticsearch-ubuntu-2404
           machineType: n4-standard-32
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
@@ -54,7 +54,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2004
+          image: family/elasticsearch-ubuntu-2404
           machineType: n4-standard-32
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
@@ -67,7 +67,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2004
+          image: family/elasticsearch-ubuntu-2404
           machineType: n4-standard-32
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
@@ -80,7 +80,7 @@ steps:
             BWC_VERSION: $SNAPSHOT_BWC_VERSIONS
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2004
+          image: family/elasticsearch-ubuntu-2404
           machineType: n4-standard-32
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6-fips-140-3.yml
+++ b/.buildkite/pipelines/pull-request/part-6-fips-140-3.yml
@@ -8,7 +8,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
-      image: family/elasticsearch-ubuntu-2004
+      image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-6-fips.yml
@@ -7,7 +7,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
-      image: family/elasticsearch-ubuntu-2004
+      image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6.yml
+++ b/.buildkite/pipelines/pull-request/part-6.yml
@@ -5,7 +5,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: gcp
-      image: family/elasticsearch-ubuntu-2004
+      image: family/elasticsearch-ubuntu-2404
       machineType: n4-custom-32-98304
       diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -68,7 +68,7 @@ steps:
         timeout_in_minutes: 300
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2004
+          image: family/elasticsearch-ubuntu-2404
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         matrix:

--- a/.buildkite/scripts/run-pr-upgrade-tests.sh
+++ b/.buildkite/scripts/run-pr-upgrade-tests.sh
@@ -35,7 +35,7 @@ steps:
           agents:
             provider: gcp
             zones: us-east1-b,us-east1-c,us-east1-d,us-west1-a,us-west1-b,us-west1-c
-            image: family/elasticsearch-ubuntu-2004
+            image: family/elasticsearch-ubuntu-2404
             machineType: n4-standard-32
             diskType: hyperdisk-balanced
             buildDirectory: /dev/shm/bk


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [[CI] Move Ubuntu 20.04 jobs to 24.04 (#148258)](https://github.com/elastic/elasticsearch/pull/148258)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)