### PR TITLE
Memory estimator for fuzzy query automata

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/fuzzy/FuzzyAutomatonRamEstimatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/fuzzy/FuzzyAutomatonRamEstimatorBenchmark.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.search.fuzzy;
+
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.util.automaton.CompiledAutomaton;
+import org.elasticsearch.lucene.search.FuzzyAutomatonRamEstimator;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compares the closed-form RAM estimate produced by {@link FuzzyAutomatonRamEstimator#estimate}
+ * against the actual {@link CompiledAutomaton#ramBytesUsed()} of the automata Lucene's
+ * {@link FuzzyQuery#getFuzzyAutomaton} would build, both in <em>cost</em> (time per call) and in
+ * <em>value</em> (bytes returned) across a representative grid of fuzzy-query parameters.
+ *
+ * <p>The two {@code @Benchmark} methods are intentionally apples-to-apples on the work performed
+ * at search time:
+ * <ul>
+ *   <li>{@link #estimate} runs the closed-form formula only — what the circuit breaker would
+ *       charge before any automaton is built.</li>
+ *   <li>{@link #measureBuild} actually builds the {@code maxEdits + 1} compiled automata and sums
+ *       their {@code ramBytesUsed()} — what the breaker is trying to bound.</li>
+ * </ul>
+ *
+ * <p>The {@link Metrics} aux counters report the byte values themselves alongside the timing
+ * numbers so a single JMH run shows, per parameter combination, the estimate, the measurement,
+ * and their ratio. The estimate must always be a ceiling on the measurement; the ratio
+ * quantifies how loose that ceiling is for each input shape.
+ *
+ */
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@SuppressWarnings("unused") // invoked by JMH
+public class FuzzyAutomatonRamEstimatorBenchmark {
+
+    public enum Alphabet {
+        SINGLE_CHAR {
+            @Override
+            String generate(int n, Random r) {
+                return "a".repeat(n);
+            }
+        },
+        ASCII_LETTERS {
+            @Override
+            String generate(int n, Random r) {
+                StringBuilder sb = new StringBuilder(n);
+                for (int i = 0; i < n; i++) {
+                    sb.append((char) ('a' + r.nextInt(26)));
+                }
+                return sb.toString();
+            }
+        },
+        UNICODE_BMP {
+            @Override
+            String generate(int n, Random r) {
+                StringBuilder sb = new StringBuilder(n);
+                for (int i = 0; i < n; i++) {
+                    int cp;
+                    do {
+                        cp = r.nextInt(0xD800);
+                    } while (Character.isISOControl(cp) || Character.isWhitespace(cp));
+                    sb.appendCodePoint(cp);
+                }
+                return sb.toString();
+            }
+        };
+
+        abstract String generate(int n, Random r);
+    }
+
+    @Param({ "5", "20", "50", "200", "1024" })
+    public int termLength;
+
+    @Param({ "1", "2" })
+    public int maxEdits;
+
+    @Param({ "0", "3" })
+    public int prefixLength;
+
+    @Param({ "true", "false" })
+    public boolean transpositions;
+
+    @Param({ "SINGLE_CHAR", "ASCII_LETTERS", "UNICODE_BMP" })
+    public Alphabet alphabet;
+
+    private String term;
+    private int termByteLength;
+    private int distinctUtf8Bytes;
+    private long precomputedEstimate;
+    private long precomputedMeasured;
+    private double precomputedRatio;
+
+
+    @AuxCounters(AuxCounters.Type.EVENTS)
+    @State(Scope.Thread)
+    public static class Metrics {
+        public double estimatedBytes;
+        public double measuredBytes;
+        public double estimateOverMeasuredRatio;
+    }
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        if (prefixLength > termLength) {
+            term = null;
+            return;
+        }
+        Random rnd = new Random(0xC0FFEEL ^ termLength ^ alphabet.ordinal());
+        term = alphabet.generate(termLength, rnd);
+        byte[] utf8 = term.getBytes(StandardCharsets.UTF_8);
+        termByteLength = utf8.length;
+        distinctUtf8Bytes = countDistinctUtf8Bytes(utf8);
+
+        precomputedEstimate = FuzzyAutomatonRamEstimator.estimate(termLength, termByteLength, distinctUtf8Bytes, maxEdits, prefixLength);
+        precomputedMeasured = sumRamBytes(term, maxEdits, prefixLength, transpositions);
+        precomputedRatio = precomputedMeasured == 0 ? 0.0 : (double) precomputedEstimate / (double) precomputedMeasured;
+    }
+
+    @Benchmark
+    public long estimate(Metrics metrics) {
+        if (term == null) {
+            return 0L;
+        }
+        publish(metrics);
+        return FuzzyAutomatonRamEstimator.estimate(termLength, termByteLength, distinctUtf8Bytes, maxEdits, prefixLength);
+    }
+
+    @Benchmark
+    public long measureBuild(Metrics metrics) {
+        if (term == null) {
+            return 0L;
+        }
+        publish(metrics);
+        return sumRamBytes(term, maxEdits, prefixLength, transpositions);
+    }
+
+    private void publish(Metrics metrics) {
+        metrics.estimatedBytes = precomputedEstimate;
+        metrics.measuredBytes = precomputedMeasured;
+        metrics.estimateOverMeasuredRatio = precomputedRatio;
+    }
+
+    private static long sumRamBytes(String term, int maxEdits, int prefixLength, boolean transpositions) {
+        long sum = 0L;
+        for (int e = 0; e <= maxEdits; e++) {
+            CompiledAutomaton ca = FuzzyQuery.getFuzzyAutomaton(term, e, prefixLength, transpositions);
+            sum += ca.ramBytesUsed();
+        }
+        return sum;
+    }
+
+    private static int countDistinctUtf8Bytes(byte[] utf8) {
+        BitSet seen = new BitSet(256);
+        for (byte b : utf8) {
+            seen.set(b & 0xff);
+        }
+        return seen.cardinality();
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/fuzzy/FuzzyAutomatonRamEstimatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/fuzzy/FuzzyAutomatonRamEstimatorBenchmark.java
@@ -118,7 +118,6 @@ public class FuzzyAutomatonRamEstimatorBenchmark {
     private long precomputedMeasured;
     private double precomputedRatio;
 
-
     @AuxCounters(AuxCounters.Type.EVENTS)
     @State(Scope.Thread)
     public static class Metrics {

--- a/server/src/main/java/org/elasticsearch/lucene/search/FuzzyAutomatonRamEstimator.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/FuzzyAutomatonRamEstimator.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.search;
+
+import org.apache.lucene.util.automaton.LevenshteinAutomata;
+
+/**
+ * Closed-form, pre-flight estimator for the RAM retained by the
+ * {@link org.apache.lucene.util.automaton.CompiledAutomaton} instances Lucene builds for a
+ * fuzzy query. Used to charge the circuit breaker <em>before</em> any Levenshtein automaton
+ * is constructed.
+ *
+ * <p>For a query with {@code maxEdits = E} the total is the sum over edit levels
+ * {@code e ∈ [0, E]} of:
+ *
+ * <pre>
+ *     bytes(e)      = PER_AUTOMATON_OVERHEAD + stateCount(e) · perState(e)
+ *     stateCount(e) = effectiveByteLen · (2·e + 1) + 1
+ *     perState(e)   = max(0, BASE[e] + COEF[e] · sqrt(min(bd, 256)))
+ * </pre>
+ *
+ * where {@code effectiveByteLen} is the term's UTF-8 byte length minus the prefix's byte
+ * share and {@code bd = distinctUtf8Bytes} is the byte-level alphabet width. State count
+ * is driven by UTF-8 byte length (not codepoints) because the compiled automaton wraps a
+ * {@code ByteRunAutomaton}; the {@code sqrt(bd)} alphabet term lets one calibration cover
+ * both ASCII and multi-byte alphabets.
+ */
+public final class FuzzyAutomatonRamEstimator {
+
+    /**
+     * {@code BASE[e]} in the per-state formula, indexed by edit level. {@code BASE[2]} is
+     * negative on purpose — the level-2 fit is a {@code sqrt(bd)} line with a negative
+     * intercept; {@code perState} is clamped to {@code >= 0} before use. Sized for
+     * {@code maxEdits ≤ 2}; grow alongside {@link LevenshteinAutomata#MAXIMUM_SUPPORTED_DISTANCE}.
+     */
+    static final long[] BYTES_PER_STATE_BASE_BY_LEVEL = { 80L, 300L, -337L };
+
+    /**
+     * {@code COEF[e]} in the per-state formula, indexed by edit level. Multiplied by
+     * {@code sqrt(min(bd, 256))} (see {@link #BYTE_DISTINCT_EXPONENT}).
+     */
+    static final long[] BYTES_PER_STATE_PER_DISTINCT_BYTE_BY_LEVEL = { 5L, 183L, 917L };
+
+    /** Fixed bytes per {@link org.apache.lucene.util.automaton.CompiledAutomaton} that don't scale with state count. */
+    static final long PER_AUTOMATON_OVERHEAD = 2000L;
+
+    /** Exponent applied to {@code bd}; {@code 0.5} ({@code sqrt}) is the empirical best fit. */
+    static final double BYTE_DISTINCT_EXPONENT = 0.5;
+
+    /** Cap on {@code bd}: a UTF-8 transition table has at most one entry per byte value. */
+    static final long MAX_BYTE_DISTINCT_BOUND = 256L;
+
+    private FuzzyAutomatonRamEstimator() {}
+
+    /**
+     * Estimated aggregate RAM, in bytes, of the compiled automata for a
+     * {@link org.apache.lucene.search.FuzzyQuery} with the given parameters. See the
+     * class-level Javadoc for the formula. Returns {@code 0} when {@code maxEdits == 0}.
+     *
+     * @param termLength        term length in Unicode code points; used only to apportion
+     *                          {@code prefixLength}. Must be {@code >= 0}.
+     * @param termByteLength    term length in UTF-8 bytes (e.g. {@code BytesRef.length}).
+     *                          Conservative callers may pass {@code 4 * termLength}. Must be
+     *                          {@code >= 0}.
+     * @param distinctUtf8Bytes number of distinct byte values in the UTF-8 encoding;
+     *                          conservative callers may pass {@code 256}. Must be {@code >= 0}.
+     * @param maxEdits          {@code [0, MAXIMUM_SUPPORTED_DISTANCE]}.
+     * @param prefixLength      common non-fuzzy prefix length in code points; clamped to
+     *                          {@code termLength}. Must be {@code >= 0}.
+     */
+    public static long estimate(int termLength, int termByteLength, int distinctUtf8Bytes, int maxEdits, int prefixLength) {
+        if (termLength < 0) {
+            throw new IllegalArgumentException("termLength must be >= 0, got: " + termLength);
+        }
+        if (termByteLength < 0) {
+            throw new IllegalArgumentException("termByteLength must be >= 0, got: " + termByteLength);
+        }
+        if (distinctUtf8Bytes < 0) {
+            throw new IllegalArgumentException("distinctUtf8Bytes must be >= 0, got: " + distinctUtf8Bytes);
+        }
+        if (maxEdits < 0 || maxEdits > LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE) {
+            throw new IllegalArgumentException(
+                "maxEdits must be 0.." + LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE + ", got: " + maxEdits
+            );
+        }
+        if (prefixLength < 0) {
+            throw new IllegalArgumentException("prefixLength must be >= 0, got: " + prefixLength);
+        }
+        if (maxEdits == 0) {
+            return 0L;
+        }
+
+        int effectiveByteLen = effectiveSuffixByteLength(termLength, termByteLength, prefixLength);
+        double byteDistinctSqrt = byteDistinctSqrt(distinctUtf8Bytes, effectiveByteLen);
+
+        long total = 0L;
+        for (int e = 0; e <= maxEdits; e++) {
+            total = Math.addExact(total, levelBytes(e, effectiveByteLen, byteDistinctSqrt));
+        }
+        return total;
+    }
+
+    /**
+     * UTF-8 byte length of the suffix fed to the Levenshtein automaton: {@code termByteLength}
+     * minus the prefix's apportioned byte share. {@code prefixLength} is in code points but
+     * state count scales with bytes, so the prefix is charged proportionally.
+     */
+    private static int effectiveSuffixByteLength(int termLength, int termByteLength, int prefixLength) {
+        if (termLength == 0 || termByteLength == 0) {
+            return 0;
+        }
+        int clampedPrefix = Math.min(prefixLength, termLength);
+        long prefixByteShare = ((long) clampedPrefix * termByteLength + termLength / 2) / termLength;
+        return (int) Math.max(0L, termByteLength - prefixByteShare);
+    }
+
+    /**
+     * {@code sqrt(min(distinctUtf8Bytes, 256))} — the alphabet term of {@code perState(e)}.
+     * Returns {@code 0} when the suffix is empty (single transitionless state, no alphabet
+     * contribution). Kept in {@code double}; rounding happens once per level in
+     * {@link #levelBytes}.
+     */
+    private static double byteDistinctSqrt(int distinctUtf8Bytes, int effectiveByteLen) {
+        if (effectiveByteLen == 0) {
+            return 0.0;
+        }
+        long byteDistinctBound = Math.min(MAX_BYTE_DISTINCT_BOUND, distinctUtf8Bytes);
+        return Math.pow(byteDistinctBound, BYTE_DISTINCT_EXPONENT);
+    }
+
+    /**
+     * Estimated bytes for one compiled automaton at edit level {@code e}:
+     * {@code PER_AUTOMATON_OVERHEAD + stateCount(e) · perState(e)}, with {@code perState}
+     * clamped to {@code >= 0} (see {@link #BYTES_PER_STATE_BASE_BY_LEVEL}).
+     */
+    private static long levelBytes(int e, int effectiveByteLen, double byteDistinctSqrt) {
+        long stateCount = (long) effectiveByteLen * (2L * e + 1L) + 1L;
+        double rawPerState = BYTES_PER_STATE_BASE_BY_LEVEL[e] + BYTES_PER_STATE_PER_DISTINCT_BYTE_BY_LEVEL[e] * byteDistinctSqrt;
+        long bytesPerState = Math.max(0L, Math.round(rawPerState));
+        return Math.addExact(PER_AUTOMATON_OVERHEAD, Math.multiplyExact(stateCount, bytesPerState));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/lucene/search/FuzzyAutomatonRamEstimatorTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/search/FuzzyAutomatonRamEstimatorTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.search;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class FuzzyAutomatonRamEstimatorTests extends ESTestCase {
+
+    public void testZeroEditsReturnsZero() {
+        assertEquals(0L, FuzzyAutomatonRamEstimator.estimate(0, 0, 0, 0, 0));
+        assertEquals(0L, FuzzyAutomatonRamEstimator.estimate(50, 50, 1, 0, 0));
+        assertEquals(0L, FuzzyAutomatonRamEstimator.estimate(50, 50, 1, 0, 5));
+    }
+
+    public void testEstimateIsMonotonicInTermLength() {
+        long shorter = FuzzyAutomatonRamEstimator.estimate(10, 10, 10, 2, 0);
+        long longer = FuzzyAutomatonRamEstimator.estimate(50, 50, 10, 2, 0);
+        long longest = FuzzyAutomatonRamEstimator.estimate(200, 200, 10, 2, 0);
+        assertTrue(shorter < longer);
+        assertTrue(longer < longest);
+    }
+
+    public void testEstimateIsMonotonicInMaxEdits() {
+        long e1 = FuzzyAutomatonRamEstimator.estimate(20, 20, 20, 1, 0);
+        long e2 = FuzzyAutomatonRamEstimator.estimate(20, 20, 20, 2, 0);
+        assertTrue("expected estimate to grow with maxEdits", e1 < e2);
+    }
+
+    public void testEstimateIsMonotonicInDistinctUtf8Bytes() {
+        long narrow = FuzzyAutomatonRamEstimator.estimate(20, 60, 1, 2, 0);
+        long medium = FuzzyAutomatonRamEstimator.estimate(20, 60, 5, 2, 0);
+        long wide = FuzzyAutomatonRamEstimator.estimate(20, 60, 60, 2, 0);
+        assertTrue("distinct alphabet should grow the estimate", narrow < medium);
+        assertTrue("distinct alphabet should grow the estimate", medium < wide);
+    }
+
+    public void testPrefixLengthShrinksEstimate() {
+        long noPrefix = FuzzyAutomatonRamEstimator.estimate(20, 60, 60, 2, 0);
+        long withPrefix = FuzzyAutomatonRamEstimator.estimate(20, 60, 60, 2, 5);
+        assertTrue("prefix should reduce the suffix-driven cost", withPrefix < noPrefix);
+    }
+
+    public void testPrefixLongerThanTermIsClampedNotNegative() {
+        long allPrefix = FuzzyAutomatonRamEstimator.estimate(5, 5, 5, 2, 100);
+        long zeroLen = FuzzyAutomatonRamEstimator.estimate(0, 0, 0, 2, 0);
+        assertEquals("prefix >= termLength should behave like termLength == 0", zeroLen, allPrefix);
+    }
+
+    public void testEstimateRejectsNegativeArguments() {
+        expectThrows(IllegalArgumentException.class, () -> FuzzyAutomatonRamEstimator.estimate(-1, 0, 0, 1, 0));
+        expectThrows(IllegalArgumentException.class, () -> FuzzyAutomatonRamEstimator.estimate(10, -1, 0, 1, 0));
+        expectThrows(IllegalArgumentException.class, () -> FuzzyAutomatonRamEstimator.estimate(10, 10, -1, 1, 0));
+        expectThrows(IllegalArgumentException.class, () -> FuzzyAutomatonRamEstimator.estimate(10, 10, 10, -1, 0));
+        expectThrows(IllegalArgumentException.class, () -> FuzzyAutomatonRamEstimator.estimate(10, 10, 10, 1, -1));
+    }
+
+    public void testEstimateRejectsMaxEditsAboveLuceneLimit() {
+        expectThrows(IllegalArgumentException.class, () -> FuzzyAutomatonRamEstimator.estimate(10, 10, 10, 99, 0));
+    }
+}


### PR DESCRIPTION
When a `FuzzyQuery` executes, Lucene builds one `CompiledAutomaton` per edit level (maxEdits + 1 automata) at rewrite time. For long terms or large alphabets, these automata can be several MB in size. Today, nothing accounts for this allocation against the request-cb, so a single oversized fuzzy query can OOM a node. 

The breaker, ideally, needs the cost before the automata exist. We therefore need a closed-form, sub-microsecond estimate that returns a faithful lower/upper-bound on `sum(CompiledAutomaton#ramBytesUsed)`.

This **PR** introduces an estimator that predicts the bytes retained by Lucene's compiled fuzzy automata before they are built, so the circuit breaker can reject pathological queries (long terms × maxEdits=2 × multi-byte alphabets). This is **AI-inspired**, however I spent a good time tweaking the memory parameters and benchmarking.

I've run the following benchmark to evaluate how close the estimator is to a real measurement.
```
./gradlew run --args "org.elasticsearch.benchmark.search.fuzzy.FuzzyAutomatonRamEstimatorBenchmark 
-f 3 -wi 5 -i 10 -w 2s -r 2s -rf json -rff build/jmh-result.json" 
```

###  Benchmarks
Two @Benchmark methods on the same parameter set so JMH gives an apples-to-apples cost-and-value comparison per row
- **estimate** runs only the closed-form formula. This is what the breaker would charge.
- **measureBuild**  invokes `FuzzyQuery.getFuzzyAutomaton` for every level e in [0, maxEdits] and sums `CompiledAutomaton.ramBytesUsed()`. This is what the breaker is trying to bound.

###  Alphabets
- **SINGLE_CHAR**  "a".repeat(n) — **1** distinct UTF-8 byte; the smallest realistic alphabet.
- **ASCII_LETTERS**  uniform random [a-z] — typical English-text shape, **~26** distinct bytes.
- **UNICODE_BMP**  uniform random codepoints in [0, 0xD800) skipping ISO-control and whitespace — wide multi-byte alphabet, mostly 3-byte UTF-8, expanding the byte alphabet up to **~256**.

### Parameter grid
(Cartesian product, minus prefixLength > termLength)
-  termLength in {5, 20, 50, 200, 1024},
-  maxEdits in {1, 2},
- prefixLength in {0, 3}, 
- transpositions in {true, false}, 
- alphabet in {SINGLE_CHAR, ASCII_LETTERS, UNICODE_BMP} 


###  Headline numbers

Metric | Value
-- | --
Median estimated / measured | 0.998
Within ±10 % | 100 / 120 (83 %)
Within ±20 % | 112 / 120 (93 %)
Worst over-estimate | 2.01× — UNICODE_BMP, L=5, e=2, prefix=3
Worst under-estimate | 0.77× — ASCII_LETTERS, L=5, e=2, prefix=0
estimate() cost (median) | 6 ns / call
measureBuild() cost (median / max) | 1.1 ms / 2.1 s per call


The error is symmetric around 1.0 (median 0.998, mean 1.016) 

### Where the residual lives

**By term length** — error concentrates at termLength = 5. Total RAM in this regime is small in absolute terms (the worst absolute over-estimate is 3.8 MB), so it does not affect breaker decisions in practice, or it affects very little

termLength | median | min | max | within ±10 %
-- | -- | -- | -- | --
5  | 1.002 | 0.771 | 2.009 | 10 / 24
20 | 0.990 | 0.844 | 1.088 | 22 / 24
50 | 0.995 | 0.855 | 1.037 | 22 / 24
200 | 1.007 | 0.934 | 1.074 | 24 / 24
1024 | 0.998 | 0.881 | 1.074 | 22 / 24

**By alphabet**

Alphabet  | median | mean | max | within ±10 %
-- | -- | -- | -- | --
SINGLE_CHAR | 0.998 | 0.989 | 1.016 | 38 / 40
ASCII_LETTERS | 0.979 | 0.984 | 1.279 | 32 / 40
UNICODE_BMP | 1.022 | 1.074 | 2.009 | 30 / 40

**By edit distance**

maxEdits | median | max | within ±10 %
--  | -- | -- | --
1 | 1.000 | 1.202 | 56 / 60
2 | 0.990 | 2.009 | 44 / 60


`maxEdits = 1`. Estimate tracks measurement to within ±2% across all alphabets and term lengths, including the heavy ones
- ASCII_LETTERS, term=1024, prefix=0: est 117.0 MB, meas 109.0 MB (R = 1.07).
- UNICODE_BMP, term=1024, prefix=0: est 591.8 MB, meas 640.3 MB (R = 0.92).
- SINGLE_CHAR, term=1024, prefix=0: est 47.3 MB, meas 47.4 MB (R = 1.00).

`maxEdits = 2`, long terms. Still within ~10%:
- ASCII_LETTERS, term=200, prefix=0, transp=false: est 153.3 MB, meas 164.2 MB (R = 0.93).
- ASCII_LETTERS, term=1024, prefix=0, transp=false: est 783.7 MB, meas 846.4 MB (R = 0.93).
- UNICODE_BMP, term=1024, prefix=0, transp=false: est 4.59 GB, meas 5.22 GB (R = 0.88).

 `Over-shoot` lives in the small-term, high-edit corner,  `term = 5`, `maxEdits = 2`. 
- UNICODE_BMP, term=5, prefix=3, maxEdits=2: est 3.77 MB, meas 1.87 MB (R = 2.01).
- UNICODE_BMP, term=5, prefix=0, maxEdits=2: est 8.95 MB, meas 7.18 MB (R = 1.25).
- ASCII_LETTERS, term=5, prefix=3, maxEdits=2: est 0.82 MB, meas 0.64 MB (R = 1.28).

Verified that in every overshoot row, both estimate and measurement are under **9 MB** total. The CB-breaker is sized in MB-to-GB and is being protected against the multi-hundred-MB / multi-GB calculated fuzzy queries. As said, loose ceilings on tiny automata do not push real workloads near the limit.

`Below` the measurement. A handful of `maxEdits = 2`, `transpositions = false` rows under-charge by **7–23%**, with the worst absolute gap on long terms
- ASCII_LETTERS, term=5, prefix=0, transp=false: est 1.68 MB, meas 2.18 MB (R = 0.77, gap 0.5 MB).
- ASCII_LETTERS, term=200, prefix=0, transp=false: est 153.3 MB, meas 164.2 MB (R = 0.93, gap 11 MB).
- UNICODE_BMP, term=1024, prefix=0, transp=false: est 4.59 GB, meas 5.22 GB (R = 0.88, gap 620 MB).

The pattern is consistent, `transpositions = false` measures higher than `transpositions = true` for the same shape. The estimator currently ignores the transpositions flag and could be a follow-up improvement.

The estimator would be the first step. Explicit transposition handling and memory tuning can be applied separately afterward. A follow-up pr will introduce request-CB accounting for fuzzy queries, using this estimator.