### PR TITLE
Add kernel-direct benchmark for striped d2q4

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q4StripedOperationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q4StripedOperationBenchmark.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.benchmark.vector.scorer;
+
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.benchmark.Utils;
+import org.elasticsearch.nativeaccess.BBQTestUtils;
+import org.elasticsearch.nativeaccess.NativeAccess;
+import org.elasticsearch.nativeaccess.VectorSimilarityFunctions;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.benchmark.vector.scorer.BenchmarkUtils.rethrow;
+
+/**
+ * Kernel-direct benchmark for the 2-bit-doc / 4-bit-query striped (bit-plane) BBQ
+ * dot product, dispatching straight to {@code vec_dotd2q4} via {@link VectorSimilarityFunctions}
+ * and bypassing all Lucene/scorer infrastructure. Three modes are exercised on the same dataset:
+ * <ul>
+ *   <li>{@code scoreSingle} — single-pair calls in a sequential walk (control)</li>
+ *   <li>{@code scoreBulk} — contiguous bulk slice</li>
+ *   <li>{@code scoreBulkOffsets} — bulk via an offsets array (random access pattern)</li>
+ * </ul>
+ * Sparse is intentionally skipped: OSQ's {@code NativeMemorySegmentScorer} does not use it for D2Q4.
+ * <p>
+ * Run with: {@code ./gradlew -p benchmarks run --args 'VectorScorerD2Q4StripedOperationBenchmark'}
+ */
+@Fork(value = 1, jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class VectorScorerD2Q4StripedOperationBenchmark {
+
+    static {
+        Utils.configureBenchmarkLogging();
+    }
+
+    @Param({ "128", "256", "512", "1024", "1536", "2048" })
+    public int dims;
+
+    // At dims=1024, packed doc length is 256 bytes.
+    // 512 vectors = 128KB (overflows L1),
+    // 10000 = 2.5MB (overflows L2),
+    // 2000000 = ~488MB (overflows L3 on most cores).
+    @Param({ "512", "10000", "2000000" })
+    public int numVectors;
+
+    @Param({ "32" })
+    public int bulkSize;
+
+    private Arena arena;
+
+    // dataset: numVectors * docBytes laid out contiguously in native memory
+    private MemorySegment dataset;
+    // query: queryBytes (4 bit-planes back-to-back, produced by transposeHalfByte-style packing)
+    private MemorySegment query;
+    // shuffled ordinals for the random-access offsets path
+    private int[] ordinals;
+    private int numVectorsToScore;
+    // doc bytes per vector = dims/4 (2 bit-planes, dims/8 bytes each). This is also the
+    // length parameter passed to the kernel.
+    private int docBytes;
+    // native scratch for bulk_offsets ordinals and bulk results
+    private MemorySegment ordinalsSeg;
+    private MemorySegment resultsSeg;
+    // Java-side results returned from each @Benchmark to suppress dead-code elimination
+    private float[] scores;
+
+    private MethodHandle singleImpl;
+    private MethodHandle bulkImpl;
+    private MethodHandle bulkOffsetsImpl;
+
+    static final class VectorData extends VectorScorerBulkBenchmark.VectorData {
+        private final byte[][] packedDocs;
+        private final byte[] packedQuery;
+
+        VectorData(int dims, int numVectors, int numVectorsToScore, Random random) {
+            super(numVectors, numVectorsToScore, random);
+            packedDocs = new byte[numVectors][];
+            byte[] unpackedDoc = new byte[dims];
+            for (int v = 0; v < numVectors; v++) {
+                randomBytes(random, unpackedDoc, 4);
+                packedDocs[v] = BBQTestUtils.packStriped(unpackedDoc, 2);
+            }
+            byte[] unpackedQuery = new byte[dims];
+            randomBytes(random, unpackedQuery, 16);
+            packedQuery = BBQTestUtils.packStriped(unpackedQuery, 4);
+        }
+
+        @Override
+        void writeVectorData(Directory directory) throws IOException {
+            // not directory-backed
+        }
+    }
+
+    @Setup
+    public void setup() {
+        setup(new VectorData(dims, numVectors, Math.min(numVectors, 20_000), ThreadLocalRandom.current()));
+    }
+
+    void setup(VectorData vectorData) {
+        assert dims % 8 == 0 : "D2Q4 striped requires dims divisible by 8: " + dims;
+        arena = Arena.ofConfined();
+        numVectorsToScore = vectorData.numVectorsToScore;
+        docBytes = dims / 4;
+
+        dataset = arena.allocate((long) numVectors * docBytes);
+        for (int v = 0; v < numVectors; v++) {
+            MemorySegment.copy(vectorData.packedDocs[v], 0, dataset, ValueLayout.JAVA_BYTE, (long) v * docBytes, docBytes);
+        }
+
+        int queryBytes = dims / 2;
+        query = arena.allocate(queryBytes);
+        MemorySegment.copy(vectorData.packedQuery, 0, query, ValueLayout.JAVA_BYTE, 0L, queryBytes);
+
+        ordinals = vectorData.ordinals;
+
+        ordinalsSeg = arena.allocate((long) bulkSize * Integer.BYTES);
+        resultsSeg = arena.allocate((long) bulkSize * Float.BYTES);
+        scores = new float[bulkSize];
+
+        singleImpl = vectorSimilarityFunctions.getHandle(
+            VectorSimilarityFunctions.Function.DOT_PRODUCT,
+            VectorSimilarityFunctions.BBQType.D2Q4,
+            VectorSimilarityFunctions.Operation.SINGLE
+        );
+        bulkImpl = vectorSimilarityFunctions.getHandle(
+            VectorSimilarityFunctions.Function.DOT_PRODUCT,
+            VectorSimilarityFunctions.BBQType.D2Q4,
+            VectorSimilarityFunctions.Operation.BULK
+        );
+        bulkOffsetsImpl = vectorSimilarityFunctions.getHandle(
+            VectorSimilarityFunctions.Function.DOT_PRODUCT,
+            VectorSimilarityFunctions.BBQType.D2Q4,
+            VectorSimilarityFunctions.Operation.BULK_OFFSETS
+        );
+    }
+
+    @TearDown
+    public void teardown() {
+        arena.close();
+    }
+
+    /** Single-pair scoring, sequential walk (control vs scoreBulk). */
+    @Benchmark
+    public float[] scoreSingle() {
+        try {
+            int v = 0;
+            while (v < numVectorsToScore) {
+                for (int i = 0; i < bulkSize && v < numVectorsToScore; i++, v++) {
+                    MemorySegment vec = dataset.asSlice((long) v * docBytes, docBytes);
+                    scores[i] = (long) singleImpl.invokeExact(vec, query, docBytes);
+                }
+            }
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+        return scores;
+    }
+
+    /** BULK: contiguous slice, sequential by construction. */
+    @Benchmark
+    public float[] scoreBulk() {
+        try {
+            for (int i = 0; i < numVectorsToScore; i += bulkSize) {
+                int count = Math.min(bulkSize, numVectorsToScore - i);
+                MemorySegment slice = dataset.asSlice((long) i * docBytes, (long) count * docBytes);
+                bulkImpl.invokeExact(slice, query, docBytes, count, resultsSeg);
+            }
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+        MemorySegment.copy(resultsSeg, ValueLayout.JAVA_FLOAT, 0L, scores, 0, scores.length);
+        return scores;
+    }
+
+    /** BULK_OFFSETS: scattered access driven by an int32 ordinals array. */
+    @Benchmark
+    public float[] scoreBulkOffsets() {
+        try {
+            for (int i = 0; i < numVectorsToScore; i += bulkSize) {
+                int count = Math.min(bulkSize, numVectorsToScore - i);
+                MemorySegment.copy(ordinals, i, ordinalsSeg, ValueLayout.JAVA_INT, 0L, count);
+                bulkOffsetsImpl.invokeExact(dataset, query, docBytes, docBytes, ordinalsSeg, count, resultsSeg);
+            }
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+        MemorySegment.copy(resultsSeg, ValueLayout.JAVA_FLOAT, 0L, scores, 0, scores.length);
+        return scores;
+    }
+
+    /**
+     * Test-only helper: single-pair scoring using the same shuffled ordinals as
+     * {@link #scoreBulkOffsets}, so the test can assert offsets correctness.
+     */
+    float[] scoreSingleAtOrdinals() {
+        try {
+            int v = 0;
+            while (v < numVectorsToScore) {
+                for (int i = 0; i < bulkSize && v < numVectorsToScore; i++, v++) {
+                    MemorySegment vec = dataset.asSlice((long) ordinals[v] * docBytes, docBytes);
+                    scores[i] = (long) singleImpl.invokeExact(vec, query, docBytes);
+                }
+            }
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+        return scores;
+    }
+
+    private static void randomBytes(Random random, byte[] dst, int rangeExcl) {
+        for (int i = 0; i < dst.length; i++) {
+            dst[i] = (byte) random.nextInt(rangeExcl);
+        }
+    }
+
+    private static final VectorSimilarityFunctions vectorSimilarityFunctions = NativeAccess.instance()
+        .getVectorSimilarityFunctions()
+        .orElseThrow();
+}

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q4StripedOperationBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerD2Q4StripedOperationBenchmarkTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.vector.scorer;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+public class VectorScorerD2Q4StripedOperationBenchmarkTests extends BenchmarkTest {
+
+    private final int dims;
+
+    public VectorScorerD2Q4StripedOperationBenchmarkTests(int dims) {
+        assert dims % 8 == 0 : "D2Q4 striped requires dims divisible by 8: " + dims;
+        this.dims = dims;
+    }
+
+    private VectorScorerD2Q4StripedOperationBenchmark newBench() {
+        var vectorData = new VectorScorerD2Q4StripedOperationBenchmark.VectorData(dims, 1000, 200, random());
+        var bench = new VectorScorerD2Q4StripedOperationBenchmark();
+        bench.dims = dims;
+        bench.numVectors = 1000;
+        bench.bulkSize = 200;
+        bench.setup(vectorData);
+        return bench;
+    }
+
+    public void testBulk() {
+        for (int i = 0; i < 100; i++) {
+            var bench = newBench();
+            try {
+                assertArrayEquals("DOT_PRODUCT", bench.scoreSingle(), bench.scoreBulk(), 0f);
+            } finally {
+                bench.teardown();
+            }
+        }
+    }
+
+    public void testBulkOffsets() {
+        for (int i = 0; i < 100; i++) {
+            var bench = newBench();
+            try {
+                assertArrayEquals("DOT_PRODUCT", bench.scoreSingleAtOrdinals(), bench.scoreBulkOffsets(), 0f);
+            } finally {
+                bench.teardown();
+            }
+        }
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parametersFactory() throws NoSuchFieldException {
+        return generateParameters(VectorScorerD2Q4StripedOperationBenchmark.class.getField("dims"));
+    }
+}

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryBBQTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/jdk/JDKVectorLibraryBBQTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.nativeaccess.jdk;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.nativeaccess.BBQTestUtils;
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctions;
 import org.elasticsearch.nativeaccess.VectorSimilarityFunctionsTests;
 import org.junit.AfterClass;
@@ -70,14 +71,14 @@ public class JDKVectorLibraryBBQTests extends VectorSimilarityFunctionsTests {
         final int dims = size;
         final int numVecs = randomIntBetween(2, 101);
 
-        final int indexVectorBytes = numBytes(dims, type.dataBits());
-        final int queryVectorBytes = numBytes(dims, type.queryBits());
+        final int indexVectorBytes = BBQTestUtils.numBytes(dims, type.dataBits());
+        final int queryVectorBytes = BBQTestUtils.numBytes(dims, type.queryBits());
 
         var unpackedIndexVectors = new byte[numVecs][dims];
         var unpackedQueryVectors = new byte[numVecs][dims];
 
-        var indexVectors = new byte[numVecs][indexVectorBytes];
-        var queryVectors = new byte[numVecs][queryVectorBytes];
+        var indexVectors = new byte[numVecs][];
+        var queryVectors = new byte[numVecs][];
 
         var indexSegment = arena.allocate((long) indexVectorBytes * numVecs);
         var querySegment = arena.allocate((long) queryVectorBytes * numVecs);
@@ -87,8 +88,8 @@ public class JDKVectorLibraryBBQTests extends VectorSimilarityFunctionsTests {
             randomBytesBetween(unpackedIndexVectors[i], (byte) 0, maxIndexValue);
             randomBytesBetween(unpackedQueryVectors[i], (byte) 0, maxQueryValue);
 
-            pack(unpackedIndexVectors[i], indexVectors[i], type.dataBits());
-            pack(unpackedQueryVectors[i], queryVectors[i], type.queryBits());
+            indexVectors[i] = BBQTestUtils.packStriped(unpackedIndexVectors[i], type.dataBits());
+            queryVectors[i] = BBQTestUtils.packStriped(unpackedQueryVectors[i], type.queryBits());
 
             MemorySegment.copy(indexVectors[i], 0, indexSegment, ValueLayout.JAVA_BYTE, (long) i * indexVectorBytes, indexVectorBytes);
             MemorySegment.copy(queryVectors[i], 0, querySegment, ValueLayout.JAVA_BYTE, (long) i * queryVectorBytes, queryVectorBytes);
@@ -146,14 +147,13 @@ public class JDKVectorLibraryBBQTests extends VectorSimilarityFunctionsTests {
         final byte maxIndexValue = (byte) ((1 << type.dataBits()) - 1);
         final byte maxQueryValue = (byte) ((1 << type.queryBits()) - 1);
 
-        final int indexVectorBytes = numBytes(dims, type.dataBits());
-        final int queryVectorBytes = numBytes(dims, type.queryBits());
+        final int indexVectorBytes = BBQTestUtils.numBytes(dims, type.dataBits());
+        final int queryVectorBytes = BBQTestUtils.numBytes(dims, type.queryBits());
 
         var unpackedIndexVectors = new byte[numVecs][dims];
         var unpackedQueryVector = new byte[dims];
 
-        var indexVectors = new byte[numVecs][indexVectorBytes];
-        var queryVector = new byte[queryVectorBytes];
+        var indexVectors = new byte[numVecs][];
 
         // Mimics extra data at the end
         var indexLineLength = indexVectorBytes + extraData;
@@ -162,12 +162,12 @@ public class JDKVectorLibraryBBQTests extends VectorSimilarityFunctionsTests {
         var querySegment = arena.allocate(queryVectorBytes);
 
         randomBytesBetween(unpackedQueryVector, (byte) 0, maxQueryValue);
-        pack(unpackedQueryVector, queryVector, type.queryBits());
+        var queryVector = BBQTestUtils.packStriped(unpackedQueryVector, type.queryBits());
         MemorySegment.copy(queryVector, 0, querySegment, ValueLayout.JAVA_BYTE, 0L, queryVectorBytes);
 
         for (int i = 0; i < numVecs; i++) {
             randomBytesBetween(unpackedIndexVectors[i], (byte) 0, maxIndexValue);
-            pack(unpackedIndexVectors[i], indexVectors[i], type.dataBits());
+            indexVectors[i] = BBQTestUtils.packStriped(unpackedIndexVectors[i], type.dataBits());
             MemorySegment.copy(indexVectors[i], 0, indexSegment, ValueLayout.JAVA_BYTE, (long) i * indexLineLength, indexVectorBytes);
         }
 
@@ -337,8 +337,8 @@ public class JDKVectorLibraryBBQTests extends VectorSimilarityFunctionsTests {
         assumeTrue(notSupportedMsg(), supported());
 
         final int numVecs = randomIntBetween(2, 101);
-        final int indexVectorBytes = numBytes(size, type.dataBits());
-        final int queryVectorBytes = numBytes(size, type.queryBits());
+        final int indexVectorBytes = BBQTestUtils.numBytes(size, type.dataBits());
+        final int queryVectorBytes = BBQTestUtils.numBytes(size, type.queryBits());
 
         var unpackedIndexVectors = new byte[numVecs][size];
         var unpackedQueryVector = new byte[size];
@@ -347,14 +347,12 @@ public class JDKVectorLibraryBBQTests extends VectorSimilarityFunctionsTests {
         var querySegment = arena.allocate(queryVectorBytes);
 
         randomBytesBetween(unpackedQueryVector, (byte) 0, maxQueryValue);
-        var queryVector = new byte[queryVectorBytes];
-        pack(unpackedQueryVector, queryVector, type.queryBits());
+        var queryVector = BBQTestUtils.packStriped(unpackedQueryVector, type.queryBits());
         MemorySegment.copy(queryVector, 0, querySegment, ValueLayout.JAVA_BYTE, 0L, queryVectorBytes);
 
         for (int i = 0; i < numVecs; i++) {
             randomBytesBetween(unpackedIndexVectors[i], (byte) 0, maxIndexValue);
-            var indexVector = new byte[indexVectorBytes];
-            pack(unpackedIndexVectors[i], indexVector, type.dataBits());
+            var indexVector = BBQTestUtils.packStriped(unpackedIndexVectors[i], type.dataBits());
             indexSegments[i] = arena.allocate(indexVectorBytes);
             MemorySegment.copy(indexVector, 0, indexSegments[i], ValueLayout.JAVA_BYTE, 0L, indexVectorBytes);
         }
@@ -379,8 +377,8 @@ public class JDKVectorLibraryBBQTests extends VectorSimilarityFunctionsTests {
 
     public void testBulkSparseIllegalArgs() {
         assumeTrue(notSupportedMsg(), supported());
-        final int indexVectorBytes = numBytes(size, type.dataBits());
-        final int queryVectorBytes = numBytes(size, type.queryBits());
+        final int indexVectorBytes = BBQTestUtils.numBytes(size, type.dataBits());
+        final int queryVectorBytes = BBQTestUtils.numBytes(size, type.queryBits());
         int count = 3;
         var query = arena.allocate(queryVectorBytes);
         var scores = arena.allocate((long) count * Float.BYTES);
@@ -441,8 +439,8 @@ public class JDKVectorLibraryBBQTests extends VectorSimilarityFunctionsTests {
     // Verifies that individual offset values are bounds-checked against the data segment.
     public void testBulkOffsetsOutOfRange() {
         assumeTrue(notSupportedMsg(), supported());
-        final int indexVectorBytes = numBytes(size, type.dataBits());
-        final int queryVectorBytes = numBytes(size, type.queryBits());
+        final int indexVectorBytes = BBQTestUtils.numBytes(size, type.dataBits());
+        final int queryVectorBytes = BBQTestUtils.numBytes(size, type.queryBits());
         final int numVecs = 3;
         var indexSegment = arena.allocate((long) indexVectorBytes * numVecs);
         var query = arena.allocate(queryVectorBytes);
@@ -464,27 +462,6 @@ public class JDKVectorLibraryBBQTests extends VectorSimilarityFunctionsTests {
             () -> nativeSimilarityBulkWithOffsets(indexSegment, query, indexVectorBytes, indexVectorBytes, offsetsSegment, numVecs, scores)
         );
         assertThat(ex.getMessage(), containsString("out of bounds for length"));
-    }
-
-    private static void pack(byte[] unpackedVector, byte[] packedVector, byte elementBits) {
-        for (int i = 0; i < unpackedVector.length; i++) {
-            var value = unpackedVector[i];
-            var packedIndex = i / 8;
-            var packedBitPosition = (7 - (i % 8));
-
-            for (int j = 0; j < elementBits; ++j) {
-                int v = value & 0x1;
-                int shifted = v << packedBitPosition;
-                value >>= 1;
-                packedVector[packedIndex + j * (packedVector.length / elementBits)] |= (byte) shifted;
-            }
-        }
-    }
-
-    // Returns how many bytes do we need to store the quantized vector
-    private static int numBytes(int dimensions, int bits) {
-        assert dimensions % 8 == 0;
-        return dimensions / (8 / bits);
     }
 
     long nativeSimilarity(MemorySegment a, MemorySegment b, int length) {

--- a/libs/native/src/testFixtures/java/org/elasticsearch/nativeaccess/BBQTestUtils.java
+++ b/libs/native/src/testFixtures/java/org/elasticsearch/nativeaccess/BBQTestUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.nativeaccess;
+
+/**
+ * Shared test utilities for BBQ vector operations in the {@code STRIPED} (bit-plane) layout —
+ * the packing convention consumed by {@code vec_dotdNqM} kernels and produced on disk by the
+ * existing OSQ writers via {@code ESVectorUtil.transposeHalfByte}, {@code packDibit}, and
+ * {@code packAsBinary}.
+ *
+ * <p>BBQ striped vectors use two representations:
+ * <ul>
+ *   <li><b>Unpacked</b>: {@code dims} bytes. One value per byte, range {@code [0, 2^elementBits - 1]}.</li>
+ *   <li><b>Packed (striped)</b>: {@code elementBits * dims / 8} bytes — {@code elementBits}
+ *       contiguous bit-planes of {@code dims/8} bytes each. Plane {@code j} carries bit {@code j}
+ *       (LSB-first) of every unpacked value, packed 8-per-byte with the bit at index {@code i}
+ *       landing in byte {@code i/8}, bit position {@code 7 - (i % 8)} (MSB-first within byte).</li>
+ * </ul>
+ * Plane {@code 0} is at offset {@code 0} of the packed buffer; plane {@code j} is at offset
+ * {@code j * dims/8}. This is the layout the {@code dotd1q4_inner} kernel reads from each query
+ * stripe and from each consecutive doc plane.
+ */
+public final class BBQTestUtils {
+
+    private BBQTestUtils() {}
+
+    /**
+     * Packs unpacked BBQ values (one value per byte) into the bit-plane striped format.
+     * Output length is {@code elementBits * unpacked.length / 8} bytes.
+     *
+     * @param unpacked one value per byte, range {@code [0, 2^elementBits - 1]}; length must be a multiple of 8
+     * @param elementBits number of bits per value (e.g. 1, 2, 4, 7)
+     */
+    public static byte[] packStriped(byte[] unpacked, int elementBits) {
+        assert unpacked.length % 8 == 0 : "unpacked length must be a multiple of 8: " + unpacked.length;
+        int planeBytes = unpacked.length / 8;
+        byte[] packed = new byte[elementBits * planeBytes];
+        for (int i = 0; i < unpacked.length; i++) {
+            byte value = unpacked[i];
+            int byteIdx = i / 8;
+            int bitPos = 7 - (i % 8);
+            for (int j = 0; j < elementBits; j++) {
+                int v = value & 0x1;
+                packed[byteIdx + j * planeBytes] |= (byte) (v << bitPos);
+                value >>= 1;
+            }
+        }
+        return packed;
+    }
+
+    /**
+     * Inverse of {@link #packStriped}. Unpacks a bit-plane striped buffer into one value per byte.
+     *
+     * @param packed bit-plane striped buffer, length {@code elementBits * dims / 8}
+     * @param dims number of unpacked values
+     * @param elementBits number of bits per value
+     */
+    public static byte[] unpackStriped(byte[] packed, int dims, int elementBits) {
+        assert dims % 8 == 0 : "dims must be a multiple of 8: " + dims;
+        assert packed.length == elementBits * dims / 8 : "packed length " + packed.length + " != elementBits * dims / 8";
+        byte[] unpacked = new byte[dims];
+        int planeBytes = dims / 8;
+        for (int i = 0; i < dims; i++) {
+            int byteIdx = i / 8;
+            int bitPos = 7 - (i % 8);
+            byte value = 0;
+            for (int j = 0; j < elementBits; j++) {
+                int bit = (packed[byteIdx + j * planeBytes] >>> bitPos) & 0x1;
+                value |= (byte) (bit << j);
+            }
+            unpacked[i] = value;
+        }
+        return unpacked;
+    }
+
+    /** Bytes required to hold {@code dimensions} values quantized to {@code bits} bits each, packed striped. */
+    public static int numBytes(int dimensions, int bits) {
+        assert dimensions % 8 == 0 : "dimensions must be a multiple of 8: " + dimensions;
+        return dimensions / (8 / bits);
+    }
+}


### PR DESCRIPTION
Before working on packed formats for 2 bits data/query, let's add low-level, focused benchmarks for the existing format (striped d2q4), so we can quickly compare like-for-like without the noise/distraction of e.g. scorers or corrections.

This PR retrofits a kernel-direct JMH benchmark for the existing `vec_dotd2q4` (2-bit doc, 4-bit query, bit-plane striped) BBQ kernel. Sparse is skipped on purpose -- DiskBBQ does not use `dotProductBulkSparse` for D2Q4.

Following existing patterns, refactors test utilities to a utility class in testFixture (`BBQTestUtils`).

Relates to https://github.com/elastic/elasticsearch/issues/145407