### PR TITLE
Support prefetch in BytesRefSwissHash

### DIFF
--- a/libs/swisshash/src/main/java/org/elasticsearch/swisshash/BytesRefSwissHash.java
+++ b/libs/swisshash/src/main/java/org/elasticsearch/swisshash/BytesRefSwissHash.java
@@ -15,6 +15,7 @@ import jdk.incubator.vector.VectorSpecies;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.StringHelper;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.PagedBytesCursor;
 import org.elasticsearch.common.util.BigArrays;
@@ -80,6 +81,9 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
     // but we want to be consistent with the page-based sizing logic.
     // PAGE_SIZE / ID_AND_HASH_SIZE = 16384 / 8 = 2048.
     static final int INITIAL_CAPACITY = PageCacheRecycler.PAGE_SIZE_IN_BYTES / ID_AND_HASH_SIZE;
+
+    public static final int DEFAULT_PREFETCH_THRESHOLD = (int) ((1 << 17) * BytesRefSwissHash.BigCore.FILL_FACTOR); // ~114k entries
+    public static int PREFETCH_THRESHOLD = DEFAULT_PREFETCH_THRESHOLD;
 
     static {
         if (PageCacheRecycler.PAGE_SIZE_IN_BYTES >> PAGE_SHIFT != 1) {
@@ -152,6 +156,21 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
     }
 
     /**
+     * Whether the hash table is large enough for prefetch to be useful
+     */
+    public boolean shouldPrefetch() {
+        return size >= PREFETCH_THRESHOLD && bigCore != null;
+    }
+
+    /**
+     * Prefetch the data at the slot of the given hash. The caller should only call this method
+     * when {@link #shouldPrefetch()} return true.
+     */
+    public int prefetch(int hash) {
+        return bigCore.prefetch(hash);
+    }
+
+    /**
      * Finds an {@code id} by a {@code key}.
      */
     public long find(PagedBytesCursor key) {
@@ -171,17 +190,20 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
     @Override
     public long add(BytesRef key) {
         final int hash = hash(key);
-        return add(key, hash);
+        return addWithHash(key, hash);
     }
 
-    private long add(BytesRef key, int hash) {
+    /**
+     * Same semantic as {@link #add(BytesRef)} but accepts a pre-computed hash.
+     */
+    public int addWithHash(BytesRef key, int hash) {
         if (smallCore != null) {
             if (size < nextGrowSize) {
                 return smallCore.add(key, hash);
             }
             smallCore.transitionToBigCore();
         }
-        return bigCore.add(key, hash);
+        return bigCore.addWithHash(key, hash);
     }
 
     /**
@@ -514,7 +536,13 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
             }
         }
 
-        private int add(final BytesRef key, final int hash) {
+        int prefetch(int hash) {
+            final int group = hash & mask;
+            final int idOff = idAndHashOffset(group);
+            return controlData[group] ^ idAndHashPages[idOff >> PAGE_SHIFT][idOff & PAGE_MASK];
+        }
+
+        private int addWithHash(final BytesRef key, final int hash) {
             maybeGrow();
             return bigCore.addImpl(key, hash);
         }
@@ -712,8 +740,12 @@ public final class BytesRefSwissHash extends SwissHash implements Accountable, B
         return (int) value;
     }
 
-    int hash(BytesRef v) {
+    public static int hash(BytesRef v) {
         return BitMixer.mix32(v.hashCode());
+    }
+
+    public static int hash(byte[] bytes, int offset, int length) {
+        return BitMixer.mix32(StringHelper.murmurhash3_x86_32(bytes, offset, length, StringHelper.GOOD_FAST_HASH_SEED));
     }
 
     int hash(PagedBytesCursor cursor) {

--- a/libs/swisshash/src/test/java/org/elasticsearch/swisshash/BytesRefSwissHashTests.java
+++ b/libs/swisshash/src/test/java/org/elasticsearch/swisshash/BytesRefSwissHashTests.java
@@ -226,6 +226,11 @@ public class BytesRefSwissHashTests extends ESTestCase {
         }
     }
 
+    public void testConsistentHash() {
+        BytesRef value = new BytesRef(randomByteArrayOfLength(between(1, 1024)));
+        assertEquals(BytesRefSwissHash.hash(value), BytesRefSwissHash.hash(value.bytes, value.offset, value.length));
+    }
+
     private void assertStatus(BytesRefSwissHash hash) {
         SwissHash.Status status = hash.status();
 
@@ -300,7 +305,11 @@ public class BytesRefSwissHashTests extends ESTestCase {
         SINGLE_VALUE {
             @Override
             long add(BytesRefSwissHash hash, BytesRef value) {
-                return hash.add(value);
+                if (randomBoolean()) {
+                    return hash.add(value);
+                } else {
+                    return hash.addWithHash(value, BytesRefSwissHash.hash(value.bytes, value.offset, value.length));
+                }
             }
 
             @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -33,6 +33,7 @@ import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupe;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeBytesRef;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeInt;
 import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.swisshash.BytesRefSwissHash;
 import java.util.BitSet;
 // end generated imports
 
@@ -52,6 +53,16 @@ final class BytesRefBlockHash extends BlockHash {
      * </p>
      */
     private boolean seenNull;
+
+    private static final int PREFETCH_BATCH = 128;
+    private final PrefetchBarrier prefetchBarrier = new PrefetchBarrier();
+    private final int[] batchHashes = new int[PREFETCH_BATCH];
+    private final BytesRef[] batchKeys = new BytesRef[PREFETCH_BATCH];
+    {
+        for (int i = 0; i < PREFETCH_BATCH; i++) {
+            batchKeys[i] = new BytesRef();
+        }
+    }
 
     BytesRefBlockHash(int channel, BlockFactory blockFactory) {
         super(blockFactory);
@@ -96,6 +107,9 @@ final class BytesRefBlockHash extends BlockHash {
         if (ordinals != null) {
             return addOrdinalsVector(ordinals);
         }
+        if (hash instanceof BytesRefSwissHash swiss && swiss.shouldPrefetch()) {
+            return addWithPrefetch(vector, swiss);
+        }
         BytesRef scratch = new BytesRef();
         int positions = vector.getPositionCount();
         try (var builder = blockFactory.newIntVectorFixedBuilder(positions)) {
@@ -103,6 +117,30 @@ final class BytesRefBlockHash extends BlockHash {
                 BytesRef v = vector.getBytesRef(i, scratch);
                 builder.appendInt(Math.toIntExact(hashOrdToGroupNullReserved(hash.add(v))));
             }
+            return builder.build();
+        }
+    }
+
+    private IntVector addWithPrefetch(BytesRefVector vector, BytesRefSwissHash swiss) {
+        int positions = vector.getPositionCount();
+        int dummy = 0;
+        try (var builder = blockFactory.newIntVectorFixedBuilder(positions)) {
+            for (int offset = 0; offset < positions; offset += PREFETCH_BATCH) {
+                int batchSize = Math.min(PREFETCH_BATCH, positions - offset);
+                for (int i = 0; i < batchSize; i++) {
+                    vector.getBytesRef(offset + i, batchKeys[i]);
+                    batchHashes[i] = BytesRefSwissHash.hash(batchKeys[i]);
+                    dummy ^= swiss.prefetch(batchHashes[i]);
+                }
+                for (int i = 0; i < batchSize; i++) {
+                    final long id = swiss.addWithHash(batchKeys[i], batchHashes[i]);
+                    builder.appendInt(Math.toIntExact(hashOrdToGroupNullReserved(id)));
+                }
+            }
+            for (int i = 0; i < PREFETCH_BATCH; i++) {
+                batchKeys[i].bytes = BytesRef.EMPTY_BYTES;
+            }
+            prefetchBarrier.consume(dummy);
             return builder.build();
         }
     }
@@ -249,6 +287,7 @@ final class BytesRefBlockHash extends BlockHash {
 
     @Override
     public void close() {
+        prefetchBarrier.flush();
         hash.close();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
@@ -17,17 +17,28 @@ import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.compute.operator.mvdedupe.BatchEncoder;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupe;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.swisshash.BytesRefSwissHash;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.List;
 
@@ -66,6 +77,8 @@ final class PackedValuesBlockHash extends BlockHash {
     private final int nullTrackingBytes;
     private final BreakingBytesRefBuilder bytes;
     private final List<GroupSpec> specs;
+    private final BatchWork batchWork;
+    private boolean seenNull;
 
     PackedValuesBlockHash(List<GroupSpec> specs, BlockFactory blockFactory, int emitBatchSize) {
         this(specs, blockFactory, blockFactory.breaker(), emitBatchSize);
@@ -80,13 +93,28 @@ final class PackedValuesBlockHash extends BlockHash {
         this.specs = specs;
         this.emitBatchSize = emitBatchSize;
         this.nullTrackingBytes = (specs.size() + 7) / 8;
+        final int[] columnOffsets = new int[specs.size()];
+        int keyLength = nullTrackingBytes;
+        for (int g = 0; g < specs.size(); g++) {
+            int size = elementSize(specs.get(g).elementType());
+            if (size < 0) {
+                keyLength = -1;
+                break;
+            }
+            columnOffsets[g] = keyLength;
+            keyLength += size;
+        }
+        this.bytesRefHash = HashImplFactory.newBytesRefHash(blockFactory);
         boolean success = false;
         try {
-            this.bytesRefHash = HashImplFactory.newBytesRefHash(blockFactory);
             this.bytes = new BreakingBytesRefBuilder(circuitBreaker, "PackedValuesBlockHash", this.nullTrackingBytes);
+            if (keyLength != -1 && bytesRefHash instanceof BytesRefSwissHash swiss) {
+                this.batchWork = new BatchWork(swiss, columnOffsets, keyLength, emitBatchSize, blockFactory, specs);
+            } else {
+                this.batchWork = null;
+            }
             success = true;
         } finally {
-            // close bytesRefHash and bytes to prevent memory leaks in case of the initialization fails
             if (success == false) {
                 close();
             }
@@ -95,7 +123,20 @@ final class PackedValuesBlockHash extends BlockHash {
 
     @Override
     public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+        if (batchWork != null && allVectors(page)) {
+            batchWork.bulkAdd(page, addInput);
+            return;
+        }
         add(page, addInput, DEFAULT_BATCH_SIZE);
+    }
+
+    private boolean allVectors(Page page) {
+        for (GroupSpec spec : specs) {
+            if (page.getBlock(spec.channel()).asVector() == null) {
+                return false;
+            }
+        }
+        return true;
     }
 
     void add(Page page, GroupingAggregatorFunction.AddInput addInput, int batchSize) {
@@ -325,11 +366,13 @@ final class PackedValuesBlockHash extends BlockHash {
             assert group.writtenValues == 0;
             assert group.valueCount == 1;
             if (group.encoder.read(group.valueOffset++, bytes) == 0) {
+                seenNull = true;
                 int nullByte = g / 8;
                 int nullShift = g % 8;
                 bytes.bytes()[nullByte] |= (byte) (1 << nullShift);
             }
         }
+        padZerosForFixedLengthKey();
     }
 
     private void fillBytesMv(Group[] groups, int startingGroup) {
@@ -338,11 +381,25 @@ final class PackedValuesBlockHash extends BlockHash {
             group.bytesStart = bytes.length();
             if (group.encoder.read(group.valueOffset + group.writtenValues, bytes) == 0) {
                 assert group.valueCount == 1 : "null value in non-singleton list";
+                seenNull = true;
                 int nullByte = g / 8;
                 int nullShift = g % 8;
                 bytes.bytes()[nullByte] |= (byte) (1 << nullShift);
             }
             ++group.writtenValues;
+        }
+        padZerosForFixedLengthKey();
+    }
+
+    private void padZerosForFixedLengthKey() {
+        if (batchWork != null) {
+            final int keyLength = batchWork.keyLength;
+            final int len = bytes.length();
+            if (len < keyLength) {
+                bytes.grow(keyLength);
+                Arrays.fill(bytes.bytes(), len, keyLength, (byte) 0);
+                bytes.setLength(keyLength);
+            }
         }
     }
 
@@ -364,6 +421,13 @@ final class PackedValuesBlockHash extends BlockHash {
 
     @Override
     public Block[] getKeys(IntVector selected) {
+        if (batchWork != null && seenNull == false) {
+            return batchWork.getNonNullKeys(selected, bytesRefHash, blockFactory);
+        }
+        return getKeysWithNulls(selected);
+    }
+
+    private Block[] getKeysWithNulls(IntVector selected) {
         int positions = selected.getPositionCount();
         BatchEncoder.Decoder[] decoders = new BatchEncoder.Decoder[specs.size()];
         Block.Builder[] builders = new Block.Builder[specs.size()];
@@ -438,14 +502,13 @@ final class PackedValuesBlockHash extends BlockHash {
 
     @Override
     public void close() {
-        Releasables.close(bytesRefHash, bytes);
+        Releasables.close(bytesRefHash, bytes, batchWork);
     }
 
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
         b.append("PackedValuesBlockHash{groups=[");
-        boolean first = true;
         for (int i = 0; i < specs.size(); i++) {
             if (i > 0) {
                 b.append(", ");
@@ -456,5 +519,191 @@ final class PackedValuesBlockHash extends BlockHash {
         b.append("], entries=").append(bytesRefHash.size());
         b.append(", size=").append(ByteSizeValue.ofBytes(bytesRefHash.ramBytesUsed()));
         return b.append("}").toString();
+    }
+
+    private static int elementSize(ElementType type) {
+        return switch (type) {
+            case NULL -> 0;
+            case BOOLEAN -> 1;
+            case INT -> Integer.BYTES;
+            case LONG, DOUBLE -> Long.BYTES;
+            default -> -1;
+        };
+    }
+
+    // TODO: Support BytesRef
+    private static final class BatchWork implements Releasable {
+        private static final int BATCH_SIZE = 128;
+        private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.nativeOrder());
+        private static final VarHandle INT_HANDLE = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.nativeOrder());
+        private static final VarHandle DOUBLE_HANDLE = MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.nativeOrder());
+        private final PrefetchBarrier prefetchBarrier = new PrefetchBarrier();
+        final int[] offsets;
+        final int keyLength;
+        final byte[] keys;
+        final int[] hashes;
+        final int[] groupIds;
+        private final int emitBatchSize;
+        private final BytesRefSwissHash swiss;
+
+        private final BlockFactory blockFactory;
+        private final List<GroupSpec> specs;
+        private long usedBytes;
+
+        BatchWork(
+            BytesRefSwissHash swiss,
+            int[] offsets,
+            int keyLength,
+            int emitBatchSize,
+            BlockFactory blockFactory,
+            List<GroupSpec> specs
+        ) {
+            this.swiss = swiss;
+            this.offsets = offsets;
+            this.keyLength = keyLength;
+            this.blockFactory = blockFactory;
+            this.specs = specs;
+            this.usedBytes = (long) BATCH_SIZE * keyLength + (long) emitBatchSize * Integer.BYTES + (long) BATCH_SIZE * Integer.BYTES;
+            blockFactory.adjustBreaker(usedBytes);
+            this.keys = new byte[BATCH_SIZE * keyLength];
+            this.hashes = new int[BATCH_SIZE];
+            this.groupIds = new int[emitBatchSize];
+            this.emitBatchSize = emitBatchSize;
+        }
+
+        void bulkAdd(Page page, GroupingAggregatorFunction.AddInput addInput) {
+            int positionCount = page.getPositionCount();
+            int positionOffset = 0;
+            final BytesRef key = new BytesRef();
+            key.bytes = keys;
+            key.length = keyLength;
+            int dummy = 0;
+            while (positionOffset < positionCount) {
+                final int emitSize = Math.min(emitBatchSize, positionCount - positionOffset);
+                int batchOffset = 0;
+                while (batchOffset < emitSize) {
+                    final int chunkSize = Math.min(BATCH_SIZE, emitSize - batchOffset);
+                    fillKeys(page, positionOffset + batchOffset, chunkSize);
+                    if (swiss.shouldPrefetch()) {
+                        for (int i = 0; i < chunkSize; i++) {
+                            hashes[i] = BytesRefSwissHash.hash(keys, i * keyLength, keyLength);
+                            dummy ^= swiss.prefetch(hashes[i]);
+                        }
+                        for (int i = 0; i < chunkSize; i++) {
+                            key.offset = i * keyLength;
+                            long id = swiss.addWithHash(key, hashes[i]);
+                            groupIds[batchOffset + i] = Math.toIntExact(hashOrdToGroup(id));
+                        }
+                    } else {
+                        for (int i = 0; i < chunkSize; i++) {
+                            key.offset = i * keyLength;
+                            long id = swiss.add(key);
+                            groupIds[batchOffset + i] = Math.toIntExact(hashOrdToGroup(id));
+                        }
+                    }
+                    batchOffset += chunkSize;
+                }
+                try (var groupIdsVec = blockFactory.newIntArrayVector(groupIds, emitSize)) {
+                    addInput.add(positionOffset, groupIdsVec);
+                }
+                positionOffset += emitSize;
+            }
+            prefetchBarrier.consume(dummy);
+        }
+
+        private void fillKeys(Page page, int positionOffset, int batchSize) {
+            for (int g = 0; g < specs.size(); g++) {
+                final int offset = offsets[g];
+                final Vector vector = page.getBlock(specs.get(g).channel()).asVector();
+                switch (specs.get(g).elementType()) {
+                    case LONG -> {
+                        LongVector longVector = (LongVector) vector;
+                        for (int i = 0; i < batchSize; i++) {
+                            LONG_HANDLE.set(keys, i * keyLength + offset, longVector.getLong(positionOffset + i));
+                        }
+                    }
+                    case INT -> {
+                        IntVector intVector = (IntVector) vector;
+                        for (int i = 0; i < batchSize; i++) {
+                            INT_HANDLE.set(keys, i * keyLength + offset, intVector.getInt(positionOffset + i));
+                        }
+                    }
+                    case DOUBLE -> {
+                        DoubleVector doubleVector = (DoubleVector) vector;
+                        for (int i = 0; i < batchSize; i++) {
+                            DOUBLE_HANDLE.set(keys, i * keyLength + offset, doubleVector.getDouble(positionOffset + i));
+                        }
+                    }
+                    case BOOLEAN -> {
+                        BooleanVector booleanVector = (BooleanVector) vector;
+                        for (int i = 0; i < batchSize; i++) {
+                            keys[i * keyLength + offset] = booleanVector.getBoolean(positionOffset + i) ? (byte) 1 : (byte) 0;
+                        }
+                    }
+                    default -> throw new IllegalStateException("unsupported type: " + specs.get(g).elementType());
+                }
+            }
+        }
+
+        Block[] getNonNullKeys(IntVector selected, BytesRefHashTable hash, BlockFactory blockFactory) {
+            final int positions = selected.getPositionCount();
+            final Block.Builder[] builders = new Block.Builder[specs.size()];
+            final BytesRef[] bytes = new BytesRef[BATCH_SIZE];
+            for (int i = 0; i < BATCH_SIZE; i++) {
+                bytes[i] = new BytesRef();
+            }
+            try {
+                for (int g = 0; g < builders.length; g++) {
+                    builders[g] = specs.get(g).elementType().newBlockBuilder(positions, blockFactory);
+                }
+                for (int p = 0; p < positions; p += BATCH_SIZE) {
+                    final int batchSize = Math.min(BATCH_SIZE, positions - p);
+                    for (int r = 0; r < batchSize; r++) {
+                        hash.get(selected.getInt(p + r), bytes[r]);
+                    }
+                    for (int g = 0; g < specs.size(); g++) {
+                        final int columnOffset = offsets[g];
+                        switch (specs.get(g).elementType()) {
+                            case LONG -> {
+                                var b = (LongBlock.Builder) builders[g];
+                                for (int r = 0; r < batchSize; r++) {
+                                    b.appendLong((long) LONG_HANDLE.get(bytes[r].bytes, bytes[r].offset + columnOffset));
+                                }
+                            }
+                            case INT -> {
+                                var b = (IntBlock.Builder) builders[g];
+                                for (int r = 0; r < batchSize; r++) {
+                                    b.appendInt((int) INT_HANDLE.get(bytes[r].bytes, bytes[r].offset + columnOffset));
+                                }
+                            }
+                            case DOUBLE -> {
+                                var b = (DoubleBlock.Builder) builders[g];
+                                for (int r = 0; r < batchSize; r++) {
+                                    b.appendDouble((double) DOUBLE_HANDLE.get(bytes[r].bytes, bytes[r].offset + columnOffset));
+                                }
+                            }
+                            case BOOLEAN -> {
+                                var b = (BooleanBlock.Builder) builders[g];
+                                for (int r = 0; r < batchSize; r++) {
+                                    b.appendBoolean(bytes[r].bytes[bytes[r].offset + columnOffset] != 0);
+                                }
+                            }
+                            default -> throw new IllegalStateException("unsupported type: " + specs.get(g).elementType());
+                        }
+                    }
+                }
+                return Block.Builder.buildAll(builders);
+            } finally {
+                Releasables.closeExpectNoException(builders);
+            }
+        }
+
+        @Override
+        public void close() {
+            final long bytes = usedBytes;
+            usedBytes = 0;
+            blockFactory.adjustBreaker(-bytes);
+            prefetchBarrier.flush();
+        }
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PrefetchBarrier.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PrefetchBarrier.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.blockhash;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+// We don't have _prefetch available; hence, we have to use speculative reads to enable prefetch
+final class PrefetchBarrier {
+    private static final VarHandle SINK_HANDLE;
+    static {
+        try {
+            SINK_HANDLE = MethodHandles.lookup().findVarHandle(PrefetchBarrier.class, "barrier", int.class);
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private int barrier;
+
+    void consume(int prefetch) {
+        this.barrier = prefetch;
+    }
+
+    void flush() {
+        SINK_HANDLE.setOpaque(this, barrier);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -33,6 +33,9 @@ import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupe;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupe$Type$;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeInt;
 import org.elasticsearch.core.ReleasableIterator;
+$if(BytesRef)$
+import org.elasticsearch.swisshash.BytesRefSwissHash;
+$endif$
 import java.util.BitSet;
 // end generated imports
 
@@ -52,6 +55,18 @@ final class $Type$BlockHash extends BlockHash {
      * </p>
      */
     private boolean seenNull;
+
+$if(BytesRef)$
+    private static final int PREFETCH_BATCH = 128;
+    private final PrefetchBarrier prefetchBarrier = new PrefetchBarrier();
+    private final int[] batchHashes = new int[PREFETCH_BATCH];
+    private final BytesRef[] batchKeys = new BytesRef[PREFETCH_BATCH];
+    {
+        for (int i = 0; i < PREFETCH_BATCH; i++) {
+            batchKeys[i] = new BytesRef();
+        }
+    }
+$endif$
 
     $Type$BlockHash(int channel, BlockFactory blockFactory) {
         super(blockFactory);
@@ -97,6 +112,9 @@ $if(BytesRef)$
         if (ordinals != null) {
             return addOrdinalsVector(ordinals);
         }
+        if (hash instanceof BytesRefSwissHash swiss && swiss.shouldPrefetch()) {
+            return addWithPrefetch(vector, swiss);
+        }
         BytesRef scratch = new BytesRef();
 $endif$
         int positions = vector.getPositionCount();
@@ -114,6 +132,32 @@ $endif$
             return builder.build();
         }
     }
+
+$if(BytesRef)$
+    private IntVector addWithPrefetch(BytesRefVector vector, BytesRefSwissHash swiss) {
+        int positions = vector.getPositionCount();
+        int dummy = 0;
+        try (var builder = blockFactory.newIntVectorFixedBuilder(positions)) {
+            for (int offset = 0; offset < positions; offset += PREFETCH_BATCH) {
+                int batchSize = Math.min(PREFETCH_BATCH, positions - offset);
+                for (int i = 0; i < batchSize; i++) {
+                    vector.getBytesRef(offset + i, batchKeys[i]);
+                    batchHashes[i] = BytesRefSwissHash.hash(batchKeys[i]);
+                    dummy ^= swiss.prefetch(batchHashes[i]);
+                }
+                for (int i = 0; i < batchSize; i++) {
+                    final long id = swiss.addWithHash(batchKeys[i], batchHashes[i]);
+                    builder.appendInt(Math.toIntExact(hashOrdToGroupNullReserved(id)));
+                }
+            }
+            for (int i = 0; i < PREFETCH_BATCH; i++) {
+                batchKeys[i].bytes = BytesRef.EMPTY_BYTES;
+            }
+            prefetchBarrier.consume(dummy);
+            return builder.build();
+        }
+    }
+$endif$
 
     /**
      *  Adds the block values to the hash, and returns a new vector with the group IDs for those positions.
@@ -281,6 +325,9 @@ $endif$
 
     @Override
     public void close() {
+$if(BytesRef)$
+        prefetchBarrier.flush();
+$endif$
         hash.close();
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTestCase.java
@@ -31,8 +31,10 @@ import org.elasticsearch.compute.test.TestBlockFactory;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.swisshash.BytesRefSwissHash;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
+import org.junit.Before;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -49,6 +51,18 @@ public abstract class BlockHashTestCase extends ESTestCase {
     final MockBlockFactory blockFactory = new MockBlockFactory(
         BlockFactory.builder(new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, breakerService))
     );
+
+    @Before
+    public void setHashTablePrefetchThreshold() {
+        if (randomBoolean()) {
+            BytesRefSwissHash.PREFETCH_THRESHOLD = between(1, 10 * 1024);
+        }
+    }
+
+    @After
+    public void resetHashTablePrefetchThreshold() {
+        BytesRefSwissHash.PREFETCH_THRESHOLD = BytesRefSwissHash.DEFAULT_PREFETCH_THRESHOLD;
+    }
 
     @After
     public void checkBreaker() {


### PR DESCRIPTION
This change adds prefetch support to BytesRefSwissHash and uses it from PackedValuesBlockHash and BytesRefBlockHash to reduce cache misses. It also adds a fast path in PackedValuesBlockHash for fixed-length keys that packs values directly into a byte array. This is the first step to make PackedValuesBlockHash fast enough that we can remove the adaptive block hashes.