### PR TITLE
Add Uyghur community analysis plugin

### DIFF
--- a/docs/changelog/148570.yaml
+++ b/docs/changelog/148570.yaml
@@ -1,0 +1,5 @@
+area: Analysis
+issues: []
+pr: 148570
+summary: Add Uyghur community analysis plugin to analysis plugin docs
+type: enhancement

--- a/docs/reference/elasticsearch-plugins/analysis-plugins.md
+++ b/docs/reference/elasticsearch-plugins/analysis-plugins.md
@@ -42,6 +42,7 @@ A number of analysis plugins have been contributed by our community:
 * [Pinyin Analysis Plugin](https://github.com/medcl/elasticsearch-analysis-pinyin) (by Medcl)
 * [Vietnamese Analysis Plugin](https://github.com/duydo/elasticsearch-analysis-vietnamese) (by Duy Do)
 * [STConvert Analysis Plugin](https://github.com/medcl/elasticsearch-analysis-stconvert) (by Medcl)
+* [Uyghur Analysis Plugin](https://github.com/TocharianOU/elastic-uyghur-analyzer) (by TocharianOU)
 
 
 


### PR DESCRIPTION
## Summary
- Adds the Uyghur Analysis Plugin to the community contributed analysis plugins list.
- The plugin provides morphology-based Uyghur analyzers for Elasticsearch 8.x and 9.x, with release artifacts for each supported major version.

## Verification
- Documentation-only change.
- Plugin repository CI currently verifies Elasticsearch 8.7.0, 8.19.15, and 9.4.0 Docker smoke tests.