### PR TITLE
[ESQL] Two-phase I/O for Parquet on remote storage

### DIFF
--- a/docs/changelog/148439.yaml
+++ b/docs/changelog/148439.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148439
+summary: Two-phase I/O for Parquet on remote storage
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -242,7 +242,6 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             lateMaterialization,
             storageObject,
             columnInfos,
-            isPredicateColumn,
             reader.getRowGroups(),
             projectedColumnPaths,
             predicateColumnPaths,
@@ -349,6 +348,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         // Larger projected sizes need deeper prefetch: an S3 GET for a 20MB string column takes
         // ~200ms while decode takes ~10ms, so single-ahead can't hide the latency. The circuit
         // breaker caps actual memory regardless of depth.
+        //
+        // Two-phase note: under two-phase the queued prefetches carry only predicate columns, so
+        // the actual queued bytes are a fraction of {@code projectedBytes}. We intentionally keep
+        // the depth sized on the full projection footprint because the synchronous Phase-2 fetch
+        // we issue inside {@code advanceRowGroup} is what dominates per-row-group latency under
+        // two-phase, and a deeper queue lets Phase 1 of the next row group overlap that wait.
         if (projectedBytes > DEEPER_PREFETCH_BYTES) {
             return 3;
         }
@@ -402,17 +407,21 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
      * <p>Two-phase requires (a) late materialization to be active, (b) at least one
      * projection-only column (otherwise Phase 2 has nothing to fetch), (c) a storage object that
      * benefits from skipping bytes (i.e., remote — proxied here via
-     * {@link StorageObject#supportsNativeAsync()} since all remote backends override it and
-     * local files do not), (d) no list columns (their decode path needs a unified
-     * {@code ColumnReadStoreImpl} that we don't split between predicate and projection stores),
-     * and (e) the projected bytes must be dominated by projection-only columns rather than
-     * predicate columns.
+     * {@link StorageObject#supportsNativeAsync()}; today this is the de-facto remote signal,
+     * overridden by every cloud-backed {@code StorageObject} in the codebase — {@code S3StorageObject},
+     * {@code GcsStorageObject}, {@code AzureStorageObject}, and {@code HttpStorageObject} — and not
+     * by any local-only implementation. If a future {@code StorageObject} returns {@code true}
+     * without remote-like fetch cost, this gate may activate two-phase where it isn't profitable;
+     * the fallback is the single-phase late-mat path, so the worst case is wasted CPU on the
+     * unnecessary survivor-mask plumbing rather than incorrect results.), (d) no list columns
+     * (their decode path needs a unified {@code ColumnReadStoreImpl} that we don't split between
+     * predicate and projection stores), and (e) the projected bytes must be dominated by
+     * projection-only columns rather than predicate columns.
      */
     private static boolean shouldUseTwoPhase(
         boolean lateMaterialization,
         StorageObject storageObject,
         ColumnInfo[] columnInfos,
-        boolean[] isPredicateColumn,
         List<BlockMetaData> rowGroups,
         Set<String> projectedColumnPaths,
         Set<String> predicateColumnPaths,
@@ -785,8 +794,22 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 rowsConsumed += rowsToRead;
             }
         } catch (Exception e) {
+            // Mirror the success path's cleanup so a partially-decoded row group doesn't leak the
+            // predicate PageReadStore / PageColumnReaders even if the caller forgets to close()
+            // the iterator. close() itself is still defensive against this state, so doing the
+            // teardown here just narrows the leak window to "exception propagated and iterator
+            // immediately discarded".
             for (Block[] arr : predicateBatches) {
                 Releasables.closeExpectNoException(arr);
+            }
+            closePageColumnReaders();
+            if (rowGroup != null) {
+                try {
+                    rowGroup.close();
+                } catch (Exception closeEx) {
+                    e.addSuppressed(closeEx);
+                }
+                rowGroup = null;
             }
             throw e;
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -34,6 +34,8 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -41,6 +43,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -86,6 +89,8 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private final PreloadedRowGroupMetadata preloadedMetadata;
     private final StorageObject storageObject;
     private final Set<String> projectedColumnPaths;
+    private final Set<String> predicateColumnPaths;
+    private final Set<String> projectionOnlyColumnPaths;
     private final CircuitBreaker breaker;
     private final RowRanges[] allRowRanges;
     /**
@@ -117,6 +122,30 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private int pageBatchIndexInRowGroup = 0;
 
     private final boolean lateMaterialization;
+    /**
+     * When {@code true}, switches the prefetch + decode pipeline to a per-row-group two-phase
+     * I/O flow: Phase 1 fetches only predicate column chunks, the iterator fully decodes them
+     * to evaluate the filter and accumulate a global survivor mask, and Phase 2 then fetches
+     * only the projection column pages that contain at least one survivor. On remote storage
+     * with a selective filter this avoids the dominant cost of transferring projection-only
+     * column data (typically large strings) for rows that are immediately filtered out.
+     *
+     * <p>Disabled when:
+     * <ul>
+     *   <li>Late materialization is off ({@link #lateMaterialization} is false).</li>
+     *   <li>The storage object is local (non-async) — the extra Phase-1 → Phase-2 sequencing
+     *       adds latency without saving meaningful I/O on a memory-mapped file.</li>
+     *   <li>Predicate columns are themselves a large fraction of projected bytes — the savings
+     *       on projection columns no longer justify the per-row-group sequential dependency
+     *       (see {@link #TWO_PHASE_PREDICATE_BYTE_RATIO_THRESHOLD}).</li>
+     *   <li>Any projected column is a list column — list decoding goes through
+     *       {@code ColumnReadStoreImpl} which expects a single combined {@link PageReader}
+     *       store; supporting it under two-phase is left for follow-up work.</li>
+     *   <li>There are no projection-only columns (every projected column is also a predicate
+     *       column) — there is nothing for Phase 2 to save.</li>
+     * </ul>
+     */
+    private final boolean useTwoPhase;
     private final boolean[] isPredicateColumn;
     private final ParquetPushedExpressions pushedExpressions;
     /**
@@ -141,6 +170,28 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     private boolean currentRowGroupTriviallyPasses;
     /** Diagnostic counter: number of row groups for which the filter was proven to trivially pass. */
     private long rowGroupsWithTrivialFilter;
+
+    /**
+     * Per-row-group two-phase decode state. Populated in {@link #advanceRowGroup()} when
+     * {@link #useTwoPhase} is active and the current row group survives Phase-1 filter
+     * evaluation; consumed batch-by-batch in {@link #nextTwoPhaseBatch()} and cleared in
+     * {@link #closeTwoPhaseState()} when the iterator advances to the next row group or is
+     * closed.
+     */
+    private TwoPhaseRowGroup twoPhase;
+    /**
+     * Diagnostic counter: number of row groups served via the two-phase Phase-2 page-skipping
+     * path (i.e., where Phase 2 fetched only surviving pages instead of full chunks).
+     */
+    private long twoPhaseRowGroupsWithPageSkipping;
+    /**
+     * Diagnostic counter: number of row groups where two-phase fell back to fetching whole
+     * projection chunks because the survivor RowRanges was too dense or fragmented to
+     * benefit from page skipping.
+     */
+    private long twoPhaseRowGroupsFullProjectionFetch;
+    /** Diagnostic counter: number of row groups skipped entirely because no row survived the filter. */
+    private long twoPhaseRowGroupsAllFiltered;
 
     OptimizedParquetColumnIterator(
         ParquetFileReader reader,
@@ -185,6 +236,19 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.triviallyPassesPredicate = lateMaterialization ? triviallyPassesPredicate : null;
 
         this.projectedColumnPaths = buildProjectedColumnPaths(columnInfos);
+        this.predicateColumnPaths = buildColumnPaths(columnInfos, isPredicateColumn, true);
+        this.projectionOnlyColumnPaths = buildColumnPaths(columnInfos, isPredicateColumn, false);
+        this.useTwoPhase = shouldUseTwoPhase(
+            lateMaterialization,
+            storageObject,
+            columnInfos,
+            isPredicateColumn,
+            reader.getRowGroups(),
+            projectedColumnPaths,
+            predicateColumnPaths,
+            projectionOnlyColumnPaths,
+            fileLocation
+        );
         this.prefetchDepth = computePrefetchDepth(reader.getRowGroups(), this.projectedColumnPaths);
 
         reader.setRequestedSchema(projectedSchema);
@@ -212,10 +276,15 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
      */
     private void fillPrefetchQueue(int fromOrdinal) {
         List<BlockMetaData> rowGroups = reader.getRowGroups();
+        // Under two-phase, the queued (Phase 1) prefetch only covers predicate columns; the
+        // projection columns are fetched synchronously in advanceRowGroup once the survivor mask
+        // is known. We therefore size the breaker reservation, the I/O ranges, and the column
+        // set against the same, smaller column subset.
+        Set<String> phaseColumns = useTwoPhase ? predicateColumnPaths : projectedColumnPaths;
         int nextOrdinal = fromOrdinal;
         while (pendingPrefetches.size() < prefetchDepth && nextOrdinal < rowGroups.size()) {
             BlockMetaData nextBlock = rowGroups.get(nextOrdinal);
-            long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, projectedColumnPaths);
+            long prefetchBytes = ColumnChunkPrefetcher.computePrefetchBytes(nextBlock, phaseColumns);
             if (prefetchBytes <= 0) {
                 nextOrdinal = nextSurvivingRowGroupOrdinal(nextOrdinal + 1);
                 continue;
@@ -234,6 +303,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             try {
                 RowRanges nextRowRanges = allRowRanges != null && nextOrdinal < allRowRanges.length ? allRowRanges[nextOrdinal] : null;
                 if (lateMaterialization) {
+                    // Late-mat (single-phase or two-phase) handles row-level filtering itself via
+                    // the survivor mask and would double-filter if ColumnIndex RowRanges were
+                    // applied to the predicate-column prefetch here.
                     nextRowRanges = null;
                 }
                 CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future;
@@ -241,14 +313,14 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                     future = ColumnChunkPrefetcher.prefetchAsync(
                         storageObject,
                         nextBlock,
-                        projectedColumnPaths,
+                        phaseColumns,
                         nextRowRanges,
                         preloadedMetadata,
                         nextOrdinal,
                         nextBlock.getRowCount()
                     );
                 } else {
-                    future = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, projectedColumnPaths);
+                    future = ColumnChunkPrefetcher.prefetchAsync(storageObject, nextBlock, phaseColumns);
                 }
                 pendingPrefetches.addLast(new PendingPrefetch(nextOrdinal, future, prefetchBytes));
             } catch (Exception e) {
@@ -296,6 +368,112 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         return paths;
     }
 
+    /**
+     * Builds an immutable subset of {@link #projectedColumnPaths}: when {@code wantPredicate} is
+     * {@code true} the result contains the dotted paths of predicate columns, otherwise it
+     * contains the projection-only columns (i.e., projected columns that are not predicate
+     * columns).
+     */
+    private static Set<String> buildColumnPaths(ColumnInfo[] columnInfos, boolean[] isPredicateColumn, boolean wantPredicate) {
+        Set<String> paths = new HashSet<>();
+        for (int i = 0; i < columnInfos.length; i++) {
+            if (columnInfos[i] != null && isPredicateColumn[i] == wantPredicate) {
+                paths.add(String.join(".", columnInfos[i].descriptor().getPath()));
+            }
+        }
+        return paths;
+    }
+
+    /**
+     * Predicate-byte ratio threshold above which two-phase I/O is disabled because the projection
+     * columns are not large enough relative to predicate columns to justify the extra round trip.
+     * The single-phase late-mat path remains in effect in that case. A separate, lower threshold
+     * than {@code LATE_MATERIALIZATION_PREDICATE_RATIO_THRESHOLD} is intentional: late-mat already
+     * pays off at 50% predicate share, but two-phase amortizes a sequential dependency and only
+     * wins when the projection columns clearly dominate.
+     */
+    static final double TWO_PHASE_PREDICATE_BYTE_RATIO_THRESHOLD = 0.4;
+
+    /**
+     * Returns {@code true} when the iterator should run with two-phase I/O for the lifetime of
+     * this scan. The decision is fixed at construction time so the prefetch pipeline and the
+     * decode loop can specialize accordingly without per-row-group branching.
+     *
+     * <p>Two-phase requires (a) late materialization to be active, (b) at least one
+     * projection-only column (otherwise Phase 2 has nothing to fetch), (c) a storage object that
+     * benefits from skipping bytes (i.e., remote — proxied here via
+     * {@link StorageObject#supportsNativeAsync()} since all remote backends override it and
+     * local files do not), (d) no list columns (their decode path needs a unified
+     * {@code ColumnReadStoreImpl} that we don't split between predicate and projection stores),
+     * and (e) the projected bytes must be dominated by projection-only columns rather than
+     * predicate columns.
+     */
+    private static boolean shouldUseTwoPhase(
+        boolean lateMaterialization,
+        StorageObject storageObject,
+        ColumnInfo[] columnInfos,
+        boolean[] isPredicateColumn,
+        List<BlockMetaData> rowGroups,
+        Set<String> projectedColumnPaths,
+        Set<String> predicateColumnPaths,
+        Set<String> projectionOnlyColumnPaths,
+        String fileLocation
+    ) {
+        if (lateMaterialization == false) {
+            return false;
+        }
+        if (projectionOnlyColumnPaths.isEmpty() || predicateColumnPaths.isEmpty()) {
+            return false;
+        }
+        if (storageObject == null || storageObject.supportsNativeAsync() == false) {
+            return false;
+        }
+        for (ColumnInfo info : columnInfos) {
+            if (info != null && info.maxRepLevel() > 0) {
+                // List columns need a single ColumnReadStoreImpl across all columns of a row
+                // group; we'd have to either build that store from a merged page-read store or
+                // teach two-phase about list decoding. Defer to follow-up work and stay on the
+                // single-phase path when any list column appears.
+                return false;
+            }
+        }
+        long predicateBytes = 0;
+        long totalBytes = 0;
+        for (BlockMetaData block : rowGroups) {
+            for (ColumnChunkMetaData col : block.getColumns()) {
+                String path = col.getPath().toDotString();
+                if (projectedColumnPaths.contains(path) == false) {
+                    continue;
+                }
+                long size = col.getTotalSize();
+                totalBytes += size;
+                if (predicateColumnPaths.contains(path)) {
+                    predicateBytes += size;
+                }
+            }
+        }
+        if (totalBytes <= 0) {
+            return false;
+        }
+        double ratio = (double) predicateBytes / totalBytes;
+        if (ratio >= TWO_PHASE_PREDICATE_BYTE_RATIO_THRESHOLD) {
+            logger.debug(
+                "Two-phase I/O disabled for [{}]: predicate columns occupy [{}%] of projected bytes (>= threshold [{}%])",
+                fileLocation,
+                (long) (ratio * 100),
+                (long) (TWO_PHASE_PREDICATE_BYTE_RATIO_THRESHOLD * 100)
+            );
+            return false;
+        }
+        logger.debug(
+            "Two-phase I/O enabled for [{}]: predicate columns occupy [{}%] of projected bytes, projection-only columns [{}]",
+            fileLocation,
+            (long) (ratio * 100),
+            projectionOnlyColumnPaths.size()
+        );
+        return true;
+    }
+
     private static boolean[] classifyPredicateColumns(
         List<Attribute> attributes,
         ColumnInfo[] columnInfos,
@@ -332,6 +510,14 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             exhausted = true;
             return false;
         }
+        // Under two-phase, drain leading fully-filtered batches before deciding: the source-row
+        // counter would otherwise claim there is data when every remaining batch is empty.
+        if (twoPhase != null) {
+            drainEmptyTwoPhaseBatches();
+            if (twoPhase != null && twoPhase.hasMoreBatches() == false) {
+                rowsRemainingInGroup = 0;
+            }
+        }
         if (rowsRemainingInGroup > 0) {
             return true;
         }
@@ -346,72 +532,136 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     }
 
     /**
+     * Skips past any leading fully-filtered batches in the current two-phase row group, advancing
+     * the projection {@link PageColumnReader}s by the same number of source rows so subsequent
+     * survivor-bearing batches stay aligned with their internal row cursor.
+     */
+    private void drainEmptyTwoPhaseBatches() {
+        TwoPhaseRowGroup state = twoPhase;
+        while (state.hasMoreBatches() && state.currentSurvivorCount() == 0) {
+            int skippedSource = state.currentSourceRows();
+            advanceProjectionReadersBy(skippedSource);
+            Block[] empty = state.takeCurrentPredicateBlocks();
+            Releasables.closeExpectNoException(empty);
+            pageBatchIndexInRowGroup++;
+            rowsRemainingInGroup -= skippedSource;
+        }
+    }
+
+    /**
      * Advances to the next surviving row group: applies the row-group statistics filter to skip
      * dropped row groups, then builds a {@link PrefetchedPageReadStore} from the prefetched
      * (or sync-fetched) bytes for the surviving row group. Triggers prefetch for the row group
      * after that.
      */
     private boolean advanceRowGroup() throws IOException {
+        closeTwoPhaseState();
         if (rowGroup != null) {
             rowGroup.close();
             rowGroup = null;
         }
 
-        int nextOrdinal = nextSurvivingRowGroupOrdinal(rowGroupOrdinal + 1);
-        if (nextOrdinal >= reader.getRowGroups().size()) {
-            exhausted = true;
-            cancelPendingPrefetch();
-            releaseCurrentReservation();
-            if (rowsEliminatedByLateMaterialization > 0) {
-                logger.debug("Late materialization eliminated [{}] rows in [{}]", rowsEliminatedByLateMaterialization, fileLocation);
+        // Loop is for the two-phase "all rows filtered out" case, where the current row group
+        // contributes zero rows and we must immediately attempt the next surviving ordinal.
+        // Single-phase always returns within the first iteration via the standard return below.
+        while (true) {
+            int nextOrdinal = nextSurvivingRowGroupOrdinal(rowGroupOrdinal + 1);
+            if (nextOrdinal >= reader.getRowGroups().size()) {
+                exhausted = true;
+                cancelPendingPrefetch();
+                releaseCurrentReservation();
+                logIteratorDiagnostics();
+                return false;
             }
-            if (rowGroupsWithTrivialFilter > 0) {
-                logger.debug(
-                    "Trivially-passes guard skipped late-materialization for [{}] row groups in [{}]",
-                    rowGroupsWithTrivialFilter,
-                    fileLocation
-                );
-            }
-            return false;
-        }
-        rowGroupOrdinal = nextOrdinal;
-        pageBatchIndexInRowGroup = 0;
+            rowGroupOrdinal = nextOrdinal;
+            pageBatchIndexInRowGroup = 0;
 
-        BlockMetaData block = reader.getRowGroups().get(rowGroupOrdinal);
-        // Per-row-group trivially-passes check: when stats prove every row matches the filter,
-        // the late-materialization machinery (decode predicate columns → evaluate filter → compact
-        // survivors) is pure overhead. Switching to the standard path eliminates filter evaluation.
-        currentRowGroupTriviallyPasses = triviallyPassesPredicate != null && TriviallyPassesChecker.check(triviallyPassesPredicate, block);
-        if (currentRowGroupTriviallyPasses) {
-            rowGroupsWithTrivialFilter++;
+            BlockMetaData block = reader.getRowGroups().get(rowGroupOrdinal);
+            // Per-row-group trivially-passes check: when stats prove every row matches the
+            // filter, the late-materialization machinery (decode predicate columns → evaluate
+            // filter → compact survivors) is pure overhead. Switching to the standard path
+            // eliminates filter evaluation. Note: when the trivially-passes case applies we
+            // also force the single-phase code path even if useTwoPhase is enabled, since
+            // there are no survivors-only pages to skip in Phase 2.
+            currentRowGroupTriviallyPasses = triviallyPassesPredicate != null
+                && TriviallyPassesChecker.check(triviallyPassesPredicate, block);
+            if (currentRowGroupTriviallyPasses) {
+                rowGroupsWithTrivialFilter++;
+            }
+            NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = takePendingPrefetch(rowGroupOrdinal);
+            try {
+                if (useTwoPhase) {
+                    if (currentRowGroupTriviallyPasses) {
+                        // Phase-1 chunks contain only predicate columns; the trivially-passes path
+                        // bypasses late-mat entirely and decodes every projected column through
+                        // {@link #nextStandard}. Synchronously fetch the projection columns now so
+                        // the standard read path sees a complete row-group store.
+                        prepareTwoPhaseTriviallyPassesRowGroup(block, chunks);
+                        triggerNextRowGroupPrefetch();
+                        return rowsRemainingInGroup > 0;
+                    }
+                    // Two-phase decode: pre-decode predicate columns from chunks, accumulate the
+                    // global survivor mask, fetch projection columns for surviving pages only, and
+                    // emit per-batch results in nextTwoPhaseBatch. When all rows are filtered out
+                    // we drop the row group entirely and continue with the next survivor.
+                    boolean prepared = prepareTwoPhaseRowGroup(block, chunks);
+                    if (prepared == false) {
+                        // All rows filtered out; loop and try the next surviving row group.
+                        continue;
+                    }
+                    triggerNextRowGroupPrefetch();
+                    return rowsRemainingInGroup > 0;
+                }
+
+                RowRanges currentRowRanges = resolveCurrentRowRanges(block);
+                // When late materialization is active, skip ColumnIndex page filtering — late-mat
+                // handles row-level filtering itself via the survivor mask. Applying both
+                // ColumnIndex RowRanges AND late-mat evaluation causes double-filtering that
+                // drops rows incorrectly. The trivially-passes case is handled the same way:
+                // we already know all rows match, so leaving page filtering off is consistent and
+                // safe (RowRanges would be all() anyway).
+                RowRanges buildRowRanges = lateMaterialization ? null : currentRowRanges;
+                rowGroup = PrefetchedRowGroupBuilder.build(
+                    block,
+                    rowGroupOrdinal,
+                    projectedSchema,
+                    projectedColumnPaths,
+                    buildRowRanges,
+                    preloadedMetadata,
+                    chunks,
+                    storageObject,
+                    codecFactory
+                );
+                rowsRemainingInGroup = buildRowRanges != null ? buildRowRanges.selectedRowCount() : rowGroup.getRowCount();
+                triggerNextRowGroupPrefetch();
+                initColumnReaders(buildRowRanges);
+                return rowsRemainingInGroup > 0;
+            } catch (Exception e) {
+                releaseCurrentReservation();
+                throw e;
+            }
         }
-        NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks = takePendingPrefetch(rowGroupOrdinal);
-        try {
-            RowRanges currentRowRanges = resolveCurrentRowRanges(block);
-            // When late materialization is active, skip ColumnIndex page filtering — late-mat handles
-            // row-level filtering itself via the survivor mask. Applying both ColumnIndex RowRanges
-            // AND late-mat evaluation causes double-filtering that drops rows incorrectly.
-            // The trivially-passes case is handled the same way: we already know all rows match,
-            // so leaving page filtering off is consistent and safe (RowRanges would be all() anyway).
-            RowRanges buildRowRanges = lateMaterialization ? null : currentRowRanges;
-            rowGroup = PrefetchedRowGroupBuilder.build(
-                block,
-                rowGroupOrdinal,
-                projectedSchema,
-                projectedColumnPaths,
-                buildRowRanges,
-                preloadedMetadata,
-                chunks,
-                storageObject,
-                codecFactory
+    }
+
+    private void logIteratorDiagnostics() {
+        if (rowsEliminatedByLateMaterialization > 0) {
+            logger.debug("Late materialization eliminated [{}] rows in [{}]", rowsEliminatedByLateMaterialization, fileLocation);
+        }
+        if (rowGroupsWithTrivialFilter > 0) {
+            logger.debug(
+                "Trivially-passes guard skipped late-materialization for [{}] row groups in [{}]",
+                rowGroupsWithTrivialFilter,
+                fileLocation
             );
-            rowsRemainingInGroup = buildRowRanges != null ? buildRowRanges.selectedRowCount() : rowGroup.getRowCount();
-            triggerNextRowGroupPrefetch();
-            initColumnReaders(buildRowRanges);
-            return rowsRemainingInGroup > 0;
-        } catch (Exception e) {
-            releaseCurrentReservation();
-            throw e;
+        }
+        if (twoPhaseRowGroupsWithPageSkipping > 0 || twoPhaseRowGroupsFullProjectionFetch > 0 || twoPhaseRowGroupsAllFiltered > 0) {
+            logger.debug(
+                "Two-phase I/O for [{}]: page-skipping [{}], full-projection-fetch [{}], all-filtered [{}]",
+                fileLocation,
+                twoPhaseRowGroupsWithPageSkipping,
+                twoPhaseRowGroupsFullProjectionFetch,
+                twoPhaseRowGroupsAllFiltered
+            );
         }
     }
 
@@ -466,6 +716,414 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 + rowGroupOrdinal
                 + "]";
         return allRowRanges[rowGroupOrdinal];
+    }
+
+    /**
+     * Phase 1 of the two-phase decode pipeline: decodes predicate columns, accumulates a
+     * row-group-wide survivor mask, then issues a synchronous Phase-2 prefetch for the
+     * projection columns and stitches the decoded predicate blocks together with projection
+     * {@link PageColumnReader}s ready to emit per-batch.
+     *
+     * @param block metadata for the row group being prepared
+     * @param phase1Chunks Phase-1 prefetched chunks (predicate columns only); may be {@code null}
+     *            when the prefetch failed and we need to fall back to a synchronous phase-1 build
+     * @return {@code true} if the row group has at least one surviving row and is ready to emit;
+     *         {@code false} when every row was filtered out and the iterator should advance to
+     *         the next surviving row group ordinal
+     */
+    private boolean prepareTwoPhaseRowGroup(BlockMetaData block, NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> phase1Chunks) {
+        long rowGroupRowCount = block.getRowCount();
+        if (rowGroupRowCount > Integer.MAX_VALUE) {
+            throw new IllegalStateException(
+                "Two-phase decode does not support row groups with more than Integer.MAX_VALUE rows; row group ["
+                    + rowGroupOrdinal
+                    + "] in ["
+                    + fileLocation
+                    + "] has ["
+                    + rowGroupRowCount
+                    + "] rows"
+            );
+        }
+        // Build predicate-only PageReadStore. We pass predicateColumnPaths so PrefetchedRowGroupBuilder
+        // skips projection columns entirely; phase1Chunks were prefetched for the same subset, so
+        // the storeObject fallback should not be needed except when prefetch failed (handled below
+        // via the standard PrefetchedRowGroupBuilder.build code path).
+        PrefetchedPageReadStore predicateStore = PrefetchedRowGroupBuilder.build(
+            block,
+            rowGroupOrdinal,
+            projectedSchema,
+            predicateColumnPaths,
+            null,
+            preloadedMetadata,
+            phase1Chunks,
+            storageObject,
+            codecFactory
+        );
+        rowGroup = predicateStore;
+        initPredicateColumnReaders();
+
+        // Pre-decode all predicate batches for this row group, accumulating the global survivor
+        // mask. Predicate compacted blocks stay live in TwoPhaseRowGroup; we re-emit them
+        // alongside fresh projection blocks during nextWithTwoPhase.
+        WordMask globalSurvivors = new WordMask();
+        globalSurvivors.reset((int) rowGroupRowCount);
+        List<Block[]> predicateBatches = new ArrayList<>();
+        List<int[]> survivorPositionsPerBatch = new ArrayList<>();
+        List<Integer> sourceRowsPerBatch = new ArrayList<>();
+        List<Integer> survivorCountsPerBatch = new ArrayList<>();
+        long totalSurvivors = 0;
+        long rowsConsumed = 0;
+        try {
+            while (rowsConsumed < rowGroupRowCount) {
+                int rowsToRead = (int) Math.min(batchSize, rowGroupRowCount - rowsConsumed);
+                BatchPredicateResult batch = decodePredicateBatch(rowsToRead, (int) rowsConsumed, globalSurvivors);
+                predicateBatches.add(batch.compactedPredicateBlocks);
+                survivorPositionsPerBatch.add(batch.survivorPositions);
+                survivorCountsPerBatch.add(batch.survivorCount);
+                sourceRowsPerBatch.add(rowsToRead);
+                totalSurvivors += batch.survivorCount;
+                rowsConsumed += rowsToRead;
+            }
+        } catch (Exception e) {
+            for (Block[] arr : predicateBatches) {
+                Releasables.closeExpectNoException(arr);
+            }
+            throw e;
+        }
+
+        // Predicate readers are exhausted; their per-column dictionary caches are still useful
+        // only if we kept reading predicates, which we don't. Releasing them now frees the
+        // BytesRefArray refcounts before we hand the projection store to the same field.
+        closePageColumnReaders();
+        rowGroup.close();
+        rowGroup = null;
+        // Phase 1 chunks are no longer referenced by any reader: dictionary entries were
+        // deep-copied into their own BytesRefArray, plain values were copied into compacted
+        // predicate Blocks, and the page-column-readers themselves have been closed. Releasing
+        // the breaker reservation here halves the memory footprint during Phase 2 fetch +
+        // decode, which is the regime where the iterator typically holds the most memory.
+        releaseCurrentReservation();
+
+        if (totalSurvivors == 0) {
+            twoPhaseRowGroupsAllFiltered++;
+            rowsEliminatedByLateMaterialization += rowGroupRowCount;
+            for (Block[] arr : predicateBatches) {
+                Releasables.closeExpectNoException(arr);
+            }
+            return false;
+        }
+        rowsEliminatedByLateMaterialization += (rowGroupRowCount - totalSurvivors);
+
+        RowRanges survivorRanges = WordMaskRowRangesConverter.fromWordMask(globalSurvivors, rowGroupRowCount);
+        // Phase-2 fetch path:
+        // - If projection-only columns is empty (shouldn't happen because the gate excludes that
+        // case, but defend against it): no fetch needed, projection store is empty.
+        // - If survivorRanges.shouldDiscard(): the survivors are too dense or fragmented to
+        // benefit from page skipping; fetch full projection chunks instead.
+        // - Otherwise: fetch only pages that overlap survivor ranges.
+        boolean usePageFiltering = survivorRanges.shouldDiscard() == false;
+        PrefetchedPageReadStore projectionStore;
+        try {
+            projectionStore = fetchProjectionPhase(block, survivorRanges, usePageFiltering);
+        } catch (RuntimeException e) {
+            for (Block[] arr : predicateBatches) {
+                Releasables.closeExpectNoException(arr);
+            }
+            throw e;
+        }
+        if (usePageFiltering) {
+            twoPhaseRowGroupsWithPageSkipping++;
+        } else {
+            twoPhaseRowGroupsFullProjectionFetch++;
+        }
+
+        TwoPhaseRowGroup state = new TwoPhaseRowGroup(
+            predicateBatches,
+            survivorPositionsPerBatch,
+            toIntArray(survivorCountsPerBatch),
+            toIntArray(sourceRowsPerBatch),
+            totalSurvivors,
+            projectionStore,
+            // Pass the survivor RowRanges to the projection PageColumnReaders only when page
+            // filtering is actually in play; otherwise we have full chunks and the readers
+            // should not skip pages.
+            usePageFiltering ? survivorRanges : null
+        );
+        this.twoPhase = state;
+        // The iterator's row counter tracks source rows so existing per-batch bookkeeping
+        // (row budget, batch index, etc.) keeps working unchanged. Survivor count is
+        // applied per-batch via TwoPhaseRowGroup state.
+        rowsRemainingInGroup = rowGroupRowCount;
+        rowGroup = projectionStore;
+        initProjectionColumnReaders(state.survivorRowRanges());
+        return true;
+    }
+
+    /**
+     * Decodes one batch of predicate columns and updates {@code globalSurvivors} for the rows
+     * that survived. Returns the compacted predicate {@link Block}s for the batch alongside the
+     * per-batch survivor positions used to align projection column decoding.
+     *
+     * <p>The per-batch survivor mask is materialized inside {@code pushedExpressions.evaluateFilter}
+     * which reuses {@link #survivorMask}; we then OR-set the corresponding bits into
+     * {@code globalSurvivors} at offset {@code rowsConsumedSoFar}.
+     */
+    private BatchPredicateResult decodePredicateBatch(int rowsToRead, int rowsConsumedSoFar, WordMask globalSurvivors) {
+        Block[] predicateBlocks = new Block[attributes.size()];
+        Map<String, Block> predicateBlockMap = new HashMap<>();
+        try {
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (isPredicateColumn[col] == false) {
+                    continue;
+                }
+                ColumnInfo info = columnInfos[col];
+                if (info == null) {
+                    predicateBlocks[col] = blockFactory.newConstantNullBlock(rowsToRead);
+                } else {
+                    predicateBlocks[col] = readColumnBlockWithAttribution(col, info, rowsToRead, predicateBlocks);
+                }
+                predicateBlockMap.put(attributes.get(col).name(), predicateBlocks[col]);
+            }
+            WordMask mask = pushedExpressions.evaluateFilter(predicateBlockMap, rowsToRead, survivorMask);
+            int survivorCount;
+            int[] positions;
+            if (mask == null) {
+                // All rows survive in this batch.
+                survivorCount = rowsToRead;
+                positions = null;
+                // Mark all rowsToRead bits in the global mask.
+                globalSurvivors.setRange(rowsConsumedSoFar, rowsConsumedSoFar + rowsToRead);
+            } else {
+                survivorCount = mask.popCount();
+                positions = survivorCount == 0 || survivorCount == rowsToRead ? null : mask.survivingPositions();
+                if (survivorCount == rowsToRead) {
+                    globalSurvivors.setRange(rowsConsumedSoFar, rowsConsumedSoFar + rowsToRead);
+                } else if (survivorCount > 0) {
+                    int[] toMark = positions != null ? positions : mask.survivingPositions();
+                    for (int p : toMark) {
+                        globalSurvivors.set(rowsConsumedSoFar + p);
+                    }
+                }
+            }
+            // Compact predicate blocks to surviving rows. When all rows survive (positions==null
+            // and survivorCount==rowsToRead) we keep the full-size blocks as-is.
+            if (positions != null) {
+                for (int col = 0; col < columnInfos.length; col++) {
+                    if (isPredicateColumn[col] && predicateBlocks[col] != null) {
+                        predicateBlocks[col] = PageColumnReader.filterBlock(predicateBlocks[col], positions, survivorCount, blockFactory);
+                    }
+                }
+            } else if (survivorCount == 0) {
+                // Nothing survives: drop the predicate blocks; the batch contributes 0 rows.
+                for (int col = 0; col < columnInfos.length; col++) {
+                    if (predicateBlocks[col] != null) {
+                        predicateBlocks[col].close();
+                        predicateBlocks[col] = null;
+                    }
+                }
+            }
+            return new BatchPredicateResult(predicateBlocks, positions, survivorCount);
+        } catch (RuntimeException e) {
+            Releasables.closeExpectNoException(predicateBlocks);
+            throw e;
+        }
+    }
+
+    /** Result of decoding and filtering a single predicate-column batch under two-phase. */
+    private record BatchPredicateResult(Block[] compactedPredicateBlocks, int[] survivorPositions, int survivorCount) {}
+
+    /**
+     * Variant of {@link #prepareTwoPhaseRowGroup} for the trivially-passes case: every row matches
+     * the filter, so late-materialization is bypassed and the standard read path is used. The
+     * Phase-1 chunks already include the predicate columns; we synchronously fetch the projection
+     * columns and merge them into a unified row-group store so {@link #nextStandard} can read all
+     * columns from a single store.
+     */
+    private void prepareTwoPhaseTriviallyPassesRowGroup(
+        BlockMetaData block,
+        NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> phase1Chunks
+    ) {
+        long projectionBytes = ColumnChunkPrefetcher.computePrefetchBytes(block, projectionOnlyColumnPaths);
+        long phase1Reserved = currentReservedBytes;
+        if (projectionBytes > 0) {
+            try {
+                breaker.addEstimateBytesAndMaybeBreak(projectionBytes, "esql_parquet_phase2");
+            } catch (CircuitBreakingException e) {
+                logger.debug(
+                    "Trivially-passes Phase-2 reservation failed for row group [{}] in [{}] ({} bytes): {}",
+                    rowGroupOrdinal,
+                    fileLocation,
+                    projectionBytes,
+                    e.getMessage()
+                );
+                throw e;
+            }
+        }
+        NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> phase2Chunks;
+        try {
+            phase2Chunks = ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projectionOnlyColumnPaths).join();
+        } catch (Exception e) {
+            if (projectionBytes > 0) {
+                breaker.addWithoutBreaking(-projectionBytes);
+            }
+            throw new ElasticsearchException(
+                "Trivially-passes Phase-2 fetch failed for row group ["
+                    + rowGroupOrdinal
+                    + "] in ["
+                    + fileLocation
+                    + "]: "
+                    + e.getMessage(),
+                e
+            );
+        }
+        // Merge the two chunk maps. Both phases prefetched disjoint columns (predicate vs.
+        // projection-only), so file offsets cannot collide.
+        NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> merged = new TreeMap<>();
+        if (phase1Chunks != null) {
+            merged.putAll(phase1Chunks);
+        }
+        if (phase2Chunks != null) {
+            merged.putAll(phase2Chunks);
+        }
+        currentReservedBytes = phase1Reserved + projectionBytes;
+        rowGroup = PrefetchedRowGroupBuilder.build(
+            block,
+            rowGroupOrdinal,
+            projectedSchema,
+            projectedColumnPaths,
+            null,
+            preloadedMetadata,
+            merged,
+            storageObject,
+            codecFactory
+        );
+        rowsRemainingInGroup = rowGroup.getRowCount();
+        initColumnReaders(null);
+    }
+
+    /**
+     * Synchronously fetches the Phase-2 (projection-only) chunks for the current row group,
+     * reserves the appropriate amount on the circuit breaker, and builds the projection
+     * {@link PrefetchedPageReadStore}.
+     *
+     * @param block metadata for the row group
+     * @param survivorRanges row ranges of survivors as produced by {@link WordMaskRowRangesConverter}
+     * @param usePageFiltering when {@code true}, only pages overlapping {@code survivorRanges}
+     *            are fetched; when {@code false}, full column chunks are fetched (i.e., page
+     *            filtering would not pay off because survivors are too dense or fragmented)
+     */
+    private PrefetchedPageReadStore fetchProjectionPhase(BlockMetaData block, RowRanges survivorRanges, boolean usePageFiltering) {
+        long projectionBytes;
+        if (usePageFiltering) {
+            // Mirror what ColumnChunkPrefetcher.computeFilteredPageRanges will allocate, including
+            // the dictionary pages and merged adjacencies. Reusing the helper keeps the breaker
+            // estimate consistent with the actual coalesced fetch.
+            List<CoalescedRangeReader.ByteRange> ranges = ColumnChunkPrefetcher.computeFilteredPageRanges(
+                block,
+                survivorRanges,
+                preloadedMetadata,
+                rowGroupOrdinal,
+                projectionOnlyColumnPaths,
+                block.getRowCount()
+            );
+            long total = 0;
+            for (CoalescedRangeReader.ByteRange r : ranges) {
+                total += r.length();
+            }
+            projectionBytes = total;
+        } else {
+            projectionBytes = ColumnChunkPrefetcher.computePrefetchBytes(block, projectionOnlyColumnPaths);
+        }
+        if (projectionBytes > 0) {
+            try {
+                breaker.addEstimateBytesAndMaybeBreak(projectionBytes, "esql_parquet_phase2");
+            } catch (CircuitBreakingException e) {
+                logger.debug(
+                    "Phase 2 prefetch reservation failed for row group [{}] in [{}] ({} bytes): {}",
+                    rowGroupOrdinal,
+                    fileLocation,
+                    projectionBytes,
+                    e.getMessage()
+                );
+                throw e;
+            }
+        }
+
+        NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk> chunks;
+        try {
+            CompletableFuture<NavigableMap<Long, ColumnChunkPrefetcher.PrefetchedChunk>> future = usePageFiltering
+                ? ColumnChunkPrefetcher.prefetchAsync(
+                    storageObject,
+                    block,
+                    projectionOnlyColumnPaths,
+                    survivorRanges,
+                    preloadedMetadata,
+                    rowGroupOrdinal,
+                    block.getRowCount()
+                )
+                : ColumnChunkPrefetcher.prefetchAsync(storageObject, block, projectionOnlyColumnPaths);
+            chunks = future.join();
+        } catch (Exception e) {
+            // Release the reservation we just made; it isn't pinned to a row-group store yet.
+            if (projectionBytes > 0) {
+                breaker.addWithoutBreaking(-projectionBytes);
+            }
+            throw new ElasticsearchException(
+                "Phase 2 prefetch failed for row group [" + rowGroupOrdinal + "] in [" + fileLocation + "]: " + e.getMessage(),
+                e
+            );
+        }
+        // Pin the Phase-2 reservation to the standard `currentReservedBytes` field so the existing
+        // advance / close path releases it without special-casing two-phase. The Phase-1 reservation
+        // was already released by the caller after predicate decode.
+        currentReservedBytes = projectionBytes;
+        return PrefetchedRowGroupBuilder.build(
+            block,
+            rowGroupOrdinal,
+            projectedSchema,
+            projectionOnlyColumnPaths,
+            usePageFiltering ? survivorRanges : null,
+            preloadedMetadata,
+            chunks,
+            storageObject,
+            codecFactory
+        );
+    }
+
+    /**
+     * Initializes {@link #pageColumnReaders} for predicate columns only. Projection-only columns
+     * are intentionally left {@code null}; the iterator routes their decode through
+     * {@link #initProjectionColumnReaders} once Phase 2 has materialized.
+     */
+    private void initPredicateColumnReaders() {
+        closePageColumnReaders();
+        pageColumnReaders = new PageColumnReader[columnInfos.length];
+        columnReaders = null;
+        for (int i = 0; i < columnInfos.length; i++) {
+            if (columnInfos[i] != null && isPredicateColumn[i] && columnInfos[i].maxRepLevel() == 0) {
+                ColumnDescriptor desc = columnInfos[i].descriptor();
+                PageReader pr = rowGroup.getPageReader(desc);
+                pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], null);
+            }
+        }
+    }
+
+    /**
+     * Initializes {@link #pageColumnReaders} for projection-only columns under the projection
+     * {@link PrefetchedPageReadStore}. Predicate columns stay {@code null} because their decoded
+     * blocks are already cached inside {@link #twoPhase}.
+     */
+    private void initProjectionColumnReaders(RowRanges survivorRowRanges) {
+        closePageColumnReaders();
+        pageColumnReaders = new PageColumnReader[columnInfos.length];
+        columnReaders = null;
+        for (int i = 0; i < columnInfos.length; i++) {
+            if (columnInfos[i] != null && isPredicateColumn[i] == false && columnInfos[i].maxRepLevel() == 0) {
+                ColumnDescriptor desc = columnInfos[i].descriptor();
+                PageReader pr = rowGroup.getPageReader(desc);
+                pageColumnReaders[i] = new PageColumnReader(pr, desc, columnInfos[i], survivorRowRanges);
+            }
+        }
     }
 
     private void initColumnReaders(RowRanges currentRowRanges) {
@@ -598,6 +1256,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         if (hasNext() == false) {
             throw new NoSuchElementException();
         }
+        if (twoPhase != null) {
+            return nextTwoPhaseBatch();
+        }
         int effectiveBatch = batchSize;
         if (rowBudget != FormatReader.NO_LIMIT) {
             effectiveBatch = Math.min(effectiveBatch, rowBudget);
@@ -613,6 +1274,183 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             rowBudget -= useLateMaterialization ? result.getPositionCount() : rowsToRead;
         }
         return result;
+    }
+
+    /**
+     * Emits the next batch under two-phase decoding. The predicate columns for the batch were
+     * already decoded and compacted in {@link #prepareTwoPhaseRowGroup}; this method only has
+     * to fetch the corresponding projection-column slice from the (already in-memory) projection
+     * store and combine the two halves into a {@link Page}.
+     *
+     * <p>The row budget is enforced on emitted (post-filter) rows since downstream operators
+     * see survivor counts and that's what {@code rowBudget} is meant to limit. We respect both
+     * the budget and the survivor count of the current batch by emitting the smaller of the
+     * two as the first row range; if a partial slice is needed, the remainder of this batch's
+     * survivors is dropped (its predicate blocks are released so we don't leak).
+     */
+    private Page nextTwoPhaseBatch() {
+        TwoPhaseRowGroup state = twoPhase;
+        // hasNext() drains any leading fully-filtered batches before returning true, so the
+        // current cursor must point at a batch with at least one survivor by the time we get
+        // here. An assertion guards against an unexpected entry from a buggy hasNext path.
+        assert state.hasMoreBatches() && state.currentSurvivorCount() > 0
+            : "nextTwoPhaseBatch invoked on empty/missing batch (hasNext should have advanced or returned false)";
+        int sourceRows = state.currentSourceRows();
+        int survivorCount = state.currentSurvivorCount();
+        int[] survivorPositions = state.currentSurvivorPositions();
+        Block[] predicateBlocks = state.takeCurrentPredicateBlocks();
+
+        // Apply the row budget to survivor count: if the budget is smaller than the number of
+        // surviving rows in this batch, truncate predicate and projection blocks to the first
+        // {@code rowBudget} survivors and mark the iterator as exhausted after emission. We
+        // re-slice predicate blocks via {@link #sliceBlockHead} (cheap because they're already
+        // compacted) and pass {@code emitCount} to the projection read so it doesn't decode
+        // beyond the budget either.
+        int emitCount = survivorCount;
+        boolean budgetExhaustsBatch = false;
+        if (rowBudget != FormatReader.NO_LIMIT && rowBudget < emitCount) {
+            // Truncate this batch to the remaining budget: keep the first `rowBudget` survivors.
+            // We rebuild a positions array for the slice when needed.
+            int newCount = rowBudget;
+            int[] truncated;
+            if (survivorPositions != null) {
+                truncated = Arrays.copyOf(survivorPositions, newCount);
+            } else {
+                // All rows in this batch survived; the projection reader will read sourceRows
+                // and we'll filter to the first newCount via a synthesized positions array.
+                truncated = new int[newCount];
+                for (int i = 0; i < newCount; i++) {
+                    truncated[i] = i;
+                }
+            }
+            survivorPositions = truncated;
+            // Compact predicate blocks down to the first newCount survivors.
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (isPredicateColumn[col] && predicateBlocks[col] != null) {
+                    predicateBlocks[col] = sliceBlockHead(predicateBlocks[col], newCount);
+                }
+            }
+            emitCount = newCount;
+            budgetExhaustsBatch = true;
+        }
+
+        Block[] blocks = new Block[attributes.size()];
+        try {
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (isPredicateColumn[col]) {
+                    blocks[col] = predicateBlocks[col];
+                    continue;
+                }
+                ColumnInfo info = columnInfos[col];
+                if (info == null) {
+                    blocks[col] = blockFactory.newConstantNullBlock(emitCount);
+                    continue;
+                }
+                if (survivorCount == 0) {
+                    // Should not happen — TwoPhaseRowGroup never queues a fully-empty batch
+                    // (those are dropped before reaching here). Defensive null block.
+                    blocks[col] = blockFactory.newConstantNullBlock(0);
+                    continue;
+                }
+                if (survivorPositions == null) {
+                    // All sourceRows survived this batch.
+                    blocks[col] = readColumnBlockWithAttribution(col, info, sourceRows, blocks);
+                    if (budgetExhaustsBatch) {
+                        blocks[col] = sliceBlockHead(blocks[col], emitCount);
+                    }
+                } else if (pageColumnReaders != null && pageColumnReaders[col] != null) {
+                    blocks[col] = pageColumnReaders[col].readBatchFiltered(sourceRows, blockFactory, survivorPositions, emitCount);
+                } else {
+                    Block fullBlock = readColumnBlockWithAttribution(col, info, sourceRows, blocks);
+                    blocks[col] = PageColumnReader.filterBlock(fullBlock, survivorPositions, emitCount, blockFactory);
+                }
+            }
+            // Predicate slot ownership has been transferred into blocks[]; clear references in
+            // predicateBlocks[] so the failure path below does not double-close them.
+            for (int col = 0; col < columnInfos.length; col++) {
+                if (isPredicateColumn[col]) {
+                    predicateBlocks[col] = null;
+                }
+            }
+        } catch (CircuitBreakingException e) {
+            // Surface breaker failures unwrapped, matching nextStandard / nextWithLateMaterialization
+            // so upstream operators (LIMIT, exchange, breaker telemetry) classify them correctly.
+            Releasables.closeExpectNoException(blocks);
+            Releasables.closeExpectNoException(predicateBlocks);
+            throw e;
+        } catch (RuntimeException e) {
+            Releasables.closeExpectNoException(blocks);
+            Releasables.closeExpectNoException(predicateBlocks);
+            throw new ElasticsearchException(
+                "Failed to emit two-phase Page at row group ["
+                    + (rowGroupOrdinal + 1)
+                    + "] batch ["
+                    + state.nextBatchIndex()
+                    + "] in file ["
+                    + fileLocation
+                    + "]: "
+                    + e.getMessage(),
+                e
+            );
+        }
+
+        pageBatchIndexInRowGroup++;
+        rowsRemainingInGroup -= sourceRows;
+        if (rowBudget != FormatReader.NO_LIMIT) {
+            rowBudget -= emitCount;
+        }
+        if (budgetExhaustsBatch) {
+            // Drop any remaining batches in this row group; the budget will short-circuit hasNext.
+            // Their predicate blocks will be closed via closeTwoPhaseState on next advanceRowGroup
+            // or close().
+            rowsRemainingInGroup = 0;
+        }
+        return new Page(blocks);
+    }
+
+    /**
+     * Advances every active projection {@link PageColumnReader} by {@code rows} source positions
+     * without producing blocks, so the readers stay aligned with the consumer's expected row
+     * coordinate after we discarded a fully-filtered batch.
+     */
+    private void advanceProjectionReadersBy(int rows) {
+        if (rows <= 0 || pageColumnReaders == null) {
+            return;
+        }
+        for (int col = 0; col < columnInfos.length; col++) {
+            if (isPredicateColumn[col]) {
+                continue;
+            }
+            if (pageColumnReaders[col] != null) {
+                pageColumnReaders[col].skipRows(rows);
+            }
+        }
+    }
+
+    private Block sliceBlockHead(Block source, int newCount) {
+        if (newCount == source.getPositionCount()) {
+            return source;
+        }
+        int[] head = new int[newCount];
+        for (int i = 0; i < newCount; i++) {
+            head[i] = i;
+        }
+        return PageColumnReader.filterBlock(source, head, newCount, blockFactory);
+    }
+
+    private void closeTwoPhaseState() {
+        if (twoPhase != null) {
+            twoPhase.close();
+            twoPhase = null;
+        }
+    }
+
+    private static int[] toIntArray(List<Integer> values) {
+        int[] out = new int[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            out[i] = values.get(i);
+        }
+        return out;
     }
 
     private Page nextStandard(int rowsToRead) {
@@ -817,6 +1655,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     public void close() throws IOException {
         cancelPendingPrefetch();
         try {
+            closeTwoPhaseState();
             closePageColumnReaders();
             if (rowGroup != null) {
                 rowGroup.close();

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseRowGroup.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseRowGroup.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.core.Releasables;
+
+import java.util.List;
+
+/**
+ * Per-row-group state for the two-phase late-materialization decode flow.
+ *
+ * <p>Phase 1 of {@link OptimizedParquetColumnIterator#advanceRowGroup()} fully decodes the
+ * predicate columns batch-by-batch (using the same {@code batchSize} the consumer will see),
+ * evaluates the filter, and stashes the per-batch survivor positions and the survivor-only
+ * predicate {@link Block}s here. Phase 2 then fetches only the projection columns and decodes
+ * them lazily when the consumer pulls each batch.
+ *
+ * <p>Storing the predicate blocks per batch keeps memory usage bounded by survivor count
+ * (typically tiny for a selective filter), avoids re-decoding predicate columns once the
+ * filter is known, and lets the iterator emit each batch in its original {@code rowsToRead}
+ * granularity so downstream operators see the same shape they would under single-phase.
+ */
+final class TwoPhaseRowGroup {
+
+    /**
+     * Compacted predicate-column {@link Block}s per batch, in batch order. Slot {@code [batch][col]}
+     * is the survivor-only block for column {@code col} in batch {@code batch}, or {@code null} for
+     * columns that are not predicate columns. Ownership is transferred to this object on
+     * construction; {@link #close()} closes any blocks that have not been emitted yet.
+     */
+    private final List<Block[]> predicateBlockBatches;
+    /**
+     * Per-batch survivor positions within the original (pre-compaction) batch row indices.
+     * Slot {@code i} is {@code null} when either every row in batch {@code i} survives the
+     * filter (caller treats this as identity) or no row survives (size encoded in
+     * {@link #survivorCountsPerBatch}); a non-null array otherwise lists the surviving row
+     * offsets in ascending order.
+     */
+    private final List<int[]> survivorPositionsPerBatch;
+    /**
+     * Per-batch survivor counts. When {@link #survivorPositionsPerBatch} slot {@code i} is
+     * non-null this equals its length; when null the count is either {@code sourceRowsPerBatch[i]}
+     * (all-survive) or {@code 0} (none-survive).
+     */
+    private final int[] survivorCountsPerBatch;
+    /** Per-batch source row counts (number of rows decoded in batch {@code i}, before filtering). */
+    private final int[] sourceRowsPerBatch;
+    /** Total surviving rows across all batches in this row group. */
+    private final long totalSurvivors;
+    /** Projection-column page read store keyed for the projection-only columns. */
+    private final PrefetchedPageReadStore projectionStore;
+    /** Survivor row ranges across the row group, used to seed projection {@code PageColumnReader}s. */
+    private final RowRanges survivorRowRanges;
+    /** Cursor into {@link #predicateBlockBatches} tracking the next batch to emit. */
+    private int nextBatchIndex;
+
+    TwoPhaseRowGroup(
+        List<Block[]> predicateBlockBatches,
+        List<int[]> survivorPositionsPerBatch,
+        int[] survivorCountsPerBatch,
+        int[] sourceRowsPerBatch,
+        long totalSurvivors,
+        PrefetchedPageReadStore projectionStore,
+        RowRanges survivorRowRanges
+    ) {
+        assert predicateBlockBatches.size() == survivorPositionsPerBatch.size();
+        assert predicateBlockBatches.size() == survivorCountsPerBatch.length;
+        assert predicateBlockBatches.size() == sourceRowsPerBatch.length;
+        this.predicateBlockBatches = predicateBlockBatches;
+        this.survivorPositionsPerBatch = survivorPositionsPerBatch;
+        this.survivorCountsPerBatch = survivorCountsPerBatch;
+        this.sourceRowsPerBatch = sourceRowsPerBatch;
+        this.totalSurvivors = totalSurvivors;
+        this.projectionStore = projectionStore;
+        this.survivorRowRanges = survivorRowRanges;
+    }
+
+    int batchCount() {
+        return predicateBlockBatches.size();
+    }
+
+    int nextBatchIndex() {
+        return nextBatchIndex;
+    }
+
+    boolean hasMoreBatches() {
+        return nextBatchIndex < predicateBlockBatches.size();
+    }
+
+    int currentSourceRows() {
+        return sourceRowsPerBatch[nextBatchIndex];
+    }
+
+    int currentSurvivorCount() {
+        return survivorCountsPerBatch[nextBatchIndex];
+    }
+
+    int[] currentSurvivorPositions() {
+        return survivorPositionsPerBatch.get(nextBatchIndex);
+    }
+
+    /**
+     * Returns the predicate block array for the current batch, transferring ownership of every
+     * non-null entry to the caller. Subsequent reads of the same batch return arrays whose
+     * predicate slots are {@code null}, since the blocks now belong to the caller. The cursor
+     * is advanced as a side effect, so a single call serves a single batch.
+     */
+    Block[] takeCurrentPredicateBlocks() {
+        Block[] batch = predicateBlockBatches.get(nextBatchIndex);
+        // Replace the owned references with null so close() does not double-release any block
+        // that is now held by the caller's emitted Page.
+        Block[] handed = batch.clone();
+        for (int i = 0; i < batch.length; i++) {
+            batch[i] = null;
+        }
+        nextBatchIndex++;
+        return handed;
+    }
+
+    long totalSurvivors() {
+        return totalSurvivors;
+    }
+
+    PrefetchedPageReadStore projectionStore() {
+        return projectionStore;
+    }
+
+    RowRanges survivorRowRanges() {
+        return survivorRowRanges;
+    }
+
+    /**
+     * Closes any predicate blocks that were not handed out. The projection store is not closed
+     * here — the iterator's {@code rowGroup} field owns it (or a wrapper around it) and closes
+     * it via {@link PrefetchedPageReadStore#close()} on row-group advance.
+     */
+    void close() {
+        for (Block[] batch : predicateBlockBatches) {
+            if (batch == null) {
+                continue;
+            }
+            Releasables.closeExpectNoException(batch);
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
@@ -61,10 +61,6 @@ final class WordMask {
         return words[index];
     }
 
-    int numBits() {
-        return numBits;
-    }
-
     void clear(int index) {
         words[index >>> 6] &= ~(1L << index);
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMask.java
@@ -52,6 +52,19 @@ final class WordMask {
         return (numBits + 63) >>> 6;
     }
 
+    /**
+     * Returns the raw {@code long} word at {@code index} within the backing array. Exposed for
+     * helpers that walk the mask word-by-word (e.g., survivor-run extraction); callers must
+     * apply trailing-bit masking themselves when {@code index == wordCount() - 1}.
+     */
+    long wordAt(int index) {
+        return words[index];
+    }
+
+    int numBits() {
+        return numBits;
+    }
+
     void clear(int index) {
         words[index >>> 6] &= ~(1L << index);
     }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskRowRangesConverter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskRowRangesConverter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converts a per-row {@link WordMask} representing the survivors of a late-materialization
+ * filter into a {@link RowRanges} expressed in the same row-group coordinate space. The
+ * resulting ranges are then handed to {@link ColumnChunkPrefetcher#computeFilteredPageRanges}
+ * to drive Phase-2 page-level prefetch: only data pages whose row span overlaps a surviving
+ * range are fetched from remote storage.
+ *
+ * <p>Two-phase I/O depends on this conversion to materialize a compact set of contiguous
+ * survivor runs: when the filter is highly selective (e.g., {@code Title LIKE "*foo*"}) the
+ * resulting ranges typically cover only a few percent of the row group, so the Phase-2 fetch
+ * skips the bulk of the projection column data.
+ */
+final class WordMaskRowRangesConverter {
+
+    private WordMaskRowRangesConverter() {}
+
+    /**
+     * Builds a {@link RowRanges} matching the set bits of {@code mask}. The mask must contain
+     * exactly {@code totalRows} valid bits (per its contract) and is treated as a row-aligned
+     * survivor bitmap for the entire row group.
+     *
+     * <p>For empty masks (no surviving bits) the returned {@link RowRanges} is empty; callers
+     * should detect this case before invoking Phase-2 prefetch.
+     *
+     * @param mask survivor mask whose set bits identify rows to keep within {@code [0, totalRows)}
+     * @param totalRows the row count of the row group; must match {@code mask}'s logical size
+     * @return a {@link RowRanges} of survivor runs in ascending order; {@code totalRows} matches the row group size
+     */
+    static RowRanges fromWordMask(WordMask mask, long totalRows) {
+        if (totalRows <= 0) {
+            return RowRanges.all(0);
+        }
+        // Walk set bits via numberOfTrailingZeros, coalescing adjacent positions into runs so the
+        // resulting RowRanges has the minimum number of intervals. This is O(numBits + survivors)
+        // and avoids constructing an int[] of survivor positions when only the runs are needed.
+        List<long[]> runs = new ArrayList<>();
+        long runStart = -1;
+        long runEnd = -1;
+        int numWords = (int) ((totalRows + 63) >>> 6);
+        for (int w = 0; w < numWords; w++) {
+            long word = mask.wordAt(w);
+            if (word == 0) {
+                if (runStart >= 0) {
+                    runs.add(new long[] { runStart, runEnd });
+                    runStart = -1;
+                }
+                continue;
+            }
+            // Mask off trailing bits in the last word that are beyond totalRows.
+            if (w == numWords - 1) {
+                int trailing = (int) (totalRows & 63);
+                if (trailing != 0) {
+                    word &= (1L << trailing) - 1;
+                }
+            }
+            int base = w << 6;
+            while (word != 0) {
+                int bit = Long.numberOfTrailingZeros(word);
+                long pos = (long) base + bit;
+                if (runStart < 0) {
+                    runStart = pos;
+                    runEnd = pos + 1;
+                } else if (pos == runEnd) {
+                    runEnd = pos + 1;
+                } else {
+                    runs.add(new long[] { runStart, runEnd });
+                    runStart = pos;
+                    runEnd = pos + 1;
+                }
+                word &= word - 1;
+            }
+        }
+        if (runStart >= 0) {
+            runs.add(new long[] { runStart, runEnd });
+        }
+        if (runs.isEmpty()) {
+            return RowRanges.of(0, 0, totalRows);
+        }
+        long[] starts = new long[runs.size()];
+        long[] ends = new long[runs.size()];
+        for (int i = 0; i < runs.size(); i++) {
+            starts[i] = runs.get(i)[0];
+            ends[i] = runs.get(i)[1];
+        }
+        return RowRanges.ofSorted(starts, ends, totalRows);
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseReaderTests.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * End-to-end tests for the two-phase I/O decode flow added to
+ * {@link OptimizedParquetColumnIterator}. The main correctness invariants exercised here are:
+ * <ul>
+ *   <li>The output is identical to the single-phase late-materialization path on the same
+ *       file and filter.</li>
+ *   <li>Two-phase fetches strictly fewer projection-column bytes when the filter is selective,
+ *       proving that page skipping is engaged.</li>
+ *   <li>Fallbacks (local storage, no projection-only columns, dense survivors, all rows
+ *       filtered out) all produce correct rows and don't leak the breaker reservation.</li>
+ * </ul>
+ */
+public class TwoPhaseReaderTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testTwoPhaseProducesSameRowsAsSinglePhase() throws Exception {
+        // Build a file that is large enough relative to predicate column bytes to clear the 0.4
+        // ratio gate: an INT64 id (predicate, ~8 bytes/row) and a sizeable BINARY label
+        // (projection-only, large bytes/row). The filter keeps about 1% of rows.
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = buildParquet(schema, 5_000, i -> {
+            SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+            Group g = factory.newGroup();
+            g.add("id", (long) i);
+            g.add("label", repeat('x', 256) + "_" + i);
+            return g;
+        });
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        Expression filter = new LessThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 50L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(filter));
+
+        CountingStorageObject syncObj = new CountingStorageObject(parquetData, false);
+        ParquetFormatReader syncReader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        List<Page> singlePhasePages = readAllPages(syncReader, syncObj);
+
+        CountingStorageObject asyncObj = new CountingStorageObject(parquetData, true);
+        ParquetFormatReader asyncReader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        List<Page> twoPhasePages = readAllPages(asyncReader, asyncObj);
+
+        // Both paths should produce the same number of surviving rows and the same id values.
+        int singleRows = singlePhasePages.stream().mapToInt(Page::getPositionCount).sum();
+        int twoPhaseRows = twoPhasePages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("two-phase row count", twoPhaseRows, equalTo(singleRows));
+        assertThat("expected survivor count", twoPhaseRows, equalTo(50));
+
+        Set<Long> singleIds = collectIds(singlePhasePages);
+        Set<Long> twoIds = collectIds(twoPhasePages);
+        assertEquals("id sets differ", singleIds, twoIds);
+    }
+
+    public void testTwoPhaseFetchesFewerProjectionBytesThanSinglePhase() throws Exception {
+        // Selective filter on a small predicate column with a much larger projection column.
+        // We expect two-phase to skip pages of the label column for filtered-out rows.
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = buildParquet(schema, 10_000, i -> {
+            SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+            Group g = factory.newGroup();
+            g.add("id", (long) i);
+            g.add("label", repeat('z', 512) + "_" + i);
+            return g;
+        });
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        Expression filter = new LessThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 100L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(filter));
+
+        // Single-phase: pretend storage is local (no native async) so two-phase is bypassed.
+        CountingStorageObject singlePhaseObj = new CountingStorageObject(parquetData, false);
+        readAllPages(new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed), singlePhaseObj).forEach(Page::releaseBlocks);
+
+        // Two-phase: storage advertises native async, enabling the two-phase path.
+        CountingStorageObject twoPhaseObj = new CountingStorageObject(parquetData, true);
+        readAllPages(new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed), twoPhaseObj).forEach(Page::releaseBlocks);
+
+        // Two-phase should fetch strictly fewer bytes (Phase 1 saves predicate-only data, Phase 2
+        // saves only surviving label pages). The exact ratio depends on dictionary + page layout
+        // but selective filters should reliably trim well over 50%.
+        long single = singlePhaseObj.totalBytesRead.get();
+        long two = twoPhaseObj.totalBytesRead.get();
+        assertThat(
+            "two-phase should read fewer bytes than single-phase: " + two + " vs " + single,
+            two,
+            org.hamcrest.Matchers.lessThan(single)
+        );
+    }
+
+    public void testTwoPhaseFallsBackToSinglePhaseWhenNoProjectionOnlyColumn() throws Exception {
+        // When the only projected column is also a predicate column, two-phase has nothing to
+        // save in Phase 2 — the gate should reject and the iterator should fall back to the
+        // standard read path. Late-materialization is also off (no projection-only columns), so
+        // the parquet-mr filter only drives row-group / page-index pruning, not row-level
+        // filtering. With a single small row group, no rows are dropped — but the iterator must
+        // still read the file end-to-end without throwing.
+        MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
+
+        byte[] parquetData = buildParquet(schema, 100, i -> {
+            SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+            Group g = factory.newGroup();
+            g.add("id", (long) i);
+            return g;
+        });
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        Expression filter = new LessThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 30L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(filter));
+
+        StorageObject obj = new CountingStorageObject(parquetData, true);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        List<Page> pages = readAllPages(reader, obj);
+
+        // Reader returns all rows; the filter would have been applied by an upstream operator.
+        int total = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("expected all rows when there's no late-mat opportunity", total, equalTo(100));
+    }
+
+    public void testTwoPhaseHandlesAllFilteredOutRowGroup() throws Exception {
+        // A small file where a selective filter removes every row; verifies the all-filtered
+        // path returns no rows and does not leave the iterator hung on a stale state.
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        byte[] parquetData = buildParquet(schema, 200, i -> {
+            SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+            Group g = factory.newGroup();
+            g.add("id", (long) i);
+            g.add("label", repeat('a', 128));
+            return g;
+        });
+
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        // No row has id > 10000; every row is filtered.
+        Expression filter = new GreaterThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, 10_000L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(filter));
+
+        StorageObject obj = new CountingStorageObject(parquetData, true);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        List<Page> pages = readAllPages(reader, obj);
+        int total = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("expect zero rows after impossible filter", total, equalTo(0));
+    }
+
+    private byte[] buildParquet(MessageType schema, int rowCount, java.util.function.IntFunction<Group> rowFactory) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputFile out = new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return new PositionOutputStream() {
+                    private long pos = 0;
+
+                    @Override
+                    public long getPos() {
+                        return pos;
+                    }
+
+                    @Override
+                    public void write(int b) {
+                        baos.write(b);
+                        pos++;
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) {
+                        baos.write(b, off, len);
+                        pos += len;
+                    }
+                };
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return create(blockSizeHint);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+        };
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(out)
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withConf(new PlainParquetConfiguration())
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                writer.write(rowFactory.apply(i));
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private List<Page> readAllPages(ParquetFormatReader reader, StorageObject obj) throws IOException {
+        try (CloseableIterator<Page> it = reader.read(obj, FormatReadContext.builder().batchSize(1024).build())) {
+            List<Page> pages = new ArrayList<>();
+            while (it.hasNext()) {
+                pages.add(it.next());
+            }
+            return pages;
+        }
+    }
+
+    private static String repeat(char c, int n) {
+        char[] arr = new char[n];
+        java.util.Arrays.fill(arr, c);
+        return new String(arr);
+    }
+
+    private static Set<Long> collectIds(List<Page> pages) {
+        Set<Long> out = new HashSet<>();
+        for (Page p : pages) {
+            // Schema layout: id is the first long column we projected; with the default no-projection
+            // path that means block 0.
+            LongBlock block = p.getBlock(0);
+            for (int i = 0; i < block.getPositionCount(); i++) {
+                if (block.isNull(i) == false) {
+                    out.add(block.getLong(i));
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * In-memory {@link StorageObject} that counts the bytes read across all stream and async
+     * read calls. Used to assert that two-phase fetches strictly fewer projection bytes than
+     * single-phase. When {@code nativeAsync} is true the object reports
+     * {@link StorageObject#supportsNativeAsync()} as true so two-phase activates; otherwise it
+     * stays on the single-phase path.
+     */
+    private static final class CountingStorageObject implements StorageObject {
+        private final byte[] data;
+        private final boolean nativeAsync;
+        final AtomicLong totalBytesRead = new AtomicLong();
+
+        CountingStorageObject(byte[] data, boolean nativeAsync) {
+            this.data = data;
+            this.nativeAsync = nativeAsync;
+        }
+
+        @Override
+        public InputStream newStream() {
+            return new ByteArrayInputStream(data);
+        }
+
+        @Override
+        public InputStream newStream(long position, long length) {
+            int pos = (int) position;
+            int len = (int) Math.min(length, data.length - position);
+            totalBytesRead.addAndGet(len);
+            return new ByteArrayInputStream(data, pos, len);
+        }
+
+        @Override
+        public long length() {
+            return data.length;
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.now();
+        }
+
+        @Override
+        public boolean exists() {
+            return true;
+        }
+
+        @Override
+        public StoragePath path() {
+            return StoragePath.of("memory://test.parquet");
+        }
+
+        @Override
+        public boolean supportsNativeAsync() {
+            return nativeAsync;
+        }
+
+        @Override
+        public void readBytesAsync(long position, long length, Executor executor, ActionListener<ByteBuffer> listener) {
+            // Run inline like the default sync wrapper but go through our stream-based newStream
+            // path so the byte counter reflects the read. We mimic StorageObject's default async
+            // implementation: count once, copy once.
+            try (InputStream stream = newStream(position, length)) {
+                byte[] bytes = stream.readAllBytes();
+                listener.onResponse(ByteBuffer.wrap(bytes));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseReaderTests.java
@@ -163,11 +163,14 @@ public class TwoPhaseReaderTests extends ESTestCase {
 
     public void testTwoPhaseFallsBackToSinglePhaseWhenNoProjectionOnlyColumn() throws Exception {
         // When the only projected column is also a predicate column, two-phase has nothing to
-        // save in Phase 2 — the gate should reject and the iterator should fall back to the
-        // standard read path. Late-materialization is also off (no projection-only columns), so
-        // the parquet-mr filter only drives row-group / page-index pruning, not row-level
-        // filtering. With a single small row group, no rows are dropped — but the iterator must
-        // still read the file end-to-end without throwing.
+        // save in Phase 2 — the gate rejects and the iterator falls back to the standard read
+        // path. The reader is still constructed with the late-materialization *flag* enabled
+        // ({@code lateMaterializationEnabled=true} via the default ctor), but the runtime
+        // {@code lateMaterialization} decision inside {@code OptimizedParquetColumnIterator}
+        // turns off because there are no projection-only columns. With late-mat off, the
+        // parquet-mr filter only drives row-group / page-index pruning, not row-level filtering;
+        // a single small row group survives entirely. The iterator must still read the file
+        // end-to-end without throwing — that's the contract this test pins.
         MessageType schema = Types.buildMessage().required(PrimitiveType.PrimitiveTypeName.INT64).named("id").named("test_schema");
 
         byte[] parquetData = buildParquet(schema, 100, i -> {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskRowRangesConverterTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/WordMaskRowRangesConverterTests.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class WordMaskRowRangesConverterTests extends ESTestCase {
+
+    public void testEmptyMaskProducesEmptyRanges() {
+        WordMask mask = new WordMask();
+        mask.reset(100);
+        RowRanges ranges = WordMaskRowRangesConverter.fromWordMask(mask, 100);
+        assertTrue(ranges.isEmpty());
+        assertThat(ranges.totalRows(), equalTo(100L));
+    }
+
+    public void testZeroSizeRowGroupProducesAll() {
+        WordMask mask = new WordMask();
+        mask.reset(0);
+        RowRanges ranges = WordMaskRowRangesConverter.fromWordMask(mask, 0);
+        assertTrue(ranges.isEmpty());
+    }
+
+    public void testSingleRunWithinFirstWord() {
+        WordMask mask = new WordMask();
+        mask.reset(64);
+        for (int i = 5; i < 12; i++) {
+            mask.set(i);
+        }
+        RowRanges ranges = WordMaskRowRangesConverter.fromWordMask(mask, 64);
+        assertThat(ranges.rangeCount(), equalTo(1));
+        assertThat(ranges.rangeStart(0), equalTo(5L));
+        assertThat(ranges.rangeEnd(0), equalTo(12L));
+        assertThat(ranges.selectedRowCount(), equalTo(7L));
+    }
+
+    public void testTwoSeparateRuns() {
+        WordMask mask = new WordMask();
+        mask.reset(64);
+        for (int i : new int[] { 1, 2, 3 }) {
+            mask.set(i);
+        }
+        for (int i : new int[] { 30, 31 }) {
+            mask.set(i);
+        }
+        RowRanges ranges = WordMaskRowRangesConverter.fromWordMask(mask, 64);
+        assertThat(ranges.rangeCount(), equalTo(2));
+        assertThat(ranges.rangeStart(0), equalTo(1L));
+        assertThat(ranges.rangeEnd(0), equalTo(4L));
+        assertThat(ranges.rangeStart(1), equalTo(30L));
+        assertThat(ranges.rangeEnd(1), equalTo(32L));
+    }
+
+    public void testRunSpanningWordBoundary() {
+        WordMask mask = new WordMask();
+        mask.reset(200);
+        // Set bits 60-70, spanning the boundary between word 0 and word 1.
+        for (int i = 60; i < 70; i++) {
+            mask.set(i);
+        }
+        RowRanges ranges = WordMaskRowRangesConverter.fromWordMask(mask, 200);
+        assertThat(ranges.rangeCount(), equalTo(1));
+        assertThat(ranges.rangeStart(0), equalTo(60L));
+        assertThat(ranges.rangeEnd(0), equalTo(70L));
+    }
+
+    public void testAllBitsSetProducesSingleAllRange() {
+        WordMask mask = new WordMask();
+        mask.setAll(150);
+        RowRanges ranges = WordMaskRowRangesConverter.fromWordMask(mask, 150);
+        assertThat(ranges.rangeCount(), equalTo(1));
+        assertThat(ranges.rangeStart(0), equalTo(0L));
+        assertThat(ranges.rangeEnd(0), equalTo(150L));
+        assertTrue(ranges.isAll());
+    }
+
+    public void testTrailingBitsBeyondTotalRowsAreIgnored() {
+        // Create a 70-bit logical mask but underlying long array has 64-bit words; bits 65..71
+        // beyond totalRows must not become ranges.
+        WordMask mask = new WordMask();
+        mask.reset(70);
+        for (int i = 60; i < 64; i++) {
+            mask.set(i);
+        }
+        // Position 65 is within the logical mask; positions 70+ are not.
+        mask.set(65);
+        // Manually set bits 70..71 inside the trailing word (out-of-range for the converter).
+        mask.set(70);
+        mask.set(71);
+        RowRanges ranges = WordMaskRowRangesConverter.fromWordMask(mask, 70);
+        // Expect runs [60,64), [65,66) — bits 70..71 must be ignored even though they were set
+        // in the underlying word. Bits 70..71 lie at totalRows or beyond and must not extend
+        // the second run.
+        assertThat(ranges.rangeCount(), equalTo(2));
+        assertThat(ranges.rangeStart(0), equalTo(60L));
+        assertThat(ranges.rangeEnd(0), equalTo(64L));
+        assertThat(ranges.rangeStart(1), equalTo(65L));
+        assertThat(ranges.rangeEnd(1), equalTo(66L));
+    }
+
+    public void testSparseMaskProducesManyRanges() {
+        WordMask mask = new WordMask();
+        mask.reset(20);
+        // Every other bit: positions 0, 2, 4, ..., 18.
+        int expected = 0;
+        for (int i = 0; i < 20; i += 2) {
+            mask.set(i);
+            expected++;
+        }
+        RowRanges ranges = WordMaskRowRangesConverter.fromWordMask(mask, 20);
+        assertThat(ranges.rangeCount(), equalTo(expected));
+        long total = 0;
+        for (int i = 0; i < ranges.rangeCount(); i++) {
+            assertThat(ranges.rangeEnd(i) - ranges.rangeStart(i), equalTo(1L));
+            total += ranges.rangeEnd(i) - ranges.rangeStart(i);
+        }
+        assertThat(total, equalTo((long) expected));
+    }
+
+    public void testRandomizedRoundTripAgainstSurvivingPositions() {
+        // Build a random mask, derive ranges, then verify each surviving position lies in some
+        // range and each in-range position has its bit set.
+        int totalRows = randomIntBetween(1, 5000);
+        WordMask mask = new WordMask();
+        mask.reset(totalRows);
+        List<Integer> set = new ArrayList<>();
+        for (int i = 0; i < totalRows; i++) {
+            if (randomBoolean()) {
+                mask.set(i);
+                set.add(i);
+            }
+        }
+        RowRanges ranges = WordMaskRowRangesConverter.fromWordMask(mask, totalRows);
+        // Every set position should be inside one of the ranges.
+        for (int p : set) {
+            boolean found = false;
+            for (int r = 0; r < ranges.rangeCount(); r++) {
+                if (ranges.rangeStart(r) <= p && p < ranges.rangeEnd(r)) {
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue("position " + p + " should be in ranges " + ranges, found);
+        }
+        // Every in-range position should have its bit set (no false positives).
+        for (int r = 0; r < ranges.rangeCount(); r++) {
+            for (long p = ranges.rangeStart(r); p < ranges.rangeEnd(r); p++) {
+                assertTrue("position " + p + " in range but bit not set", mask.get((int) p));
+            }
+        }
+        // Selected count should equal the number of set bits.
+        assertThat(ranges.selectedRowCount(), equalTo((long) set.size()));
+    }
+
+    public void testRangesAreContiguousAndNonOverlapping() {
+        // A descriptive sanity check: produced ranges must be sorted, non-overlapping, and have
+        // strictly positive length.
+        int totalRows = 1000;
+        WordMask mask = new WordMask();
+        mask.reset(totalRows);
+        for (int i = 0; i < totalRows; i++) {
+            if (random().nextDouble() < 0.3) {
+                mask.set(i);
+            }
+        }
+        RowRanges ranges = WordMaskRowRangesConverter.fromWordMask(mask, totalRows);
+        long prevEnd = -1;
+        for (int r = 0; r < ranges.rangeCount(); r++) {
+            assertTrue("range " + r + " has non-positive length", ranges.rangeEnd(r) > ranges.rangeStart(r));
+            assertTrue("range " + r + " overlaps or precedes previous", ranges.rangeStart(r) > prevEnd);
+            prevEnd = ranges.rangeEnd(r);
+        }
+    }
+}


### PR DESCRIPTION
When late materialization is active and storage is remote, split the
prefetch into a predicate-columns phase (Phase 1) and a projection-
columns phase (Phase 2). Phase 2 fetches only data pages that overlap
rows surviving the filter, materially shrinking remote bytes for
selective queries.

Gated by remote async storage, presence of projection-only columns,
absence of list columns, and a predicate-byte-ratio threshold.

Developed with AI-assisted tooling