### PR TITLE
Fix CCR follow to handle indexing_complete race (#145304)

### DIFF
--- a/docs/changelog/145304.yaml
+++ b/docs/changelog/145304.yaml
@@ -1,0 +1,5 @@
+area: CCR
+issues: []
+pr: 145304
+summary: Fix CCR follow to handle `indexing_complete` race
+type: bug

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -329,16 +329,15 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
      */
     private static void validateSettings(final Settings leaderIndexSettings, final Settings followerIndexSettings) {
         // make a copy, remove settings that are allowed to be different, and then compare if the settings are equal
-        final Settings leaderSettings = Settings.builder()
-            .put(filter(leaderIndexSettings))
-            // index.lifecycle.indexing_complete can legitimately differ at follow startup: the leader's ILM may
-            // set it during the restore window, before the shard follow task starts syncing settings.
-            .remove(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE)
-            .build();
-        final Settings followerSettings = Settings.builder()
-            .put(filter(followerIndexSettings))
-            .remove(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE)
-            .build();
+        final Settings.Builder leaderSettingsBuilder = Settings.builder().put(filter(leaderIndexSettings));
+        // index.lifecycle.indexing_complete can legitimately differ at follow startup: the leader's ILM may
+        // set it during the restore window, before the shard follow task starts syncing settings.
+        leaderSettingsBuilder.remove(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE);
+        final Settings leaderSettings = leaderSettingsBuilder.build();
+
+        final Settings.Builder followerSettingsBuilder = Settings.builder().put(filter(followerIndexSettings));
+        followerSettingsBuilder.remove(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE);
+        final Settings followerSettings = followerSettingsBuilder.build();
         if (leaderSettings.equals(followerSettings) == false) {
             final String message = String.format(
                 Locale.ROOT,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -55,6 +55,7 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ccr.action.FollowParameters;
 import org.elasticsearch.xpack.core.ccr.action.ResumeFollowAction;
 import org.elasticsearch.xpack.core.ccr.action.ShardFollowTask;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -328,8 +329,16 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
      */
     private static void validateSettings(final Settings leaderIndexSettings, final Settings followerIndexSettings) {
         // make a copy, remove settings that are allowed to be different, and then compare if the settings are equal
-        final Settings leaderSettings = filter(leaderIndexSettings);
-        final Settings followerSettings = filter(followerIndexSettings);
+        final Settings leaderSettings = Settings.builder()
+            .put(filter(leaderIndexSettings))
+            // index.lifecycle.indexing_complete can legitimately differ at follow startup: the leader's ILM may
+            // set it during the restore window, before the shard follow task starts syncing settings.
+            .remove(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE)
+            .build();
+        final Settings followerSettings = Settings.builder()
+            .put(filter(followerIndexSettings))
+            .remove(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE)
+            .build();
         if (leaderSettings.equals(followerSettings) == false) {
             final String message = String.format(
                 Locale.ROOT,

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowActionTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ccr.Ccr;
 import org.elasticsearch.xpack.ccr.CcrSettings;
 import org.elasticsearch.xpack.core.ccr.action.ResumeFollowAction;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -307,6 +308,24 @@ public class TransportResumeFollowActionTests extends ESTestCase {
                 followIMD.getSettings(),
                 "index2"
             );
+            mapperService.merge(followIMD, MapperService.MergeReason.MAPPING_RECOVERY);
+            validate(request, leaderIMD, followIMD, UUIDs, mapperService);
+        }
+        {
+            // should succeed when leader has indexing_complete=true but follower does not (race during auto-follow restore)
+            IndexMetadata leaderIMD = createIMD(
+                "index1",
+                5,
+                Settings.builder().put(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE, true).build(),
+                null
+            );
+            IndexMetadata followIMD = createIMD(
+                "index2",
+                5,
+                Settings.builder().put(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey(), true).build(),
+                customMetadata
+            );
+            MapperService mapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), Settings.EMPTY, "index2");
             mapperService.merge(followIMD, MapperService.MergeReason.MAPPING_RECOVERY);
             validate(request, leaderIMD, followIMD, UUIDs, mapperService);
         }


### PR DESCRIPTION
# Backport

This will backport the following commits:
- [Fix CCR follow to handle indexing_complete race#145304](https://github.com/elastic/elasticsearch/pull/145304)