### PR TITLE
[9.4] Reduce per-call allocation in bulk vector scoring (#148438)

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/AddressesScratch.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/AddressesScratch.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.simdvec.internal;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+/**
+ * Reusable, lazily-grown scratch buffer for an array of native addresses
+ * (pointer-width values), used to hand a contiguous {@code MemorySegment}
+ * of {@code MemorySegment#address()}-style values (array of pointers).
+ *
+ * <p>Not thread-safe; instances must not be shared across threads.
+ */
+public final class AddressesScratch {
+
+    private MemorySegment seg;
+
+    /**
+     * Returns a {@link MemorySegment} of at least {@code count} native-address slots.
+     * The buffer may be larger than requested (it is grown lazily and never shrunk
+     * across calls); callers must respect their own {@code count} when reading or
+     * writing addresses. Always returns the same backing segment for a given
+     * instance until a larger one is needed.
+     */
+    public MemorySegment get(int count) {
+        long needed = (long) count * ValueLayout.ADDRESS.byteSize();
+        if (seg == null || seg.byteSize() < needed) {
+            seg = Arena.ofAuto().allocate(needed, ValueLayout.ADDRESS.byteAlignment());
+        }
+        return seg;
+    }
+}

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/ByteVectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/ByteVectorScorer.java
@@ -36,6 +36,8 @@ public abstract sealed class ByteVectorScorer extends RandomVectorScorer.Abstrac
     final IndexInput input;
     final MemorySegment query;
     byte[] scratch;
+    final AddressesScratch addrsScratch = new AddressesScratch();
+    final OffsetsScratch offsetsScratch = new OffsetsScratch();
 
     public static Optional<RandomVectorScorer> create(VectorSimilarityFunction sim, ByteVectorValues values, byte[] queryVector) {
         if (SUPPORTS_HEAP_SEGMENTS == false) {
@@ -99,11 +101,11 @@ public abstract sealed class ByteVectorScorer extends RandomVectorScorer.Abstrac
         if (numNodes == 0) {
             return false;
         }
-        long[] offsets = new long[numNodes];
+        long[] offsets = offsetsScratch.get(numNodes);
         for (int i = 0; i < numNodes; i++) {
             offsets[i] = (long) nodes[i] * vectorByteSize;
         }
-        return IndexInputUtils.withSliceAddresses(input, offsets, vectorByteSize, numNodes, a -> {
+        return IndexInputUtils.withSliceAddresses(input, offsets, vectorByteSize, numNodes, addrsScratch::get, a -> {
             sparseScorer.score(a, query, dimensions, numNodes, MemorySegment.ofArray(scores));
         });
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/IndexInputUtils.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/IndexInputUtils.java
@@ -181,13 +181,18 @@ public final class IndexInputUtils {
      * the lifetime contract explicit and protect against future changes to either
      * the callers or the backing-memory implementations.
      *
-     * @param in      the index input
-     * @param offsets file byte offsets for each range (caller-owned, not modified)
-     * @param length  byte length of each range (same for all)
-     * @param count   number of ranges to resolve
-     * @param action  receives a {@link MemorySegment} of {@code count} pointer-width
-     *                addresses, allocated from a confined arena that is closed after
-     *                the action returns
+     * @param in            the index input
+     * @param offsets       file byte offsets for each range (caller-owned, not modified)
+     * @param length        byte length of each range (same for all)
+     * @param count         number of ranges to resolve
+     * @param addressesBufferSupplier  called with {@code count}; must return a writable
+     *                      {@link MemorySegment} with room for at least {@code count}
+     *                      pointer-width entries. The segment may be larger and may be
+     *                      reused across calls; only entries {@code [0, count)} are
+     *                      written by this method.
+     * @param action        invoked with the same segment returned by the supplier; only
+     *                      the first {@code count} address slots contain valid data, and
+     *                      those addresses are valid only for the duration of the call.
      * @return {@code true} if addresses were resolved and the action was invoked
      */
     public static boolean withSliceAddresses(
@@ -195,14 +200,18 @@ public final class IndexInputUtils {
         long[] offsets,
         int length,
         int count,
+        IntFunction<MemorySegment> addressesBufferSupplier,
         CheckedConsumer<MemorySegment, IOException> action
     ) throws IOException {
         assert validateInputs(in, offsets, length, count);
+        MemorySegment addrs = addressesBufferSupplier.apply(count);
+        assert addrs.byteSize() >= (long) count * ValueLayout.ADDRESS.byteSize()
+            : "address buffer too small: " + addrs.byteSize() + " < " + ((long) count * ValueLayout.ADDRESS.byteSize());
         if (in instanceof MemorySegmentAccessInput msai) {
-            return resolveFromMmap(msai, offsets, length, count, action);
+            return resolveFromMmap(msai, offsets, length, count, addrs, action);
         }
         if (in instanceof DirectAccessInput dai) {
-            return resolveFromDirectAccess(dai, offsets, length, count, action);
+            return resolveFromDirectAccess(dai, offsets, length, count, addrs, action);
         }
         return false;
     }
@@ -212,24 +221,26 @@ public final class IndexInputUtils {
         long[] offsets,
         int length,
         int count,
+        MemorySegment addrs,
         CheckedConsumer<MemorySegment, IOException> action
     ) throws IOException {
-        MemorySegment full = msai.segmentSliceOrNull(0, ((IndexInput) msai).length());
-        if (full == null) {
-            return false;
+        for (int i = 0; i < count; i++) {
+            var segment = msai.segmentSliceOrNull(offsets[i], length);
+            if (segment == null) {
+                return false;
+            }
+            assert validateNativeSegment(segment, "mmap segment");
+            addrs.setAtIndex(ValueLayout.ADDRESS, i, segment);
         }
-        assert validateNativeSegment(full, "mmap segment");
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment addrs = allocateAddrs(arena, count);
-            for (int i = 0; i < count; i++) {
-                addrs.setAtIndex(ValueLayout.ADDRESS, i, full.asSlice(offsets[i], length));
-            }
-            assert validateAddresses(addrs, count);
-            try {
-                action.accept(addrs);
-            } finally {
-                Reference.reachabilityFence(full);
-            }
+        assert validateAddresses(addrs, count);
+        try {
+            action.accept(addrs);
+        } finally {
+            // We rely on the MSAI contract that segments returned by
+            // segmentSliceOrNull remain valid until the input is closed:
+            // keeping msai reachable across the native call keeps the
+            // backing memory alive.
+            Reference.reachabilityFence(msai);
         }
         return true;
     }
@@ -239,27 +250,21 @@ public final class IndexInputUtils {
         long[] offsets,
         int length,
         int count,
+        MemorySegment addrs,
         CheckedConsumer<MemorySegment, IOException> action
     ) throws IOException {
         return dai.withByteBufferSlices(offsets, length, count, bbs -> {
             assert validateByteBuffers(bbs, count, length);
-            try (Arena arena = Arena.ofConfined()) {
-                MemorySegment addrs = allocateAddrs(arena, count);
-                for (int i = 0; i < count; i++) {
-                    addrs.setAtIndex(ValueLayout.ADDRESS, i, MemorySegment.ofBuffer(bbs[i]));
-                }
-                assert validateAddresses(addrs, count);
-                try {
-                    action.accept(addrs);
-                } finally {
-                    Reference.reachabilityFence(bbs);
-                }
+            for (int i = 0; i < count; i++) {
+                addrs.setAtIndex(ValueLayout.ADDRESS, i, MemorySegment.ofBuffer(bbs[i]));
+            }
+            assert validateAddresses(addrs, count);
+            try {
+                action.accept(addrs);
+            } finally {
+                Reference.reachabilityFence(bbs);
             }
         });
-    }
-
-    private static MemorySegment allocateAddrs(Arena arena, int count) {
-        return arena.allocate(ValueLayout.ADDRESS.byteSize() * count, ValueLayout.ADDRESS.byteAlignment());
     }
 
     private static boolean validateInputs(IndexInput in, long[] offsets, int length, int count) {

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int4VectorScorer.java
@@ -141,6 +141,8 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
         private final Int4Corrections.SingleCorrection correction;
         private final Int4Corrections.BulkCorrection bulkCorrection;
         private byte[] scratch;
+        private final AddressesScratch addrsScratch = new AddressesScratch();
+        private final OffsetsScratch offsetsScratch = new OffsetsScratch();
 
         ScorerImpl(
             IndexInput input,
@@ -216,15 +218,21 @@ public final class Int4VectorScorer extends RandomVectorScorer.AbstractRandomVec
                 return Float.NEGATIVE_INFINITY;
             }
             if (SUPPORTS_HEAP_SEGMENTS) {
-                long[] offsets = new long[numNodes];
+                long[] offsets = offsetsScratch.get(numNodes);
                 for (int i = 0; i < numNodes; i++) {
                     offsets[i] = (long) ordinals[i] * vectorPitch;
                 }
-                boolean resolved = IndexInputUtils.withSliceAddresses(input, offsets, packedDims, numNodes, addrs -> {
-                    dotProductI4BulkSparse(addrs, query.unpackedQuery(), packedDims, numNodes, MemorySegment.ofArray(scores));
-                });
+                MemorySegment scoresSeg = MemorySegment.ofArray(scores);
+                boolean resolved = IndexInputUtils.withSliceAddresses(
+                    input,
+                    offsets,
+                    packedDims,
+                    numNodes,
+                    addrsScratch::get,
+                    addrs -> dotProductI4BulkSparse(addrs, query.unpackedQuery(), packedDims, numNodes, scoresSeg)
+                );
                 if (resolved) {
-                    return applyCorrectionsBulk(MemorySegment.ofArray(scores), MemorySegment.ofArray(ordinals), numNodes, query);
+                    return applyCorrectionsBulk(scoresSeg, MemorySegment.ofArray(ordinals), numNodes, query);
                 }
             }
 

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7SQVectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/Int7SQVectorScorer.java
@@ -38,6 +38,8 @@ public abstract sealed class Int7SQVectorScorer extends RandomVectorScorer.Abstr
     final float scoreCorrectionConstant;
     final float queryCorrection;
     byte[] scratch;
+    final AddressesScratch addrsScratch = new AddressesScratch();
+    final OffsetsScratch offsetsScratch = new OffsetsScratch();
 
     /** Return an optional whose value, if present, is the scorer. Otherwise, an empty optional is returned. */
     public static Optional<RandomVectorScorer> create(VectorSimilarityFunction sim, QuantizedByteVectorValues values, float[] queryVector) {
@@ -106,11 +108,11 @@ public abstract sealed class Int7SQVectorScorer extends RandomVectorScorer.Abstr
         if (numNodes == 0) {
             return false;
         }
-        long[] offsets = new long[numNodes];
+        long[] offsets = offsetsScratch.get(numNodes);
         for (int i = 0; i < numNodes; i++) {
             offsets[i] = (long) nodes[i] * vectorPitch;
         }
-        return IndexInputUtils.withSliceAddresses(input, offsets, vectorByteSize, numNodes, a -> {
+        return IndexInputUtils.withSliceAddresses(input, offsets, vectorByteSize, numNodes, addrsScratch::get, a -> {
             sparseScorer.score(a, query, vectorByteSize, numNodes, MemorySegment.ofArray(scores));
         });
     }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/OffsetsScratch.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/OffsetsScratch.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.simdvec.internal;
+
+/**
+ * Reusable, lazily-grown {@code long[]} scratch buffer. Holding
+ * one instance per scorer avoids allocating a fresh {@code long[]} on
+ * every bulk-score call.
+ *
+ * <p>Not thread-safe; instances must not be shared across threads.
+ */
+public final class OffsetsScratch {
+
+    private long[] offsets;
+
+    /**
+     * Returns a {@code long[]} of at least {@code count} slots. The buffer
+     * may be larger than requested (it is grown lazily and never shrunk
+     * across calls); callers must respect their own {@code count} when
+     * reading or writing.
+     */
+    public long[] get(int count) {
+        if (offsets == null || offsets.length < count) {
+            offsets = new long[count];
+        }
+        return offsets;
+    }
+}

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/NativeBinaryQuantizedVectorScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/NativeBinaryQuantizedVectorScorer.java
@@ -11,7 +11,9 @@ package org.elasticsearch.simdvec.internal.vectorization;
 
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.simdvec.internal.AddressesScratch;
 import org.elasticsearch.simdvec.internal.IndexInputUtils;
+import org.elasticsearch.simdvec.internal.OffsetsScratch;
 import org.elasticsearch.simdvec.internal.Similarities;
 
 import java.io.IOException;
@@ -21,6 +23,8 @@ import java.lang.foreign.ValueLayout;
 public class NativeBinaryQuantizedVectorScorer extends DefaultES93BinaryQuantizedVectorScorer {
 
     private byte[] scratch;
+    private final AddressesScratch addrsScratch = new AddressesScratch();
+    private final OffsetsScratch offsetsScratch = new OffsetsScratch();
 
     public NativeBinaryQuantizedVectorScorer(IndexInput in, int dimensions, int vectorLengthInBytes) {
         super(in, dimensions, vectorLengthInBytes);
@@ -79,12 +83,12 @@ public class NativeBinaryQuantizedVectorScorer extends DefaultES93BinaryQuantize
         if (bulkSize == 0) {
             return Float.NEGATIVE_INFINITY;
         }
-        long[] vectorOffsets = new long[bulkSize];
+        long[] vectorOffsets = offsetsScratch.get(bulkSize);
         for (int i = 0; i < bulkSize; i++) {
             vectorOffsets[i] = (long) nodes[i] * byteSize;
         }
 
-        boolean resolved = IndexInputUtils.withSliceAddresses(slice, vectorOffsets, numBytes, bulkSize, addrs -> {
+        boolean resolved = IndexInputUtils.withSliceAddresses(slice, vectorOffsets, numBytes, bulkSize, addrsScratch::get, addrs -> {
             Similarities.dotProductD1Q4BulkSparse(addrs, MemorySegment.ofArray(q), numBytes, bulkSize, MemorySegment.ofArray(scores));
         });
 

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/IndexInputUtilsTests.java
@@ -233,13 +233,9 @@ public class IndexInputUtilsTests extends ESTestCase {
                 assertThat(in, not(instanceOf(MemorySegmentAccessInput.class)));
                 assertThat(in, not(instanceOf(DirectAccessInput.class)));
                 long[] offsets = { 0, 64, 128, 192 };
-                boolean result = IndexInputUtils.withSliceAddresses(
-                    in,
-                    offsets,
-                    64,
-                    4,
-                    a -> { fail("action should not be called for plain IndexInput"); }
-                );
+                boolean result = IndexInputUtils.withSliceAddresses(in, offsets, 64, 4, new AddressesScratch()::get, a -> {
+                    fail("action should not be called for plain IndexInput");
+                });
                 assertFalse(result);
             }
         }
@@ -251,7 +247,7 @@ public class IndexInputUtilsTests extends ESTestCase {
         for (int i = 0; i < count; i++) {
             offsets[i] = (long) i * sliceLen * 2;
         }
-        boolean result = IndexInputUtils.withSliceAddresses(in, offsets, sliceLen, count, a -> {
+        boolean result = IndexInputUtils.withSliceAddresses(in, offsets, sliceLen, count, new AddressesScratch()::get, a -> {
             for (int i = 0; i < count; i++) {
                 MemorySegment addr = a.getAtIndex(ValueLayout.ADDRESS, i);
                 assertTrue("address should be non-null", addr != MemorySegment.NULL);


### PR DESCRIPTION
Backport of #148438