### PR TITLE
[9.4] Pin server-launcher native -march to x86-64-v2 (#148542)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/NativeImageBuildTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/NativeImageBuildTask.java
@@ -15,6 +15,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.ServiceReference;
 import org.gradle.api.tasks.CacheableTask;
@@ -87,6 +88,11 @@ public abstract class NativeImageBuildTask extends DefaultTask {
     @Optional
     public abstract Property<Boolean> getStatic();
 
+    /** Extra arguments passed verbatim to {@code native-image}, inserted after {@code --no-fallback}. */
+    @Input
+    @Optional
+    public abstract ListProperty<String> getExtraArgs();
+
     @OutputFile
     public abstract RegularFileProperty getOutputFile();
 
@@ -105,6 +111,7 @@ public abstract class NativeImageBuildTask extends DefaultTask {
             params.getPlatform().set(getPlatform());
             params.getMainClass().set(getMainClass());
             params.getStatic().set(getStatic().getOrElse(false));
+            params.getExtraArgs().set(getExtraArgs().getOrElse(List.of()));
             params.getOutputFile().set(getOutputFile());
             params.getDockerExecutable().set(dockerExecutable);
         });
@@ -120,6 +127,8 @@ public abstract class NativeImageBuildTask extends DefaultTask {
         Property<String> getMainClass();
 
         Property<Boolean> getStatic();
+
+        ListProperty<String> getExtraArgs();
 
         RegularFileProperty getOutputFile();
 
@@ -186,6 +195,7 @@ public abstract class NativeImageBuildTask extends DefaultTask {
             if (params.getStatic().get()) {
                 args.add("--static");
             }
+            args.addAll(params.getExtraArgs().get());
             args.add("-cp");
             args.add(cpString);
             args.add("-o");

--- a/distribution/tools/server-launcher/build.gradle
+++ b/distribution/tools/server-launcher/build.gradle
@@ -45,6 +45,8 @@ def nativeImageLinuxX64 = tasks.register('nativeImageLinuxX64', NativeImageBuild
   imageTag = nativeImageImage
   platform = 'linux/amd64'
   mainClass = launcherMainClass
+  // Use the AMD64 baseline so the binary runs on any x86_64 CPU; GraalVM 25 defaults to v3 which requires AVX2.
+  extraArgs = ['-march=compatibility']
   outputFile = layout.buildDirectory.file('native/linux-x86_64/server-launcher')
 }
 

--- a/docs/changelog/148542.yaml
+++ b/docs/changelog/148542.yaml
@@ -1,0 +1,6 @@
+area: Infra/Core
+issues:
+ - 148326
+pr: 148542
+summary: Pin server-launcher native -march to x86-64-v2
+type: bug


### PR DESCRIPTION
Backport of #148542 to 9.4 (auto-backport failed; cherry-picked manually).

9.4.0 ships a GraalVM native-image `server-launcher` built without an explicit `-march`, so it inherits GraalVM 25's default x86-64-v3 baseline and refuses to start on pre-Haswell CPUs (Nehalem/Sandy Bridge/Ivy Bridge). 

This PR pins `-march=compatibility` on the x86_64 task — GraalVM's AMD64-baseline mode (CX8/CMOV/FXSR/MMX/SSE/SSE2 only) — so the binary runs on any 64-bit x86 CPU, verified under `qemu-x86_64` across every model from Core 2 Duo through Skylake-Server. 

Closes #148326.


### Workaround for affected installs: 

> 
> Until the patched release ships, you can force the launcher to take the JVM fallback path:
> ```
> sudo systemctl stop elasticsearch
> sudo chmod -x /usr/share/elasticsearch/lib/tools/server-launcher/server-launcher
> sudo systemctl start elasticsearch
> ```
> 
> The startup script bin/elasticsearch checks [ -x "$NATIVE_LAUNCHER" ] and falls through to a JVM launcher if the native binary isn't executable. Performance impact is negligible, the launcher is a short-lived bootstrap, not on the request path. Note: package upgrades reinstall the binary with 0755, so the workaround needs to be reapplied after each upgrade until you're on a release containing the fix.
> 
> If you're on a hypervisor (VMware / Proxmox / Hyper-V) and your physical host CPU is Haswell or newer, switching the guest CPU type to host-passthrough is an alternative that doesn't require touching files (but caveats apply when live-migrating hosts between mixed generations).
> 
> The native launcher is a startup-time optimization introduced in 9.4.0 — it replaces a small JVM-based launcher process that ran for the life of the node in 9.3.x and earlier, saving ~40–90 MB of RSS and ~1–2 s of startup latency. Disabling it returns the launcher to the pre-9.4 JVM-based path, which has shipped unchanged for years and is still the default on Windows, macOS, and any Linux install without the native binary. There is no functional or security difference; the actual Elasticsearch server JVM behaves identically.