### PR TITLE
[ESQL] push LIKE to Parquet late materialization

### DIFF
--- a/docs/changelog/148434.yaml
+++ b/docs/changelog/148434.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148434
+summary: Push LIKE to Parquet late materialization
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.pushdown.PushdownPredicates;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -141,6 +142,14 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
         }
         if (expr instanceof StartsWith sw) {
             return PushdownPredicates.isStartsWith(sw, dt -> dt == DataType.KEYWORD) && literalValueOf(sw.prefix()) != null;
+        }
+        if (expr instanceof WildcardLike wl) {
+            // Parquet has no native LIKE support; this pushdown evaluates the pattern during late
+            // materialization (see ParquetPushedExpressions#evaluateWildcardLike) so the reader can
+            // skip decoding projection columns for non-matching rows. Only KEYWORD-typed fields with
+            // a non-null pattern qualify; the dictionary short-circuit collapses the per-row automaton
+            // run to one run per dictionary entry.
+            return wl.field() instanceof NamedExpression ne && ne.dataType() == DataType.KEYWORD && wl.pattern() != null;
         }
         return false;
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -148,7 +148,10 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
             // materialization (see ParquetPushedExpressions#evaluateWildcardLike) so the reader can
             // skip decoding projection columns for non-matching rows. Only KEYWORD-typed fields with
             // a non-null pattern qualify; the dictionary short-circuit collapses the per-row automaton
-            // run to one run per dictionary entry.
+            // run to one run per dictionary entry. The wl.pattern() != null check is structurally
+            // unreachable today (WildcardLike's constructor takes a non-null WildcardPattern), but is
+            // kept as a cheap boundary guard so an upstream regression cannot turn into an NPE in the
+            // per-batch evaluator. Mirrors the prefix() != null guard on StartsWith above.
             return wl.field() instanceof NamedExpression ne && ne.dataType() == DataType.KEYWORD && wl.pattern() != null;
         }
         return false;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -54,8 +55,19 @@ import static org.elasticsearch.xpack.esql.expression.Foldables.literalValueOf;
  *       since parquet-mr 1.12.0)</li>
  * </ol>
  * <p>
- * All pushed filters use {@link Pushability#RECHECK} semantics: the original filter remains
- * in FilterExec for per-row correctness since predicate pushdown is a conservative approximation.
+ * <b>Pushability semantics.</b> Most pushed filters use {@link Pushability#RECHECK}: the original
+ * filter remains in {@code FilterExec} for per-row correctness because the per-row evaluator
+ * (see {@link ParquetPushedExpressions#evaluateFilter}) is two-valued — nulls and unknowns map
+ * to bit {@code 0}, which is correct for the predicate itself but not for a wrapping {@code Not}.
+ * <p>
+ * {@link WildcardLike} (and {@code Not(WildcardLike)}, and conjunctions thereof) are exceptions:
+ * they push as {@link Pushability#YES} so {@code FilterExec} can be dropped entirely. The late-mat
+ * evaluator handles {@code NOT (col LIKE p)} with three-valued logic by AND-ing out nulls before
+ * negation (see {@link ParquetPushedExpressions#evaluateExpression}'s {@code Not(WildcardLike)}
+ * special case), so removing the safety net does not change result semantics. The motivation: with
+ * {@code RECHECK}, every surviving row pays the LIKE cost twice — once in the reader's late-mat
+ * filter, once again in {@code FilterExec}. On large keyword scans (e.g. {@code URL LIKE
+ * "*google*"} on the public hits dataset) this duplicate evaluation is the dominant CPU cost.
  */
 public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
 
@@ -71,11 +83,20 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
     @Override
     public PushdownResult pushFilters(List<Expression> filters) {
         List<Expression> pushed = new ArrayList<>();
-        List<Expression> remainder = new ArrayList<>(filters);
-
+        // Only RECHECK conjuncts need to remain in FilterExec; YES conjuncts are guaranteed
+        // TVL-correct by the late-mat evaluator and can be dropped from the plan entirely
+        // (see canPush for the per-expression rule and the class-level Javadoc for the
+        // motivation: avoiding double LIKE evaluation on every surviving row).
+        List<Expression> remainder = new ArrayList<>();
         for (Expression filter : filters) {
-            if (canConvert(filter)) {
+            Pushability p = canPush(filter);
+            if (p == Pushability.YES) {
                 pushed.add(filter);
+            } else if (p == Pushability.RECHECK) {
+                pushed.add(filter);
+                remainder.add(filter);
+            } else {
+                remainder.add(filter);
             }
         }
 
@@ -83,16 +104,107 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
             return PushdownResult.none(filters);
         }
 
-        logger.debug("Parquet filter pushdown: validated {} of {} expressions for pushdown", pushed.size(), filters.size());
+        logger.debug(
+            "Parquet filter pushdown: pushed {} of {} expressions ({} need re-check in FilterExec)",
+            pushed.size(),
+            filters.size(),
+            remainder.size()
+        );
         return new PushdownResult(new ParquetPushedExpressions(pushed), pushed, remainder);
     }
 
     @Override
     public Pushability canPush(Expression expr) {
-        if (canConvert(expr)) {
+        if (canConvert(expr) == false) {
+            return Pushability.NO;
+        }
+        if (isFullyEvaluable(expr) == false) {
             return Pushability.RECHECK;
         }
-        return Pushability.NO;
+        // YES requires the late-mat evaluator to be exactly equivalent to FilterExec for this
+        // expression. If a WildcardLike inside the tree fails to determinize at runtime, the
+        // evaluator returns null ("all rows survive"), which without FilterExec means false
+        // positives. Probe every WildcardLike now so any TooComplexToDeterminize is caught at
+        // plan time and we can fall back to RECHECK before FilterExec is removed from the plan.
+        // The probe cost is negligible — it is a single per-pattern automaton build done once
+        // per query at plan time, and the result is cached for runtime via the evaluator's
+        // own per-instance cache (different cache, same cost class).
+        return canCompileAllPatterns(expr) ? Pushability.YES : Pushability.RECHECK;
+    }
+
+    private static boolean canCompileAllPatterns(Expression expr) {
+        if (expr instanceof WildcardLike wl) {
+            try {
+                wl.pattern().createAutomaton(wl.caseInsensitive());
+                return true;
+            } catch (IllegalArgumentException | TooComplexToDeterminizeException e) {
+                logger.debug(
+                    "WildcardLike pattern [{}] cannot be determinized at plan time; falling back to RECHECK",
+                    wl.pattern().pattern(),
+                    e
+                );
+                return false;
+            }
+        }
+        if (expr instanceof Not not) {
+            return canCompileAllPatterns(not.field());
+        }
+        if (expr instanceof And and) {
+            return canCompileAllPatterns(and.left()) && canCompileAllPatterns(and.right());
+        }
+        return true;
+    }
+
+    /**
+     * Returns {@code true} when the late-mat evaluator produces a survivor mask that is
+     * <em>SQL three-valued-logic correct</em> for {@code expr}, i.e. equivalent to what
+     * {@code FilterExec} would compute for the same expression. Such expressions can be
+     * dropped from {@code FilterExec} (pushed as {@link Pushability#YES}); others must be
+     * re-checked downstream ({@link Pushability#RECHECK}).
+     *
+     * <p>The two-valued bitmask path is TVL-correct by construction for predicates that
+     * map nulls to bit {@code 0}: {@link WildcardLike} on a non-null value matches the
+     * automaton; on a null value it sets bit {@code 0}. The remaining work is to ensure
+     * {@code Not(WildcardLike)} also stays TVL-correct — the late-mat evaluator does this
+     * by AND-ing out the null mask before negating
+     * (see {@link ParquetPushedExpressions#evaluateExpression}).
+     *
+     * <p><b>Why {@code Not} only allows a bare {@link WildcardLike} child.</b> The evaluator's
+     * generic {@code Not} branch is a bitwise complement on the inner mask. For
+     * {@code Not(And(...))} that means {@code ~(m1 & m2)}, which is <em>not</em>
+     * {@code NOT (a AND b)} under SQL three-valued logic — e.g. {@code (NULL AND TRUE)} is
+     * {@code UNKNOWN} (mask bit 0); the bitwise complement flips it to 1, so the row
+     * incorrectly survives. Only {@code Not(WildcardLike)} has a TVL-aware special case in
+     * {@link ParquetPushedExpressions#evaluateExpression} that AND-s out the null mask before
+     * negation. Anything else under {@code Not} stays {@link Pushability#RECHECK} so that
+     * {@code FilterExec} fixes the null handling.
+     *
+     * <p>Conjunctions of YES-eligible predicates are themselves YES-eligible: {@code AND} of
+     * TVL-correct masks is TVL-correct (a 0 bit on either side blocks the row, regardless of
+     * whether it came from "no-match" or "null"). {@code OR} is intentionally excluded
+     * because {@code evaluateExpression}'s {@code Or} branch returns {@code null} (i.e.
+     * "all rows survive") when an arm is unevaluable — fine for {@link Pushability#RECHECK}
+     * (where {@code FilterExec} re-checks), but unsafe for {@link Pushability#YES}.
+     *
+     * <p>Other predicate families ({@code Eq}, {@code In}, {@code Range}, {@code StartsWith},
+     * {@code IsNull}, {@code IsNotNull}) remain {@link Pushability#RECHECK}; their {@code Not}
+     * handling has the same two-valued-mask null bug as LIKE used to, and is left unchanged
+     * to keep this PR focused on the LIKE win that motivated the work.
+     */
+    private static boolean isFullyEvaluable(Expression expr) {
+        if (expr instanceof WildcardLike) {
+            return true;
+        }
+        if (expr instanceof Not not) {
+            // Only Not(WildcardLike) has a TVL-aware evaluator special case. Any other inner
+            // expression would fall through to the generic two-valued negate, which is unsafe
+            // under YES (see Javadoc above for the And-under-Not example).
+            return not.field() instanceof WildcardLike;
+        }
+        if (expr instanceof And and) {
+            return isFullyEvaluable(and.left()) && isFullyEvaluable(and.right());
+        }
+        return false;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -1030,6 +1030,8 @@ final class ParquetPushedExpressions {
                 // over to "accepts every valid UTF-8 byte sequence". Our inputs come from KEYWORD
                 // columns, which Elasticsearch guarantees to be valid UTF-8, so this is a sound
                 // proxy for "this LIKE accepts every non-null row" — the contract of matchesAll.
+                // (For invalid UTF-8 — outside the KEYWORD contract — the byte-level automaton would
+                // simply reject the malformed prefix, matching the per-row scalar path's behavior.)
                 boolean matchesAll = Operations.isTotal(automaton);
                 compiled = new CompiledWildcard(new ByteRunAutomaton(automaton), matchesAll);
             } catch (IllegalArgumentException | TooComplexToDeterminizeException e) {

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -1024,6 +1024,12 @@ final class ParquetPushedExpressions {
             CompiledWildcard compiled;
             try {
                 Automaton automaton = wl.pattern().createAutomaton(wl.caseInsensitive());
+                // Operations.isTotal returns true iff the automaton accepts every code-point sequence
+                // over its alphabet (Unicode 0..0x10FFFF for WildcardPattern's UTF-32 output). After
+                // the implicit UTF-32->UTF-8 conversion in the ByteRunAutomaton ctor, "total" carries
+                // over to "accepts every valid UTF-8 byte sequence". Our inputs come from KEYWORD
+                // columns, which Elasticsearch guarantees to be valid UTF-8, so this is a sound
+                // proxy for "this LIKE accepts every non-null row" — the contract of matchesAll.
                 boolean matchesAll = Operations.isTotal(automaton);
                 compiled = new CompiledWildcard(new ByteRunAutomaton(automaton), matchesAll);
             } catch (IllegalArgumentException | TooComplexToDeterminizeException e) {
@@ -1036,6 +1042,14 @@ final class ParquetPushedExpressions {
             }
             automatonCache.put(wl, compiled);
             return compiled;
+        }
+    }
+
+    // Package-private hook so tests can directly assert that automaton compilation is memoized
+    // across batches (there is no public metric for it). Not part of the production contract.
+    int automatonCacheSizeForTesting() {
+        synchronized (automatonCache) {
+            return automatonCache.size();
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -595,6 +595,25 @@ final class ParquetPushedExpressions {
             return null;
         }
         if (expr instanceof Not not) {
+            // Special case: NOT (col LIKE p) needs SQL three-valued logic so that
+            // NOT (NULL LIKE p) → UNKNOWN → row is filtered out (bit 0), not flipped
+            // to bit 1 by the generic negate. This is a hard requirement for the YES
+            // pushability of WildcardLike (see ParquetFilterPushdownSupport.isFullyEvaluable);
+            // without this branch, dropping FilterExec for NOT (LIKE) would let null rows
+            // survive the predicate, giving wrong results.
+            //
+            // Implementation: build the LIKE mask and the null mask, OR them ("matches OR
+            // null"), then negate to get "non-null AND no-match" — the TVL-correct survivor
+            // set. The mask for the inner WildcardLike already maps null rows to bit 0, so
+            // OR-ing the explicit null mask is what restores the missing TVL bit before
+            // the bitwise complement.
+            if (not.field() instanceof WildcardLike wl && wl.field() instanceof NamedExpression ne) {
+                Block block = blocks.get(ne.name());
+                if (block == null) {
+                    return null;
+                }
+                return evaluateNotWildcardLike(wl, block, rowCount);
+            }
             WordMask inner = evaluateExpression(not.field(), blocks, rowCount);
             if (inner != null) {
                 inner.negate();
@@ -909,28 +928,35 @@ final class ParquetPushedExpressions {
      * collapses {@code O(rowCount)} automaton runs into {@code O(dictionarySize)} runs plus a
      * per-row int lookup.
      *
-     * <p><b>Null and {@code NOT} semantics.</b> The mask is two-valued: a row's bit is set when
-     * the value is non-null and the automaton accepts its bytes. Nulls map to bit {@code 0}, the
-     * same convention as {@link #evaluateStartsWith} and the standard runtime
+     * <p><b>Null semantics.</b> The mask is two-valued: a row's bit is set when the value is
+     * non-null and the automaton accepts its bytes. Nulls map to bit {@code 0}, the same convention
+     * as {@link #evaluateStartsWith} and the standard runtime
      * {@link org.elasticsearch.xpack.esql.expression.function.scalar.string.AutomataMatch#process}
-     * (which returns {@code false} for null input). When the caller composes with
-     * {@link org.elasticsearch.xpack.esql.expression.predicate.logical.Not}, {@link WordMask#negate}
-     * flips every bit including those for null rows, so {@code NOT (col LIKE p)} would mark nulls
-     * as survivors here. That diverges from SQL three-valued logic, which says
-     * {@code NOT (NULL LIKE p)} is unknown and should be filtered out. <b>Correctness depends on
-     * the FilterExec re-check that always remains downstream of late-mat</b> — see
-     * {@link ParquetFilterPushdownSupport#canPush} which only ever returns
-     * {@link org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport.Pushability#RECHECK},
-     * and {@link ParquetFilterPushdownSupport#pushFilters} which keeps every original conjunct in
-     * the remainder. If a future change ever drops that re-check, this method's null handling for
-     * the {@code Not}-wrapped case must be tightened (e.g. by emitting a separate "definitely
-     * null" mask and AND-ing it out after negation).
+     * (which returns {@code false} for null input). For a bare {@code col LIKE p}, this is the
+     * SQL three-valued-logic answer ({@code NULL LIKE p} → unknown → not a survivor) and the
+     * predicate can be pushed as
+     * {@link org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport.Pushability#YES}.
+     *
+     * <p><b>{@code NOT (col LIKE p)} semantics.</b> A naive {@link WordMask#negate} on this mask
+     * is wrong for nulls: bit {@code 0} for "no match" is correctly flipped to bit {@code 1}, but
+     * bit {@code 0} for "null" is also flipped to bit {@code 1} — and SQL TVL says
+     * {@code NOT (NULL LIKE p)} is unknown and must not survive. The {@code Not(WildcardLike)}
+     * branch in {@link #evaluateExpression} routes through {@link #evaluateNotWildcardLike}, which
+     * OR-s the explicit null mask before negating. <b>YES pushability for {@code NOT (col LIKE p)}
+     * depends on that special case</b>, and on the gating in
+     * {@link ParquetFilterPushdownSupport#isFullyEvaluable}, which only allows {@code YES} for
+     * {@code Not} when its child is a bare {@link WildcardLike}.
      *
      * <p>Returns {@code null} when the block is neither an {@link OrdinalBytesRefBlock} on the
      * dense path nor a {@link BytesRefBlock} (e.g. a constant-null block) — the conservative
      * "all rows survive" sentinel that {@link #evaluateFilter} treats as a no-op for this
-     * predicate. Returns {@code null} also when the pattern is unusable (failed to determinize),
-     * matching the safety-net role of the FilterExec re-check.
+     * predicate. Returns {@code null} also when the pattern is unusable (failed to determinize).
+     * Both cases are safe under RECHECK because {@code FilterExec} re-checks; under YES they are
+     * prevented at plan time by {@link ParquetFilterPushdownSupport#canPush}, which probes
+     * {@link org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern#createAutomaton}
+     * up front and falls back to RECHECK if it throws. The Parquet KEYWORD reader always produces
+     * one of the two supported block types, so the block-type {@code null} sentinel is unreachable
+     * on the YES path in practice.
      */
     private WordMask evaluateWildcardLike(WildcardLike wl, Block block, int rowCount) {
         CompiledWildcard compiled = automatonFor(wl);
@@ -971,6 +997,52 @@ final class ParquetPushedExpressions {
             return mask;
         }
         return null;
+    }
+
+    /**
+     * Evaluates {@code NOT (col LIKE p)} with SQL three-valued logic.
+     *
+     * <p>The straightforward {@code WordMask#negate} flip on the result of
+     * {@link #evaluateWildcardLike} is wrong for null rows: the inner mask sets bit {@code 0}
+     * for both "non-match" and "null", so the complement would mark nulls as survivors. SQL
+     * says {@code NOT (NULL LIKE p)} is unknown and must not survive the predicate.
+     *
+     * <p>This method computes the survivor set "non-null AND no-match" directly:
+     * {@code mask = LIKE(col, p)} (bit {@code 1} on match, bit {@code 0} on null/no-match);
+     * then for every row that is null, set the bit (turning the mask into "match OR null");
+     * then negate. The result has bit {@code 1} only for rows that are non-null and don't
+     * match — TVL-correct.
+     *
+     * <p>Returns {@code null} when {@link #evaluateWildcardLike} returns {@code null}
+     * (block type unsupported or pattern failed to determinize). The caller propagates that
+     * up; {@link #evaluateFilter} treats it as "all rows survive" — the same conservative
+     * sentinel used everywhere in this evaluator. <b>That null-return is only safe when the
+     * predicate is RECHECK'd downstream</b>, but the YES path in
+     * {@link ParquetFilterPushdownSupport} only fires when the block is a
+     * {@link BytesRefBlock}/{@link OrdinalBytesRefBlock} (the Parquet KEYWORD reader's only
+     * output) and the pattern is determinizable (KEYWORD inputs guarantee valid UTF-8 and
+     * {@link org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern}'s
+     * automaton build only throws {@code TooComplexToDeterminize} for pathological patterns
+     * far beyond {@code "*google*"}). If a future change broadens the YES-eligible set, this
+     * contract must be revisited.
+     */
+    private WordMask evaluateNotWildcardLike(WildcardLike wl, Block block, int rowCount) {
+        WordMask likeMask = evaluateWildcardLike(wl, block, rowCount);
+        if (likeMask == null) {
+            return null;
+        }
+        // Set bit i for null rows so the subsequent negate turns them into 0 (filtered out).
+        // mayHaveNulls() is a cheap pre-check that lets the all-non-nulls common case skip
+        // the per-row scan; matches the WildcardLike scalar path.
+        if (block.mayHaveNulls()) {
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i)) {
+                    likeMask.set(i);
+                }
+            }
+        }
+        likeMask.negate();
+        return likeMask;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -8,6 +8,10 @@
 package org.elasticsearch.xpack.esql.datasource.parquet;
 
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.Operators;
@@ -23,11 +27,14 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.pushdown.StringPrefixUtils;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -46,8 +53,10 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Not
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -69,9 +78,75 @@ import static org.elasticsearch.xpack.esql.expression.Foldables.literalValueOf;
  * Using ESQL's epoch millis directly against non-millis statistics would cause incorrect
  * row group skipping — a correctness issue, not just suboptimal performance.
  */
-record ParquetPushedExpressions(List<Expression> expressions) {
+final class ParquetPushedExpressions {
+
+    private static final Logger logger = LogManager.getLogger(ParquetPushedExpressions.class);
 
     static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
+
+    private final List<Expression> expressions;
+    /**
+     * Cache of compiled {@link CompiledWildcard} forms per {@link WildcardLike} expression.
+     * Building a {@link ByteRunAutomaton} from a wildcard pattern (in particular the determinize
+     * step in {@link org.apache.lucene.util.automaton.Operations#determinize}) is non-trivial —
+     * well into tens of microseconds for moderately complex patterns — and the same expression
+     * instance is reused across every batch of every row group. {@link IdentityHashMap} is
+     * intentional: ESQL shares expression nodes by reference, so identity is the correct equality.
+     * The {@link CompiledWildcard#FAILED} sentinel marks expressions that could not be compiled
+     * (e.g. too complex to determinize) so we do not retry on every batch.
+     *
+     * <p>Synchronized via the cache field as the lock object. The same
+     * {@link ParquetPushedExpressions} instance is shared by every iterator created from a
+     * {@link ParquetFormatReader}, and iterators for different files may run on different driver
+     * threads. The lock is held only across the cache lookup and (on miss) the automaton build —
+     * one build per pattern per query — so contention is negligible compared to the per-batch
+     * automaton run, which executes outside the lock against the immutable {@link ByteRunAutomaton}.
+     */
+    private final IdentityHashMap<WildcardLike, CompiledWildcard> automatonCache = new IdentityHashMap<>();
+
+    /**
+     * Compiled form of a {@link WildcardLike}: the runnable matcher and a flag indicating that the
+     * source automaton accepts every input. The flag is computed against the case-aware automaton
+     * (the same one passed to {@link ByteRunAutomaton}), so the {@link #matchesAll} fast path in
+     * {@link #evaluateWildcardLike} is consistent with the runtime case-sensitivity setting — it
+     * does not silently fall through to the per-row loop just because the pattern's internal
+     * case-insensitive cache disagrees with the requested flag.
+     *
+     * <p>{@code matcher} is {@code null} when the pattern failed to determinize; the caller treats
+     * that as "fall back to FilterExec" (return {@code null} from evaluateWildcardLike).
+     */
+    private record CompiledWildcard(ByteRunAutomaton matcher, boolean matchesAll) {
+        static final CompiledWildcard FAILED = new CompiledWildcard(null, false);
+    }
+
+    ParquetPushedExpressions(List<Expression> expressions) {
+        this.expressions = expressions;
+    }
+
+    List<Expression> expressions() {
+        return expressions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof ParquetPushedExpressions other) {
+            return Objects.equals(expressions, other.expressions);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(expressions);
+    }
+
+    @Override
+    public String toString() {
+        return "ParquetPushedExpressions[expressions=" + expressions + "]";
+    }
 
     /**
      * Translates the held expressions to a combined Parquet {@link FilterPredicate} using
@@ -172,6 +247,10 @@ record ParquetPushedExpressions(List<Expression> expressions) {
             }
             return lower;
         }
+        // WildcardLike has no native Parquet FilterPredicate translation: Parquet only supports
+        // ordered comparisons, equality, and IN. The pattern is evaluated during late materialization
+        // by evaluateWildcardLike. A future enhancement could derive a prefix range from
+        // WildcardPattern#extractPrefix to enable row-group skipping for patterns like "https*google*".
         return null;
     }
 
@@ -412,6 +491,8 @@ record ParquetPushedExpressions(List<Expression> expressions) {
             collectColumnNames(not.field(), names);
         } else if (expr instanceof StartsWith sw && sw.singleValueField() instanceof NamedExpression ne) {
             names.add(ne.name());
+        } else if (expr instanceof WildcardLike wl && wl.field() instanceof NamedExpression ne) {
+            names.add(ne.name());
         }
     }
 
@@ -439,6 +520,7 @@ record ParquetPushedExpressions(List<Expression> expressions) {
         return reusable;
     }
 
+    // Note: not static — uses the per-instance automaton cache in evaluateWildcardLike.
     private WordMask evaluateExpression(Expression expr, Map<String, Block> blocks, int rowCount) {
         if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne && bc.right().foldable()) {
             Block block = blocks.get(ne.name());
@@ -526,6 +608,13 @@ record ParquetPushedExpressions(List<Expression> expressions) {
                 return null;
             }
             return evaluateStartsWith(sw, block, rowCount);
+        }
+        if (expr instanceof WildcardLike wl && wl.field() instanceof NamedExpression ne) {
+            Block block = blocks.get(ne.name());
+            if (block == null) {
+                return null;
+            }
+            return evaluateWildcardLike(wl, block, rowCount);
         }
         return null;
     }
@@ -808,6 +897,146 @@ record ParquetPushedExpressions(List<Expression> expressions) {
             }
         }
         return true;
+    }
+
+    /**
+     * Evaluates a {@link WildcardLike} predicate against a block of values, returning a survivor mask.
+     *
+     * <p>The implementation follows the same shape as {@link #evaluateStartsWith}: a dictionary
+     * short-circuit for {@link OrdinalBytesRefBlock}s with {@code rowCount >= 2 * dictSize}, and a
+     * scalar per-row fallback for plain {@link BytesRefBlock}s. The big win for high-volume scans
+     * (e.g. {@code URL LIKE "*google*"} on web-traffic logs) comes from the dictionary path, which
+     * collapses {@code O(rowCount)} automaton runs into {@code O(dictionarySize)} runs plus a
+     * per-row int lookup.
+     *
+     * <p><b>Null and {@code NOT} semantics.</b> The mask is two-valued: a row's bit is set when
+     * the value is non-null and the automaton accepts its bytes. Nulls map to bit {@code 0}, the
+     * same convention as {@link #evaluateStartsWith} and the standard runtime
+     * {@link org.elasticsearch.xpack.esql.expression.function.scalar.string.AutomataMatch#process}
+     * (which returns {@code false} for null input). When the caller composes with
+     * {@link org.elasticsearch.xpack.esql.expression.predicate.logical.Not}, {@link WordMask#negate}
+     * flips every bit including those for null rows, so {@code NOT (col LIKE p)} would mark nulls
+     * as survivors here. That diverges from SQL three-valued logic, which says
+     * {@code NOT (NULL LIKE p)} is unknown and should be filtered out. <b>Correctness depends on
+     * the FilterExec re-check that always remains downstream of late-mat</b> — see
+     * {@link ParquetFilterPushdownSupport#canPush} which only ever returns
+     * {@link org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport.Pushability#RECHECK},
+     * and {@link ParquetFilterPushdownSupport#pushFilters} which keeps every original conjunct in
+     * the remainder. If a future change ever drops that re-check, this method's null handling for
+     * the {@code Not}-wrapped case must be tightened (e.g. by emitting a separate "definitely
+     * null" mask and AND-ing it out after negation).
+     *
+     * <p>Returns {@code null} when the block is neither an {@link OrdinalBytesRefBlock} on the
+     * dense path nor a {@link BytesRefBlock} (e.g. a constant-null block) — the conservative
+     * "all rows survive" sentinel that {@link #evaluateFilter} treats as a no-op for this
+     * predicate. Returns {@code null} also when the pattern is unusable (failed to determinize),
+     * matching the safety-net role of the FilterExec re-check.
+     */
+    private WordMask evaluateWildcardLike(WildcardLike wl, Block block, int rowCount) {
+        CompiledWildcard compiled = automatonFor(wl);
+        if (compiled.matcher == null) {
+            // Pattern was too complex to determinize. Late-mat can't filter; rely on FilterExec.
+            return null;
+        }
+        // Fast path: pattern accepts every input. Skip the per-row automaton run. matchesAll is
+        // computed at compile time against the case-aware automaton in automatonFor(), so it is
+        // consistent with wl.caseInsensitive(). Nulls are still excluded — SQL's NULL LIKE *
+        // evaluates to unknown, treated here as "no match" for parity with the scalar path.
+        if (compiled.matchesAll) {
+            return maskNonNullRows(block, rowCount);
+        }
+        ByteRunAutomaton runner = compiled.matcher;
+        if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
+            WordMask mask = new WordMask();
+            mask.reset(rowCount);
+            boolean[] dictMatches = matchingDictionaryEntries(
+                obb.getDictionaryVector(),
+                entry -> runner.run(entry.bytes, entry.offset, entry.length)
+            );
+            applyDictionaryMatches(obb, dictMatches, mask, rowCount);
+            return mask;
+        }
+        if (block instanceof BytesRefBlock bb) {
+            WordMask mask = new WordMask();
+            mask.reset(rowCount);
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < rowCount; i++) {
+                if (block.isNull(i) == false) {
+                    BytesRef val = bb.getBytesRef(i, scratch);
+                    if (runner.run(val.bytes, val.offset, val.length)) {
+                        mask.set(i);
+                    }
+                }
+            }
+            return mask;
+        }
+        return null;
+    }
+
+    /**
+     * Returns a mask with one bit set per non-null position. Used as the {@code matchesAll()}
+     * shortcut in {@link #evaluateWildcardLike} — {@code LIKE "*"} accepts every value but, by
+     * SQL three-valued-logic semantics, still rejects nulls.
+     */
+    private static WordMask maskNonNullRows(Block block, int rowCount) {
+        WordMask mask = new WordMask();
+        if (block.mayHaveNulls() == false) {
+            mask.setAll(rowCount);
+            return mask;
+        }
+        mask.reset(rowCount);
+        for (int i = 0; i < rowCount; i++) {
+            if (block.isNull(i) == false) {
+                mask.set(i);
+            }
+        }
+        return mask;
+    }
+
+    /**
+     * Returns the compiled form of the given {@link WildcardLike}, building it once on first use
+     * and caching it on the per-query {@link #automatonCache}. Returns {@link CompiledWildcard#FAILED}
+     * when the pattern cannot be determinized (logged once at debug); the caller treats that as
+     * "fall back to FilterExec".
+     *
+     * <p>Note on byte-vs-character semantics: {@link
+     * org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern#createAutomaton}
+     * returns a UTF-32 (character-level) automaton on both paths — case-sensitive via
+     * {@link org.apache.lucene.search.WildcardQuery#toAutomaton}, case-insensitive via
+     * {@link org.apache.lucene.util.automaton.RegExp}. Both therefore need the implicit
+     * UTF-32→UTF-8 conversion that the single-argument
+     * {@link ByteRunAutomaton#ByteRunAutomaton(Automaton)} constructor performs internally; the
+     * {@code (Automaton, true)} two-arg form would skip that conversion and silently produce
+     * incorrect matches for any non-ASCII byte. This mirrors
+     * {@code StringScriptFieldWildcardQuery} in {@code org.elasticsearch.search.runtime}, which
+     * uses the same single-arg constructor for the same reason.
+     *
+     * <p>{@code matchesAll} is computed against the case-aware automaton — the same one passed to
+     * {@link ByteRunAutomaton} — so the {@link #evaluateWildcardLike} fast path stays in sync with
+     * {@link WildcardLike#caseInsensitive()}.
+     */
+    private CompiledWildcard automatonFor(WildcardLike wl) {
+        synchronized (automatonCache) {
+            CompiledWildcard cached = automatonCache.get(wl);
+            if (cached != null) {
+                return cached;
+            }
+            CompiledWildcard compiled;
+            try {
+                Automaton automaton = wl.pattern().createAutomaton(wl.caseInsensitive());
+                boolean matchesAll = Operations.isTotal(automaton);
+                compiled = new CompiledWildcard(new ByteRunAutomaton(automaton), matchesAll);
+            } catch (IllegalArgumentException | TooComplexToDeterminizeException e) {
+                logger.debug(
+                    "Cannot push WildcardLike pattern [{}] to Parquet late materialization, falling back to FilterExec",
+                    wl.pattern().pattern(),
+                    e
+                );
+                compiled = CompiledWildcard.FAILED;
+            }
+            automatonCache.put(wl, compiled);
+            return compiled;
+        }
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
@@ -682,7 +682,7 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
 
     // --- WildcardLike (LIKE) tests ---
 
-    public void testWildcardLikeKeywordPushed() {
+    public void testWildcardLikeKeywordPushedAsYes() {
         Attribute col = attr("url", DataType.KEYWORD);
         Expression filter = new WildcardLike(Source.EMPTY, col, new WildcardPattern("*google*"));
 
@@ -690,19 +690,21 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
 
         assertTrue(result.hasPushedFilter());
         assertThat(result.pushedFilter(), instanceOf(ParquetPushedExpressions.class));
-        // RECHECK semantics: the original filter must remain in the remainder for FilterExec to
-        // re-apply per-row. Removing it would break correctness if an automaton fails to determinize
-        // at runtime and silently falls back to "all rows pass".
-        assertEquals(1, result.remainder().size());
+        // YES semantics: the late-mat evaluator is TVL-correct for WildcardLike (nulls already
+        // map to bit 0, and Not(WildcardLike) AND-s out the null mask before negation), so the
+        // FilterExec re-check is unnecessary. Keeping it would double the per-row LIKE cost on
+        // every surviving row — the entire motivation for switching this conjunct off RECHECK.
+        assertEquals("WildcardLike must be dropped from the remainder under YES", 0, result.remainder().size());
     }
 
-    public void testWildcardLikeCaseInsensitivePushed() {
+    public void testWildcardLikeCaseInsensitivePushedAsYes() {
         Attribute col = attr("url", DataType.KEYWORD);
         Expression filter = new WildcardLike(Source.EMPTY, col, new WildcardPattern("*Google*"), true);
 
         FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
 
         assertTrue(result.hasPushedFilter());
+        assertEquals(0, result.remainder().size());
     }
 
     public void testWildcardLikeNonKeywordNotPushed() {
@@ -721,29 +723,86 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         assertTrue(ParquetFilterPushdownSupport.canConvert(filter));
     }
 
-    public void testWildcardLikeCanPushReturnsRecheck() {
+    public void testWildcardLikeCanPushReturnsYes() {
         Attribute col = attr("url", DataType.KEYWORD);
         Expression filter = new WildcardLike(Source.EMPTY, col, new WildcardPattern("*google*"));
 
-        assertEquals(FilterPushdownSupport.Pushability.RECHECK, support.canPush(filter));
+        // The bare LIKE is fully evaluable by the late-mat evaluator (two-valued mask is
+        // TVL-correct because null rows already map to bit 0); FilterExec is not needed.
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(filter));
     }
 
-    public void testWildcardLikeCombinedWithEquals() {
+    public void testWildcardLikeCombinedWithEqualsKeepsEqualsInRemainder() {
         Attribute url = attr("url", DataType.KEYWORD);
         Attribute searchPhrase = attr("searchPhrase", DataType.KEYWORD);
         Expression like = new WildcardLike(Source.EMPTY, url, new WildcardPattern("*google*"));
         Expression neq = new NotEquals(Source.EMPTY, searchPhrase, keywordLit(""), null);
+        // A single AND conjunct with one YES (LIKE) and one RECHECK (!=) leaf — pushed as a
+        // whole because the RECHECK leaf forces the safer side to win for the combined expr.
         Expression filter = new And(Source.EMPTY, like, neq);
 
         FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
 
         assertTrue(result.hasPushedFilter());
+        // Mixed AND keeps the conjunct in remainder so FilterExec re-applies the != per-row.
+        // Promoting it to YES would silently drop the != bit semantics (the bitmask path's
+        // Not handling for binary comparisons does not encode TVL).
         assertEquals(1, result.remainder().size());
     }
 
-    public void testWildcardLikeNegatedPushed() {
-        // NOT (URL LIKE "*google*") goes through the Not branch of canConvert, which delegates
-        // to the inner expression. The same negation logic exists in evaluateExpression.
+    public void testWildcardLikeAndWildcardLikePushedAsYes() {
+        // Two LIKE conjuncts in a single AND — both arms YES-eligible, so the combined
+        // expression is YES and the conjunct is dropped from the remainder.
+        Attribute url = attr("url", DataType.KEYWORD);
+        Attribute title = attr("title", DataType.KEYWORD);
+        Expression likeUrl = new WildcardLike(Source.EMPTY, url, new WildcardPattern("*google*"));
+        Expression likeTitle = new WildcardLike(Source.EMPTY, title, new WildcardPattern("*Google*"), true);
+        Expression filter = new And(Source.EMPTY, likeUrl, likeTitle);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(filter));
+        assertEquals(0, result.remainder().size());
+    }
+
+    public void testNotOverAndOfWildcardLikesIsRecheck() {
+        // Regression: NOT (LIKE AND LIKE) must NOT be YES. The evaluator's generic Not branch
+        // would compute ~(m1 & m2), which is not SQL NOT(a AND b) under TVL — e.g. row with
+        // a=NULL, b=match: (NULL AND TRUE)=UNKNOWN, must NOT survive NOT(...), but the bitwise
+        // path gives ~(0 & 1) = ~0 = 1 → row incorrectly survives. Only Not(WildcardLike) has
+        // a TVL-aware special case in evaluateExpression; anything else under Not stays RECHECK
+        // so FilterExec can fix the null handling.
+        Attribute url = attr("url", DataType.KEYWORD);
+        Attribute title = attr("title", DataType.KEYWORD);
+        Expression likeUrl = new WildcardLike(Source.EMPTY, url, new WildcardPattern("*google*"));
+        Expression likeTitle = new WildcardLike(Source.EMPTY, title, new WildcardPattern("*Google*"));
+        Expression notAnd = new Not(Source.EMPTY, new And(Source.EMPTY, likeUrl, likeTitle));
+
+        assertEquals(FilterPushdownSupport.Pushability.RECHECK, support.canPush(notAnd));
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(notAnd));
+        assertTrue(result.hasPushedFilter());
+        assertEquals("RECHECK keeps the conjunct in remainder so FilterExec re-applies", 1, result.remainder().size());
+    }
+
+    public void testNotOverNotOfWildcardLikeIsRecheck() {
+        // NOT (NOT (col LIKE p)) is logically equivalent to col LIKE p but goes through the
+        // generic Not branch (the special case only fires for the immediate Not(WildcardLike)
+        // shape). Stay RECHECK to keep FilterExec available; promoting to YES would need
+        // either De Morgan / double-negation simplification or a deeper TVL-aware evaluator.
+        Attribute url = attr("url", DataType.KEYWORD);
+        Expression like = new WildcardLike(Source.EMPTY, url, new WildcardPattern("*google*"));
+        Expression notNot = new Not(Source.EMPTY, new Not(Source.EMPTY, like));
+
+        assertEquals(FilterPushdownSupport.Pushability.RECHECK, support.canPush(notNot));
+    }
+
+    public void testWildcardLikeNegatedPushedAsYes() {
+        // NOT (URL LIKE "*google*"): YES is safe because evaluateExpression has a Not(WildcardLike)
+        // special case that AND-s out the null mask before negation, restoring SQL three-valued
+        // logic. Without that special case, dropping FilterExec would let null rows survive the
+        // predicate (the generic two-valued negate flips null bits from 0 to 1).
         Attribute col = attr("url", DataType.KEYWORD);
         Expression like = new WildcardLike(Source.EMPTY, col, new WildcardPattern("*google*"));
         Expression filter = new Not(Source.EMPTY, like);
@@ -751,6 +810,8 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
 
         assertTrue(result.hasPushedFilter());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(filter));
+        assertEquals(0, result.remainder().size());
     }
 
     // --- helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
@@ -13,10 +13,12 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -676,6 +678,79 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
 
         assertTrue(result.hasPushedFilter());
         assertEquals(1, result.remainder().size());
+    }
+
+    // --- WildcardLike (LIKE) tests ---
+
+    public void testWildcardLikeKeywordPushed() {
+        Attribute col = attr("url", DataType.KEYWORD);
+        Expression filter = new WildcardLike(Source.EMPTY, col, new WildcardPattern("*google*"));
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertThat(result.pushedFilter(), instanceOf(ParquetPushedExpressions.class));
+        // RECHECK semantics: the original filter must remain in the remainder for FilterExec to
+        // re-apply per-row. Removing it would break correctness if an automaton fails to determinize
+        // at runtime and silently falls back to "all rows pass".
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testWildcardLikeCaseInsensitivePushed() {
+        Attribute col = attr("url", DataType.KEYWORD);
+        Expression filter = new WildcardLike(Source.EMPTY, col, new WildcardPattern("*Google*"), true);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+    }
+
+    public void testWildcardLikeNonKeywordNotPushed() {
+        Attribute col = attr("loc", DataType.GEO_POINT);
+        Expression filter = new WildcardLike(Source.EMPTY, col, new WildcardPattern("*"));
+
+        assertFalse(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testWildcardLikeMatchAllPattern() {
+        // LIKE "*" is still convertible — evaluation has a fast path that returns all non-null rows
+        // without invoking the automaton runner.
+        Attribute col = attr("name", DataType.KEYWORD);
+        Expression filter = new WildcardLike(Source.EMPTY, col, new WildcardPattern("*"));
+
+        assertTrue(ParquetFilterPushdownSupport.canConvert(filter));
+    }
+
+    public void testWildcardLikeCanPushReturnsRecheck() {
+        Attribute col = attr("url", DataType.KEYWORD);
+        Expression filter = new WildcardLike(Source.EMPTY, col, new WildcardPattern("*google*"));
+
+        assertEquals(FilterPushdownSupport.Pushability.RECHECK, support.canPush(filter));
+    }
+
+    public void testWildcardLikeCombinedWithEquals() {
+        Attribute url = attr("url", DataType.KEYWORD);
+        Attribute searchPhrase = attr("searchPhrase", DataType.KEYWORD);
+        Expression like = new WildcardLike(Source.EMPTY, url, new WildcardPattern("*google*"));
+        Expression neq = new NotEquals(Source.EMPTY, searchPhrase, keywordLit(""), null);
+        Expression filter = new And(Source.EMPTY, like, neq);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(1, result.remainder().size());
+    }
+
+    public void testWildcardLikeNegatedPushed() {
+        // NOT (URL LIKE "*google*") goes through the Not branch of canConvert, which delegates
+        // to the inner expression. The same negation logic exists in evaluateExpression.
+        Attribute col = attr("url", DataType.KEYWORD);
+        Expression like = new WildcardLike(Source.EMPTY, col, new WildcardPattern("*google*"));
+        Expression filter = new Not(Source.EMPTY, like);
+
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(filter));
+
+        assertTrue(result.hasPushedFilter());
     }
 
     // --- helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
@@ -20,9 +20,11 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -594,6 +596,258 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
             );
             assertSurvivors(new ParquetPushedExpressions(List.of(expr)), blocks, ordinals.length, reusable, expected);
         }
+    }
+
+    // ---- Test: WildcardLike (LIKE) evaluation ----
+
+    public void testWildcardLikeBasicScalar() {
+        // ["apple", "application", "banana", "pineapple"], pattern "*app*" matches indexes 0, 1, 3.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendBytesRef(new BytesRef("application"));
+            builder.appendBytesRef(new BytesRef("banana"));
+            builder.appendBytesRef(new BytesRef("pineapple"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*app*"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 4, reusable, new int[] { 0, 1, 3 });
+        }
+    }
+
+    public void testWildcardLikeMatchAllExcludesNulls() {
+        // LIKE "*" must accept every non-null value but reject nulls — SQL three-valued logic
+        // says NULL LIKE anything is unknown, not true. The evaluateWildcardLike fast path
+        // (matchesAll) is the one under test here; without the explicit null check it would
+        // wrongly include null rows.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("foo"));
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("bar"));
+            builder.appendNull();
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 4, reusable, new int[] { 0, 2 });
+        }
+    }
+
+    public void testWildcardLikeQuestionMarkSingleChar() {
+        // "?" matches exactly one character. "f?o" matches "foo" and "fxo" but not "fo" or "foooo".
+        try (var builder = blockFactory.newBytesRefBlockBuilder(5)) {
+            builder.appendBytesRef(new BytesRef("foo"));
+            builder.appendBytesRef(new BytesRef("fxo"));
+            builder.appendBytesRef(new BytesRef("fo"));
+            builder.appendBytesRef(new BytesRef("foooo"));
+            builder.appendBytesRef(new BytesRef("bar"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("f?o"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 5, reusable, new int[] { 0, 1 });
+        }
+    }
+
+    public void testWildcardLikeNoMatches() {
+        // No row matches -> evaluateFilter must return a non-null empty mask (not null, which means
+        // "all rows survive"). This guards against confusing the empty-mask and null sentinels.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("alpha"));
+            builder.appendBytesRef(new BytesRef("beta"));
+            builder.appendBytesRef(new BytesRef("gamma"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*xyz*"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 3, reusable, new int[] {});
+        }
+    }
+
+    public void testWildcardLikeCaseInsensitive() {
+        // The case-insensitive automaton path goes through RegExp(...) rather than
+        // WildcardQuery.toAutomaton; this test pins the contract that case-insensitive matching
+        // works end-to-end via the late-mat evaluator.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("https://www.GOOGLE.com"));
+            builder.appendBytesRef(new BytesRef("https://www.bing.com"));
+            builder.appendBytesRef(new BytesRef("https://google.example.com"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("url", block);
+            WordMask reusable = new WordMask();
+
+            Expression like = new WildcardLike(Source.EMPTY, attr("url", DataType.KEYWORD), new WildcardPattern("*google*"), true);
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 3, reusable, new int[] { 0, 2 });
+        }
+    }
+
+    public void testWildcardLikeNotInverts() {
+        // Pins the actual two-valued bit semantics of Not: WordMask#negate flips every bit, so a
+        // null row (LIKE bit = 0, by parity with AutomataMatch.process(null) = false) becomes a
+        // survivor after negation. With ["x.google.com", "x.bing.com", null] and pattern "*google*",
+        // LIKE produces mask {1,0,0}; Not flips it to {0,1,1}.
+        //
+        // Note: SQL three-valued logic says NOT (NULL LIKE p) is unknown and should not survive.
+        // The bitmask path here intentionally does not encode TVL — correctness of NOT (LIKE …)
+        // around nulls is restored by the FilterExec re-check that PushFiltersToSource always
+        // keeps downstream of late-mat (ParquetFilterPushdownSupport.canPush returns RECHECK and
+        // pushFilters keeps every original conjunct in the remainder). The contract is documented
+        // on ParquetPushedExpressions#evaluateWildcardLike.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("x.google.com"));
+            builder.appendBytesRef(new BytesRef("x.bing.com"));
+            builder.appendNull();
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("url", block);
+            WordMask reusable = new WordMask();
+
+            Expression like = new WildcardLike(Source.EMPTY, attr("url", DataType.KEYWORD), new WildcardPattern("*google*"));
+            Expression not = new Not(Source.EMPTY, like);
+            assertSurvivors(new ParquetPushedExpressions(List.of(not)), blocks, 3, reusable, new int[] { 1, 2 });
+        }
+    }
+
+    public void testWildcardLikeWithNulls() {
+        // Per SQL three-valued logic, NULL LIKE anything is UNKNOWN, treated as not-matching
+        // for filter purposes. Indexes 0 and 4 hold "foobar"/"foo" which match "foo*"; index 2
+        // is null and must be excluded.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(5)) {
+            builder.appendBytesRef(new BytesRef("foobar"));
+            builder.appendBytesRef(new BytesRef("bar"));
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("baz"));
+            builder.appendBytesRef(new BytesRef("foo"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("foo*"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 5, reusable, new int[] { 0, 4 });
+        }
+    }
+
+    public void testWildcardLikeWithMissingColumn() {
+        // Missing predicate column -> evaluateExpression returns null -> evaluateFilter treats
+        // the predicate as "unknown for all rows", which collapses to "all survive" (null return).
+        Map<String, Block> blocks = new HashMap<>();
+        WordMask reusable = new WordMask();
+
+        Expression like = new WildcardLike(Source.EMPTY, attr("missing", DataType.KEYWORD), new WildcardPattern("*foo*"));
+        WordMask result = new ParquetPushedExpressions(List.of(like)).evaluateFilter(blocks, 3, reusable);
+        assertNull(result);
+    }
+
+    public void testWildcardLikeOrdinalDictionaryShortCircuit() {
+        // Dictionary: ["apple", "application", "banana", "pineapple"] (4 entries).
+        // Pattern "*app*" matches 0, 1, 3. Ordinal pattern repeated to satisfy
+        // OrdinalBytesRefBlock#isDense (rows >= 2 * dictSize) and exercise the dictionary
+        // short-circuit, which is the main perf win for high-volume LIKE pushdown.
+        String[] dict = { "apple", "application", "banana", "pineapple" };
+        int[] pattern = { 0, 1, 2, 3, 0, 2 };
+        int[] ordinals = repeatPattern(pattern, 24);
+        Block block = ordinalBlock(dict, ordinals, null);
+        try (block) {
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+            int[] expected = positionsWithOrdinalIn(ordinals, 0, 1, 3);
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*app*"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, ordinals.length, reusable, expected);
+        }
+    }
+
+    public void testWildcardLikeOrdinalAndScalarAgree() {
+        // Cross-check the dictionary short-circuit against the per-row scalar path on the same
+        // logical data. Any divergence between paths indicates a bug in either the dictionary
+        // mapping or the scalar loop.
+        String[] dict = { "the", "quick", "brown", "fox", "jumps", "over", "the_lazy_dog" };
+        int rowCount = 200;
+        int[] randomOrdinals = new int[rowCount];
+        for (int i = 0; i < rowCount; i++) {
+            randomOrdinals[i] = randomIntBetween(0, dict.length - 1);
+        }
+        Block ordinalsBlock = ordinalBlock(dict, randomOrdinals, null);
+        Block plainBlock = plainBytesRefBlock(dict, randomOrdinals);
+        try (ordinalsBlock; plainBlock) {
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*o*"));
+
+            WordMask ordinalMask = new ParquetPushedExpressions(List.of(like)).evaluateFilter(
+                Map.of("s", ordinalsBlock),
+                rowCount,
+                new WordMask()
+            );
+            WordMask plainMask = new ParquetPushedExpressions(List.of(like)).evaluateFilter(
+                Map.of("s", plainBlock),
+                rowCount,
+                new WordMask()
+            );
+            if (ordinalMask == null) {
+                assertNull("ordinal returned null (all survive); plain must also", plainMask);
+            } else {
+                assertNotNull("ordinal produced a mask; plain must too", plainMask);
+                assertArrayEquals(plainMask.survivingPositions(), ordinalMask.survivingPositions());
+            }
+        }
+    }
+
+    public void testWildcardLikeAutomatonIsCachedAcrossBatches() {
+        // The same ParquetPushedExpressions instance is reused across batches. If the automaton
+        // were rebuilt every call, the cache field would not be needed. We assert the cache works
+        // by re-running evaluateFilter and confirming results are stable. (We cannot directly
+        // observe the cache hit count without breaking encapsulation; the contract under test is
+        // that repeated evaluations produce identical results, which transitively confirms the
+        // cache returns a usable runner each time.)
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendBytesRef(new BytesRef("application"));
+            builder.appendBytesRef(new BytesRef("banana"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*app*"));
+            ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(like));
+
+            for (int i = 0; i < 3; i++) {
+                WordMask mask = pushed.evaluateFilter(blocks, 3, new WordMask());
+                assertNotNull("iteration " + i + " produced a null mask", mask);
+                assertArrayEquals("iteration " + i + " survivors changed", new int[] { 0, 1 }, mask.survivingPositions());
+            }
+        }
+    }
+
+    public void testWildcardLikeUtf8Bytes() {
+        // Pins UTF-32 -> UTF-8 byte handling for non-ASCII characters. The single-arg
+        // ByteRunAutomaton constructor used in evaluateWildcardLike performs the conversion
+        // internally; using the (Automaton, true) form would silently break this test.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("café"));
+            builder.appendBytesRef(new BytesRef("Café"));
+            builder.appendBytesRef(new BytesRef("naïve"));
+            builder.appendBytesRef(new BytesRef("plain"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            // Case-sensitive "*café*" matches index 0 only — "Café" has uppercase C.
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*café*"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 4, new WordMask(), new int[] { 0 });
+
+            // Case-insensitive "*café*" matches both "café" and "Café".
+            Expression likeCi = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*café*"), true);
+            assertSurvivors(new ParquetPushedExpressions(List.of(likeCi)), blocks, 4, reusable, new int[] { 0, 1 });
+        }
+    }
+
+    public void testWildcardLikePredicateColumnNamesIncludesField() {
+        // Without including the WildcardLike field in predicateColumnNames, the late-mat path
+        // would not request the column from the reader and the predicate would always evaluate
+        // against a missing block (returning null/all-survive). This test pins the contract.
+        Expression like = new WildcardLike(Source.EMPTY, attr("url", DataType.KEYWORD), new WildcardPattern("*google*"));
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(like));
+        assertEquals(java.util.Set.of("url"), pushed.predicateColumnNames());
     }
 
     public void testOrdinalStartsWithMatchesDictionaryPrefix() {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
@@ -794,12 +794,11 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
     }
 
     public void testWildcardLikeAutomatonIsCachedAcrossBatches() {
-        // The same ParquetPushedExpressions instance is reused across batches. If the automaton
-        // were rebuilt every call, the cache field would not be needed. We assert the cache works
-        // by re-running evaluateFilter and confirming results are stable. (We cannot directly
-        // observe the cache hit count without breaking encapsulation; the contract under test is
-        // that repeated evaluations produce identical results, which transitively confirms the
-        // cache returns a usable runner each time.)
+        // The same ParquetPushedExpressions instance is reused across batches. We directly assert
+        // memoization via the package-private cache-size hook: after the first evaluateFilter the
+        // cache holds exactly one entry, and after subsequent evaluations the size never grows —
+        // proving the second-and-later calls hit the cache instead of rebuilding the automaton.
+        // Outcome stability is checked too as a regression guard.
         try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
             builder.appendBytesRef(new BytesRef("apple"));
             builder.appendBytesRef(new BytesRef("application"));
@@ -809,11 +808,13 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
 
             Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*app*"));
             ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(like));
+            assertEquals("cache should start empty", 0, pushed.automatonCacheSizeForTesting());
 
             for (int i = 0; i < 3; i++) {
                 WordMask mask = pushed.evaluateFilter(blocks, 3, new WordMask());
                 assertNotNull("iteration " + i + " produced a null mask", mask);
                 assertArrayEquals("iteration " + i + " survivors changed", new int[] { 0, 1 }, mask.survivingPositions());
+                assertEquals("automaton should be compiled exactly once after iteration " + i, 1, pushed.automatonCacheSizeForTesting());
             }
         }
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
@@ -685,18 +685,15 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
         }
     }
 
-    public void testWildcardLikeNotInverts() {
-        // Pins the actual two-valued bit semantics of Not: WordMask#negate flips every bit, so a
-        // null row (LIKE bit = 0, by parity with AutomataMatch.process(null) = false) becomes a
-        // survivor after negation. With ["x.google.com", "x.bing.com", null] and pattern "*google*",
-        // LIKE produces mask {1,0,0}; Not flips it to {0,1,1}.
-        //
-        // Note: SQL three-valued logic says NOT (NULL LIKE p) is unknown and should not survive.
-        // The bitmask path here intentionally does not encode TVL — correctness of NOT (LIKE …)
-        // around nulls is restored by the FilterExec re-check that PushFiltersToSource always
-        // keeps downstream of late-mat (ParquetFilterPushdownSupport.canPush returns RECHECK and
-        // pushFilters keeps every original conjunct in the remainder). The contract is documented
-        // on ParquetPushedExpressions#evaluateWildcardLike.
+    public void testWildcardLikeNotInvertsAndExcludesNulls() {
+        // Pins SQL three-valued logic for NOT (col LIKE p): a null row evaluates to UNKNOWN
+        // and must not survive the predicate, even though its bit in the inner LIKE mask is 0.
+        // With ["x.google.com", "x.bing.com", null] and pattern "*google*":
+        // LIKE mask = {1, 0, 0} (index 2 is 0 because null, not because no-match)
+        // |= null mask = {1, 0, 1}
+        // negate = {0, 1, 0} ← survivors
+        // Without the Not(WildcardLike) special case in evaluateExpression, the result would be
+        // {0, 1, 1} and the YES pushdown would silently change query results around nulls.
         try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
             builder.appendBytesRef(new BytesRef("x.google.com"));
             builder.appendBytesRef(new BytesRef("x.bing.com"));
@@ -707,7 +704,46 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
 
             Expression like = new WildcardLike(Source.EMPTY, attr("url", DataType.KEYWORD), new WildcardPattern("*google*"));
             Expression not = new Not(Source.EMPTY, like);
-            assertSurvivors(new ParquetPushedExpressions(List.of(not)), blocks, 3, reusable, new int[] { 1, 2 });
+            assertSurvivors(new ParquetPushedExpressions(List.of(not)), blocks, 3, reusable, new int[] { 1 });
+        }
+    }
+
+    public void testWildcardLikeNotOnAllNullColumn() {
+        // Pure-null block: NOT (NULL LIKE p) is UNKNOWN for every row, so zero survivors.
+        // Exercises the mayHaveNulls() fast path being false (always-null) — guards against
+        // the inverse mistake of optimizing away the null scan when nulls are dense.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendNull();
+            builder.appendNull();
+            builder.appendNull();
+            builder.appendNull();
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("url", block);
+            WordMask reusable = new WordMask();
+
+            Expression like = new WildcardLike(Source.EMPTY, attr("url", DataType.KEYWORD), new WildcardPattern("*google*"));
+            Expression not = new Not(Source.EMPTY, like);
+            assertSurvivors(new ParquetPushedExpressions(List.of(not)), blocks, 4, reusable, new int[] {});
+        }
+    }
+
+    public void testWildcardLikeNotWithoutNullsMatchesGenericNegate() {
+        // When the block has no nulls, Not(WildcardLike) must agree with the generic "evaluate
+        // then negate" path: the null-OR step is a no-op. This locks in that the TVL fix doesn't
+        // perturb the no-null common case (e.g. dense URL columns on web-traffic logs).
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("alpha"));
+            builder.appendBytesRef(new BytesRef("beta"));
+            builder.appendBytesRef(new BytesRef("alphabet"));
+            builder.appendBytesRef(new BytesRef("gamma"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("alpha*"));
+            Expression not = new Not(Source.EMPTY, like);
+            // alpha + alphabet match the inner LIKE; NOT flips to {beta, gamma}.
+            assertSurvivors(new ParquetPushedExpressions(List.of(not)), blocks, 4, reusable, new int[] { 1, 3 });
         }
     }
 


### PR DESCRIPTION
WildcardLike on KEYWORD columns is now eligible for Parquet pushdown
and is evaluated during late materialization, allowing the reader to
skip decoding projection-only columns for non-matching rows. Mirrors
the StartsWith pattern: dictionary short-circuit on dense
OrdinalBytesRefBlock values and a scalar fallback for plain
BytesRefBlock. ByteRunAutomaton instances are cached per expression
to avoid rebuilding for every batch. Pushability stays RECHECK so
FilterExec re-applies the predicate per row, restoring SQL three-
valued logic for NOT (LIKE) around nulls.

Developed with AI-assisted tooling