### PR TITLE
Add Uyghur community analysis plugin

### DIFF
--- a/docs/changelog/148571.yaml
+++ b/docs/changelog/148571.yaml
@@ -1,0 +1,5 @@
+area: Analysis
+issues: []
+pr: 148571
+summary: Add Uyghur community analysis plugin to analysis plugin docs
+type: enhancement

--- a/docs/plugins/analysis.asciidoc
+++ b/docs/plugins/analysis.asciidoc
@@ -53,6 +53,7 @@ A number of analysis plugins have been contributed by our community:
 * https://github.com/medcl/elasticsearch-analysis-pinyin[Pinyin Analysis Plugin] (by Medcl)
 * https://github.com/duydo/elasticsearch-analysis-vietnamese[Vietnamese Analysis Plugin] (by Duy Do)
 * https://github.com/medcl/elasticsearch-analysis-stconvert[STConvert Analysis Plugin] (by Medcl)
+* https://github.com/TocharianOU/elastic-uyghur-analyzer[Uyghur Analysis Plugin] (by TocharianOU)
 
 include::analysis-icu.asciidoc[]
 


### PR DESCRIPTION
## Summary
- Adds the Uyghur Analysis Plugin to the community contributed analysis plugins list for the 8.19 docs branch.
- The plugin provides morphology-based Uyghur analyzers and includes an Elasticsearch 8.x release artifact verified against 8.19.15.

## Verification
- Documentation-only change.
- Plugin repository CI verifies Elasticsearch 8.7.0 and 8.19.15 Docker smoke tests for the ES8 artifact.