### PR TITLE
[8.19] Only add product use case header if not present (#126212)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/BaseTransportInferenceAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/BaseTransportInferenceAction.java
@@ -147,7 +147,13 @@ public abstract class BaseTransportInferenceAction<Request extends BaseInference
             // We want to pass InferenceContext through the various infer methods in InferenceService in the long term
             var context = request.getContext();
             if (Objects.nonNull(context)) {
-                threadPool.getThreadContext().putHeader(InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER, context.productUseCase());
+                var headerNotPresentInThreadContext = Objects.isNull(
+                    threadPool.getThreadContext().getHeader(InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER)
+                );
+                if (headerNotPresentInThreadContext) {
+                    threadPool.getThreadContext()
+                        .putHeader(InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER, context.productUseCase());
+                }
             }
 
             var service = serviceRegistry.getService(serviceName).get();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Only add product use case header if not present (#126212)](https://github.com/elastic/elasticsearch/pull/126212)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Fixes https://github.com/elastic/elasticsearch/issues/148172
Fixes https://github.com/elastic/elasticsearch/issues/148177