### PR TITLE
Remove assertion from ReindexDoubleRelocationIT

### DIFF
--- a/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexDoubleRelocationIT.java
+++ b/modules/reindex-management/src/internalClusterTest/java/org/elasticsearch/reindex/management/ReindexDoubleRelocationIT.java
@@ -198,7 +198,7 @@ public class ReindexDoubleRelocationIT extends ESIntegTestCase {
         assertThat(afterCancelMap.get("original_task_id"), is(nullValue()));
         assertThat(afterCancelMap.get("original_start_time_in_millis"), is(nullValue()));
         assertThat(ObjectPath.eval("status.canceled", afterCancelMap), equalTo("by user request"));
-        assertThat(ObjectPath.eval("response.canceled", afterCancelMap), equalTo("by user request"));
+        // depending on how quickly we cancel, we might either get an error (shard failure) or response, so not asserting
     }
 
     private GetReindexResponse getReindex(final TaskId taskId, final boolean waitForCompletion) {

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -509,9 +509,6 @@ tests:
 - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
   method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
   issue: https://github.com/elastic/elasticsearch/issues/147972
-- class: org.elasticsearch.reindex.management.ReindexDoubleRelocationIT
-  method: testDoubleRelocationWithManagementEndpoints
-  issue: https://github.com/elastic/elasticsearch/issues/148462
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardIT
   method: testReshardMetrics
   issue: https://github.com/elastic/elasticsearch/issues/148463


### PR DESCRIPTION
- Depending on when you cancel, you can either get `response` or `error`
- for this we got `org.elasticsearch.action.search.SearchPhaseExecutionException: Partial shards failure`
- we already assert status has cancelled, this check doesn't really add much IMO, same approach as [existing yaml rest test](https://github.com/szybia/elasticsearch/blob/d97bdf5fd10eb1d8ea743c26c9de259af6ac8ad6/modules/reindex-management/src/yamlRestTest/resources/rest-api-spec/test/reindex/30_cancel_reindex.yml#L57)

Closes https://github.com/elastic/elasticsearch/issues/148462