### PR TITLE
[Test] Unmute ReindexClientYamlTestSuiteIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -208,9 +208,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_forceTrue_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/146955
-- class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
-  method: test {yaml=reindex/10_basic/Response format for created}
-  issue: https://github.com/elastic/elasticsearch/issues/147005
 - class: org.elasticsearch.reindex.management.ReindexManagementClientYamlTestSuiteIT
   method: test {yaml=reindex/30_cancel_reindex/Cancel running reindex returns response and GET confirms completed}
   issue: https://github.com/elastic/elasticsearch/issues/146314


### PR DESCRIPTION
This is the same issue as https://github.com/elastic/elasticsearch/issues/146047, where a race exists between closing PIT context and reindex finishing. Already fixed in https://github.com/elastic/elasticsearch/pull/146142. This unmutes the test

Closes #147005