### PR TITLE
Add jdk.management.agent module to list of instrumented modules

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
@@ -177,7 +177,8 @@ final class SystemJvmOptions {
 
         // We instrument classes in these modules to call the bridge. Because the bridge gets patched
         // into java.base, we must export the bridge from java.base to these modules, as a comma-separated list
-        String modulesContainingEntitlementInstrumentation = "java.logging,java.net.http,java.naming,jdk.net,jdk.zipfs";
+        String modulesContainingEntitlementInstrumentation =
+            "java.logging,java.net.http,java.naming,jdk.net,jdk.zipfs,jdk.management.agent";
         return Stream.of(
             "-XX:+EnableDynamicAgentLoading",
             "-Djdk.attach.allowAttachSelf=true",


### PR DESCRIPTION
Some debugging actions (such as thread dumps) will load classes from the jdk.management.agent module which have entitlement rules that apply to them. For this to work, we need to explicitly allow that module to access the entitlement bridge module in order to avoid errors like the following:

```
[2026-05-08T12:38:47,913][WARN ][s.r.t.tcp                ] [runTask-0] RMI TCP Accept-0: accept loop for ServerSocket[addr=0.0.0.0/0.0.0.0,localport=55610] throws java.lang.IllegalAccessError: class sun.management.jmxremote.LocalRMIServerSocketFactory$1 (in module jdk.management.agent) cannot access class org.elasticsearch.entitlement.bridge.InstrumentationRegistryHandle (in module java.base) because module java.base does not export org.elasticsearch.entitlement.bridge to module jdk.management.agent
        at jdk.management.agent/sun.management.jmxremote.LocalRMIServerSocketFactory$1.accept(LocalRMIServerSocketFactory.java)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$AcceptLoop.executeAcceptLoop(TCPTransport.java:369)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$AcceptLoop.run(TCPTransport.java:333)
        at java.base/java.lang.Thread.run(Thread.java:1516)

[2026-05-08T12:38:47,921][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [runTask-0] fatal error in thread [RMI TCP Accept-0], exiting java.lang.IllegalAccessError: class sun.management.jmxremote.LocalRMIServerSocketFactory$1 (in module jdk.management.agent) cannot access class org.elasticsearch.entitlement.bridge.InstrumentationRegistryHandle (in module java.base) because module java.base does not export org.elasticsearch.entitlement.bridge to module jdk.management.agent
        at jdk.management.agent/sun.management.jmxremote.LocalRMIServerSocketFactory$1.accept(LocalRMIServerSocketFactory.java)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$AcceptLoop.executeAcceptLoop(TCPTransport.java:369)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$AcceptLoop.run(TCPTransport.java:333)
        at java.base/java.lang.Thread.run(Thread.java:1516)
```