### PR TITLE
[9.3] SQL: fix REPLACE with empty pattern (#148616)

### DIFF
--- a/docs/changelog/148616.yaml
+++ b/docs/changelog/148616.yaml
@@ -1,0 +1,5 @@
+area: SQL
+issues: []
+pr: 148616
+summary: Fix REPLACE with empty pattern
+type: bug

--- a/x-pack/plugin/sql/qa/server/src/main/resources/functions.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/functions.csv-spec
@@ -225,6 +225,18 @@ Bojan          |Bojan
 
 ;
 
+selectReplaceWithEmptyPattern
+SELECT REPLACE("first_name",'','X') same, "first_name" original FROM "test_emp" ORDER BY "first_name" LIMIT 5;
+
+      same:s     |   original:s
+-----------------+---------------
+Alejandro        |Alejandro
+Amabile          |Amabile
+Anneke           |Anneke
+Anoosh           |Anoosh
+Arumugam         |Arumugam
+;
+
 selectReplaceWithGroupBy
 SELECT REPLACE("first_name",'jan','_JAN_') modified, COUNT(*) count FROM "test_emp" GROUP BY REPLACE("first_name",'jan','_JAN_') ORDER BY REPLACE("first_name",'jan','_JAN_') LIMIT 10;
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceFunctionProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceFunctionProcessor.java
@@ -67,6 +67,9 @@ public class ReplaceFunctionProcessor implements Processor {
 
     private static void checkResultLength(String input, String pattern, String replacement) {
         int patternLen = pattern.length();
+        if (patternLen == 0) {
+            return;
+        }
         long matches = 0;
         for (int i = input.indexOf(pattern); i >= 0; i = input.indexOf(pattern, i + patternLen)) {
             matches++;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/ReplaceProcessorTests.java
@@ -58,6 +58,11 @@ public class ReplaceProcessorTests extends AbstractWireSerializingTestCase<Repla
         assertNull(new Replace(EMPTY, l(null), l(null), l(null)).makePipe().asProcessor().process(null));
     }
 
+    public void testReplaceFunctionWithEmptyPattern() {
+        assertEquals("foobar", new Replace(EMPTY, l("foobar"), l(""), l("baz")).makePipe().asProcessor().process(null));
+        assertEquals("foobar", new Replace(EMPTY, l("foobar"), l(""), l("")).makePipe().asProcessor().process(null));
+    }
+
     public void testReplaceFunctionInputsValidation() {
         SqlIllegalArgumentException siae = expectThrows(
             SqlIllegalArgumentException.class,


### PR DESCRIPTION
Backports the following commits to 9.3:
 - SQL: fix REPLACE with empty pattern (#148616)