### PR TITLE
Fix source mode parameter path in docs

### DIFF
--- a/docs/reference/elasticsearch/index-settings/source.md
+++ b/docs/reference/elasticsearch/index-settings/source.md
@@ -13,7 +13,7 @@ All settings around the `_source` metadata field.
 
 $$$source-mode$$$
 
-`index.source.mode`
+`index.mapping.source.mode`
 : (Static, string) The source mode for the index. Valid values are [`synthetic`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source), [`disabled`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#disable-source-field) or `stored`. Defaults to `stored`. The `stored` source mode always stores the source metadata field on disk.
 
 $$$recovery-use_synthetic_source$$$


### PR DESCRIPTION
The source-related index settings page was documenting that source mode was controlled by the setting `index.source.mode.` This is incorrect, the source mode is actually controlled by the index setting `index.mapping.source.mode`.