### PR TITLE
[9.4] Add jdk.management.agent module to list of instrumented modules (#148631)

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
@@ -177,7 +177,8 @@ final class SystemJvmOptions {
 
         // We instrument classes in these modules to call the bridge. Because the bridge gets patched
         // into java.base, we must export the bridge from java.base to these modules, as a comma-separated list
-        String modulesContainingEntitlementInstrumentation = "java.logging,java.net.http,java.naming,jdk.net,jdk.zipfs";
+        String modulesContainingEntitlementInstrumentation =
+            "java.logging,java.net.http,java.naming,jdk.net,jdk.zipfs,jdk.management.agent";
         return Stream.of(
             "-XX:+EnableDynamicAgentLoading",
             "-Djdk.attach.allowAttachSelf=true",


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Add jdk.management.agent module to list of instrumented modules (#148631)