### PR TITLE
[8.19] [CI] Propagate vault read failures and timeouts in Buildkite hooks (#148305)

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 if [[ "${USE_IPV6_TESTING:-}" == "true" ]]; then
   # Ensure that `localhost` resolves to only `::1`
   sudo bash -c 'echo "::1   localhost" | cat - /etc/hosts > temp_file && mv temp_file /etc/hosts'
@@ -45,22 +47,37 @@ if [[ "${ES_RUNTIME_JAVA:-}" ]]; then
   export RUNTIME_JAVA_HOME
 fi
 
-GRADLE_BUILD_CACHE_USERNAME=$(vault read -field=username secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)
+vault_with_retry() {
+  local attempt delays=(1 5 10)
+  for attempt in 0 1 2 3; do
+    if vault "$@"; then
+      return 0
+    fi
+    if [[ $attempt -lt 3 ]]; then
+      echo "Vault command failed (attempt $((attempt + 1))/4), retrying in ${delays[$attempt]}s..." >&2
+      sleep "${delays[$attempt]}"
+    fi
+  done
+  echo "Vault command failed after 4 attempts" >&2
+  return 1
+}
+
+GRADLE_BUILD_CACHE_USERNAME=$(vault_with_retry read -field=username secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)
 export GRADLE_BUILD_CACHE_USERNAME
 
-GRADLE_BUILD_CACHE_PASSWORD=$(vault read -field=password secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)
+GRADLE_BUILD_CACHE_PASSWORD=$(vault_with_retry read -field=password secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)
 export GRADLE_BUILD_CACHE_PASSWORD
 
-DEVELOCITY_API_ACCESS_KEY=$(vault read -field=accesskey secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)
+DEVELOCITY_API_ACCESS_KEY=$(vault_with_retry read -field=accesskey secret/ci/elastic-elasticsearch/migrated/gradle-build-cache)
 export DEVELOCITY_API_ACCESS_KEY
 
 DEVELOCITY_ACCESS_KEY="gradle-enterprise.elastic.co=$DEVELOCITY_API_ACCESS_KEY"
 export DEVELOCITY_ACCESS_KEY
 
-BUILDKITE_API_TOKEN=$(vault read -field=token secret/ci/elastic-elasticsearch/buildkite-api-token)
+BUILDKITE_API_TOKEN=$(vault_with_retry read -field=token secret/ci/elastic-elasticsearch/buildkite-api-token)
 export BUILDKITE_API_TOKEN
 
-export GH_TOKEN="$VAULT_GITHUB_TOKEN"
+export GH_TOKEN="${VAULT_GITHUB_TOKEN:-}"
 
 if [[ "${USE_LUCENE_SNAPSHOT_CREDS:-}" == "true" ]]; then
   data=$(.buildkite/scripts/get-legacy-secret.sh aws-elastic/creds/lucene-snapshots)
@@ -76,17 +93,17 @@ fi
 
 if [[ "${USE_MAVEN_GPG:-}" == "true" ]]; then
   vault_path="kv/ci-shared/release-eng/team-release-secrets/es-delivery/gpg"
-  ORG_GRADLE_PROJECT_signingKey=$(vault kv get --field="private_key" $vault_path)
-  ORG_GRADLE_PROJECT_signingPassword=$(vault kv get --field="passphase" $vault_path)
+  ORG_GRADLE_PROJECT_signingKey=$(vault_with_retry kv get --field="private_key" $vault_path)
+  ORG_GRADLE_PROJECT_signingPassword=$(vault_with_retry kv get --field="passphase" $vault_path)
   export ORG_GRADLE_PROJECT_signingKey
   export ORG_GRADLE_PROJECT_signingPassword
 fi
 
 if [[ "${USE_DRA_CREDENTIALS:-}" == "true" ]]; then
-  DRA_VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-elasticsearch/legacy-vault-credentials)
+  DRA_VAULT_ROLE_ID_SECRET=$(vault_with_retry read -field=role-id secret/ci/elastic-elasticsearch/legacy-vault-credentials)
   export DRA_VAULT_ROLE_ID_SECRET
 
-  DRA_VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-elasticsearch/legacy-vault-credentials)
+  DRA_VAULT_SECRET_ID_SECRET=$(vault_with_retry read -field=secret-id secret/ci/elastic-elasticsearch/legacy-vault-credentials)
   export DRA_VAULT_SECRET_ID_SECRET
 
   DRA_VAULT_ADDR=https://secrets.elastic.co:8200
@@ -96,16 +113,16 @@ fi
 source .buildkite/scripts/third-party-test-credentials.sh
 
 if [[ "${USE_SNYK_CREDENTIALS:-}" == "true" ]]; then
-  SNYK_TOKEN=$(vault read -field=token secret/ci/elastic-elasticsearch/migrated/snyk)
+  SNYK_TOKEN=$(vault_with_retry read -field=token secret/ci/elastic-elasticsearch/migrated/snyk)
   export SNYK_TOKEN
 fi
 
 if [[ "${USE_PROD_DOCKER_CREDENTIALS:-}" == "true" ]]; then
   if which docker > /dev/null 2>&1; then
-    DOCKER_REGISTRY_USERNAME="$(vault read -field=username secret/ci/elastic-elasticsearch/migrated/prod_docker_registry_credentials)"
+    DOCKER_REGISTRY_USERNAME="$(vault_with_retry read -field=username secret/ci/elastic-elasticsearch/migrated/prod_docker_registry_credentials)"
     export DOCKER_REGISTRY_USERNAME
 
-    DOCKER_REGISTRY_PASSWORD="$(vault read -field=password secret/ci/elastic-elasticsearch/migrated/prod_docker_registry_credentials)"
+    DOCKER_REGISTRY_PASSWORD="$(vault_with_retry read -field=password secret/ci/elastic-elasticsearch/migrated/prod_docker_registry_credentials)"
     export DOCKER_REGISTRY_PASSWORD
 
     docker login --username "$DOCKER_REGISTRY_USERNAME" --password "$DOCKER_REGISTRY_PASSWORD" docker.elastic.co
@@ -113,9 +130,9 @@ if [[ "${USE_PROD_DOCKER_CREDENTIALS:-}" == "true" ]]; then
 fi
 
 if [[ "${USE_PERF_CREDENTIALS:-}" == "true" ]]; then
-  PERF_METRICS_HOST=$(vault read -field=es_host /secret/ci/elastic-elasticsearch/microbenchmarks-metrics)
-  PERF_METRICS_USERNAME=$(vault read -field=es_user /secret/ci/elastic-elasticsearch/microbenchmarks-metrics)
-  PERF_METRICS_PASSWORD=$(vault read -field=es_password /secret/ci/elastic-elasticsearch/microbenchmarks-metrics)
+  PERF_METRICS_HOST=$(vault_with_retry read -field=es_host /secret/ci/elastic-elasticsearch/microbenchmarks-metrics)
+  PERF_METRICS_USERNAME=$(vault_with_retry read -field=es_user /secret/ci/elastic-elasticsearch/microbenchmarks-metrics)
+  PERF_METRICS_PASSWORD=$(vault_with_retry read -field=es_password /secret/ci/elastic-elasticsearch/microbenchmarks-metrics)
 
   export PERF_METRICS_HOST
   export PERF_METRICS_USERNAME
@@ -125,13 +142,13 @@ fi
 
 # Authenticate to the Docker Hub public read-only registry
 if which docker > /dev/null 2>&1; then
-  DOCKERHUB_REGISTRY_USERNAME="$(vault read -field=username secret/ci/elastic-elasticsearch/docker_hub_public_ro_credentials)"
-  DOCKERHUB_REGISTRY_PASSWORD="$(vault read -field=password secret/ci/elastic-elasticsearch/docker_hub_public_ro_credentials)"
+  DOCKERHUB_REGISTRY_USERNAME="$(vault_with_retry read -field=username secret/ci/elastic-elasticsearch/docker_hub_public_ro_credentials)"
+  DOCKERHUB_REGISTRY_PASSWORD="$(vault_with_retry read -field=password secret/ci/elastic-elasticsearch/docker_hub_public_ro_credentials)"
 
   echo "$DOCKERHUB_REGISTRY_PASSWORD" | docker login --username "$DOCKERHUB_REGISTRY_USERNAME" --password-stdin docker.io
 fi
 
-if [[ "$BUILDKITE_AGENT_META_DATA_PROVIDER" != *"k8s"* ]]; then
+if [[ "${BUILDKITE_AGENT_META_DATA_PROVIDER:-}" != *"k8s"* ]]; then
   # Run in the background, while the job continues
   nohup .buildkite/scripts/setup-monitoring.sh </dev/null >/dev/null 2>&1 &
 fi

--- a/.buildkite/scripts/third-party-test-credentials.sh
+++ b/.buildkite/scripts/third-party-test-credentials.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 # The second/lowercase export is what the tests expect/require
 
 if [[ "${USE_3RD_PARTY_AZURE_CREDENTIALS:-}" == "true" ]]; then
-  json=$(vault read -format=json secret/ci/elastic-elasticsearch/migrated/azure_thirdparty_test_creds)
+  # These credentials expire periodically and must be manually renewed - the process is in the onboarding/process docs.
+  json=$(vault_with_retry read -format=json secret/ci/elastic-elasticsearch/migrated/azure_thirdparty_test_creds)
 
   AZURE_STORAGE_ACCOUNT_SECRET=$(echo "$json" | jq -r .data.account_id)
   export AZURE_STORAGE_ACCOUNT_SECRET
@@ -19,7 +20,7 @@ if [[ "${USE_3RD_PARTY_AZURE_CREDENTIALS:-}" == "true" ]]; then
 fi
 
 if [[ "${USE_3RD_PARTY_AZURE_SAS_CREDENTIALS:-}" == "true" ]]; then
-  json=$(vault read -format=json secret/ci/elastic-elasticsearch/migrated/azure_thirdparty_sas_test_creds)
+  json=$(vault_with_retry read -format=json secret/ci/elastic-elasticsearch/migrated/azure_thirdparty_sas_test_creds)
 
   AZURE_STORAGE_ACCOUNT_SECRET=$(echo "$json" | jq -r .data.account_id)
   export AZURE_STORAGE_ACCOUNT_SECRET
@@ -47,7 +48,7 @@ if [[ "${USE_3RD_PARTY_GCS_CREDENTIALS:-}" == "true" ]]; then
 fi
 
 if [[ "${USE_3RD_PARTY_MS_GRAPH_CREDENTIALS:-}" == "true" ]]; then
-  json=$(vault read -format=json secret/ci/elastic-elasticsearch/ms_graph_thirdparty_test_creds)
+  json=$(vault_with_retry read -format=json secret/ci/elastic-elasticsearch/ms_graph_thirdparty_test_creds)
 
   MS_GRAPH_TENANT_ID=$(echo "$json" | jq -r .data.tenant_id)
   export ms_graph_tenant_id="$MS_GRAPH_TENANT_ID"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[CI] Propagate vault read failures and timeouts in Buildkite hooks (#148305)](https://github.com/elastic/elasticsearch/pull/148305)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)