### PR TITLE
Fix flaky SearchDirectoryTests.testGetHighestOffsetSegmentInfos

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -344,9 +344,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.engine.translog.StatelessTranslogIT
   method: testTranslogMasterFailureOnlyStressRecoveryTest
   issue: https://github.com/elastic/elasticsearch/issues/147835
-- class: org.elasticsearch.xpack.stateless.lucene.SearchDirectoryTests
-  method: testGetHighestOffsetSegmentInfos
-  issue: https://github.com/elastic/elasticsearch/issues/147837
 - class: org.elasticsearch.xpack.stateless.cache.StatelessOnlinePrewarmingIT
   method: testShardPrewarming
   issue: https://github.com/elastic/elasticsearch/issues/147838

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectoryTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectoryTests.java
@@ -383,10 +383,10 @@ public class SearchDirectoryTests extends ESTestCase {
                         searchDirectory.shardId,
                         blobLocations,
                         List.of(
-                            randomAlphaOfLength(10),
-                            randomAlphaOfLength(10),
-                            randomAlphaOfLength(10),
-                            randomAlphaOfLength(10),
+                            randomNonSiFileName(),
+                            randomNonSiFileName(),
+                            randomNonSiFileName(),
+                            randomNonSiFileName(),
                             // last file is the segment info so the last location should be returned
                             randomAlphaOfLength(10) + LuceneFilesExtensions.SI.getExtension()
                         )
@@ -414,10 +414,10 @@ public class SearchDirectoryTests extends ESTestCase {
                             blobLocations,
                             List.of(
                                 randomAlphaOfLength(10) + LuceneFilesExtensions.SI.getExtension(),
-                                randomAlphaOfLength(10),
-                                randomAlphaOfLength(10),
-                                randomAlphaOfLength(10),
-                                randomAlphaOfLength(10)
+                                randomNonSiFileName(),
+                                randomNonSiFileName(),
+                                randomNonSiFileName(),
+                                randomNonSiFileName()
                             )
                         )
                     );
@@ -429,6 +429,11 @@ public class SearchDirectoryTests extends ESTestCase {
                 }
             }
         }
+    }
+
+    private String randomNonSiFileName() {
+        String siExtension = LuceneFilesExtensions.SI.getExtension();
+        return randomValueOtherThanMany(name -> name.endsWith(siExtension), () -> randomAlphaOfLength(10));
     }
 
     public void testUpdateCommitWithReplicatedContent() throws IOException {


### PR DESCRIPTION
Random non-SI file names can accidentally end with "si". 
This causes the getHighestOffsetSegmentInfos() to misidentify them as segment info files which leads
to the observed test failures. Fixed by making sure to exclude names ending with the SI extension from
the random file name generation.

Closes #147837