### PR TITLE
[8.19] Migrate :docs yamlRestTest to rule-based test cluster (#147923)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/archunit/IntegTestCoverageArchUnitSpec.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/archunit/IntegTestCoverageArchUnitSpec.groovy
@@ -123,7 +123,7 @@ class IntegTestCoverageArchUnitSpec extends Specification {
         // their original base class until the harness supports deferred/multi-project application.
         "org.elasticsearch.gradle.internal.InternalDistributionArchiveCheckPlugin",
         "org.elasticsearch.gradle.internal.InternalDistributionDownloadPlugin",
-        // "org.elasticsearch.gradle.internal.doc.DocsTestPlugin",
+        "org.elasticsearch.gradle.internal.doc.DocsTestPlugin",
         "org.elasticsearch.gradle.internal.test.rest.LegacyYamlRestTestPlugin",
         "org.elasticsearch.gradle.internal.test.rest.RestResourcesPlugin",
         "org.elasticsearch.gradle.internal.test.rest.compat.compat.LegacyYamlRestCompatTestPlugin",

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPluginFuncTest.groovy
@@ -9,20 +9,50 @@
 
 package org.elasticsearch.gradle.internal.doc
 
-import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
-import org.gradle.api.Plugin
+import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
 import org.gradle.testkit.runner.TaskOutcome
 
-class DocsTestPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
-    Class<? extends Plugin> pluginClassUnderTest = DocsTestPlugin.class
+class DocsTestPluginFuncTest extends AbstractGradleFuncTest {
 
     def setup() {
+        // DocsTestPlugin now applies elasticsearch.internal-yaml-rest-test, which transitively
+        // applies RestTestBasePlugin. RestTestBasePlugin requires bwcVersions to be resolvable
+        // at apply time, so set them up via internalBuild() before applying the plugin.
+        settingsFile.text = """
+        plugins {
+            id 'elasticsearch.java-toolchain'
+        }
+
+        toolchainManagement {
+          jvm {
+            javaRepositories {
+              repository('bundledOracleOpendJdk') {
+                resolverClass = org.elasticsearch.gradle.internal.toolchain.OracleOpenJdkToolchainResolver
+              }
+              repository('adoptiumJdks') {
+                resolverClass = org.elasticsearch.gradle.internal.toolchain.AdoptiumJdkToolchainResolver
+              }
+              repository('archivedOracleJdks') {
+                resolverClass = org.elasticsearch.gradle.internal.toolchain.ArchivedOracleJdkToolchainResolver
+              }
+            }
+          }
+        }
+        """ + settingsFile.text
+
         File docDir = new File(projectDir, 'doc')
         docDir.mkdirs()
         addSampleDoc(docDir)
         buildApiRestrictionsDisabled = true
         configurationCacheCompatible = false
+
+        internalBuild()
+
         buildFile << """
+import org.elasticsearch.gradle.internal.doc.DocsTestPlugin
+
+plugins.apply(DocsTestPlugin)
+
 tasks.named('listSnippets') {
    docs = fileTree('doc')
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -27,7 +27,7 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
 
     private static ListMultimap<Class<?>, String> createLegacyRestTestBasePluginUsage() {
         ListMultimap<Class<?>, String> map = ArrayListMultimap.create(1, 200);
-        map.put(LegacyRestTestBasePlugin.class, ":docs");
+        map.put(LegacyRestTestBasePlugin.class, ":distribution:docker");
         map.put(LegacyRestTestBasePlugin.class, ":modules:reindex");
         map.put(LegacyRestTestBasePlugin.class, ":qa:ccs-rolling-upgrade-remote-cluster");
         map.put(LegacyRestTestBasePlugin.class, ":qa:mixed-cluster");

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/doc/DocsTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/doc/DocsTestPlugin.java
@@ -12,10 +12,6 @@ package org.elasticsearch.gradle.internal.doc;
 import org.elasticsearch.gradle.OS;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
-import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
-import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
-import org.elasticsearch.gradle.testclusters.TestDistribution;
-import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
@@ -41,18 +37,9 @@ public class DocsTestPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getPluginManager().apply("elasticsearch.legacy-yaml-rest-test");
+        project.getPluginManager().apply("elasticsearch.internal-yaml-rest-test");
 
         String distribution = System.getProperty("tests.distribution", "default");
-        // The distribution can be configured with -Dtests.distribution on the command line
-        NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
-            .getExtensions()
-            .getByName(TestClustersPlugin.EXTENSION_NAME);
-
-        testClusters.matching((c) -> c.getName().equals("yamlRestTest")).configureEach(c -> {
-            c.setTestDistribution(TestDistribution.valueOf(distribution.toUpperCase()));
-            c.setNameCustomization((name) -> name.replace("yamlRestTest", "node"));
-        });
 
         project.getTasks().named("assemble").configure(task -> { task.setEnabled(false); });
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,7 +1,5 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.doc.DocSnippetTask
-import static org.elasticsearch.gradle.testclusters.TestDistribution.DEFAULT
 
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
@@ -78,112 +76,47 @@ restResources {
   }
 }
 
-testClusters.matching { it.name == "yamlRestTest"}.configureEach {
-  if (singleNode().testDistribution == DEFAULT) {
-    setting 'xpack.license.self_generated.type', 'trial'
-    setting 'indices.lifecycle.history_index_enabled', 'false'
-    keystorePassword 'keystore-password'
-  }
+// The cluster definition has moved into DocsClientYamlTestSuiteIT (JUnit-rule based test cluster framework).
+// We only wire up plugin and resource dependencies on the Gradle side.
 
-  // debug ccr test failures:
-  // https://github.com/elastic/elasticsearch/issues/95678
-  // https://github.com/elastic/elasticsearch/issues/94359
-  // https://github.com/elastic/elasticsearch/issues/96561
-  setting 'logger.org.elasticsearch.transport.SniffConnectionStrategy', 'DEBUG'
-  setting 'logger.org.elasticsearch.transport.RemoteClusterService', 'DEBUG'
-
-  // enable regexes in painless so our tests don't complain about example snippets that use them
-  setting 'script.painless.regex.enabled', 'true'
-  setting 'path.repo', "${buildDir}/cluster/shared/repo"
-  Closure configFile = {
-    extraConfigFile it, file("src/test/cluster/config/$it")
-  }
-  configFile 'analysis/example_word_list.txt'
-  configFile 'analysis/hyphenation_patterns.xml'
-  configFile 'analysis/synonym.txt'
-  configFile 'analysis/stemmer_override.txt'
-  configFile 'userdict_ja.txt'
-  configFile 'userdict_ko.txt'
-  configFile 'KeywordTokenizer.rbbi'
-  extraConfigFile 'hunspell/en_US/en_US.aff', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.aff')
-  extraConfigFile 'hunspell/en_US/en_US.dic', project(":server").file('src/test/resources/indices/analyze/conf_dir/hunspell/en_US/en_US.dic')
-  extraConfigFile 'httpCa.p12', file("./httpCa.p12")
-  extraConfigFile 'transport.p12', file("./transport.p12")
-  // Whitelist reindexing from the local node so we can test it.
-  setting 'reindex.remote.whitelist', '127.0.0.1:*'
-
-  extraConfigFile 'ingest-geoip/GeoLite2-City.mmdb', file("src/yamlRestTest/resources/GeoLite2-City.mmdb")
-  extraConfigFile 'ingest-geoip/GeoLite2-Country.mmdb', file("src/yamlRestTest/resources/GeoLite2-Country.mmdb")
-
-  // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
-  systemProperty 'es.transport.cname_in_publish_address', 'true'
-  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
-
-
-  requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
-
-  // TODO Rene: clean up this kind of cross project file references
-  extraConfigFile 'op-jwks.json', project(':x-pack:test:idp-fixture').file("src/main/resources/oidc/op-jwks.json")
-  extraConfigFile 'idp-docs-metadata.xml', project(':x-pack:test:idp-fixture').file("src/main/resources/idp/shibboleth-idp/metadata/idp-docs-metadata.xml")
-  extraConfigFile 'testClient.crt', project(':x-pack:plugin:security').file("src/test/resources/org/elasticsearch/xpack/security/action/pki_delegation/testClient.crt")
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.security.authc.api_key.enabled', 'true'
-  setting 'xpack.security.authc.token.enabled', 'true'
-  // disable the ILM and SLM history for doc tests to avoid potential lingering tasks that'd cause test flakiness
-  setting 'indices.lifecycle.history_index_enabled', 'false'
-  setting 'slm.history_index_enabled', 'false'
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'xpack.security.authc.realms.file.file.order', '0'
-  setting 'xpack.security.authc.realms.native.native.order', '1'
-  setting 'xpack.security.authc.realms.oidc.oidc1.order', '2'
-  setting 'xpack.security.authc.realms.oidc.oidc1.op.issuer', 'http://127.0.0.1:8080'
-  setting 'xpack.security.authc.realms.oidc.oidc1.op.authorization_endpoint', "http://127.0.0.1:8080/c2id-login"
-  setting 'xpack.security.authc.realms.oidc.oidc1.op.token_endpoint', "http://127.0.0.1:8080/c2id/token"
-  setting 'xpack.security.authc.realms.oidc.oidc1.op.jwkset_path', 'op-jwks.json'
-  setting 'xpack.security.authc.realms.oidc.oidc1.rp.redirect_uri', 'https://my.fantastic.rp/cb'
-  setting 'xpack.security.authc.realms.oidc.oidc1.rp.client_id', 'elasticsearch-rp'
-  keystore 'xpack.security.authc.realms.oidc.oidc1.rp.client_secret', 'b07efb7a1cf6ec9462afe7b6d3ab55c6c7880262aa61ac28dded292aca47c9a2'
-  setting 'xpack.security.authc.realms.oidc.oidc1.rp.response_type', 'id_token'
-  setting 'xpack.security.authc.realms.oidc.oidc1.claims.principal', 'sub'
-  setting 'xpack.security.authc.realms.pki.pki1.order', '3'
-  setting 'xpack.security.authc.realms.pki.pki1.certificate_authorities', '[ "testClient.crt" ]'
-  setting 'xpack.security.authc.realms.pki.pki1.delegation.enabled', 'true'
-  setting 'xpack.security.authc.realms.saml.saml1.order', '4'
-  setting 'xpack.security.authc.realms.saml.saml1.sp.logout', 'https://kibana.org/logout'
-  setting 'xpack.security.authc.realms.saml.saml1.idp.entity_id', 'https://my-idp.org'
-  setting 'xpack.security.authc.realms.saml.saml1.idp.metadata.path', 'idp-docs-metadata.xml'
-  setting 'xpack.security.authc.realms.saml.saml1.sp.entity_id', 'https://kibana.org'
-  setting 'xpack.security.authc.realms.saml.saml1.sp.acs', 'https://kibana.org/api/security/saml/callback'
-  setting 'xpack.security.authc.realms.saml.saml1.attributes.principal', 'uid'
-  setting 'xpack.security.authc.realms.saml.saml1.attributes.name', 'urn:oid:2.5.4.3'
-
-  user username: 'test_admin'
-  user username: 'test_user'
-
-  // build the cluster with all plugins
+dependencies {
+  // build the cluster with all non-repository plugins
   project.rootProject.subprojects.findAll { it.parent.path == ':plugins' }.each { subproj ->
-    /* Skip repositories. We just aren't going to be able to test them so it
-     * doesn't make sense to waste time installing them.
-     */
     if (subproj.path.startsWith(':plugins:repository-')) {
       return
     }
-    // Do not install ingest-attachment in a FIPS 140 JVM as this is not supported
-    if (subproj.path.startsWith(':modules:ingest-attachment') && buildParams.inFipsJvm) {
-      return
-    }
-    plugin subproj.path
+    clusterPlugins(project(subproj.path))
+  }
+}
+
+// Cross-project resources copied onto the test classpath so the cluster's @ClassRule
+// can pick them up via Resource.fromClasspath(...).
+tasks.named("processYamlRestTestResources").configure {
+  from(project(":server").file("src/test/resources/indices/analyze/conf_dir/hunspell/en_US")) {
+    into "indices/analyze/conf_dir/hunspell/en_US"
+  }
+  from(project(":x-pack:test:idp-fixture").file("src/main/resources/oidc")) {
+    include "op-jwks.json"
+    into "oidc"
+  }
+  from(project(":x-pack:test:idp-fixture").file("src/main/resources/idp/shibboleth-idp/metadata")) {
+    include "idp-docs-metadata.xml"
+    into "idp/shibboleth-idp/metadata"
+  }
+  from(project(":x-pack:plugin:security").file("src/test/resources/org/elasticsearch/xpack/security/action/pki_delegation")) {
+    include "testClient.crt"
+    into "org/elasticsearch/xpack/security/action/pki_delegation"
   }
 }
 
 tasks.named("yamlRestTest").configure {
-  def repoFolder = "${layout.buildDirectory.asFile.get()}/cluster/shared/repo"
-  doFirst {
-    delete(repoFolder)
-  }
+  // Pass the docs project directory through so the test class can resolve config files
+  // (analysis configs, p12 truststores, etc.) that still live under docs/src/test/cluster/config
+  // and docs/*.p12 by their original paths.
+  systemProperty 'tests.docs.dir', projectDir.absolutePath
 }
 
-tasks.named("forbiddenPatterns").configure {
+tasks.matching { it.name == 'forbiddenPatterns' }.configureEach {
   exclude '**/*.mmdb'
 }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -42,6 +42,7 @@ tasks.named("yamlRestTest") {
       "reference/esql/processing-commands/lookup/esql-lookup-example"
     ].join(',')
   }
+  usesDefaultDistribution()
 }
 
 /* List of files that have snippets that will not work until platinum tests can occur ... */
@@ -2062,7 +2063,7 @@ buildRestTests.teardowns['failure-store-recipes-2-td'] = '''
   }
 
   /* Load the actual events only if we're going to use them. */
-  File atomicRedRegsvr32File = new File("$projectDir/src/yamlRestTest/resources/normalized-T1117-AtomicRed-regsvr32.json")
+  File atomicRedRegsvr32File = new File("$projectDir/src/Test/resources/normalized-T1117-AtomicRed-regsvr32.json")
   inputs.file(atomicRedRegsvr32File).withPathSensitivity(PathSensitivity.RELATIVE)
 
   doFirst {

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -2063,7 +2063,7 @@ buildRestTests.teardowns['failure-store-recipes-2-td'] = '''
   }
 
   /* Load the actual events only if we're going to use them. */
-  File atomicRedRegsvr32File = new File("$projectDir/src/Test/resources/normalized-T1117-AtomicRed-regsvr32.json")
+  File atomicRedRegsvr32File = new File("$projectDir/src/yamlRestTest/resources/normalized-T1117-AtomicRed-regsvr32.json")
   inputs.file(atomicRedRegsvr32File).withPathSensitivity(PathSensitivity.RELATIVE)
 
   doFirst {

--- a/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -25,6 +25,10 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.yaml.ClientYamlDocsTestClient;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
@@ -44,8 +48,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -60,6 +68,98 @@ import static org.hamcrest.Matchers.is;
 
 @TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    private static final String USER = "test_admin";
+    private static final String PASS = "x-pack-test-password";
+
+    private static final TemporaryFolder repoDirectory = new TemporaryFolder();
+
+    /**
+     * Resolve a path against the docs project directory. The {@code tests.docs.dir} system
+     * property is wired up in {@code docs/build.gradle} and points to the docs project's
+     * {@code projectDir}, so we can keep referencing the existing files in {@code src/test/cluster/config}
+     * and friends without copying them onto the test classpath.
+     */
+    private static Path docsFile(String relative) {
+        return Path.of(System.getProperty("tests.docs.dir"), relative);
+    }
+
+    private static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .feature(FeatureFlag.TIME_SERIES_MODE)
+        .keystorePassword("keystore-password")
+        // debug ccr test failures:
+        // https://github.com/elastic/elasticsearch/issues/95678
+        // https://github.com/elastic/elasticsearch/issues/94359
+        // https://github.com/elastic/elasticsearch/issues/96561
+        .setting("logger.org.elasticsearch.transport.SniffConnectionStrategy", "DEBUG")
+        .setting("logger.org.elasticsearch.transport.RemoteClusterService", "DEBUG")
+        // enable regexes in painless so our tests don't complain about example snippets that use them
+        .setting("script.painless.regex.enabled", "true")
+        .setting("path.repo", () -> repoDirectory.getRoot().getPath())
+        // Whitelist reindexing from the local node so we can test it.
+        .setting("reindex.remote.whitelist", "127.0.0.1:*")
+        // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
+        .systemProperty("es.transport.cname_in_publish_address", "true")
+        .systemProperty("es.queryable_built_in_roles_enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        // disable the ILM and SLM history for doc tests to avoid potential lingering tasks that'd cause test flakiness
+        .setting("indices.lifecycle.history_index_enabled", "false")
+        .setting("slm.history_index_enabled", "false")
+        .setting("xpack.security.enabled", "true")
+        .setting("xpack.security.authc.api_key.enabled", "true")
+        .setting("xpack.security.authc.token.enabled", "true")
+        .setting("xpack.security.authc.realms.file.file.order", "0")
+        .setting("xpack.security.authc.realms.native.native.order", "1")
+        .setting("xpack.security.authc.realms.oidc.oidc1.order", "2")
+        .setting("xpack.security.authc.realms.oidc.oidc1.op.issuer", "http://127.0.0.1:8080")
+        .setting("xpack.security.authc.realms.oidc.oidc1.op.authorization_endpoint", "http://127.0.0.1:8080/c2id-login")
+        .setting("xpack.security.authc.realms.oidc.oidc1.op.token_endpoint", "http://127.0.0.1:8080/c2id/token")
+        .setting("xpack.security.authc.realms.oidc.oidc1.op.jwkset_path", "op-jwks.json")
+        .setting("xpack.security.authc.realms.oidc.oidc1.rp.redirect_uri", "https://my.fantastic.rp/cb")
+        .setting("xpack.security.authc.realms.oidc.oidc1.rp.client_id", "elasticsearch-rp")
+        .keystore(
+            "xpack.security.authc.realms.oidc.oidc1.rp.client_secret",
+            "b07efb7a1cf6ec9462afe7b6d3ab55c6c7880262aa61ac28dded292aca47c9a2"
+        )
+        .setting("xpack.security.authc.realms.oidc.oidc1.rp.response_type", "id_token")
+        .setting("xpack.security.authc.realms.oidc.oidc1.claims.principal", "sub")
+        .setting("xpack.security.authc.realms.pki.pki1.order", "3")
+        .setting("xpack.security.authc.realms.pki.pki1.certificate_authorities", "[ \"testClient.crt\" ]")
+        .setting("xpack.security.authc.realms.pki.pki1.delegation.enabled", "true")
+        .setting("xpack.security.authc.realms.saml.saml1.order", "4")
+        .setting("xpack.security.authc.realms.saml.saml1.sp.logout", "https://kibana.org/logout")
+        .setting("xpack.security.authc.realms.saml.saml1.idp.entity_id", "https://my-idp.org")
+        .setting("xpack.security.authc.realms.saml.saml1.idp.metadata.path", "idp-docs-metadata.xml")
+        .setting("xpack.security.authc.realms.saml.saml1.sp.entity_id", "https://kibana.org")
+        .setting("xpack.security.authc.realms.saml.saml1.sp.acs", "https://kibana.org/api/security/saml/callback")
+        .setting("xpack.security.authc.realms.saml.saml1.attributes.principal", "uid")
+        .setting("xpack.security.authc.realms.saml.saml1.attributes.name", "urn:oid:2.5.4.3")
+        .configFile("analysis/example_word_list.txt", Resource.fromFile(docsFile("src/test/cluster/config/analysis/example_word_list.txt")))
+        .configFile(
+            "analysis/hyphenation_patterns.xml",
+            Resource.fromFile(docsFile("src/test/cluster/config/analysis/hyphenation_patterns.xml"))
+        )
+        .configFile("analysis/synonym.txt", Resource.fromFile(docsFile("src/test/cluster/config/analysis/synonym.txt")))
+        .configFile("analysis/stemmer_override.txt", Resource.fromFile(docsFile("src/test/cluster/config/analysis/stemmer_override.txt")))
+        .configFile("userdict_ja.txt", Resource.fromFile(docsFile("src/test/cluster/config/userdict_ja.txt")))
+        .configFile("userdict_ko.txt", Resource.fromFile(docsFile("src/test/cluster/config/userdict_ko.txt")))
+        .configFile("KeywordTokenizer.rbbi", Resource.fromFile(docsFile("src/test/cluster/config/KeywordTokenizer.rbbi")))
+        .configFile("hunspell/en_US/en_US.aff", Resource.fromClasspath("indices/analyze/conf_dir/hunspell/en_US/en_US.aff"))
+        .configFile("hunspell/en_US/en_US.dic", Resource.fromClasspath("indices/analyze/conf_dir/hunspell/en_US/en_US.dic"))
+        .configFile("httpCa.p12", Resource.fromFile(docsFile("httpCa.p12")))
+        .configFile("transport.p12", Resource.fromFile(docsFile("transport.p12")))
+        .configFile("ingest-geoip/GeoLite2-City.mmdb", Resource.fromClasspath("GeoLite2-City.mmdb"))
+        .configFile("ingest-geoip/GeoLite2-Country.mmdb", Resource.fromClasspath("GeoLite2-Country.mmdb"))
+        .configFile("op-jwks.json", Resource.fromClasspath("oidc/op-jwks.json"))
+        .configFile("idp-docs-metadata.xml", Resource.fromClasspath("idp/shibboleth-idp/metadata/idp-docs-metadata.xml"))
+        .configFile("testClient.crt", Resource.fromClasspath("org/elasticsearch/xpack/security/action/pki_delegation/testClient.crt"))
+        .user(USER, PASS)
+        .user("test_user", PASS)
+        .build();
+
+    @ClassRule
+    public static TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
 
     public DocsClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -86,6 +186,11 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
             );
         }
     };
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     @Override
     protected void afterIfFailed(List<Throwable> errors) {
@@ -228,7 +333,7 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         return testName != null && (testName.contains("/info/") || testName.contains("\\info\\"));
     }
 
-    private static final String USER_TOKEN = basicAuthHeaderValue("test_admin", new SecureString("x-pack-test-password".toCharArray()));
+    private static final String USER_TOKEN = basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray()));
 
     /**
      * All tests run as a an administrative user but use <code>es-shield-runas-user</code> to become a less privileged user.

--- a/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -86,6 +86,9 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     private static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
+        // Match the cluster name and node name the docs tests expect (mirrors the old testClusters DSL behaviour)
+        .name("yamlRestTest")
+        .withNode(n -> n.name("node-0"))
         .feature(FeatureFlag.TIME_SERIES_MODE)
         // Install all non-repository plugins from :plugins:* — mirrors the old testClusters DSL loop.
         .plugin("analysis-icu")

--- a/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -87,6 +87,21 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
     private static final ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
         .feature(FeatureFlag.TIME_SERIES_MODE)
+        // Install all non-repository plugins from :plugins:* — mirrors the old testClusters DSL loop.
+        .plugin("analysis-icu")
+        .plugin("analysis-kuromoji")
+        .plugin("analysis-nori")
+        .plugin("analysis-phonetic")
+        .plugin("analysis-smartcn")
+        .plugin("analysis-stempel")
+        .plugin("analysis-ukrainian")
+        .plugin("discovery-azure-classic")
+        .plugin("discovery-ec2")
+        .plugin("discovery-gce")
+        .plugin("mapper-annotated-text")
+        .plugin("mapper-murmur3")
+        .plugin("mapper-size")
+        .plugin("store-smb")
         .keystorePassword("keystore-password")
         // debug ccr test failures:
         // https://github.com/elastic/elasticsearch/issues/95678


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Migrate :docs yamlRestTest to rule-based test cluster (#147923)](https://github.com/elastic/elasticsearch/pull/147923)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)