### PR TITLE
[9.4] Entitlement: log denial at DEBUG, not WARN (#148442)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyCheckerImpl.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyCheckerImpl.java
@@ -452,7 +452,7 @@ public class PolicyCheckerImpl implements PolicyChecker {
         var exception = new NotEntitledException(message);
         // Don't emit a log for suppressed packages, e.g. packages containing self tests
         if (suppressFailureLogPackages.contains(requestingClass.getPackage()) == false) {
-            entitlements.logger(requestingClass).warn("Not entitled: {}", message, exception);
+            entitlements.logger(requestingClass).debug("Not entitled: {}", message, exception);
         }
         throw exception;
     }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Entitlement: log denial at DEBUG, not WARN (#148442)