### PR TITLE
[8.19] Key plugin entitlement policies by descriptor name (#148447)

### DIFF
--- a/docs/changelog/148537.yaml
+++ b/docs/changelog/148537.yaml
@@ -1,5 +1,0 @@
-area: Infra/Entitlements
-issues: []
-pr: 148537
-summary: "[8.19] Key plugin entitlement policies by descriptor name"
-type: bug

--- a/docs/changelog/148537.yaml
+++ b/docs/changelog/148537.yaml
@@ -1,0 +1,5 @@
+area: Infra/Entitlements
+issues: []
+pr: 148537
+summary: "[8.19] Key plugin entitlement policies by descriptor name"
+type: bug

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsAllowedNonModularNameMismatchIT.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsAllowedNonModularNameMismatchIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.qa;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.entitlement.qa.test.RestEntitlementsCheckAction;
+import org.junit.ClassRule;
+
+import java.util.Map;
+
+/**
+ * Runs the allowed-action suite when the plugin's install directory differs from its descriptor
+ * {@code name=} (rewritten to {@code "renamed_test_plugin"} before install).
+ */
+public class EntitlementsAllowedNonModularNameMismatchIT extends AbstractEntitlementsIT {
+
+    private static final String OVERRIDE_DESCRIPTOR_NAME = "renamed_test_plugin";
+
+    @ClassRule
+    public static EntitlementsTestRule testRule = new EntitlementsTestRule(
+        false,
+        ALLOWED_TEST_ENTITLEMENTS,
+        tempDir -> Map.of(),
+        OVERRIDE_DESCRIPTOR_NAME
+    );
+
+    public EntitlementsAllowedNonModularNameMismatchIT(@Name("actionName") String actionName) {
+        super(actionName, true);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> data() {
+        return RestEntitlementsCheckAction.getCheckActionsAllowedInPlugins().stream().map(action -> new Object[] { action }).toList();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return testRule.cluster.getHttpAddresses();
+    }
+}

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsTestRule.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsTestRule.java
@@ -62,13 +62,28 @@ class EntitlementsTestRule implements TestRule {
     final TemporaryFolder testDir;
     final ElasticsearchCluster cluster;
     final TestRule ruleChain;
+    private final String overrideDescriptorName;
 
     EntitlementsTestRule(boolean modular, PolicyBuilder policyBuilder) {
-        this(modular, policyBuilder, tempDir -> Map.of());
+        this(modular, policyBuilder, tempDir -> Map.of(), null);
     }
 
-    @SuppressWarnings("this-escape")
     EntitlementsTestRule(boolean modular, PolicyBuilder policyBuilder, TempDirSystemPropertyProvider tempDirSystemPropertyProvider) {
+        this(modular, policyBuilder, tempDirSystemPropertyProvider, null);
+    }
+
+    /**
+     * @param overrideDescriptorName if non-null, rewrites the test plugin's descriptor {@code name=}
+     *                               to this value (the install directory stays {@link #ENTITLEMENT_TEST_PLUGIN_NAME}).
+     */
+    @SuppressWarnings("this-escape")
+    EntitlementsTestRule(
+        boolean modular,
+        PolicyBuilder policyBuilder,
+        TempDirSystemPropertyProvider tempDirSystemPropertyProvider,
+        String overrideDescriptorName
+    ) {
+        this.overrideDescriptorName = overrideDescriptorName;
         testDir = new TemporaryFolder();
         var tempDirSetup = new ExternalResource() {
             @Override
@@ -124,9 +139,17 @@ class EntitlementsTestRule implements TestRule {
             buildEntitlements(spec, moduleName, policyBuilder);
         }
 
-        if (modular == false) {
+        boolean rewriteModulename = (modular == false);
+        boolean rewriteName = overrideDescriptorName != null;
+        if (rewriteModulename || rewriteName) {
             spec.withPropertiesOverride(old -> {
-                String props = old.replace("modulename=" + ENTITLEMENT_QA_TEST_MODULE_NAME, "");
+                String props = old;
+                if (rewriteModulename) {
+                    props = props.replace("modulename=" + ENTITLEMENT_QA_TEST_MODULE_NAME, "");
+                }
+                if (rewriteName) {
+                    props = props.replaceAll("(?m)^name=.*$", "name=" + overrideDescriptorName);
+                }
                 System.out.println("Using plugin properties:\n" + props);
                 return Resource.fromString(props);
             });

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyUtils.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyUtils.java
@@ -42,9 +42,14 @@ public class PolicyUtils {
 
     private static final Logger logger = LogManager.getLogger(PolicyUtils.class);
 
-    public record PluginData(Path pluginPath, boolean isModular, boolean isExternalPlugin) {
+    /**
+     * {@code pluginName} must be the descriptor {@code name=} value (not the install directory),
+     * since the runtime entitlement lookup keys off the descriptor name.
+     */
+    public record PluginData(Path pluginPath, String pluginName, boolean isModular, boolean isExternalPlugin) {
         public PluginData {
             requireNonNull(pluginPath);
+            requireNonNull(pluginName);
         }
     }
 
@@ -58,7 +63,7 @@ public class PolicyUtils {
         Map<String, Policy> pluginPolicies = new HashMap<>(pluginData.size());
         for (var entry : pluginData) {
             Path pluginRoot = entry.pluginPath();
-            String pluginName = pluginRoot.getFileName().toString();
+            String pluginName = entry.pluginName();
             final Set<String> moduleNames = getModuleNames(pluginRoot, entry.isModular());
 
             var pluginPolicyPatch = parseEncodedPolicyIfExists(

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
@@ -161,6 +161,50 @@ public class PolicyManagerTests extends ESTestCase {
         assertEquals("Map is unchanged", Map.of(requestingClass.getModule(), expectedEntitlements), policyManager.moduleEntitlementsMap);
     }
 
+    /**
+     * Full registration→lookup chain: the policy map must be keyed by the same descriptor name
+     * {@code ScopeResolver} resolves to, otherwise {@code getEntitlements} returns the empty set.
+     */
+    public void testGetEntitlementsForPluginWithDirectoryNameDifferentFromDescriptorName() {
+        String descriptorName = "myPlugin";
+        var pluginPolicy = new Policy(
+            descriptorName,
+            List.of(new Scope(PolicyManager.ALL_UNNAMED, List.of(new OutboundNetworkEntitlement())))
+        );
+
+        var correctlyKeyed = new PolicyManager(
+            createEmptyTestServerPolicy(),
+            List.of(),
+            Map.of(descriptorName, pluginPolicy),
+            c -> PolicyScope.plugin(descriptorName, PolicyManager.ALL_UNNAMED),
+            name -> Collections.emptyList(),
+            TEST_PATH_LOOKUP
+        );
+        var entitlements = correctlyKeyed.getEntitlements(getClass());
+        assertThat(
+            "policy keyed by descriptor name must produce the granted entitlement at runtime lookup",
+            entitlements.hasEntitlement(OutboundNetworkEntitlement.class),
+            is(true)
+        );
+
+        // Inverse: with the map mis-keyed by directory name, ScopeResolver's descriptor-name lookup misses.
+        var directoryName = "my-plugin";
+        var misKeyed = new PolicyManager(
+            createEmptyTestServerPolicy(),
+            List.of(),
+            Map.of(directoryName, pluginPolicy),
+            c -> PolicyScope.plugin(descriptorName, PolicyManager.ALL_UNNAMED),
+            name -> Collections.emptyList(),
+            TEST_PATH_LOOKUP
+        );
+        var misKeyedEntitlements = misKeyed.getEntitlements(getClass());
+        assertThat(
+            "policy keyed by anything other than descriptor name causes the runtime lookup to miss",
+            misKeyedEntitlements.hasEntitlement(OutboundNetworkEntitlement.class),
+            is(false)
+        );
+    }
+
     public void testAgentsEntitlements() throws IOException, ClassNotFoundException {
         Path home = createTempDir();
         Path unnamedJar = createMockPluginJarForUnnamedModule(home);

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyUtilsTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyUtilsTests.java
@@ -22,9 +22,11 @@ import org.elasticsearch.entitlement.runtime.policy.entitlements.WriteSystemProp
 import org.elasticsearch.test.ESTestCase;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement.SEPARATOR;
@@ -35,6 +37,50 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 public class PolicyUtilsTests extends ESTestCase {
+
+    /** A plugin policy must be registered under the descriptor name, since the runtime lookup keys off it. */
+    public void testCreatePluginPoliciesKeyedByDescriptorNameNotDirectoryName() throws Exception {
+        Path pluginDir = createTempDir("dir-name-differs-from-descriptor");
+        Files.writeString(pluginDir.resolve(PolicyUtils.POLICY_FILE_NAME), """
+            ALL-UNNAMED:
+              - outbound_network
+            """);
+
+        String descriptorName = "myPlugin";
+        var pluginData = new PolicyUtils.PluginData(pluginDir, descriptorName, false, true);
+
+        var result = PolicyUtils.createPluginPolicies(List.of(pluginData), Map.of(), "9.0.0");
+
+        assertThat(result.keySet(), containsInAnyOrder(descriptorName));
+        assertThat(
+            result.get(descriptorName).scopes(),
+            containsInAnyOrder(new Scope("ALL-UNNAMED", List.of(new OutboundNetworkEntitlement())))
+        );
+        assertThat(result.get(pluginDir.getFileName().toString()), nullValue());
+    }
+
+    /** Policy patches are keyed by descriptor name, so the patch lookup must use it too. */
+    public void testCreatePluginPoliciesAppliesPatchByDescriptorName() throws Exception {
+        Path pluginDir = createTempDir("dir-name-differs-from-descriptor-patch");
+        Files.writeString(pluginDir.resolve(PolicyUtils.POLICY_FILE_NAME), """
+            ALL-UNNAMED:
+              - outbound_network
+            """);
+
+        String descriptorName = "myPlugin";
+        var patch = new String(Base64.getEncoder().encode("""
+            policy:
+              ALL-UNNAMED:
+                - manage_threads
+            """.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
+
+        var pluginData = new PolicyUtils.PluginData(pluginDir, descriptorName, false, true);
+        var result = PolicyUtils.createPluginPolicies(List.of(pluginData), Map.of(descriptorName, patch), "9.0.0");
+
+        assertThat(result.keySet(), containsInAnyOrder(descriptorName));
+        var entitlements = result.get(descriptorName).scopes().stream().flatMap(s -> s.entitlements().stream()).toList();
+        assertThat(entitlements, containsInAnyOrder(new OutboundNetworkEntitlement(), new ManageThreadsEntitlement()));
+    }
 
     public void testCreatePluginPolicyWithPatch() {
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -235,8 +235,23 @@ class Elasticsearch {
 
         var pluginData = Stream.concat(
             modulesBundles.stream()
-                .map(bundle -> new PolicyUtils.PluginData(bundle.getDir(), bundle.pluginDescriptor().isModular(), false)),
-            pluginsBundles.stream().map(bundle -> new PolicyUtils.PluginData(bundle.getDir(), bundle.pluginDescriptor().isModular(), true))
+                .map(
+                    bundle -> new PolicyUtils.PluginData(
+                        bundle.getDir(),
+                        bundle.pluginDescriptor().getName(),
+                        bundle.pluginDescriptor().isModular(),
+                        false
+                    )
+                ),
+            pluginsBundles.stream()
+                .map(
+                    bundle -> new PolicyUtils.PluginData(
+                        bundle.getDir(),
+                        bundle.pluginDescriptor().getName(),
+                        bundle.pluginDescriptor().isModular(),
+                        true
+                    )
+                )
         ).toList();
 
         var pluginPolicyPatches = collectPluginPolicyPatches(modulesBundles, pluginsBundles, logger);


### PR DESCRIPTION
Backport of #148447 to 8.19. Cherry-pick applied with auto-merge in `Elasticsearch.java` and `PolicyUtils.java` (no manual conflict resolution).