### PR TITLE
Multi Project Isolation Allocation Decider

### DIFF
--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/StatelessPlugin.java
@@ -131,6 +131,7 @@ import org.elasticsearch.xpack.stateless.action.TransportGetVirtualBatchedCompou
 import org.elasticsearch.xpack.stateless.action.TransportNewCommitNotificationAction;
 import org.elasticsearch.xpack.stateless.allocation.EstimatedHeapUsageAllocationDecider;
 import org.elasticsearch.xpack.stateless.allocation.EstimatedHeapUsageMonitor;
+import org.elasticsearch.xpack.stateless.allocation.ProjectIsolationAllocationDecider;
 import org.elasticsearch.xpack.stateless.allocation.StatelessAllocationDecider;
 import org.elasticsearch.xpack.stateless.allocation.StatelessBalancingWeightsFactory;
 import org.elasticsearch.xpack.stateless.allocation.StatelessExistingShardsAllocator;
@@ -1260,6 +1261,7 @@ public class StatelessPlugin extends Plugin
             EstimatedHeapUsageAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ESTIMATED_HEAP_HIGH_WATERMARK_ENABLED,
             EstimatedHeapUsageAllocationDecider.MINIMUM_LOGGING_INTERVAL,
             EstimatedHeapUsageAllocationDecider.MINIMUM_HEAP_SIZE_FOR_ENABLEMENT,
+            ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING,
             SearchCommitPrefetcher.BACKGROUND_PREFETCH_ENABLED_SETTING,
             SearchCommitPrefetcherDynamicSettings.PREFETCH_COMMITS_UPON_NOTIFICATIONS_ENABLED_SETTING,
             SearchCommitPrefetcher.PREFETCH_NON_UPLOADED_COMMITS_SETTING,
@@ -1883,6 +1885,7 @@ public class StatelessPlugin extends Plugin
     public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
         return List.of(
             new StatelessAllocationDecider(),
+            new ProjectIsolationAllocationDecider(clusterSettings),
             new EstimatedHeapUsageAllocationDecider(clusterSettings),
             new StatelessThrottlingConcurrentRecoveriesAllocationDecider(clusterSettings)
         );

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/IsolatedProjects.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/IsolatedProjects.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.allocation;
+
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParser.Token;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Parsed cluster setting mapping projects to isolated tier names per tier.
+ * Parsed from JSON (cluster setting value) shaped as:
+ * {@code [{"project":"<id>","tiers":{"index":"<name>","search":"<name>"}}, ...]}.
+ */
+public final class IsolatedProjects {
+
+    /** Isolated tier names are used in Kubernetes resource names in the control plane. */
+    public static final int MAX_ISOLATED_TIER_NAME_LENGTH = 15;
+
+    public static final IsolatedProjects EMPTY = new IsolatedProjects(Map.of());
+
+    private final Map<ProjectId, TierIsolationNames> projectIdToTierIsolationNamesMap;
+
+    private IsolatedProjects(Map<ProjectId, TierIsolationNames> projectIdToTierIsolationNamesMap) {
+        this.projectIdToTierIsolationNamesMap = projectIdToTierIsolationNamesMap;
+    }
+
+    public Optional<String> isolatedTierName(ProjectId projectId, IsolationShardTier isolationShardTier) {
+        TierIsolationNames tierIsolationNames = projectIdToTierIsolationNamesMap.get(projectId);
+        if (tierIsolationNames == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(switch (isolationShardTier) {
+            case INDEX -> tierIsolationNames.indexIsolatedTierName();
+            case SEARCH -> tierIsolationNames.searchIsolatedTierName();
+        });
+    }
+
+    public static IsolatedProjects parse(String rawSettingValue) {
+        if (rawSettingValue == null || rawSettingValue.isBlank()) {
+            return EMPTY;
+        }
+        try (
+            XContentParser xContentParser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, rawSettingValue)
+        ) {
+            xContentParser.nextToken();
+            return parse(xContentParser);
+        } catch (IOException ioException) {
+            throw new IllegalArgumentException("failed to parse [" + rawSettingValue + "]", ioException);
+        }
+    }
+
+    private static IsolatedProjects parse(XContentParser xContentParser) throws IOException {
+        XContentParserUtils.ensureExpectedToken(Token.START_ARRAY, xContentParser.currentToken(), xContentParser);
+        Map<ProjectId, TierIsolationNames> mergedProjectIdToTierNames = new LinkedHashMap<>();
+        Token arrayElementToken;
+        while ((arrayElementToken = xContentParser.nextToken()) != Token.END_ARRAY) {
+            XContentParserUtils.ensureExpectedToken(Token.START_OBJECT, arrayElementToken, xContentParser);
+            String projectIdRawString = null;
+            TierIsolationNames tierIsolationNames = null;
+            while (xContentParser.nextToken() != Token.END_OBJECT) {
+                XContentParserUtils.ensureExpectedToken(Token.FIELD_NAME, xContentParser.currentToken(), xContentParser);
+                String entryFieldName = xContentParser.currentName();
+                xContentParser.nextToken();
+                switch (entryFieldName) {
+                    case "project" -> projectIdRawString = xContentParser.text();
+                    case "tiers" -> tierIsolationNames = parseTiersObject(xContentParser);
+                    default -> throw new IllegalArgumentException("unknown field [" + entryFieldName + "] in isolated_projects entry");
+                }
+            }
+            if (Strings.isNullOrEmpty(projectIdRawString)) {
+                throw new IllegalArgumentException("missing required field [project] in isolated_projects entry");
+            }
+            if (tierIsolationNames == null) {
+                throw new IllegalArgumentException("missing required field [tiers] for project [" + projectIdRawString + "]");
+            }
+            ProjectId parsedProjectId = ProjectId.fromId(projectIdRawString);
+            mergedProjectIdToTierNames.merge(parsedProjectId, tierIsolationNames, TierIsolationNames::mergeWith);
+        }
+        return mergedProjectIdToTierNames.isEmpty() ? EMPTY : new IsolatedProjects(Map.copyOf(mergedProjectIdToTierNames));
+    }
+
+    private static TierIsolationNames parseTiersObject(XContentParser xContentParser) throws IOException {
+        XContentParserUtils.ensureExpectedToken(Token.START_OBJECT, xContentParser.currentToken(), xContentParser);
+        String indexIsolatedTierName = null;
+        String searchIsolatedTierName = null;
+        while (xContentParser.nextToken() != Token.END_OBJECT) {
+            XContentParserUtils.ensureExpectedToken(Token.FIELD_NAME, xContentParser.currentToken(), xContentParser);
+            String tierConfigurationFieldName = xContentParser.currentName();
+            xContentParser.nextToken();
+            switch (tierConfigurationFieldName) {
+                case "index" -> indexIsolatedTierName = validateIsolatedTierName(xContentParser.text());
+                case "search" -> searchIsolatedTierName = validateIsolatedTierName(xContentParser.text());
+                default -> throw new IllegalArgumentException("unknown field [" + tierConfigurationFieldName + "] under [tiers]");
+            }
+        }
+        return new TierIsolationNames(indexIsolatedTierName, searchIsolatedTierName);
+    }
+
+    private static String validateIsolatedTierName(String candidateIsolatedTierName) {
+        if (candidateIsolatedTierName == null || candidateIsolatedTierName.isEmpty()) {
+            throw new IllegalArgumentException("isolated tier name cannot be empty");
+        }
+        if (candidateIsolatedTierName.length() > MAX_ISOLATED_TIER_NAME_LENGTH) {
+            throw new IllegalArgumentException(
+                "isolated tier name [" + candidateIsolatedTierName + "] exceeds max length [" + MAX_ISOLATED_TIER_NAME_LENGTH + "]"
+            );
+        }
+        for (int charIndex = 0; charIndex < candidateIsolatedTierName.length(); charIndex++) {
+            char tierNameCharacter = candidateIsolatedTierName.charAt(charIndex);
+            boolean isLegalDnsLabelCharacter = (tierNameCharacter >= 'a' && tierNameCharacter <= 'z')
+                || (tierNameCharacter >= '0' && tierNameCharacter <= '9')
+                || tierNameCharacter == '-';
+            if (isLegalDnsLabelCharacter == false) {
+                throw new IllegalArgumentException(
+                    "isolated tier name [" + candidateIsolatedTierName + "] must contain only [a-z0-9-] (DNS label characters)"
+                );
+            }
+        }
+        if (candidateIsolatedTierName.startsWith("-") || candidateIsolatedTierName.endsWith("-")) {
+            throw new IllegalArgumentException("isolated tier name [" + candidateIsolatedTierName + "] must not start or end with '-'");
+        }
+        return candidateIsolatedTierName;
+    }
+
+    /**
+     * Optional index and search isolated tier names for one project (either may be null).
+     */
+    public record TierIsolationNames(String indexIsolatedTierName, String searchIsolatedTierName) {
+        static TierIsolationNames mergeWith(TierIsolationNames firstTierNames, TierIsolationNames secondTierNames) {
+            return new TierIsolationNames(
+                secondTierNames.indexIsolatedTierName != null
+                    ? secondTierNames.indexIsolatedTierName
+                    : firstTierNames.indexIsolatedTierName,
+                secondTierNames.searchIsolatedTierName != null
+                    ? secondTierNames.searchIsolatedTierName
+                    : firstTierNames.searchIsolatedTierName
+            );
+        }
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/IsolatedProjects.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/IsolatedProjects.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 /**
  * Parsed cluster setting mapping projects to isolated tier names per tier.
- * Parsed from JSON (cluster setting value) shaped as:
+ * Parsed from JSON shaped as:
  * {@code [{"project":"<id>","tiers":{"index":"<name>","search":"<name>"}}, ...]}.
  */
 public final class IsolatedProjects {
@@ -38,6 +38,16 @@ public final class IsolatedProjects {
         this.projectIdToTierIsolationNamesMap = projectIdToTierIsolationNamesMap;
     }
 
+    /**
+     * Returns the configured isolated tier name for {@code projectId} and shard tier, if that project is listed
+     * in {@code cluster.routing.allocation.isolated_projects} and has a value for that tier.
+     * <p>
+     * If the project is missing from the map, or the tier key is absent from its {@code tiers} object, returns empty.
+     *
+     * @param projectId         project to look up
+     * @param isolationShardTier index or search isolation tier
+     * @return non-empty when a non-null tier name was configured, and empty when unknown or unset
+     */
     public Optional<String> isolatedTierName(ProjectId projectId, IsolationShardTier isolationShardTier) {
         TierIsolationNames tierIsolationNames = projectIdToTierIsolationNamesMap.get(projectId);
         if (tierIsolationNames == null) {
@@ -49,6 +59,22 @@ public final class IsolatedProjects {
         });
     }
 
+    /**
+     * Parses the {@code cluster.routing.allocation.isolated_projects} setting value from JSON.
+     * <p>
+     * Expects a JSON <em>array</em> of objects, each with {@code project} (project id string) and {@code tiers}
+     * (object with optional {@code index} and {@code search} string values). Unknown fields are rejected.
+     * Duplicate {@code project} entries are merged, with later non-null tier values overriding earlier ones.
+     * <p>
+     * Tier names must be non-empty, at most {@link #MAX_ISOLATED_TIER_NAME_LENGTH} characters, and use only
+     * DNS-label characters {@code [a-z0-9-]} without a leading or trailing {@code '-'}.
+     *
+     * @param rawSettingValue serialized JSON, or {@code null} / blank for no isolation configuration
+     * @return {@link #EMPTY} when {@code rawSettingValue} is null, blank, or parses to an empty array.
+     *         Otherwise, returns an immutable map of projects to tier names
+     * @throws IllegalArgumentException if JSON is invalid, required fields are missing, extra fields appear,
+     *                                  or a tier name fails validation
+     */
     public static IsolatedProjects parse(String rawSettingValue) {
         if (rawSettingValue == null || rawSettingValue.isBlank()) {
             return EMPTY;

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/IsolationShardTier.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/IsolationShardTier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.allocation;
+
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.core.Nullable;
+
+import static org.elasticsearch.cluster.routing.ShardRouting.Role.INDEX_ONLY;
+import static org.elasticsearch.cluster.routing.ShardRouting.Role.SEARCH_ONLY;
+
+/**
+ * Stateless shard tiers that participate in project isolation
+ */
+public enum IsolationShardTier {
+    INDEX,
+    SEARCH;
+
+    /**
+     * Maps a shard routing role to an isolation tier, or {@code null} if this decider should not apply.
+     */
+    public static @Nullable IsolationShardTier fromShardRole(ShardRouting.Role shardRoutingRole) {
+        if (shardRoutingRole == INDEX_ONLY) {
+            return INDEX;
+        }
+        if (shardRoutingRole == SEARCH_ONLY) {
+            return SEARCH;
+        }
+        return null;
+    }
+
+    /** Key used under the cluster setting {@code tiers} object ({@code index} / {@code search}). */
+    public String isolationTierName() {
+        return this == INDEX ? "index" : "search";
+    }
+}

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/ProjectIsolationAllocationDecider.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/ProjectIsolationAllocationDecider.java
@@ -42,6 +42,9 @@ public class ProjectIsolationAllocationDecider extends AllocationDecider {
         Setting.Property.NodeScope
     );
 
+    /**
+     * Allocation is the hotpath, so it is more efficient to define the decision upfront rather than recomputing it
+     */
     private static final Decision YES_ISOLATION_MATCH = Decision.single(
         Type.YES,
         NAME,
@@ -75,7 +78,7 @@ public class ProjectIsolationAllocationDecider extends AllocationDecider {
     private Decision decide(ShardRouting shardRouting, RoutingNode routingNode, RoutingAllocation routingAllocation) {
         IsolationShardTier isolationShardTier = IsolationShardTier.fromShardRole(shardRouting.role());
 
-        // Project isolation applies only to stateless index vs search shard copies.
+        // Project isolation applies only to stateless index vs search shards
         if (isolationShardTier == null) {
             return Decision.ALWAYS;
         }
@@ -120,7 +123,7 @@ public class ProjectIsolationAllocationDecider extends AllocationDecider {
         }
 
         // The project is not marked as isolated
-        // This is not an isolated node, so default to normal allocation
+        // This is not an isolated node, so default to the other allocators
         return Decision.ALWAYS;
     }
 }

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/ProjectIsolationAllocationDecider.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/ProjectIsolationAllocationDecider.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.allocation;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRouting.Role;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+
+import java.util.Optional;
+
+/**
+ * Enforces project isolation for stateless {@link Role#INDEX_ONLY} and
+ * {@link Role#SEARCH_ONLY} shards by forbidding isolated workloads on shared nodes.
+ */
+public class ProjectIsolationAllocationDecider extends AllocationDecider {
+
+    public static final String NAME = "project_isolation";
+
+    /**
+     * Node attribute set on isolated tier nodes by the control plane. Shared tier nodes omit this attribute.
+     */
+    public static final String NODE_ATTRIBUTE_ISOLATED_TIER = "isolated_tier";
+
+    public static final Setting<IsolatedProjects> CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING = new Setting<>(
+        "cluster.routing.allocation.isolated_projects",
+        "[]",
+        IsolatedProjects::parse,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    private static final Decision YES_ISOLATION_MATCH = Decision.single(
+        Type.YES,
+        NAME,
+        "shard project and tier match isolated tier for this node"
+    );
+
+    private volatile IsolatedProjects isolatedProjects = IsolatedProjects.EMPTY;
+
+    public ProjectIsolationAllocationDecider(ClusterSettings clusterSettings) {
+        clusterSettings.initializeAndWatch(
+            CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING,
+            updatedIsolatedProjects -> this.isolatedProjects = updatedIsolatedProjects
+        );
+    }
+
+    @Override
+    public Decision canAllocate(ShardRouting shardRouting, RoutingNode routingNode, RoutingAllocation routingAllocation) {
+        return decide(shardRouting, routingNode, routingAllocation);
+    }
+
+    @Override
+    public Decision canRemain(
+        IndexMetadata indexMetadata,
+        ShardRouting shardRouting,
+        RoutingNode routingNode,
+        RoutingAllocation routingAllocation
+    ) {
+        return decide(shardRouting, routingNode, routingAllocation);
+    }
+
+    private Decision decide(ShardRouting shardRouting, RoutingNode routingNode, RoutingAllocation routingAllocation) {
+        IsolationShardTier isolationShardTier = IsolationShardTier.fromShardRole(shardRouting.role());
+
+        // Project isolation applies only to stateless index vs search shard copies.
+        if (isolationShardTier == null) {
+            return Decision.ALWAYS;
+        }
+
+        ProjectId projectId = routingAllocation.metadata().projectFor(shardRouting.index()).id();
+        Optional<String> optionalConfiguredIsolatedTierName = isolatedProjects.isolatedTierName(projectId, isolationShardTier);
+        String nodeIsolatedTierAttributeValue = routingNode.node().getAttributes().get(NODE_ATTRIBUTE_ISOLATED_TIER);
+
+        // This project is marked as isolated for at least one tier
+        if (optionalConfiguredIsolatedTierName.isPresent()) {
+            String configuredIsolatedTierName = optionalConfiguredIsolatedTierName.get();
+            // The tier of the node matches the tier to be isolated
+            if (configuredIsolatedTierName.equals(nodeIsolatedTierAttributeValue)) {
+                return YES_ISOLATION_MATCH;
+            }
+            if (routingAllocation.debugDecision()) {
+                return routingAllocation.decision(
+                    Decision.NO,
+                    NAME,
+                    "shard requires isolated tier [%s] for project [%s] and tier [%s]; node isolated tier is [%s]",
+                    configuredIsolatedTierName,
+                    projectId.id(),
+                    isolationShardTier.isolationTierName(),
+                    nodeIsolatedTierAttributeValue
+                );
+            }
+            return Decision.NO;
+        }
+
+        // The project is not marked as isolated.
+        // If this is an isolated node, then we do not want to allocate non-isolated projects here
+        if (nodeIsolatedTierAttributeValue != null) {
+            if (routingAllocation.debugDecision()) {
+                return routingAllocation.decision(
+                    Decision.NO,
+                    NAME,
+                    "non-isolated shard cannot be assigned to isolated tier node [%s]",
+                    nodeIsolatedTierAttributeValue
+                );
+            }
+            return Decision.NO;
+        }
+
+        // The project is not marked as isolated
+        // This is not an isolated node, so default to normal allocation
+        return Decision.ALWAYS;
+    }
+}

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/IsolatedProjectsTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/IsolatedProjectsTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.allocation;
+
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class IsolatedProjectsTests extends ESTestCase {
+
+    public void testIsolatedTierNameReturnsEmptyWhenParsedTiersObjectHasNoTierKeys() {
+        IsolatedProjects isolatedProjects = IsolatedProjects.parse("[{\"project\":\"pz\",\"tiers\":{}}]");
+        ProjectId projectId = ProjectId.fromId("pz");
+        assertFalse(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.INDEX).isPresent());
+        assertFalse(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.SEARCH).isPresent());
+    }
+
+    public void testIsolatedTierNameReturnsEmptyWhenProjectAbsentFromParsedMap() {
+        IsolatedProjects isolatedProjects = IsolatedProjects.parse("[{\"project\":\"knownp\",\"tiers\":{\"index\":\"pool\"}}]");
+        ProjectId unknownProjectId = ProjectId.fromId("otherpr");
+        assertFalse(isolatedProjects.isolatedTierName(unknownProjectId, IsolationShardTier.INDEX).isPresent());
+        assertFalse(isolatedProjects.isolatedTierName(unknownProjectId, IsolationShardTier.SEARCH).isPresent());
+    }
+
+    public void testParseThenIsolatedTierNameReturnsPoolsForIndexAndSearch() {
+        IsolatedProjects isolatedProjects = IsolatedProjects.parse(
+            "[{\"project\":\"proj1abcd\",\"tiers\":{\"index\":\"iso-n1\",\"search\":\"iso-s1\"}}]"
+        );
+        ProjectId projectId = ProjectId.fromId("proj1abcd");
+        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.INDEX).orElse(null), equalTo("iso-n1"));
+        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.SEARCH).orElse(null), equalTo("iso-s1"));
+    }
+
+    public void testParseMergesTierIsolationWhenSameProjectAppearsMultipleTimes() {
+        IsolatedProjects isolatedProjects = IsolatedProjects.parse("""
+            [
+              {"project":"p1","tiers":{"index":"first"}},
+              {"project":"p1","tiers":{"search":"second","index":"override"}}
+            ]""");
+        ProjectId projectId = ProjectId.fromId("p1");
+        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.INDEX).orElse(null), equalTo("override"));
+        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.SEARCH).orElse(null), equalTo("second"));
+    }
+
+    public void testParseAllowsTierNameAtMaximumLength() {
+        String isolatedTierNameAtMaxLength = "abcdefghijklmno";
+        IsolatedProjects isolatedProjects = IsolatedProjects.parse(
+            String.format(
+                Locale.ROOT,
+                "[{\"project\":\"plen\",\"tiers\":{\"index\":\"%s\",\"search\":\"%s\"}}]",
+                isolatedTierNameAtMaxLength,
+                isolatedTierNameAtMaxLength
+            )
+        );
+        ProjectId projectId = ProjectId.fromId("plen");
+        assertThat(
+            isolatedProjects.isolatedTierName(projectId, IsolationShardTier.INDEX).orElseThrow(),
+            equalTo(isolatedTierNameAtMaxLength)
+        );
+        assertThat(
+            isolatedProjects.isolatedTierName(projectId, IsolationShardTier.SEARCH).orElseThrow(),
+            equalTo(isolatedTierNameAtMaxLength)
+        );
+    }
+
+    public void testParseReturnsEmptyWhenRawIsNull() {
+        assertSame(IsolatedProjects.EMPTY, IsolatedProjects.parse(null));
+    }
+
+    public void testParseReturnsEmptyWhenJsonIsEmptyArrayOrBlank() {
+        assertSame(IsolatedProjects.EMPTY, IsolatedProjects.parse("[]"));
+        assertSame(IsolatedProjects.EMPTY, IsolatedProjects.parse("  "));
+    }
+
+    public void testParseThrowsIllegalArgumentWhenEntryHasUnknownField() {
+        IllegalArgumentException illegalArgumentException = expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{},\"x\":1}]")
+        );
+        assertThat(illegalArgumentException.getMessage().contains("unknown field"), equalTo(true));
+    }
+
+    public void testParseThrowsIllegalArgumentWhenTiersObjectHasUnknownField() {
+        expectThrows(IllegalArgumentException.class, () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"ml\":\"x\"}}]"));
+    }
+
+    public void testParseThrowsIllegalArgumentWhenTierNameHasIllegalCharactersOrLength() {
+        expectThrows(IllegalArgumentException.class, () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"index\":\"BAD\"}}]"));
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"index\":\"name-longer-than-15\"}}]")
+        );
+    }
+
+    public void testParseThrowsIllegalArgumentWhenProjectFieldMissing() {
+        IllegalArgumentException illegalArgumentException = expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse("[{\"tiers\":{}}]")
+        );
+        assertThat(illegalArgumentException.getMessage(), equalTo("missing required field [project] in isolated_projects entry"));
+    }
+
+    public void testParseThrowsIllegalArgumentWhenTiersFieldMissing() {
+        IllegalArgumentException illegalArgumentException = expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse("[{\"project\":\"p1only\"}]")
+        );
+        assertThat(illegalArgumentException.getMessage(), equalTo("missing required field [tiers] for project [p1only]"));
+    }
+
+    public void testParseThrowsIllegalArgumentWhenProjectFieldIsEmptyString() {
+        IllegalArgumentException illegalArgumentException = expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse("[{\"project\":\"\",\"tiers\":{}}]")
+        );
+        assertThat(illegalArgumentException.getMessage(), equalTo("missing required field [project] in isolated_projects entry"));
+    }
+
+    public void testParseThrowsIllegalArgumentWhenTierNameIsEmptyString() {
+        IllegalArgumentException illegalArgumentException = expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"index\":\"\"}}]")
+        );
+        assertThat(illegalArgumentException.getMessage(), equalTo("isolated tier name cannot be empty"));
+    }
+
+    public void testParseThrowsIllegalArgumentWhenTierNameStartsWithHyphen() {
+        IllegalArgumentException illegalArgumentException = expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"index\":\"-x\"}}]")
+        );
+        assertThat(illegalArgumentException.getMessage(), equalTo("isolated tier name [-x] must not start or end with '-'"));
+    }
+
+    public void testParseThrowsIllegalArgumentWhenTierNameEndsWithHyphen() {
+        IllegalArgumentException illegalArgumentException = expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"search\":\"ab-\"}}]")
+        );
+        assertThat(illegalArgumentException.getMessage(), equalTo("isolated tier name [ab-] must not start or end with '-'"));
+    }
+
+    public void testParseThrowsIllegalArgumentWhenTierNameContainsUnderscore() {
+        expectThrows(IllegalArgumentException.class, () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"index\":\"a_b\"}}]"));
+    }
+
+    public void testParseThrowsParsingExceptionWhenJsonRootIsNotArray() {
+        expectThrows(ParsingException.class, () -> IsolatedProjects.parse("{}"));
+    }
+
+    public void testParseWrapsIOExceptionCauseInIllegalArgumentWhenInputUnreadableAsJson() {
+        IllegalArgumentException illegalArgumentException = expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse("\0")
+        );
+        assertTrue(illegalArgumentException.getMessage().startsWith("failed to parse "));
+        assertNotNull(illegalArgumentException.getCause());
+        assertEquals(IOException.class, illegalArgumentException.getCause().getClass());
+    }
+}

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/IsolatedProjectsTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/IsolatedProjectsTests.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.Locale;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class IsolatedProjectsTests extends ESTestCase {
 
@@ -229,9 +230,10 @@ public class IsolatedProjectsTests extends ESTestCase {
             IllegalArgumentException.class,
             () -> IsolatedProjects.parse("\0")
         );
-        assertTrue(illegalArgumentException.getMessage().startsWith("failed to parse "));
+        // JsonXContent turns low-level parse failures into XContentParseException (IllegalArgumentException) with a Jackson cause.
+        // The outer try in IsolatedProjects.parse may also wrap a plain IOException with "failed to parse [...]".
         assertNotNull(illegalArgumentException.getCause());
-        assertEquals(IOException.class, illegalArgumentException.getCause().getClass());
+        assertThat(illegalArgumentException.getCause(), instanceOf(IOException.class));
     }
 
     private static String randomProjectIdString() {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/IsolatedProjectsTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/IsolatedProjectsTests.java
@@ -19,50 +19,76 @@ import static org.hamcrest.Matchers.equalTo;
 public class IsolatedProjectsTests extends ESTestCase {
 
     public void testIsolatedTierNameReturnsEmptyWhenParsedTiersObjectHasNoTierKeys() {
-        IsolatedProjects isolatedProjects = IsolatedProjects.parse("[{\"project\":\"pz\",\"tiers\":{}}]");
-        ProjectId projectId = ProjectId.fromId("pz");
+        String projectIdRaw = randomProjectIdString();
+        IsolatedProjects isolatedProjects = IsolatedProjects.parse(isolatedProjectsEntryJson(projectIdRaw, "{}", ""));
+        ProjectId projectId = ProjectId.fromId(projectIdRaw);
         assertFalse(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.INDEX).isPresent());
         assertFalse(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.SEARCH).isPresent());
     }
 
     public void testIsolatedTierNameReturnsEmptyWhenProjectAbsentFromParsedMap() {
-        IsolatedProjects isolatedProjects = IsolatedProjects.parse("[{\"project\":\"knownp\",\"tiers\":{\"index\":\"pool\"}}]");
-        ProjectId unknownProjectId = ProjectId.fromId("otherpr");
+        String configuredProjectRaw = randomProjectIdString();
+        String randomIsolatedTierName = randomValidIsolatedTierName();
+        String unknownProjectRaw = randomValueOtherThan(configuredProjectRaw, IsolatedProjectsTests::randomProjectIdString);
+
+        IsolatedProjects isolatedProjects = IsolatedProjects.parse(
+            isolatedProjectsEntryJson(configuredProjectRaw, "{\"index\":\"" + randomIsolatedTierName + "\"}", "")
+        );
+        ProjectId unknownProjectId = ProjectId.fromId(unknownProjectRaw);
         assertFalse(isolatedProjects.isolatedTierName(unknownProjectId, IsolationShardTier.INDEX).isPresent());
         assertFalse(isolatedProjects.isolatedTierName(unknownProjectId, IsolationShardTier.SEARCH).isPresent());
     }
 
-    public void testParseThenIsolatedTierNameReturnsPoolsForIndexAndSearch() {
+    public void testIsolatedTierNameReturnsTierNamesForIndexAndSearch() {
+        String projectIdRaw = randomProjectIdString();
+        String indexTier = randomValidIsolatedTierName();
+        String searchTier = randomValidIsolatedTierName();
         IsolatedProjects isolatedProjects = IsolatedProjects.parse(
-            "[{\"project\":\"proj1abcd\",\"tiers\":{\"index\":\"iso-n1\",\"search\":\"iso-s1\"}}]"
+            isolatedProjectsEntryJson(
+                projectIdRaw,
+                String.format(Locale.ROOT, "{\"index\":\"%s\",\"search\":\"%s\"}", indexTier, searchTier),
+                ""
+            )
         );
-        ProjectId projectId = ProjectId.fromId("proj1abcd");
-        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.INDEX).orElse(null), equalTo("iso-n1"));
-        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.SEARCH).orElse(null), equalTo("iso-s1"));
+        ProjectId projectId = ProjectId.fromId(projectIdRaw);
+        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.INDEX).orElse(null), equalTo(indexTier));
+        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.SEARCH).orElse(null), equalTo(searchTier));
     }
 
     public void testParseMergesTierIsolationWhenSameProjectAppearsMultipleTimes() {
-        IsolatedProjects isolatedProjects = IsolatedProjects.parse("""
+        String projectIdRaw = randomProjectIdString();
+        String indexFirst = randomValidIsolatedTierName();
+        String searchSecond = randomValidIsolatedTierName();
+        String indexOverride = randomValidIsolatedTierName();
+
+        IsolatedProjects isolatedProjects = IsolatedProjects.parse(String.format(Locale.ROOT, """
             [
-              {"project":"p1","tiers":{"index":"first"}},
-              {"project":"p1","tiers":{"search":"second","index":"override"}}
-            ]""");
-        ProjectId projectId = ProjectId.fromId("p1");
-        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.INDEX).orElse(null), equalTo("override"));
-        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.SEARCH).orElse(null), equalTo("second"));
+              {"project":"%s","tiers":{"index":"%s"}},
+              {"project":"%s","tiers":{"search":"%s","index":"%s"}}
+            ]""", projectIdRaw, indexFirst, projectIdRaw, searchSecond, indexOverride));
+        ProjectId projectId = ProjectId.fromId(projectIdRaw);
+        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.INDEX).orElse(null), equalTo(indexOverride));
+        assertThat(isolatedProjects.isolatedTierName(projectId, IsolationShardTier.SEARCH).orElse(null), equalTo(searchSecond));
     }
 
     public void testParseAllowsTierNameAtMaximumLength() {
-        String isolatedTierNameAtMaxLength = "abcdefghijklmno";
+        String isolatedTierNameAtMaxLength = randomValidIsolatedTierNameExactly(IsolatedProjects.MAX_ISOLATED_TIER_NAME_LENGTH);
+        String projectIdRaw = randomProjectIdString();
+
         IsolatedProjects isolatedProjects = IsolatedProjects.parse(
-            String.format(
-                Locale.ROOT,
-                "[{\"project\":\"plen\",\"tiers\":{\"index\":\"%s\",\"search\":\"%s\"}}]",
-                isolatedTierNameAtMaxLength,
-                isolatedTierNameAtMaxLength
+            isolatedProjectsEntryJson(
+                projectIdRaw,
+                String.format(
+                    Locale.ROOT,
+                    "{\"index\":\"%s\",\"search\":\"%s\"}",
+                    isolatedTierNameAtMaxLength,
+                    isolatedTierNameAtMaxLength
+                ),
+                ""
             )
         );
-        ProjectId projectId = ProjectId.fromId("plen");
+
+        ProjectId projectId = ProjectId.fromId(projectIdRaw);
         assertThat(
             isolatedProjects.isolatedTierName(projectId, IsolationShardTier.INDEX).orElseThrow(),
             equalTo(isolatedTierNameAtMaxLength)
@@ -83,22 +109,39 @@ public class IsolatedProjectsTests extends ESTestCase {
     }
 
     public void testParseThrowsIllegalArgumentWhenEntryHasUnknownField() {
+        String projectIdRaw = randomProjectIdString();
         IllegalArgumentException illegalArgumentException = expectThrows(
             IllegalArgumentException.class,
-            () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{},\"x\":1}]")
+            () -> IsolatedProjects.parse("[{\"project\":\"" + projectIdRaw + "\",\"tiers\":{},\"x\":1}]")
         );
         assertThat(illegalArgumentException.getMessage().contains("unknown field"), equalTo(true));
     }
 
     public void testParseThrowsIllegalArgumentWhenTiersObjectHasUnknownField() {
-        expectThrows(IllegalArgumentException.class, () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"ml\":\"x\"}}]"));
-    }
-
-    public void testParseThrowsIllegalArgumentWhenTierNameHasIllegalCharactersOrLength() {
-        expectThrows(IllegalArgumentException.class, () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"index\":\"BAD\"}}]"));
+        String projectIdRaw = randomProjectIdString();
         expectThrows(
             IllegalArgumentException.class,
-            () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"index\":\"name-longer-than-15\"}}]")
+            () -> IsolatedProjects.parse("[{\"project\":\"" + projectIdRaw + "\",\"tiers\":{\"ml\":\"x\"}}]")
+        );
+    }
+
+    public void testParseThrowsIllegalArgumentWhenTierNameHasIllegalCharacters() {
+        String projectIdRaw = randomProjectIdString();
+        String uppercaseIllegalTier = randomAlphaOfLength(randomIntBetween(3, IsolatedProjects.MAX_ISOLATED_TIER_NAME_LENGTH)).toUpperCase(
+            Locale.ROOT
+        );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse(isolatedProjectsEntryJson(projectIdRaw, "{\"index\":\"" + uppercaseIllegalTier + "\"}", ""))
+        );
+    }
+
+    public void testParseThrowsIllegalArgumentWhenTierNameIsTooLong() {
+        String projectIdRaw = randomProjectIdString();
+        String tooLongTierName = randomAlphanumericOfLength(IsolatedProjects.MAX_ISOLATED_TIER_NAME_LENGTH + 1).toLowerCase(Locale.ROOT);
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse(isolatedProjectsEntryJson(projectIdRaw, "{\"index\":\"" + tooLongTierName + "\"}", ""))
         );
     }
 
@@ -111,11 +154,15 @@ public class IsolatedProjectsTests extends ESTestCase {
     }
 
     public void testParseThrowsIllegalArgumentWhenTiersFieldMissing() {
+        String projectIdMissingTiersRaw = randomProjectIdString();
         IllegalArgumentException illegalArgumentException = expectThrows(
             IllegalArgumentException.class,
-            () -> IsolatedProjects.parse("[{\"project\":\"p1only\"}]")
+            () -> IsolatedProjects.parse("[{\"project\":\"" + projectIdMissingTiersRaw + "\"}]")
         );
-        assertThat(illegalArgumentException.getMessage(), equalTo("missing required field [tiers] for project [p1only]"));
+        assertThat(
+            illegalArgumentException.getMessage(),
+            equalTo("missing required field [tiers] for project [" + projectIdMissingTiersRaw + "]")
+        );
     }
 
     public void testParseThrowsIllegalArgumentWhenProjectFieldIsEmptyString() {
@@ -127,31 +174,50 @@ public class IsolatedProjectsTests extends ESTestCase {
     }
 
     public void testParseThrowsIllegalArgumentWhenTierNameIsEmptyString() {
+        String projectIdRaw = randomProjectIdString();
         IllegalArgumentException illegalArgumentException = expectThrows(
             IllegalArgumentException.class,
-            () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"index\":\"\"}}]")
+            () -> IsolatedProjects.parse("[{\"project\":\"" + projectIdRaw + "\",\"tiers\":{\"index\":\"\"}}]")
         );
         assertThat(illegalArgumentException.getMessage(), equalTo("isolated tier name cannot be empty"));
     }
 
     public void testParseThrowsIllegalArgumentWhenTierNameStartsWithHyphen() {
+        String projectIdRaw = randomProjectIdString();
+        String tierStartingWithHyphen = "-" + randomAlphanumericOfLength(1).toLowerCase(Locale.ROOT);
         IllegalArgumentException illegalArgumentException = expectThrows(
             IllegalArgumentException.class,
-            () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"index\":\"-x\"}}]")
+            () -> IsolatedProjects.parse(isolatedProjectsEntryJson(projectIdRaw, "{\"index\":\"" + tierStartingWithHyphen + "\"}", ""))
         );
-        assertThat(illegalArgumentException.getMessage(), equalTo("isolated tier name [-x] must not start or end with '-'"));
+        assertThat(
+            illegalArgumentException.getMessage(),
+            equalTo("isolated tier name [" + tierStartingWithHyphen + "] must not start or end with '-'")
+        );
     }
 
     public void testParseThrowsIllegalArgumentWhenTierNameEndsWithHyphen() {
+        String projectIdRaw = randomProjectIdString();
+        String tierEndingWithHyphen = randomValidIsolatedTierNameExactly(randomIntBetween(1, 5)) + "-";
         IllegalArgumentException illegalArgumentException = expectThrows(
             IllegalArgumentException.class,
-            () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"search\":\"ab-\"}}]")
+            () -> IsolatedProjects.parse(isolatedProjectsEntryJson(projectIdRaw, "{\"search\":\"" + tierEndingWithHyphen + "\"}", ""))
         );
-        assertThat(illegalArgumentException.getMessage(), equalTo("isolated tier name [ab-] must not start or end with '-'"));
+        assertThat(
+            illegalArgumentException.getMessage(),
+            equalTo("isolated tier name [" + tierEndingWithHyphen + "] must not start or end with '-'")
+        );
     }
 
     public void testParseThrowsIllegalArgumentWhenTierNameContainsUnderscore() {
-        expectThrows(IllegalArgumentException.class, () -> IsolatedProjects.parse("[{\"project\":\"p1\",\"tiers\":{\"index\":\"a_b\"}}]"));
+        String projectIdRaw = randomProjectIdString();
+        String tierWithUnderscore = randomAlphanumericOfLength(randomIntBetween(1, 3)).toLowerCase(Locale.ROOT)
+            + "_"
+            + randomAlphanumericOfLength(randomIntBetween(1, 3)).toLowerCase(Locale.ROOT);
+
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> IsolatedProjects.parse(isolatedProjectsEntryJson(projectIdRaw, "{\"index\":\"" + tierWithUnderscore + "\"}", ""))
+        );
     }
 
     public void testParseThrowsParsingExceptionWhenJsonRootIsNotArray() {
@@ -166,5 +232,27 @@ public class IsolatedProjectsTests extends ESTestCase {
         assertTrue(illegalArgumentException.getMessage().startsWith("failed to parse "));
         assertNotNull(illegalArgumentException.getCause());
         assertEquals(IOException.class, illegalArgumentException.getCause().getClass());
+    }
+
+    private static String randomProjectIdString() {
+        return randomAlphanumericOfLength(randomIntBetween(12, 32));
+    }
+
+    /**
+     * Isolated tier name matching {@link IsolatedProjects} validation ([a-z0-9-], no leading/trailing '-').
+     */
+    private static String randomValidIsolatedTierName() {
+        return randomValidIsolatedTierNameExactly(randomIntBetween(1, IsolatedProjects.MAX_ISOLATED_TIER_NAME_LENGTH));
+    }
+
+    /** Lowercase alphanumeric, satisfying isolated tier naming rules ([a-z0-9]). */
+    private static String randomValidIsolatedTierNameExactly(int length) {
+        assert length >= 1 && length <= IsolatedProjects.MAX_ISOLATED_TIER_NAME_LENGTH;
+        return randomAlphanumericOfLength(length).toLowerCase(Locale.ROOT);
+    }
+
+    /** One JSON array entry */
+    private static String isolatedProjectsEntryJson(String projectIdRawString, String tiersJsonObjectBody, String suffixAfterEntry) {
+        return "[" + "{\"project\":\"" + projectIdRawString + "\",\"tiers\":" + tiersJsonObjectBody + "}" + suffixAfterEntry + "]";
     }
 }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/ProjectIsolationAllocationDeciderTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/ProjectIsolationAllocationDeciderTests.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.allocation;
+
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRouting.Role;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.TestRoutingAllocationFactory;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision.Single;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.shard.ShardId;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.INDEX_ROLE;
+import static org.elasticsearch.cluster.routing.ShardRouting.Role.INDEX_ONLY;
+import static org.elasticsearch.cluster.routing.ShardRouting.Role.SEARCH_ONLY;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class ProjectIsolationAllocationDeciderTests extends ESAllocationTestCase {
+
+    private static final ProjectId ISOLATION_TEST_PROJECT_ID = ProjectId.fromId("projisolatedaaaa");
+
+    private static final String ALLOC_TEST_INDEX_NAME = "alloc-test-idx";
+
+    public void testIsolatedProjectRequiresMatchingNodeAttribute() {
+        ProjectIsolationAllocationDecider projectIsolationAllocationDecider = newProjectIsolationAllocationDecider(
+            Settings.builder()
+                .put(
+                    ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
+                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "index", "iso-pool")
+                )
+                .build()
+        );
+        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).build();
+        ShardRouting indexOnlyShardRouting = findShardRoutingByRole(
+            clusterState,
+            ISOLATION_TEST_PROJECT_ID,
+            ALLOC_TEST_INDEX_NAME,
+            INDEX_ONLY
+        );
+
+        assertThat(
+            projectIsolationAllocationDecider.canAllocate(
+                indexOnlyShardRouting,
+                clusterState.getRoutingNodes().node("n-iso"),
+                routingAllocation
+            ).type(),
+            equalTo(Type.YES)
+        );
+        assertThat(
+            projectIsolationAllocationDecider.canAllocate(
+                indexOnlyShardRouting,
+                clusterState.getRoutingNodes().node("n-shared"),
+                routingAllocation
+            ).type(),
+            equalTo(Type.NO)
+        );
+        assertThat(
+            projectIsolationAllocationDecider.canAllocate(
+                indexOnlyShardRouting,
+                clusterState.getRoutingNodes().node("n-other"),
+                routingAllocation
+            ).type(),
+            equalTo(Type.NO)
+        );
+    }
+
+    public void testIsolatedProjectSearchTierRequiresMatchingNodeAttribute() {
+        ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(
+            Settings.builder()
+                .put(
+                    ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
+                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "search", "iso-pool")
+                )
+                .build()
+        );
+        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).build();
+        ShardRouting searchOnlyShard = findShardRoutingByRole(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME, SEARCH_ONLY);
+
+        assertThat(
+            decider.canAllocate(searchOnlyShard, clusterState.getRoutingNodes().node("n-iso"), routingAllocation).type(),
+            equalTo(Type.YES)
+        );
+        assertThat(
+            decider.canAllocate(searchOnlyShard, clusterState.getRoutingNodes().node("n-shared"), routingAllocation).type(),
+            equalTo(Type.NO)
+        );
+        assertThat(
+            decider.canAllocate(searchOnlyShard, clusterState.getRoutingNodes().node("n-other"), routingAllocation).type(),
+            equalTo(Type.NO)
+        );
+    }
+
+    public void testNonIsolatedProjectRejectedOnIsolatedNodes() {
+        ProjectIsolationAllocationDecider projectIsolationAllocationDecider = newProjectIsolationAllocationDecider(Settings.EMPTY);
+        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).build();
+        ShardRouting indexOnlyShardRouting = findShardRoutingByRole(
+            clusterState,
+            ISOLATION_TEST_PROJECT_ID,
+            ALLOC_TEST_INDEX_NAME,
+            INDEX_ONLY
+        );
+
+        RoutingNode isolatedIndexingRoutingNode = clusterState.getRoutingNodes().node("n-iso");
+        assertThat(
+            projectIsolationAllocationDecider.canAllocate(indexOnlyShardRouting, isolatedIndexingRoutingNode, routingAllocation).type(),
+            equalTo(Type.NO)
+        );
+    }
+
+    public void testNonIsolatedProjectAllowedOnSharedNode() {
+        ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(Settings.EMPTY);
+        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).immutable();
+        ShardRouting indexOnlyShardRouting = findShardRoutingByRole(
+            clusterState,
+            ISOLATION_TEST_PROJECT_ID,
+            ALLOC_TEST_INDEX_NAME,
+            INDEX_ONLY
+        );
+        RoutingNode sharedNode = clusterState.getRoutingNodes().node("n-shared");
+        Decision decision = decider.canAllocate(indexOnlyShardRouting, sharedNode, routingAllocation);
+        assertThat(decision.type(), equalTo(Type.YES));
+        assertThat(decision, sameInstance(Decision.ALWAYS));
+    }
+
+    public void testNonStatefulShardRolesAlwaysDefer() {
+        ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(
+            Settings.builder()
+                .put(
+                    ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
+                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "index", "iso-pool")
+                )
+                .build()
+        );
+        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        IndexMetadata indexMetadata = routingIndexMetadata(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ShardId shardId = new ShardId(indexMetadata.getIndex().getName(), indexMetadata.getIndexUUID(), 0);
+        ShardRouting defaultRoleShard = ShardRouting.newUnassigned(
+            shardId,
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test"),
+            Role.DEFAULT
+        );
+        RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).immutable();
+        RoutingNode mismatchedIsolationNode = clusterState.getRoutingNodes().node("n-other");
+
+        Decision decision = decider.canAllocate(defaultRoleShard, mismatchedIsolationNode, routingAllocation);
+        assertThat(decision, sameInstance(Decision.ALWAYS));
+    }
+
+    public void testCanRemainMatchesCanAllocateIndexTier() {
+        ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(
+            Settings.builder()
+                .put(
+                    ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
+                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "index", "iso-pool")
+                )
+                .build()
+        );
+        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).immutable();
+        ShardRouting indexOnlyShard = findShardRoutingByRole(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME, INDEX_ONLY);
+        IndexMetadata indexMetadata = routingIndexMetadata(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+
+        assertThat(
+            decider.canRemain(indexMetadata, indexOnlyShard, clusterState.getRoutingNodes().node("n-iso"), routingAllocation).type(),
+            equalTo(Type.YES)
+        );
+        assertThat(
+            decider.canRemain(indexMetadata, indexOnlyShard, clusterState.getRoutingNodes().node("n-shared"), routingAllocation).type(),
+            equalTo(Type.NO)
+        );
+    }
+
+    public void testCanRemainMatchesCanAllocateSearchTier() {
+        ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(
+            Settings.builder()
+                .put(
+                    ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
+                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "search", "iso-pool")
+                )
+                .build()
+        );
+        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).immutable();
+        ShardRouting searchOnlyShard = findShardRoutingByRole(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME, SEARCH_ONLY);
+        IndexMetadata indexMetadata = routingIndexMetadata(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+
+        assertThat(
+            decider.canRemain(indexMetadata, searchOnlyShard, clusterState.getRoutingNodes().node("n-iso"), routingAllocation).type(),
+            equalTo(Type.YES)
+        );
+        assertThat(
+            decider.canRemain(indexMetadata, searchOnlyShard, clusterState.getRoutingNodes().node("n-shared"), routingAllocation).type(),
+            equalTo(Type.NO)
+        );
+    }
+
+    public void testDebugDecisionExplainsIsolationTierMismatch() {
+        ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(
+            Settings.builder()
+                .put(
+                    ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
+                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "index", "iso-pool")
+                )
+                .build()
+        );
+        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).mutable();
+        routingAllocation.debugDecision(true);
+        ShardRouting indexOnlyShard = findShardRoutingByRole(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME, INDEX_ONLY);
+
+        Single decision = (Single) decider.canAllocate(indexOnlyShard, clusterState.getRoutingNodes().node("n-shared"), routingAllocation);
+        assertThat(decision.type(), equalTo(Type.NO));
+        String explanation = decision.getExplanation();
+        assertThat(explanation, containsString("iso-pool"));
+        assertThat(explanation, containsString(ISOLATION_TEST_PROJECT_ID.id()));
+        assertThat(explanation, containsString("index"));
+    }
+
+    public void testDebugDecisionExplainsNonIsolatedShardOnIsolationNode() {
+        ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(Settings.EMPTY);
+        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).mutable();
+        routingAllocation.debugDecision(true);
+        ShardRouting indexOnlyShard = findShardRoutingByRole(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME, INDEX_ONLY);
+
+        Single decision = (Single) decider.canAllocate(indexOnlyShard, clusterState.getRoutingNodes().node("n-iso"), routingAllocation);
+        assertThat(decision.type(), equalTo(Type.NO));
+        assertThat(decision.getExplanation(), containsString("non-isolated"));
+        assertThat(decision.getExplanation(), containsString("iso-pool"));
+    }
+
+    private static IndexMetadata routingIndexMetadata(ClusterState clusterState, ProjectId projectId, String indexName) {
+        return clusterState.metadata().getProject(projectId).index(indexName);
+    }
+
+    private static ShardRouting findShardRoutingByRole(ClusterState clusterState, ProjectId projectId, String indexName, Role role) {
+        IndexShardRoutingTable indexShardRoutingTable = clusterState.routingTable(projectId).index(indexName).shard(0);
+        for (int replicaIndex = 0; replicaIndex < indexShardRoutingTable.size(); replicaIndex++) {
+            ShardRouting shardRouting = indexShardRoutingTable.shard(replicaIndex);
+            if (shardRouting.role() == role) {
+                return shardRouting;
+            }
+        }
+        throw new AssertionError("no shard with role " + role);
+    }
+
+    /** JSON body for {@link ProjectIsolationAllocationDecider#CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING} with one tier key. */
+    private static String isolatedProjectTierJson(ProjectId projectId, String tierJsonKey, String poolName) {
+        return "[{\"project\":\"" + projectId.id() + "\",\"tiers\":{\"" + tierJsonKey + "\":\"" + poolName + "\"}}]";
+    }
+
+    /**
+     * Cluster with one stateless index and three index nodes: shared, isolated matching "iso-pool", isolated "other-pool".
+     */
+    private static ClusterState newClusterStateForIsolationFixture(ProjectId projectId, String indexName) {
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .build();
+
+        Set<DiscoveryNodeRole> indexingNodeRoles = Set.of(INDEX_ROLE);
+
+        return ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(DiscoveryNodeUtils.builder("n-shared").roles(indexingNodeRoles).build())
+                    .add(
+                        DiscoveryNodeUtils.builder("n-iso")
+                            .roles(indexingNodeRoles)
+                            .attributes(Map.of(ProjectIsolationAllocationDecider.NODE_ATTRIBUTE_ISOLATED_TIER, "iso-pool"))
+                            .build()
+                    )
+                    .add(
+                        DiscoveryNodeUtils.builder("n-other")
+                            .roles(indexingNodeRoles)
+                            .attributes(Map.of(ProjectIsolationAllocationDecider.NODE_ATTRIBUTE_ISOLATED_TIER, "other-pool"))
+                            .build()
+                    )
+                    .build()
+            )
+            .putProjectMetadata(ProjectMetadata.builder(projectId).put(indexMetadata, false))
+            .routingTable(projectId, RoutingTable.builder(new StatelessShardRoutingRoleStrategy()).addAsNew(indexMetadata).build())
+            .build();
+    }
+
+    private static ProjectIsolationAllocationDecider newProjectIsolationAllocationDecider(Settings nodeSettings) {
+        Set<Setting<?>> clusterSettingsRegistrations = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        clusterSettingsRegistrations.add(ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING);
+        ClusterSettings clusterSettings = new ClusterSettings(nodeSettings, clusterSettingsRegistrations);
+        return new ProjectIsolationAllocationDecider(clusterSettings);
+    }
+}

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/ProjectIsolationAllocationDeciderTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/allocation/ProjectIsolationAllocationDeciderTests.java
@@ -47,27 +47,24 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class ProjectIsolationAllocationDeciderTests extends ESAllocationTestCase {
 
-    private static final ProjectId ISOLATION_TEST_PROJECT_ID = ProjectId.fromId("projisolatedaaaa");
-
-    private static final String ALLOC_TEST_INDEX_NAME = "alloc-test-idx";
-
+    /**
+     * For a project configured with index tier isolation, {@code canAllocate} returns yes only when the node's
+     * {@code isolated_tier} attribute matches the configured pool name.
+     */
     public void testIsolatedProjectRequiresMatchingNodeAttribute() {
+        ProjectId isolationTestProjectId = randomIsolationTestProjectId();
+        String testIndexName = randomTestIndexName();
         ProjectIsolationAllocationDecider projectIsolationAllocationDecider = newProjectIsolationAllocationDecider(
             Settings.builder()
                 .put(
                     ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
-                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "index", "iso-pool")
+                    isolatedProjectTierJson(isolationTestProjectId, "index", "iso-pool")
                 )
                 .build()
         );
-        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ClusterState clusterState = newClusterStateForIsolationFixture(isolationTestProjectId, testIndexName);
         RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).build();
-        ShardRouting indexOnlyShardRouting = findShardRoutingByRole(
-            clusterState,
-            ISOLATION_TEST_PROJECT_ID,
-            ALLOC_TEST_INDEX_NAME,
-            INDEX_ONLY
-        );
+        ShardRouting indexOnlyShardRouting = findShardRoutingByRole(clusterState, isolationTestProjectId, testIndexName, INDEX_ONLY);
 
         assertThat(
             projectIsolationAllocationDecider.canAllocate(
@@ -95,18 +92,24 @@ public class ProjectIsolationAllocationDeciderTests extends ESAllocationTestCase
         );
     }
 
+    /**
+     * For a project configured with search tier isolation, a {@link Role#SEARCH_ONLY} shard is allowed on a node only when that node's
+     * {@code isolated_tier} attribute matches the pool, using the same matching idea as the index tier.
+     */
     public void testIsolatedProjectSearchTierRequiresMatchingNodeAttribute() {
+        ProjectId isolationTestProjectId = randomIsolationTestProjectId();
+        String testIndexName = randomTestIndexName();
         ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(
             Settings.builder()
                 .put(
                     ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
-                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "search", "iso-pool")
+                    isolatedProjectTierJson(isolationTestProjectId, "search", "iso-pool")
                 )
                 .build()
         );
-        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ClusterState clusterState = newClusterStateForIsolationFixture(isolationTestProjectId, testIndexName);
         RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).build();
-        ShardRouting searchOnlyShard = findShardRoutingByRole(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME, SEARCH_ONLY);
+        ShardRouting searchOnlyShard = findShardRoutingByRole(clusterState, isolationTestProjectId, testIndexName, SEARCH_ONLY);
 
         assertThat(
             decider.canAllocate(searchOnlyShard, clusterState.getRoutingNodes().node("n-iso"), routingAllocation).type(),
@@ -122,16 +125,17 @@ public class ProjectIsolationAllocationDeciderTests extends ESAllocationTestCase
         );
     }
 
+    /**
+     * If isolation is not configured for the cluster, the decider rejects placing the shard on any node that still carries an
+     * {@code isolated_tier} attribute.
+     */
     public void testNonIsolatedProjectRejectedOnIsolatedNodes() {
+        ProjectId isolationTestProjectId = randomIsolationTestProjectId();
+        String testIndexName = randomTestIndexName();
         ProjectIsolationAllocationDecider projectIsolationAllocationDecider = newProjectIsolationAllocationDecider(Settings.EMPTY);
-        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ClusterState clusterState = newClusterStateForIsolationFixture(isolationTestProjectId, testIndexName);
         RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).build();
-        ShardRouting indexOnlyShardRouting = findShardRoutingByRole(
-            clusterState,
-            ISOLATION_TEST_PROJECT_ID,
-            ALLOC_TEST_INDEX_NAME,
-            INDEX_ONLY
-        );
+        ShardRouting indexOnlyShardRouting = findShardRoutingByRole(clusterState, isolationTestProjectId, testIndexName, INDEX_ONLY);
 
         RoutingNode isolatedIndexingRoutingNode = clusterState.getRoutingNodes().node("n-iso");
         assertThat(
@@ -140,33 +144,40 @@ public class ProjectIsolationAllocationDeciderTests extends ESAllocationTestCase
         );
     }
 
+    /**
+     * If isolation is not configured for the cluster, a shard on a shared node without an {@code isolated_tier} attribute gets
+     * {@link Decision#ALWAYS} so other allocation deciders can apply.
+     */
     public void testNonIsolatedProjectAllowedOnSharedNode() {
+        ProjectId isolationTestProjectId = randomIsolationTestProjectId();
+        String testIndexName = randomTestIndexName();
         ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(Settings.EMPTY);
-        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ClusterState clusterState = newClusterStateForIsolationFixture(isolationTestProjectId, testIndexName);
         RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).immutable();
-        ShardRouting indexOnlyShardRouting = findShardRoutingByRole(
-            clusterState,
-            ISOLATION_TEST_PROJECT_ID,
-            ALLOC_TEST_INDEX_NAME,
-            INDEX_ONLY
-        );
+        ShardRouting indexOnlyShardRouting = findShardRoutingByRole(clusterState, isolationTestProjectId, testIndexName, INDEX_ONLY);
         RoutingNode sharedNode = clusterState.getRoutingNodes().node("n-shared");
         Decision decision = decider.canAllocate(indexOnlyShardRouting, sharedNode, routingAllocation);
         assertThat(decision.type(), equalTo(Type.YES));
         assertThat(decision, sameInstance(Decision.ALWAYS));
     }
 
+    /**
+     * A shard with {@link Role#DEFAULT} does not participate in project isolation. This decider always defers, even when the owning
+     * project is configured as isolated for index tiers.
+     */
     public void testNonStatefulShardRolesAlwaysDefer() {
+        ProjectId isolationTestProjectId = randomIsolationTestProjectId();
+        String testIndexName = randomTestIndexName();
         ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(
             Settings.builder()
                 .put(
                     ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
-                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "index", "iso-pool")
+                    isolatedProjectTierJson(isolationTestProjectId, "index", "iso-pool")
                 )
                 .build()
         );
-        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
-        IndexMetadata indexMetadata = routingIndexMetadata(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ClusterState clusterState = newClusterStateForIsolationFixture(isolationTestProjectId, testIndexName);
+        IndexMetadata indexMetadata = routingIndexMetadata(clusterState, isolationTestProjectId, testIndexName);
         ShardId shardId = new ShardId(indexMetadata.getIndex().getName(), indexMetadata.getIndexUUID(), 0);
         ShardRouting defaultRoleShard = ShardRouting.newUnassigned(
             shardId,
@@ -182,19 +193,25 @@ public class ProjectIsolationAllocationDeciderTests extends ESAllocationTestCase
         assertThat(decision, sameInstance(Decision.ALWAYS));
     }
 
+    /**
+     * For {@link Role#INDEX_ONLY} shards under index tier isolation, {@code canRemain} agrees with {@code canAllocate} on isolated nodes
+     * versus shared nodes.
+     */
     public void testCanRemainMatchesCanAllocateIndexTier() {
+        ProjectId isolationTestProjectId = randomIsolationTestProjectId();
+        String testIndexName = randomTestIndexName();
         ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(
             Settings.builder()
                 .put(
                     ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
-                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "index", "iso-pool")
+                    isolatedProjectTierJson(isolationTestProjectId, "index", "iso-pool")
                 )
                 .build()
         );
-        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ClusterState clusterState = newClusterStateForIsolationFixture(isolationTestProjectId, testIndexName);
         RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).immutable();
-        ShardRouting indexOnlyShard = findShardRoutingByRole(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME, INDEX_ONLY);
-        IndexMetadata indexMetadata = routingIndexMetadata(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ShardRouting indexOnlyShard = findShardRoutingByRole(clusterState, isolationTestProjectId, testIndexName, INDEX_ONLY);
+        IndexMetadata indexMetadata = routingIndexMetadata(clusterState, isolationTestProjectId, testIndexName);
 
         assertThat(
             decider.canRemain(indexMetadata, indexOnlyShard, clusterState.getRoutingNodes().node("n-iso"), routingAllocation).type(),
@@ -206,19 +223,25 @@ public class ProjectIsolationAllocationDeciderTests extends ESAllocationTestCase
         );
     }
 
+    /**
+     * For {@link Role#SEARCH_ONLY} shards under search tier isolation, {@code canRemain} agrees with {@code canAllocate} on isolated
+     * nodes versus shared nodes.
+     */
     public void testCanRemainMatchesCanAllocateSearchTier() {
+        ProjectId isolationTestProjectId = randomIsolationTestProjectId();
+        String testIndexName = randomTestIndexName();
         ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(
             Settings.builder()
                 .put(
                     ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
-                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "search", "iso-pool")
+                    isolatedProjectTierJson(isolationTestProjectId, "search", "iso-pool")
                 )
                 .build()
         );
-        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ClusterState clusterState = newClusterStateForIsolationFixture(isolationTestProjectId, testIndexName);
         RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).immutable();
-        ShardRouting searchOnlyShard = findShardRoutingByRole(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME, SEARCH_ONLY);
-        IndexMetadata indexMetadata = routingIndexMetadata(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ShardRouting searchOnlyShard = findShardRoutingByRole(clusterState, isolationTestProjectId, testIndexName, SEARCH_ONLY);
+        IndexMetadata indexMetadata = routingIndexMetadata(clusterState, isolationTestProjectId, testIndexName);
 
         assertThat(
             decider.canRemain(indexMetadata, searchOnlyShard, clusterState.getRoutingNodes().node("n-iso"), routingAllocation).type(),
@@ -230,34 +253,46 @@ public class ProjectIsolationAllocationDeciderTests extends ESAllocationTestCase
         );
     }
 
+    /**
+     * With allocation debug enabled and a tier mismatch, the decider returns {@link Decision.Type#NO} as a {@link Decision.Single} whose
+     * explanation names the project, tier, and pool values involved.
+     */
     public void testDebugDecisionExplainsIsolationTierMismatch() {
+        ProjectId isolationTestProjectId = randomIsolationTestProjectId();
+        String testIndexName = randomTestIndexName();
         ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(
             Settings.builder()
                 .put(
                     ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING.getKey(),
-                    isolatedProjectTierJson(ISOLATION_TEST_PROJECT_ID, "index", "iso-pool")
+                    isolatedProjectTierJson(isolationTestProjectId, "index", "iso-pool")
                 )
                 .build()
         );
-        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ClusterState clusterState = newClusterStateForIsolationFixture(isolationTestProjectId, testIndexName);
         RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).mutable();
         routingAllocation.debugDecision(true);
-        ShardRouting indexOnlyShard = findShardRoutingByRole(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME, INDEX_ONLY);
+        ShardRouting indexOnlyShard = findShardRoutingByRole(clusterState, isolationTestProjectId, testIndexName, INDEX_ONLY);
 
         Single decision = (Single) decider.canAllocate(indexOnlyShard, clusterState.getRoutingNodes().node("n-shared"), routingAllocation);
         assertThat(decision.type(), equalTo(Type.NO));
         String explanation = decision.getExplanation();
         assertThat(explanation, containsString("iso-pool"));
-        assertThat(explanation, containsString(ISOLATION_TEST_PROJECT_ID.id()));
+        assertThat(explanation, containsString(isolationTestProjectId.id()));
         assertThat(explanation, containsString("index"));
     }
 
+    /**
+     * With allocation debug enabled, a non-isolated shard proposed on an isolated-capable node gets {@link Decision.Type#NO} with an
+     * explanation that calls out the non-isolated case and the node's pool name.
+     */
     public void testDebugDecisionExplainsNonIsolatedShardOnIsolationNode() {
+        ProjectId isolationTestProjectId = randomIsolationTestProjectId();
+        String testIndexName = randomTestIndexName();
         ProjectIsolationAllocationDecider decider = newProjectIsolationAllocationDecider(Settings.EMPTY);
-        ClusterState clusterState = newClusterStateForIsolationFixture(ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME);
+        ClusterState clusterState = newClusterStateForIsolationFixture(isolationTestProjectId, testIndexName);
         RoutingAllocation routingAllocation = TestRoutingAllocationFactory.forClusterState(clusterState).mutable();
         routingAllocation.debugDecision(true);
-        ShardRouting indexOnlyShard = findShardRoutingByRole(clusterState, ISOLATION_TEST_PROJECT_ID, ALLOC_TEST_INDEX_NAME, INDEX_ONLY);
+        ShardRouting indexOnlyShard = findShardRoutingByRole(clusterState, isolationTestProjectId, testIndexName, INDEX_ONLY);
 
         Single decision = (Single) decider.canAllocate(indexOnlyShard, clusterState.getRoutingNodes().node("n-iso"), routingAllocation);
         assertThat(decision.type(), equalTo(Type.NO));
@@ -325,5 +360,16 @@ public class ProjectIsolationAllocationDeciderTests extends ESAllocationTestCase
         clusterSettingsRegistrations.add(ProjectIsolationAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ISOLATED_PROJECTS_SETTING);
         ClusterSettings clusterSettings = new ClusterSettings(nodeSettings, clusterSettingsRegistrations);
         return new ProjectIsolationAllocationDecider(clusterSettings);
+    }
+
+    /** Random lowercase index name valid for allocation tests. */
+    private String randomTestIndexName() {
+        return randomIdentifier("test-i-");
+    }
+
+    /** Random id valid for {@link ProjectId#fromId(String)} (not {@link ProjectId#DEFAULT}). */
+    private ProjectId randomIsolationTestProjectId() {
+        String id = randomValueOtherThan(ProjectId.DEFAULT.id(), () -> randomAlphanumericOfLength(randomIntBetween(12, 32)));
+        return ProjectId.fromId(id);
     }
 }


### PR DESCRIPTION
Implements `ProjectIsolationAllocationDecider` which will move shards of isolated projects onto dedicated nodes within a multi-project cluster.

Closes: ES-11234
