### PR TITLE
Update TS_INFO to GA

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/ts-info.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/ts-info.md
@@ -1,6 +1,6 @@
 ```yaml {applies_to}
 serverless: ga
-stack: preview 9.4.0
+stack: ga 9.4.0
 ```
 
 The `TS_INFO` [processing command](/reference/query-languages/esql/commands/processing-commands.md) retrieves


### PR DESCRIPTION
We are labeling TS_INFO as Tech preview for 9.4 - We should update it to GA
