### PR TITLE
[9.3] Use toTruncatedString in chunked objects toString (#147860)

### DIFF
--- a/docs/changelog/147860.yaml
+++ b/docs/changelog/147860.yaml
@@ -1,0 +1,6 @@
+area: Infra/Core
+issues:
+ - 143694
+pr: 147860
+summary: Use `toTruncatedString` in chunked objects `toString`
+type: bug

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1478,7 +1478,7 @@ public class DataStreamIT extends ESIntegTestCase {
         bulkRequest.add(new IndexRequest("logs-barbaz").opType(CREATE).source("{\"@timestamp\": \"2020-12-12\"}", XContentType.JSON));
         bulkRequest.add(new IndexRequest("logs-barfoo").opType(CREATE).source("{\"@timestamp\": \"2020-12-12\"}", XContentType.JSON));
         BulkResponse bulkResponse = client().bulk(bulkRequest).actionGet();
-        assertThat("bulk failures: " + Strings.toString(bulkResponse), bulkResponse.hasFailures(), is(false));
+        assertThat("bulk failures: " + Strings.toTruncatedString(bulkResponse), bulkResponse.hasFailures(), is(false));
 
         bulkRequest = new BulkRequest();
         bulkRequest.add(new IndexRequest("logs-foobar").opType(CREATE).source("{\"@timestamp\": \"2020-12-12\"}", XContentType.JSON));
@@ -1486,7 +1486,7 @@ public class DataStreamIT extends ESIntegTestCase {
         bulkRequest.add(new IndexRequest("logs-barbaz").opType(CREATE).source("{\"@timestamp\": \"2020-12-12\"}", XContentType.JSON));
         bulkRequest.add(new IndexRequest("logs-barfoo2").opType(CREATE).source("{\"@timestamp\": \"2020-12-12\"}", XContentType.JSON));
         bulkResponse = client().bulk(bulkRequest).actionGet();
-        assertThat("bulk failures: " + Strings.toString(bulkResponse), bulkResponse.hasFailures(), is(false));
+        assertThat("bulk failures: " + Strings.toTruncatedString(bulkResponse), bulkResponse.hasFailures(), is(false));
 
         bulkRequest = new BulkRequest();
         bulkRequest.add(new IndexRequest("logs-foobar").opType(CREATE).source("{\"@timestamp\": \"2020-12-12\"}", XContentType.JSON));
@@ -1496,7 +1496,7 @@ public class DataStreamIT extends ESIntegTestCase {
         bulkRequest.add(new IndexRequest("logs-barfoo2").opType(CREATE).source("{\"@timestamp\": \"2020-12-12\"}", XContentType.JSON));
         bulkRequest.add(new IndexRequest("logs-barfoo3").opType(CREATE).source("{\"@timestamp\": \"2020-12-12\"}", XContentType.JSON));
         bulkResponse = client().bulk(bulkRequest).actionGet();
-        assertThat("bulk failures: " + Strings.toString(bulkResponse), bulkResponse.hasFailures(), is(false));
+        assertThat("bulk failures: " + Strings.toTruncatedString(bulkResponse), bulkResponse.hasFailures(), is(false));
 
         GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(TEST_REQUEST_TIMEOUT, new String[] { "*" });
         GetDataStreamAction.Response getDataStreamsResponse = client().execute(GetDataStreamAction.INSTANCE, getDataStreamRequest)
@@ -1535,7 +1535,7 @@ public class DataStreamIT extends ESIntegTestCase {
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.add(new IndexRequest("logs-foobar").opType(CREATE).source("{}", XContentType.JSON));
         BulkResponse bulkResponse = client().bulk(bulkRequest).actionGet();
-        assertThat("bulk failures: " + Strings.toString(bulkResponse), bulkResponse.hasFailures(), is(false));
+        assertThat("bulk failures: " + Strings.toTruncatedString(bulkResponse), bulkResponse.hasFailures(), is(false));
 
         GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(TEST_REQUEST_TIMEOUT, new String[] { "*" });
         GetDataStreamAction.Response getDataStreamsResponse = client().execute(GetDataStreamAction.INSTANCE, getDataStreamRequest)

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
@@ -181,6 +181,6 @@ public class MultiSearchTemplateResponse extends ActionResponse implements Itera
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 }

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponse.java
@@ -181,6 +181,6 @@ public class MultiSearchTemplateResponse extends ActionResponse implements Itera
 
     @Override
     public String toString() {
-        return Strings.toTruncatedString(this);
+        return Strings.toString(this);
     }
 }

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/BulkByScrollUsesAllScrollDocumentsAfterConflictsIntegTests.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/BulkByScrollUsesAllScrollDocumentsAfterConflictsIntegTests.java
@@ -254,7 +254,7 @@ public class BulkByScrollUsesAllScrollDocumentsAfterConflictsIntegTests extends 
 
         final BulkResponse bulkItemResponses = bulkFuture.actionGet();
         for (BulkItemResponse bulkItemResponse : bulkItemResponses) {
-            assertThat(Strings.toString(bulkItemResponses), bulkItemResponse.isFailed(), is(false));
+            assertThat(Strings.toTruncatedString(bulkItemResponses), bulkItemResponse.isFailed(), is(false));
         }
 
         final BulkByScrollResponse bulkByScrollResponse = updateByQueryResponse.actionGet();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -1225,7 +1225,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         request.includeDiskInfo(includeDiskInfo);
         final var explanation = safeGet(client().execute(TransportClusterAllocationExplainAction.TYPE, request)).getExplanation();
         if (logger.isDebugEnabled()) {
-            logger.debug("--> explain json output: \n{}", Strings.toString(explanation, true, true));
+            logger.debug("--> explain json output: \n{}", Strings.toTruncatedString(explanation, true, true));
         }
         return explanation;
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -103,7 +103,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         assertThat(bulkResponse.hasFailures(), equalTo(false));
         assertThat(bulkResponse.getItems().length, equalTo(2));
 
-        logger.info(Strings.toString(bulkResponse, true, true));
+        logger.info(Strings.toTruncatedString(bulkResponse, true, true));
 
         internalCluster().assertSeqNos();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
@@ -292,7 +292,10 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
             harness.indexName
         ).setShard(0).setPrimary(true);
         var allocationExplainResponse = safeGet(client().execute(TransportClusterAllocationExplainAction.TYPE, allocationExplainRequest));
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplainResponse.getExplanation(), true, true));
+        logger.info(
+            "---> Allocation explain response: {}",
+            Strings.toTruncatedString(allocationExplainResponse.getExplanation(), true, true)
+        );
 
         var decision = allocationExplainResponse.getExplanation().getShardAllocationDecision().getMoveDecision();
         assertThat("Rebalancing should be disabled", decision.canRebalanceCluster(), equalTo(false));
@@ -559,7 +562,10 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
             harness.indexName
         ).setShard(0).setPrimary(true);
         var allocationExplainResponse = safeGet(client().execute(TransportClusterAllocationExplainAction.TYPE, allocationExplainRequest));
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplainResponse.getExplanation(), true, true));
+        logger.info(
+            "---> Allocation explain response: {}",
+            Strings.toTruncatedString(allocationExplainResponse.getExplanation(), true, true)
+        );
 
         var decision = allocationExplainResponse.getExplanation().getShardAllocationDecision().getMoveDecision();
         assertThat("Rebalancing should be enabled", decision.canRebalanceCluster(), equalTo(true));

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
@@ -81,7 +81,7 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
         assertBusy(() -> {
             // assertBusy since the shard starts out unassigned with reason CLUSTER_RECOVERED, then it's assigned, and then it fails.
             final var allocationExplainResponse = getClusterAllocationExplanation(client(), "test", 0, true);
-            final var description = Strings.toString(allocationExplainResponse);
+            final var description = Strings.toTruncatedString(allocationExplainResponse);
             final var unassignedInfo = allocationExplainResponse.getUnassignedInfo();
             assertThat(description, unassignedInfo, not(nullValue()));
             assertThat(description, unassignedInfo.reason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
@@ -330,7 +330,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
             metadata.getProject().indexGraveyard().toString(),
             metadata.getProject().indexGraveyard().containsIndex(new Index(INDEX_NAME, danglingIndexUUID))
         );
-        assertNull(Strings.toString(metadata, true, true), metadata.getProject().index(INDEX_NAME));
+        assertNull(Strings.toTruncatedString(metadata, true, true), metadata.getProject().index(INDEX_NAME));
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -74,7 +74,7 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
         awaitForBlock(plugins);
         cancelSearch(TransportSearchAction.TYPE.name());
         disableBlocks(plugins);
-        logger.info("Segments {}", Strings.toString(indicesAdmin().prepareSegments("test").get()));
+        logger.info("Segments {}", Strings.toTruncatedString(indicesAdmin().prepareSegments("test").get()));
         ensureSearchWasCancelled(searchResponse);
     }
 
@@ -92,7 +92,7 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
         awaitForBlock(plugins);
         cancelSearch(TransportSearchAction.TYPE.name());
         disableBlocks(plugins);
-        logger.info("Segments {}", Strings.toString(indicesAdmin().prepareSegments("test").get()));
+        logger.info("Segments {}", Strings.toTruncatedString(indicesAdmin().prepareSegments("test").get()));
         ensureSearchWasCancelled(searchResponse);
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -1062,7 +1062,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             new ClusterAllocationExplainRequest(TEST_REQUEST_TIMEOUT).setIndex(indexName).setShard(0).setPrimary(true)
         ).actionGet();
 
-        logger.info("--> clusterExplainResponse1: {}", Strings.toString(clusterExplainResponse1, true, true));
+        logger.info("--> clusterExplainResponse1: {}", Strings.toTruncatedString(clusterExplainResponse1, true, true));
         for (var nodeDecision : clusterExplainResponse1.getExplanation()
             .getShardAllocationDecision()
             .getAllocateDecision()
@@ -1080,7 +1080,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             new ClusterAllocationExplainRequest(TEST_REQUEST_TIMEOUT).setIndex(indexName).setShard(0).setPrimary(true)
         ).actionGet();
 
-        logger.info("--> clusterExplainResponse2: {}", Strings.toString(clusterExplainResponse2, true, true));
+        logger.info("--> clusterExplainResponse2: {}", Strings.toTruncatedString(clusterExplainResponse2, true, true));
         for (var nodeDecision : clusterExplainResponse2.getExplanation()
             .getShardAllocationDecision()
             .getAllocateDecision()

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
@@ -362,7 +362,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                 logger.warn("--> failed to acquire all permits: {}", failedPermitAcquisitions);
                 logger.info(
                     "--> current cluster state:\n{}",
-                    Strings.toString(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), true, true)
+                    Strings.toTruncatedString(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), true, true)
                 );
                 fail("failed to acquire all permits: " + failedPermitAcquisitions);
             }
@@ -372,7 +372,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                 logger.warn("--> threadpool termination timed out");
                 logger.info(
                     "--> current cluster state:\n{}",
-                    Strings.toString(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), true, true)
+                    Strings.toTruncatedString(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), true, true)
                 );
             }
         }
@@ -393,7 +393,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                         logger.warn("--> failed to acquire permit [{}]", label);
                         logger.info(
                             "--> current cluster state:\n{}",
-                            Strings.toString(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), true, true)
+                            Strings.toTruncatedString(clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState(), true, true)
                         );
                         HotThreads.logLocalHotThreads(
                             logger,
@@ -1232,7 +1232,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                                     @Override
                                     public ClusterState execute(ClusterState currentState) {
                                         assertTrue(
-                                            Strings.toString(currentState),
+                                            Strings.toTruncatedString(currentState),
                                             currentState.metadata().nodeShutdowns().getAll().isEmpty()
                                         );
                                         final var discoveryNode = currentState.nodes().resolveNode(node.nodeName);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
@@ -60,6 +60,6 @@ public class NodesStatsResponse extends BaseNodesXContentResponse<NodeStats> {
 
     @Override
     public String toString() {
-        return Strings.toString(this, true, true);
+        return Strings.toTruncatedString(this, true, true);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -131,6 +131,6 @@ public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXCo
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -163,7 +163,7 @@ public class SnapshotStatus implements ChunkedToXContentObject, Writeable {
 
     @Override
     public String toString() {
-        return Strings.toString(this, true, false);
+        return Strings.toTruncatedString(this, true, false);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -226,7 +226,7 @@ public class GetIndexResponse extends ActionResponse implements ChunkedToXConten
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
@@ -71,7 +71,7 @@ public class GetMappingsResponse extends ActionResponse implements ChunkedToXCon
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
@@ -97,6 +97,6 @@ public class RecoveryResponse extends BaseBroadcastResponse implements ChunkedTo
 
     @Override
     public String toString() {
-        return Strings.toString(this, true, true);
+        return Strings.toTruncatedString(this, true, true);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -268,6 +268,6 @@ public class IndicesStatsResponse extends ChunkedBroadcastResponse {
 
     @Override
     public String toString() {
-        return Strings.toString(this, true, false);
+        return Strings.toTruncatedString(this, true, false);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -289,7 +289,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
 
     @Override
     public String toString() {
-        return indexResponses.isEmpty() ? Strings.toString(this) : "FieldCapabilitiesResponse{unmerged}";
+        return indexResponses.isEmpty() ? Strings.toTruncatedString(this) : "FieldCapabilitiesResponse{unmerged}";
     }
 
     public static class Builder {

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -221,6 +221,6 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -455,7 +455,7 @@ public class ClusterInfo implements ChunkedToXContent, Writeable, ExpectedShardS
 
     @Override
     public String toString() {
-        return Strings.toString(this, true, false);
+        return Strings.toTruncatedString(this, true, false);
     }
 
     // exposed for tests, computed here rather than exposing all the collections separately

--- a/server/src/main/java/org/elasticsearch/cluster/RepositoryCleanupInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/RepositoryCleanupInProgress.java
@@ -105,7 +105,7 @@ public final class RepositoryCleanupInProgress extends AbstractNamedDiffable<Clu
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
@@ -124,7 +124,7 @@ public class ComponentTemplateMetadata implements Metadata.ProjectCustom {
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     static class ComponentTemplateMetadataDiff implements NamedDiff<Metadata.ProjectCustom> {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
@@ -125,7 +125,7 @@ public class ComposableIndexTemplateMetadata implements Metadata.ProjectCustom {
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     static class ComposableIndexTemplateMetadataDiff implements NamedDiff<Metadata.ProjectCustom> {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -259,7 +259,7 @@ public class DataStreamMetadata implements Metadata.ProjectCustom {
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     static class DataStreamMetadataDiff implements NamedDiff<Metadata.ProjectCustom> {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
@@ -300,6 +300,6 @@ public class RepositoriesMetadata extends AbstractNamedDiffable<Metadata.Project
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -644,7 +644,7 @@ public class DesiredBalanceComputer {
                     "computation converged for input index [{}] with unassigned shard [{}] due to allocation decision {}",
                     inputIndex,
                     lastTrackedUnassignedShard,
-                    org.elasticsearch.common.Strings.toString(
+                    org.elasticsearch.common.Strings.toTruncatedString(
                         p -> ChunkedToXContentHelper.object("node_allocation_decision", shardAllocationDecision.toXContentChunked(p))
                     )
                 );

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -768,6 +768,21 @@ public class Strings {
     }
 
     /**
+     * Returns a {@link String} containing the JSON representation of the provided {@link ChunkedToXContent}. The content will be truncated
+     * up to 1 mebibyte; if the limit happens to be in the middle of a UTF-8 character, {@code \uFFFD} will be printed out instead.
+     * <p>
+     * This method is intended to be used for logging/debugging purposes, since it might return an invalid JSON value if the limit happens
+     * to be enforced.
+     *
+     * @param chunkedToXContent A {@link ChunkedToXContent} instance to be serialized to JSON.
+     * @param pretty True if the content should be pretty-printed. Also see {@link XContentBuilder#prettyPrint()}.
+     * @param human True if the values should be printed in a human-readable way. Also see {@link XContentBuilder#humanReadable()}}.
+     */
+    public static String toTruncatedString(ChunkedToXContent chunkedToXContent, boolean pretty, boolean human) {
+        return toTruncatedString(chunkedToXContent, 1024 * 1024 /* 1 MiB */, pretty, human).appendIfTruncated("[...]");
+    }
+
+    /**
      * Returns a {@link TruncatedString} containing the JSON representation of the provided {@link ChunkedToXContent}. The content will
      * be truncated up to {@code maxBytes} bytes; if the limit happens to be in the middle of a UTF-8 character, {@code \uFFFD} will be
      * printed out instead. The returned content is neither pretty-printed (see {@link XContentBuilder#prettyPrint()}), nor are the values
@@ -851,17 +866,6 @@ public class Strings {
     }
 
     /**
-     * Return a {@link String} that is the json representation of the provided {@link ChunkedToXContent}.
-     * @deprecated don't add usages of this method, it will be removed eventually. Use {@link #toTruncatedString(ChunkedToXContent, int)}
-     *             instead.
-     * TODO: remove this method, it makes no sense to turn potentially very large chunked xcontent instances into a string
-     */
-    @Deprecated
-    public static String toString(ChunkedToXContent chunkedToXContent) {
-        return toString(chunkedToXContent, false, false);
-    }
-
-    /**
      * Return a {@link String} that is the json representation of the provided {@link ToXContent}.
      * Wraps the output into an anonymous object if needed.
      * Allows to configure the params.
@@ -893,18 +897,6 @@ public class Strings {
      */
     public static String toString(ToXContent toXContent, boolean pretty, boolean human) {
         return toString(toXContent, ToXContent.EMPTY_PARAMS, pretty, human);
-    }
-
-    /**
-     * Return a {@link String} that is the json representation of the provided {@link ChunkedToXContent}.
-     * Allows to control whether the outputted json needs to be pretty printed and human readable.
-     * @deprecated don't add usages of this method, it will be removed eventually. Use
-     *             {@link #toTruncatedString(ChunkedToXContent, int, boolean, boolean)} instead.
-     * TODO: remove this method, it makes no sense to turn potentially very large chunked xcontent instances into a string
-     */
-    @Deprecated
-    public static String toString(ChunkedToXContent chunkedToXContent, boolean pretty, boolean human) {
-        return toString(ChunkedToXContent.wrapAsToXContent(chunkedToXContent), pretty, human);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/persistent/ClusterPersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/elasticsearch/persistent/ClusterPersistentTasksCustomMetadata.java
@@ -115,7 +115,7 @@ public final class ClusterPersistentTasksCustomMetadata extends AbstractNamedDif
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
@@ -104,7 +104,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsServiceUtils.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsServiceUtils.java
@@ -214,7 +214,7 @@ public class SnapshotsServiceUtils {
                         : "Found shard snapshot actively executing in ["
                             + entry
                             + "] when it should be blocked by a running delete ["
-                            + Strings.toString(snapshotDeletionsInProgress)
+                            + Strings.toTruncatedString(snapshotDeletionsInProgress)
                             + "]";
                 }
             }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -141,7 +141,7 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
             )
         );
 
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplanation, true, true));
+        logger.info("---> Allocation explain response: {}", Strings.toTruncatedString(allocationExplanation, true, true));
         // canRemain on the current node should be NO.
         assertThat(allocationExplanation.getShardAllocationDecision().getMoveDecision().canRemain(), equalTo(false));
         assertThat(
@@ -200,7 +200,7 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
             )
         );
 
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplanation, true, true));
+        logger.info("---> Allocation explain response: {}", Strings.toTruncatedString(allocationExplanation, true, true));
         // canRemain on the current node should be NOT_PREFERRED.
         assertThat(allocationExplanation.getShardAllocationDecision().getMoveDecision().canRemainNotPreferred(), equalTo(true));
         assertThat(
@@ -257,7 +257,7 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
             )
         );
 
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplanation, true, true));
+        logger.info("---> Allocation explain response: {}", Strings.toTruncatedString(allocationExplanation, true, true));
         // canRemain on the current node should be NOT_PREFERRED.
         assertThat(allocationExplanation.getShardAllocationDecision().getMoveDecision().canRemainNotPreferred(), equalTo(true));
         assertThat(
@@ -312,7 +312,7 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
             )
         );
 
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplanation, true, true));
+        logger.info("---> Allocation explain response: {}", Strings.toTruncatedString(allocationExplanation, true, true));
         // canRemain on the current node should be NOT_PREFERRED.
         assertThat(allocationExplanation.getShardAllocationDecision().getMoveDecision().canRemainNotPreferred(), equalTo(true));
         assertThat(

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/MergedFieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/MergedFieldCapabilitiesResponseTests.java
@@ -147,7 +147,7 @@ public class MergedFieldCapabilitiesResponseTests extends AbstractChunkedSeriali
                   }
                 }
               ]
-            }""".replaceAll("\\s+", ""), Strings.toString(response));
+            }""".replaceAll("\\s+", ""), Strings.toTruncatedString(response));
     }
 
     private static FieldCapabilitiesResponse createSimpleResponse() {

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -238,7 +238,7 @@ public class MultiSearchRequestTests extends ESTestCase {
                       "status": 500
                     }
                   ]
-                }""", tookInMillis)), Strings.toString(response));
+                }""", tookInMillis)), Strings.toTruncatedString(response));
         } finally {
             response.decRef();
         }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
@@ -406,7 +406,7 @@ public class SearchResponseTests extends ESTestCase {
                         "hits": [ { "_id": "id1", "_score": 2.0 } ]
                       }
                     }""");
-                assertEquals(expectedString, Strings.toString(response));
+                assertEquals(expectedString, Strings.toTruncatedString(response));
             } finally {
                 response.decRef();
             }
@@ -456,7 +456,7 @@ public class SearchResponseTests extends ESTestCase {
                         "hits": [ { "_id": "id1", "_score": 2.0 } ]
                       }
                     }""");
-                assertEquals(expectedString, Strings.toString(response));
+                assertEquals(expectedString, Strings.toTruncatedString(response));
             } finally {
                 response.decRef();
             }
@@ -600,7 +600,7 @@ public class SearchResponseTests extends ESTestCase {
                         ]
                       }
                     }""");
-                assertEquals(expectedString, Strings.toString(response));
+                assertEquals(expectedString, Strings.toTruncatedString(response));
             } finally {
                 response.decRef();
             }

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponseTests.java
@@ -61,6 +61,6 @@ public class BaseNodesXContentResponseTests extends ESTestCase {
               },
               "cluster_name" : "elasticsearch",
               "content" : { }
-            }""", Strings.toString(fullResponse, true, false));
+            }""", Strings.toTruncatedString(fullResponse, true, false));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexGraveyardTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexGraveyardTests.java
@@ -65,7 +65,7 @@ public class IndexGraveyardTests extends ESTestCase {
         if (graveyard.getTombstones().size() > 0) {
             // check that date properly printed
             assertThat(
-                Strings.toString(graveyard, false, true),
+                Strings.toTruncatedString(graveyard, false, true),
                 containsString(
                     XContentElasticsearchExtension.DEFAULT_FORMATTER.format(
                         Instant.ofEpochMilli(graveyard.getTombstones().get(0).getDeleteDateInMillis())

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/ClusterStateToStringTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/ClusterStateToStringTests.java
@@ -60,7 +60,7 @@ public class ClusterStateToStringTests extends ESAllocationTestCase {
             .routingTable(strategy.reroute(clusterState, "reroute", ActionListener.noop()).routingTable())
             .build();
 
-        String clusterStateString = Strings.toString(clusterState);
+        String clusterStateString = Strings.toTruncatedString(clusterState);
         assertNotNull(clusterStateString);
 
         assertThat(clusterStateString, containsString("test_idx"));

--- a/server/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -339,6 +339,28 @@ public class StringsTests extends ESTestCase {
         assertEquals(1024 * 1024 + "[...]".length(), result.length());
     }
 
+    public void testToTruncatedStringPrettyHumanReadableOutputWithDefaultLimit() {
+        ChunkedToXContent chunkedToXContent = __ -> List.of(new TestToXContent(1, false), new TestToXContent(2, false)).iterator();
+
+        var result = Strings.toTruncatedString(chunkedToXContent, true, true);
+
+        assertFalse(result.endsWith("[...]"));
+        assertEquals("""
+            {
+              "field1" : "this is a value number 1",
+              "field2" : "this is a value number 2"
+            }""", result);
+    }
+
+    public void testToTruncatedStringPrettyHumanReadableOutputWithDefaultLimitEndsWithEllipsis() {
+        ChunkedToXContent chunkedToXContent = __ -> IntStream.range(1, 1_000_000).mapToObj(i -> new TestToXContent(i, false)).iterator();
+
+        var result = Strings.toTruncatedString(chunkedToXContent, true, false);
+
+        assertThat(result, endsWith("[...]"));
+        assertEquals(1024 * 1024 + "[...]".length(), result.length());
+    }
+
     public void testToTruncatedStringException() {
         ToXContent chunk = (b, p) -> { throw new IOException("boom!"); };
         ChunkedToXContent chunkedToXContent = __ -> List.of(chunk).iterator();

--- a/server/src/test/java/org/elasticsearch/http/HttpStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpStatsTests.java
@@ -64,7 +64,7 @@ public class HttpStatsTests extends ESTestCase {
         );
 
         assertThat(
-            Strings.toString(new HttpStats(1, 2, List.of(), Map.of("http/path", httpRouteStats)), false, true),
+            Strings.toTruncatedString(new HttpStats(1, 2, List.of(), Map.of("http/path", httpRouteStats)), false, true),
             equalTo(
                 Strings.format(
                     """

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1414,7 +1414,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
         deterministicTaskQueue.runAllRunnableTasks();
         assertTrue(
             "executed all runnable tasks but test steps are still incomplete: "
-                + Strings.toString(SnapshotsInProgress.get(masterClusterService.state()), true, true),
+                + Strings.toTruncatedString(SnapshotsInProgress.get(masterClusterService.state()), true, true),
             testListener.isDone()
         );
         safeAwait(testListener); // shouldn't throw
@@ -1638,7 +1638,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
         deterministicTaskQueue.runAllRunnableTasks();
         assertTrue(
             "executed all runnable tasks but test steps are still incomplete: "
-                + Strings.toString(SnapshotsInProgress.get(masterClusterService.state()), true, true),
+                + Strings.toTruncatedString(SnapshotsInProgress.get(masterClusterService.state()), true, true),
             testListener.isDone()
         );
         safeAwait(testListener); // shouldn't throw

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -551,7 +551,7 @@ public class SnapshotsInProgressSerializationTests extends SimpleDiffableWireSer
             );
 
         AbstractChunkedSerializingTestCase.assertChunkCount(sip, instance -> Math.toIntExact(instance.asStream().count() + 5));
-        final var json = Strings.toString(sip, false, true);
+        final var json = Strings.toTruncatedString(sip, false, true);
         assertThat(
             json,
             anyOf(

--- a/server/src/test/java/org/elasticsearch/transport/TransportStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportStatsTests.java
@@ -34,7 +34,7 @@ public class TransportStatsTests extends ESTestCase {
         final var exampleActionStats = new TransportActionStats(7, 8, requestSizeHistogram, 11, 12, responseSizeHistogram);
 
         assertEquals(
-            Strings.toString(
+            Strings.toTruncatedString(
                 new TransportStats(
                     1,
                     2,

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1160,9 +1160,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
             logger.info(
                 "{} timed out\nallocation explain:\n{}\ncluster state:\n{}\npending tasks:\n{}\nhot threads:\n{}\n",
                 method,
-                safeFormat(allocationExplainRef.get(), r -> Strings.toString(r.getExplanation(), true, true)),
+                safeFormat(allocationExplainRef.get(), r -> Strings.toTruncatedString(r.getExplanation(), true, true)),
                 safeFormat(clusterStateRef.get(), r -> r.getState().toString()),
-                safeFormat(pendingTasksRef.get(), r -> Strings.toString(r, true, true)),
+                safeFormat(pendingTasksRef.get(), r -> Strings.toTruncatedString(r, true, true)),
                 hotThreadsRef.get()
             );
             fail("timed out waiting for " + color + " state");

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -504,7 +504,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
                 new CcrStatsAction.Request(TEST_REQUEST_TIMEOUT)
             ).actionGet();
             assertThat(
-                "Follow stats not empty: " + Strings.toString(statsResponse.getFollowStats()),
+                "Follow stats not empty: " + Strings.toTruncatedString(statsResponse.getFollowStats()),
                 statsResponse.getFollowStats().getStatsResponses(),
                 empty()
             );

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderIT.java
@@ -552,7 +552,7 @@ public class DataTierAllocationDeciderIT extends ESIntegTestCase {
     }
 
     private String explainAllocation(int shard) {
-        return Strings.toString(
+        return Strings.toTruncatedString(
             ClusterAllocationExplanationUtils.getClusterAllocationExplanation(client(), index, shard, true),
             true,
             true

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
@@ -130,7 +130,7 @@ public class FollowInfoAction extends ActionType<FollowInfoAction.Response> {
         }
 
         public String toString() {
-            return Strings.toString(this);
+            return Strings.toTruncatedString(this);
         }
 
         public static class FollowerInfo implements Writeable, ToXContentObject {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleMetadata.java
@@ -155,7 +155,7 @@ public class IndexLifecycleMetadata implements Metadata.ProjectCustom {
 
     @Override
     public String toString() {
-        return Strings.toString(this, false, true);
+        return Strings.toTruncatedString(this, false, true);
     }
 
     public static class IndexLifecycleMetadataDiff implements NamedDiff<Metadata.ProjectCustom> {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleOperationMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecycleOperationMetadata.java
@@ -166,7 +166,7 @@ public class LifecycleOperationMetadata implements Metadata.ProjectCustom {
 
     @Override
     public String toString() {
-        return Strings.toString(this, true, true);
+        return Strings.toTruncatedString(this, true, true);
     }
 
     public static class LifecycleOperationMetadataDiff implements NamedDiff<Metadata.ProjectCustom> {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleAction.java
@@ -81,7 +81,7 @@ public class GetLifecycleAction extends ActionType<GetLifecycleAction.Response> 
 
         @Override
         public String toString() {
-            return Strings.toString(this, true, true);
+            return Strings.toTruncatedString(this, true, true);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -169,7 +169,7 @@ public class MlMetadata implements Metadata.ProjectCustom {
 
     @Override
     public final String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -188,7 +188,7 @@ public class TrainedModelAssignmentMetadata implements Metadata.ProjectCustom {
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     public boolean hasOutdatedAssignments() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
@@ -154,7 +154,7 @@ public class SnapshotLifecycleMetadata implements Metadata.ProjectCustom {
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMetadata.java
@@ -155,7 +155,7 @@ public class TransformMetadata implements Metadata.ProjectCustom {
 
     @Override
     public final String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/ChatCompletionResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/ChatCompletionResultsTests.java
@@ -29,7 +29,7 @@ public class ChatCompletionResultsTests extends AbstractWireSerializingTestCase<
             is(Map.of(ChatCompletionResults.COMPLETION, List.of(Map.of(ChatCompletionResults.Result.RESULT, resultContent))))
         );
 
-        String xContentResult = Strings.toString(result, true, true);
+        String xContentResult = Strings.toTruncatedString(result, true, true);
         assertThat(xContentResult, is("""
             {
               "completion" : [
@@ -61,7 +61,7 @@ public class ChatCompletionResultsTests extends AbstractWireSerializingTestCase<
             )
         );
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "completion" : [

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingBitResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingBitResultsTests.java
@@ -45,7 +45,7 @@ public class DenseEmbeddingBitResultsTests extends AbstractWireSerializingTestCa
     public void testToXContent_CreatesTheRightFormatForASingleEmbedding() throws IOException {
         var entity = new DenseEmbeddingBitResults(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23 })));
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "text_embedding_bits" : [
@@ -66,7 +66,7 @@ public class DenseEmbeddingBitResultsTests extends AbstractWireSerializingTestCa
             )
         );
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "text_embedding_bits" : [

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingByteResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingByteResultsTests.java
@@ -46,7 +46,7 @@ public class DenseEmbeddingByteResultsTests extends AbstractWireSerializingTestC
     public void testToXContent_CreatesTheRightFormatForASingleEmbedding() throws IOException {
         var entity = new DenseEmbeddingByteResults(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23 })));
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "text_embedding_bytes" : [
@@ -67,7 +67,7 @@ public class DenseEmbeddingByteResultsTests extends AbstractWireSerializingTestC
             )
         );
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "text_embedding_bytes" : [

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingFloatResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingFloatResultsTests.java
@@ -45,7 +45,7 @@ public class DenseEmbeddingFloatResultsTests extends AbstractWireSerializingTest
     public void testToXContent_CreatesTheRightFormatForASingleEmbedding() throws IOException {
         var entity = new DenseEmbeddingFloatResults(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.1F })));
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "text_embedding" : [
@@ -67,7 +67,7 @@ public class DenseEmbeddingFloatResultsTests extends AbstractWireSerializingTest
 
         );
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "text_embedding" : [

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/GenericDenseEmbeddingBitResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/GenericDenseEmbeddingBitResultsTests.java
@@ -45,7 +45,7 @@ public class GenericDenseEmbeddingBitResultsTests extends AbstractWireSerializin
     public void testToXContent_CreatesTheRightFormatForASingleEmbedding() throws IOException {
         var entity = new GenericDenseEmbeddingBitResults(List.of(new GenericDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23 })));
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "embeddings_bits" : [
@@ -66,7 +66,7 @@ public class GenericDenseEmbeddingBitResultsTests extends AbstractWireSerializin
             )
         );
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "embeddings_bits" : [

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/GenericDenseEmbeddingByteResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/GenericDenseEmbeddingByteResultsTests.java
@@ -48,7 +48,7 @@ public class GenericDenseEmbeddingByteResultsTests extends AbstractWireSerializi
             List.of(new GenericDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23 }))
         );
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "embeddings_bytes" : [
@@ -69,7 +69,7 @@ public class GenericDenseEmbeddingByteResultsTests extends AbstractWireSerializi
             )
         );
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "embeddings_bytes" : [

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/GenericDenseEmbeddingFloatResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/GenericDenseEmbeddingFloatResultsTests.java
@@ -45,7 +45,7 @@ public class GenericDenseEmbeddingFloatResultsTests extends AbstractWireSerializ
     public void testToXContent_CreatesTheRightFormatForASingleEmbedding() throws IOException {
         var entity = new GenericDenseEmbeddingFloatResults(List.of(new GenericDenseEmbeddingFloatResults.Embedding(new float[] { 0.1F })));
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "embeddings" : [
@@ -67,7 +67,7 @@ public class GenericDenseEmbeddingFloatResultsTests extends AbstractWireSerializ
 
         );
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "embeddings" : [

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/SparseEmbeddingResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/SparseEmbeddingResultsTests.java
@@ -87,7 +87,7 @@ public class SparseEmbeddingResultsTests extends AbstractWireSerializingTestCase
     public void testToXContent_CreatesTheRightFormatForASingleEmbedding() throws IOException {
         var entity = createSparseResult(List.of(createEmbedding(List.of(new WeightedToken("token", 0.1F)), false)));
         assertThat(entity.asMap(), is(buildExpectationSparseEmbeddings(List.of(new EmbeddingExpectation(Map.of("token", 0.1F), false)))));
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "sparse_embedding" : [
@@ -120,7 +120,7 @@ public class SparseEmbeddingResultsTests extends AbstractWireSerializingTestCase
             )
         );
 
-        String xContentResult = Strings.toString(entity, true, true);
+        String xContentResult = Strings.toTruncatedString(entity, true, true);
         assertThat(xContentResult, is("""
             {
               "sparse_embedding" : [

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverProfile.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DriverProfile.java
@@ -114,6 +114,6 @@ public record DriverProfile(
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverProfileTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverProfileTests.java
@@ -45,7 +45,7 @@ public class DriverProfileTests extends AbstractWireSerializingTestCase<DriverPr
                 List.of(new DriverSleeps.Sleep("driver time", Thread.currentThread().getName(), 1, 1))
             )
         );
-        assertThat(Strings.toString(status, true, true), equalTo("""
+        assertThat(Strings.toTruncatedString(status, true, true), equalTo("""
             {
               "description" : "test",
               "cluster_name" : "elasticsearch",

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistryMetadata.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ModelRegistryMetadata.java
@@ -321,7 +321,7 @@ public class ModelRegistryMetadata implements Metadata.ProjectCustom {
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     public Collection<String> getTombstones() {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -134,7 +134,7 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
 
         GetIndexResponse getIndexResponse = client().admin().indices().prepareGetIndex(TEST_REQUEST_TIMEOUT).setIndices(".ml-state*").get();
         assertThat(
-            Strings.toString(getIndexResponse),
+            Strings.toTruncatedString(getIndexResponse),
             getIndexResponse.getIndices(),
             is(arrayContaining(".ml-state", ".ml-state-000001", ".ml-state-000003", ".ml-state-000005", ".ml-state-000007"))
         );
@@ -144,7 +144,7 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
 
         getIndexResponse = client().admin().indices().prepareGetIndex(TEST_REQUEST_TIMEOUT).setIndices(".ml-state*").get();
         assertThat(
-            Strings.toString(getIndexResponse),
+            Strings.toTruncatedString(getIndexResponse),
             getIndexResponse.getIndices(),
             // Only non-empty or current indices should survive deletion process
             is(arrayContaining(".ml-state-000001", ".ml-state-000005", ".ml-state-000007"))

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
@@ -276,7 +276,7 @@ abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTest
             // If the job is stopped during writing_results phase and it is then restarted, there is a chance two trained models
             // were persisted as there is no way currently for the process to be certain the model was persisted.
             searchResponse -> assertThat(
-                "Hits were: " + Strings.toString(searchResponse.getHits()),
+                "Hits were: " + Strings.toTruncatedString(searchResponse.getHits()),
                 searchResponse.getHits().getHits(),
                 is(arrayWithSize(modelHitsArraySizeMatcher))
             )

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -1058,7 +1058,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         }
         BulkResponse response = bulkRequest.get();
         if (response.hasFailures()) {
-            throw new IllegalStateException(Strings.toString(response));
+            throw new IllegalStateException(Strings.toTruncatedString(response));
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDecider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDecider.java
@@ -243,7 +243,7 @@ class MlMemoryAutoscalingDecider {
             logger.debug(
                 () -> format(
                     "persistent tasks that caused unexpected scaling situation: [%s]",
-                    (mlContext.persistentTasks == null) ? "null" : Strings.toString(mlContext.persistentTasks)
+                    (mlContext.persistentTasks == null) ? "null" : Strings.toTruncatedString(mlContext.persistentTasks)
                 )
             );
             return refreshMemoryTrackerAndBuildEmptyDecision(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -184,7 +184,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 rebalanceReason.get(),
                 ActionListener.wrap(
                     newMetadata -> logger.debug(
-                        () -> format("rebalanced model assignments [%s]", Strings.toString(newMetadata, false, true))
+                        () -> format("rebalanced model assignments [%s]", Strings.toTruncatedString(newMetadata, false, true))
                     ),
                     e -> {
                         List<String> deploymentIdsBeforeRebalance = TrainedModelAssignmentMetadata.fromState(event.state())
@@ -258,7 +258,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                     logger.debug(
                         () -> format(
                             "updated model assignments based on node changes in the cluster; new metadata [%s]",
-                            Strings.toString(TrainedModelAssignmentMetadata.fromState(newState), false, true)
+                            Strings.toTruncatedString(TrainedModelAssignmentMetadata.fromState(newState), false, true)
                         )
                     );
                 }
@@ -1085,7 +1085,9 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         final String deploymentId = request.getDeploymentId();
         final String nodeId = request.getNodeId();
         TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(currentState);
-        logger.trace(() -> format("[%s] [%s] current metadata before update %s", deploymentId, nodeId, Strings.toString(metadata)));
+        logger.trace(
+            () -> format("[%s] [%s] current metadata before update %s", deploymentId, nodeId, Strings.toTruncatedString(metadata))
+        );
         final TrainedModelAssignment existingAssignment = metadata.getDeploymentAssignment(deploymentId);
         final TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.builder(currentState);
         // If state is stopped, this indicates the node process is closed, remove the node from the assignment

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -1034,7 +1034,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         assertBusy(() -> {
             final var clusterAllocationExplanation = getClusterAllocationExplanation(client(), restoredIndexName, 0, true);
-            final String description = Strings.toString(clusterAllocationExplanation);
+            final String description = Strings.toTruncatedString(clusterAllocationExplanation);
             final AllocateUnassignedDecision allocateDecision = clusterAllocationExplanation.getShardAllocationDecision()
                 .getAllocateDecision();
             assertTrue(description, allocateDecision.isDecisionTaken());
@@ -1057,7 +1057,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             final RestoreInProgress restoreInProgress = RestoreInProgress.get(
                 clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).clear().setCustoms(true).get().getState()
             );
-            assertTrue(Strings.toString(restoreInProgress, true, true), restoreInProgress.isEmpty());
+            assertTrue(Strings.toTruncatedString(restoreInProgress, true, true), restoreInProgress.isEmpty());
         });
 
         // Re-register the repository containing the actual data & verify that the shards are now allocated

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
@@ -113,7 +113,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         final var explanation = getClusterAllocationExplanation(client(), req.mountedIndexName(), 0, true);
         for (NodeAllocationResult nodeDecision : explanation.getShardAllocationDecision().getAllocateDecision().getNodeDecisions()) {
             assertTrue(
-                nodeDecision.getNode() + " vs " + Strings.toString(explanation),
+                nodeDecision.getNode() + " vs " + Strings.toTruncatedString(explanation),
                 nodeDecision.getCanAllocateDecision()
                     .getDecisions()
                     .stream()
@@ -239,10 +239,13 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         assertBusy(() -> {
             try {
                 final var explanation = getClusterAllocationExplanation(client(), req.mountedIndexName(), 0, true);
-                assertTrue(Strings.toString(explanation), explanation.getShardAllocationDecision().getAllocateDecision().isDecisionTaken());
+                assertTrue(
+                    Strings.toTruncatedString(explanation),
+                    explanation.getShardAllocationDecision().getAllocateDecision().isDecisionTaken()
+                );
 
                 assertThat(
-                    Strings.toString(explanation),
+                    Strings.toTruncatedString(explanation),
                     explanation.getShardAllocationDecision().getAllocateDecision().getAllocationStatus(),
                     equalTo(UnassignedInfo.AllocationStatus.FETCHING_SHARD_DATA)
                 );
@@ -259,7 +262,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         assertFalse(responseFuture.isDone());
         final var explanation = getClusterAllocationExplanation(client(), req.mountedIndexName(), 0, true);
         assertThat(
-            Strings.toString(explanation),
+            Strings.toTruncatedString(explanation),
             explanation.getShardAllocationDecision().getAllocateDecision().getAllocationStatus(),
             equalTo(UnassignedInfo.AllocationStatus.FETCHING_SHARD_DATA)
         );

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/DesiredBalanceShutdownIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/DesiredBalanceShutdownIT.java
@@ -88,7 +88,7 @@ public class DesiredBalanceShutdownIT extends ESIntegTestCase {
                 new GetShutdownStatusAction.Request(TEST_REQUEST_TIMEOUT)
             ).actionGet(10, TimeUnit.SECONDS);
             assertTrue(
-                Strings.toString(getShutdownResponse, true, true),
+                Strings.toTruncatedString(getShutdownResponse, true, true),
                 getShutdownResponse.getShutdownStatuses()
                     .stream()
                     .allMatch(s -> s.overallStatus() == SingleNodeShutdownMetadata.Status.COMPLETE)

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusAction.java
@@ -133,7 +133,7 @@ public class GetShutdownStatusAction extends ActionType<GetShutdownStatusAction.
 
         @Override
         public String toString() {
-            return Strings.toString(this);
+            return Strings.toTruncatedString(this);
         }
     }
 

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/SingleNodeShutdownStatus.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/SingleNodeShutdownStatus.java
@@ -111,7 +111,7 @@ public class SingleNodeShutdownStatus implements Writeable, ChunkedToXContentObj
 
     @Override
     public String toString() {
-        return Strings.toString(this);
+        return Strings.toTruncatedString(this);
     }
 
     @Override

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -322,17 +322,19 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
             })
             // If ILM is shrinking the index this shard is part of, it'll look like it's unmovable, but we can just wait for ILM to finish
             .filter(pair -> isIlmRestrictingShardMovement(currentState.metadata().getProject(), pair.v1()) == false)
-            .peek(
-                pair -> logger.debug(
-                    "node [{}] shutdown of type [{}] stalled: found shard [{}][{}] from index [{}] with negative decision: [{}]",
-                    nodeId,
-                    shutdownType,
-                    pair.v1().getId(),
-                    pair.v1().primary() ? "primary" : "replica",
-                    pair.v1().shardId().getIndexName(),
-                    Strings.toString(pair.v2())
-                )
-            )
+            .peek(pair -> {
+                if (logger.isDebugEnabled()) {
+                    logger.debug(
+                        "node [{}] shutdown of type [{}] stalled: found shard [{}][{}] from index [{}] with negative decision: [{}]",
+                        nodeId,
+                        shutdownType,
+                        pair.v1().getId(),
+                        pair.v1().primary() ? "primary" : "replica",
+                        pair.v1().shardId().getIndexName(),
+                        Strings.toTruncatedString(pair.v2())
+                    );
+                }
+            })
             .findFirst();
 
         var temporarilyUnmovableShards = unmovableShards.stream()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Use toTruncatedString in chunked objects toString (#147860)](https://github.com/elastic/elasticsearch/pull/147860)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)