### PR TITLE
Disable columnar modes in integration tests.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -676,9 +676,6 @@ public enum IndexMode {
      * Columnar modes are excluded in non-snapshot builds where the feature flag is disabled.
      */
     public static IndexMode[] availableModes() {
-        if (COLUMNAR_FEATURE_FLAG.isEnabled()) {
-            return values();
-        }
         return Arrays.stream(values()).filter(m -> m != COLUMNAR && m != COLUMNAR_LOGSDB).toArray(IndexMode[]::new);
     }
 


### PR DESCRIPTION
Tentative fix to avoid test failure noise.

Related to #148498