### PR TITLE
Add configurable OTel histogram aggregation

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
@@ -92,6 +92,7 @@ public class APM extends Plugin implements NetworkPlugin, TelemetryPlugin {
             OtelSdkSettings.TELEMETRY_OTEL_METRICS_ENDPOINT,
             OtelSdkSettings.TELEMETRY_OTEL_METRICS_INTERVAL,
             OtelSdkSettings.TELEMETRY_OTEL_METRICS_ENABLED,
+            OtelSdkSettings.TELEMETRY_OTEL_METRICS_HISTOGRAM_AGGREGATION,
             // Tracing
             APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING,
             APMAgentSettings.TELEMETRY_TRACING_NAMES_INCLUDE_SETTING,

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkExportMeterSupplier.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkExportMeterSupplier.java
@@ -16,8 +16,11 @@ import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder
 import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.common.InternalTelemetryVersion;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
+import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import io.opentelemetry.sdk.resources.Resource;
 
@@ -101,12 +104,26 @@ public class OtelSdkExportMeterSupplier implements MeterSupplier {
             .setEndpoint(endpoint)
             .setMeterProvider(() -> healthExportMeterProvider)
             .setAggregationTemporalitySelector(AggregationTemporalitySelector.deltaPreferred())
+            .setDefaultAggregationSelector(
+                DefaultAggregationSelector.getDefault().with(InstrumentType.HISTOGRAM, histogramAggregation(settings))
+            )
             .setInternalTelemetryVersion(InternalTelemetryVersion.LATEST);
         String authHeader = buildOtlpAuthorizationHeader(settings);
         if (authHeader != null) {
             builder.addHeader("Authorization", authHeader);
         }
         return builder.build();
+    }
+
+    /**
+     * Resolves the {@link Aggregation} applied to {@code HISTOGRAM} instruments based on
+     * {@link OtelSdkSettings#TELEMETRY_OTEL_METRICS_HISTOGRAM_AGGREGATION}.
+     */
+    static Aggregation histogramAggregation(Settings settings) {
+        return switch (OtelSdkSettings.TELEMETRY_OTEL_METRICS_HISTOGRAM_AGGREGATION.get(settings)) {
+            case EXPLICIT_BUCKET_HISTOGRAM -> Aggregation.explicitBucketHistogram();
+            case BASE2_EXPONENTIAL_BUCKET_HISTOGRAM -> Aggregation.base2ExponentialBucketHistogram();
+        };
     }
 
     /**

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkSettings.java
@@ -38,4 +38,38 @@ public final class OtelSdkSettings {
         false,
         NodeScope
     );
+
+    /**
+     * Default aggregation applied to every {@code HISTOGRAM} instrument exported by the OTel SDK.
+     * <p>
+     * Histograms emitted by Elasticsearch land in metric indices whose ES field type is determined by the
+     * OTLP wire shape. With {@link HistogramAggregation#EXPLICIT_BUCKET_HISTOGRAM} (the default, matching
+     * OTel's built-in default and the behavior prior to this setting being introduced) histograms map to
+     * the ES {@code histogram} field type, which is <strong>not</strong> queryable by ES|QL
+     * {@code percentile()}. With {@link HistogramAggregation#BASE2_EXPONENTIAL_BUCKET_HISTOGRAM} they map
+     * to {@code exponential_histogram}, which ES|QL {@code percentile()} accepts.
+     * <p>
+     * This is set programmatically (via {@link OtelSdkExportMeterSupplier}) rather than read from the
+     * OTel autoconfigure system property {@code otel.exporter.otlp.metrics.default.histogram.aggregation}
+     * because the OTLP exporter here is hand-built and bypasses autoconfigure.
+     * <p>
+     * Note: when the elastic-apm-java agent is also loaded into the JVM (e.g. with
+     * {@code telemetry.agent.server_url} configured for tracing) its parallel metrics exporter does not
+     * yet handle exponential histograms and will throw {@code IndexOutOfBoundsException} per export
+     * cycle. Disable the offending instrumentation with
+     * {@code -Delastic.apm.disable_instrumentations=otelmetricsdk} until
+     * <a href="https://github.com/elastic/apm-agent-java/issues/4464">elastic/apm-agent-java#4464</a>
+     * is resolved.
+     */
+    public static final Setting<HistogramAggregation> TELEMETRY_OTEL_METRICS_HISTOGRAM_AGGREGATION = Setting.enumSetting(
+        HistogramAggregation.class,
+        "telemetry.otel.metrics.histogram.aggregation",
+        HistogramAggregation.EXPLICIT_BUCKET_HISTOGRAM,
+        NodeScope
+    );
+
+    public enum HistogramAggregation {
+        EXPLICIT_BUCKET_HISTOGRAM,
+        BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
+    }
 }

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkExportMeterSupplierTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/export/otelsdk/OtelSdkExportMeterSupplierTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.telemetry.apm.internal.export.otelsdk;
 
+import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporter;
@@ -22,6 +23,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class OtelSdkExportMeterSupplierTests extends ESTestCase {
 
@@ -96,6 +98,32 @@ public class OtelSdkExportMeterSupplierTests extends ESTestCase {
             greaterThan(0)
         );
         supplier.close();
+    }
+
+    /** Default preserves OTel's built-in behavior: explicit-bucket histograms. */
+    public void testHistogramAggregationDefaultsToExplicitBucket() {
+        assertThat(OtelSdkExportMeterSupplier.histogramAggregation(Settings.EMPTY), sameInstance(Aggregation.explicitBucketHistogram()));
+    }
+
+    public void testHistogramAggregationExplicitBucketWhenConfigured() {
+        Settings settings = Settings.builder()
+            .put(OtelSdkSettings.TELEMETRY_OTEL_METRICS_HISTOGRAM_AGGREGATION.getKey(), "EXPLICIT_BUCKET_HISTOGRAM")
+            .build();
+        assertThat(OtelSdkExportMeterSupplier.histogramAggregation(settings), sameInstance(Aggregation.explicitBucketHistogram()));
+    }
+
+    public void testHistogramAggregationBase2ExponentialBucketWhenConfigured() {
+        Settings settings = Settings.builder()
+            .put(OtelSdkSettings.TELEMETRY_OTEL_METRICS_HISTOGRAM_AGGREGATION.getKey(), "BASE2_EXPONENTIAL_BUCKET_HISTOGRAM")
+            .build();
+        assertThat(OtelSdkExportMeterSupplier.histogramAggregation(settings), sameInstance(Aggregation.base2ExponentialBucketHistogram()));
+    }
+
+    public void testHistogramAggregationRejectsUnknownValue() {
+        Settings settings = Settings.builder()
+            .put(OtelSdkSettings.TELEMETRY_OTEL_METRICS_HISTOGRAM_AGGREGATION.getKey(), "TDIGEST")
+            .build();
+        expectThrows(IllegalArgumentException.class, () -> OtelSdkExportMeterSupplier.histogramAggregation(settings));
     }
 
     private static OtelSdkExportMeterSupplier.OTelMetricsResources testResources(InMemoryMetricExporter exporter) {


### PR DESCRIPTION
## Summary

ES|QL `percentile()` requires `exponential_histogram` or `tdigest` field types — it does not support `histogram`. Histograms exported by Elasticsearch via the bundled OTel SDK currently land as explicit-bucket histograms (mapped to `histogram` in metric indices), so values like `es.search_response.took_durations.*` are unqueryable from ES|QL.

This PR adds `telemetry.otel.metrics.histogram.aggregation`, an enum-backed node setting that selects the default aggregation applied to `HISTOGRAM` instruments by the OTLP exporter:

- `EXPLICIT_BUCKET_HISTOGRAM` (default) — preserves prior behavior; equivalent to OTel's built-in default.
- `BASE2_EXPONENTIAL_BUCKET_HISTOGRAM` — emits OTLP exponential histograms; these map to `exponential_histogram` in destination indices and unblock ES|QL `percentile()` queries.

Wired via `OtlpHttpMetricExporterBuilder.setDefaultAggregationSelector` because the SDK is built without OTel autoconfigure, so the analogous OTel system property `otel.exporter.otlp.metrics.default.histogram.aggregation` is not honored here.

## Known limitation

When the bundled elastic-apm-java agent is also loaded, its parallel metrics exporter does not yet handle exponential histograms and throws `IndexOutOfBoundsException` per export cycle. Tracked at elastic/apm-agent-java#4464. Until that is fixed, deployments opting into `BASE2_EXPONENTIAL_BUCKET_HISTOGRAM` should also pass `-Delastic.apm.disable_instrumentations=otelmetricsdk`. This is captured in the new setting's Javadoc. There is a proposed fix in https://github.com/elastic/apm-agent-java/pull/4465.

## Downstream / index mapping note

Producing exponential histograms on the wire is necessary but not sufficient for ES|QL `percentile()` — the destination metric data stream must also map these fields to `exponential_histogram` (not `histogram`). This is a downstream concern (APM Server / index template) outside the scope of this PR.

## Test plan

- [x] New unit tests in `OtelSdkExportMeterSupplierTests`: default value, both enum values, rejection of unknown values.
- [x] `./gradlew :modules:apm:test` passes.
- [x] `./gradlew :modules:apm:spotlessJavaCheck` clean.
- [x] Manual run-task verification: with `--with-apm-server --using-otel-sdk` and `-Dtests.es.telemetry.otel.metrics.histogram.aggregation=BASE2_EXPONENTIAL_BUCKET_HISTOGRAM`, the mock APM server logs `OTLP Metricset:` lines containing the expected `exponential_histogram { scale: 7, positive { offset: …, bucket_counts: … } }` shape for `es.search_response.took_durations.*` instruments.