### PR TITLE
ES|QL RerankIT cheaper parameters

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/RerankIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/RerankIT.java
@@ -47,6 +47,19 @@ public class RerankIT extends InferenceCommandIntegTestCase {
         cleanupClusterSettings(InferenceSettings.RERANK_ENABLED_SETTING, InferenceSettings.RERANK_ROW_LIMIT_SETTING);
     }
 
+    @Override
+    protected QueryPragmas getPragmas() {
+        Settings.Builder settings = Settings.builder();
+        settings.put("task_concurrency", randomLongBetween(1, 4));
+        settings.put("task_queue_size", randomIntBetween(1, 10));
+        settings.put("exchange_buffer_size", randomIntBetween(1, 10));
+        settings.put("exchange_concurrent_clients", randomIntBetween(1, 4));
+        settings.put("data_partitioning", "segment");
+        settings.put("page_size", between(1, 1024));
+        settings.put("max_concurrent_shards_per_node", randomIntBetween(1, 2));
+        return new QueryPragmas(settings.build());
+    }
+
     // ============================================
     // Basic Functionality Tests
     // ============================================


### PR DESCRIPTION
This constraints the variability of the ES|QL RERANK integration test parameters and make them cheaper, to avoid problems like the one mentioned at https://github.com/elastic/elasticsearch/issues/146127, https://github.com/elastic/elasticsearch/issues/148102.

