### PR TITLE
Allow port 0 for TCP/UDP/SCTP Community ID calculation per spec

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/CommunityIdProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/CommunityIdProcessor.java
@@ -229,11 +229,11 @@ public final class CommunityIdProcessor extends AbstractProcessor {
         switch (flow.protocol.getType()) {
             case Tcp, Udp, Sctp -> {
                 flow.sourcePort = parseIntFromObjectOrString(sourcePort.get(), "source port");
-                if (flow.sourcePort < 1 || flow.sourcePort > 65535) {
+                if (flow.sourcePort < 0 || flow.sourcePort > 65535) {
                     throw new IllegalArgumentException("invalid source port [" + sourcePort.get() + "]");
                 }
                 flow.destinationPort = parseIntFromObjectOrString(destinationPort.get(), "destination port");
-                if (flow.destinationPort < 1 || flow.destinationPort > 65535) {
+                if (flow.destinationPort < 0 || flow.destinationPort > 65535) {
                     throw new IllegalArgumentException("invalid destination port [" + destinationPort.get() + "]");
                 }
             }


### PR DESCRIPTION
This change relaxes TCP/UDP/SCTP port validation in the community_id ingest processor to allow port value 0, aligning the implementation with the Community ID v1 specification and behavior of other producers such as Zeek/Corelight.

The Community ID v1 spec explicitly allows port 0 to represent “unknown” or “not yet assigned” ports (e.g., kernel‑level telemetry, pre‑bind sockets, partial flows). 

Zeek, Suricata, and the reference community-id.py tool all successfully generate Community IDs for UDP/TCP flows where one or both ports are 0.
However, the current Elasticsearch ingest processor rejects these events by enforcing 1–65535 for port‑based protocols, throwing illegal_argument_exception before hashing.


```
python community-id.py -vvv 172.24.225.209 0 172.25.226.249 4789 udp
DEBUG    DefaultParser failure: Could not parse IP protocol number

INFO     CommunityID for 172.24.225.209 0 -> 172.25.226.249 4789, proto 17, ordered:
INFO     | seed    00:00
INFO     | ipaddr  ac:18:e1:d1
INFO     | ipaddr  ac:19:e2:f9
INFO     | proto   11
INFO     | padding 00
INFO     | port    00:00
INFO     | port    12:b5
1:9ayyFkI/hn0776trgTtxzvo6f8k=
```

```
POST /_ingest/pipeline/_simulate
{
  "pipeline": {
    "processors": [
      {
        "community_id": {
        }
      }
    ]
  },
  "docs": [
    {
      "_index": "index",
      "_id": "id",
      "_source": {
        "source": {
          "ip": "172.24.225.209",
          "port": 0
        },
        "destination": {
          "ip": "172.25.226.249",
          "port": 4789
        },
        "network": {
          "transport": "udp"
        }
      }
    }
  ]
}

{
  "docs": [
    {
      "error": {
        "root_cause": [
          {
            "type": "illegal_argument_exception",
            "reason": "invalid source port [0]"
          }
        ],
        "type": "illegal_argument_exception",
        "reason": "invalid source port [0]"
      }
    }
  ]
}
```