### PR TITLE
Add rank-feature search phase to SearchResponseMetrics

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/MetricValidator.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/MetricValidator.java
@@ -256,6 +256,7 @@ public class MetricValidator {
             Map.entry("es.search_response.took_durations.histogram", SEARCH_ATTRIBUTES),
             Map.entry("es.search_response.took_durations.open_pit.histogram", SEARCH_ATTRIBUTES),
             Map.entry("es.search_response.took_durations.query.histogram", SEARCH_ATTRIBUTES),
+            Map.entry("es.search_response.took_durations.rank_feature.histogram", SEARCH_ATTRIBUTES),
             Map.entry("es.search.shards.phases.can_match.duration.histogram", SEARCH_SHARD_ATTRIBUTES),
             Map.entry("es.search.shards.phases.dfs.duration.histogram", SEARCH_SHARD_ATTRIBUTES),
             Map.entry("es.search.shards.phases.fetch.duration.histogram", SEARCH_SHARD_ATTRIBUTES),

--- a/server/src/main/java/org/elasticsearch/action/search/RankFeaturePhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/RankFeaturePhase.java
@@ -48,6 +48,7 @@ public class RankFeaturePhase extends SearchPhase {
     private final AggregatedDfs aggregatedDfs;
     private final SearchProgressListener progressListener;
     private final RankFeaturePhaseRankCoordinatorContext rankFeaturePhaseRankCoordinatorContext;
+    private long phaseStartTimeInNanos;
 
     RankFeaturePhase(
         SearchPhaseResults<SearchPhaseResult> queryPhaseResults,
@@ -76,6 +77,7 @@ public class RankFeaturePhase extends SearchPhase {
 
     @Override
     protected void run() {
+        phaseStartTimeInNanos = System.nanoTime();
         context.execute(new AbstractRunnable() {
             @Override
             protected void doRun() throws Exception {
@@ -218,6 +220,7 @@ public class RankFeaturePhase extends SearchPhase {
                         );
                         moveToNextPhase(rankPhaseResults, reducedRankFeaturePhase);
                     } else {
+                        // do not record duration of failed phases
                         context.onPhaseFailure(NAME, "Computing updated ranks for results failed", e);
                     }
                 }
@@ -268,6 +271,8 @@ public class RankFeaturePhase extends SearchPhase {
     }
 
     void moveToNextPhase(SearchPhaseResults<SearchPhaseResult> phaseResults, SearchPhaseController.ReducedQueryPhase reducedQueryPhase) {
+        context.getSearchResponseMetrics()
+            .recordSearchPhaseDuration(getName(), System.nanoTime() - phaseStartTimeInNanos, context.getSearchRequestAttributes());
         context.executeNextPhase(NAME, () -> new FetchSearchPhase(phaseResults, aggregatedDfs, context, reducedQueryPhase));
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchResponseMetrics.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchResponseMetrics.java
@@ -101,6 +101,12 @@ public class SearchResponseMetrics {
                 String.format(Locale.ROOT, SEARCH_PHASE_METRIC_FORMAT, "query"),
                 "The search phase query duration in milliseconds at the coordinator, expressed as a histogram",
                 "millis"
+            ),
+            "rank-feature",
+            meterRegistry.registerLongHistogram(
+                String.format(Locale.ROOT, SEARCH_PHASE_METRIC_FORMAT, "rank_feature"),
+                "The search phase rank-feature duration in milliseconds at the coordinator, expressed as a histogram",
+                "millis"
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/rest/action/search/SearchResponseMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/SearchResponseMetricsTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.rest.action.search;
+
+import org.elasticsearch.telemetry.InstrumentType;
+import org.elasticsearch.telemetry.Measurement;
+import org.elasticsearch.telemetry.RecordingMeterRegistry;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItems;
+
+public class SearchResponseMetricsTests extends ESTestCase {
+
+    public void testAllSearchPhaseHistogramsRegistered() {
+        RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
+        new SearchResponseMetrics(meterRegistry);
+        assertThat(
+            meterRegistry.getRecorder().getRegisteredMetrics(InstrumentType.LONG_HISTOGRAM),
+            hasItems(
+                "es.search_response.took_durations.histogram",
+                "es.search_response.took_durations.can_match.histogram",
+                "es.search_response.took_durations.dfs.histogram",
+                "es.search_response.took_durations.dfs_query.histogram",
+                "es.search_response.took_durations.fetch.histogram",
+                "es.search_response.took_durations.open_pit.histogram",
+                "es.search_response.took_durations.query.histogram",
+                "es.search_response.took_durations.rank_feature.histogram"
+            )
+        );
+    }
+
+    public void testRecordRankFeaturePhaseDuration() {
+        RecordingMeterRegistry meterRegistry = new RecordingMeterRegistry();
+        SearchResponseMetrics metrics = new SearchResponseMetrics(meterRegistry);
+
+        Map<String, Object> attributes = Map.of("target", "user");
+        long durationMillis = randomLongBetween(1, 1000);
+        metrics.recordSearchPhaseDuration("rank-feature", TimeUnit.MILLISECONDS.toNanos(durationMillis), attributes);
+
+        List<Measurement> measurements = meterRegistry.getRecorder()
+            .getMeasurements(InstrumentType.LONG_HISTOGRAM, "es.search_response.took_durations.rank_feature.histogram");
+        assertThat(measurements, contains(new Measurement(durationMillis, attributes, false)));
+    }
+}


### PR DESCRIPTION
Registers an es.search_response.took_durations.rank_feature.histogram
LongHistogram and records the duration from RankFeaturePhase#run to
moveToNextPhase, mirroring how DfsQueryPhase and FetchSearchPhase
report their coordinator-side durations.

Note: I originally wrote this PR thinking it would be part of https://github.com/elastic/elasticsearch/issues/146131, but I only discovered rank is not re-rank after writing the feature, so I am opening the PR in case it is helpful. If it is not, let's close it.