### PR TITLE
ESQL:DS: fix CSV reader on uncompressed splits

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFixtureParser.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFixtureParser.java
@@ -103,19 +103,83 @@ public final class CsvFixtureParser {
         return new CsvFixtureResult(schema, rows);
     }
 
+    /**
+     * RFC-4180-style: a {@code "} only opens quoting at field start (after {@code ,} or line-start, optionally
+     * preceded by whitespace) and is ignored inside {@code [..]} MVC cells. Stray {@code "} chars in unquoted
+     * cells are literal bytes and must not cause multi-line gluing — kept consistent with
+     * {@link CsvFormatReader} so fixture parsing matches runtime parsing.
+     */
     private static boolean hasUnclosedQuote(String s, char quote) {
         boolean inQuotes = false;
+        int bracketDepth = 0;
+        boolean fieldHasNonWhitespace = false;
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
-            if (c == quote) {
-                if (i + 1 < s.length() && s.charAt(i + 1) == quote) {
-                    i++;
-                    continue;
+            if (inQuotes) {
+                if (c == quote) {
+                    if (i + 1 < s.length() && s.charAt(i + 1) == quote) {
+                        i++;
+                        continue;
+                    }
+                    inQuotes = false;
                 }
-                inQuotes = !inQuotes;
+                continue;
+            }
+            if (bracketDepth > 0) {
+                if (c == '[') {
+                    bracketDepth++;
+                } else if (c == ']') {
+                    bracketDepth--;
+                }
+                continue;
+            }
+            if (c == ',') {
+                fieldHasNonWhitespace = false;
+                continue;
+            }
+            if (c == quote && fieldHasNonWhitespace == false) {
+                inQuotes = true;
+                continue;
+            }
+            if (c == '[' && fieldHasNonWhitespace == false) {
+                bracketDepth = 1;
+                continue;
+            }
+            if (Character.isWhitespace(c) == false) {
+                fieldHasNonWhitespace = true;
             }
         }
         return inQuotes;
+    }
+
+    /** Same as {@link CsvFormatReader}: whitespace-only prefix still allows bracket MVC to open at {@code [}. */
+    private static boolean isWhitespaceOnlyFieldPrefix(StringBuilder current) {
+        for (int k = 0; k < current.length(); k++) {
+            if (Character.isWhitespace(current.charAt(k)) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Same semantics as {@link CsvFormatReader} bracket lookahead — see that class. */
+    private static boolean hasMvcBracketClose(String line, int openBracketIndex, char quote, char esc, char delim) {
+        if (openBracketIndex < 0 || openBracketIndex >= line.length() || line.charAt(openBracketIndex) != '[') {
+            return false;
+        }
+        int depth = 0;
+        for (int j = openBracketIndex; j < line.length(); j++) {
+            char c = line.charAt(j);
+            if (c == '[') {
+                depth++;
+            } else if (c == ']') {
+                depth--;
+                if (depth == 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -125,7 +189,7 @@ public final class CsvFixtureParser {
         List<String> entries = new ArrayList<>();
         StringBuilder current = new StringBuilder();
         boolean inQuotes = false;
-        boolean inBrackets = false;
+        int bracketDepth = 0;
         int i = 0;
         while (i < line.length()) {
             char c = line.charAt(i);
@@ -145,28 +209,23 @@ public final class CsvFixtureParser {
                     current.append(c);
                 }
                 i++;
-            } else if (inBrackets) {
+            } else if (bracketDepth > 0) {
+                // See {@link CsvFormatReader} for the rationale: keep accumulating after the cell closes,
+                // so a field like `[37] Title` stays a single field instead of producing a phantom column.
                 current.append(c);
-                if (c == ']') {
-                    inBrackets = false;
-                    entries.add(current.toString());
-                    current = new StringBuilder();
-                    i++;
-                    while (i < line.length() && line.charAt(i) == ' ') {
-                        i++;
-                    }
-                    if (i < line.length() && line.charAt(i) == delim) {
-                        i++;
-                        continue;
-                    }
-                    continue;
+                if (c == '[') {
+                    bracketDepth++;
+                } else if (c == ']') {
+                    bracketDepth--;
                 }
                 i++;
-            } else if (c == quote) {
+            } else if (c == quote && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
                 inQuotes = true;
                 i++;
-            } else if (c == '[' && current.length() == 0) {
-                inBrackets = true;
+            } else if (c == '[' && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
+                if (hasMvcBracketClose(line, i, quote, esc, delim)) {
+                    bracketDepth = 1;
+                }
                 current.append(c);
                 i++;
             } else if (c == delim) {
@@ -185,14 +244,14 @@ public final class CsvFixtureParser {
         if (inQuotes) {
             throw new IllegalArgumentException("Unclosed quoted field in line [" + line + "]");
         }
-        if (inBrackets) {
+        if (bracketDepth > 0) {
             throw new IllegalArgumentException("Unclosed bracket cell in line [" + line + "]");
         }
         if (current.length() > 0) {
             entries.add(current.toString().trim());
         }
         // Trailing delimiter (RFC 4180): one more empty field after the last comma, unless escaped as \,
-        if (line.endsWith(String.valueOf(delim)) && inQuotes == false) {
+        if (line.length() > 0 && line.charAt(line.length() - 1) == delim) {
             int last = line.length() - 1;
             if (last == 0 || line.charAt(last - 1) != esc) {
                 entries.add("");

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFixtureParser.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFixtureParser.java
@@ -142,6 +142,8 @@ public final class CsvFixtureParser {
                 continue;
             }
             if (c == '[' && fieldHasNonWhitespace == false) {
+                // No hasMvcBracketClose check here: see CsvFormatReader.CsvBatchIterator.hasUnclosedQuote
+                // for the rationale — unconditional bracket entry is safe and avoids false multi-line gluing.
                 bracketDepth = 1;
                 continue;
             }
@@ -162,8 +164,12 @@ public final class CsvFixtureParser {
         return true;
     }
 
-    /** Same semantics as {@link CsvFormatReader} bracket lookahead — see that class. */
-    private static boolean hasMvcBracketClose(String line, int openBracketIndex, char quote, char esc, char delim) {
+    /**
+     * Whether {@code line} starting at {@code openBracketIndex} contains a balanced bracket suffix that closes the
+     * MVC cell. Only {@code [} and {@code ]} adjust depth — quote/escape/delimiter characters inside the bracket
+     * cell are treated as literal data, matching the splitter's {@code bracketDepth > 0} branch.
+     */
+    private static boolean hasMvcBracketClose(String line, int openBracketIndex) {
         if (openBracketIndex < 0 || openBracketIndex >= line.length() || line.charAt(openBracketIndex) != '[') {
             return false;
         }
@@ -223,7 +229,7 @@ public final class CsvFixtureParser {
                 inQuotes = true;
                 i++;
             } else if (c == '[' && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
-                if (hasMvcBracketClose(line, i, quote, esc, delim)) {
+                if (hasMvcBracketClose(line, i)) {
                     bracketDepth = 1;
                 }
                 current.append(c);
@@ -251,6 +257,7 @@ public final class CsvFixtureParser {
             entries.add(current.toString().trim());
         }
         // Trailing delimiter (RFC 4180): one more empty field after the last comma, unless escaped as \,
+        // No inQuotes guard needed: if we reach here with an unclosed quote the throw above fires first.
         if (line.length() > 0 && line.charAt(line.length() - 1) == delim) {
             int last = line.length() - 1;
             if (last == 0 || line.charAt(last - 1) != esc) {

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -45,6 +45,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -446,7 +447,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     private List<Attribute> inferSchemaFromSample(String headerLine, BufferedReader reader) throws IOException {
-        String[] columnNames = headerLine.split(Pattern.quote(Character.toString(options.delimiter())));
+        String[] columnNames = splitFieldsForOptions(headerLine, options);
         Iterator<List<?>> csvIterator = newCsvIterator(reader);
         CircuitBreaker breaker = blockFactory.breaker();
         SchemaSample sample = collectSampleRows(csvIterator, options.commentPrefix(), schemaSampleSize, breaker, effectivePolicy);
@@ -782,6 +783,135 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     @Override
     public long findNextRecordBoundary(InputStream stream) throws IOException {
+        if (options.multiValueSyntax() != CsvFormatOptions.MultiValueSyntax.BRACKETS || options.delimiter() != ',') {
+            return findNextRecordBoundaryQuotedFieldsOnly(stream);
+        }
+        BufferedInputStream bis = stream instanceof BufferedInputStream b ? b : new BufferedInputStream(stream);
+        int markLimit = recordBoundaryMarkLimit();
+        long maxMvcSuffixBytes = Math.max(0L, markLimit - 1L);
+        return findNextRecordBoundaryBracketCommaMvc(bis, markLimit, maxMvcSuffixBytes);
+    }
+
+    /**
+     * Upper bound for {@link BufferedInputStream#mark(int)} while probing bracket MVC cells during record-boundary
+     * scans. Matches {@link CsvFormatOptions#maxFieldSize()} so an unclosed bracket cell cannot invalidate the mark
+     * before we reset and treat {@code [} as a literal byte.
+     */
+    private int recordBoundaryMarkLimit() {
+        int maxField = options.maxFieldSize();
+        if (maxField <= 0) {
+            return Math.min(64 * 1024 * 1024, Integer.MAX_VALUE - 8);
+        }
+        return Math.min(maxField + 1024, Integer.MAX_VALUE - 8);
+    }
+
+    /**
+     * Bytes consumed after an opening {@code [} until bracket depth returns to zero, or {@code -1} if EOF was reached
+     * first or the scan exceeded {@link CsvFormatOptions#maxFieldSize()} (unclosed cell).
+     */
+    private long consumeBracketMvcSuffixBytes(BufferedInputStream in, long maxSuffixBytes) throws IOException {
+        int depth = 1;
+        long bytes = 0;
+        while (depth > 0) {
+            if (bytes >= maxSuffixBytes) {
+                return -1;
+            }
+            int ib = in.read();
+            if (ib == -1) {
+                return -1;
+            }
+            bytes++;
+            byte b = (byte) ib;
+            if (b == '[') {
+                depth++;
+            } else if (b == ']') {
+                depth--;
+            }
+        }
+        return bytes;
+    }
+
+    private static boolean isAsciiCsvFieldLeadingWhitespace(int ib) {
+        return ib == ' ' || ib == '\t' || ib == '\f';
+    }
+
+    /**
+     * Record boundary scan for comma-delimited CSV with bracket MVC. Newlines inside {@code [..]} or quoted fields
+     * must not end the record. Quote opening follows RFC 4180 — only at field start, optionally preceded by whitespace
+     * — so stray {@code "} chars in unquoted cells do not trigger multi-line gluing or pathological segment splits.
+     */
+    private long findNextRecordBoundaryBracketCommaMvc(BufferedInputStream bis, int markLimit, long maxMvcSuffixBytes) throws IOException {
+        long consumed = 0;
+        boolean inQuotes = false;
+        boolean fieldHasNonWhitespace = false;
+        byte quoteAsByte = (byte) options.quoteChar();
+        byte escAsByte = (byte) options.escapeChar();
+        byte delimAsByte = (byte) options.delimiter();
+
+        while (true) {
+            int ib = bis.read();
+            if (ib == -1) {
+                return -1;
+            }
+            consumed++;
+            byte b = (byte) ib;
+
+            if (inQuotes) {
+                if (b == quoteAsByte) {
+                    bis.mark(2);
+                    int ib2 = bis.read();
+                    if (ib2 == -1) {
+                        inQuotes = false;
+                        continue;
+                    }
+                    if ((byte) ib2 == quoteAsByte) {
+                        consumed++;
+                        continue;
+                    }
+                    bis.reset();
+                    inQuotes = false;
+                } else if (b == escAsByte) {
+                    bis.mark(2);
+                    int ib2 = bis.read();
+                    if (ib2 != -1 && (byte) ib2 == delimAsByte) {
+                        consumed++;
+                        continue;
+                    }
+                    bis.reset();
+                }
+                continue;
+            }
+
+            if (b == '\n') {
+                return consumed;
+            }
+            if (b == delimAsByte) {
+                fieldHasNonWhitespace = false;
+                continue;
+            }
+            if (b == quoteAsByte && fieldHasNonWhitespace == false) {
+                inQuotes = true;
+                continue;
+            }
+            if (b == '[' && fieldHasNonWhitespace == false) {
+                bis.mark(markLimit);
+                long suffix = consumeBracketMvcSuffixBytes(bis, maxMvcSuffixBytes);
+                if (suffix >= 0) {
+                    consumed += suffix;
+                    fieldHasNonWhitespace = true;
+                    continue;
+                }
+                bis.reset();
+                fieldHasNonWhitespace = true;
+                continue;
+            }
+            if (isAsciiCsvFieldLeadingWhitespace(ib & 0xff) == false) {
+                fieldHasNonWhitespace = true;
+            }
+        }
+    }
+
+    private long findNextRecordBoundaryQuotedFieldsOnly(InputStream stream) throws IOException {
         long consumed = 0;
         boolean inQuotes = false;
         byte quoteAsByte = (byte) options.quoteChar();
@@ -860,7 +990,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     private List<Attribute> parseSchema(String schemaLine) {
-        String[] columns = schemaLine.split(Pattern.quote(Character.toString(options.delimiter())));
+        String[] columns = splitFieldsForOptions(schemaLine, options);
         if (hasTypeAnnotations(columns)) {
             return parseTypedSchema(columns);
         }
@@ -922,6 +1052,198 @@ public class CsvFormatReader implements SegmentableFormatReader {
             case "NULL", "N" -> DataType.NULL;
             default -> throw EsqlIllegalArgumentException.illegalDataType(typeName);
         };
+    }
+
+    /**
+     * Whether {@code line} contains a bracket-multi-value cell opener at {@code openBracketIndex} that is closed by a
+     * matching {@code ]} with correct nesting. If not (e.g. literal {@code [6:42)} text), bracket-aware splitting must
+     * not treat {@code ,} inside the cell as internal MV commas — otherwise the parser never sees {@code ]} and fails
+     * with "Unclosed bracket cell".
+     * <p>
+     * Quote and {@code esc}+{@code delim} rules match {@code splitLineBracketAware} on the batch iterator.
+     */
+    /**
+     * Whether {@code current} contains only whitespace — treated like an empty field prefix so a following {@code [}
+     * still opens bracket MVC parsing (mirrors parallel record-boundary scanning).
+     */
+    private static boolean isWhitespaceOnlyFieldPrefix(StringBuilder current) {
+        for (int k = 0; k < current.length(); k++) {
+            if (Character.isWhitespace(current.charAt(k)) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Whether {@code line} starting at {@code openBracketIndex} contains a balanced bracket suffix that closes the
+     * MVC cell. Mirrors the splitter's {@code bracketDepth > 0} branch which treats every byte inside the cell as
+     * literal: only {@code [} and {@code ]} adjust depth. A stray {@code "} or {@code \} inside the cell is data,
+     * not a quote toggle — otherwise real-world rows like {@code [text",1,2013-...,38,-12345]} would look unclosed
+     * here, the splitter would treat the leading {@code [} as literal, and the inner commas would become delimiters,
+     * yielding extra columns and the {@code "row has [N+k] columns but schema defines [N]"} failure.
+     */
+    private static boolean hasMvcBracketClose(String line, int openBracketIndex, char quote, char esc, char delim) {
+        if (openBracketIndex < 0 || openBracketIndex >= line.length() || line.charAt(openBracketIndex) != '[') {
+            return false;
+        }
+        int depth = 0;
+        for (int j = openBracketIndex; j < line.length(); j++) {
+            char c = line.charAt(j);
+            if (c == '[') {
+                depth++;
+            } else if (c == ']') {
+                depth--;
+                if (depth == 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Splits a <strong>header</strong> line into fields using the same comma/bracket/quote awareness as the data
+     * splitter, but <em>preserves the original substring</em> of each field — including any surrounding quote
+     * characters. Header fields like {@code "host:port"} need quotes intact so {@link #hasTypeAnnotations} can tell
+     * a quoted name from a {@code name:type} annotation.
+     */
+    private static String[] splitFieldsForOptions(String line, CsvFormatOptions options) {
+        if (options.multiValueSyntax() == CsvFormatOptions.MultiValueSyntax.BRACKETS && options.delimiter() == ',') {
+            return splitHeaderCommaDelimiterBracketAware(line, options.quoteChar(), options.escapeChar());
+        }
+        return line.split(Pattern.quote(Character.toString(options.delimiter())));
+    }
+
+    /**
+     * Header-only variant of {@link #splitCommaDelimiterBracketAwareFields}: tracks the same state machine but
+     * emits the raw substring between commas instead of accumulating into a {@link StringBuilder} that strips
+     * quotes. Used by schema discovery / inference.
+     */
+    private static String[] splitHeaderCommaDelimiterBracketAware(String line, char quote, char esc) {
+        final char delim = ',';
+        List<String> entries = new ArrayList<>();
+        int start = 0;
+        boolean inQuotes = false;
+        int bracketDepth = 0;
+        boolean fieldHasNonWhitespace = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (inQuotes) {
+                if (c == quote) {
+                    if (i + 1 < line.length() && line.charAt(i + 1) == quote) {
+                        i++;
+                        continue;
+                    }
+                    inQuotes = false;
+                } else if (c == esc && i + 1 < line.length() && line.charAt(i + 1) == delim) {
+                    i++;
+                }
+                continue;
+            }
+            if (bracketDepth > 0) {
+                if (c == '[') {
+                    bracketDepth++;
+                } else if (c == ']') {
+                    bracketDepth--;
+                }
+                continue;
+            }
+            if (c == delim) {
+                entries.add(line.substring(start, i).trim());
+                start = i + 1;
+                fieldHasNonWhitespace = false;
+                continue;
+            }
+            if (c == quote && fieldHasNonWhitespace == false) {
+                inQuotes = true;
+                continue;
+            }
+            if (c == '[' && fieldHasNonWhitespace == false && hasMvcBracketClose(line, i, quote, esc, delim)) {
+                bracketDepth = 1;
+                continue;
+            }
+            if (Character.isWhitespace(c) == false) {
+                fieldHasNonWhitespace = true;
+            }
+        }
+        entries.add(line.substring(start).trim());
+        return entries.toArray(String[]::new);
+    }
+
+    /**
+     * Bracket- and quote-aware comma split; must stay aligned with {@link CsvBatchIterator#splitLineBracketAware}.
+     */
+    private static String[] splitCommaDelimiterBracketAwareFields(String line, char quote, char esc) {
+        final char delim = ',';
+        List<String> entries = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        int bracketDepth = 0;
+        int i = 0;
+        while (i < line.length()) {
+            char c = line.charAt(i);
+            if (inQuotes) {
+                if (c == quote) {
+                    if (i + 1 < line.length() && line.charAt(i + 1) == quote) {
+                        current.append(quote);
+                        i += 2;
+                        continue;
+                    }
+                    inQuotes = false;
+                } else if (c == esc && i + 1 < line.length() && line.charAt(i + 1) == delim) {
+                    current.append(delim);
+                    i += 2;
+                    continue;
+                } else {
+                    current.append(c);
+                }
+                i++;
+            } else if (bracketDepth > 0) {
+                // Inside an MVC cell: only `[` and `]` adjust depth; quotes and the field delimiter are literal.
+                // When `]` brings depth back to zero we deliberately keep `current` and fall through to the regular
+                // text-accumulation branch on subsequent iterations: real-world rows like `[37] Title text,...`
+                // mean "[37] Title text" is one field. Closing the cell here would split off the trailing text
+                // into a phantom extra column, which is exactly the "row has [N+1] columns" failure.
+                current.append(c);
+                if (c == '[') {
+                    bracketDepth++;
+                } else if (c == ']') {
+                    bracketDepth--;
+                }
+                i++;
+            } else if (c == quote && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
+                inQuotes = true;
+                i++;
+            } else if (c == '[' && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
+                if (hasMvcBracketClose(line, i, quote, esc, delim)) {
+                    bracketDepth = 1;
+                }
+                current.append(c);
+                i++;
+            } else if (c == delim) {
+                if (i > 0 && line.charAt(i - 1) == esc) {
+                    current.append(c);
+                } else {
+                    entries.add(current.toString().trim());
+                    current = new StringBuilder();
+                }
+                i++;
+            } else {
+                current.append(c);
+                i++;
+            }
+        }
+        if (inQuotes) {
+            throw new MalformedRowException("Unclosed quoted field in line [" + CsvErrorMessages.summarize(line) + "]");
+        }
+        if (bracketDepth > 0) {
+            throw new MalformedRowException("Unclosed bracket cell in line [" + CsvErrorMessages.summarize(line) + "]");
+        }
+        if (current.length() > 0) {
+            entries.add(current.toString().trim());
+        }
+        return entries.toArray(String[]::new);
     }
 
     private class CsvBatchIterator implements CloseableIterator<Page> {
@@ -1168,16 +1490,52 @@ public class CsvFormatReader implements SegmentableFormatReader {
             }
         }
 
+        /**
+         * RFC-4180-style detection for whether {@code s} ends inside a quoted field. A {@code "} only
+         * opens quoting at field start (after {@code ,} or line-start, optionally preceded by whitespace);
+         * stray {@code "} inside an unquoted cell or inside a {@code [..]} MVC cell is a literal byte, not a
+         * quote toggle. Without this guard, real-world rows with embedded {@code "} characters cause
+         * {@link #readRowsBracketAware} to merge adjacent physical lines until the {@code "} count is even,
+         * yielding "row has [N] columns but schema defines [M]" failures and pathological multi-line scans.
+         */
         private static boolean hasUnclosedQuote(String s, char quote) {
             boolean inQuotes = false;
+            int bracketDepth = 0;
+            boolean fieldHasNonWhitespace = false;
             for (int i = 0; i < s.length(); i++) {
                 char c = s.charAt(i);
-                if (c == quote) {
-                    if (i + 1 < s.length() && s.charAt(i + 1) == quote) {
-                        i++;
-                        continue;
+                if (inQuotes) {
+                    if (c == quote) {
+                        if (i + 1 < s.length() && s.charAt(i + 1) == quote) {
+                            i++;
+                            continue;
+                        }
+                        inQuotes = false;
                     }
-                    inQuotes = !inQuotes;
+                    continue;
+                }
+                if (bracketDepth > 0) {
+                    if (c == '[') {
+                        bracketDepth++;
+                    } else if (c == ']') {
+                        bracketDepth--;
+                    }
+                    continue;
+                }
+                if (c == ',') {
+                    fieldHasNonWhitespace = false;
+                    continue;
+                }
+                if (c == quote && fieldHasNonWhitespace == false) {
+                    inQuotes = true;
+                    continue;
+                }
+                if (c == '[' && fieldHasNonWhitespace == false) {
+                    bracketDepth = 1;
+                    continue;
+                }
+                if (Character.isWhitespace(c) == false) {
+                    fieldHasNonWhitespace = true;
                 }
             }
             return inQuotes;
@@ -1185,86 +1543,15 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
         /**
          * Splits a CSV line by delimiter, treating quoted fields and {@code [..,..,..]} as single cells.
+         * Nested brackets ({@code [[37]]}) stay one cell: closing happens when MVC bracket depth returns to zero.
          * Commas inside quotes or brackets are not delimiters. Escaped commas ({@code \,}) are skipped.
          */
         private String[] splitLineBracketAware(String line) {
-            List<String> entries = new ArrayList<>();
-            char delim = options.delimiter();
-            char quote = options.quoteChar();
-            char esc = options.escapeChar();
-            StringBuilder current = new StringBuilder();
-            boolean inQuotes = false;
-            boolean inBrackets = false;
-            int i = 0;
-            while (i < line.length()) {
-                char c = line.charAt(i);
-                if (inQuotes) {
-                    if (c == quote) {
-                        if (i + 1 < line.length() && line.charAt(i + 1) == quote) {
-                            current.append(quote);
-                            i += 2;
-                            continue;
-                        }
-                        inQuotes = false;
-                    } else if (c == esc && i + 1 < line.length() && line.charAt(i + 1) == delim) {
-                        current.append(delim);
-                        i += 2;
-                        continue;
-                    } else {
-                        current.append(c);
-                    }
-                    i++;
-                } else if (inBrackets) {
-                    current.append(c);
-                    if (c == ']') {
-                        inBrackets = false;
-                        entries.add(current.toString());
-                        current = new StringBuilder();
-                        i++;
-                        while (i < line.length() && line.charAt(i) == ' ') {
-                            i++;
-                        }
-                        if (i < line.length() && line.charAt(i) == delim) {
-                            i++;
-                            continue;
-                        }
-                        continue;
-                    }
-                    i++;
-                } else if (c == quote) {
-                    inQuotes = true;
-                    i++;
-                } else if (c == '[' && current.length() == 0) {
-                    inBrackets = true;
-                    current.append(c);
-                    i++;
-                } else if (c == delim) {
-                    if (i > 0 && line.charAt(i - 1) == esc) {
-                        current.append(c);
-                    } else {
-                        entries.add(current.toString().trim());
-                        current = new StringBuilder();
-                    }
-                    i++;
-                } else {
-                    current.append(c);
-                    i++;
-                }
-            }
-            if (inQuotes) {
-                throw new MalformedRowException("Unclosed quoted field in line [" + CsvErrorMessages.summarize(line) + "]");
-            }
-            if (inBrackets) {
-                throw new MalformedRowException("Unclosed bracket cell in line [" + CsvErrorMessages.summarize(line) + "]");
-            }
-            if (current.length() > 0) {
-                entries.add(current.toString().trim());
-            }
-            return entries.toArray(String[]::new);
+            return splitCommaDelimiterBracketAwareFields(line, options.quoteChar(), options.escapeChar());
         }
 
         private List<Attribute> inferSchemaFromBatchReader(String headerLine) throws IOException {
-            String[] columnNames = headerLine.split(Pattern.quote(Character.toString(options.delimiter())));
+            String[] columnNames = splitFieldsForOptions(headerLine, options);
             csvIterator = newCsvIterator(reader);
             SchemaSample sample = collectSampleRows(
                 csvIterator,

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -1055,14 +1055,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     /**
-     * Whether {@code line} contains a bracket-multi-value cell opener at {@code openBracketIndex} that is closed by a
-     * matching {@code ]} with correct nesting. If not (e.g. literal {@code [6:42)} text), bracket-aware splitting must
-     * not treat {@code ,} inside the cell as internal MV commas — otherwise the parser never sees {@code ]} and fails
-     * with "Unclosed bracket cell".
-     * <p>
-     * Quote and {@code esc}+{@code delim} rules match {@code splitLineBracketAware} on the batch iterator.
-     */
-    /**
      * Whether {@code current} contains only whitespace — treated like an empty field prefix so a following {@code [}
      * still opens bracket MVC parsing (mirrors parallel record-boundary scanning).
      */
@@ -1077,13 +1069,14 @@ public class CsvFormatReader implements SegmentableFormatReader {
 
     /**
      * Whether {@code line} starting at {@code openBracketIndex} contains a balanced bracket suffix that closes the
-     * MVC cell. Mirrors the splitter's {@code bracketDepth > 0} branch which treats every byte inside the cell as
-     * literal: only {@code [} and {@code ]} adjust depth. A stray {@code "} or {@code \} inside the cell is data,
-     * not a quote toggle — otherwise real-world rows like {@code [text",1,2013-...,38,-12345]} would look unclosed
-     * here, the splitter would treat the leading {@code [} as literal, and the inner commas would become delimiters,
-     * yielding extra columns and the {@code "row has [N+k] columns but schema defines [N]"} failure.
+     * MVC cell. Only {@code [} and {@code ]} adjust depth — quote/escape/delimiter characters inside the bracket
+     * cell are treated as literal data (matching the splitter's {@code bracketDepth > 0} branch). A stray {@code "}
+     * or {@code \} inside the cell is data, not a quote toggle — otherwise real-world rows like
+     * {@code [text",1,2013-...,38,-12345]} would look unclosed here, the splitter would treat the leading {@code [}
+     * as literal, and the inner commas would become delimiters, yielding extra columns and the
+     * {@code "row has [N+k] columns but schema defines [N]"} failure.
      */
-    private static boolean hasMvcBracketClose(String line, int openBracketIndex, char quote, char esc, char delim) {
+    private static boolean hasMvcBracketClose(String line, int openBracketIndex) {
         if (openBracketIndex < 0 || openBracketIndex >= line.length() || line.charAt(openBracketIndex) != '[') {
             return false;
         }
@@ -1159,7 +1152,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 inQuotes = true;
                 continue;
             }
-            if (c == '[' && fieldHasNonWhitespace == false && hasMvcBracketClose(line, i, quote, esc, delim)) {
+            if (c == '[' && fieldHasNonWhitespace == false && hasMvcBracketClose(line, i)) {
                 bracketDepth = 1;
                 continue;
             }
@@ -1216,7 +1209,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
                 inQuotes = true;
                 i++;
             } else if (c == '[' && (current.length() == 0 || isWhitespaceOnlyFieldPrefix(current))) {
-                if (hasMvcBracketClose(line, i, quote, esc, delim)) {
+                if (hasMvcBracketClose(line, i)) {
                     bracketDepth = 1;
                 }
                 current.append(c);
@@ -1531,6 +1524,11 @@ public class CsvFormatReader implements SegmentableFormatReader {
                     continue;
                 }
                 if (c == '[' && fieldHasNonWhitespace == false) {
+                    // Intentionally enters bracket mode without calling hasMvcBracketClose: this
+                    // method only determines whether a quote is unclosed for multi-line gluing.
+                    // An unclosed bracket here is harmless (it suppresses quote detection for the
+                    // remainder of the line) while a false-negative hasMvcBracketClose would cause
+                    // spurious multi-line gluing on rows with stray quotes inside bracket cells.
                     bracketDepth = 1;
                     continue;
                 }

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -2155,6 +2155,67 @@ public class CsvFormatReaderTests extends ESTestCase {
         }
     }
 
+    /**
+     * A cell that starts with {@code [} but has no MVC-closing {@code ]} (e.g. interval-like {@code [6:42)}) must not
+     * trigger bracket-swallowing — commas in the rest of the row remain column delimiters.
+     */
+    public void testBracketAwareOpenBracketWithoutMvcCloseIsLiteralColumnSplit() throws IOException {
+        String csv = "id:integer,title:keyword,dt:keyword\n1,[6:42) literal title text,2013-07-20\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            IntBlock idBlock = (IntBlock) page.getBlock(0);
+            BytesRefBlock titleBlock = (BytesRefBlock) page.getBlock(1);
+            BytesRefBlock dtBlock = (BytesRefBlock) page.getBlock(2);
+            assertEquals(1, idBlock.getInt(0));
+            assertEquals(new BytesRef("[6:42) literal title text"), titleBlock.getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("2013-07-20"), dtBlock.getBytesRef(0, new BytesRef()));
+        }
+    }
+
+    /**
+     * Typed headers must use the same bracket-aware field splitting as data rows; otherwise bound schema width disagrees
+     * with row parses under parallel reads.
+     */
+    public void testMetadataSchemaColumnCountUsesBracketAwareHeaderSplit() throws IOException {
+        String csv = "id:integer,title:keyword\n1,[[37]]\n2,[hello,world]\n";
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        assertEquals(2, reader.metadata(createStorageObject(csv)).schema().size());
+        try (CloseableIterator<Page> iterator = reader.read(createStorageObject(csv), null, 10)) {
+            int rows = 0;
+            while (iterator.hasNext()) {
+                rows += iterator.next().getPositionCount();
+            }
+            assertEquals(2, rows);
+        }
+    }
+
+    /**
+     * Nested {@code [[…]]} must not close the MVC cell on the inner {@code ]} — otherwise an extra column appears.
+     * With {@code multi_value_syntax=brackets}, the outer MV strips once; the inner {@code [37]} is the single keyword element.
+     */
+    public void testBracketAwareNestedBracketsStaySingleCell() throws IOException {
+        String csv = "prefix:keyword,mid:keyword,suffix:keyword\nx,[[37]],y\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            assertEquals(3, page.getBlockCount());
+            BytesRefBlock midBlock = (BytesRefBlock) page.getBlock(1);
+            assertEquals(1, midBlock.getValueCount(0));
+            assertEquals(new BytesRef("[37]"), midBlock.getBytesRef(midBlock.getFirstValueIndex(0), new BytesRef()));
+            BytesRefBlock suffixBlock = (BytesRefBlock) page.getBlock(2);
+            assertEquals(new BytesRef("y"), suffixBlock.getBytesRef(0, new BytesRef()));
+        }
+    }
+
     public void testMultiValueBracketsQuotedElements() throws IOException {
         String csv = "id:integer,names:keyword\n1,\"[\"\"hello\"\",\"\"world\"\"]\"\n";
         StorageObject object = createStorageObject(csv);
@@ -2486,6 +2547,119 @@ public class CsvFormatReaderTests extends ESTestCase {
         long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
         int expected = "partial,\"quoted\nfield\nwith\nnewlines\",end\n".length();
         assertEquals(expected, boundary);
+    }
+
+    public void testBracketPrefixedFieldStaysOneField() throws IOException {
+        // Production hits CSV pattern: `,[37] Title text,...` — the `[37]` looks like an MVC cell, but the field
+        // continues past the closing `]` until the next comma. Closing the cell on `]` (and starting a fresh entry)
+        // turns the trailing text into a phantom extra column → "row has [N+1] columns" failures.
+        String csv = "id:long,text:keyword,when:keyword\n1,[37] Title with text,2013-07-29\n2,plain,2013-07-30\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(3, page.getBlockCount());
+            BytesRefBlock text = (BytesRefBlock) page.getBlock(1);
+            assertEquals(new BytesRef("[37] Title with text"), text.getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("plain"), text.getBytesRef(1, new BytesRef()));
+            BytesRefBlock when = (BytesRefBlock) page.getBlock(2);
+            assertEquals(new BytesRef("2013-07-29"), when.getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("2013-07-30"), when.getBytesRef(1, new BytesRef()));
+        }
+    }
+
+    public void testBracketCellWithStrayQuoteAndCommasIsOneField() throws IOException {
+        // Reproduces the production hits CSV pattern where bracket MVC cells contain literal `"` characters
+        // and embedded commas (e.g. `[some text",1,2013-...,38,-12345]`). The lookahead must mirror the splitter:
+        // inside `[..]` only `[` and `]` matter — a stray `"` is a literal byte. Otherwise the lookahead reports
+        // "no matching ]" and the splitter falls back to treating `[` as plain text, which turns inner commas into
+        // delimiters and produces `row has [N+k] columns but schema defines [N]` failures.
+        String csv = "id:long,tags:keyword,when:keyword\n"
+            + "1,[some text\",1,2013-07-15 13:51:28,2013-07-15,38,177794517],ok\n"
+            + "2,[plain],ok\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(3, page.getBlockCount());
+            BytesRefBlock when = (BytesRefBlock) page.getBlock(2);
+            assertEquals(new BytesRef("ok"), when.getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("ok"), when.getBytesRef(1, new BytesRef()));
+        }
+    }
+
+    public void testStrayQuoteInUnquotedFieldIsLiteralAndDoesNotMergeRows() throws IOException {
+        // Two physical rows, each fully formed for a 3-column schema. The first row contains
+        // a single literal `"` inside an unquoted text cell. RFC-4180 says quoting only opens at
+        // field start; without the field-start check the parser would conclude the first row has an
+        // open quote, glue the second row's bytes onto it, and report 6 columns instead of 3.
+        String csv = "id:long,title:keyword,value:long\n1,Inch \" mark,42\n2,plain,7\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(2, page.getPositionCount());
+            assertEquals(3, page.getBlockCount());
+            BytesRefBlock title = (BytesRefBlock) page.getBlock(1);
+            assertEquals(new BytesRef("Inch \" mark"), title.getBytesRef(0, new BytesRef()));
+            assertEquals(new BytesRef("plain"), title.getBytesRef(1, new BytesRef()));
+            LongBlock value = (LongBlock) page.getBlock(2);
+            assertEquals(42L, value.getLong(0));
+            assertEquals(7L, value.getLong(1));
+        }
+    }
+
+    public void testFindNextRecordBoundaryStrayQuoteIsNotAQuoteOpener() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        // Stray `"` inside an unquoted cell must not switch the scanner into quote mode; otherwise the
+        // first `\n` is skipped and the segment boundary lands far past the next record.
+        byte[] data = "1,Inch \" mark,42\n2,plain,7\n".getBytes(StandardCharsets.UTF_8);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        assertEquals("1,Inch \" mark,42\n".length(), boundary);
+    }
+
+    public void testFindNextRecordBoundaryNewlineInsideBracketMvc() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] data = "before,[line1\nline2\nline3],after\nnext\n".getBytes(StandardCharsets.UTF_8);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        assertEquals("before,[line1\nline2\nline3],after\n".length(), boundary);
+    }
+
+    public void testFindNextRecordBoundaryNestedBracketMvcWithEmbeddedNewlines() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] data = "a,[[cell\ninner]],b\nz\n".getBytes(StandardCharsets.UTF_8);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        assertEquals("a,[[cell\ninner]],b\n".length(), boundary);
+    }
+
+    public void testFindNextRecordBoundaryMultiValueSyntaxNoneDoesNotTreatBracketsAsMvc() throws IOException {
+        CsvFormatReader reader = (CsvFormatReader) new CsvFormatReader(blockFactory).withConfig(Map.of("multi_value_syntax", "none"));
+        byte[] data = "before,[not\nmvc],after\nnext\n".getBytes(StandardCharsets.UTF_8);
+        long boundary = reader.findNextRecordBoundary(new ByteArrayInputStream(data));
+        assertEquals("before,[not\n".length(), boundary);
+    }
+
+    public void testBracketAwareLeadingWhitespaceBeforeBracketOpensMvc() throws IOException {
+        String csv = "prefix:keyword,mid:keyword,suffix:keyword\nx,  [[37]],y\n";
+        StorageObject object = createStorageObject(csv);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        try (CloseableIterator<Page> iterator = reader.read(object, null, 10)) {
+            assertTrue(iterator.hasNext());
+            Page page = iterator.next();
+            assertEquals(1, page.getPositionCount());
+            assertEquals(3, page.getBlockCount());
+            BytesRefBlock midBlock = (BytesRefBlock) page.getBlock(1);
+            assertEquals(1, midBlock.getValueCount(0));
+            assertEquals(new BytesRef("[37]"), midBlock.getBytesRef(midBlock.getFirstValueIndex(0), new BytesRef()));
+        }
     }
 
     public void testFindNextRecordBoundaryAtBufferBoundary() throws IOException {
@@ -3401,12 +3575,13 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testSkipRowOnBracketParseError() throws IOException {
-        // Unclosed bracket in last cell is detected by splitLineBracketAware which throws
-        // EsqlIllegalArgumentException; the policy must intercept it.
+        // splitLineBracketAware no longer throws on a stray `[` without a closing `]` (real data has things like
+        // [6:42), so a literal `[` falls back to plain text). Use a structural error instead — too many fields for
+        // the declared schema — which is the canonical "row malformed" case routed through the policy.
         String csv = """
             id:long,tags:keyword
             1,[a,b,c]
-            2,[broken
+            2,extra,unexpected,fields
             3,[x,y]
             """;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FileSplitProvider.java
@@ -653,12 +653,17 @@ public class FileSplitProvider implements SplitProvider {
         return groups.toArray(new int[0][]);
     }
 
+    /**
+     * Line-oriented formats that are safe for macro-splitting at approximate byte spans.
+     * {@code .csv} and {@code .tsv} are excluded because RFC-style quoting and embedded newlines
+     * mean record boundaries do not align with fixed byte strides.
+     */
     static boolean isSplittableFormat(String format) {
         if (format == null) {
             return false;
         }
         return switch (format) {
-            case ".csv", ".tsv", ".ndjson", ".jsonl", ".json", ".txt" -> true;
+            case ".ndjson", ".jsonl", ".json", ".txt" -> true;
             default -> false;
         };
     }
@@ -877,16 +882,26 @@ public class FileSplitProvider implements SplitProvider {
         if (a instanceof Number na && b instanceof Number nb) {
             return Double.compare(na.doubleValue(), nb.doubleValue());
         }
-        if (a instanceof Comparable<?> && b instanceof Comparable<?>) {
+        // Coerce mixed Number/String cases: a partition value may be stored as "2024" (String)
+        // while the literal from the filter is Integer 2024, or vice versa.
+        if (a instanceof Number && b instanceof Number == false) {
             try {
-                @SuppressWarnings("rawtypes")
-                Comparable ca = (Comparable) a;
-                @SuppressWarnings("unchecked")
-                int result = ca.compareTo(b);
-                return result;
-            } catch (ClassCastException e) {
+                return Double.compare(((Number) a).doubleValue(), Double.parseDouble(b.toString()));
+            } catch (NumberFormatException e) {
                 return a.toString().compareTo(b.toString());
             }
+        }
+        if (b instanceof Number && a instanceof Number == false) {
+            try {
+                return Double.compare(Double.parseDouble(a.toString()), ((Number) b).doubleValue());
+            } catch (NumberFormatException e) {
+                return a.toString().compareTo(b.toString());
+            }
+        }
+        if (a instanceof Comparable<?> && b instanceof Comparable<?> && a.getClass() == b.getClass()) {
+            @SuppressWarnings("unchecked")
+            Comparable<Object> ca = (Comparable<Object>) a;
+            return ca.compareTo(b);
         }
         return a.toString().compareTo(b.toString());
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinator.java
@@ -95,6 +95,17 @@ public final class ParallelParsingCoordinator {
         long fileLength = storageObject.length();
         long minSegment = reader.minimumSegmentSize();
 
+        // COUNT(*) and similar: projectedColumns is empty while rows still need structural validation
+        // against the file width. Non-first parallel segments do not re-scan the header; bind the
+        // full on-disk schema before segment workers run (see CsvFormatReader#read firstSplit/recordAligned).
+        SegmentableFormatReader parallelReader = reader;
+        if (projectedColumns != null && projectedColumns.isEmpty()) {
+            var meta = parallelReader.metadata(storageObject);
+            if (meta != null && meta.schema() != null && meta.schema().isEmpty() == false) {
+                parallelReader = (SegmentableFormatReader) parallelReader.withSchema(meta.schema());
+            }
+        }
+
         ErrorPolicy effectivePolicy = errorPolicy != null ? errorPolicy : ErrorPolicy.STRICT;
         FormatReadContext baseCtx = FormatReadContext.builder()
             .projectedColumns(projectedColumns)
@@ -102,16 +113,16 @@ public final class ParallelParsingCoordinator {
             .errorPolicy(effectivePolicy)
             .build();
         if (parallelism <= 1 || fileLength < minSegment * 2) {
-            return reader.read(storageObject, baseCtx);
+            return parallelReader.read(storageObject, baseCtx);
         }
 
-        List<long[]> segments = computeSegments(reader, storageObject, fileLength, parallelism, minSegment);
+        List<long[]> segments = computeSegments(parallelReader, storageObject, fileLength, parallelism, minSegment);
 
         if (segments.size() <= 1) {
-            return reader.read(storageObject, baseCtx);
+            return parallelReader.read(storageObject, baseCtx);
         }
 
-        return new OrderedParallelIterator(reader, storageObject, projectedColumns, batchSize, segments, executor, effectivePolicy);
+        return new OrderedParallelIterator(parallelReader, storageObject, projectedColumns, batchSize, segments, executor, effectivePolicy);
     }
 
     /**
@@ -265,7 +276,7 @@ public final class ParallelParsingCoordinator {
                             break;
                         }
                         Page page = pages.next();
-                        queue.put(page);
+                        enqueueOrRelease(queue, page);
                     }
                 }
             } catch (Exception e) {
@@ -273,6 +284,20 @@ public final class ParallelParsingCoordinator {
             } finally {
                 enqueuePoison(queue);
                 allDone.countDown();
+            }
+        }
+
+        private void enqueueOrRelease(BlockingQueue<Page> queue, Page page) throws InterruptedException {
+            while (true) {
+                if (closed || firstError.get() != null) {
+                    if (page.getPositionCount() > 0) {
+                        page.releaseBlocks();
+                    }
+                    return;
+                }
+                if (queue.offer(page, 500, TimeUnit.MILLISECONDS)) {
+                    return;
+                }
             }
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FileSplitProviderTests.java
@@ -372,12 +372,12 @@ public class FileSplitProviderTests extends ESTestCase {
 
     // -- sub-file splitting --
 
-    public void testLargeCsvFileIsSplitIntoChunks() {
+    public void testLargeNdjsonFileIsSplitIntoChunks() {
         long targetSize = 1000;
         FileSplitProvider splitter = new FileSplitProvider(targetSize);
 
-        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/big.csv"), 3500, Instant.EPOCH);
-        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/big.ndjson"), 3500, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.ndjson");
 
         SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), PartitionMetadata.EMPTY, List.of());
         List<ExternalSplit> splits = splitter.discoverSplits(ctx);
@@ -450,10 +450,10 @@ public class FileSplitProviderTests extends ESTestCase {
         assertEquals(0, ((FileSplit) splits.get(0)).offset());
     }
 
-    public void testDefaultProviderSplitsLargeTextFile() {
+    public void testDefaultProviderSplitsLargeNdjsonFile() {
         long fileSize = 500 * 1024 * 1024L; // 500 MB
-        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/huge.csv"), fileSize, Instant.EPOCH);
-        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/huge.ndjson"), fileSize, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.ndjson");
 
         SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), PartitionMetadata.EMPTY, List.of());
         List<ExternalSplit> splits = provider.discoverSplits(ctx);
@@ -478,8 +478,8 @@ public class FileSplitProviderTests extends ESTestCase {
     }
 
     public void testTargetSplitSizeConfigOverride() {
-        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.csv"), 3000, Instant.EPOCH);
-        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.ndjson"), 3000, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.ndjson");
 
         Map<String, Object> config = Map.of(FileSplitProvider.CONFIG_TARGET_SPLIT_SIZE, "1kb");
         SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, config, PartitionMetadata.EMPTY, List.of());
@@ -523,8 +523,8 @@ public class FileSplitProviderTests extends ESTestCase {
     }
 
     public void testTargetSplitSizeInvalidValue() {
-        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.csv"), 3000, Instant.EPOCH);
-        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.ndjson"), 3000, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.ndjson");
 
         Map<String, Object> config = Map.of(FileSplitProvider.CONFIG_TARGET_SPLIT_SIZE, "not_a_number");
         SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, config, PartitionMetadata.EMPTY, List.of());
@@ -532,8 +532,8 @@ public class FileSplitProviderTests extends ESTestCase {
     }
 
     public void testTargetSplitSizeUnitlessIsRejected() {
-        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.csv"), 3000, Instant.EPOCH);
-        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.ndjson"), 3000, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.ndjson");
 
         Map<String, Object> config = Map.of(FileSplitProvider.CONFIG_TARGET_SPLIT_SIZE, "1024");
         SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, config, PartitionMetadata.EMPTY, List.of());
@@ -541,8 +541,8 @@ public class FileSplitProviderTests extends ESTestCase {
     }
 
     public void testTargetSplitSizeZeroIsRejected() {
-        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.csv"), 3000, Instant.EPOCH);
-        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/data.ndjson"), 3000, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.ndjson");
 
         Map<String, Object> config = Map.of(FileSplitProvider.CONFIG_TARGET_SPLIT_SIZE, "0b");
         SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, config, PartitionMetadata.EMPTY, List.of());
@@ -553,8 +553,8 @@ public class FileSplitProviderTests extends ESTestCase {
         long targetSize = 1000;
         FileSplitProvider splitter = new FileSplitProvider(targetSize);
 
-        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/exact.csv"), targetSize, Instant.EPOCH);
-        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.csv");
+        StorageEntry entry = new StorageEntry(StoragePath.of("s3://b/exact.ndjson"), targetSize, Instant.EPOCH);
+        FileList fileList = GlobExpander.fileListOf(List.of(entry), "s3://b/*.ndjson");
 
         SplitDiscoveryContext ctx = new SplitDiscoveryContext(null, fileList, Map.of(), PartitionMetadata.EMPTY, List.of());
         List<ExternalSplit> splits = splitter.discoverSplits(ctx);
@@ -580,8 +580,8 @@ public class FileSplitProviderTests extends ESTestCase {
     }
 
     public void testIsSplittableFormat() {
-        assertTrue(FileSplitProvider.isSplittableFormat(".csv"));
-        assertTrue(FileSplitProvider.isSplittableFormat(".tsv"));
+        assertFalse(FileSplitProvider.isSplittableFormat(".csv"));
+        assertFalse(FileSplitProvider.isSplittableFormat(".tsv"));
         assertTrue(FileSplitProvider.isSplittableFormat(".ndjson"));
         assertTrue(FileSplitProvider.isSplittableFormat(".jsonl"));
         assertTrue(FileSplitProvider.isSplittableFormat(".txt"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/ParallelParsingCoordinatorTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.datasource.csv.CsvFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.SegmentableFormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
@@ -357,6 +358,39 @@ public class ParallelParsingCoordinatorTests extends ESTestCase {
         FormatReadContext only = seen.get(0);
         assertTrue("Whole-file fallback path must mark firstSplit=true", only.firstSplit());
         assertTrue("Whole-file fallback path must mark lastSplit=true", only.lastSplit());
+    }
+
+    /**
+     * Regression: {@code COUNT(*)} passes empty projected columns; parallel segment workers must
+     * still see the file column width via metadata-bound schema (otherwise structural validation
+     * compares rows against schema size 0).
+     */
+    public void testParallelReadEmptyProjectionInfersCsvSchemaBeforeSegments() throws Exception {
+        String header = "a,b,c\n";
+        String row = "1,2,3\n";
+        StringBuilder sb = new StringBuilder(header);
+        while (sb.length() < 3 * 1024 * 1024) {
+            sb.append(row);
+        }
+        byte[] bytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+        StorageObject obj = new InMemoryStorageObject(bytes);
+        CsvFormatReader reader = new CsvFormatReader(blockFactory());
+
+        ExecutorService exec = Executors.newFixedThreadPool(4);
+        try {
+            CloseableIterator<Page> iter = ParallelParsingCoordinator.parallelRead(reader, obj, List.of(), 500, 4, exec);
+            long rows = 0;
+            try (iter) {
+                while (iter.hasNext()) {
+                    Page p = iter.next();
+                    rows += p.getPositionCount();
+                    p.releaseBlocks();
+                }
+            }
+            assertTrue(rows > 0);
+        } finally {
+            exec.shutdown();
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes the handling of the "plain" CSV files.
There were three independent bugs in the bracket-aware CSV path.

* Premature MVC cell close. When ] brought bracket depth back to zero, the splitter immediately added the cell and started a new one.
* Incorrect quote handling: any " was treated as a toggle.
* Incorrect quote-aware bracket lookahead.

Bzip2-compression masked all of this because of the parallelism.