### PR TITLE
[9.3] [Gradle] Cleanup on build logic integration testing and build documentation  (#142614)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -27,8 +27,59 @@ These build tools are also used by the `elasticsearch-hadoop` project maintained
 
 ### `build-tools-internal`
 
-This project contains all Elasticsearch project specific build logic that is not meant to be shared
+This project contains all Elasticsearch project specific build logic not meant to be shared
 with other internal or external projects.
+
+## Third-Party Gradle Plugins
+
+The Elasticsearch build uses several third-party Gradle plugins. All versions are centralized in
+`/gradle/build.versions.toml` (version catalog).
+
+### Build Infrastructure Plugins
+
+| Plugin ID | Purpose |
+|-----------|---------|
+| `com.gradle.develocity` | Enables build scans and integration with Gradle Enterprise at `gradle-enterprise.elastic.co`. Provides build performance metrics, failure diagnostics, and CI integration for Buildkite. |
+| `com.gradleup.nmcp.aggregation` | Aggregates all Maven artifacts from projects applying `elasticsearch.publish` for publishing to Maven Central via DRA infrastructure. |
+
+### Packaging & Distribution Plugins
+
+| Plugin ID | Purpose |
+|-----------|---------|
+| `com.netflix.nebula.ospackage-base` | Creates DEB and RPM Linux packages for Elasticsearch distribution. Handles package metadata, install/remove scripts, file permissions, and package signing. |
+| `com.gradleup.shadow` | Creates fat JARs (uber-jars) by merging dependencies into a single JAR. Used for standalone CLI tools (`plugin-cli`, `sql-cli`) and the JDBC driver. |
+
+### Code Quality & Precommit Plugins
+
+| Plugin ID | Purpose |
+|-----------|---------|
+| `de.thetaphi:forbiddenapis` | Static bytecode analysis that detects invocations of forbidden API methods. Ensures code doesn't use unsafe or deprecated JDK APIs. Integrated via `ForbiddenApisPrecommitPlugin`. |
+| `org.apache.rat:apache-rat` | License header validation (Apache RAT - Release Audit Tool). Ensures all source files have proper license headers. |
+| `com.diffplug.spotless` | Code formatting enforcement using Eclipse JDT formatter. Provides `spotlessJavaCheck` and `spotlessApply` tasks. Configuration in `build-conventions/formatterConfig.xml`. |
+
+### Build Metadata & Tooling Plugins
+
+| Plugin ID | Purpose |
+|-----------|---------|
+| `com.netflix.nebula:gradle-info-plugin` | Automatically includes build metadata (git info, build time, Java version) in JAR manifests. Applied as `nebula.info-broker`, `nebula.info-basic`, `nebula.info-java`, `nebula.info-jar`. |
+| `com.avast.gradle:docker-compose` | Manages Docker Compose environments for integration testing fixtures. Used by `TestFixturesPlugin` for test infrastructure (AWS, Azure, GCS, HDFS mocks). |
+| `org.jetbrains.gradle.plugin.idea-ext` | Enhanced IntelliJ IDEA project configuration. Customizes IDE settings, JUnit configurations, and post-sync tasks. |
+
+## Internal Plugin Selection Guide
+
+When creating a new subproject, choose the appropriate Elasticsearch plugin based on your project type:
+
+| Project Type | Plugin to Apply | Example Projects |
+|--------------|-----------------|------------------|
+| Core library | `elasticsearch.build` | `server`, `libs/*` |
+| Module shipped with ES | `elasticsearch.internal-es-plugin` | `modules/*` |
+| External plugin | `elasticsearch.internal-es-plugin` + `elasticsearch.publish` | `plugins/*` |
+| X-Pack plugin | `elasticsearch.internal-es-plugin` + `elasticsearch.publish` | `x-pack/plugin/*` |
+| YAML REST tests | `elasticsearch.internal-yaml-rest-test` | modules/plugins with REST APIs |
+| Java REST tests | `elasticsearch.internal-java-rest-test` | modules/plugins needing Java test flexibility |
+| Cluster integration tests | `elasticsearch.internal-cluster-test` | Projects testing cluster behavior |
+| BWC/upgrade tests | `elasticsearch.bwc-test` or `elasticsearch.fwc-test` | `qa/rolling-upgrade`, `qa/full-cluster-restart` |
+| Standalone QA project | `elasticsearch.standalone-rest-test` | `qa/*` subprojects |
 
 ## Build guidelines
 
@@ -161,16 +212,25 @@ When adding or updating dependencies, ensure that any required transitive depend
 2. Added as direct dependencies if they're actually used by our code
 3. Properly excluded if they're not needed
 
-#### Custom plugin and task implementations
+#### Custom Gradle plugin and Gradle task implementations
 
-Build logic that is used across multiple subprojects should be considered to be moved into a Gradle plugin with according Gradle task implementation.
-Elasticsearch specific build logic is located in the `build-tools-internal` subproject including integration tests.
+Build logic that is used across multiple subprojects should be considered to be
+moved into a Gradle plugin with according Gradle task implementation.
+Elasticsearch specific build logic is located in the `build-tools-internal`
+subproject including integration tests.
 
 - Gradle plugins and Tasks should be written in Java
 - We use a groovy and spock for setting up Gradle integration tests.
-  (see https://github.com/elastic/elasticsearch/blob/main/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy)
+- For each Gradle Plugin and Gradle Task implementation (e.g.
+  org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin) we aim for
+  a dedicated
+    - unit test class containing all relaed unit tests in src/test (e.g. GlobalBuildInfoPluginSpec) for basic unit testing of
+      the plugin logic and
+    - integration test containing all related Gradle TestKit based integration tests in src/integTest (e.g. GlobalBuildInfoPluginFuncTest) for testing the
+      plugin in a real Gradle build based on
+      src/main/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy)
 
-#### Declaring tasks
+#### Declaring Gradle tasks
 
 The Elasticsearch build makes use of the [task avoidance API](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) to keep the configuration time of the build low.
 
@@ -240,6 +300,69 @@ similar to how the Gradle build-in `java-test-fixtures` plugin works.
 dependencies {
   testImplementation(project(":fixture-providing-project')) {
     requireCapabilities(${project(":fixture-providing-project').group}:fixture-providing-project-test-artifacts")
+  }
+}
+```
+
+#### Configuring precommit tasks
+
+Several precommit tasks support project-specific configuration. Use the task avoidance API when configuring them.
+
+##### thirdPartyAudit
+
+Configure missing class and violation ignores when third-party dependencies use optional APIs:
+
+```groovy
+tasks.named("thirdPartyAudit").configure {
+  // Ignore classes that are optional dependencies of our dependencies
+  ignoreMissingClasses(
+    'javax.servlet.ServletContextEvent',
+    'org.apache.log.Logger'
+  )
+
+  // Ignore known-safe internal API usage in dependencies
+  ignoreViolations(
+    'com.google.common.hash.Striped64'
+  )
+}
+```
+
+##### dependencyLicenses
+
+Map related artifacts to a single license when dependencies are published as multiple JARs:
+
+```groovy
+tasks.named("dependencyLicenses").configure {
+  mapping from: /lucene-.*/, to: 'lucene'
+  mapping from: /netty-.*/, to: 'netty'
+  mapping from: /jackson-.*/, to: 'jackson'
+}
+```
+
+##### forbiddenPatterns
+
+Exclude files that legitimately contain patterns detected as forbidden:
+
+```groovy
+tasks.named("forbiddenPatterns").configure {
+  exclude '**/*.key'     // Test certificates
+  exclude '**/*.p12'     // PKCS12 keystores
+  exclude '**/*.json'    // Test data files
+}
+```
+
+#### Configuring REST resources
+
+Projects with REST APIs should declare which specs and tests they need:
+
+```groovy
+restResources {
+  restApi {
+    include '_common', 'cluster', 'indices', 'your_api_name'
+  }
+  restTests {
+    includeCore 'your_api_tests'  // For core APIs
+    includeXpack 'your_xpack_tests'  // For X-Pack APIs
   }
 }
 ```
@@ -314,7 +437,7 @@ by JitPack in the background before we can resolve the adhoc built dependency.
 
 > [!Note]
 > You should only use that approach locally or on a developer branch for production dependencies as we do
-not want to ship unreleased libraries into our releases.
+> not want to ship unreleased libraries into our releases.
 
 #### How to use a custom third party artifact?
 
@@ -352,7 +475,7 @@ allprojects {
 
 > [!Note]
 > As Gradle prefers to use modules whose descriptor has been created from real meta-data rather than being generated,
-flat directory repositories cannot be used to override artifacts with real meta-data from other repositories declared in the build.
+> flat directory repositories cannot be used to override artifacts with real meta-data from other repositories declared in the build.
 > For example, if Gradle finds only `jmxri-1.2.1.jar` in a flat directory repository, but `jmxri-1.2.1.pom` in another repository
-that supports meta-data, it will use the second repository to provide the module.
+> that supports meta-data, it will use the second repository to provide the module.
 > Therefore, it is recommended to declare a version that is not resolvable from public repositories we use (e.g. Maven Central)

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaPluginFuncTest.groovy
@@ -16,7 +16,7 @@ class ElasticsearchJavaPluginFuncTest extends AbstractGradleInternalPluginFuncTe
 
     Class<? extends Plugin> pluginClassUnderTest = ElasticsearchJavaPlugin.class
 
-    def "compatibility options are resolved from from build params minimum runtime version"() {
+    def "compatibility options are resolved from build params minimum runtime version"() {
         when:
         buildFile.text << """
         import org.elasticsearch.gradle.Architecture

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
@@ -481,7 +481,6 @@ def "handles project shadow dependencies"() {
 def "generates artifacts for shadowed elasticsearch plugin"() {
     given:
     // we use the esplugin plugin in this test that is not configuration cache compatible yet
-    configurationCacheCompatible = false
     file('license.txt') << "License file"
     file('notice.txt') << "Notice file"
     buildFile << """
@@ -572,7 +571,6 @@ def "generates artifacts for shadowed elasticsearch plugin"() {
 def "generates pom for elasticsearch plugin"() {
     given:
     // we use the esplugin plugin in this test that is not configuration cache compatible yet
-    configurationCacheCompatible = false
     file('license.txt') << "License file"
     file('notice.txt') << "Notice file"
     buildFile << """
@@ -712,20 +710,14 @@ private boolean assertXmlEquals(String toTest, String expected) {
         .normalizeWhitespace()
         .withTest(Input.fromString(toTest))
         .build()
-    diff.differences.each { difference ->
-        println difference
+    if (diff.hasDifferences()) {
+        def message = "XML documents differ:\n"
+        diff.differences.each { difference ->
+            message += "  ${difference}\n"
+        }
+        message += "\ngiven:\n${toTest}\n\nexpected:\n${expected}\n"
+        assert false : message
     }
-    if (diff.differences.size() > 0) {
-        println """ given:
-$toTest
-"""
-        println """ expected:
-$expected
-"""
-
-
-    }
-    assert diff.hasDifferences() == false
     true
 }
 

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/StringTemplatePluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/StringTemplatePluginFuncTest.groovy
@@ -12,11 +12,14 @@ package org.elasticsearch.gradle.internal;
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest;
 import org.gradle.testkit.runner.TaskOutcome;
 
-class StringTemplatePluginTest extends AbstractGradleFuncTest {
+class StringTemplatePluginFuncTest extends AbstractGradleFuncTest {
+
+    def setup() {
+        internalBuild()
+    }
 
     def "test substitution"() {
         given:
-        internalBuild()
         file('src/main/p/X-Box.java.st') << """
           public class \$Type\$Box {
             final \$type\$ value;
@@ -77,7 +80,6 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
 
     def "test basic conditional"() {
         given:
-        internalBuild()
         file('src/main/Color.txt.st') << """
           \$if(Red)\$1 Red\$endif\$
           \$if(Blue)\$2 Blue\$endif\$
@@ -112,7 +114,6 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
 
     def "test if then else"() {
         given:
-        internalBuild()
         file('src/main/Token.txt.st') << """
           \$if(Foo)\$1 Foo
           \$elseif(Bar)\$2 Bar
@@ -147,7 +148,6 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
 
     def "output file already present and up to date"() {
         given:
-        internalBuild()
         file('src/main/UpToDate.txt.st') << """
           Hello World!
         """.stripIndent().stripTrailing()
@@ -183,7 +183,6 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
 
     def "output file already present but not up to date"() {
         given:
-        internalBuild()
         file('src/main/Message.txt.st') << """
           Hello World!
         """.stripIndent().stripTrailing()
@@ -219,7 +218,6 @@ class StringTemplatePluginTest extends AbstractGradleFuncTest {
 
     def "cleanup delete files"() {
         given:
-        internalBuild()
         file('src/main/generated-src/someFile.txt') << """
           Just some random data
         """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distribution/ElasticsearchDistributionPluginFuncTest.groovy
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-package org.elasticsearch.gradle.internal.distibution
+package org.elasticsearch.gradle.internal.distribution
 
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
 import org.gradle.testkit.runner.TaskOutcome

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPluginFuncTest.groovy
@@ -10,18 +10,18 @@
 package org.elasticsearch.gradle.internal.doc
 
 import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
-import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin
+import org.gradle.api.Plugin
 import org.gradle.testkit.runner.TaskOutcome
 
 class DocsTestPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
-    Class<? extends PrecommitPlugin> pluginClassUnderTest = DocsTestPlugin.class
+    Class<? extends Plugin> pluginClassUnderTest = DocsTestPlugin.class
 
     def setup() {
-        File docDir = new File(projectDir, 'doc');
+        File docDir = new File(projectDir, 'doc')
         docDir.mkdirs()
         addSampleDoc(docDir)
         buildApiRestrictionsDisabled = true
-    configurationCacheCompatible = false;
+        configurationCacheCompatible = false
         buildFile << """
 tasks.named('listSnippets') {
    docs = fileTree('doc')

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/dra/DraResolvePluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/dra/DraResolvePluginFuncTest.groovy
@@ -15,6 +15,7 @@ import org.elasticsearch.gradle.fixtures.WiremockFixture
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.ClassRule
 import spock.lang.Shared
+import spock.lang.Unroll
 
 class DraResolvePluginFuncTest extends AbstractGradleFuncTest {
 
@@ -38,7 +39,7 @@ class DraResolvePluginFuncTest extends AbstractGradleFuncTest {
     }
 
     def "provides flag indicating dra usage"() {
-        setup:
+        given:
         repository.generateJar("org.acme", "ml-cpp", "8.6.0-SNAPSHOT")
         buildFile << """
         if(useDra == false) {
@@ -84,8 +85,9 @@ class DraResolvePluginFuncTest extends AbstractGradleFuncTest {
         result.output.contains("Cannot resolve external dependency org.acme:ml-cpp:8.6.0-SNAPSHOT because no repositories are defined.")
     }
 
+    @Unroll
     def "configures repositories to resolve #draKey like dra #workflow artifacts"() {
-        setup:
+        given:
         repository.generateJar("some.group", "bar", "1.0.0")
         repository.generateJar("some.group", "baz", "1.0.0-SNAPSHOT")
         repository.configureBuild(buildFile)

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/LicenseHeadersPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/LicenseHeadersPrecommitPluginFuncTest.groovy
@@ -38,7 +38,7 @@ class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleInternalPlugin
         assertOutputContains(result.output, "> Check failed. License header problems were found. Full details: ./build/reports/licenseHeaders/rat.xml")
         assertOutputContains(result.output, "./src/main/java/org/acme/UnknownLicensed.java")
         assertOutputContains(result.output, "./src/main/java/org/acme/UnapprovedLicensed.java")
-        result.output.contains("./src/main/java/org/acme/DualLicensed.java") == false
+        assertOutputMissing(result.output, "./src/main/java/org/acme/DualLicensed.java")
     }
 
     def "can filter source files"() {
@@ -88,7 +88,7 @@ class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleInternalPlugin
     }
 
     private File unapprovedSourceFile(String filePath = "src/main/java/org/acme/UnapprovedLicensed.java") {
-        File sourceFile = file(filePath);
+        File sourceFile = file(filePath)
         sourceFile << """
 /*
  * Copyright (C) 2007 Google Inc.
@@ -114,7 +114,7 @@ class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleInternalPlugin
     }
 
     private File unknownSourceFile(String filePath = "src/main/java/org/acme/UnknownLicensed.java") {
-        File sourceFile = file(filePath);
+        File sourceFile = file(filePath)
         sourceFile << """
 /*
  * Blubb my custom license shrug!

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPluginFuncTest.groovy
@@ -15,9 +15,7 @@ import net.bytebuddy.description.modifier.Visibility
 import net.bytebuddy.dynamic.DynamicType
 import net.bytebuddy.implementation.FixedValue
 import org.apache.logging.log4j.LogManager
-import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
 import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
-import org.elasticsearch.gradle.internal.conventions.precommit.LicenseHeadersPrecommitPlugin
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -25,7 +23,7 @@ import org.gradle.testkit.runner.TaskOutcome
 
 import static org.elasticsearch.gradle.fixtures.TestClasspathUtils.setupJarJdkClasspath
 
-class ThirdPartyAuditTaskFuncTest extends AbstractGradleInternalPluginFuncTest {
+class ThirdPartyAuditPrecommitPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
 
     Class<? extends PrecommitPlugin> pluginClassUnderTest = ThirdPartyAuditPrecommitPlugin.class
 

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -123,6 +123,7 @@ abstract class AbstractGradleFuncTest extends Specification {
                                 )
                                 .withProjectDir(projectDir)
                                 .withPluginClasspath()
+                                .withTestKitDir(gradleUserHome)
                                 .forwardOutput()
             ), configurationCacheCompatible,
                 buildApiRestrictionsDisabled)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Gradle] Cleanup on build logic integration testing and build documentation  (#142614)](https://github.com/elastic/elasticsearch/pull/142614)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)