### PR TITLE
Remove flaky agent assertion in nodes.stats yaml test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -485,9 +485,6 @@ tests:
 - class: org.elasticsearch.index.mapper.DateRangeDocValuesLoaderTests
   method: testEmptyRangesAppendsNull
   issue: https://github.com/elastic/elasticsearch/issues/148378
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=nodes.stats/11_indices_metrics/Metric - http}
-  issue: https://github.com/elastic/elasticsearch/issues/148430
 - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
   method: testRestartForConfiguringReservedRolesAndClosingIndex
   issue: https://github.com/elastic/elasticsearch/issues/148431

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/11_indices_metrics.yml
@@ -314,7 +314,6 @@
   - gte: { nodes.$node_id.http.total_opened: 1 }
   - is_true:  nodes.$node_id.http.clients
   - gte: { nodes.$node_id.http.clients.0.id: 1 }
-  - match: { nodes.$node_id.http.clients.0.agent: "/.*/" }
   - match: { nodes.$node_id.http.clients.0.local_address: "/.*/" }
   - match: { nodes.$node_id.http.clients.0.remote_address: "/.*/" }
   - is_true:  nodes.$node_id.http.clients.0.last_uri
@@ -322,8 +321,7 @@
   - gte: { nodes.$node_id.http.clients.0.last_request_time_millis: 1614028911317 }
   - gte: { nodes.$node_id.http.clients.0.request_count: 1 }
   - gte: { nodes.$node_id.http.clients.0.request_size_bytes: 0 }
-  # values for clients.0.closed_time_millis, clients.0.x_forwarded_for, and clients.0.x_opaque_id are often
-  # null and cannot be tested here
+  # Values for clients.0.{agent, closed_time_millis, x_forwarded_for, x_opaque_id} can be null and cannot be tested here
 
 ---
 "Metric - blank for indices shard_stats":


### PR DESCRIPTION
The `clients.0.agent` assertion is flaky because the clients array order is non-deterministic and `agent` can legitimately be null when a tracked channel closes before any request reaches `update()`. Drop the assertion and remove the mute; agent extraction is covered by `HttpClientStatsTrackerTests`.

Closes #148430