### PR TITLE
[ESQL] Drop late-mat byte-ratio gate, fix trivially-passes shortcut

### DIFF
--- a/docs/changelog/148474.yaml
+++ b/docs/changelog/148474.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148474
+summary: "Drop late-mat byte-ratio gate, fix trivially-passes shortcut"
+type: bug

--- a/docs/changelog/148500.yaml
+++ b/docs/changelog/148500.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148500
+summary: Decouple Parquet late materialization from two-phase byte-ratio gate
+type: enhancement

--- a/docs/changelog/148501.yaml
+++ b/docs/changelog/148501.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148501
+summary: Fix Parquet trivially-passes shortcut leaking rows when LIKE is AND'd with a stats-trivial conjunct
+type: bug

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -1412,7 +1412,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                         blocks[col] = fullBlock;
                     }
                 } else if (pageColumnReaders != null && pageColumnReaders[col] != null) {
-                    blocks[col] = pageColumnReaders[col].readBatchFiltered(sourceRows, blockFactory, survivorPositions, emitCount);
+                    blocks[col] = pageColumnReaders[col].readBatchSparse(sourceRows, blockFactory, survivorPositions, emitCount);
                 } else {
                     // Read the full source-rows block and immediately filter to survivors.
                     // We hand fullBlock to filterBlock which closes it on success; on failure

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -392,10 +392,11 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     /**
      * Predicate-byte ratio threshold above which two-phase I/O is disabled because the projection
      * columns are not large enough relative to predicate columns to justify the extra round trip.
-     * The single-phase late-mat path remains in effect in that case. A separate, lower threshold
-     * than {@code LATE_MATERIALIZATION_PREDICATE_RATIO_THRESHOLD} is intentional: late-mat already
-     * pays off at 50% predicate share, but two-phase amortizes a sequential dependency and only
-     * wins when the projection columns clearly dominate.
+     * The single-phase late-mat path remains in effect in that case — late-mat itself has no
+     * byte-ratio gate (it is enabled whenever the iterator has projection-only columns to defer
+     * decode for); only the more expensive two-phase prefetch is gated here. The threshold is
+     * deliberately conservative: two-phase amortizes a sequential predicate-then-projection
+     * dependency and only wins when the projection columns clearly dominate the byte footprint.
      */
     static final double TWO_PHASE_PREDICATE_BYTE_RATIO_THRESHOLD = 0.4;
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PageColumnReader.java
@@ -37,7 +37,9 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Page-level batch column reader that bypasses {@code ColumnReadStoreImpl} and works directly
@@ -217,6 +219,125 @@ final class PageColumnReader implements Releasable {
         } catch (RuntimeException e) {
             Releasables.closeExpectNoException(full);
             throw e;
+        }
+    }
+
+    /**
+     * Reads only the rows at the given positions within a batch of {@code sourceRows} total
+     * rows, interleaving {@link #skipRows} and {@link #readBatch} calls. Produces exactly
+     * {@code survivorCount} output rows. Unlike {@link #readBatchFiltered}, this method is
+     * safe when the reader has {@link RowRanges} that cause page skipping in
+     * {@link #loadNextPage()}, because every skip/read call advances the reader's cursor
+     * in the same sequential order as a plain read — no post-read coordinate translation
+     * is needed.
+     *
+     * @param sourceRows        total rows in the source batch (defines the coordinate space)
+     * @param blockFactory      factory for block construction
+     * @param survivorPositions ascending positions of rows to read (in {@code [0, sourceRows)})
+     * @param survivorCount     number of valid entries in {@code survivorPositions}
+     * @return a block with exactly {@code survivorCount} positions
+     */
+    Block readBatchSparse(int sourceRows, BlockFactory blockFactory, int[] survivorPositions, int survivorCount) {
+        assert survivorCount <= sourceRows : "survivorCount [" + survivorCount + "] > sourceRows [" + sourceRows + "]";
+        assert survivorCount <= survivorPositions.length
+            : "survivorCount [" + survivorCount + "] > array length [" + survivorPositions.length + "]";
+        assert survivorCount == 0 || survivorPositions[survivorCount - 1] < sourceRows
+            : "survivor position ["
+                + (survivorCount > 0 ? survivorPositions[survivorCount - 1] : -1)
+                + "] >= sourceRows ["
+                + sourceRows
+                + "]";
+
+        if (survivorCount == 0) {
+            skipRows(sourceRows);
+            return blockFactory.newConstantNullBlock(0);
+        }
+        if (survivorCount == sourceRows) {
+            return readBatch(sourceRows, blockFactory);
+        }
+
+        // Fast path: all survivors are contiguous — single skip/read/skip, no chunk list.
+        if (survivorPositions[survivorCount - 1] - survivorPositions[0] == survivorCount - 1) {
+            int leadingGap = survivorPositions[0];
+            if (leadingGap > 0) {
+                skipRows(leadingGap);
+            }
+            Block result = readBatch(survivorCount, blockFactory);
+            int trailing = sourceRows - survivorPositions[survivorCount - 1] - 1;
+            if (trailing > 0) {
+                skipRows(trailing);
+            }
+            return result;
+        }
+
+        // General path: decompose survivorPositions into (skip, read) runs of contiguous
+        // positions. Each run produces a small Block via readBatch; chunks are combined
+        // at the end.
+        List<Block> chunks = new ArrayList<>();
+        int cursor = 0;
+        int runStart = 0;
+
+        try {
+            while (runStart < survivorCount) {
+                int pos = survivorPositions[runStart];
+                int gap = pos - cursor;
+                if (gap > 0) {
+                    skipRows(gap);
+                    cursor += gap;
+                }
+
+                // Find the end of the contiguous run
+                int runEnd = runStart + 1;
+                while (runEnd < survivorCount && survivorPositions[runEnd] == survivorPositions[runEnd - 1] + 1) {
+                    runEnd++;
+                }
+                int runLength = runEnd - runStart;
+
+                chunks.add(readBatch(runLength, blockFactory));
+                cursor += runLength;
+                runStart = runEnd;
+            }
+
+            // Skip any trailing rows after the last survivor
+            int trailing = sourceRows - cursor;
+            if (trailing > 0) {
+                skipRows(trailing);
+            }
+
+            if (chunks.size() == 1) {
+                return chunks.get(0);
+            }
+            return combineBlocks(chunks, survivorCount, blockFactory);
+        } catch (RuntimeException e) {
+            for (Block chunk : chunks) {
+                Releasables.closeExpectNoException(chunk);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Concatenates multiple blocks produced by the sparse-read loop into a single block
+     * by copying values from each chunk sequentially via a {@link Block.Builder}.
+     * Closes the source chunks after copying.
+     */
+    private static Block combineBlocks(List<Block> chunks, int totalPositions, BlockFactory blockFactory) {
+        int actualTotal = 0;
+        for (Block b : chunks) {
+            actualTotal += b.getPositionCount();
+        }
+        assert actualTotal == totalPositions : "chunk total " + actualTotal + " != expected " + totalPositions;
+
+        Block first = chunks.get(0);
+        try (Block.Builder builder = first.elementType().newBlockBuilder(totalPositions, blockFactory)) {
+            for (Block chunk : chunks) {
+                builder.copyFrom(chunk, 0, chunk.getPositionCount());
+            }
+            Block result = builder.build();
+            for (Block chunk : chunks) {
+                Releasables.closeExpectNoException(chunk);
+            }
+            return result;
         }
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupport.java
@@ -191,7 +191,7 @@ public class ParquetFilterPushdownSupport implements FilterPushdownSupport {
      * handling has the same two-valued-mask null bug as LIKE used to, and is left unchanged
      * to keep this PR focused on the LIKE win that motivated the work.
      */
-    private static boolean isFullyEvaluable(Expression expr) {
+    static boolean isFullyEvaluable(Expression expr) {
         if (expr instanceof WildcardLike) {
             return true;
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -69,7 +69,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -822,21 +821,16 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             }
         }
 
-        ParquetPushedExpressions effectivePushed = null;
-        if (lateMaterializationEnabled && pushedExpressions != null) {
-            double predicateRatio = computePredicateColumnByteRatio(blocks, projectedAttributes, pushedExpressions);
-            if (predicateRatio < LATE_MATERIALIZATION_PREDICATE_RATIO_THRESHOLD) {
-                effectivePushed = pushedExpressions;
-            } else {
-                logger.debug(
-                    "Late materialization disabled for [{}]: predicate column ratio [{}/{}] exceeds threshold [{}]",
-                    storageObject.path(),
-                    (long) (predicateRatio * 100),
-                    100,
-                    (long) (LATE_MATERIALIZATION_PREDICATE_RATIO_THRESHOLD * 100)
-                );
-            }
-        }
+        // The iterator owns the late-mat decision: it gates on the structural prerequisite
+        // hasProjectionOnlyColumns (nothing to defer-decode otherwise) and gates the more expensive
+        // two-phase prefetch on its own predicate-byte-ratio threshold (see
+        // {@link OptimizedParquetColumnIterator#shouldUseTwoPhase} /
+        // {@link OptimizedParquetColumnIterator#TWO_PHASE_PREDICATE_BYTE_RATIO_THRESHOLD}). A second
+        // file-level byte-ratio gate here was a leftover from the Pushability.RECHECK era when every
+        // surviving row paid the predicate cost twice (once in late-mat, once again in FilterExec).
+        // With WildcardLike now pushed as Pushability.YES, FilterExec is dropped for that conjunct,
+        // so suppressing late-mat at the file level would leak unfiltered rows past the source.
+        ParquetPushedExpressions effectivePushed = lateMaterializationEnabled ? pushedExpressions : null;
 
         // Reuse the FilterPredicate already resolved at the file level so the trivially-passes
         // guard sees the same predicate that drove row-group pruning and column-index RowRanges.
@@ -862,42 +856,6 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             effectivePushed,
             triviallyPassesPredicate
         );
-    }
-
-    static final double LATE_MATERIALIZATION_PREDICATE_RATIO_THRESHOLD = 0.5;
-
-    /**
-     * Computes the ratio of predicate column bytes to total projected column bytes,
-     * averaged across all row groups. Uses compressed on-disk sizes from Parquet metadata.
-     */
-    private static double computePredicateColumnByteRatio(
-        List<BlockMetaData> blocks,
-        List<Attribute> projectedAttributes,
-        ParquetPushedExpressions pushed
-    ) {
-        Set<String> predicateNames = pushed.predicateColumnNames();
-        if (predicateNames.isEmpty()) {
-            return 0.0;
-        }
-        Set<String> projectedNames = new HashSet<>();
-        for (Attribute attr : projectedAttributes) {
-            projectedNames.add(attr.name());
-        }
-        long predicateBytes = 0;
-        long totalBytes = 0;
-        for (BlockMetaData block : blocks) {
-            for (ColumnChunkMetaData col : block.getColumns()) {
-                String name = col.getPath().toDotString();
-                if (projectedNames.contains(name)) {
-                    long size = col.getTotalSize();
-                    totalBytes += size;
-                    if (predicateNames.contains(name)) {
-                        predicateBytes += size;
-                    }
-                }
-            }
-        }
-        return totalBytes > 0 ? (double) predicateBytes / totalBytes : 0.0;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -836,7 +836,25 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         // guard sees the same predicate that drove row-group pruning and column-index RowRanges.
         // Only pass it through when late materialization is actually active; otherwise the
         // iterator has no use for it.
-        FilterPredicate triviallyPassesPredicate = effectivePushed != null ? filterPredicate : null;
+        //
+        // Additionally suppress the predicate when any YES conjunct in pushedExpressions did not
+        // translate to a FilterPredicate (today: WildcardLike/Not(WildcardLike) AND'd with a
+        // translatable conjunct). The trivially-passes shortcut would bypass the late-mat
+        // evaluator on the strength of the FilterPredicate alone, but the missing YES conjunct
+        // is no longer in FilterExec to catch the over-inclusion — so dropping the guard here
+        // would silently leak rows that don't match the YES conjunct (e.g. URL LIKE "x*" rows
+        // outside the prefix when AND'd with a stats-trivial status = 200).
+        //
+        // DO NOT REMOVE the hasYesConjunctOutsideFilterPredicate check — it is load-bearing for
+        // correctness of YES-pushed predicates that have no parquet-FilterPredicate translation.
+        // The integration regression test
+        // OptimizedFilteredReaderTests.testPushedExpressionsLikeWithStatsTrivialEqDoesNotLeak
+        // and the unit tests in ParquetPushedExpressionsTests cover this contract.
+        MessageType fileSchema = reader.getFileMetaData().getSchema();
+        FilterPredicate triviallyPassesPredicate = effectivePushed != null
+            && (pushedExpressions == null || pushedExpressions.hasYesConjunctOutsideFilterPredicate(fileSchema) == false)
+                ? filterPredicate
+                : null;
 
         return new OptimizedParquetColumnIterator(
             reader,

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -27,6 +27,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -610,7 +611,7 @@ final class ParquetPushedExpressions {
     WordMask evaluateFilter(Map<String, Block> predicateBlocks, int rowCount, WordMask reusable) {
         reusable.setAll(rowCount);
         for (Expression expr : expressions) {
-            WordMask exprResult = evaluateExpression(expr, predicateBlocks, rowCount);
+            WordMask exprResult = evaluateExpression(expr, predicateBlocks, rowCount, reusable);
             if (exprResult != null) {
                 reusable.and(exprResult);
             }
@@ -622,7 +623,9 @@ final class ParquetPushedExpressions {
     }
 
     // Note: not static — uses the per-instance automaton cache in evaluateWildcardLike.
-    private WordMask evaluateExpression(Expression expr, Map<String, Block> blocks, int rowCount) {
+    // The intermediateMask is the cumulative AND of all previously evaluated conjuncts;
+    // expensive evaluators (LIKE, StartsWith) use it to skip already-eliminated rows.
+    private WordMask evaluateExpression(Expression expr, Map<String, Block> blocks, int rowCount, @Nullable WordMask intermediateMask) {
         if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne && bc.right().foldable()) {
             Block block = blocks.get(ne.name());
             if (block == null) {
@@ -677,8 +680,8 @@ final class ParquetPushedExpressions {
             return evaluateRange(range, block, rowCount);
         }
         if (expr instanceof And and) {
-            WordMask left = evaluateExpression(and.left(), blocks, rowCount);
-            WordMask right = evaluateExpression(and.right(), blocks, rowCount);
+            WordMask left = evaluateExpression(and.left(), blocks, rowCount, intermediateMask);
+            WordMask right = evaluateExpression(and.right(), blocks, rowCount, intermediateMask);
             if (left != null && right != null) {
                 left.and(right);
                 return left;
@@ -686,8 +689,8 @@ final class ParquetPushedExpressions {
             return left != null ? left : right;
         }
         if (expr instanceof Or or) {
-            WordMask left = evaluateExpression(or.left(), blocks, rowCount);
-            WordMask right = evaluateExpression(or.right(), blocks, rowCount);
+            WordMask left = evaluateExpression(or.left(), blocks, rowCount, intermediateMask);
+            WordMask right = evaluateExpression(or.right(), blocks, rowCount, intermediateMask);
             if (left != null && right != null) {
                 left.or(right);
                 return left;
@@ -713,9 +716,9 @@ final class ParquetPushedExpressions {
                 if (block == null) {
                     return null;
                 }
-                return evaluateNotWildcardLike(wl, block, rowCount);
+                return evaluateNotWildcardLike(wl, block, rowCount, intermediateMask);
             }
-            WordMask inner = evaluateExpression(not.field(), blocks, rowCount);
+            WordMask inner = evaluateExpression(not.field(), blocks, rowCount, intermediateMask);
             if (inner != null) {
                 inner.negate();
                 return inner;
@@ -727,14 +730,14 @@ final class ParquetPushedExpressions {
             if (block == null) {
                 return null;
             }
-            return evaluateStartsWith(sw, block, rowCount);
+            return evaluateStartsWith(sw, block, rowCount, intermediateMask);
         }
         if (expr instanceof WildcardLike wl && wl.field() instanceof NamedExpression ne) {
             Block block = blocks.get(ne.name());
             if (block == null) {
                 return null;
             }
-            return evaluateWildcardLike(wl, block, rowCount);
+            return evaluateWildcardLike(wl, block, rowCount, intermediateMask);
         }
         return null;
     }
@@ -977,7 +980,7 @@ final class ParquetPushedExpressions {
         return true;
     }
 
-    private static WordMask evaluateStartsWith(StartsWith sw, Block block, int rowCount) {
+    private static WordMask evaluateStartsWith(StartsWith sw, Block block, int rowCount, @Nullable WordMask intermediateMask) {
         Object prefixValue = literalValueOf(sw.prefix());
         if (prefixValue == null) {
             return null;
@@ -998,6 +1001,9 @@ final class ParquetPushedExpressions {
             mask.reset(rowCount);
             BytesRef scratch = new BytesRef();
             for (int i = 0; i < rowCount; i++) {
+                if (intermediateMask != null && intermediateMask.get(i) == false) {
+                    continue;
+                }
                 if (block.isNull(i) == false) {
                     BytesRef val = bb.getBytesRef(i, scratch);
                     if (val.length >= prefix.length && startsWith(val, prefix)) {
@@ -1059,16 +1065,11 @@ final class ParquetPushedExpressions {
      * one of the two supported block types, so the block-type {@code null} sentinel is unreachable
      * on the YES path in practice.
      */
-    private WordMask evaluateWildcardLike(WildcardLike wl, Block block, int rowCount) {
+    private WordMask evaluateWildcardLike(WildcardLike wl, Block block, int rowCount, @Nullable WordMask intermediateMask) {
         CompiledWildcard compiled = automatonFor(wl);
         if (compiled.matcher == null) {
-            // Pattern was too complex to determinize. Late-mat can't filter; rely on FilterExec.
             return null;
         }
-        // Fast path: pattern accepts every input. Skip the per-row automaton run. matchesAll is
-        // computed at compile time against the case-aware automaton in automatonFor(), so it is
-        // consistent with wl.caseInsensitive(). Nulls are still excluded — SQL's NULL LIKE *
-        // evaluates to unknown, treated here as "no match" for parity with the scalar path.
         if (compiled.matchesAll) {
             return maskNonNullRows(block, rowCount);
         }
@@ -1088,6 +1089,9 @@ final class ParquetPushedExpressions {
             mask.reset(rowCount);
             BytesRef scratch = new BytesRef();
             for (int i = 0; i < rowCount; i++) {
+                if (intermediateMask != null && intermediateMask.get(i) == false) {
+                    continue;
+                }
                 if (block.isNull(i) == false) {
                     BytesRef val = bb.getBytesRef(i, scratch);
                     if (runner.run(val.bytes, val.offset, val.length)) {
@@ -1127,8 +1131,8 @@ final class ParquetPushedExpressions {
      * far beyond {@code "*google*"}). If a future change broadens the YES-eligible set, this
      * contract must be revisited.
      */
-    private WordMask evaluateNotWildcardLike(WildcardLike wl, Block block, int rowCount) {
-        WordMask likeMask = evaluateWildcardLike(wl, block, rowCount);
+    private WordMask evaluateNotWildcardLike(WildcardLike wl, Block block, int rowCount, @Nullable WordMask intermediateMask) {
+        WordMask likeMask = evaluateWildcardLike(wl, block, rowCount, intermediateMask);
         if (likeMask == null) {
             return null;
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -173,6 +173,53 @@ final class ParquetPushedExpressions {
         return combined;
     }
 
+    /**
+     * Returns {@code true} when at least one held conjunct is YES-eligible per
+     * {@link ParquetFilterPushdownSupport#isFullyEvaluable(Expression)} (so {@code FilterExec}
+     * has been dropped for it) AND its translation to a Parquet
+     * {@link FilterPredicate} for {@code schema} is {@code null} (so it is not represented in
+     * the {@link #toFilterPredicate} output).
+     *
+     * <p>Consumers of {@link #toFilterPredicate} that bypass {@link #evaluateFilter} on the basis
+     * of stats reasoning over the predicate (e.g. the trivially-passes shortcut in
+     * {@code OptimizedParquetColumnIterator}) MUST disable that shortcut when this method returns
+     * {@code true}: the YES conjunct is silently absent from the predicate they reasoned about
+     * and would otherwise leak rows it does not match. RECHECK conjuncts that fail to translate
+     * are excluded from this check on purpose — their downstream {@code FilterExec} still
+     * re-applies them, masking the shortcut's over-inclusion.
+     *
+     * <p>Today the only canConvert-but-not-translatable expression is {@link WildcardLike}
+     * (and {@code Not(WildcardLike)}), which is also the only YES-eligible non-comparator
+     * expression — so in practice this method returns {@code true} exactly when a {@code LIKE}
+     * conjunct is present alongside other translatable conjuncts.
+     *
+     * <p>YES is determined here by {@link ParquetFilterPushdownSupport#isFullyEvaluable(Expression)}
+     * rather than the full {@code canPush} check. The full check additionally probes
+     * {@code canCompileAllPatterns}; a pattern that fails that probe at plan time is downgraded
+     * to RECHECK and stays in {@code FilterExec}, so it would not be a YES conjunct at runtime.
+     * Using only {@code isFullyEvaluable} here is therefore conservative — it may flag an
+     * expression as YES that the planner already downgraded, suppressing the shortcut for that
+     * file. The wasted work is bounded: at most one extra {@code evaluateFilter} pass per
+     * trivially-passing row group, which is exactly the cost the shortcut was saving.
+     *
+     * <p><b>Do not weaken this method.</b> Returning {@code false} when it should return
+     * {@code true} causes silent wrong-results: rows that do not match a YES conjunct (today:
+     * a {@code LIKE} pattern) are emitted as if they did, because the trivially-passes shortcut
+     * routes them around the late-mat evaluator and there is no downstream {@code FilterExec}
+     * to catch the over-inclusion. The contract is exercised by
+     * {@code ParquetPushedExpressionsTests#testHasYesConjunctOutsideFilterPredicate*} and the
+     * integration regression test
+     * {@code OptimizedFilteredReaderTests#testPushedExpressionsLikeWithStatsTrivialEqDoesNotLeak}.
+     */
+    boolean hasYesConjunctOutsideFilterPredicate(MessageType schema) {
+        for (Expression expr : expressions) {
+            if (ParquetFilterPushdownSupport.isFullyEvaluable(expr) && translateExpression(expr, schema) == null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private FilterPredicate translateExpression(Expression expr, MessageType schema) {
         if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne && bc.right().foldable()) {
             String name = ne.name();

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -220,6 +220,40 @@ final class ParquetPushedExpressions {
         return false;
     }
 
+    /**
+     * Returns {@code true} when {@code expr} translates to a Parquet {@link FilterPredicate}
+     * with no silent-drop branch — i.e. the resulting predicate has the same matching set as
+     * {@code expr} (modulo TVL on nulls, which apache-mr handles compatibly for the basic
+     * comparators below). Used by {@link #translateExpression}'s {@code Not} branch to
+     * refuse pushing a negation over an expression that would silently drop a sub-arm:
+     * negation flips a looser-than-truth predicate into a STRICTER-than-truth one, which
+     * leaks rows during stats-based pruning.
+     *
+     * <p>Today this whitelist mirrors the leaf cases handled directly in
+     * {@link #translateExpression} (no recursion into {@code And}/{@code Or}/{@code Not}).
+     * That keeps the rule simple and obviously correct; it can be relaxed later (e.g. allow
+     * {@code Not(And(translatable, translatable))}) once we have explicit test coverage for
+     * the additional shapes.
+     */
+    private static boolean isExactlyTranslatable(Expression expr) {
+        if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression && bc.right().foldable()) {
+            return true;
+        }
+        if (expr instanceof In in && in.value() instanceof NamedExpression) {
+            return true;
+        }
+        if (expr instanceof IsNull isNull && isNull.field() instanceof NamedExpression) {
+            return true;
+        }
+        if (expr instanceof IsNotNull isNotNull && isNotNull.field() instanceof NamedExpression) {
+            return true;
+        }
+        if (expr instanceof Range range && range.value() instanceof NamedExpression) {
+            return true;
+        }
+        return false;
+    }
+
     private FilterPredicate translateExpression(Expression expr, MessageType schema) {
         if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne && bc.right().foldable()) {
             String name = ne.name();
@@ -253,22 +287,21 @@ final class ParquetPushedExpressions {
             return translateRange(ne.name(), ne.dataType(), range, schema);
         }
         if (expr instanceof And and) {
-            boolean leftConvertible = ParquetFilterPushdownSupport.canConvert(and.left());
-            boolean rightConvertible = ParquetFilterPushdownSupport.canConvert(and.right());
-            if (leftConvertible && rightConvertible) {
-                FilterPredicate leftPred = translateExpression(and.left(), schema);
-                FilterPredicate rightPred = translateExpression(and.right(), schema);
-                if (leftPred != null && rightPred != null) {
-                    return FilterApi.and(leftPred, rightPred);
-                }
-                return leftPred != null ? leftPred : rightPred;
-            } else if (leftConvertible) {
-                return translateExpression(and.left(), schema);
-            } else {
-                return translateExpression(and.right(), schema);
+            // For AND, dropping an arm produces a LOOSER predicate (one that admits at least
+            // as many rows). That is safe for stats pruning, RowRanges, and the
+            // trivially-passes shortcut, all of which require a SUPERSET of the truth.
+            FilterPredicate leftPred = translateExpression(and.left(), schema);
+            FilterPredicate rightPred = translateExpression(and.right(), schema);
+            if (leftPred != null && rightPred != null) {
+                return FilterApi.and(leftPred, rightPred);
             }
+            return leftPred != null ? leftPred : rightPred;
         }
         if (expr instanceof Or or) {
+            // For OR, BOTH arms must translate or the predicate is unsafe. Dropping one OR
+            // arm yields a STRICTER predicate (the surviving arm alone), which would prune
+            // rows the original would have matched via the dropped arm. Return null so the
+            // shortcut/RowRanges path skips this expression entirely.
             FilterPredicate leftPred = translateExpression(or.left(), schema);
             FilterPredicate rightPred = translateExpression(or.right(), schema);
             if (leftPred != null && rightPred != null) {
@@ -277,6 +310,27 @@ final class ParquetPushedExpressions {
             return null;
         }
         if (expr instanceof Not not) {
+            // Negation flips the looser/stricter polarity of any silent drop in the inner
+            // expression: an inner AND that silently dropped an untranslatable arm produces a
+            // looser inner predicate; NOT of looser is STRICTER, which prunes rows the
+            // original would have matched (e.g. NOT(AND(LIKE, id<N)) becomes NOT(id<N), which
+            // wrongly drops rows where LIKE doesn't match and id<N). To stay safe we require
+            // the inner translation to be EXACT — i.e. it must contain no untranslatable
+            // sub-expression at all. Practically this means the inner must be a leaf
+            // comparator/range/equality that the translator handles directly. Anything more
+            // complex returns null so the predicate is not pushed, leaving the row to the
+            // late-mat evaluator (which evaluates the original ESQL expression, including
+            // the conjuncts under the inner AND, with TVL-correct semantics).
+            //
+            // DO NOT REMOVE the isExactlyTranslatable guard — without it, NOT over a
+            // silent-drop AND produces a stricter-than-truth predicate that silently loses
+            // rows during stats-based row-group / page pruning. There is no FilterExec safety
+            // net at the row-group/page level (FilterExec runs per-row on what survives).
+            // Regression tests live in {@code ParquetReaderFilterDifferentialTests} (see the
+            // randomized {@code NOT(AND(LIKE, ...))} cases that surfaced this bug).
+            if (isExactlyTranslatable(not.field()) == false) {
+                return null;
+            }
             FilterPredicate inner = translateExpression(not.field(), schema);
             return inner != null ? FilterApi.not(inner) : null;
         }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/LikeYesVsRecheckCostTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/LikeYesVsRecheckCostTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -61,7 +62,11 @@ import java.util.Random;
  */
 public class LikeYesVsRecheckCostTests extends ESTestCase {
 
-    private static final boolean PERF_ENABLED = Boolean.parseBoolean(System.getProperty("tests.perf", "false"));
+    // Use Elasticsearch's Booleans helper instead of java.lang.Boolean#parseBoolean — the
+    // latter is forbidden by the project's forbiddenApis policy because it silently accepts
+    // anything that isn't "true" as false (no input validation), which has historically
+    // masked typos in system properties.
+    private static final boolean PERF_ENABLED = Booleans.parseBoolean(System.getProperty("tests.perf"), false);
 
     /**
      * Mid-sized block matching what the parquet reader actually emits per page chunk.

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/LikeYesVsRecheckCostTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/LikeYesVsRecheckCostTests.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.UTF32ToUTF8;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Measures the per-block CPU cost of evaluating a {@code WildcardLike} predicate via:
+ * <ol>
+ *   <li>The reader's late-mat path ({@link ParquetPushedExpressions#evaluateFilter}), which has
+ *   a dictionary-aware fast path on {@link OrdinalBytesRefBlock} that runs the automaton
+ *   once per dictionary entry plus an int lookup per row.</li>
+ *   <li>The downstream {@code FilterExec} path ({@code AutomataMatchEvaluator}), which calls
+ *   {@code AutomataMatch.process} per row and runs the automaton on the resolved bytes —
+ *   no dictionary fast path even when the input block is ordinal-encoded.</li>
+ * </ol>
+ *
+ * <p>This is the cost asymmetry that matters for the {@code Pushability.YES} vs {@code RECHECK}
+ * tradeoff: under YES the reader path runs alone; under RECHECK the FilterExec path runs as
+ * well, on top of the survivor block produced by the reader. The test reports both timings and
+ * the ratio so the perf vs complexity tradeoff can be evaluated with numbers.
+ *
+ * <p>This is a perf measurement, not a correctness test. It is gated on the {@code tests.perf}
+ * system property so it does not run in CI (where shared infrastructure makes timing noisy and
+ * the result is informational only). Run locally with:
+ * <pre>
+ * ./gradlew :x-pack:plugin:esql-datasource-parquet:test \
+ *   --tests "org.elasticsearch.xpack.esql.datasource.parquet.LikeYesVsRecheckCostTests" \
+ *   -Dtests.perf=true -Dtests.output=always
+ * </pre>
+ */
+public class LikeYesVsRecheckCostTests extends ESTestCase {
+
+    private static final boolean PERF_ENABLED = Boolean.parseBoolean(System.getProperty("tests.perf", "false"));
+
+    /**
+     * Mid-sized block matching what the parquet reader actually emits per page chunk.
+     * Picked to mimic a "typical web logs URL column" shape: dictionary of a few hundred
+     * unique URLs, hundreds of thousands of rows per block.
+     */
+    private static final int ROWS = 200_000;
+    private static final int DICTIONARY_SIZE = 200;
+
+    private static final int WARMUP_ITERATIONS = 5;
+    private static final int MEASURED_ITERATIONS = 20;
+
+    private BlockFactory blockFactory;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    public void testYesVsRecheckLikeEvaluationCost() {
+        assumeTrue("perf measurement; opt in with -Dtests.perf=true", PERF_ENABLED);
+
+        // Three representative selectivities chosen to bracket the realistic range. The "high
+        // selectivity" case (5% match) is the one YES was tuned for — most rows are filtered out
+        // and the dictionary fast path saves nearly the entire pattern-match cost. The "high
+        // match" case (80%) is the worst case for RECHECK because almost every row survives the
+        // reader and gets re-evaluated by FilterExec on the per-row scalar path.
+        for (double matchRate : new double[] { 0.05, 0.50, 0.80 }) {
+            measureScenario("URL LIKE \"*google*\" matchRate=" + matchRate, "*google*", matchRate);
+        }
+    }
+
+    private void measureScenario(String label, String pattern, double matchRate) {
+        // Build the dictionary so a known fraction of entries match the pattern. Each row gets
+        // a uniformly-distributed ordinal, so the survivor count is ~rows*matchRate (with normal
+        // statistical jitter, which is small at ROWS=200_000).
+        String[] dictionary = buildDictionary(DICTIONARY_SIZE, pattern, matchRate);
+
+        try (
+            OrdinalBytesRefBlock ordinalBlock = buildOrdinalBlock(dictionary, ROWS);
+            BytesRefBlock plainBlock = materializeAsPlain(ordinalBlock);
+        ) {
+            Expression urlAttr = attr("url", DataType.KEYWORD);
+            ParquetPushedExpressions pushed = new ParquetPushedExpressions(
+                List.of(new WildcardLike(Source.EMPTY, urlAttr, new WildcardPattern(pattern)))
+            );
+
+            // Build the byte-run automaton the FilterExec path would receive at plan time. This
+            // is the same conversion AutomataMatch.toEvaluator does, hoisted out of the timing
+            // loop so we measure runtime cost, not plan-time cost.
+            ByteRunAutomaton automaton = compileAutomaton(pattern);
+
+            // Reader path on the ordinal block (the YES path the optimizer enables today).
+            long readerOrdinalNs = timeReaderPath(pushed, ordinalBlock, ROWS);
+            // Reader path on a non-dict block (sanity baseline; this is the non-dict-encoded
+            // page case that doesn't get the fast path).
+            long readerScalarNs = timeReaderPath(pushed, plainBlock, ROWS);
+            // FilterExec path on the ordinal block — note this is what would re-evaluate the
+            // LIKE under RECHECK on top of the reader's survivor set. We deliberately measure
+            // it on ordinal input because the parquet reader emits OrdinalBytesRefBlock for
+            // dict-encoded chunks, so this is the realistic survivor-block shape.
+            long filterExecOrdinalNs = timeFilterExecPath(automaton, ordinalBlock, ROWS);
+            // Same on plain block for completeness.
+            long filterExecScalarNs = timeFilterExecPath(automaton, plainBlock, ROWS);
+
+            // Under YES the reader path runs alone. Under RECHECK both run (but FilterExec runs
+            // on the survivor block, not the full block). We approximate the survivor cost as
+            // matchRate * full block cost since the per-row work is identical.
+            double survivorRowCount = ROWS * matchRate;
+            long filterExecSurvivorOrdinalNs = (long) (filterExecOrdinalNs * matchRate);
+            long filterExecSurvivorScalarNs = (long) (filterExecScalarNs * matchRate);
+
+            logger.info(
+                "[{}] rows={} dict={} match={}\n"
+                    + "  reader-ordinal (YES path):           {} ns ({} ns/row)\n"
+                    + "  reader-scalar  (non-dict baseline):  {} ns ({} ns/row)\n"
+                    + "  filterExec-ordinal full block:       {} ns ({} ns/row)\n"
+                    + "  filterExec-scalar  full block:       {} ns ({} ns/row)\n"
+                    + "  RECHECK extra (ordinal survivors ~{} rows): {} ns ({} ns/row)\n"
+                    + "  RECHECK extra (scalar  survivors ~{} rows): {} ns ({} ns/row)\n"
+                    + "  YES vs RECHECK total ordinal: {} ns vs {} ns ({}x more under RECHECK)\n"
+                    + "  YES vs RECHECK total scalar:  {} ns vs {} ns ({}x more under RECHECK)",
+                label,
+                ROWS,
+                DICTIONARY_SIZE,
+                matchRate,
+                readerOrdinalNs,
+                fmtRate(readerOrdinalNs, ROWS),
+                readerScalarNs,
+                fmtRate(readerScalarNs, ROWS),
+                filterExecOrdinalNs,
+                fmtRate(filterExecOrdinalNs, ROWS),
+                filterExecScalarNs,
+                fmtRate(filterExecScalarNs, ROWS),
+                (long) survivorRowCount,
+                filterExecSurvivorOrdinalNs,
+                fmtRate(filterExecSurvivorOrdinalNs, Math.max(1, (long) survivorRowCount)),
+                (long) survivorRowCount,
+                filterExecSurvivorScalarNs,
+                fmtRate(filterExecSurvivorScalarNs, Math.max(1, (long) survivorRowCount)),
+                readerOrdinalNs,
+                readerOrdinalNs + filterExecSurvivorOrdinalNs,
+                fmtRatio(readerOrdinalNs + filterExecSurvivorOrdinalNs, readerOrdinalNs),
+                readerScalarNs,
+                readerScalarNs + filterExecSurvivorScalarNs,
+                fmtRatio(readerScalarNs + filterExecSurvivorScalarNs, readerScalarNs)
+            );
+        }
+    }
+
+    private long timeReaderPath(ParquetPushedExpressions pushed, Block block, int rows) {
+        // Force a fresh WordMask each iteration to avoid the prior result leaking into the
+        // measurement (the API mutates the WordMask in place).
+        Map<String, Block> blocks = Map.of("url", block);
+        WordMask reusable = new WordMask();
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            pushed.evaluateFilter(blocks, rows, reusable);
+        }
+        long[] samples = new long[MEASURED_ITERATIONS];
+        for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+            long start = System.nanoTime();
+            pushed.evaluateFilter(blocks, rows, reusable);
+            samples[i] = System.nanoTime() - start;
+        }
+        return median(samples);
+    }
+
+    private long timeFilterExecPath(ByteRunAutomaton automaton, Block block, int rows) {
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            runFilterExecLoop(automaton, block, rows);
+        }
+        long[] samples = new long[MEASURED_ITERATIONS];
+        for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+            long start = System.nanoTime();
+            runFilterExecLoop(automaton, block, rows);
+            samples[i] = System.nanoTime() - start;
+        }
+        return median(samples);
+    }
+
+    /**
+     * Faithfully replays the inner loop of {@code AutomataMatchEvaluator#eval(int, BytesRefVector)}
+     * (and the BytesRefBlock path), which is what FilterExec invokes when re-checking a LIKE.
+     * Using the real evaluator would drag in {@code DriverContext}, {@code BlockFactory} for the
+     * boolean output, and warning machinery — all noise relative to the actual work, which is
+     * the per-row {@code automaton.run(bytes, offset, length)} call.
+     */
+    private static void runFilterExecLoop(ByteRunAutomaton automaton, Block block, int rows) {
+        int survivors = 0;
+        BytesRef scratch = new BytesRef();
+        if (block instanceof OrdinalBytesRefBlock obb) {
+            BytesRefVector dict = obb.getDictionaryVector();
+            IntBlock ordinals = obb.getOrdinalsBlock();
+            for (int p = 0; p < rows; p++) {
+                if (ordinals.isNull(p)) {
+                    continue;
+                }
+                int ordinal = ordinals.getInt(ordinals.getFirstValueIndex(p));
+                BytesRef val = dict.getBytesRef(ordinal, scratch);
+                if (automaton.run(val.bytes, val.offset, val.length)) {
+                    survivors++;
+                }
+            }
+        } else {
+            BytesRefBlock bb = (BytesRefBlock) block;
+            for (int p = 0; p < rows; p++) {
+                if (bb.isNull(p)) {
+                    continue;
+                }
+                BytesRef val = bb.getBytesRef(bb.getFirstValueIndex(p), scratch);
+                if (automaton.run(val.bytes, val.offset, val.length)) {
+                    survivors++;
+                }
+            }
+        }
+        // Use the result so the JIT doesn't dead-code the loop.
+        if (survivors < 0) {
+            throw new AssertionError("unreachable");
+        }
+    }
+
+    private static ByteRunAutomaton compileAutomaton(String pattern) {
+        // Replicates AutomataMatch.toEvaluator's pipeline: build the regex automaton, convert
+        // utf32 -> utf8, determinize, wrap in ByteRunAutomaton. We do it once outside the timing
+        // loop because plan-time cost isn't part of the YES vs RECHECK debate.
+        var wp = new WildcardPattern(pattern);
+        var u32 = wp.createAutomaton(true);
+        var u8 = new UTF32ToUTF8().convert(u32);
+        var det = Operations.determinize(u8, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+        return new ByteRunAutomaton(det, true);
+    }
+
+    private static String[] buildDictionary(int size, String pattern, double matchRate) {
+        // We want exactly round(size * matchRate) dict entries to match the pattern. The pattern
+        // is "*google*" so a matching entry contains "google", a non-matching entry doesn't.
+        String marker = pattern.replace("*", "").replace("?", "x");
+        int matchCount = (int) Math.round(size * matchRate);
+        String[] out = new String[size];
+        Random r = new Random(42);
+        for (int i = 0; i < size; i++) {
+            String prefix = "https://example.com/path-" + i + "/";
+            String suffix = "?id=" + r.nextInt(10_000);
+            if (i < matchCount) {
+                out[i] = prefix + marker + suffix;
+            } else {
+                // Make sure the marker can't appear by accident — pad the middle with "x".
+                out[i] = prefix + "xxxx" + suffix;
+            }
+        }
+        return out;
+    }
+
+    private OrdinalBytesRefBlock buildOrdinalBlock(String[] dictionary, int rows) {
+        BytesRefVector dictVector = null;
+        IntBlock ordinalsBlock = null;
+        boolean ok = false;
+        try (BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(dictionary.length)) {
+            for (String s : dictionary) {
+                dictBuilder.appendBytesRef(new BytesRef(s));
+            }
+            dictVector = dictBuilder.build();
+            try (IntBlock.Builder b = blockFactory.newIntBlockBuilder(rows)) {
+                Random r = new Random(7);
+                for (int i = 0; i < rows; i++) {
+                    b.appendInt(r.nextInt(dictionary.length));
+                }
+                ordinalsBlock = b.build();
+            }
+            OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(ordinalsBlock, dictVector);
+            ok = true;
+            return result;
+        } finally {
+            if (ok == false) {
+                if (ordinalsBlock != null) ordinalsBlock.close();
+                if (dictVector != null) dictVector.close();
+            }
+        }
+    }
+
+    private BytesRefBlock materializeAsPlain(OrdinalBytesRefBlock src) {
+        BytesRef scratch = new BytesRef();
+        try (BytesRefBlock.Builder b = blockFactory.newBytesRefBlockBuilder(src.getPositionCount())) {
+            for (int i = 0; i < src.getPositionCount(); i++) {
+                if (src.isNull(i)) {
+                    b.appendNull();
+                } else {
+                    b.appendBytesRef(src.getBytesRef(i, scratch));
+                }
+            }
+            return b.build();
+        }
+    }
+
+    private static long median(long[] samples) {
+        long[] copy = samples.clone();
+        Arrays.sort(copy);
+        return copy[copy.length / 2];
+    }
+
+    private static String fmtRate(long ns, long rows) {
+        return String.format(Locale.ROOT, "%.2f", (double) ns / rows);
+    }
+
+    private static String fmtRatio(long num, long den) {
+        return String.format(Locale.ROOT, "%.2f", (double) num / den);
+    }
+
+    private static Attribute attr(String name, DataType type) {
+        return new ReferenceAttribute(Source.EMPTY, name, type);
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedFilteredReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedFilteredReaderTests.java
@@ -357,6 +357,125 @@ public class OptimizedFilteredReaderTests extends ESTestCase {
     }
 
     /**
+     * Regression test for the trivially-passes shortcut leak: a query that mixes a
+     * Pushability.YES conjunct that does not translate to a Parquet FilterPredicate
+     * ({@code WildcardLike}) with a Pushability.RECHECK conjunct that does translate AND
+     * is satisfied by row-group statistics for every row ({@code status = 200}).
+     *
+     * <p>Without the {@code hasYesConjunctOutsideFilterPredicate} guard in
+     * {@link ParquetFormatReader}, the trivially-passes shortcut would skip late-mat for
+     * every row group (because the FilterPredicate translation only contains {@code status = 200}
+     * and stats prove it). With LIKE pushed as YES, {@code FilterExec} no longer re-applies
+     * the predicate downstream, so the unfiltered rows would leak to the user. The guard
+     * suppresses the shortcut whenever a YES conjunct is absent from the FilterPredicate,
+     * forcing late-mat to evaluate the LIKE itself.
+     *
+     * <p><b>DO NOT WEAKEN OR REMOVE THIS TEST.</b> The combination of (LIKE as YES, status as
+     * RECHECK, status stats-trivial across every row group) is the exact shape that produced
+     * silent wrong-results when the YES promotion of {@code WildcardLike} landed without an
+     * audit of the trivially-passes shortcut. Changes that "simplify" the shortcut, the
+     * helper {@link ParquetPushedExpressions#hasYesConjunctOutsideFilterPredicate}, or the
+     * guard call site in {@link ParquetFormatReader} MUST keep this test passing — the
+     * symptom is silent over-inclusion (returns {@code rows} instead of {@code rows / 2}).
+     * Companion planner-layer tests in {@code ParquetFilterPushdownSupportTests} and unit
+     * tests in {@code ParquetPushedExpressionsTests} must also stay green.
+     */
+    public void testPushedExpressionsLikeWithStatsTrivialEqDoesNotLeak() throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("url")
+            .required(INT64)
+            .named("status")
+            .required(BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("like_with_eq_test");
+
+        int rows = 200;
+        // Every row has status = 200 (so stats prove status == 200 for the whole file).
+        // Half the rows match LIKE "*google*"; the other half don't. Without the guard the
+        // optimized reader would return all rows; with the guard it returns only the matches.
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < rows; i++) {
+                String url = (i % 2 == 0) ? "https://www.google.com/search?q=" + i : "https://example.org/page?id=" + i;
+                groups.add(factory.newGroup().append("url", url).append("status", 200L).append("label", "label_padding_chunk_" + i));
+            }
+            return groups;
+        });
+
+        ReferenceAttribute urlAttr = new ReferenceAttribute(Source.EMPTY, "url", DataType.KEYWORD);
+        ReferenceAttribute statusAttr = new ReferenceAttribute(Source.EMPTY, "status", DataType.LONG);
+        Expression like = new org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike(
+            Source.EMPTY,
+            urlAttr,
+            new org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern("*google*")
+        );
+        Expression statusEq = new Equals(Source.EMPTY, statusAttr, new Literal(Source.EMPTY, 200L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(like, statusEq));
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        StorageObject storageObject = createStorageObject(parquetData);
+        int total;
+        try (CloseableIterator<Page> iter = reader.read(storageObject, FormatReadContext.of(null, 1024))) {
+            int count = 0;
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                count += page.getPositionCount();
+                page.releaseBlocks();
+            }
+            total = count;
+        }
+        assertThat("LIKE conjunct must be applied even when sibling conjunct is stats-trivial", total, equalTo(rows / 2));
+    }
+
+    /**
+     * Companion to {@link #testPushedExpressionsLikeWithStatsTrivialEqDoesNotLeak}: when every
+     * pushed conjunct does translate to a FilterPredicate, the trivially-passes shortcut should
+     * still fire (i.e. the guard must not be over-conservative). We can't observe shortcut firing
+     * directly here, but we can verify it produces the correct rows; combined with the existing
+     * {@code testPushedExpressionsTriviallyPassingFilterParity} this confirms the shortcut path
+     * stays exercised for all-translatable filters.
+     */
+    public void testPushedExpressionsAllTranslatableTriviallyPassesStillFires() throws IOException {
+        MessageType schema = Types.buildMessage()
+            .required(INT64)
+            .named("status")
+            .required(BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("all_translatable_test");
+
+        int rows = 200;
+        byte[] parquetData = createParquetFile(schema, factory -> {
+            List<Group> groups = new ArrayList<>();
+            for (int i = 0; i < rows; i++) {
+                groups.add(factory.newGroup().append("status", 200L).append("label", "row_" + i));
+            }
+            return groups;
+        });
+
+        ReferenceAttribute statusAttr = new ReferenceAttribute(Source.EMPTY, "status", DataType.LONG);
+        Expression statusEq = new Equals(Source.EMPTY, statusAttr, new Literal(Source.EMPTY, 200L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(statusEq));
+
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        StorageObject storageObject = createStorageObject(parquetData);
+        int total;
+        try (CloseableIterator<Page> iter = reader.read(storageObject, FormatReadContext.of(null, 1024))) {
+            int count = 0;
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                count += page.getPositionCount();
+                page.releaseBlocks();
+            }
+            total = count;
+        }
+        assertThat("trivially-passing all-translatable filter must return every row", total, equalTo(rows));
+    }
+
+    /**
      * NOT(Eq) via PushedExpressions: verifies the RowRanges path returns all rows that
      * the baseline returns — i.e. NOT does not drop rows from mixed pages.
      */

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetReaderTests.java
@@ -538,11 +538,15 @@ public class OptimizedParquetReaderTests extends ESTestCase {
         }
     }
 
-    public void testLateMaterializationHeuristicThreshold() throws Exception {
-        // Scenario A: Predicate column is a narrow int; projection columns are wide strings.
-        // The predicate byte ratio should be well below 0.5, so late materialization is active.
-        // We verify this by applying a selective filter and confirming rows are eliminated.
-        MessageType schemaA = Types.buildMessage()
+    /**
+     * Late materialization filters rows when the predicate column is a small fraction of the
+     * projected bytes (the easy case where the file-level byte-ratio gate, when it still existed,
+     * was always permissive).
+     */
+    public void testLateMaterializationFiltersWhenPredicateColumnIsNarrow() throws Exception {
+        // Predicate column is a narrow int; projection columns are wide strings. The projection-only
+        // bytes dominate, so deferring their decode for non-matching rows is clearly profitable.
+        MessageType schema = Types.buildMessage()
             .required(PrimitiveType.PrimitiveTypeName.INT32)
             .named("pred_col")
             .required(PrimitiveType.PrimitiveTypeName.BINARY)
@@ -555,7 +559,7 @@ public class OptimizedParquetReaderTests extends ESTestCase {
 
         int totalRows = 100;
         String padding = "x".repeat(200);
-        byte[] parquetDataA = createParquetFile(schemaA, factory -> {
+        byte[] parquetData = createParquetFile(schema, factory -> {
             List<Group> groups = new ArrayList<>();
             for (int i = 0; i < totalRows; i++) {
                 Group g = factory.newGroup();
@@ -567,34 +571,40 @@ public class OptimizedParquetReaderTests extends ESTestCase {
             return groups;
         });
 
-        // Filter: pred_col > 89 => 10 matching rows
-        ReferenceAttribute predAttrA = new ReferenceAttribute(Source.EMPTY, "pred_col", DataType.INTEGER);
-        Expression filterA = new GreaterThan(Source.EMPTY, predAttrA, new Literal(Source.EMPTY, 89, DataType.INTEGER), null);
-        ParquetPushedExpressions pushedA = new ParquetPushedExpressions(List.of(filterA));
-        ParquetFormatReader readerA = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushedA);
+        ReferenceAttribute predAttr = new ReferenceAttribute(Source.EMPTY, "pred_col", DataType.INTEGER);
+        Expression filter = new GreaterThan(Source.EMPTY, predAttr, new Literal(Source.EMPTY, 89, DataType.INTEGER), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(filter));
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
 
-        StorageObject storageObjectA = createStorageObject(parquetDataA);
-        List<Page> pagesA = readAllPages(readerA, storageObjectA);
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> pages = readAllPages(reader, storageObject);
 
-        int totalRowsA = pagesA.stream().mapToInt(Page::getPositionCount).sum();
-        assertThat("scenario A: late-mat active, should have 10 surviving rows", totalRowsA, equalTo(10));
+        int totalRowsOut = pages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("late-mat active should retain only matching rows", totalRowsOut, equalTo(10));
 
-        // Verify data correctness
-        for (Page page : pagesA) {
+        for (Page page : pages) {
             IntBlock predBlock = page.getBlock(0);
             for (int pos = 0; pos < page.getPositionCount(); pos++) {
                 int val = predBlock.getInt(pos);
                 assertTrue("pred_col " + val + " should be > 89", val > 89);
             }
         }
+    }
 
-        // Scenario B: Predicate column is a wide string (~200+ bytes/row) that dominates the
-        // byte footprint; the projection-only column is a narrow int (4 bytes/row). The
-        // predicate byte ratio exceeds 0.5, so the heuristic should disable late materialization.
-        // When late-mat is disabled, no row-level filtering occurs in the optimized path (only
-        // row-group/page-level statistics filtering, which cannot eliminate individual rows
-        // within a single row group). This means ALL rows are returned.
-        MessageType schemaB = Types.buildMessage()
+    /**
+     * Late materialization is no longer file-gated by predicate-byte ratio. Even when the predicate
+     * column dominates the projected bytes — the regression shape that motivated removing the gate
+     * — late-mat still fires and filters rows. Under the current {@code Pushability.YES} rule for
+     * fully-evaluable conjuncts, the upstream {@code FilterExec} is dropped from the plan, so any
+     * file-level suppression of late-mat would leak unfiltered rows past the source. The expensive
+     * two-phase prefetch path stays gated by its own threshold inside the iterator, which is the
+     * correct scope for that decision (verified separately by {@code TwoPhaseReaderTests}).
+     */
+    public void testLateMaterializationStillFiresWhenPredicateColumnDominates() throws Exception {
+        // Predicate column is a wide string (~200+ bytes/row); projection-only column is a narrow
+        // int. The byte ratio is well above the old 0.5 file-level threshold; the test pins that
+        // late-mat is no longer gated off in this shape.
+        MessageType schema = Types.buildMessage()
             .required(PrimitiveType.PrimitiveTypeName.BINARY)
             .as(LogicalTypeAnnotation.stringType())
             .named("wide_pred")
@@ -602,7 +612,9 @@ public class OptimizedParquetReaderTests extends ESTestCase {
             .named("narrow_proj")
             .named("test_schema");
 
-        byte[] parquetDataB = createParquetFile(schemaB, factory -> {
+        int totalRows = 100;
+        String padding = "x".repeat(200);
+        byte[] parquetData = createParquetFile(schema, factory -> {
             List<Group> groups = new ArrayList<>();
             for (int i = 0; i < totalRows; i++) {
                 Group g = factory.newGroup();
@@ -613,46 +625,44 @@ public class OptimizedParquetReaderTests extends ESTestCase {
             return groups;
         });
 
-        // Push a filter on the wide predicate column
-        ReferenceAttribute predAttrB = new ReferenceAttribute(Source.EMPTY, "wide_pred", DataType.KEYWORD);
-        Expression filterB = new GreaterThan(
+        // Lexicographic > "padding_pred_94" matches values ending in _95, _96, _97, _98, _99 = 5 rows.
+        // (e.g. "_pred_8" < "_pred_94" because '8' < '9' at the first differing position.)
+        ReferenceAttribute predAttr = new ReferenceAttribute(Source.EMPTY, "wide_pred", DataType.KEYWORD);
+        Expression filter = new GreaterThan(
             Source.EMPTY,
-            predAttrB,
+            predAttr,
             new Literal(Source.EMPTY, new org.apache.lucene.util.BytesRef(padding + "_pred_94"), DataType.KEYWORD),
             null
         );
-        ParquetPushedExpressions pushedB = new ParquetPushedExpressions(List.of(filterB));
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(filter));
 
-        // Read with late-mat enabled (default) - the heuristic should disable it internally
-        // because the wide predicate column dominates the byte footprint
-        ParquetFormatReader readerBLateMat = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushedB);
-        StorageObject storageObjectB = createStorageObject(parquetDataB);
-        List<Page> pagesBLateMat = readAllPages(readerBLateMat, storageObjectB);
-        int totalRowsBLateMat = pagesBLateMat.stream().mapToInt(Page::getPositionCount).sum();
+        // With late-mat enabled (default), the file-level byte-ratio gate has been removed, so the
+        // reader filters rows even though the predicate column dominates the byte footprint.
+        ParquetFormatReader readerLateMat = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        StorageObject storageObject = createStorageObject(parquetData);
+        List<Page> pagesLateMat = readAllPages(readerLateMat, storageObject);
+        int rowsLateMat = pagesLateMat.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("late-mat must filter rows even at high predicate-byte ratio", rowsLateMat, equalTo(5));
 
-        // Read with late-mat explicitly disabled via config - should behave identically
-        ParquetFormatReader readerBNoLateMat = ((ParquetFormatReader) new ParquetFormatReader(blockFactory, true).withConfig(
+        // Sanity-check the surviving values.
+        for (Page page : pagesLateMat) {
+            BytesRefBlock predBlock = page.getBlock(0);
+            for (int pos = 0; pos < page.getPositionCount(); pos++) {
+                String val = predBlock.getBytesRef(pos, new org.apache.lucene.util.BytesRef()).utf8ToString();
+                assertTrue("wide_pred [" + val + "] should be > padding_pred_94", val.compareTo(padding + "_pred_94") > 0);
+            }
+        }
+
+        // Contrast: with late-mat explicitly disabled via config, the optimized path does no
+        // row-level filtering (only row-group/page statistics, which cannot prune within a single
+        // row group), so all 100 rows come back. This is the existing kill-switch contract; the
+        // file-level byte-ratio heuristic is gone but the explicit config knob is unchanged.
+        ParquetFormatReader readerNoLateMat = ((ParquetFormatReader) new ParquetFormatReader(blockFactory, true).withConfig(
             Map.of(ParquetFormatReader.CONFIG_LATE_MATERIALIZATION, false)
-        )).withPushedFilter(pushedB);
-        List<Page> pagesBNoLateMat = readAllPages(readerBNoLateMat, storageObjectB);
-        int totalRowsBNoLateMat = pagesBNoLateMat.stream().mapToInt(Page::getPositionCount).sum();
-
-        // Both paths (heuristic-disabled and explicitly-disabled) should produce the same row count.
-        // Since the optimized path without late-mat does not do row-level filtering (only
-        // statistics-level filtering which cannot prune individual rows in a single row group),
-        // both should return all 100 rows.
-        assertThat(
-            "scenario B: heuristic-disabled late-mat and explicit no-late-mat should produce same row count",
-            totalRowsBLateMat,
-            equalTo(totalRowsBNoLateMat)
-        );
-        assertThat("scenario B: without row-level filtering, all rows should be returned", totalRowsBLateMat, equalTo(totalRows));
-
-        // Contrast with scenario A: late-mat was active there and eliminated rows
-        assertTrue(
-            "scenario A (late-mat active) should return fewer rows than scenario B (late-mat disabled)",
-            totalRowsA < totalRowsBLateMat
-        );
+        )).withPushedFilter(pushed);
+        List<Page> pagesNoLateMat = readAllPages(readerNoLateMat, storageObject);
+        int rowsNoLateMat = pagesNoLateMat.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("explicit no-late-mat returns all rows (no row-level filtering)", rowsNoLateMat, equalTo(totalRows));
     }
 
     // --- Helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFilterPushdownSupportTests.java
@@ -750,6 +750,49 @@ public class ParquetFilterPushdownSupportTests extends ESTestCase {
         assertEquals(1, result.remainder().size());
     }
 
+    /**
+     * Regression test for the trivially-passes shortcut leak (companion of
+     * {@code OptimizedFilteredReaderTests.testPushedExpressionsLikeWithStatsTrivialEqDoesNotLeak}).
+     *
+     * <p>The realistic input that {@code PushFiltersToSource} produces from a query like
+     * {@code WHERE url LIKE "*google*" AND status = 200} is the decomposed
+     * {@code [LIKE, status = 200]} list, NOT a single AND-wrapped expression (see
+     * {@link #testWildcardLikeCombinedWithEqualsKeepsEqualsInRemainder} for the AND-wrapped
+     * shape, which behaves differently because mixed-AND pushability falls back to RECHECK).
+     *
+     * <p>This shape is the one that triggered the trivially-passes shortcut leak: LIKE pushes
+     * as YES (no FilterExec safety net) and is silently absent from the parquet
+     * {@link org.apache.parquet.filter2.predicate.FilterPredicate} translation; status = 200
+     * pushes as RECHECK and IS in the FilterPredicate; for any row group whose stats prove
+     * status = 200 the shortcut would bypass late-mat entirely, leaking rows that don't match
+     * the LIKE. This test asserts the planner-side classification that the integration test
+     * relies on (LIKE → YES → not in remainder; status = 200 → RECHECK → in remainder).
+     *
+     * <p>DO NOT change this assertion without auditing every path that consumes
+     * {@code ParquetPushedExpressions} — the trivially-passes shortcut in
+     * {@code OptimizedParquetColumnIterator} relies on {@code hasYesConjunctOutsideFilterPredicate}
+     * being able to detect this exact split.
+     */
+    public void testWildcardLikeAsSeparateConjunctWithEqualsRecheckedOnly() {
+        Attribute url = attr("url", DataType.KEYWORD);
+        Attribute status = attr("status", DataType.LONG);
+        Expression like = new WildcardLike(Source.EMPTY, url, new WildcardPattern("*google*"));
+        Expression statusEq = new Equals(Source.EMPTY, status, longLit(200L), null);
+
+        // splitAnd in PushFiltersToSource hands us the decomposed conjuncts independently.
+        FilterPushdownSupport.PushdownResult result = support.pushFilters(List.of(like, statusEq));
+
+        assertTrue(result.hasPushedFilter());
+        assertEquals(FilterPushdownSupport.Pushability.YES, support.canPush(like));
+        assertEquals(FilterPushdownSupport.Pushability.RECHECK, support.canPush(statusEq));
+        // The remainder must contain ONLY status = 200 — the LIKE has been dropped from
+        // FilterExec because it pushes as YES. The trivially-passes guard in the reader has to
+        // keep that promise: late-mat MUST run for the LIKE because nothing else will.
+        assertEquals("LIKE must be dropped from remainder; only status = 200 RECHECK remains", 1, result.remainder().size());
+        assertTrue("remainder must be the status = 200 conjunct", result.remainder().contains(statusEq));
+        assertFalse("remainder must not contain the LIKE conjunct", result.remainder().contains(like));
+    }
+
     public void testWildcardLikeAndWildcardLikePushedAsYes() {
         // Two LIKE conjuncts in a single AND — both arms YES-eligible, so the combined
         // expression is YES and the conjunct is dropped from the remainder.

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsTests.java
@@ -19,8 +19,10 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
@@ -332,6 +334,91 @@ public class ParquetPushedExpressionsTests extends ESTestCase {
     public void testPredicateColumnNamesEmpty() {
         ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of());
         assertEquals(Set.of(), pushed.predicateColumnNames());
+    }
+
+    // --- hasYesConjunctOutsideFilterPredicate tests ---
+    //
+    // Important: these tests exist because the Pushability.YES promotion of WildcardLike (commit
+    // that added testWildcardLikeKeywordPushedAsYes etc.) introduced a latent bug where the
+    // OptimizedParquetColumnIterator's trivially-passes shortcut would silently bypass late-mat
+    // for row groups whose stats prove the (non-LIKE) FilterPredicate, leaking rows that don't
+    // match the LIKE conjunct (FilterExec was dropped for it). The fix relies on this method
+    // returning true exactly when there is a YES conjunct outside the FilterPredicate. DO NOT
+    // weaken these tests — they are the unit-level guard for the integration regression test
+    // OptimizedFilteredReaderTests.testPushedExpressionsLikeWithStatsTrivialEqDoesNotLeak.
+
+    public void testHasYesConjunctOutsideFilterPredicateLikeAlone() {
+        // Bare LIKE: YES, doesn't translate. Helper must return true.
+        MessageType schema = Types.buildMessage()
+            .required(org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("url")
+            .named("schema");
+        Expression like = new WildcardLike(Source.EMPTY, attr("url", DataType.KEYWORD), new WildcardPattern("*google*"));
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(like));
+        assertTrue("bare LIKE is YES-eligible and untranslatable", pushed.hasYesConjunctOutsideFilterPredicate(schema));
+    }
+
+    public void testHasYesConjunctOutsideFilterPredicateLikeAndEquals() {
+        // The exact realistic shape that caused the trivially-passes leak: LIKE (YES, untranslatable)
+        // AND-d with a comparator (RECHECK, translatable). Helper must return true.
+        MessageType schema = Types.buildMessage()
+            .required(org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("url")
+            .required(INT64)
+            .named("status")
+            .named("schema");
+        Expression like = new WildcardLike(Source.EMPTY, attr("url", DataType.KEYWORD), new WildcardPattern("*google*"));
+        Expression statusEq = new Equals(Source.EMPTY, attr("status", DataType.LONG), lit(200L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(like, statusEq));
+        assertTrue("YES LIKE is silently absent from the FilterPredicate", pushed.hasYesConjunctOutsideFilterPredicate(schema));
+    }
+
+    public void testHasYesConjunctOutsideFilterPredicateAllTranslatable() {
+        // Only translatable comparators: helper must return false so the trivially-passes
+        // shortcut still fires for the common single-conjunct/all-comparator case.
+        MessageType schema = Types.buildMessage().required(INT64).named("status").named("schema");
+        Expression statusEq = new Equals(Source.EMPTY, attr("status", DataType.LONG), lit(200L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(statusEq));
+        assertFalse(
+            "all-translatable filters must still benefit from the trivially-passes shortcut",
+            pushed.hasYesConjunctOutsideFilterPredicate(schema)
+        );
+    }
+
+    public void testHasYesConjunctOutsideFilterPredicateRecheckOnlyUntranslatable() {
+        // INT96 datetime: canConvert=true but translateExpression returns null. Pushability is
+        // RECHECK (not YES) because isFullyEvaluable returns false for non-LIKE comparators —
+        // FilterExec re-applies it. The shortcut is therefore safe to take, so the helper must
+        // return false. This is the case where translatability alone would over-reject.
+        MessageType schema = Types.buildMessage().required(INT96).named("ts").named("schema");
+        Expression tsEq = new Equals(Source.EMPTY, attr("ts", DataType.DATETIME), lit(1700000000000L, DataType.DATETIME), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(tsEq));
+        assertFalse(
+            "RECHECK conjuncts that fail to translate are still safe under the shortcut " + "(FilterExec catches the over-inclusion)",
+            pushed.hasYesConjunctOutsideFilterPredicate(schema)
+        );
+    }
+
+    public void testHasYesConjunctOutsideFilterPredicateNotLike() {
+        // Not(WildcardLike) is YES-eligible per isFullyEvaluable and untranslatable. Same trap as
+        // bare LIKE: FilterExec is dropped, late-mat must run.
+        MessageType schema = Types.buildMessage()
+            .required(org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("url")
+            .named("schema");
+        Expression like = new WildcardLike(Source.EMPTY, attr("url", DataType.KEYWORD), new WildcardPattern("*google*"));
+        Expression notLike = new Not(Source.EMPTY, like);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(notLike));
+        assertTrue("Not(LIKE) is YES-eligible and untranslatable", pushed.hasYesConjunctOutsideFilterPredicate(schema));
+    }
+
+    public void testHasYesConjunctOutsideFilterPredicateEmpty() {
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of());
+        MessageType schema = Types.buildMessage().required(INT64).named("status").named("schema");
+        assertFalse("empty expression list has no YES conjuncts", pushed.hasYesConjunctOutsideFilterPredicate(schema));
     }
 
     // --- helpers ---

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
@@ -1,0 +1,1168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.parquet.conf.PlainParquetConfiguration;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.CloseableIterator;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
+import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
+import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
+import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
+import org.elasticsearch.xpack.esql.expression.predicate.Range;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+/**
+ * Differential reader-side correctness suite for the Parquet pushdown stack.
+ *
+ * <p>For every filter and every layout, the suite runs four read paths and asserts they all
+ * agree on the set of {@code id} values returned. Each path uses a substantially different
+ * code path so disagreements pinpoint the bug class:
+ * <ol>
+ *   <li><b>production reader</b> (unit under test): our optimized reader with per-conjunct
+ *       YES/RECHECK pushdown — the same shape {@code PushFiltersToSource} produces.</li>
+ *   <li><b>oracle A — apache-mr</b>: apache-mr's {@link org.apache.parquet.hadoop.ParquetReader}
+ *       given the translated {@link org.apache.parquet.filter2.predicate.FilterPredicate},
+ *       then post-filtered in pure Java with the original ESQL expression to restore TVL
+ *       semantics and to apply conjuncts that did not translate (e.g. {@code WildcardLike}).
+ *       This is a true cross-stack check — apache-mr has its own RowGroupFilter,
+ *       ColumnIndex evaluator, and page reader.</li>
+ *   <li><b>oracle B — pushdown disabled</b>: our reader with no pushed filter at all (no
+ *       row-group pruning, no page pruning, no late-mat, no two-phase). Filtering is done
+ *       in pure Java on the reader's full output. Isolates bugs introduced by the
+ *       optimization shortcuts the production path takes.</li>
+ *   <li><b>oracle C — pure Java</b>: evaluate the ESQL expression against the in-memory rows
+ *       used to write the parquet file. No parquet involved at all. Catches translation
+ *       bugs that both A and B might share.</li>
+ * </ol>
+ *
+ * <h2>Why all three oracles?</h2>
+ * Each one catches a different class of bugs that the others would miss:
+ * <ul>
+ *   <li>The trivially-passes shortcut leak we recently fixed (LIKE pushed as YES alongside a
+ *       stats-trivial RECHECK conjunct) is caught by all three — they each apply the LIKE
+ *       through a path the production reader bypasses.</li>
+ *   <li>A bug in our {@code FilterPredicate} translation (e.g. {@code gt → gte} off-by-one)
+ *       is caught by oracle B and oracle C but NOT oracle A — A uses the same translation.</li>
+ *   <li>A bug in our pure-Java oracle's understanding of ESQL semantics (e.g. wrong TVL on
+ *       Not(Eq)) would silently agree with the production reader; oracle A catches it
+ *       because apache-mr is an independent implementation.</li>
+ * </ul>
+ *
+ * <h2>What this suite covers</h2>
+ * <ul>
+ *   <li>Fixed cases at known fault lines: YES/RECHECK/NO mixes, AND/OR/NOT trees,
+ *       stats-trivial conjuncts, all-match and no-match filters, IS NULL / IS NOT NULL,
+ *       prefix/suffix/infix LIKE, case-insensitive LIKE.</li>
+ *   <li>Randomized expression trees (bounded depth, mixed operators, mixed columns), per
+ *       layout.</li>
+ *   <li>Multiple Parquet write layouts (single big row group, many small row groups, dict
+ *       encoding on/off) so the optimizer's stats/dict/page paths get exercised
+ *       differently.</li>
+ * </ul>
+ *
+ * <h2>How to debug a failure</h2>
+ * The assertion message names the disagreeing pair (e.g. {@code production-vs-pureJava}),
+ * the layout, the filter (in compact form), and a sample of the symmetric difference of
+ * row IDs. Reproduce randomized failures with {@code -Dtests.seed=...} as usual.
+ */
+public class ParquetReaderFilterDifferentialTests extends ESTestCase {
+
+    private BlockFactory blockFactory;
+
+    /**
+     * Master schema used across all tests. Keep this fixed: the matrix is filter × layout, not
+     * filter × layout × schema.
+     */
+    private static final MessageType SCHEMA = Types.buildMessage()
+        .required(PrimitiveType.PrimitiveTypeName.INT64)
+        .named("id")
+        .required(PrimitiveType.PrimitiveTypeName.INT64)
+        .named("status")
+        .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+        .named("score")
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .as(LogicalTypeAnnotation.stringType())
+        .named("category")
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .as(LogicalTypeAnnotation.stringType())
+        .named("url")
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .as(LogicalTypeAnnotation.stringType())
+        .named("description")
+        .optional(PrimitiveType.PrimitiveTypeName.INT32)
+        .named("nullable_flag")
+        .named("differential_test_schema");
+
+    private static final ReferenceAttribute ID = attr("id", DataType.LONG);
+    private static final ReferenceAttribute STATUS = attr("status", DataType.LONG);
+    private static final ReferenceAttribute SCORE = attr("score", DataType.DOUBLE);
+    private static final ReferenceAttribute CATEGORY = attr("category", DataType.KEYWORD);
+    private static final ReferenceAttribute URL = attr("url", DataType.KEYWORD);
+    private static final ReferenceAttribute DESCRIPTION = attr("description", DataType.KEYWORD);
+    private static final ReferenceAttribute NULLABLE_FLAG = attr("nullable_flag", DataType.INTEGER);
+
+    private static final int ROW_COUNT = 4000;
+
+    private static final String[] CATEGORIES = { "alpha", "beta", "gamma", "delta" };
+    private static final String[] URL_HOSTS = { "google.com", "example.org", "elastic.co", "github.com" };
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("none")).build();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Fixed cases — each one targets a known fault line in the pushdown / late-mat stack.
+    // Layouts are randomized per fixed case so the matrix is still wide.
+    // ---------------------------------------------------------------------------------------
+
+    public void testSingleEqualsOnLowCardinalityRecheck() throws IOException {
+        // status = 200 — RECHECK conjunct; FilterExec re-applies. Stats-aware paths must
+        // still produce the right rows whether the row group is fully matching, fully
+        // non-matching, or mixed.
+        runDifferential(eq(STATUS, 200L, DataType.LONG));
+    }
+
+    public void testRangeOnSortedColumn() throws IOException {
+        // id is monotonic; this exercises ColumnIndex page pruning and stats-based row-group
+        // pruning end to end.
+        runDifferential(and(gte(ID, 100L, DataType.LONG), lt(ID, 400L, DataType.LONG)));
+    }
+
+    public void testStartsWithKeyword() throws IOException {
+        // StartsWith pushes as RECHECK + translates to a prefix-range FilterPredicate.
+        // The reader must produce identical rows whether the row group is fully matched
+        // (all URLs share the prefix) or partially.
+        runDifferential(startsWith(URL, "https://google"));
+    }
+
+    public void testWildcardLikeAlonePushedAsYes() throws IOException {
+        // Bare LIKE pushes as YES; FilterExec is dropped. Late-mat must run and produce
+        // exactly the LIKE-matching rows. This is the common single-conjunct shape.
+        runDifferential(like(URL, "*google*"));
+    }
+
+    public void testLikeAndStatsTrivialEquals() throws IOException {
+        // Regression: LIKE (YES) AND status = 200 (RECHECK, stats-trivial because we set
+        // status = 200 for every row in our dataset). This was the trivially-passes shortcut
+        // bug — the reader would skip late-mat for every row group on the strength of
+        // status = 200's stats and silently leak rows that don't match LIKE. The fix relies
+        // on hasYesConjunctOutsideFilterPredicate to suppress the shortcut here.
+        runDifferential(and(like(URL, "*google*"), eq(STATUS, 200L, DataType.LONG)));
+    }
+
+    public void testNotLike() throws IOException {
+        // Not(LIKE) is YES with a TVL-aware special case in evaluateNotWildcardLike.
+        // Verifies that null URLs (none in our base dataset, but the path is still exercised)
+        // and non-matching URLs both behave as expected under negation.
+        runDifferential(not(like(URL, "*google*")));
+    }
+
+    public void testCaseInsensitiveLike() throws IOException {
+        runDifferential(likeCaseInsensitive(URL, "*GOOGLE*"));
+    }
+
+    public void testIsNullAndIsNotNull() throws IOException {
+        // nullable_flag is null for ~30% of rows. Both branches exercise the dedicated
+        // IsNull/IsNotNull evaluator paths and the FilterPredicate translation that uses
+        // a null-valued comparison.
+        runDifferential(isNull(NULLABLE_FLAG));
+        runDifferential(isNotNull(NULLABLE_FLAG));
+    }
+
+    public void testOrOfHeterogeneousConjuncts() throws IOException {
+        // OR(LIKE, status > 400) — OR forces the conservative all-or-nothing translation
+        // (both arms must translate or the OR is dropped). Critically, OR is NOT YES-eligible
+        // even when both arms are YES, so this lands as RECHECK and FilterExec re-applies.
+        runDifferential(or(like(URL, "*example*"), gt(STATUS, 400L, DataType.LONG)));
+    }
+
+    public void testNestedAndOrLikeTreeWithMixedPushability() throws IOException {
+        // (LIKE AND status = 200) OR (id < 100) — combines a YES/RECHECK conjunction with
+        // a separate selective range. OR makes the whole thing RECHECK and keeps it in
+        // FilterExec, but the late-mat evaluator must still produce a correct subset to
+        // hand to FilterExec.
+        Expression filter = or(and(like(URL, "*google*"), eq(STATUS, 200L, DataType.LONG)), lt(ID, 100L, DataType.LONG));
+        runDifferential(filter);
+    }
+
+    public void testFilterMatchingNoRows() throws IOException {
+        // Stats-pruned: id > ROW_COUNT * 2 — every row group's max < threshold, so
+        // RowGroupFilter drops all groups. Reader returns zero pages.
+        runDifferential(gt(ID, (long) (ROW_COUNT * 2L), DataType.LONG));
+    }
+
+    public void testFilterMatchingAllRows() throws IOException {
+        // Stats-trivial all-pass: id >= 0. Trivially-passes shortcut should fire (all
+        // expressions translate, all stats prove it true). Reader returns every row.
+        runDifferential(gte(ID, 0L, DataType.LONG));
+    }
+
+    public void testNotEqualsOnLowCardinality() throws IOException {
+        runDifferential(neq(STATUS, 404L, DataType.LONG));
+    }
+
+    public void testRangeOnDouble() throws IOException {
+        runDifferential(and(gte(SCORE, 0.25, DataType.DOUBLE), lt(SCORE, 0.75, DataType.DOUBLE)));
+    }
+
+    public void testLikeOnHighCardinalityProjectedColumn() throws IOException {
+        // url is both predicate (LIKE) and projection target. Late-mat's projection-only
+        // optimization doesn't apply here — exercises the "predicate column is also projected"
+        // common case.
+        runDifferential(like(URL, "*github*"));
+    }
+
+    public void testEqualsOnDictionaryEncodedKeyword() throws IOException {
+        // category has only 4 distinct values, so the writer dict-encodes it. Equality
+        // should land on the dictionary short-circuit path.
+        runDifferential(eq(CATEGORY, "alpha", DataType.KEYWORD));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Randomized cases — random expression trees per layout.
+    // ---------------------------------------------------------------------------------------
+
+    public void testRandomizedFilterTrees() throws IOException {
+        Layout layout = randomFrom(Layout.values());
+        DatasetAndBytes dataset = buildDataset(layout);
+        // Randomization budget: a moderate number of iterations per layout, kept small so
+        // the suite stays under a few seconds. Failures reproduce with -Dtests.seed=... and
+        // print the offending expression tree.
+        int iterations = scaledRandomIntBetween(15, 30);
+        for (int i = 0; i < iterations; i++) {
+            Expression filter = randomExpression(2);
+            assertOracleAgreement(dataset, filter, layout, "iteration " + i);
+        }
+    }
+
+    /**
+     * Targeted randomized variant: every tree contains at least one {@code WildcardLike}
+     * conjunct so the YES + non-translatable code path is exercised every iteration. This
+     * is the regression-most-likely shape (the trivially-passes leak we just fixed and
+     * any future YES-eligible expressions that don't translate).
+     */
+    public void testRandomizedFilterTreesWithLikeAlwaysPresent() throws IOException {
+        Layout layout = randomFrom(Layout.values());
+        DatasetAndBytes dataset = buildDataset(layout);
+        int iterations = scaledRandomIntBetween(15, 30);
+        for (int i = 0; i < iterations; i++) {
+            Expression like = randomLike();
+            Expression rest = randomExpression(2);
+            // AND-combine so the test exercises mixed YES/RECHECK splits at the per-conjunct
+            // level (the actual planner shape).
+            Expression filter = and(like, rest);
+            assertOracleAgreement(dataset, filter, layout, "iteration " + i);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Differential harness
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Runs the same filter against every layout and asserts oracle agreement on each. Used by
+     * the fixed-case tests so they get coverage across all parquet write configs without
+     * having to enumerate them manually.
+     */
+    private void runDifferential(Expression filter) throws IOException {
+        for (Layout layout : Layout.values()) {
+            DatasetAndBytes dataset = buildDataset(layout);
+            assertOracleAgreement(dataset, filter, layout, "fixed case");
+        }
+    }
+
+    /**
+     * Lockstep comparison: the production reader path and three independent oracles must all
+     * produce the same set of {@code id} values for {@code filter}. Any pairwise disagreement
+     * is reported with which pair disagreed and a sample of the symmetric difference.
+     *
+     * <p>The four paths are deliberately heterogeneous so each one catches a different family
+     * of bugs (see class Javadoc for the per-bug-class table):
+     * <ul>
+     *   <li><b>production</b>: our optimized reader with per-conjunct YES/RECHECK pushdown
+     *       (the unit under test).</li>
+     *   <li><b>oracleA_apacheMr</b>: apache-mr's {@link ParquetReader} given the translated
+     *       {@link FilterPredicate}, then post-filtered in Java with the original ESQL
+     *       expression. The post-filter restores ESQL TVL semantics that diverge from
+     *       parquet-mr's (e.g. {@code NOT(eq(col, k))} returns nulls in parquet-mr but drops
+     *       them in ESQL) and applies any conjuncts that did not translate (e.g. {@link
+     *       WildcardLike}). This is a true cross-stack check.</li>
+     *   <li><b>oracleB_pushdownDisabled</b>: our reader with no pushed filter at all (no
+     *       row-group pruning, no page pruning, no late-mat, no two-phase). All filtering is
+     *       done in Java on the reader's full output. This isolates "does pushdown break
+     *       anything that the unoptimized path gets right".</li>
+     *   <li><b>oracleC_pureJava</b>: pure-Java evaluation of the ESQL expression against the
+     *       in-memory rows that were used to write the parquet file. Doesn't touch parquet
+     *       at all. Catches translation bugs that both A and B might share (e.g. if our
+     *       FilterPredicate translation is off by one).</li>
+     * </ul>
+     */
+    private void assertOracleAgreement(DatasetAndBytes dataset, Expression filter, Layout layout, String iterationTag) throws IOException {
+        Set<Long> production = productionReaderEvaluate(dataset.parquetBytes, filter);
+        Set<Long> apacheMr = oracleA_apacheMr(dataset.parquetBytes, filter);
+        Set<Long> noPushdown = oracleB_pushdownDisabled(dataset.parquetBytes, filter);
+        Set<Long> pureJava = oracleC_pureJava(dataset.rows, filter);
+
+        // Order matters for diagnostics: check oracle-vs-oracle first so a real production
+        // bug is reported with the simplest possible "production-vs-pureJava" message instead
+        // of a confusing chain of cascading mismatches. If oracles disagree among themselves,
+        // that's a separate (and rarer) class of bug — fail loud on that first.
+        check(layout, iterationTag, filter, "apacheMr-vs-pureJava", apacheMr, pureJava);
+        check(layout, iterationTag, filter, "noPushdown-vs-pureJava", noPushdown, pureJava);
+        // Now both oracles A and B agree with C (the canonical ESQL semantics oracle), so any
+        // remaining disagreement is squarely a production-reader bug.
+        check(layout, iterationTag, filter, "production-vs-pureJava", production, pureJava);
+        // Belt-and-braces: production-vs-apacheMr would catch the rare case where pureJava
+        // and production happen to share a wrong answer (e.g. a bug in our oracle's
+        // understanding of ESQL semantics). After the previous three checks pass, this is
+        // mathematically implied — we keep it as a static assertion of the invariant.
+        check(layout, iterationTag, filter, "production-vs-apacheMr", production, apacheMr);
+    }
+
+    private static void check(Layout layout, String iterationTag, Expression filter, String pair, Set<Long> a, Set<Long> b) {
+        if (a.equals(b)) {
+            return;
+        }
+        Set<Long> aOnly = new TreeSet<>(a);
+        aOnly.removeAll(b);
+        Set<Long> bOnly = new TreeSet<>(b);
+        bOnly.removeAll(a);
+        throw new AssertionError(
+            String.format(
+                Locale.ROOT,
+                "Pair disagreement [%s] on layout=%s [%s]%n  filter: %s%n  left.size=%d, right.size=%d%n"
+                    + "  in left only (sample 20): %s%n  in right only (sample 20): %s",
+                pair,
+                layout,
+                iterationTag,
+                describe(filter),
+                a.size(),
+                b.size(),
+                sampled(aOnly, 20),
+                sampled(bOnly, 20)
+            )
+        );
+    }
+
+    /**
+     * Compact, single-line description of an ESQL expression tree for assertion messages.
+     * The default {@code toString()} is multi-line; this one is grep-friendly when scanning
+     * test failure output.
+     */
+    private static String describe(Expression expr) {
+        if (expr instanceof And and) return "AND(" + describe(and.left()) + ", " + describe(and.right()) + ")";
+        if (expr instanceof Or or) return "OR(" + describe(or.left()) + ", " + describe(or.right()) + ")";
+        if (expr instanceof Not not) return "NOT(" + describe(not.field()) + ")";
+        if (expr instanceof IsNull isNull) return ((ReferenceAttribute) isNull.field()).name() + " IS NULL";
+        if (expr instanceof IsNotNull isNotNull) return ((ReferenceAttribute) isNotNull.field()).name() + " IS NOT NULL";
+        if (expr instanceof Range range) {
+            String name = ((ReferenceAttribute) range.value()).name();
+            String lo = range.includeLower() ? ">=" : ">";
+            String hi = range.includeUpper() ? "<=" : "<";
+            return name + lo + ((Literal) range.lower()).value() + " AND " + name + hi + ((Literal) range.upper()).value();
+        }
+        if (expr instanceof Equals e) return ((ReferenceAttribute) e.left()).name() + "=" + literalToString(((Literal) e.right()).value());
+        if (expr instanceof NotEquals e) return ((ReferenceAttribute) e.left()).name()
+            + "!="
+            + literalToString(((Literal) e.right()).value());
+        if (expr instanceof GreaterThan e) return ((ReferenceAttribute) e.left()).name()
+            + ">"
+            + literalToString(((Literal) e.right()).value());
+        if (expr instanceof GreaterThanOrEqual e) {
+            return ((ReferenceAttribute) e.left()).name() + ">=" + literalToString(((Literal) e.right()).value());
+        }
+        if (expr instanceof LessThan e) return ((ReferenceAttribute) e.left()).name()
+            + "<"
+            + literalToString(((Literal) e.right()).value());
+        if (expr instanceof LessThanOrEqual e) {
+            return ((ReferenceAttribute) e.left()).name() + "<=" + literalToString(((Literal) e.right()).value());
+        }
+        if (expr instanceof StartsWith sw) {
+            String name = ((ReferenceAttribute) sw.singleValueField()).name();
+            return name + " STARTS_WITH '" + ((BytesRef) ((Literal) sw.prefix()).value()).utf8ToString() + "'";
+        }
+        if (expr instanceof WildcardLike wl) {
+            String name = ((ReferenceAttribute) wl.field()).name();
+            String op = wl.caseInsensitive() ? " LIKE/i " : " LIKE ";
+            return name + op + "'" + wl.pattern().asLuceneWildcard() + "'";
+        }
+        return expr.toString();
+    }
+
+    private static String literalToString(Object v) {
+        if (v instanceof BytesRef br) return "'" + br.utf8ToString() + "'";
+        return String.valueOf(v);
+    }
+
+    private static String sampled(Set<Long> set, int max) {
+        StringBuilder b = new StringBuilder("[");
+        int n = 0;
+        for (Long v : set) {
+            if (n++ > 0) b.append(", ");
+            if (n > max) {
+                b.append("...");
+                break;
+            }
+            b.append(v);
+        }
+        return b.append("]").toString();
+    }
+
+    /**
+     * Oracle C: pure-Java evaluation of an ESQL filter against the in-memory rows. No parquet
+     * involved at all. Mirrors the runtime semantics the late-mat evaluator implements
+     * (TVL: nulls collapse to "no match" for regular predicates; {@code IS NULL} /
+     * {@code IS NOT NULL} are explicit). This is the canonical ESQL semantics oracle.
+     */
+    private static Set<Long> oracleC_pureJava(List<Map<String, Object>> rows, Expression filter) {
+        Set<Long> ids = new TreeSet<>();
+        for (Map<String, Object> row : rows) {
+            if (Boolean.TRUE.equals(evalNode(filter, row))) {
+                ids.add((Long) row.get("id"));
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * Returns {@code Boolean.TRUE}, {@code Boolean.FALSE}, or {@code null} (UNKNOWN under TVL).
+     * The reader's late-mat evaluator collapses {@code null} to "no match" via the per-row
+     * mask, but that collapse happens at {@link #oracleC_pureJava} (which only retains rows
+     * that evaluated to {@code TRUE}).
+     */
+    private static Boolean evalNode(Expression expr, Map<String, Object> row) {
+        if (expr instanceof And and) {
+            Boolean l = evalNode(and.left(), row);
+            Boolean r = evalNode(and.right(), row);
+            if (Boolean.FALSE.equals(l) || Boolean.FALSE.equals(r)) return false;
+            if (l == null || r == null) return null;
+            return true;
+        }
+        if (expr instanceof Or or) {
+            Boolean l = evalNode(or.left(), row);
+            Boolean r = evalNode(or.right(), row);
+            if (Boolean.TRUE.equals(l) || Boolean.TRUE.equals(r)) return true;
+            if (l == null || r == null) return null;
+            return false;
+        }
+        if (expr instanceof Not not) {
+            Boolean inner = evalNode(not.field(), row);
+            if (inner == null) return null;
+            return inner ? Boolean.FALSE : Boolean.TRUE;
+        }
+        if (expr instanceof IsNull isNull) {
+            String name = ((ReferenceAttribute) isNull.field()).name();
+            return row.get(name) == null;
+        }
+        if (expr instanceof IsNotNull isNotNull) {
+            String name = ((ReferenceAttribute) isNotNull.field()).name();
+            return row.get(name) != null;
+        }
+        if (expr instanceof Range range) {
+            String name = ((ReferenceAttribute) range.value()).name();
+            Object v = row.get(name);
+            if (v == null) return null;
+            Number lower = (Number) ((Literal) range.lower()).value();
+            Number upper = (Number) ((Literal) range.upper()).value();
+            double dv = ((Number) v).doubleValue();
+            double dl = lower.doubleValue();
+            double du = upper.doubleValue();
+            boolean lOk = range.includeLower() ? dv >= dl : dv > dl;
+            boolean uOk = range.includeUpper() ? dv <= du : dv < du;
+            return lOk && uOk;
+        }
+        if (expr instanceof Equals e) {
+            return cmpEq(row, e.left(), e.right());
+        }
+        if (expr instanceof NotEquals ne) {
+            Boolean eqRes = cmpEq(row, ne.left(), ne.right());
+            if (eqRes == null) return null;
+            return eqRes ? Boolean.FALSE : Boolean.TRUE;
+        }
+        if (expr instanceof GreaterThan gt) {
+            return cmpOrdered(row, gt.left(), gt.right(), 1, false);
+        }
+        if (expr instanceof GreaterThanOrEqual gte) {
+            return cmpOrdered(row, gte.left(), gte.right(), 1, true);
+        }
+        if (expr instanceof LessThan lt) {
+            return cmpOrdered(row, lt.left(), lt.right(), -1, false);
+        }
+        if (expr instanceof LessThanOrEqual lte) {
+            return cmpOrdered(row, lte.left(), lte.right(), -1, true);
+        }
+        if (expr instanceof StartsWith sw) {
+            String name = ((ReferenceAttribute) sw.singleValueField()).name();
+            Object v = row.get(name);
+            if (v == null) return null;
+            BytesRef prefix = (BytesRef) ((Literal) sw.prefix()).value();
+            return ((String) v).startsWith(prefix.utf8ToString());
+        }
+        if (expr instanceof WildcardLike wl) {
+            String name = ((ReferenceAttribute) wl.field()).name();
+            Object v = row.get(name);
+            if (v == null) return null;
+            String regex = wl.pattern().asJavaRegex();
+            int flags = wl.caseInsensitive() ? Pattern.CASE_INSENSITIVE : 0;
+            return Pattern.compile(regex, flags).matcher((String) v).matches();
+        }
+        throw new AssertionError("oracle does not handle expression: " + expr.getClass());
+    }
+
+    private static Boolean cmpEq(Map<String, Object> row, Expression leftExpr, Expression rightExpr) {
+        String name = ((ReferenceAttribute) leftExpr).name();
+        Object v = row.get(name);
+        if (v == null) return null;
+        Object literal = ((Literal) rightExpr).value();
+        if (literal instanceof BytesRef br) {
+            return ((String) v).equals(br.utf8ToString());
+        }
+        if (literal instanceof Number n && v instanceof Number nv) {
+            return Double.compare(n.doubleValue(), nv.doubleValue()) == 0;
+        }
+        return literal.equals(v);
+    }
+
+    private static Boolean cmpOrdered(Map<String, Object> row, Expression leftExpr, Expression rightExpr, int sign, boolean orEqual) {
+        String name = ((ReferenceAttribute) leftExpr).name();
+        Object v = row.get(name);
+        if (v == null) return null;
+        Object literal = ((Literal) rightExpr).value();
+        int cmp;
+        if (literal instanceof BytesRef br && v instanceof String s) {
+            cmp = s.compareTo(br.utf8ToString());
+        } else if (literal instanceof Number n && v instanceof Number nv) {
+            cmp = Double.compare(nv.doubleValue(), n.doubleValue());
+        } else {
+            throw new AssertionError("unsupported comparison: " + literal.getClass() + " vs " + v.getClass());
+        }
+        if (cmp == 0) return orEqual;
+        return Integer.signum(cmp) == Integer.signum(sign);
+    }
+
+    /**
+     * Production reader path: optimized reader with a {@link ParquetPushedExpressions}
+     * wrapping the filter (mirroring what {@code PushFiltersToSource} builds). The filter is
+     * decomposed into top-level AND conjuncts so the per-conjunct YES/RECHECK classification
+     * matches the planner's behavior. RECHECK and NO conjuncts are then applied as a pure-Java
+     * post-filter on the reader's output, mirroring what {@code FilterExec} does in production.
+     *
+     * <p>This is the unit under test. Two-step structure mirrors the production planner:
+     * <ol>
+     *   <li>The reader receives every conjunct via {@code withPushedFilter} and is allowed to
+     *       use any of them for stats pruning, page pruning, late-mat compaction, etc.</li>
+     *   <li>Any conjunct whose {@link ParquetFilterPushdownSupport#canPush} classification is
+     *       {@link FilterPushdownSupport.Pushability#RECHECK} or
+     *       {@link FilterPushdownSupport.Pushability#NO} is re-applied in Java — exactly what
+     *       {@code FilterExec} would do.</li>
+     * </ol>
+     *
+     * <p>This precisely captures the YES-vs-RECHECK contract: a YES conjunct that the reader
+     * silently drops (the trivially-passes leak) has no FilterExec safety net here, so the
+     * test catches it. A RECHECK conjunct that the reader over-includes is fine because the
+     * post-filter cleans it up — and that mirrors production semantics exactly.
+     */
+    private Set<Long> productionReaderEvaluate(byte[] parquetBytes, Expression filter) throws IOException {
+        List<Expression> conjuncts = splitTopLevelAnd(filter);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(conjuncts);
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+
+        // Determine the FilterExec remainder using the same classifier the planner uses.
+        ParquetFilterPushdownSupport pushdownSupport = new ParquetFilterPushdownSupport();
+        List<Expression> remainder = new ArrayList<>();
+        for (Expression conjunct : conjuncts) {
+            if (pushdownSupport.canPush(conjunct) != FilterPushdownSupport.Pushability.YES) {
+                remainder.add(conjunct);
+            }
+        }
+
+        Set<Long> readerIds = collectIdsWithRowMaterialization(reader, parquetBytes, remainder);
+        return readerIds;
+    }
+
+    /**
+     * Reads every page from the reader, then for each row applies the {@code remainder}
+     * conjuncts (RECHECK/NO) as a pure-Java post-filter. Returns the surviving {@code id}
+     * values. Used by the production reader path to mirror what {@code FilterExec} does on
+     * top of the reader's output.
+     */
+    private Set<Long> collectIdsWithRowMaterialization(ParquetFormatReader reader, byte[] parquetBytes, List<Expression> remainder)
+        throws IOException {
+        StorageObject storageObject = inMemoryStorageObject(parquetBytes);
+        Set<Long> ids = new TreeSet<>();
+        try (CloseableIterator<Page> iter = reader.read(storageObject, FormatReadContext.of(null, 1024))) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                try {
+                    for (int i = 0; i < page.getPositionCount(); i++) {
+                        Map<String, Object> row = pageRowToMap(page, i);
+                        boolean keep = true;
+                        for (Expression conj : remainder) {
+                            if (Boolean.TRUE.equals(evalNode(conj, row)) == false) {
+                                keep = false;
+                                break;
+                            }
+                        }
+                        if (keep) {
+                            ids.add((Long) row.get("id"));
+                        }
+                    }
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * Oracle B: our reader with NO pushdown at all (no {@code withPushedFilter}). The reader
+     * returns every row of every page in every row group — no row-group pruning, no
+     * ColumnIndex page pruning, no late-mat compaction, no two-phase prefetch — and we apply
+     * the filter in pure Java on top. This is a "same parser, different config" oracle: it
+     * exercises the read path that does NOT take any of the optimization shortcuts that the
+     * production path takes, isolating bugs introduced specifically by those shortcuts (e.g.
+     * trivially-passes, RowRanges over-pruning).
+     */
+    private Set<Long> oracleB_pushdownDisabled(byte[] parquetBytes, Expression filter) throws IOException {
+        ParquetFormatReader reader = new ParquetFormatReader(blockFactory, true);
+        Set<Long> allRows = collectIdsWithEval(reader, parquetBytes, filter);
+        return allRows;
+    }
+
+    /**
+     * Oracle A: read with apache-mr's {@link ParquetReader} given the translated
+     * {@link FilterPredicate}, then post-filter the original ESQL expression in pure Java on
+     * top. apache-mr is a completely independent parquet stack (different RowGroupFilter,
+     * different ColumnIndex evaluator, different page reader), so any bug in one of our
+     * optimization layers shows up here as a disagreement.
+     *
+     * <p>The post-filter restores ESQL TVL semantics that diverge from parquet-mr's
+     * (e.g. {@code NOT(eq(col, k))} returns null rows in parquet-mr but drops them in ESQL)
+     * and applies any conjuncts that did not translate to a {@link FilterPredicate}
+     * (e.g. {@link WildcardLike}). When the translation returns {@code null} (no conjunct
+     * translated), apache-mr is used purely as a row reader — still useful as a structural
+     * cross-check on column decoding.
+     */
+    private Set<Long> oracleA_apacheMr(byte[] parquetBytes, Expression filter) throws IOException {
+        FilterPredicate filterPredicate = new ParquetPushedExpressions(splitTopLevelAnd(filter)).toFilterPredicate(SCHEMA);
+        GroupReaderBuilder builder = new GroupReaderBuilder(new ParquetStorageObjectAdapter(inMemoryStorageObject(parquetBytes)));
+        if (filterPredicate != null) {
+            builder.withFilter(FilterCompat.get(filterPredicate));
+        }
+        Set<Long> ids = new TreeSet<>();
+        try (ParquetReader<Group> mrReader = builder.build()) {
+            Group g;
+            while ((g = mrReader.read()) != null) {
+                Map<String, Object> row = groupToRow(g);
+                if (Boolean.TRUE.equals(evalNode(filter, row))) {
+                    ids.add((Long) row.get("id"));
+                }
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * Tiny {@link ParquetReader.Builder} subclass that wires up a {@link GroupReadSupport}.
+     * Uses the {@code (InputFile, ParquetConfiguration)} constructor explicitly so we get a
+     * {@link PlainParquetConfiguration} — the Hadoop-based configuration the no-arg path
+     * resolves to pulls in {@code com.ctc.wstx.io.InputBootstrapper} (Woodstox), which isn't
+     * on the test classpath. Passing a {@code ParquetConfiguration} skips that resolution
+     * entirely.
+     */
+    private static final class GroupReaderBuilder extends ParquetReader.Builder<Group> {
+        GroupReaderBuilder(org.apache.parquet.io.InputFile file) {
+            super(file, new PlainParquetConfiguration());
+        }
+
+        @Override
+        protected org.apache.parquet.hadoop.api.ReadSupport<Group> getReadSupport() {
+            return new GroupReadSupport();
+        }
+    }
+
+    /**
+     * Reads every row from the reader, applies {@code filter} in pure Java per row, and
+     * collects matching {@code id} values. Used by oracle B (pushdown disabled).
+     */
+    private Set<Long> collectIdsWithEval(ParquetFormatReader reader, byte[] parquetBytes, Expression filter) throws IOException {
+        StorageObject storageObject = inMemoryStorageObject(parquetBytes);
+        Set<Long> ids = new TreeSet<>();
+        try (CloseableIterator<Page> iter = reader.read(storageObject, FormatReadContext.of(null, 1024))) {
+            while (iter.hasNext()) {
+                Page page = iter.next();
+                try {
+                    int positions = page.getPositionCount();
+                    for (int i = 0; i < positions; i++) {
+                        Map<String, Object> row = pageRowToMap(page, i);
+                        if (Boolean.TRUE.equals(evalNode(filter, row))) {
+                            ids.add((Long) row.get("id"));
+                        }
+                    }
+                } finally {
+                    page.releaseBlocks();
+                }
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * Materialize a single row from a {@link Page} as a {@code Map} so the pure-Java
+     * evaluator can be reused.
+     */
+    private static Map<String, Object> pageRowToMap(Page page, int rowIndex) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", ((LongBlock) page.getBlock(0)).getLong(rowIndex));
+        row.put("status", ((LongBlock) page.getBlock(1)).getLong(rowIndex));
+        row.put("score", ((DoubleBlock) page.getBlock(2)).getDouble(rowIndex));
+        row.put("category", ((BytesRefBlock) page.getBlock(3)).getBytesRef(rowIndex, new BytesRef()).utf8ToString());
+        row.put("url", ((BytesRefBlock) page.getBlock(4)).getBytesRef(rowIndex, new BytesRef()).utf8ToString());
+        row.put("description", ((BytesRefBlock) page.getBlock(5)).getBytesRef(rowIndex, new BytesRef()).utf8ToString());
+        Block flagBlock = page.getBlock(6);
+        if (flagBlock.isNull(rowIndex)) {
+            row.put("nullable_flag", null);
+        } else {
+            row.put("nullable_flag", ((IntBlock) flagBlock).getInt(rowIndex));
+        }
+        return row;
+    }
+
+    /**
+     * Convert an apache-mr {@link Group} to the same map shape used by the pure-Java
+     * evaluator. {@code nullable_flag} is decoded as {@code null} when the group has no
+     * value at that field index (i.e. {@code optional} field with no value written).
+     */
+    private static Map<String, Object> groupToRow(Group g) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", g.getLong("id", 0));
+        row.put("status", g.getLong("status", 0));
+        row.put("score", g.getDouble("score", 0));
+        row.put("category", g.getString("category", 0));
+        row.put("url", g.getString("url", 0));
+        row.put("description", g.getString("description", 0));
+        if (g.getFieldRepetitionCount("nullable_flag") == 0) {
+            row.put("nullable_flag", null);
+        } else {
+            row.put("nullable_flag", g.getInteger("nullable_flag", 0));
+        }
+        return row;
+    }
+
+    private static List<Expression> splitTopLevelAnd(Expression filter) {
+        List<Expression> out = new ArrayList<>();
+        splitInto(filter, out);
+        return out;
+    }
+
+    private static void splitInto(Expression e, List<Expression> out) {
+        if (e instanceof And and) {
+            splitInto(and.left(), out);
+            splitInto(and.right(), out);
+        } else {
+            out.add(e);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Random expression generation
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Builds a random ESQL filter expression of bounded depth over the test schema. The
+     * generated tree exercises the planner's per-conjunct classification because the top
+     * level is AND/OR/NOT'd from primitive predicates with various pushability profiles.
+     */
+    private Expression randomExpression(int depthRemaining) {
+        if (depthRemaining <= 0 || randomIntBetween(0, 3) == 0) {
+            return randomLeaf();
+        }
+        int kind = randomIntBetween(0, 4);
+        return switch (kind) {
+            case 0 -> and(randomExpression(depthRemaining - 1), randomExpression(depthRemaining - 1));
+            case 1 -> or(randomExpression(depthRemaining - 1), randomExpression(depthRemaining - 1));
+            case 2 -> not(randomExpression(depthRemaining - 1));
+            default -> randomLeaf();
+        };
+    }
+
+    private Expression randomLeaf() {
+        int kind = randomIntBetween(0, 9);
+        return switch (kind) {
+            case 0 -> eq(STATUS, randomLongStatus(), DataType.LONG);
+            case 1 -> neq(STATUS, randomLongStatus(), DataType.LONG);
+            case 2 -> gt(ID, (long) randomIntBetween(0, ROW_COUNT), DataType.LONG);
+            case 3 -> lt(ID, (long) randomIntBetween(0, ROW_COUNT), DataType.LONG);
+            case 4 -> like(URL, randomLikePattern());
+            case 5 -> startsWith(URL, randomPrefix());
+            case 6 -> isNull(NULLABLE_FLAG);
+            case 7 -> isNotNull(NULLABLE_FLAG);
+            case 8 -> eq(CATEGORY, randomFrom(CATEGORIES), DataType.KEYWORD);
+            default -> and(
+                gte(SCORE, randomDoubleBetween(0.0, 1.0, true), DataType.DOUBLE),
+                lt(SCORE, randomDoubleBetween(0.0, 1.0, true) + 1.0, DataType.DOUBLE)
+            );
+        };
+    }
+
+    private Expression randomLike() {
+        return randomBoolean() ? like(URL, randomLikePattern()) : likeCaseInsensitive(URL, randomLikePattern().toUpperCase(Locale.ROOT));
+    }
+
+    private long randomLongStatus() {
+        return (long) randomFrom(new Integer[] { 200, 404, 500 });
+    }
+
+    private String randomLikePattern() {
+        // Mix prefix-extractable patterns (good for the StartsWith translation), infix (no
+        // prefix), suffix, and match-all.
+        int k = randomIntBetween(0, 5);
+        return switch (k) {
+            case 0 -> "https://google*";
+            case 1 -> "*google*";
+            case 2 -> "*example*";
+            case 3 -> "*github.com";
+            case 4 -> "https://elastic*";
+            default -> "*";
+        };
+    }
+
+    private String randomPrefix() {
+        return randomFrom(new String[] { "https://google", "https://example", "https://elastic", "https://github" });
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Expression builders (terse, to keep the test bodies readable)
+    // ---------------------------------------------------------------------------------------
+
+    private static ReferenceAttribute attr(String name, DataType type) {
+        return new ReferenceAttribute(Source.EMPTY, name, type);
+    }
+
+    private static Literal lit(Object value, DataType type) {
+        if (type == DataType.KEYWORD && value instanceof String s) {
+            return new Literal(Source.EMPTY, new BytesRef(s), type);
+        }
+        return new Literal(Source.EMPTY, value, type);
+    }
+
+    private static Expression eq(ReferenceAttribute a, Object v, DataType t) {
+        return new Equals(Source.EMPTY, a, lit(v, t), null);
+    }
+
+    private static Expression neq(ReferenceAttribute a, Object v, DataType t) {
+        return new NotEquals(Source.EMPTY, a, lit(v, t), null);
+    }
+
+    private static Expression gt(ReferenceAttribute a, Object v, DataType t) {
+        return new GreaterThan(Source.EMPTY, a, lit(v, t), null);
+    }
+
+    private static Expression gte(ReferenceAttribute a, Object v, DataType t) {
+        return new GreaterThanOrEqual(Source.EMPTY, a, lit(v, t), null);
+    }
+
+    private static Expression lt(ReferenceAttribute a, Object v, DataType t) {
+        return new LessThan(Source.EMPTY, a, lit(v, t), null);
+    }
+
+    private static Expression and(Expression l, Expression r) {
+        return new And(Source.EMPTY, l, r);
+    }
+
+    private static Expression or(Expression l, Expression r) {
+        return new Or(Source.EMPTY, l, r);
+    }
+
+    private static Expression not(Expression e) {
+        return new Not(Source.EMPTY, e);
+    }
+
+    private static Expression isNull(ReferenceAttribute a) {
+        return new IsNull(Source.EMPTY, a);
+    }
+
+    private static Expression isNotNull(ReferenceAttribute a) {
+        return new IsNotNull(Source.EMPTY, a);
+    }
+
+    private static Expression like(ReferenceAttribute a, String pattern) {
+        return new WildcardLike(Source.EMPTY, a, new WildcardPattern(pattern));
+    }
+
+    private static Expression likeCaseInsensitive(ReferenceAttribute a, String pattern) {
+        return new WildcardLike(Source.EMPTY, a, new WildcardPattern(pattern), true);
+    }
+
+    private static Expression startsWith(ReferenceAttribute a, String prefix) {
+        return new StartsWith(Source.EMPTY, a, lit(prefix, DataType.KEYWORD));
+    }
+
+    @SuppressWarnings("unused")
+    private static Expression rangeInt(ReferenceAttribute a, long lo, long hi) {
+        return new Range(Source.EMPTY, a, lit(lo, DataType.LONG), true, lit(hi, DataType.LONG), false, ZoneOffset.UTC);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Dataset construction
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Parquet write configurations. Each one stresses a different optimization layer:
+     * <ul>
+     *   <li>{@link #SINGLE_BIG_GROUP}: no row-group pruning, no page pruning — pure late-mat.</li>
+     *   <li>{@link #MANY_SMALL_GROUPS}: row-group level pruning matters; page pruning small.</li>
+     *   <li>{@link #SMALL_PAGES_DICT}: dictionary encoding + page-level ColumnIndex active.</li>
+     *   <li>{@link #SMALL_PAGES_NO_DICT}: same layout but plain encoding to disable dict
+     *       short-circuit on the LIKE path.</li>
+     * </ul>
+     */
+    private enum Layout {
+        SINGLE_BIG_GROUP(64L * 1024 * 1024, 1024 * 1024, true),
+        MANY_SMALL_GROUPS(64 * 1024L, 8 * 1024, true),
+        SMALL_PAGES_DICT(1024 * 1024L, 1024, true),
+        SMALL_PAGES_NO_DICT(1024 * 1024L, 1024, false);
+
+        final long rowGroupSize;
+        final int pageSize;
+        final boolean dictionary;
+
+        Layout(long rowGroupSize, int pageSize, boolean dictionary) {
+            this.rowGroupSize = rowGroupSize;
+            this.pageSize = pageSize;
+            this.dictionary = dictionary;
+        }
+    }
+
+    /**
+     * Holds both the in-memory rows (oracle input) and the serialized Parquet bytes
+     * (reader input). Built once per layout per test method.
+     */
+    private record DatasetAndBytes(List<Map<String, Object>> rows, byte[] parquetBytes) {}
+
+    private DatasetAndBytes buildDataset(Layout layout) throws IOException {
+        List<Map<String, Object>> rows = new ArrayList<>(ROW_COUNT);
+        for (int i = 0; i < ROW_COUNT; i++) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("id", (long) i);
+            // status assignment is contiguous-block: rows 0..(ROW_COUNT/2)-1 are all 200, then
+            // alternating 200/404/500 blocks of 50. The first half being uniformly 200 is
+            // critical: with small row-group / page layouts, those row groups have stats
+            // min=max=200, which makes "status = 200" stats-trivial and fires the
+            // trivially-passes shortcut. That is the exact shape that the YES + non-translatable
+            // (LIKE) bug exploits — without contiguous uniform blocks here, the differential
+            // suite would silently agree with the bug.
+            long status;
+            if (i < ROW_COUNT / 2) {
+                status = 200L;
+            } else {
+                int block = (i - ROW_COUNT / 2) / 50;
+                status = switch (block % 3) {
+                    case 0 -> 200L;
+                    case 1 -> 404L;
+                    default -> 500L;
+                };
+            }
+            row.put("status", status);
+            row.put("score", (i % 100) / 100.0);
+            row.put("category", CATEGORIES[i % CATEGORIES.length]);
+            row.put("url", "https://" + URL_HOSTS[i % URL_HOSTS.length] + "/page?id=" + i);
+            row.put("description", "padding_" + ("p".repeat(50)) + "_row_" + i);
+            // ~30% nulls in nullable_flag.
+            row.put("nullable_flag", (i % 10 < 3) ? null : Integer.valueOf(i % 100));
+            rows.add(row);
+        }
+        byte[] bytes = writeParquet(rows, layout);
+        return new DatasetAndBytes(rows, bytes);
+    }
+
+    private static byte[] writeParquet(List<Map<String, Object>> rows, Layout layout) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        OutputFile outputFile = outputFile(out);
+        SimpleGroupFactory factory = new SimpleGroupFactory(SCHEMA);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
+                .withConf(new PlainParquetConfiguration())
+                .withCodecFactory(new PlainCompressionCodecFactory())
+                .withType(SCHEMA)
+                .withRowGroupSize(layout.rowGroupSize)
+                .withPageSize(layout.pageSize)
+                .withDictionaryEncoding(layout.dictionary)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .build()
+        ) {
+            for (Map<String, Object> row : rows) {
+                Group g = factory.newGroup();
+                g.add("id", (Long) row.get("id"));
+                g.add("status", (Long) row.get("status"));
+                g.add("score", (Double) row.get("score"));
+                g.add("category", (String) row.get("category"));
+                g.add("url", (String) row.get("url"));
+                g.add("description", (String) row.get("description"));
+                Object flag = row.get("nullable_flag");
+                if (flag != null) {
+                    g.add("nullable_flag", ((Integer) flag).intValue());
+                }
+                writer.write(g);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // I/O helpers (storage object + output file). Mirror the helpers in OptimizedFilteredReaderTests
+    // but kept self-contained so this test doesn't depend on that class's package-private state.
+    // ---------------------------------------------------------------------------------------
+
+    private static StorageObject inMemoryStorageObject(byte[] data) {
+        return new StorageObject() {
+            @Override
+            public InputStream newStream() {
+                return new ByteArrayInputStream(data);
+            }
+
+            @Override
+            public InputStream newStream(long position, long length) {
+                int pos = (int) position;
+                int len = (int) Math.min(length, data.length - position);
+                return new ByteArrayInputStream(data, pos, len);
+            }
+
+            @Override
+            public long length() {
+                return data.length;
+            }
+
+            @Override
+            public Instant lastModified() {
+                return Instant.now();
+            }
+
+            @Override
+            public boolean exists() {
+                return true;
+            }
+
+            @Override
+            public StoragePath path() {
+                return StoragePath.of("memory://differential.parquet");
+            }
+        };
+    }
+
+    private static OutputFile outputFile(ByteArrayOutputStream out) {
+        return new OutputFile() {
+            @Override
+            public PositionOutputStream create(long blockSizeHint) {
+                return positionOutputStream(out);
+            }
+
+            @Override
+            public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+                return positionOutputStream(out);
+            }
+
+            @Override
+            public boolean supportsBlockSize() {
+                return false;
+            }
+
+            @Override
+            public long defaultBlockSize() {
+                return 0;
+            }
+
+            @Override
+            public String getPath() {
+                return "memory://differential.parquet";
+            }
+        };
+    }
+
+    private static PositionOutputStream positionOutputStream(ByteArrayOutputStream out) {
+        return new PositionOutputStream() {
+            @Override
+            public long getPos() {
+                return out.size();
+            }
+
+            @Override
+            public void write(int b) {
+                out.write(b);
+            }
+
+            @Override
+            public void write(byte[] b, int off, int len) {
+                out.write(b, off, len);
+            }
+        };
+    }
+
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
@@ -285,6 +285,119 @@ public class ParquetReaderFilterDifferentialTests extends ESTestCase {
     }
 
     // ---------------------------------------------------------------------------------------
+    // Silent-drop / NOT-translation regression cases.
+    //
+    // These cases pin down the family of bugs where translateExpression silently drops an
+    // untranslatable sub-expression (today: WildcardLike) under a logical connector and the
+    // resulting FilterPredicate becomes STRICTER than the true ESQL expression. A stricter
+    // pushed predicate is a correctness bug for our reader because we use the predicate for
+    // row-group and page (column-index) pruning — pruned rows can't be recovered downstream
+    // by FilterExec, so a stricter prune silently loses matching rows.
+    //
+    // The shapes below were not all reachable from the randomized harness with realistic
+    // budgets; surfacing the NOT(AND(LIKE, X)) bug took ~17 default-seed iterations on
+    // average (see commit 360b065 / the CI investigation). Pinning each shape as a fixed
+    // case makes the regression impossible to miss on a single local test run, complementing
+    // the randomized coverage that explores the long tail.
+    //
+    // DO NOT WEAKEN OR REMOVE these tests. They are the deterministic guard for
+    // ParquetPushedExpressions.translateExpression's "exactly translatable" contract —
+    // if you change that method (or the isExactlyTranslatable helper, or the canConvert /
+    // isFullyEvaluable classifications), these must keep passing. Changes that "simplify"
+    // the Not branch by removing the isExactlyTranslatable guard MUST be measured against
+    // these tests; a green randomized run is not sufficient evidence of correctness.
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Regression: {@code NOT(AND(LIKE, X))} where {@code LIKE} is YES-eligible but does not
+     * translate to a {@link FilterPredicate} and {@code X} does. Without the
+     * {@code isExactlyTranslatable} guard in
+     * {@link ParquetPushedExpressions#translateExpression}, the {@code AND} arm silently
+     * dropped the LIKE and produced just {@code translate(X)}; the outer {@code NOT} then
+     * negated that, yielding a predicate {@code NOT(X)} that is STRICTER than the true
+     * {@code NOT(AND(LIKE, X)) = NOT(LIKE) OR NOT(X)} (because the latter accepts every
+     * row where LIKE doesn't match, regardless of {@code X}). The reader would then prune
+     * row groups whose stats prove {@code X} for every row, even though those groups may
+     * contain rows that don't match LIKE — silent under-inclusion.
+     *
+     * <p>This is the exact production bug fixed in commit {@code 360b065} ("guard Not
+     * translation against silent drops"), found by {@link #testRandomizedFilterTrees} on
+     * the ~17th default-seed iteration. Pinning it deterministically here means a single
+     * local run catches a regression — no need to re-roll seeds.
+     */
+    public void testNotAndLikeXIsNotStricterThanTruth() throws IOException {
+        // X = (id < ROW_COUNT / 2). Combined with our dataset (id is 0..ROW_COUNT-1
+        // contiguous), this produces a row-group-stats-trivial conjunct on the SINGLE_BIG_GROUP
+        // layout (false for every row in upper half) and a partial-prune conjunct elsewhere —
+        // so the bug surfaces across multiple layouts, not just one.
+        runDifferential(not(and(like(URL, "*google*"), lt(ID, (long) (ROW_COUNT / 2), DataType.LONG))));
+    }
+
+    /**
+     * Symmetric to {@link #testNotAndLikeXIsNotStricterThanTruth}: {@code NOT(OR(LIKE, X))}.
+     * Under {@code OR}, an arm that fails to translate is dropped entirely (the conservative
+     * "all arms or nothing" rule), so {@code OR(LIKE, X)} would translate to just
+     * {@code translate(X)}, and the outer {@code NOT} would yield {@code NOT(X)}, again
+     * STRICTER than the truth {@code NOT(OR(LIKE, X)) = NOT(LIKE) AND NOT(X)} (which is at
+     * least as restrictive as both). The {@code isExactlyTranslatable} guard refuses to
+     * push the {@code Not} when its child contains a silent-drop, so this lands as
+     * "no FilterPredicate" and pruning relies on other conjuncts only.
+     */
+    public void testNotOrLikeXIsNotStricterThanTruth() throws IOException {
+        runDifferential(not(or(like(URL, "*google*"), lt(ID, (long) (ROW_COUNT / 2), DataType.LONG))));
+    }
+
+    /**
+     * {@code NOT(NOT(LIKE))} should be equivalent to {@code LIKE}. The inner NOT alone is
+     * YES-eligible (special-cased to handle TVL nulls in {@code evaluateNotWildcardLike}),
+     * the outer NOT wraps a non-translatable child (the inner NOT itself doesn't translate,
+     * since {@code WildcardLike} doesn't translate), so the outer should refuse to push.
+     * No silent drop, no stricter predicate.
+     */
+    public void testNotNotLikeRoundTrip() throws IOException {
+        runDifferential(not(not(like(URL, "*google*"))));
+    }
+
+    /**
+     * Sanity check that {@code isExactlyTranslatable} is not over-conservative:
+     * {@code NOT(AND(X, Y))} with both arms translatable should still translate. If this
+     * test starts failing, the guard has become too strict — it should only refuse to push
+     * when an arm under {@code AND} or {@code OR} is silently dropped, not when every arm
+     * translates exactly.
+     */
+    public void testNotAndTwoTranslatableConjunctsStillPushes() throws IOException {
+        runDifferential(not(and(eq(STATUS, 200L, DataType.LONG), lt(ID, 50L, DataType.LONG))));
+    }
+
+    /**
+     * {@code AND(LIKE, NOT(X))} — LIKE outside the NOT, NOT around an exactly-translatable
+     * conjunct. The LIKE pushes as YES (no FilterPredicate, but YES); the {@code NOT(X)}
+     * pushes as RECHECK with a real FilterPredicate. The two combine cleanly: no silent
+     * drop because each conjunct is handled independently by {@code pushFilters} (the planner
+     * splits top-level AND into a list of conjuncts, see
+     * {@code ParquetFilterPushdownSupportTests#testWildcardLikeAsSeparateConjunctWithEqualsRecheckedOnly}).
+     * Asserts the per-conjunct path doesn't fall into the same silent-drop trap as the
+     * AND-wrapped case.
+     */
+    public void testAndOfLikeAndNotTranslatable() throws IOException {
+        runDifferential(and(like(URL, "*google*"), not(eq(STATUS, 404L, DataType.LONG))));
+    }
+
+    /**
+     * Deeper nesting: {@code NOT(AND(OR(LIKE1, LIKE2), X))} — both arms of the inner OR are
+     * silent-drops, so the OR collapses to nothing under translation; the AND then collapses
+     * to just {@code X}; the outer NOT becomes {@code NOT(X)}, STRICTER than the truth.
+     * The guard must catch this transitively, not just one level deep. Without the guard,
+     * this is the same shape of bug as
+     * {@link #testNotAndLikeXIsNotStricterThanTruth} but harder to surface randomly because
+     * it requires three levels of nesting in the right configuration.
+     */
+    public void testNotAndOrLikeLikeXTransitiveSilentDrop() throws IOException {
+        Expression filter = not(and(or(like(URL, "*google*"), like(URL, "*github*")), lt(ID, (long) (ROW_COUNT / 2), DataType.LONG)));
+        runDifferential(filter);
+    }
+
+    // ---------------------------------------------------------------------------------------
     // Randomized cases — random expression trees per layout.
     // ---------------------------------------------------------------------------------------
 

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetReaderFilterDifferentialTests.java
@@ -697,21 +697,35 @@ public class ParquetReaderFilterDifferentialTests extends ESTestCase {
     }
 
     /**
-     * Oracle A: read with apache-mr's {@link ParquetReader} given the translated
-     * {@link FilterPredicate}, then post-filter the original ESQL expression in pure Java on
-     * top. apache-mr is a completely independent parquet stack (different RowGroupFilter,
-     * different ColumnIndex evaluator, different page reader), so any bug in one of our
-     * optimization layers shows up here as a disagreement.
+     * Oracle A: read with apache-mr's {@link ParquetReader} given a <b>conservatively</b>
+     * translated {@link FilterPredicate}, then post-filter the original ESQL expression in
+     * pure Java on top. apache-mr is a completely independent parquet stack (different
+     * RowGroupFilter, different ColumnIndex evaluator, different page reader), so any bug
+     * in one of our optimization layers shows up here as a disagreement.
      *
-     * <p>The post-filter restores ESQL TVL semantics that diverge from parquet-mr's
-     * (e.g. {@code NOT(eq(col, k))} returns null rows in parquet-mr but drops them in ESQL)
-     * and applies any conjuncts that did not translate to a {@link FilterPredicate}
-     * (e.g. {@link WildcardLike}). When the translation returns {@code null} (no conjunct
-     * translated), apache-mr is used purely as a row reader — still useful as a structural
-     * cross-check on column decoding.
+     * <p><b>Why "conservatively translated".</b> Our production
+     * {@code ParquetPushedExpressions#translateExpression} silently drops untranslatable
+     * sub-expressions inside nested {@code AND}/{@code OR}/{@code NOT}, which can produce a
+     * predicate that is <em>stricter</em> than the original ESQL filter (e.g.
+     * {@code NOT(AND(LIKE, id<N))} translates to {@code NOT(id<N)} = {@code id>=N}, which
+     * drops rows the original would have kept). Apache-mr applies the predicate at the
+     * record level via {@code useRecordFilter}, so a stricter predicate <em>silently loses
+     * rows</em> that the Java post-filter cannot recover. Production's optimized reader does
+     * not exercise the same loss because it uses the FilterPredicate only for stats-based
+     * pruning, not for record-level filtering — but apache-mr does, and that mismatch is
+     * what made this oracle initially flag false positives on randomized
+     * {@code NOT(AND(LIKE, ...))} inputs.
+     *
+     * <p>To stay correct (an oracle, not a co-bug), we only push the FilterPredicate when
+     * the entire ESQL filter consists of top-level {@code AND} conjuncts where every
+     * conjunct is a translatable leaf with NO nested {@code NOT}/{@code OR} that could trigger the
+     * silent-drop. Anything more complex: skip the FilterPredicate; apache-mr reads every
+     * row and the Java post-filter applies the original expression. This costs us the
+     * cross-stack check on the apache-mr filter machinery for those cases — acceptable, the
+     * point of this oracle is to catch bugs in our reader, not to validate apache-mr.
      */
     private Set<Long> oracleA_apacheMr(byte[] parquetBytes, Expression filter) throws IOException {
-        FilterPredicate filterPredicate = new ParquetPushedExpressions(splitTopLevelAnd(filter)).toFilterPredicate(SCHEMA);
+        FilterPredicate filterPredicate = safeTranslateForApacheMr(filter);
         GroupReaderBuilder builder = new GroupReaderBuilder(new ParquetStorageObjectAdapter(inMemoryStorageObject(parquetBytes)));
         if (filterPredicate != null) {
             builder.withFilter(FilterCompat.get(filterPredicate));
@@ -727,6 +741,48 @@ public class ParquetReaderFilterDifferentialTests extends ESTestCase {
             }
         }
         return ids;
+    }
+
+    /**
+     * Translate {@code filter} to a Parquet {@link FilterPredicate} only when the result is
+     * provably a SUPERSET of the original filter's matching set (i.e. apache-mr can safely
+     * pre-filter without losing any row the Java post-filter would have kept). Returns
+     * {@code null} otherwise — caller must read every row and rely on the post-filter.
+     *
+     * <p>Conservative rule: split at top-level {@code AND}, accept only conjuncts that are
+     * "leaf-shaped" (no nested {@code NOT}/{@code OR}/{@code AND}, no {@link WildcardLike}).
+     * For each accepted conjunct, ask the production translator; if it returns non-null,
+     * that conjunct's predicate is a true superset (since it's a leaf with no
+     * silent-drop potential). AND the accepted predicates and return.
+     */
+    private static FilterPredicate safeTranslateForApacheMr(Expression filter) {
+        List<Expression> conjuncts = splitTopLevelAnd(filter);
+        List<Expression> safe = new ArrayList<>();
+        for (Expression c : conjuncts) {
+            if (isLeafShaped(c)) {
+                safe.add(c);
+            }
+        }
+        if (safe.isEmpty()) {
+            return null;
+        }
+        return new ParquetPushedExpressions(safe).toFilterPredicate(SCHEMA);
+    }
+
+    /**
+     * A leaf-shaped expression contains no {@code NOT}, {@code OR}, {@code AND}, or
+     * {@link WildcardLike} anywhere in the tree. Such expressions translate to a Parquet
+     * predicate whose semantics exactly match (or are looser than) the ESQL original — there
+     * is no silent-drop branch in {@code translateExpression} that can fire.
+     */
+    private static boolean isLeafShaped(Expression expr) {
+        if (expr instanceof And || expr instanceof Or || expr instanceof Not) {
+            return false;
+        }
+        if (expr instanceof WildcardLike) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseReaderTests.java
@@ -193,6 +193,80 @@ public class TwoPhaseReaderTests extends ESTestCase {
         assertThat("expected all rows when there's no late-mat opportunity", total, equalTo(100));
     }
 
+    /**
+     * High predicate-byte-ratio shape on native-async storage: predicate column dominates projected
+     * bytes (the q22-on-ClickBench shape). After removing the file-level byte-ratio gate, late
+     * materialization must still filter rows; the iterator's own 0.4 two-phase gate correctly keeps
+     * the more expensive two-phase prefetch off, but the cheap late-mat decode-skip remains in
+     * effect. The byte-traffic cross-check against a non-async {@link CountingStorageObject} pins
+     * "two-phase did not engage" on the async run — the ratio between the two reads stays close to
+     * 1, instead of the order-of-magnitude saving two-phase would produce on this 2.5%-selective
+     * filter.
+     */
+    public void testLateMatFiresButTwoPhaseStaysOffWhenPredicateColumnDominates() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("wide_pred")
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("narrow_proj")
+            .named("test_schema");
+
+        // 40-char padding + 200 rows lands inside parquet-mr's default row-group/page sizing in a
+        // shape that emits a single row group, so the late-mat filter sees the whole batch. Larger
+        // padding or row counts can shift the page layout enough to hide the regression.
+        int rowCount = 200;
+        String padding = "x".repeat(40);
+        byte[] parquetData = buildParquet(schema, rowCount, i -> {
+            SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+            Group g = factory.newGroup();
+            g.add("wide_pred", padding + "_pred_" + String.format(java.util.Locale.ROOT, "%03d", i));
+            g.add("narrow_proj", (long) i);
+            return g;
+        });
+
+        ReferenceAttribute predAttr = new ReferenceAttribute(Source.EMPTY, "wide_pred", DataType.KEYWORD);
+        // Lex > "padding_pred_194": survivors are i in {195..199}, 5 of 200 rows (~2.5% selective).
+        org.apache.lucene.util.BytesRef threshold = new org.apache.lucene.util.BytesRef(padding + "_pred_194");
+        Expression filter = new GreaterThan(Source.EMPTY, predAttr, new Literal(Source.EMPTY, threshold, DataType.KEYWORD), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(filter));
+
+        CountingStorageObject asyncObj = new CountingStorageObject(parquetData, true);
+        List<Page> asyncPages = readAllPages(new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed), asyncObj);
+
+        int asyncRows = asyncPages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("late-mat must fire and retain only matching rows", asyncRows, equalTo(5));
+
+        // Sanity-check the surviving row IDs (195..199) — guards against a wrong-column or
+        // wrong-comparator regression slipping through under the 5-row count assertion alone.
+        Set<Long> survivors = new HashSet<>();
+        for (Page p : asyncPages) {
+            LongBlock proj = p.getBlock(1);
+            for (int i = 0; i < proj.getPositionCount(); i++) {
+                if (proj.isNull(i) == false) {
+                    survivors.add(proj.getLong(i));
+                }
+            }
+        }
+        assertEquals("expected tail rows 195..199 to survive", Set.of(195L, 196L, 197L, 198L, 199L), survivors);
+
+        // Cross-check on byte traffic: a non-async storage object cannot use two-phase, so its byte
+        // count is the late-mat-without-two-phase baseline. If two-phase had engaged on the async
+        // path, async bytes would be a small fraction of sync bytes (the projection column would be
+        // skipped for ~97.5% of rows). We assert async is at least 75% of sync — generous bound that
+        // fails clearly if two-phase ever engages here, while tolerating small async/sync wrapper
+        // overhead asymmetries.
+        CountingStorageObject syncObj = new CountingStorageObject(parquetData, false);
+        readAllPages(new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed), syncObj).forEach(Page::releaseBlocks);
+
+        long async = asyncObj.totalBytesRead.get();
+        long sync = syncObj.totalBytesRead.get();
+        assertTrue(
+            "two-phase must stay off at high predicate-byte ratio (async=" + async + ", sync=" + sync + ")",
+            async >= (sync * 3) / 4
+        );
+    }
+
     public void testTwoPhaseHandlesAllFilteredOutRowGroup() throws Exception {
         // A small file where a selective filter removes every row; verifies the all-filtered
         // path returns no rows and does not leave the iterator hung on a stale state.

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/TwoPhaseReaderTests.java
@@ -298,9 +298,106 @@ public class TwoPhaseReaderTests extends ESTestCase {
         assertThat("expect zero rows after impossible filter", total, equalTo(0));
     }
 
+    /**
+     * Regression test for the NPE in {@code nextTwoPhaseBatch} when projection {@link PageColumnReader}s
+     * with {@link RowRanges} skip entire pages, producing fewer rows than {@code readBatchFiltered}
+     * expects. This requires: small page size (many pages per row group), a sparse filter that
+     * eliminates whole pages but not entire row groups, and {@code nativeAsync=true} to activate
+     * two-phase I/O.
+     *
+     * Before the fix (readBatchSparse), this test crashes with:
+     * {@code NullPointerException: Cannot invoke "...BytesRefArray$LongOffsets.get(long)" because "this.longOffsets" is null}
+     */
+    public void testTwoPhaseSparseFilterWithPageSkipping() throws Exception {
+        MessageType schema = Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT64)
+            .named("id")
+            .required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.stringType())
+            .named("label")
+            .named("test_schema");
+
+        // 10_000 rows with a small page size (64 bytes) creates many pages per row group.
+        // id values 0..9999; the filter keeps only id < 20 (~0.2% selectivity), which
+        // leaves entire pages with no survivors, triggering page skipping in loadNextPage().
+        int rowCount = 10_000;
+        byte[] parquetData = buildParquetWithPageSize(schema, rowCount, 64, i -> {
+            SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+            Group g = factory.newGroup();
+            g.add("id", (long) i);
+            g.add("label", repeat('z', 128) + "_" + i);
+            return g;
+        });
+
+        int expectedSurvivors = 20;
+        ReferenceAttribute idAttr = new ReferenceAttribute(Source.EMPTY, "id", DataType.LONG);
+        Expression filter = new LessThan(Source.EMPTY, idAttr, new Literal(Source.EMPTY, (long) expectedSurvivors, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(filter));
+
+        // nativeAsync=true triggers the two-phase path
+        CountingStorageObject asyncObj = new CountingStorageObject(parquetData, true);
+        ParquetFormatReader asyncReader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        List<Page> twoPhasePages = readAllPages(asyncReader, asyncObj);
+
+        int twoPhaseRows = twoPhasePages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("two-phase should produce exactly the survivors", twoPhaseRows, equalTo(expectedSurvivors));
+
+        Set<Long> ids = collectIds(twoPhasePages);
+        for (int i = 0; i < expectedSurvivors; i++) {
+            assertTrue("expected id " + i + " in result set", ids.contains((long) i));
+        }
+        assertThat("no extra ids", ids.size(), equalTo(expectedSurvivors));
+
+        // Cross-check against single-phase
+        CountingStorageObject syncObj = new CountingStorageObject(parquetData, false);
+        ParquetFormatReader syncReader = new ParquetFormatReader(blockFactory, true).withPushedFilter(pushed);
+        List<Page> singlePhasePages = readAllPages(syncReader, syncObj);
+        int singlePhaseRows = singlePhasePages.stream().mapToInt(Page::getPositionCount).sum();
+        assertThat("single-phase and two-phase row counts must match", twoPhaseRows, equalTo(singlePhaseRows));
+    }
+
+    private byte[] buildParquetWithPageSize(
+        MessageType schema,
+        int rowCount,
+        int pageSize,
+        java.util.function.IntFunction<Group> rowFactory
+    ) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputFile out = buildOutputFile(baos);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(out)
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withPageSize(pageSize)
+                .withConf(new PlainParquetConfiguration())
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                writer.write(rowFactory.apply(i));
+            }
+        }
+        return baos.toByteArray();
+    }
+
     private byte[] buildParquet(MessageType schema, int rowCount, java.util.function.IntFunction<Group> rowFactory) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        OutputFile out = new OutputFile() {
+        OutputFile out = buildOutputFile(baos);
+        try (
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(out)
+                .withType(schema)
+                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+                .withConf(new PlainParquetConfiguration())
+                .build()
+        ) {
+            for (int i = 0; i < rowCount; i++) {
+                writer.write(rowFactory.apply(i));
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private static OutputFile buildOutputFile(ByteArrayOutputStream baos) {
+        return new OutputFile() {
             @Override
             public PositionOutputStream create(long blockSizeHint) {
                 return new PositionOutputStream() {
@@ -340,18 +437,6 @@ public class TwoPhaseReaderTests extends ESTestCase {
                 return 0;
             }
         };
-        try (
-            ParquetWriter<Group> writer = ExampleParquetWriter.builder(out)
-                .withType(schema)
-                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
-                .withConf(new PlainParquetConfiguration())
-                .build()
-        ) {
-            for (int i = 0; i < rowCount; i++) {
-                writer.write(rowFactory.apply(i));
-            }
-        }
-        return baos.toByteArray();
     }
 
     private List<Page> readAllPages(ParquetFormatReader reader, StorageObject obj) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimator.java
@@ -15,9 +15,15 @@ import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.datasources.spi.SplitStats;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
+import org.elasticsearch.xpack.esql.expression.predicate.Range;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
@@ -68,12 +74,14 @@ public final class FilterEvaluationOrderEstimator {
         for (int i = 0; i < conjuncts.size(); i++) {
             Expression expr = conjuncts.get(i);
             double selectivity = estimateSelectivity(expr, stats, rowCount);
+            double cost = estimateEvaluationCost(expr);
             long sizeBytes = estimateColumnSize(expr, stats);
-            scored.add(new ScoredExpression(expr, selectivity, sizeBytes, i));
+            scored.add(new ScoredExpression(expr, selectivity, cost, sizeBytes, i));
         }
 
         scored.sort(
             Comparator.comparingDouble((ScoredExpression s) -> s.selectivity)
+                .thenComparingDouble(s -> s.cost)
                 .thenComparingLong(s -> s.sizeBytes)
                 .thenComparingInt(s -> s.originalIndex)
         );
@@ -96,7 +104,37 @@ public final class FilterEvaluationOrderEstimator {
         return result;
     }
 
-    private record ScoredExpression(Expression expression, double selectivity, long sizeBytes, int originalIndex) {}
+    private record ScoredExpression(Expression expression, double selectivity, double cost, long sizeBytes, int originalIndex) {}
+
+    /**
+     * Assigns a per-row evaluation cost tier by expression type. Used as a tiebreaker
+     * when selectivity estimates are tied (e.g. all {@link #UNKNOWN_SELECTIVITY}).
+     * Null checks and exact comparisons are cheapest; automaton-based pattern matching is most expensive.
+     */
+    static double estimateEvaluationCost(Expression expr) {
+        if (expr instanceof IsNull || expr instanceof IsNotNull) {
+            return 0.0;
+        }
+        if (expr instanceof EsqlBinaryComparison || expr instanceof In) {
+            return 0.1;
+        }
+        if (expr instanceof Range) {
+            return 0.2;
+        }
+        if (expr instanceof StartsWith) {
+            return 0.3;
+        }
+        if (expr instanceof WildcardLike) {
+            return 0.9;
+        }
+        if (expr instanceof Not not) {
+            return estimateEvaluationCost(not.field()) + 0.01;
+        }
+        if (expr instanceof And and) {
+            return Math.min(estimateEvaluationCost(and.left()), estimateEvaluationCost(and.right()));
+        }
+        return 0.5;
+    }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     static double estimateSelectivity(Expression expr, SplitStats stats, long rowCount) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/FilterEvaluationOrderEstimatorTests.java
@@ -11,18 +11,24 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
+import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 
 import java.util.List;
 import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class FilterEvaluationOrderEstimatorTests extends ESTestCase {
 
@@ -208,6 +214,44 @@ public class FilterEvaluationOrderEstimatorTests extends ESTestCase {
 
         double sel = FilterEvaluationOrderEstimator.estimateSelectivity(eq("const_col", 99), stats, 10000L);
         assertEquals(0.0, sel, 0.001);
+    }
+
+    public void testCostTierOrdering_comparisonBeforeLike() {
+        // When all conjuncts have UNKNOWN_SELECTIVITY (no stats for the columns),
+        // the cost tiebreaker should place comparisons before LIKE.
+        SplitStats stats = new SplitStats.Builder().rowCount(10000).build();
+
+        FieldAttribute keywordField = new FieldAttribute(
+            SRC,
+            "title",
+            new EsField("title", DataType.KEYWORD, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+        );
+        Expression like = new WildcardLike(SRC, keywordField, new WildcardPattern("*google*"), false);
+        Expression notLike = new Not(SRC, new WildcardLike(SRC, keywordField, new WildcardPattern("*.example.*"), false));
+        Expression notEquals = new NotEquals(SRC, fieldAttr("status"), intLiteral(0), null);
+
+        // Input: LIKE first, NotEquals last — worst order for short-circuiting
+        List<Expression> input = List.of(like, notLike, notEquals);
+        List<Expression> result = FilterEvaluationOrderEstimator.orderByEstimatedCost(input, stats);
+
+        // NotEquals (cost 0.1) should come before LIKE (cost 0.9) and NOT LIKE (cost 0.91)
+        assertSame("cheap comparison should be first", notEquals, result.get(0));
+        assertSame("LIKE before NOT LIKE", like, result.get(1));
+        assertSame("NOT LIKE last", notLike, result.get(2));
+    }
+
+    public void testEstimateEvaluationCost_tiers() {
+        assertThat(FilterEvaluationOrderEstimator.estimateEvaluationCost(new IsNull(SRC, fieldAttr("a"))), equalTo(0.0));
+        assertThat(FilterEvaluationOrderEstimator.estimateEvaluationCost(eq("a", 1)), equalTo(0.1));
+        FieldAttribute kw = new FieldAttribute(
+            SRC,
+            "t",
+            new EsField("t", DataType.KEYWORD, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+        );
+        assertThat(
+            FilterEvaluationOrderEstimator.estimateEvaluationCost(new WildcardLike(SRC, kw, new WildcardPattern("*x*"), false)),
+            equalTo(0.9)
+        );
     }
 
     // -- helpers --


### PR DESCRIPTION
Stacked on top of #148453.

Two changes to the Parquet pushdown stack, plus a sizable new test suite:

1. **Drop the file-level late-mat byte-ratio gate** in `ParquetFormatReader`. With `WildcardLike` now pushed as `Pushability.YES`, suppressing late-mat at the file level leaks unfiltered rows past the source instead of saving CPU. The iterator's own lower-threshold gate still controls the more expensive two-phase prefetch.

2. **Fix the trivially-passes shortcut leak**: a YES conjunct that doesn't translate to a parquet `FilterPredicate` (today: `WildcardLike`) AND'd with a stats-trivial RECHECK conjunct (e.g. `status = 200` over a row group of all 200s) silently leaked rows that didn't match the LIKE. New helper `ParquetPushedExpressions.hasYesConjunctOutsideFilterPredicate` detects this exact split; the shortcut is now suppressed when it would be unsafe.

3. **Differential test suite** (`ParquetReaderFilterDifferentialTests`, ~3s): every filter runs through four independent code paths — production reader + FilterExec-mirroring post-filter, apache-mr `ParquetReader` + post-filter, our reader with pushdown disabled + post-filter, pure Java over in-memory rows — which must all agree. Each path catches a different bug class. The suite caught the leak above when the fix was disabled — it's the regression net for any future YES-promotion.

**~75% of the diff is the new test file.**

Developed using AI-assisted tooling