### PR TITLE
Use 64 bit hash in BytesRefSwissHash

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/bytes/MixHash64Benchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/bytes/MixHash64Benchmark.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 public class MixHash64Benchmark {
 
-    @Param({"4", "5", "6", "7", "8", "9", "12", "13", "16", "17", "31", "32", "33", "64", "128" })
+    @Param({ "4", "5", "6", "7", "8", "9", "12", "13", "16", "17", "31", "32", "33", "64", "128" })
     int length;
 
     private byte[] bytes;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/bytes/MixHash64Benchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/bytes/MixHash64Benchmark.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.benchmark.bytes;
+
+import org.apache.lucene.util.StringHelper;
+import org.elasticsearch.common.bytes.MixHash64;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+@State(Scope.Thread)
+public class MixHash64Benchmark {
+
+    @Param({"4", "5", "6", "7", "8", "9", "12", "13", "16", "17", "31", "32", "33", "64", "128" })
+    int length;
+
+    private byte[] bytes;
+
+    @Setup
+    public void setup() {
+        bytes = new byte[length];
+        ThreadLocalRandom.current().nextBytes(bytes);
+    }
+
+    @Benchmark
+    public long mixHash64() {
+        return MixHash64.hash64(bytes, 0, length);
+    }
+
+    @Benchmark
+    public int murmur32() {
+        return StringHelper.murmurhash3_x86_32(bytes, 0, length, StringHelper.GOOD_FAST_HASH_SEED);
+    }
+}

--- a/libs/swisshash/src/main/java/org/elasticsearch/swisshash/BytesRefSwissHash.java
+++ b/libs/swisshash/src/main/java/org/elasticsearch/swisshash/BytesRefSwissHash.java
@@ -15,8 +15,8 @@ import jdk.incubator.vector.VectorSpecies;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.StringHelper;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.bytes.MixHash64;
 import org.elasticsearch.common.bytes.PagedBytesCursor;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
@@ -147,11 +147,11 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
      */
     @Override
     public long find(BytesRef key) {
-        final int hash = hash(key);
+        final long hash = hash64(key);
         if (smallCore != null) {
             return smallCore.find(key, hash);
         } else {
-            return bigCore.find(key, hash, control(hash));
+            return bigCore.find(key, hash);
         }
     }
 
@@ -166,7 +166,7 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
      * Prefetch the data at the slot of the given hash. The caller should only call this method
      * when {@link #shouldPrefetch()} return true.
      */
-    public int prefetch(int hash) {
+    public int prefetch(long hash) {
         return bigCore.prefetch(hash);
     }
 
@@ -174,11 +174,11 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
      * Finds an {@code id} by a {@code key}.
      */
     public long find(PagedBytesCursor key) {
-        final int hash = hash(key);
+        final long hash = hash64(key);
         if (smallCore != null) {
             return smallCore.find(key, hash);
         } else {
-            return bigCore.find(key, hash, control(hash));
+            return bigCore.find(key, hash);
         }
     }
 
@@ -189,14 +189,14 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
      */
     @Override
     public long add(BytesRef key) {
-        final int hash = hash(key);
+        final long hash = hash64(key);
         return addWithHash(key, hash);
     }
 
     /**
      * Same semantic as {@link #add(BytesRef)} but accepts a pre-computed hash.
      */
-    public int addWithHash(BytesRef key, int hash) {
+    public int addWithHash(BytesRef key, long hash) {
         if (smallCore != null) {
             if (size < nextGrowSize) {
                 return smallCore.add(key, hash);
@@ -214,7 +214,7 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
      */
     @Override
     public long add(PagedBytesCursor key) {
-        final int hash = hash(key);
+        final long hash = hash64(key);
         if (smallCore != null) {
             if (size < nextGrowSize) {
                 return smallCore.add(key, hash);
@@ -247,8 +247,8 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
      * and the remaining 7 bits contain the top 7 bits of the hash.
      * So it looks like {@code 0b0xxx_xxxx}.
      */
-    private static byte control(int hash) {
-        return (byte) (hash >>> (Integer.SIZE - 7));
+    private static byte control(long hash) {
+        return (byte) (hash >>> (Long.SIZE - 7));
     }
 
     @Override
@@ -276,103 +276,95 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
      * Open addressed hash table the probes by triangle numbers. Empty
      * {@code id}s are encoded as {@code -1}. This hash table can't
      * grow, and is instead replaced by a {@link BigCore}.
-     *
-     * <p> This uses one page from the {@link PageCacheRecycler} for the
-     * {@code ids}.
      */
     final class SmallCore extends Core {
         static final float FILL_FACTOR = 0.6F;
 
-        private final byte[] idAndHashPage;
+        private final long[] slots;
+        private final byte[] controlData; // stored for rehash
 
         private SmallCore() {
-            boolean success = false;
-            try {
-                idAndHashPage = grabPage();
-                Arrays.fill(idAndHashPage, (byte) 0xff);
-                success = true;
-            } finally {
-                if (success == false) {
-                    close();
-                }
-            }
+            final long requiredBytes = (long) capacity * Long.BYTES + capacity;
+            breaker.addEstimateBytesAndMaybeBreak(requiredBytes, "BytesRefSwissHash-smallCore");
+            usedBytes += requiredBytes;
+            slots = new long[capacity];
+            controlData = new byte[capacity];
+            Arrays.fill(slots, -1L);
         }
 
         /**
-         * Find bytes in the hash. This has a lot of duplication with {@link #find(PagedBytesCursor, int)}
+         * Find bytes in the hash. This has a lot of duplication with {@link #find(PagedBytesCursor, long)}
          * but we're intentionally doing it to make them look exactly the same. And because this
          * is the hottest of the hot path.
          */
-        int find(final BytesRef key, final int hash) {
-            int slot = slot(hash);
+        int find(final BytesRef key, final long hash) {
+            int slot = slot((int) hash);
             for (;; slot = slot(slot + 1)) {
-                long value = (long) LONG_HANDLE.get(idAndHashPage, idAndHashOffset(slot));
-                int id = id(value);
-                if (id == -1 || (hash(value) == hash && matches(key, id))) {
+                final long packed = slots[slot];
+                final int id = (int) (packed >>> 32);
+                if (id == -1 || ((int) packed == (int) hash && matches(key, id))) {
                     return id;
                 }
             }
         }
 
         /**
-         * Find bytes in the hash. This has a lot of duplication with {@link #find(BytesRef, int)}
+         * Find bytes in the hash. This has a lot of duplication with {@link #find(BytesRef, long)}
          * but we're intentionally doing it to make them look exactly the same. And because this
          * is the hottest of the hot path.
          */
-        int find(final PagedBytesCursor key, final int hash) {
-            int slot = slot(hash);
+        int find(final PagedBytesCursor key, final long hash) {
+            int slot = slot((int) hash);
             for (;; slot = slot(slot + 1)) {
-                long value = (long) LONG_HANDLE.get(idAndHashPage, idAndHashOffset(slot));
-                int id = id(value);
-                if (id == -1 || (hash(value) == hash && matches(key, id))) {
+                final long packed = slots[slot];
+                final int id = (int) (packed >>> 32);
+                if (id == -1 || ((int) packed == (int) hash && matches(key, id))) {
                     return id;
                 }
             }
         }
 
         /**
-         * Adds to the hash. This has a lot of duplication with {@link #add(PagedBytesCursor, int)}
+         * Adds to the hash. This has a lot of duplication with {@link #add(PagedBytesCursor, long)}
          * but we're intentionally doing it to make them look exactly the same. And because this
          * is the hottest of the hot path.
          */
-        int add(final BytesRef key, final int hash) {
-            int slot = slot(hash);
+        int add(final BytesRef key, final long hash) {
+            int slot = slot((int) hash);
             for (;; slot = slot(slot + 1)) {
-                final int offset = idAndHashOffset(slot);
-                final long value = (long) LONG_HANDLE.get(idAndHashPage, offset);
-                final int id = id(value);
-                if (id == -1) { // means unset
+                final long packed = slots[slot];
+                final int id = (int) (packed >>> 32);
+                if (id == -1) {
                     final int nextId = (int) bytesRefs.size();
                     bytesRefs.append(key);
-                    final long newValue = ((long) nextId << 32) | Integer.toUnsignedLong(hash);
-                    LONG_HANDLE.set(idAndHashPage, offset, newValue);
+                    slots[slot] = ((long) nextId << 32) | Integer.toUnsignedLong((int) hash);
+                    controlData[slot] = control(hash);
                     size++;
                     return nextId;
-                } else if (hash(value) == hash && matches(key, id)) {
+                } else if ((int) packed == (int) hash && matches(key, id)) {
                     return -1 - id;
                 }
             }
         }
 
         /**
-         * Adds to the hash. This has a lot of duplication with {@link #add(BytesRef, int)}
+         * Adds to the hash. This has a lot of duplication with {@link #add(BytesRef, long)}
          * but we're intentionally doing it to make them look exactly the same. And because this
          * is the hottest of the hot path.
          */
-        int add(final PagedBytesCursor key, final int hash) {
-            int slot = slot(hash);
+        int add(final PagedBytesCursor key, final long hash) {
+            int slot = slot((int) hash);
             for (;; slot = slot(slot + 1)) {
-                final int offset = idAndHashOffset(slot);
-                final long value = (long) LONG_HANDLE.get(idAndHashPage, offset);
-                final int id = id(value);
-                if (id == -1) { // means unset
+                final long packed = slots[slot];
+                final int id = (int) (packed >>> 32);
+                if (id == -1) {
                     final int nextId = (int) bytesRefs.size();
                     bytesRefs.append(key);
-                    final long newValue = ((long) nextId << 32) | Integer.toUnsignedLong(hash);
-                    LONG_HANDLE.set(idAndHashPage, offset, newValue);
+                    slots[slot] = ((long) nextId << 32) | Integer.toUnsignedLong((int) hash);
+                    controlData[slot] = control(hash);
                     size++;
                     return nextId;
-                } else if (hash(value) == hash && matches(key, id)) {
+                } else if ((int) packed == (int) hash && matches(key, id)) {
                     return -1 - id;
                 }
             }
@@ -416,18 +408,13 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
 
         private void rehash(int oldCapacity) {
             for (int slot = 0; slot < oldCapacity; slot++) {
-                final long value = idAndHash(slot);
-                final int id = id(value);
+                final long packed = slots[slot];
+                final int id = (int) (packed >>> 32);
                 if (id < 0) {
                     continue;
                 }
-                final int hash = hash(value);
-                bigCore.insert(hash, control(hash), id);
+                bigCore.insert((int) packed, controlData[slot], id);
             }
-        }
-
-        private long idAndHash(int slot) {
-            return (long) LONG_HANDLE.get(idAndHashPage, idAndHashOffset(slot));
         }
     }
 
@@ -481,11 +468,13 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
         }
 
         /**
-         * Find bytes in the hash. This has a lot of duplication with {@link #find(PagedBytesCursor, int, byte)}
+         * Find bytes in the hash. This has a lot of duplication with {@link #find(PagedBytesCursor, long)}
          * but we're intentionally doing it to make them look exactly the same. And because this
          * is the hottest of the hot path.
          */
-        private int find(final BytesRef key, final int hash, final byte control) {
+        private int find(final BytesRef key, final long hash64) {
+            final int hash = hash(hash64);
+            final byte control = control(hash64);
             int group = hash & mask;
             for (;;) {
                 ByteVector vec = ByteVector.fromArray(BS, controlData, group);
@@ -509,11 +498,13 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
         }
 
         /**
-         * Find bytes in the hash. This has a lot of duplication with {@link #find(BytesRef, int, byte)}
+         * Find bytes in the hash. This has a lot of duplication with {@link #find(BytesRef, long)}
          * but we're intentionally doing it to make them look exactly the same. And because this
          * is the hottest of the hot path.
          */
-        private int find(final PagedBytesCursor key, final int hash, final byte control) {
+        private int find(final PagedBytesCursor key, final long hash64) {
+            final int hash = hash(hash64);
+            final byte control = control(hash64);
             int group = hash & mask;
             for (;;) {
                 ByteVector vec = ByteVector.fromArray(BS, controlData, group);
@@ -536,24 +527,25 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
             }
         }
 
-        int prefetch(int hash) {
-            final int group = hash & mask;
+        int prefetch(long hash64) {
+            final int group = hash(hash64) & mask;
             final int idOff = idAndHashOffset(group);
             return controlData[group] ^ idAndHashPages[idOff >> PAGE_SHIFT][idOff & PAGE_MASK];
         }
 
-        private int addWithHash(final BytesRef key, final int hash) {
+        private int addWithHash(final BytesRef key, final long hash) {
             maybeGrow();
             return bigCore.addImpl(key, hash);
         }
 
         /**
-         * Adds to the hash. This has a lot of duplication with {@link #addImpl(PagedBytesCursor, int)}
+         * Adds to the hash. This has a lot of duplication with {@link #addImpl(PagedBytesCursor, long)}
          * but we're intentionally doing it to make them look exactly the same. And because this
          * is the hottest of the hot path.
          */
-        private int addImpl(final BytesRef key, final int hash) {
-            final byte control = control(hash);
+        private int addImpl(final BytesRef key, final long hash64) {
+            final int hash = hash(hash64);
+            final byte control = control(hash64);
             int group = hash & mask;
             for (;;) {
                 ByteVector vec = ByteVector.fromArray(BS, controlData, group);
@@ -580,18 +572,19 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
             }
         }
 
-        private int add(final PagedBytesCursor key, final int hash) {
+        private int add(final PagedBytesCursor key, final long hash64) {
             maybeGrow();
-            return bigCore.addImpl(key, hash);
+            return bigCore.addImpl(key, hash64);
         }
 
         /**
-         * Adds to the hash. This has a lot of duplication with {@link #addImpl(BytesRef, int)}
+         * Adds to the hash. This has a lot of duplication with {@link #addImpl(BytesRef, long)}
          * but we're intentionally doing it to make them look exactly the same. And because this
          * is the hottest of the hot path.
          */
-        private int addImpl(final PagedBytesCursor key, final int hash) {
-            final byte control = control(hash);
+        private int addImpl(final PagedBytesCursor key, final long hash64) {
+            final int hash = hash(hash64);
+            final byte control = control(hash64);
             int group = hash & mask;
             for (;;) {
                 ByteVector vec = ByteVector.fromArray(BS, controlData, group);
@@ -674,13 +667,14 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
 
         private void rehash(int oldCapacity, BigCore newBigCore) {
             for (int i = 0; i < oldCapacity; i++) {
-                if (controlData[i] == EMPTY) {
+                final byte control = controlData[i];
+                if (control == EMPTY) {
                     continue;
                 }
                 final long value = idAndHash(i);
                 final int hash = hash(value);
                 final int id = id(value);
-                newBigCore.insert(hash, control(hash), id);
+                newBigCore.insert(hash, control, id);
             }
         }
 
@@ -736,20 +730,20 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
         return (int) (value >>> 32);
     }
 
-    int hash(long value) {
+    private static int hash(long value) {
         return (int) value;
     }
 
-    public static int hash(BytesRef v) {
-        return BitMixer.mix32(v.hashCode());
+    public static long hash64(BytesRef v) {
+        return MixHash64.hash64(v);
     }
 
-    public static int hash(byte[] bytes, int offset, int length) {
-        return BitMixer.mix32(StringHelper.murmurhash3_x86_32(bytes, offset, length, StringHelper.GOOD_FAST_HASH_SEED));
+    public static long hash64(byte[] bytes, int offset, int length) {
+        return MixHash64.hash64(bytes, offset, length);
     }
 
-    int hash(PagedBytesCursor cursor) {
-        return BitMixer.mix32(cursor.hashCode());
+    static long hash64(PagedBytesCursor cursor) {
+        return cursor.mixHash64();
     }
 
     int slot(int hash) {
@@ -767,7 +761,7 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
     @Override
     public long ramBytesUsed() {
         long keys = smallCore != null
-            ? smallCore.idAndHashPage.length
+            ? (long) smallCore.slots.length * Long.BYTES + smallCore.controlData.length
             : Arrays.stream(bigCore.idAndHashPages).mapToLong(b -> b.length).sum();
         return BASE_RAM_BYTES_USED + bytesRefs.ramBytesUsed() + keys;
     }

--- a/libs/swisshash/src/main/java/org/elasticsearch/swisshash/SwissHash.java
+++ b/libs/swisshash/src/main/java/org/elasticsearch/swisshash/SwissHash.java
@@ -232,7 +232,7 @@ public abstract class SwissHash {
      * and {@link Releasable}.
      */
     abstract class Core implements Releasable {
-        private long usedBytes = 0;
+        protected long usedBytes = 0;
         final List<Releasable> toClose;
 
         protected Core() {

--- a/libs/swisshash/src/test/java/org/elasticsearch/swisshash/BytesRefSwissHashTests.java
+++ b/libs/swisshash/src/test/java/org/elasticsearch/swisshash/BytesRefSwissHashTests.java
@@ -228,7 +228,7 @@ public class BytesRefSwissHashTests extends ESTestCase {
 
     public void testConsistentHash() {
         BytesRef value = new BytesRef(randomByteArrayOfLength(between(1, 1024)));
-        assertEquals(BytesRefSwissHash.hash(value), BytesRefSwissHash.hash(value.bytes, value.offset, value.length));
+        assertEquals(BytesRefSwissHash.hash64(value), BytesRefSwissHash.hash64(value.bytes, value.offset, value.length));
     }
 
     private void assertStatus(BytesRefSwissHash hash) {
@@ -308,7 +308,7 @@ public class BytesRefSwissHashTests extends ESTestCase {
                 if (randomBoolean()) {
                     return hash.add(value);
                 } else {
-                    return hash.addWithHash(value, BytesRefSwissHash.hash(value.bytes, value.offset, value.length));
+                    return hash.addWithHash(value, BytesRefSwissHash.hash64(value.bytes, value.offset, value.length));
                 }
             }
 

--- a/server/src/main/java/org/elasticsearch/common/bytes/MixHash64.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/MixHash64.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.bytes;
+
+import org.apache.lucene.util.BytesRef;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+/**
+ * A fast 64-bit hash using xor-multiply-shift mixing - processes 8 bytes per iteration
+ */
+public final class MixHash64 {
+    private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.nativeOrder());
+    private static final VarHandle INT_HANDLE = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.nativeOrder());
+
+    private long h = 0x9E3779B97F4A7C15L;
+    private final byte[] buf = new byte[8];
+    private int bufLen;
+    private long totalLen;
+
+    void update(byte[] bytes, int offset, int length) {
+        totalLen += length;
+        int pos = offset;
+        int rem = length;
+        if (bufLen > 0) {
+            int need = 8 - bufLen;
+            if (rem < need) {
+                System.arraycopy(bytes, pos, buf, bufLen, rem);
+                bufLen += rem;
+                return;
+            }
+            System.arraycopy(bytes, pos, buf, bufLen, need);
+            h = (h ^ (long) LONG_HANDLE.get(buf, 0)) * 0x4cf5ad432745937fL;
+            pos += need;
+            rem -= need;
+            bufLen = 0;
+        }
+        while (rem >= 8) {
+            h = (h ^ (long) LONG_HANDLE.get(bytes, pos)) * 0x4cf5ad432745937fL;
+            pos += 8;
+            rem -= 8;
+        }
+        if (rem > 0) {
+            System.arraycopy(bytes, pos, buf, 0, rem);
+            bufLen = rem;
+        }
+    }
+
+    long finish() {
+        int rem = bufLen;
+        if (rem >= 4) {
+            long lo = Integer.toUnsignedLong((int) INT_HANDLE.get(buf, 0));
+            long hi = Integer.toUnsignedLong((int) INT_HANDLE.get(buf, rem - 4));
+            h = (h ^ (lo | (hi << 32))) * 0x4cf5ad432745937fL;
+        } else if (rem > 0) {
+            long v = Byte.toUnsignedLong(buf[0]) | (Byte.toUnsignedLong(buf[rem >> 1]) << 8) | (Byte.toUnsignedLong(buf[rem - 1]) << 16);
+            h = (h ^ v) * 0x4cf5ad432745937fL;
+        }
+        h ^= totalLen;
+        h = (h ^ (h >>> 32)) * 0x4cd6944c5cc20b6dL;
+        h = (h ^ (h >>> 29)) * 0xfc12c5b19d3259e9L;
+        return h ^ (h >>> 32);
+    }
+
+    public static long hash64(byte[] bytes, int offset, int length) {
+        long h = 0x9E3779B97F4A7C15L;
+        int pos = offset;
+        int rem = length;
+        while (rem >= 8) {
+            h = (h ^ (long) LONG_HANDLE.get(bytes, pos)) * 0x4cf5ad432745937fL;
+            pos += 8;
+            rem -= 8;
+        }
+        if (rem >= 4) {
+            long lo = Integer.toUnsignedLong((int) INT_HANDLE.get(bytes, pos));
+            long hi = Integer.toUnsignedLong((int) INT_HANDLE.get(bytes, pos + rem - 4));
+            h = (h ^ (lo | (hi << 32))) * 0x4cf5ad432745937fL;
+        } else if (rem > 0) {
+            long v = Byte.toUnsignedLong(bytes[pos]) | (Byte.toUnsignedLong(bytes[pos + (rem >> 1)]) << 8) | (Byte.toUnsignedLong(
+                bytes[pos + rem - 1]
+            ) << 16);
+            h = (h ^ v) * 0x4cf5ad432745937fL;
+        }
+        h ^= length;
+        h = (h ^ (h >>> 32)) * 0x4cd6944c5cc20b6dL;
+        h = (h ^ (h >>> 29)) * 0xfc12c5b19d3259e9L;
+        return h ^ (h >>> 32);
+    }
+
+    public static long hash64(BytesRef bytes) {
+        return hash64(bytes.bytes, bytes.offset, bytes.length);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesCursor.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesCursor.java
@@ -518,6 +518,30 @@ public class PagedBytesCursor {
         return hasher.lastPage(flat, flat.length);
     }
 
+    /**
+     * Hashes the remaining unread bytes using an algorithm matching {@link MixHash64#hash64(byte[], int, int)}.
+     */
+    public long mixHash64() {
+        byte[] page = pages[pageIndex];
+        int avail = page.length - pageOffset;
+        if (avail >= remaining) {
+            return MixHash64.hash64(page, pageOffset, remaining);
+        }
+        MixHash64 hasher = new MixHash64();
+        int pi = pageIndex;
+        int po = pageOffset;
+        int rem = remaining;
+        while (rem > 0) {
+            page = pages[pi];
+            int chunk = Math.min(page.length - po, rem);
+            hasher.update(page, po, chunk);
+            rem -= chunk;
+            pi++;
+            po = 0;
+        }
+        return hasher.finish();
+    }
+
     @Override
     public String toString() {
         return PagedBytes.limitedToString(pages, pageIndex, pageOffset, remaining);

--- a/server/src/test/java/org/elasticsearch/common/bytes/MixHash64Tests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/MixHash64Tests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.bytes;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.common.util.PageCacheRecycler.BYTE_PAGE_SIZE;
+import static org.hamcrest.Matchers.equalTo;
+
+public class MixHash64Tests extends ESTestCase {
+
+    public void testEmpty() {
+        checkHash(new byte[0]);
+    }
+
+    public void testSmall() {
+        for (int len = 0; len < 1024; len++) {
+            byte[] bytes = randomByteArrayOfLength(len);
+            checkHash(bytes);
+        }
+    }
+
+    public void testRandom() {
+        for (int i = 0; i < 10; i++) {
+            byte[] bytes = randomByteArrayOfLength(between(0, BYTE_PAGE_SIZE * 20));
+            checkHash(bytes);
+        }
+    }
+
+    private void checkHash(byte[] bytes) {
+        long h1 = MixHash64.hash64(bytes, 0, bytes.length);
+        MixHash64 hasher = new MixHash64();
+        int offset = 0;
+        while (offset < bytes.length) {
+            int len = randomIntBetween(1, bytes.length - offset);
+            hasher.update(bytes, offset, len);
+            offset += len;
+        }
+        long h2 = hasher.finish();
+        assertThat(h1, equalTo(h2));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/bytes/PagedBytesCursorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/PagedBytesCursorTests.java
@@ -487,6 +487,19 @@ public class PagedBytesCursorTests extends ESTestCase {
         }
     }
 
+    public void testMixHash64() {
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(50));
+        byte[] bytes = randomByteArrayOfLength(between(0, BYTE_PAGE_SIZE * 3));
+        try (PagedBytesBuilder builder = new PagedBytesBuilder(recycler, breaker, "test", 0)) {
+            builder.append(bytes, 0, bytes.length);
+            try (PagedBytes ref = builder.build()) {
+                PagedBytesCursor cursor = ref.cursor(new PagedBytesCursor());
+                BytesRef bytesRef = new BytesRef(bytes);
+                assertThat(cursor.mixHash64(), equalTo(MixHash64.hash64(bytesRef)));
+            }
+        }
+    }
+
     public void testReadLengthPrefixedEmpty() {
         CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofMb(1));
         try (PagedBytesBuilder builder = new PagedBytesBuilder(recycler, breaker, "test", 0)) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -56,7 +56,7 @@ final class BytesRefBlockHash extends BlockHash {
 
     private static final int PREFETCH_BATCH = 128;
     private final PrefetchBarrier prefetchBarrier = new PrefetchBarrier();
-    private final int[] batchHashes = new int[PREFETCH_BATCH];
+    private final long[] batchHashes = new long[PREFETCH_BATCH];
     private final BytesRef[] batchKeys = new BytesRef[PREFETCH_BATCH];
     {
         for (int i = 0; i < PREFETCH_BATCH; i++) {
@@ -129,7 +129,7 @@ final class BytesRefBlockHash extends BlockHash {
                 int batchSize = Math.min(PREFETCH_BATCH, positions - offset);
                 for (int i = 0; i < batchSize; i++) {
                     vector.getBytesRef(offset + i, batchKeys[i]);
-                    batchHashes[i] = BytesRefSwissHash.hash(batchKeys[i]);
+                    batchHashes[i] = BytesRefSwissHash.hash64(batchKeys[i]);
                     dummy ^= swiss.prefetch(batchHashes[i]);
                 }
                 for (int i = 0; i < batchSize; i++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
@@ -541,7 +541,7 @@ final class PackedValuesBlockHash extends BlockHash {
         final int[] offsets;
         final int keyLength;
         final byte[] keys;
-        final int[] hashes;
+        final long[] hashes;
         final int[] groupIds;
         private final int emitBatchSize;
         private final BytesRefSwissHash swiss;
@@ -563,10 +563,10 @@ final class PackedValuesBlockHash extends BlockHash {
             this.keyLength = keyLength;
             this.blockFactory = blockFactory;
             this.specs = specs;
-            this.usedBytes = (long) BATCH_SIZE * keyLength + (long) emitBatchSize * Integer.BYTES + (long) BATCH_SIZE * Integer.BYTES;
+            this.usedBytes = (long) BATCH_SIZE * keyLength + (long) emitBatchSize * Integer.BYTES + (long) BATCH_SIZE * Long.BYTES;
             blockFactory.adjustBreaker(usedBytes);
             this.keys = new byte[BATCH_SIZE * keyLength];
-            this.hashes = new int[BATCH_SIZE];
+            this.hashes = new long[BATCH_SIZE];
             this.groupIds = new int[emitBatchSize];
             this.emitBatchSize = emitBatchSize;
         }
@@ -586,7 +586,7 @@ final class PackedValuesBlockHash extends BlockHash {
                     fillKeys(page, positionOffset + batchOffset, chunkSize);
                     if (swiss.shouldPrefetch()) {
                         for (int i = 0; i < chunkSize; i++) {
-                            hashes[i] = BytesRefSwissHash.hash(keys, i * keyLength, keyLength);
+                            hashes[i] = BytesRefSwissHash.hash64(keys, i * keyLength, keyLength);
                             dummy ^= swiss.prefetch(hashes[i]);
                         }
                         for (int i = 0; i < chunkSize; i++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -59,7 +59,7 @@ final class $Type$BlockHash extends BlockHash {
 $if(BytesRef)$
     private static final int PREFETCH_BATCH = 128;
     private final PrefetchBarrier prefetchBarrier = new PrefetchBarrier();
-    private final int[] batchHashes = new int[PREFETCH_BATCH];
+    private final long[] batchHashes = new long[PREFETCH_BATCH];
     private final BytesRef[] batchKeys = new BytesRef[PREFETCH_BATCH];
     {
         for (int i = 0; i < PREFETCH_BATCH; i++) {
@@ -142,7 +142,7 @@ $if(BytesRef)$
                 int batchSize = Math.min(PREFETCH_BATCH, positions - offset);
                 for (int i = 0; i < batchSize; i++) {
                     vector.getBytesRef(offset + i, batchKeys[i]);
-                    batchHashes[i] = BytesRefSwissHash.hash(batchKeys[i]);
+                    batchHashes[i] = BytesRefSwissHash.hash64(batchKeys[i]);
                     dummy ^= swiss.prefetch(batchHashes[i]);
                 }
                 for (int i = 0; i < batchSize; i++) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -1144,7 +1144,7 @@ public class BlockHashTests extends BlockHashTestCase {
     // Returns the size of the bytesRefBlockHash depending on the underlying implementation.
     static String byteRefBlockHashSize() {
         if (HashImplFactory.SWISS_HASH_AVAILABLE) {
-            return "33080b";
+            return "35128b";
         }
         return "531b";
     }

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/OperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/OperatorTestCase.java
@@ -286,7 +286,7 @@ public abstract class OperatorTestCase extends AnyOperatorTestCase {
     // Returns the size of an empty bytesRefBlockHash depending on the underlying implementation.
     protected final String byteRefBlockHashSize() {
         if (HashImplFactory.SWISS_HASH_AVAILABLE) {
-            return "33080b";
+            return "35128b";
         }
         return "440b";
     }


### PR DESCRIPTION
This PR switches to a 64-bit hash for BytesRefSwissHash so the control byte and stored hash no longer overlap. The current control byte is the top 7 bits of the 32-bit hash, meaning it provides no additional filtering beyond the hash itself. With a 64-bit hash the control byte and stored hash use separate bits, increasing the filter from 32 to 39 bits. This reduces false-positive key comparisons, which matters more as the table grows. The new hash is also faster than the default hashCode, but the difference is trivial.