### PR TITLE
Strengthen some reindex security ITs

### DIFF
--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexRelocationWithSecurityIT.java
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexRelocationWithSecurityIT.java
@@ -8,12 +8,14 @@ package org.elasticsearch.xpack.security;
 
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.junit.ClassRule;
@@ -31,15 +33,19 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
 
-    private static final String USER = "test_admin";
+    private static final String ADMIN_USER = "test_admin";
+    private static final String REINDEX_USER = "test_reindex_user";
+    private static final String RETHROTTLE_USER = "test_rethrottle_user";
+    private static final String LIST_USER = "test_list_user";
+    private static final String GET_USER = "test_get_user";
     private static final String PASS = "x-pack-test-password";
 
     private static final int MASTER_NODE = 0;
     private static final int DATA_NODE = 1;
     private static final int COORD_NODE = 2;
 
-    private static final String SOURCE = "reindex-relocation-source";
-    private static final String DEST = "reindex-relocation-dest";
+    private static final String SOURCE = "source";
+    private static final String DEST = "dest";
 
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
@@ -61,7 +67,12 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
         .setting("xpack.watcher.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.autoconfiguration.enabled", "false")
-        .user(USER, PASS, "superuser", false)
+        .rolesFile(Resource.fromClasspath("roles.yml"))
+        .user(ADMIN_USER, PASS, "superuser", false)
+        .user(REINDEX_USER, PASS, "minimal", false)
+        .user(RETHROTTLE_USER, PASS, "reindex_rethrottle_only", false)
+        .user(LIST_USER, PASS, "reindex_list_only", false)
+        .user(GET_USER, PASS, "reindex_get_only", false)
         .build();
 
     @Override
@@ -70,8 +81,17 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
     }
 
     @Override
+    protected Settings restAdminSettings() {
+        return restClientSettingsForUser(ADMIN_USER);
+    }
+
+    @Override
     protected Settings restClientSettings() {
-        String token = basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray()));
+        return restClientSettingsForUser(REINDEX_USER);
+    }
+
+    private static Settings restClientSettingsForUser(String user) {
+        String token = basicAuthHeaderValue(user, new SecureString(PASS.toCharArray()));
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
@@ -96,8 +116,8 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
         final String taskId;
         try (RestClient coordClient = buildClient(restClientSettings(), new HttpHost[] { HttpHost.create(coordHttpAddress) })) {
             taskId = startThrottledReindex(coordClient);
-            waitForRootReindexTaskOn(coordNodeId, taskId);
         }
+        waitForRootReindexTaskOn(coordNodeId, taskId);
 
         // Stage 1: tell the cluster the coordinator is going away. This populates NodesShutdownMetadata which gives the rest of the
         // cluster a chance to drain shards/PITs off the coordinator (it has none here, but it sets the right precondition for relocation).
@@ -111,12 +131,15 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
         stopThread.start();
 
         try {
-            // Stage 3: rethrottle to unlimited via a *non-coordinator* node, since the coordinator's HTTP transport is being torn down.
+            // Stage 3: assert that the list API works
+            assertListViaSurvivingNode(dataNodeAddress, taskId);
+
+            // Stage 4: rethrottle to unlimited via a *non-coordinator* node, since the coordinator's HTTP transport is being torn down.
             // The rethrottle is dispatched via internal transport (which is still up on the coordinator during the relocation hook),
             // and lets the throttled reindex advance past its current sleep so it can pick up the relocation flag.
             rethrottleViaSurvivingNode(dataNodeAddress, taskId);
 
-            // Stage 4: wait for the relocation chain in .tasks to show the original task was relocated and the relocated task completed
+            // Stage 5: wait for the relocation chain in .tasks to show the original task was relocated and the relocated task completed
             // successfully. Without the fix, the resume action is rejected by RBAC and this never happens.
             assertReindexCompletesOnDataNode(dataNodeAddress, taskId, numDocs);
         } finally {
@@ -155,7 +178,7 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
     }
 
     private String lookupNodeId(String nodeName) throws IOException {
-        final ObjectPath nodes = ObjectPath.createFromResponse(client().performRequest(new Request("GET", "/_nodes/" + nodeName)));
+        final ObjectPath nodes = ObjectPath.createFromResponse(adminClient().performRequest(new Request("GET", "/_nodes/" + nodeName)));
         final Map<String, Object> nodesMap = nodes.evaluate("nodes");
         assertThat("expected exactly one node matching name " + nodeName, nodesMap.size(), equalTo(1));
         return nodesMap.keySet().iterator().next();
@@ -192,7 +215,7 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
             final Request listTasks = new Request("GET", "/_tasks");
             listTasks.addParameter("actions", "indices:data/write/reindex");
             listTasks.addParameter("detailed", "true");
-            final ObjectPath tasks = ObjectPath.createFromResponse(client().performRequest(listTasks));
+            final ObjectPath tasks = ObjectPath.createFromResponse(adminClient().performRequest(listTasks));
             final Map<String, Object> nodes = tasks.evaluate("nodes");
             assertThat("expected reindex task to appear in cluster", nodes, notNullValue());
             assertThat(
@@ -211,12 +234,29 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
               "reason": "ReindexRelocationWithSecurityIT - shutting down coordinator to trigger relocation"
             }
             """);
-        client().performRequest(shutdown);
+        adminClient().performRequest(shutdown);
+    }
+
+    private void assertListViaSurvivingNode(String dataNodeAddress, String taskId) throws IOException {
+        // Use the data node address captured before coordinator shutdown so the fixture is not asked to resolve a dead node.
+        try (
+            RestClient dataClient = buildClient(restClientSettingsForUser(LIST_USER), new HttpHost[] { HttpHost.create(dataNodeAddress) })
+        ) {
+            Request list = new Request("GET", "/_reindex");
+            Response response = dataClient.performRequest(list);
+            ObjectPath body = ObjectPath.createFromResponse(response);
+            assertThat(body.evaluate("reindex.0.id"), equalTo(taskId));
+        }
     }
 
     private void rethrottleViaSurvivingNode(String dataNodeAddress, String taskId) throws Exception {
         // Use the data node address captured before coordinator shutdown so the fixture is not asked to resolve a dead node.
-        try (RestClient dataClient = buildClient(restClientSettings(), new HttpHost[] { HttpHost.create(dataNodeAddress) })) {
+        try (
+            RestClient dataClient = buildClient(
+                restClientSettingsForUser(RETHROTTLE_USER),
+                new HttpHost[] { HttpHost.create(dataNodeAddress) }
+            )
+        ) {
             // retry in case the reindex task is not initialized and ready to be rethrottled yet
             assertBusy(() -> {
                 final Request rethrottle = new Request("POST", "/_reindex/" + taskId + "/_rethrottle");
@@ -227,7 +267,9 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
     }
 
     private void assertReindexCompletesOnDataNode(String dataNodeAddress, String originalTaskId, int numDocs) throws Exception {
-        try (RestClient dataClient = buildClient(restClientSettings(), new HttpHost[] { HttpHost.create(dataNodeAddress) })) {
+        try (
+            RestClient dataClient = buildClient(restClientSettingsForUser(GET_USER), new HttpHost[] { HttpHost.create(dataNodeAddress) })
+        ) {
             assertBusy(() -> {
                 // Look up the original (relocated) task in the .tasks index via the dedicated GET /_reindex/{task_id} endpoint;
                 // it follows the relocated_task_id chain server-side and returns the final task once completed.

--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexRelocationWithSecurityIT.java
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexRelocationWithSecurityIT.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -245,6 +246,7 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
             Request list = new Request("GET", "/_reindex");
             Response response = dataClient.performRequest(list);
             ObjectPath body = ObjectPath.createFromResponse(response);
+            assertThat(body.<List<?>>evaluate("reindex"), hasSize(1));
             assertThat(body.evaluate("reindex.0.id"), equalTo(taskId));
         }
     }

--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexWithSecurityClientYamlTestSuiteIT.java
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexWithSecurityClientYamlTestSuiteIT.java
@@ -63,7 +63,7 @@ public class ReindexWithSecurityClientYamlTestSuiteIT extends ESClientYamlSuiteT
     }
 
     /**
-     * All tests run as a an administrative user but use <code>es-security-runas-user</code> to become a less privileged user.
+     * All tests run as an administrative user but use <code>es-security-runas-user</code> to become a less privileged user.
      */
     @Override
     protected Settings restClientSettings() {

--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexWithSecurityIT.java
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexWithSecurityIT.java
@@ -70,10 +70,10 @@ public class ReindexWithSecurityIT extends ESRestTestCase {
             .user("powerful_user", "x-pack-test-password", "superuser", false)
             .user("minimal_user", "x-pack-test-password", "minimal", false)
             .user("minimal_with_task_user", "x-pack-test-password", "minimal_with_task", false)
-            .user("minimal_with_reindex_get_user", "x-pack-test-password", "minimal_with_reindex_get", false)
-            .user("minimal_with_reindex_list_user", "x-pack-test-password", "minimal_with_reindex_list", false)
-            .user("minimal_with_reindex_rethrottle_user", "x-pack-test-password", "minimal_with_reindex_rethrottle", false)
-            .user("minimal_with_reindex_cancel_user", "x-pack-test-password", "minimal_with_reindex_cancel", false)
+            .user("reindex_get_only_user", "x-pack-test-password", "reindex_get_only", false)
+            .user("reindex_list_only_user", "x-pack-test-password", "reindex_list_only", false)
+            .user("reindex_rethrottle_only_user", "x-pack-test-password", "reindex_rethrottle_only", false)
+            .user("reindex_cancel_only_user", "x-pack-test-password", "reindex_cancel_only", false)
             .user("readonly_user", "x-pack-test-password", "readonly", false)
             .user("dest_only_user", "x-pack-test-password", "dest_only", false)
             .user("can_not_see_hidden_docs_user", "x-pack-test-password", "can_not_see_hidden_docs", false)
@@ -108,7 +108,7 @@ public class ReindexWithSecurityIT extends ESRestTestCase {
     }
 
     /**
-     * All tests run as a an administrative user but use <code>es-security-runas-user</code> to become a less privileged user.
+     * All tests run as an administrative user.
      */
     @Override
     protected Settings restClientSettings() {

--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/10_reindex.yml
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/10_reindex.yml
@@ -324,7 +324,7 @@ setup:
       indices.refresh: {}
 
   - do:
-      headers: {es-security-runas-user: minimal_with_task_user}
+      headers: {es-security-runas-user: minimal_user}
       reindex:
         refresh: true
         wait_for_completion: false
@@ -378,7 +378,7 @@ setup:
       indices.refresh: {}
 
   - do:
-      headers: {es-security-runas-user: minimal_with_reindex_get_user}
+      headers: {es-security-runas-user: minimal_user}
       reindex:
         refresh: true
         wait_for_completion: false
@@ -390,7 +390,7 @@ setup:
   - set: {task: task}
 
   - do:
-      headers: {es-security-runas-user: minimal_with_reindex_get_user}
+      headers: {es-security-runas-user: reindex_get_only_user}
       reindex_get:
         task_id: $task
         wait_for_completion: true
@@ -455,7 +455,7 @@ setup:
           - '{ "text": "test" }'
 
   - do:
-      headers: {es-security-runas-user: minimal_with_reindex_list_user}
+      headers: {es-security-runas-user: minimal_user}
       reindex:
         wait_for_completion: false
         requests_per_second: 0.000001
@@ -468,7 +468,7 @@ setup:
   - set: {task: task}
 
   - do:
-      headers: {es-security-runas-user: minimal_with_reindex_list_user}
+      headers: {es-security-runas-user: reindex_list_only_user}
       reindex_list:
         human: true
         detailed: true
@@ -544,7 +544,7 @@ setup:
           - '{ "text": "test" }'
 
   - do:
-      headers: {es-security-runas-user: minimal_with_reindex_rethrottle_user}
+      headers: {es-security-runas-user: minimal_user}
       reindex:
         wait_for_completion: false
         requests_per_second: 0.000001
@@ -557,7 +557,7 @@ setup:
   - set: {task: task}
 
   - do:
-      headers: {es-security-runas-user: minimal_with_reindex_rethrottle_user}
+      headers: {es-security-runas-user: reindex_rethrottle_only_user}
       reindex_rethrottle:
         task_id: $task
         requests_per_second: -1
@@ -686,7 +686,7 @@ setup:
           - '{ "text": "test" }'
 
   - do:
-      headers: {es-security-runas-user: minimal_with_reindex_cancel_user}
+      headers: {es-security-runas-user: minimal_user}
       reindex:
         wait_for_completion: false
         # throttle so the reindex stays running long enough for us to cancel it
@@ -700,7 +700,7 @@ setup:
   - set: {task: task}
 
   - do:
-      headers: {es-security-runas-user: minimal_with_reindex_cancel_user}
+      headers: {es-security-runas-user: reindex_cancel_only_user}
       reindex_cancel:
         task_id: $task
   - match: { completed: true }

--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/resources/roles.yml
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/resources/roles.yml
@@ -49,82 +49,25 @@ minimal_with_task:
         - create_index
         - indices:admin/refresh
 
-# Same index privileges as minimal, plus the dedicated reindex task API (GET /_reindex/{task_id}) which calls the
-# GET /_tasks API beneath the hood
-minimal_with_reindex_get:
+# Just the dedicated reindex task API (GET /_reindex/{task_id}) which calls the GET /_tasks API beneath the hood.
+reindex_get_only:
   cluster:
-    - cluster:monitor/main
     - cluster:monitor/reindex/get
-  indices:
-    - names: source
-      privileges:
-        - read
-        - write
-        - create_index
-        - indices:admin/refresh
-    - names: dest
-      privileges:
-        - read
-        - write
-        - create_index
-        - indices:admin/refresh
 
-# Same index privileges as minimal, plus the dedicated reindex list API (GET /_reindex)
-minimal_with_reindex_list:
+# Just the dedicated reindex list API (GET /_reindex)
+reindex_list_only:
   cluster:
-    - cluster:monitor/main
     - cluster:monitor/reindex/list
-  indices:
-    - names: source
-      privileges:
-        - read
-        - write
-        - create_index
-        - indices:admin/refresh
-    - names: dest
-      privileges:
-        - read
-        - write
-        - create_index
-        - indices:admin/refresh
 
-# Same index privileges as minimal, plus the dedicated reindex rethrottle API (POST /_reindex/{task_id}/_rethrottle)
-minimal_with_reindex_rethrottle:
+# Just the dedicated reindex rethrottle API (POST /_reindex/{task_id}/_rethrottle)
+reindex_rethrottle_only:
   cluster:
-    - cluster:monitor/main
     - cluster:admin/reindex/rethrottle
-  indices:
-    - names: source
-      privileges:
-        - read
-        - write
-        - create_index
-        - indices:admin/refresh
-    - names: dest
-      privileges:
-        - read
-        - write
-        - create_index
-        - indices:admin/refresh
 
-# Same index privileges as minimal, plus the dedicated reindex cancel API (POST /_reindex/{task_id}/_cancel).
-minimal_with_reindex_cancel:
+# Just the dedicated reindex cancel API (POST /_reindex/{task_id}/_cancel).
+reindex_cancel_only:
   cluster:
-    - cluster:monitor/main
     - cluster:admin/reindex/cancel
-  indices:
-    - names: source
-      privileges:
-        - read
-        - write
-        - create_index
-        - indices:admin/refresh
-    - names: dest
-      privileges:
-        - read
-        - write
-        - create_index
-        - indices:admin/refresh
 
 # Read only operations on indices
 readonly:


### PR DESCRIPTION
This applies a least-privilege approach to the security ITs for reindex relocation and the reindex management APIs.

The `minimal_with_reindex_<operation>` roles, which were previously used for both reindex calls and reindex management API calls in `10_reindex.yml`, are replaced by `reindex_<operation>_only` roles, and are only used for the corresponding reindex management API calls, with the `minimal` role being used for the reindex calls themselves. This means that we test that, for example, someone can be given permission to monitor reindex operations without being given permission to start them.

In `ReindexRelocationWithSecurityIT`, everything was previously done as `superuser`. Now, that's only used for admin tasks unrelated to the APIs under test. The `minimal` role is used most of the test, including the reindex calls, and the `reindex_<operation>_only` roles for the reindex management API calls.

An assertion that the list API works is added to that test. This means that there is now coverage for get-by-ID, list, and rethrottle. (There is not coverage for cancel, but the chances of a bug only affecting that API seem slim.)