### PR TITLE
Fix gradle precommit error with findGoldenTestClasses

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -531,7 +531,10 @@ def findGoldenTestClasses = { FileCollection runtimeClasspath, FileCollection cl
     if (dir.exists() == false) {
       return
     }
-    fileTree(dir).matching { include "**/*.class" }.each { File f ->
+    dir.eachFileRecurse(groovy.io.FileType.FILES) { File f ->
+      if (f.name.endsWith('.class') == false) {
+        return
+      }
       def rel = dir.toPath().relativize(f.toPath()).toString()
       def name = rel.replace(File.separatorChar, '.' as char).replaceAll(/\.class$/, '')
       if (name.endsWith('package-info') || name.endsWith('module-info') || name.contains('$')) {


### PR DESCRIPTION
When running:

```
./gradlew precommit --configuration-cache
```

We see the error:

```
1 problem was found storing the configuration cache.                                                                                                                                                                                              
  - Task `:x-pack:plugin:esql:goldenTestingConventions` of type `org.gradle.api.DefaultTask`: invocation of 'fileTree' references a Gradle script object from a Groovy closure at execution time, which is unsupported with the configuration       
  cache.                                                                                                                                                                                                                                            
    See https://docs.gradle.org/9.5.0/userguide/configuration_cache_requirements.html#config_cache:requirements:gradle_model_types                                                                                                                  
```

This appears to be due to the PR at https://github.com/elastic/elasticsearch/pull/148515
