### PR TITLE
[9.3] [CI] Reduce size of overprovisioned BWC and packaging instances (#148435)

### DIFF
--- a/.buildkite/pipelines/periodic.bwc.template.yml
+++ b/.buildkite/pipelines/periodic.bwc.template.yml
@@ -4,7 +4,7 @@
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -8,7 +8,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -29,7 +29,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -50,7 +50,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -71,7 +71,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -92,7 +92,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -113,7 +113,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -134,7 +134,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -155,7 +155,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -176,7 +176,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -197,7 +197,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -218,7 +218,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -239,7 +239,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -260,7 +260,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -281,7 +281,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -302,7 +302,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -323,7 +323,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -344,7 +344,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -365,7 +365,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -386,7 +386,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -407,7 +407,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -428,7 +428,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -449,7 +449,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -470,7 +470,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:
@@ -491,7 +491,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
           preemptible: true
         env:

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -16,7 +16,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n4-standard-32
+          machineType: n4-standard-16
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 2 / bwc-snapshots"
@@ -29,7 +29,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n4-standard-32
+          machineType: n4-standard-16
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 3 / bwc-snapshots"
@@ -42,7 +42,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n4-standard-32
+          machineType: n4-standard-16
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 4 / bwc-snapshots"
@@ -55,7 +55,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n4-standard-32
+          machineType: n4-standard-16
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 5 / bwc-snapshots"
@@ -68,7 +68,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n4-standard-32
+          machineType: n4-standard-16
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
       - label: "{{matrix.BWC_VERSION}} / Part 6 / bwc-snapshots"
@@ -81,6 +81,6 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n4-standard-32
+          machineType: n4-standard-16
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/full-bwc.yml
+++ b/.buildkite/pipelines/pull-request/full-bwc.yml
@@ -11,6 +11,6 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n4-custom-32-98304
+          machineType: n4-standard-16
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix-sample.yml
@@ -22,7 +22,7 @@ steps:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
-          machineType: n4-custom-16-32768
+          machineType: n4-standard-8
           diskType: hyperdisk-balanced
         env:
           USE_PROD_DOCKER_CREDENTIALS: "true"

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -37,5 +37,5 @@ steps:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
-          machineType: n4-custom-16-32768
+          machineType: n4-standard-8
           diskType: hyperdisk-balanced

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows-sample.yml
@@ -18,7 +18,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: n4-custom-32-98304
+          machineType: n4-standard-16
           diskType: hyperdisk-balanced
           diskSizeGb: 350
         env:

--- a/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-windows.yml
@@ -17,7 +17,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: n4-custom-32-98304
+          machineType: n4-standard-16
           diskType: hyperdisk-balanced
           diskSizeGb: 350
         env:

--- a/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
+++ b/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
@@ -16,7 +16,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: n4-custom-16-32768
+          machineType: n4-standard-8
           diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
         env:

--- a/.buildkite/pipelines/pull-request/part-1.yml
+++ b/.buildkite/pipelines/pull-request/part-1.yml
@@ -7,6 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n4-custom-32-98304
+      machineType: n4-standard-32
       diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-2.yml
+++ b/.buildkite/pipelines/pull-request/part-2.yml
@@ -5,6 +5,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n4-custom-32-98304
+      machineType: n4-standard-32
       diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-3.yml
+++ b/.buildkite/pipelines/pull-request/part-3.yml
@@ -7,6 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n4-custom-32-98304
+      machineType: n4-standard-32
       diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-5.yml
+++ b/.buildkite/pipelines/pull-request/part-5.yml
@@ -7,6 +7,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n4-custom-32-98304
+      machineType: n4-standard-16
       diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/pull-request/part-6.yml
+++ b/.buildkite/pipelines/pull-request/part-6.yml
@@ -6,6 +6,6 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
-      machineType: n4-custom-32-98304
+      machineType: n4-standard-16
       diskType: hyperdisk-balanced
       buildDirectory: /dev/shm/bk

--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -69,7 +69,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
-          machineType: n1-standard-32
+          machineType: n4-standard-16
           buildDirectory: /dev/shm/bk
         matrix:
           setup:

--- a/.buildkite/scripts/run-pr-upgrade-tests.sh
+++ b/.buildkite/scripts/run-pr-upgrade-tests.sh
@@ -35,7 +35,7 @@ steps:
           agents:
             provider: gcp
             image: family/elasticsearch-ubuntu-2404
-            machineType: n4-standard-32
+            machineType: n4-standard-16
             diskType: hyperdisk-balanced
             buildDirectory: /dev/shm/bk
           matrix:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[CI] Reduce size of overprovisioned BWC and packaging instances (#148435)](https://github.com/elastic/elasticsearch/pull/148435)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)