### PR TITLE
Backport SearchHit chunked fetch leak fix to 9.4

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -285,9 +285,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/148339
-- class: org.elasticsearch.search.aggregations.bucket.DateHistogramOffsetIT
-  method: testSingleValueWithNegativeOffset
-  issue: https://github.com/elastic/elasticsearch/issues/148589
 - class: org.elasticsearch.search.KnnSearchIT
   method: testKnnSearchWithScroll
   issue: https://github.com/elastic/elasticsearch/issues/148590

--- a/server/src/main/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseChunk.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseChunk.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchHit;
 
 import java.io.IOException;
+import java.util.function.ObjIntConsumer;
 
 /**
  * A single chunk of fetch results streamed from a data node to the coordinator.
@@ -34,6 +35,18 @@ import java.io.IOException;
  * <p>Supports zero-copy transport by separating header metadata from serialized hits.
  * The header is created after hits are serialized (since we don't know hit count until
  * the buffer is full), then combined using {@link CompositeBytesReference} to avoid copying.
+ *
+ * <p>Lifecycle: on the coordinator path the stream constructor reads {@code serializedHits} into a
+ * heap-backed {@link BytesReference}; subsequent {@link #getHits()} calls deserialize hits from
+ * that copy. On the data-node path the direct constructor accepts any {@link BytesReference}.
+ * {@link #close()} releases {@code serializedHits} when it is {@link Releasable}, then
+ * {@link SearchHit#decRef()}s any cached deserialized hits so pooled sources are released in a
+ * refcount-safe way (hits retain their own refs until {@code decRef}).
+ *
+ * <p>Thread-safety: instances are single-owner. A chunk is constructed, drained via
+ * {@link #consumeHits} or {@link #toReleasableBytesReference}, and closed all on one thread;
+ * it is never shared between threads concurrently. Cross-thread publication of the produced
+ * {@link SearchHit}s happens downstream through {@link FetchPhaseResponseStream}'s queue.
  */
 public class FetchPhaseResponseChunk implements Writeable, Releasable {
 
@@ -58,7 +71,9 @@ public class FetchPhaseResponseChunk implements Writeable, Releasable {
 
     /**
      * Creates a chunk with pre-serialized hits.
-     * Takes ownership of serializedHits - caller must not release it.
+     * Takes ownership of {@code serializedHits}; the caller must not release it.
+     * {@link #close()} releases that buffer when it is {@link Releasable}, and also
+     * {@link SearchHit#decRef() release}s any hits produced by {@link #getHits()}.
      *
      * @param shardId          source shard
      * @param serializedHits   pre-serialized hit bytes
@@ -83,7 +98,9 @@ public class FetchPhaseResponseChunk implements Writeable, Releasable {
     }
 
     /**
-     * Deserializes from stream (receiving side).
+     * Deserializes from stream (receiving side). Reads {@code serializedHits} as a
+     * heap-backed {@link BytesReference}; subsequent {@link #getHits()} calls deserialize hit
+     * {@code _source} bytes from this copy.
      */
     public FetchPhaseResponseChunk(StreamInput in) throws IOException {
         this.shardId = new ShardId(in);
@@ -128,22 +145,59 @@ public class FetchPhaseResponseChunk implements Writeable, Releasable {
         return serializedHits == null ? 0 : serializedHits.length();
     }
 
-    public SearchHit[] getHits() throws IOException {
-        if (deserializedHits == null && serializedHits != null && hitCount > 0) {
-            deserializedHits = new SearchHit[hitCount];
-            hitPositions = new int[hitCount];
-            try (StreamInput in = createStreamInput()) {
-                for (int i = 0; i < hitCount; i++) {
-                    hitPositions[i] = in.readVInt();
-                    deserializedHits[i] = SearchHit.readFrom(in, false);
-                }
+    /**
+     * Iterates the hits in this chunk, invoking {@code consumer} with each hit and its position.
+     * */
+    public void consumeHits(HitConsumer consumer) throws IOException {
+        ensureDeserialized();
+        drainDeserializedHits((hit, i) -> consumer.accept(hitPositions[i], hit));
+    }
+
+    /**
+     * Walks {@code deserializedHits}, invoking {@code visitor} for each non-null slot and clearing
+     * the slot afterwards so the same hit is never handed out twice. Shared by {@link #consumeHits}
+     * and {@link #close}.
+     */
+    private void drainDeserializedHits(ObjIntConsumer<SearchHit> visitor) {
+        if (deserializedHits == null) {
+            return;
+        }
+        for (int i = 0; i < deserializedHits.length; i++) {
+            SearchHit hit = deserializedHits[i];
+            if (hit != null) {
+                visitor.accept(hit, i);
+                deserializedHits[i] = null;
             }
         }
+    }
+
+    /* Visibility for tests */
+    SearchHit[] getHits() throws IOException {
+        ensureDeserialized();
         return deserializedHits != null ? deserializedHits : new SearchHit[0];
     }
 
-    public int[] getHitPositions() {
+    /* Visibility for tests */
+    int[] getHitPositions() throws IOException {
+        ensureDeserialized();
         return hitPositions;
+    }
+
+    /**
+     * Deserializes the chunk's hits on first use.
+     * */
+    private void ensureDeserialized() throws IOException {
+        if (deserializedHits != null || serializedHits == null || hitCount == 0) {
+            return;
+        }
+        deserializedHits = new SearchHit[hitCount];
+        hitPositions = new int[hitCount];
+        try (StreamInput in = createStreamInput()) {
+            for (int i = 0; i < hitCount; i++) {
+                hitPositions[i] = in.readVInt();
+                deserializedHits[i] = SearchHit.readFrom(in, true);
+            }
+        }
     }
 
     private StreamInput createStreamInput() throws IOException {
@@ -170,6 +224,11 @@ public class FetchPhaseResponseChunk implements Writeable, Releasable {
         return sequenceStart;
     }
 
+    /**
+     * Releases {@code serializedHits} when releasable, then releases deserialized hits.
+     * Each hit's {@code _source} is an independent copy on this 9.x branch (pooled deserialization
+     * via {@link SearchHit#readFrom(StreamInput, boolean)}), so the release order is unconstrained.
+     */
     @Override
     public void close() {
         if (serializedHits instanceof Releasable) {
@@ -177,14 +236,16 @@ public class FetchPhaseResponseChunk implements Writeable, Releasable {
         }
         serializedHits = null;
 
-        if (deserializedHits != null) {
-            for (SearchHit hit : deserializedHits) {
-                if (hit != null) {
-                    hit.decRef();
-                }
-            }
-            deserializedHits = null;
-        }
+        drainDeserializedHits((hit, i) -> hit.decRef());
+        deserializedHits = null;
+    }
+
+    /**
+     * Callback invoked for each hit in a chunk together with its position.
+     * */
+    @FunctionalInterface
+    public interface HitConsumer {
+        void accept(int position, SearchHit hit);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseStream.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseStream.java
@@ -48,7 +48,6 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
 
     // Accumulate hits with sequence numbers for ordering
     private final Queue<SequencedHit> queue = new ConcurrentLinkedQueue<>();
-    private volatile boolean ownershipTransferred = false;
 
     // Circuit breaker accounting
     private final CircuitBreaker circuitBreaker;
@@ -69,13 +68,10 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
     }
 
     /**
-     * Adds a chunk of hits to the accumulated result.
-     *
-     * This method increments the reference count of each {@link SearchHit}
-     * via {@link SearchHit#incRef()} to take ownership. The hits will be released in {@link #closeInternal()}.
+     * Accumulates a chunk of hits into this stream.
      *
      * @param chunk the chunk containing hits to accumulate
-     * @param releasable a releasable to close after processing (typically releases the acquired stream reference)
+     * @param releasable closed after a successful write
      */
     void writeChunk(FetchPhaseResponseChunk chunk, Releasable releasable) {
         boolean success = false;
@@ -85,20 +81,12 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
             circuitBreaker.addEstimateBytesAndMaybeBreak(bytesSize, "fetch_chunk_accumulation");
             totalBreakerBytes.addAndGet(bytesSize);
 
-            SearchHit[] chunkHits = chunk.getHits();
-            int[] positions = chunk.getHitPositions();
-
-            for (int i = 0; i < chunkHits.length; i++) {
-                SearchHit hit = chunkHits[i];
-                hit.incRef();
-
-                queue.add(new SequencedHit(hit, positions[i]));
-            }
+            chunk.consumeHits((position, hit) -> queue.add(new SequencedHit(hit, position)));
 
             if (logger.isDebugEnabled()) {
                 logger.debug(
                     "Received chunk [{}] docs for shard [{}]: [{}/{}] hits accumulated, [{}] breaker bytes, used breaker bytes [{}]",
-                    chunkHits.length,
+                    chunk.hitCount(),
                     shardIndex,
                     queue.size(),
                     expectedTotalDocs,
@@ -130,11 +118,11 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
             logger.debug("Building final result for shard [{}] with [{}] hits", shardIndex, queue.size());
         }
 
-        // Convert queue to list and sort by sequence number to restore correct order
-        List<SequencedHit> sequencedHits = new ArrayList<>(queue);
+        // Drain the queue: ownership of every hit moves to the final result.
+        List<SequencedHit> sequencedHits = drainQueue();
+        // Restore correct order (chunks may have arrived out of order).
         sequencedHits.sort(Comparator.comparingLong(sh -> sh.sequence));
 
-        // Extract hits in correct order and calculate maxScore
         List<SearchHit> orderedHits = new ArrayList<>(sequencedHits.size());
         float maxScore = Float.NEGATIVE_INFINITY;
 
@@ -150,8 +138,6 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
         if (maxScore == Float.NEGATIVE_INFINITY) {
             maxScore = Float.NaN;
         }
-
-        ownershipTransferred = true;
 
         SearchHits searchHits = new SearchHits(
             orderedHits.toArray(SearchHit[]::new),
@@ -196,12 +182,10 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
             );
         }
 
-        if (ownershipTransferred == false) {
-            for (SequencedHit sequencedHit : queue) {
-                sequencedHit.hit.decRef();
-            }
+        // Release any hits still queued
+        for (SequencedHit pending : drainQueue()) {
+            pending.hit.decRef();
         }
-        queue.clear();
 
         // Release circuit breaker bytes added during accumulation when hits are released from memory
         if (totalBreakerBytes.get() > 0) {
@@ -216,6 +200,18 @@ class FetchPhaseResponseStream extends AbstractRefCounted {
             }
             totalBreakerBytes.set(0);
         }
+    }
+
+    /**
+     * Polls and returns every hit currently in the queue.
+     */
+    private List<SequencedHit> drainQueue() {
+        List<SequencedHit> drained = new ArrayList<>();
+        SequencedHit polled;
+        while ((polled = queue.poll()) != null) {
+            drained.add(polled);
+        }
+        return drained;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseCoordinationAction.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseCoordinationAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.injection.guice.Inject;
@@ -222,7 +223,7 @@ public class TransportFetchPhaseCoordinationAction extends HandledTransportActio
                 try (StreamInput in = new NamedWriteableAwareStreamInput(lastChunkBytes.streamInput(), namedWriteableRegistry)) {
                     for (int i = 0; i < hitCount; i++) {
                         int position = in.readVInt();
-                        SearchHit hit = SearchHit.readFrom(in, false);
+                        SearchHit hit = SearchHit.readFrom(in, true);
                         responseStream.addHitWithSequence(hit, position);
                     }
                 }
@@ -236,10 +237,7 @@ public class TransportFetchPhaseCoordinationAction extends HandledTransportActio
             );
 
             ActionListener.respondAndRelease(listener.map(Response::new), finalResult);
-        }, listener::onFailure), () -> {
-            registration.close();
-            responseStream.decRef();
-        });
+        }, listener::onFailure), () -> Releasables.close(registration, responseStream::decRef));
 
         final ThreadContext threadContext = transportService.getThreadPool().getThreadContext();
         try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {

--- a/server/src/test/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/chunk/FetchPhaseResponseStreamTests.java
@@ -344,27 +344,47 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
 
     // ==================== Reference Counting Tests ====================
 
-    public void testHitsIncRefOnWrite() throws IOException {
-        CircuitBreaker breaker = new NoopCircuitBreaker("test");
+    public void testHitOwnershipTransferredToQueueOnWrite() throws IOException {
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
         FetchPhaseResponseStream stream = new FetchPhaseResponseStream(SHARD_INDEX, 5, breaker);
 
+        FetchPhaseResponseChunk chunk = createChunk(0, 5, 0);
         try {
-            FetchPhaseResponseChunk chunk = createChunk(0, 5, 0);
-            writeChunk(stream, chunk);
+            stream.writeChunk(chunk, () -> {});
 
-            FetchSearchResult result = buildFinalResult(stream);
-
-            try {
-                // Hits should still have references after writeChunk
-                for (SearchHit hit : result.hits().getHits()) {
-                    assertTrue("Hit should have references", hit.hasReferences());
-                }
-            } finally {
-                result.decRef();
+            for (SearchHit hit : chunk.getHits()) {
+                assertNull("Chunk should have released its reference to the hit after consumeHits", hit);
             }
         } finally {
-            stream.decRef();
+            chunk.close();
         }
+
+        FetchSearchResult result = buildFinalResult(stream);
+        for (SearchHit hit : result.hits().getHits()) {
+            assertTrue("Hit should have references", hit.hasReferences());
+        }
+        result.decRef();
+
+        stream.decRef();
+        assertThat("Breaker bytes should be released after stream close", breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testHitsReleasedWhenStreamClosedWithoutBuildFinalResult() throws IOException {
+        CircuitBreaker breaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));
+        FetchPhaseResponseStream stream = new FetchPhaseResponseStream(SHARD_INDEX, 5, breaker);
+
+        FetchPhaseResponseChunk chunk = createChunk(0, 5, 0);
+        try {
+            stream.writeChunk(chunk, () -> {});
+        } finally {
+            chunk.close();
+        }
+
+        assertThat("Breaker should account for the accumulated chunk bytes", breaker.getUsed(), greaterThan(0L));
+
+        stream.decRef();
+
+        assertThat("All breaker bytes should be released", breaker.getUsed(), equalTo(0L));
     }
 
     // ==================== Score Handling Tests ====================
@@ -499,7 +519,12 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
             AtomicBoolean releasableClosed = new AtomicBoolean(false);
             Releasable releasable = () -> releasableClosed.set(true);
 
-            stream.writeChunk(createChunk(0, 5, 0), releasable);
+            FetchPhaseResponseChunk chunk = createChunk(0, 5, 0);
+            try {
+                stream.writeChunk(chunk, releasable);
+            } finally {
+                chunk.close();
+            }
 
             assertTrue("Releasable should be closed after successful write", releasableClosed.get());
         } finally {
@@ -519,10 +544,12 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
             AtomicBoolean releasableClosed = new AtomicBoolean(false);
             Releasable releasable = () -> releasableClosed.set(true);
 
-            expectThrows(
-                CircuitBreakingException.class,
-                () -> { stream.writeChunk(createChunkWithSourceSize(0, 5, 0, 10000), releasable); }
-            );
+            FetchPhaseResponseChunk chunk = createChunkWithSourceSize(0, 5, 0, 10000);
+            try {
+                expectThrows(CircuitBreakingException.class, () -> stream.writeChunk(chunk, releasable));
+            } finally {
+                chunk.close();
+            }
 
             assertFalse("Releasable should not be closed on failure", releasableClosed.get());
         } finally {
@@ -539,10 +566,11 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
         AtomicBoolean releasableClosed = new AtomicBoolean(false);
 
         try {
-            CircuitBreakingException e = expectThrows(
-                CircuitBreakingException.class,
-                () -> stream.writeChunk(chunk, () -> releasableClosed.set(true))
-            );
+            try {
+                expectThrows(CircuitBreakingException.class, () -> stream.writeChunk(chunk, () -> releasableClosed.set(true)));
+            } finally {
+                chunk.close();
+            }
 
             assertFalse("Releasable should not be closed on failure", releasableClosed.get());
             assertThat("No bytes should be tracked on breaker trip", breaker.getUsed(), equalTo(0L));
@@ -734,7 +762,11 @@ public class FetchPhaseResponseStreamTests extends ESTestCase {
     }
 
     private void writeChunk(FetchPhaseResponseStream stream, FetchPhaseResponseChunk chunk) throws IOException {
-        stream.writeChunk(chunk, () -> {});
+        try {
+            stream.writeChunk(chunk, () -> {});
+        } finally {
+            chunk.close();
+        }
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseCoordinationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseCoordinationActionTests.java
@@ -24,10 +24,11 @@ import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.RescoreDocIds;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -91,11 +92,12 @@ public class TransportFetchPhaseCoordinationActionTests extends ESTestCase {
         activeFetchPhaseTasks = new ActiveFetchPhaseTasks();
         namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
 
+        CircuitBreakerService breakerService = newLimitedBreakerService(ByteSizeValue.ofMb(64));
         action = new TransportFetchPhaseCoordinationAction(
             transportService,
             new ActionFilters(Set.of()),
             activeFetchPhaseTasks,
-            new NoneCircuitBreakerService(),
+            breakerService,
             namedWriteableRegistry
         );
         new TransportFetchPhaseResponseChunkAction(transportService, activeFetchPhaseTasks, namedWriteableRegistry);
@@ -468,9 +470,9 @@ public class TransportFetchPhaseCoordinationActionTests extends ESTestCase {
         Exception failure = expectThrows(Exception.class, () -> future.actionGet(10, TimeUnit.SECONDS));
         assertThat(failure.getMessage(), equalTo("simulated data node failure during chunk streaming"));
 
-        assertBusy(() -> {
-            expectThrows(ResourceNotFoundException.class, () -> activeFetchPhaseTasks.acquireResponseStream(taskId, TEST_SHARD_ID));
-        });
+        assertBusy(
+            () -> expectThrows(ResourceNotFoundException.class, () -> activeFetchPhaseTasks.acquireResponseStream(taskId, TEST_SHARD_ID))
+        );
     }
 
     private ShardFetchSearchRequest createShardFetchSearchRequest() {


### PR DESCRIPTION
Logical backport of #147673 and #147855 with #147155 left out: keep 9.4's two-arg `SearchHit.readFrom` and force pooled=true at the chunked-fetch read sites so hits are leak-tracked and ref-counted on the queue.

Closes #148589