### PR TITLE
Disable shard-based slice optimization by setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -387,7 +387,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         SearchService.DEFAULT_SEARCH_TIMEOUT_SETTING,
         SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS_SETTING,
         SearchService.PIT_RELOCATION_ENABLED,
-        SearchService.SLICE_SHARD_OPTIMIZATION_ENABLED,
+        SearchService.SCROLL_SLICE_SHARD_OPTIMIZATION_ENABLED,
         TransportSearchAction.SHARD_COUNT_LIMIT_SETTING,
         TransportSearchAction.DEFAULT_PRE_FILTER_SHARD_SIZE,
         RemoteClusterSettings.REMOTE_CLUSTER_SKIP_UNAVAILABLE,

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -387,6 +387,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         SearchService.DEFAULT_SEARCH_TIMEOUT_SETTING,
         SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS_SETTING,
         SearchService.PIT_RELOCATION_ENABLED,
+        SearchService.SLICE_SHARD_OPTIMIZATION_ENABLED,
         TransportSearchAction.SHARD_COUNT_LIMIT_SETTING,
         TransportSearchAction.DEFAULT_PRE_FILTER_SHARD_SIZE,
         RemoteClusterSettings.REMOTE_CLUSTER_SKIP_UNAVAILABLE,

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -339,8 +339,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     // Optimizing slicing by shard isn't compatible with resharding, but disabling it may have
     // a performance impact that is noticeable in some workflows. This setting exists to allow
     // us to toggle it quickly if such a case is discovered, but should not exist permanently.
-    public static final Setting<Boolean> SLICE_SHARD_OPTIMIZATION_ENABLED = Setting.boolSetting(
-        "search.slice.shard_optimization_enabled",
+    public static final Setting<Boolean> SCROLL_SLICE_SHARD_OPTIMIZATION_ENABLED = Setting.boolSetting(
+        "search.scroll.slice_shard_optimization_enabled",
         // matches logic before setting was introduced
         true,
         Property.OperatorDynamic,
@@ -396,7 +396,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     private volatile boolean pitRelocationEnabled;
 
-    private volatile boolean sliceShardOptimizationEnabled;
+    private volatile boolean scrollSliceShardOptimizationEnabled;
 
     private final int minimumDocsPerSlice;
 
@@ -513,10 +513,10 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(
-                SLICE_SHARD_OPTIMIZATION_ENABLED,
-                slicedShardOptimizationEnabled -> this.sliceShardOptimizationEnabled = slicedShardOptimizationEnabled
+                SCROLL_SLICE_SHARD_OPTIMIZATION_ENABLED,
+                slicedShardOptimizationEnabled -> this.scrollSliceShardOptimizationEnabled = slicedShardOptimizationEnabled
             );
-        sliceShardOptimizationEnabled = SLICE_SHARD_OPTIMIZATION_ENABLED.get(settings);
+        scrollSliceShardOptimizationEnabled = SCROLL_SLICE_SHARD_OPTIMIZATION_ENABLED.get(settings);
     }
 
     public boolean isPitRelocationEnabled() {
@@ -2111,7 +2111,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }
 
         if (source.slice() != null) {
-            context.sliceBuilder(sliceShardOptimizationEnabled ? source.slice() : SliceBuilder.withoutShardOptimization(source.slice()));
+            context.sliceBuilder(
+                scrollSliceShardOptimizationEnabled ? source.slice() : SliceBuilder.withoutShardOptimization(source.slice())
+            );
         }
 
         if (source.storedFields() != null) {

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -128,6 +128,7 @@ import org.elasticsearch.search.rank.feature.RankFeatureShardPhase;
 import org.elasticsearch.search.rank.feature.RankFeatureShardRequest;
 import org.elasticsearch.search.rescore.RescorerBuilder;
 import org.elasticsearch.search.searchafter.SearchAfterBuilder;
+import org.elasticsearch.search.slice.SliceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.MinAndMax;
 import org.elasticsearch.search.sort.SortAndFormats;
@@ -335,6 +336,17 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Property.NodeScope
     );
 
+    // Optimizing slicing by shard isn't compatible with resharding, but disabling it may have
+    // a performance impact that is noticeable in some workflows. This setting exists to allow
+    // us to toggle it quickly if such a case is discovered, but should not exist permanently.
+    public static final Setting<Boolean> SLICE_SHARD_OPTIMIZATION_ENABLED = Setting.boolSetting(
+        "search.slice.shard_optimization_enabled",
+        // matches logic before setting was introduced
+        true,
+        Property.OperatorDynamic,
+        Property.NodeScope
+    );
+
     /**
      * The size of the buffer used for memory accounting.
      * This buffer is used to locally track the memory accummulated during the execution of
@@ -383,6 +395,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     private volatile boolean batchQueryPhase;
 
     private volatile boolean pitRelocationEnabled;
+
+    private volatile boolean sliceShardOptimizationEnabled;
 
     private final int minimumDocsPerSlice;
 
@@ -496,6 +510,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(PIT_RELOCATION_ENABLED, pitRelocationEnabled -> this.pitRelocationEnabled = pitRelocationEnabled);
+
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(
+                SLICE_SHARD_OPTIMIZATION_ENABLED,
+                slicedShardOptimizationEnabled -> this.sliceShardOptimizationEnabled = slicedShardOptimizationEnabled
+            );
+        sliceShardOptimizationEnabled = SLICE_SHARD_OPTIMIZATION_ENABLED.get(settings);
     }
 
     public boolean isPitRelocationEnabled() {
@@ -2090,7 +2111,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         }
 
         if (source.slice() != null) {
-            context.sliceBuilder(source.slice());
+            context.sliceBuilder(sliceShardOptimizationEnabled ? source.slice() : SliceBuilder.withoutShardOptimization(source.slice()));
         }
 
         if (source.storedFields() != null) {

--- a/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
@@ -44,6 +44,7 @@ import java.util.Objects;
  *  {@link DocValuesSliceQuery} is used to filter the results.
  */
 public class SliceBuilder implements Writeable, ToXContentObject {
+
     private static final MatchNoDocsQuery NOT_PART_OF_SLICE = new MatchNoDocsQuery("this shard is not part of the slice");
 
     private static final ParseField FIELD_FIELD = new ParseField("field");
@@ -64,6 +65,8 @@ public class SliceBuilder implements Writeable, ToXContentObject {
     private int id = -1;
     /** Max number of slices */
     private int max = -1;
+    /** Whether to optimize the slice query by shard */
+    private boolean optimizeByShard = true;
 
     private SliceBuilder() {}
 
@@ -101,6 +104,12 @@ public class SliceBuilder implements Writeable, ToXContentObject {
         out.writeOptionalString(field);
         out.writeVInt(id);
         out.writeVInt(max);
+    }
+
+    public static SliceBuilder withoutShardOptimization(SliceBuilder sb) {
+        final SliceBuilder newSliceBuilder = new SliceBuilder(sb.field, sb.id, sb.max);
+        newSliceBuilder.setOptimizeByShard(false);
+        return newSliceBuilder;
     }
 
     private SliceBuilder setField(String field) {
@@ -151,6 +160,10 @@ public class SliceBuilder implements Writeable, ToXContentObject {
         return max;
     }
 
+    private void setOptimizeByShard(boolean optimizeByShard) {
+        this.optimizeByShard = optimizeByShard;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -195,7 +208,7 @@ public class SliceBuilder implements Writeable, ToXContentObject {
         int numShards = request.shardRequestIndex() != -1 ? request.numberOfShards() : context.getIndexSettings().getNumberOfShards();
         boolean isScroll = request.scroll() != null;
 
-        if (numShards == 1) {
+        if (numShards == 1 || optimizeByShard == false) {
             return createSliceQuery(id, max, context, isScroll);
         }
         if (max > numShards) {

--- a/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/slice/SliceBuilder.java
@@ -208,7 +208,7 @@ public class SliceBuilder implements Writeable, ToXContentObject {
         int numShards = request.shardRequestIndex() != -1 ? request.numberOfShards() : context.getIndexSettings().getNumberOfShards();
         boolean isScroll = request.scroll() != null;
 
-        if (numShards == 1 || optimizeByShard == false) {
+        if (numShards == 1 || (isScroll && optimizeByShard == false)) {
             return createSliceQuery(id, max, context, isScroll);
         }
         if (max > numShards) {

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardSliceIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardSliceIT.java
@@ -7,22 +7,26 @@
 
 package org.elasticsearch.xpack.stateless.reshard;
 
+import org.elasticsearch.action.search.ClosePointInTimeRequest;
+import org.elasticsearch.action.search.OpenPointInTimeRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.TransportClosePointInTimeAction;
+import org.elasticsearch.action.search.TransportOpenPointInTimeAction;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.slice.SliceBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
 import org.junit.Ignore;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.elasticsearch.search.SearchService.SLICE_SHARD_OPTIMIZATION_ENABLED;
+import static org.elasticsearch.search.SearchService.SCROLL_SLICE_SHARD_OPTIMIZATION_ENABLED;
 import static org.elasticsearch.xpack.stateless.reshard.SplitSourceService.RESHARD_SPLIT_DELETE_UNOWNED_GRACE_PERIOD;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -31,17 +35,25 @@ public class StatelessReshardSliceIT extends AbstractStatelessPluginIntegTestCas
     // when the search is composed of a full set of sliced scrolls and resharding
     // occurs between slice queries.
     public void testSliceConsistency() throws Exception {
-        // start with small n shards
         final int numShards = randomIntBetween(1, 5);
         final int numDocs = randomIntBetween(10, 100);
         final int numSlices = randomIntBetween(2, numShards * 2);
         final String indexName = randomIndexName();
+        final boolean usePit = randomBoolean();
+        BytesReference pointInTimeId = null;
 
         final String indexNode = startMasterAndIndexNode();
         startSearchNode();
         ensureStableCluster(2);
 
-        logger.info("--> creating {} docs in index [{}] with {} shards for {} slices", numDocs, indexName, numShards, numSlices);
+        logger.info(
+            "--> creating {} docs in index [{}] with {} shards for {} slices (PIT: {})",
+            numDocs,
+            indexName,
+            numShards,
+            numSlices,
+            usePit
+        );
         createIndex(indexName, numShards, 1);
         ensureGreen(indexName);
 
@@ -49,6 +61,14 @@ public class StatelessReshardSliceIT extends AbstractStatelessPluginIntegTestCas
 
         indexDocsAndRefresh(indexName, numDocs);
 
+        if (usePit) {
+            final var pointInTimeResponse = client().execute(
+                TransportOpenPointInTimeAction.TYPE,
+                new OpenPointInTimeRequest(indexName).keepAlive(SAFE_AWAIT_TIMEOUT)
+            ).actionGet();
+            assertThat(pointInTimeResponse.getSuccessfulShards(), equalTo(numShards));
+            pointInTimeId = pointInTimeResponse.getPointInTimeId();
+        }
         final int reshardBeforeSlice = randomIntBetween(1, numSlices - 1);
         final var totalHits = new AtomicInteger();
         for (int i = 0; i < numSlices; i++) {
@@ -58,9 +78,18 @@ public class StatelessReshardSliceIT extends AbstractStatelessPluginIntegTestCas
                 client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet(SAFE_AWAIT_TIMEOUT);
                 awaitClusterState((state) -> state.metadata().indexMetadata(index).getReshardingMetadata() == null);
             }
-            final var search = prepareSearch(indexName).setSize(10000).setTrackTotalHits(true).setScroll(SAFE_AWAIT_TIMEOUT);
-            final var hits = getSliceHits(search, i, numSlices);
+            final var search = prepareSearch().setSize(10000).setTrackTotalHits(true);
+            if (usePit) {
+                search.setPointInTime(new PointInTimeBuilder(pointInTimeId).setKeepAlive(SAFE_AWAIT_TIMEOUT)).addSort(SortBuilders.fieldSort("_doc"));
+            } else {
+                search.setIndices(indexName).setScroll(SAFE_AWAIT_TIMEOUT);
+            }
+            final var hits = usePit ? getPitSliceHits(search, i, numSlices) : getScrollSliceHits(search, i, numSlices);
             totalHits.getAndAdd(hits);
+        }
+
+        if (usePit) {
+            client().execute(TransportClosePointInTimeAction.TYPE, new ClosePointInTimeRequest(pointInTimeId)).actionGet();
         }
 
         assertEquals(numDocs, totalHits.get());
@@ -81,13 +110,12 @@ public class StatelessReshardSliceIT extends AbstractStatelessPluginIntegTestCas
     }
 
     void benchmarkSliceConsistency(boolean shardOptimizationEnabled) throws Exception {
-        // start with small n shards
         final int numShards = 10;
         final int numDocs = 100000;
         final int numSlices = numShards;
         final String indexName = randomIndexName();
 
-        final Settings searchSettings = Settings.builder().put(SLICE_SHARD_OPTIMIZATION_ENABLED.getKey(), shardOptimizationEnabled).build();
+        final Settings searchSettings = Settings.builder().put(SCROLL_SLICE_SHARD_OPTIMIZATION_ENABLED.getKey(), shardOptimizationEnabled).build();
         startMasterAndIndexNode();
         startSearchNode(searchSettings);
         ensureStableCluster(2);
@@ -104,7 +132,7 @@ public class StatelessReshardSliceIT extends AbstractStatelessPluginIntegTestCas
         for (int i = 0; i < numSlices; i++) {
             logger.info("--> slice {}", i);
             final var search = prepareSearch(indexName).setSize(10000).setTrackTotalHits(true).setScroll(SAFE_AWAIT_TIMEOUT);
-            final var hits = getSliceHits(search, i, numSlices);
+            final var hits = getScrollSliceHits(search, i, numSlices);
             totalHits.getAndAdd(hits);
         }
         final var endTime = System.currentTimeMillis();
@@ -122,12 +150,12 @@ public class StatelessReshardSliceIT extends AbstractStatelessPluginIntegTestCas
             // These tests are carefully set up and do not hit the situations that the delete unowned grace period prevents.
             .put(RESHARD_SPLIT_DELETE_UNOWNED_GRACE_PERIOD.getKey(), TimeValue.ZERO)
             // Resharding relies on not optimizing by shard. Tests are expected to fail if this is true.
-            .put(SLICE_SHARD_OPTIMIZATION_ENABLED.getKey(), false);
+            .put(SCROLL_SLICE_SHARD_OPTIMIZATION_ENABLED.getKey(), false);
     }
 
-    private int getSliceHits(SearchRequestBuilder request, int slice, int numSlices) {
+    // borrowed from SearchSliceIT
+    private int getScrollSliceHits(SearchRequestBuilder request, int slice, int numSlices) {
         int totalResults = 0;
-        List<String> keys = new ArrayList<>();
         SliceBuilder sliceBuilder = new SliceBuilder(slice, numSlices);
         SearchResponse searchResponse = request.slice(sliceBuilder).get();
         try {
@@ -135,21 +163,48 @@ public class StatelessReshardSliceIT extends AbstractStatelessPluginIntegTestCas
             int expectedSliceResults = (int) searchResponse.getHits().getTotalHits().value();
             int numSliceResults = searchResponse.getHits().getHits().length;
             String scrollId = searchResponse.getScrollId();
-            for (SearchHit hit : searchResponse.getHits().getHits()) {
-                assertTrue(keys.add(hit.getId()));
-            }
             while (searchResponse.getHits().getHits().length > 0) {
                 searchResponse.decRef();
-                searchResponse = client().prepareSearchScroll("test").setScrollId(scrollId).setScroll(TimeValue.timeValueSeconds(10)).get();
+                searchResponse = client().prepareSearchScroll("test")
+                    .setScrollId(scrollId)
+                    .setScroll(TimeValue.timeValueSeconds(SAFE_AWAIT_TIMEOUT.seconds()))
+                    .get();
                 scrollId = searchResponse.getScrollId();
                 totalResults += searchResponse.getHits().getHits().length;
                 numSliceResults += searchResponse.getHits().getHits().length;
-                for (SearchHit hit : searchResponse.getHits().getHits()) {
-                    assertTrue(keys.add(hit.getId()));
-                }
             }
             assertThat(numSliceResults, equalTo(expectedSliceResults));
             clearScroll(scrollId);
+        } finally {
+            searchResponse.decRef();
+        }
+
+        return totalResults;
+    }
+
+    private int getPitSliceHits(SearchRequestBuilder request, int slice, int numSlices) {
+        int totalResults = 0;
+        int numSliceResults = 0;
+
+        SliceBuilder sliceBuilder = new SliceBuilder(slice, numSlices);
+        SearchResponse searchResponse = request.slice(sliceBuilder).get();
+        try {
+            int expectedSliceResults = (int) searchResponse.getHits().getTotalHits().value();
+
+            while (true) {
+                int numHits = searchResponse.getHits().getHits().length;
+                if (numHits == 0) {
+                    break;
+                }
+
+                totalResults += numHits;
+                numSliceResults += numHits;
+
+                Object[] sortValues = searchResponse.getHits().getHits()[numHits - 1].getSortValues();
+                searchResponse.decRef();
+                searchResponse = request.searchAfter(sortValues).get();
+            }
+            assertThat(numSliceResults, equalTo(expectedSliceResults));
         } finally {
             searchResponse.decRef();
         }

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardSliceIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardSliceIT.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.reshard;
+
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.replication.TransportReplicationAction;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.slice.SliceBuilder;
+import org.elasticsearch.xpack.stateless.AbstractStatelessPluginIntegTestCase;
+import org.junit.Ignore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.search.SearchService.SLICE_SHARD_OPTIMIZATION_ENABLED;
+import static org.elasticsearch.xpack.stateless.reshard.SplitSourceService.RESHARD_SPLIT_DELETE_UNOWNED_GRACE_PERIOD;
+import static org.hamcrest.Matchers.equalTo;
+
+public class StatelessReshardSliceIT extends AbstractStatelessPluginIntegTestCase {
+    // test that a search of an index produces exactly the documents in the index,
+    // when the search is composed of a full set of sliced scrolls and resharding
+    // occurs between slice queries.
+    public void testSliceConsistency() throws Exception {
+        // start with small n shards
+        final int numShards = randomIntBetween(1, 5);
+        final int numDocs = randomIntBetween(10, 100);
+        final int numSlices = randomIntBetween(2, numShards * 2);
+        final String indexName = randomIndexName();
+
+        final String indexNode = startMasterAndIndexNode();
+        startSearchNode();
+        ensureStableCluster(2);
+
+        logger.info("--> creating {} docs in index [{}] with {} shards for {} slices", numDocs, indexName, numShards, numSlices);
+        createIndex(indexName, numShards, 1);
+        ensureGreen(indexName);
+
+        final var index = resolveIndex(indexName);
+
+        indexDocsAndRefresh(indexName, numDocs);
+
+        final int reshardBeforeSlice = randomIntBetween(1, numSlices - 1);
+        final var totalHits = new AtomicInteger();
+        for (int i = 0; i < numSlices; i++) {
+            logger.info("--> slice {}", i);
+            if (i == reshardBeforeSlice) {
+                logger.info("--> resharding before slice {}", i);
+                client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet(SAFE_AWAIT_TIMEOUT);
+                awaitClusterState((state) -> state.metadata().indexMetadata(index).getReshardingMetadata() == null);
+            }
+            final var search = prepareSearch(indexName).setSize(10000).setTrackTotalHits(true).setScroll(SAFE_AWAIT_TIMEOUT);
+            final var hits = getSliceHits(search, i, numSlices);
+            totalHits.getAndAdd(hits);
+        }
+
+        assertEquals(numDocs, totalHits.get());
+    }
+
+    // On my laptop, this took ~800ms
+    @SuppressForbidden(reason = "only for local development")
+    @Ignore("only for local development")
+    public void testSliceConsistencyWithShardOptimization() throws Exception {
+        benchmarkSliceConsistency(true);
+    }
+
+    // and this took ~1600ms
+    @SuppressForbidden(reason = "only for local development")
+    @Ignore("only for local development")
+    public void testSliceConsistencyWithoutShardOptimization() throws Exception {
+        benchmarkSliceConsistency(false);
+    }
+
+    void benchmarkSliceConsistency(boolean shardOptimizationEnabled) throws Exception {
+        // start with small n shards
+        final int numShards = 10;
+        final int numDocs = 100000;
+        final int numSlices = numShards;
+        final String indexName = randomIndexName();
+
+        final Settings searchSettings = Settings.builder().put(SLICE_SHARD_OPTIMIZATION_ENABLED.getKey(), shardOptimizationEnabled).build();
+        startMasterAndIndexNode();
+        startSearchNode(searchSettings);
+        ensureStableCluster(2);
+
+        logger.info("--> creating {} docs in index [{}] with {} shards for {} slices", numDocs, indexName, numShards, numSlices);
+        createIndex(indexName, numShards, 1);
+        ensureGreen(indexName);
+
+        indexDocsAndRefresh(indexName, numDocs);
+
+        final var totalHits = new AtomicInteger();
+
+        final var startTime = System.currentTimeMillis();
+        for (int i = 0; i < numSlices; i++) {
+            logger.info("--> slice {}", i);
+            final var search = prepareSearch(indexName).setSize(10000).setTrackTotalHits(true).setScroll(SAFE_AWAIT_TIMEOUT);
+            final var hits = getSliceHits(search, i, numSlices);
+            totalHits.getAndAdd(hits);
+        }
+        final var endTime = System.currentTimeMillis();
+        logger.info("--> took {} ms", endTime - startTime);
+
+        assertEquals(numDocs, totalHits.get());
+    }
+
+    @Override
+    protected Settings.Builder nodeSettings() {
+        return super.nodeSettings()
+            // Test framework randomly sets this to 0, but we rely on retries to handle target shards still being in recovery
+            // when we start re-splitting bulk requests.
+            .put(TransportReplicationAction.REPLICATION_RETRY_TIMEOUT.getKey(), "60s")
+            // These tests are carefully set up and do not hit the situations that the delete unowned grace period prevents.
+            .put(RESHARD_SPLIT_DELETE_UNOWNED_GRACE_PERIOD.getKey(), TimeValue.ZERO)
+            // Resharding relies on not optimizing by shard. Tests are expected to fail if this is true.
+            .put(SLICE_SHARD_OPTIMIZATION_ENABLED.getKey(), false);
+    }
+
+    private int getSliceHits(SearchRequestBuilder request, int slice, int numSlices) {
+        int totalResults = 0;
+        List<String> keys = new ArrayList<>();
+        SliceBuilder sliceBuilder = new SliceBuilder(slice, numSlices);
+        SearchResponse searchResponse = request.slice(sliceBuilder).get();
+        try {
+            totalResults += searchResponse.getHits().getHits().length;
+            int expectedSliceResults = (int) searchResponse.getHits().getTotalHits().value();
+            int numSliceResults = searchResponse.getHits().getHits().length;
+            String scrollId = searchResponse.getScrollId();
+            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                assertTrue(keys.add(hit.getId()));
+            }
+            while (searchResponse.getHits().getHits().length > 0) {
+                searchResponse.decRef();
+                searchResponse = client().prepareSearchScroll("test").setScrollId(scrollId).setScroll(TimeValue.timeValueSeconds(10)).get();
+                scrollId = searchResponse.getScrollId();
+                totalResults += searchResponse.getHits().getHits().length;
+                numSliceResults += searchResponse.getHits().getHits().length;
+                for (SearchHit hit : searchResponse.getHits().getHits()) {
+                    assertTrue(keys.add(hit.getId()));
+                }
+            }
+            assertThat(numSliceResults, equalTo(expectedSliceResults));
+            clearScroll(scrollId);
+        } finally {
+            searchResponse.decRef();
+        }
+
+        return totalResults;
+    }
+}

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardSliceIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardSliceIT.java
@@ -80,7 +80,8 @@ public class StatelessReshardSliceIT extends AbstractStatelessPluginIntegTestCas
             }
             final var search = prepareSearch().setSize(10000).setTrackTotalHits(true);
             if (usePit) {
-                search.setPointInTime(new PointInTimeBuilder(pointInTimeId).setKeepAlive(SAFE_AWAIT_TIMEOUT)).addSort(SortBuilders.fieldSort("_doc"));
+                search.setPointInTime(new PointInTimeBuilder(pointInTimeId).setKeepAlive(SAFE_AWAIT_TIMEOUT))
+                    .addSort(SortBuilders.fieldSort("_doc"));
             } else {
                 search.setIndices(indexName).setScroll(SAFE_AWAIT_TIMEOUT);
             }
@@ -115,7 +116,9 @@ public class StatelessReshardSliceIT extends AbstractStatelessPluginIntegTestCas
         final int numSlices = numShards;
         final String indexName = randomIndexName();
 
-        final Settings searchSettings = Settings.builder().put(SCROLL_SLICE_SHARD_OPTIMIZATION_ENABLED.getKey(), shardOptimizationEnabled).build();
+        final Settings searchSettings = Settings.builder()
+            .put(SCROLL_SLICE_SHARD_OPTIMIZATION_ENABLED.getKey(), shardOptimizationEnabled)
+            .build();
         startMasterAndIndexNode();
         startSearchNode(searchSettings);
         ensureStableCluster(2);


### PR DESCRIPTION
Uses cluster dynamic setting `search.scroll.slice_shard_optimization_enabled` to control whether to optimize slices by shard. Resharding requires this to be off to ensure search results are consistent with their un-sliced equivalents.

Note that if this setting is changed in the middle of a series of slice queries, the final result will be incorrect, because the optimization changes the contents of the slice - e.g., when the number of slices is the number of shards, then a slice is just a shard in the optimized case, but in the unoptimized case it's the combination of slices of all shards where the hash of the slice field is the slice number.

Disabling the optimization makes slicing safe in the presence of resharding, but we'll still need a rollout strategy to use it, such as an index version gate.
