### PR TITLE
Report shutdowns as IN_PROGRESS if a remaining shard has canAllocate=NOT_PREFERRED

### DIFF
--- a/docs/changelog/148556.yaml
+++ b/docs/changelog/148556.yaml
@@ -1,0 +1,5 @@
+area: Allocation
+issues: []
+pr: 148556
+summary: Report shutdowns as IN_PROGRESS if a remaining shard has `canAllocate=NOT_PREFERRED`
+type: bug

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -319,8 +319,13 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
                     : "shard [" + pair + "] can remain on node [" + nodeId + "], but that node is shutting down";
                 return pair.v2().getMoveDecision().cannotRemain();
             })
-            // These shards will move as soon as possible
-            .filter(pair -> pair.v2().getMoveDecision().getAllocationDecision().equals(AllocationDecision.YES) == false)
+            // These shards will move as soon as possible. A NOT_PREFERRED move decision still
+            // means the shard can migrate (see MoveDecision#cannotRemainAndCanMove), so we must
+            // not treat it as unmovable when the shard cannot remain on the shutting down node.
+            .filter(pair -> {
+                AllocationDecision moveDecision = pair.v2().getMoveDecision().getAllocationDecision();
+                return moveDecision != AllocationDecision.YES && moveDecision != AllocationDecision.NOT_PREFERRED;
+            })
             .toList();
 
         // If there's no relocating shards and shards still on this node, we need to figure out why

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -683,7 +683,7 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
      * as IN_PROGRESS rather than STALLED.
      */
     public void testNotStalledIfShardCanMigrateToNotPreferredNode() {
-        Index index = new Index(randomAlphaOfLength(5), randomAlphaOfLengthBetween(1, 20));
+        Index index = new Index(randomIndexName(), randomUUID());
         IndexMetadata imd = generateIndexMetadata(index, 1, 0);
         IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(index)
             .addShard(TestShardRouting.newShardRouting(new ShardId(index, 0), SHUTTING_DOWN_NODE_ID, true, ShardRoutingState.STARTED))

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -677,6 +677,38 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
         assertThat(explain.getMoveDecision().getExplanation(), equalTo(Explanations.Move.THROTTLED));
     }
 
+    /**
+     * If a shard on the shutting down node can only migrate to a NOT_PREFERRED target, the shard
+     * will still relocate (since the canRemain decision is NO), so the shutdown must be reported
+     * as IN_PROGRESS rather than STALLED.
+     */
+    public void testNotStalledIfShardCanMigrateToNotPreferredNode() {
+        Index index = new Index(randomAlphaOfLength(5), randomAlphaOfLengthBetween(1, 20));
+        IndexMetadata imd = generateIndexMetadata(index, 1, 0);
+        IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(index)
+            .addShard(TestShardRouting.newShardRouting(new ShardId(index, 0), SHUTTING_DOWN_NODE_ID, true, ShardRoutingState.STARTED))
+            .build();
+
+        // Every other node is NOT_PREFERRED, but the shard cannot remain so it should still move.
+        canAllocate.set((r, n, a) -> n.nodeId().equals(SHUTTING_DOWN_NODE_ID) ? Decision.NO : Decision.NOT_PREFERRED);
+        canRemain.set((r, n, a) -> n.nodeId().equals(SHUTTING_DOWN_NODE_ID) ? Decision.NO : Decision.YES);
+
+        RoutingTable.Builder routingTable = RoutingTable.builder();
+        routingTable.add(indexRoutingTable);
+        ClusterState state = createTestClusterState(routingTable.build(), List.of(imd), SingleNodeShutdownMetadata.Type.REMOVE);
+
+        ShutdownShardMigrationStatus status = TransportGetShutdownStatusAction.shardMigrationStatus(
+            new CancellableTask(1, "direct", GetShutdownStatusAction.NAME, "", TaskId.EMPTY_TASK_ID, Map.of()),
+            state,
+            SHUTTING_DOWN_NODE_ID,
+            SingleNodeShutdownMetadata.Type.REMOVE,
+            true,
+            allocationService
+        );
+
+        assertShardMigration(status, SingleNodeShutdownMetadata.Status.IN_PROGRESS, 1, nullValue());
+    }
+
     public void testIlmShrinkingIndexAvoidsStall() {
         LifecycleExecutionState executionState = LifecycleExecutionState.builder()
             .setAction(ShrinkAction.NAME)


### PR DESCRIPTION
The get shutdown status API was erroneously returning "stalled" as the shutdown status when a remaining shard had `canAllocate=NOT_PREFERRED`. This was an oversight when `NOT_PREFERRED` was added and is incorrect.

Such shutdowns will now be reported as `IN_PROGRESS`