### PR TITLE
Buildkite: classify EA pipeline failures vs main

### DIFF
--- a/.buildkite/pipelines/periodic-java-ea.template.yml
+++ b/.buildkite/pipelines/periodic-java-ea.template.yml
@@ -211,3 +211,15 @@ steps:
         env:
           ES_VERSION: "{{matrix.ES_VERSION}}"
           ES_COMMIT: "{{matrix.ES_COMMIT}}"
+  - wait: ~
+    continue_on_failure: true
+  - label: ea-failure-classification
+    command: .buildkite/scripts/ea-classify-failures.sh
+    timeout_in_minutes: 15
+    soft_fail: true
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2404
+      machineType: n4-standard-8
+      diskType: hyperdisk-balanced
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/pipelines/periodic-java-ea.yml
+++ b/.buildkite/pipelines/periodic-java-ea.yml
@@ -706,3 +706,15 @@ steps:
         env:
           ES_VERSION: "{{matrix.ES_VERSION}}"
           ES_COMMIT: "{{matrix.ES_COMMIT}}"
+  - wait: ~
+    continue_on_failure: true
+  - label: ea-failure-classification
+    command: .buildkite/scripts/ea-classify-failures.sh
+    timeout_in_minutes: 15
+    soft_fail: true
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2404
+      machineType: n4-standard-8
+      diskType: hyperdisk-balanced
+      buildDirectory: /dev/shm/bk

--- a/.buildkite/scripts/ea-classify-failures.sh
+++ b/.buildkite/scripts/ea-classify-failures.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+#
+# Classifies failed tests from the most recent elasticsearch-periodic-java-ea
+# run into "EA-specific candidates" (no matching failures on non-EA lanes) vs
+# "inherited from main" (also failing on regular CI lanes).
+#
+# Outputs a markdown report. Posts a Buildkite annotation when invoked from a
+# Buildkite job ($BUILDKITE_BUILD_ID set), otherwise prints to stdout.
+#
+# Local prototype: data fetched via the `estc ci-stats` CLI so it runs on a
+# developer machine without ci-stats credentials. The in-CI variant should
+# replace fetch_ea_failures and count_baseline_failures with curl calls
+# against the ci-stats cluster (auth via vault, mirroring USE_PERF_CREDENTIALS
+# in pre-command). Those two functions are the only data-fetching seams.
+#
+# Usage:
+#   .buildkite/scripts/ea-classify-failures.sh
+#
+# Tunables (env, with defaults):
+#   EA_CLASSIFY_RECENT_HOURS=26          # window for "this run's" EA failures
+#   EA_CLASSIFY_BASELINE_DAYS=14         # baseline window for non-EA failures
+#   EA_CLASSIFY_INHERITED_THRESHOLD=1    # >=N non-EA failures => "inherited"
+
+set -euo pipefail
+
+EA_TAG="elasticsearch-periodic-java-ea"
+
+log() { echo "$@" >&2; }
+
+# Returns the raw `estc ci-stats list-failures` output for failures tagged as
+# EA in the recent window. Override in tests.
+fetch_ea_failures() {
+  local recent_hours="$1"
+  estc ci-stats list-failures \
+    --tag "$EA_TAG" \
+    --from "now-${recent_hours}h" \
+    --size 200
+}
+
+# Returns a single integer: count of non-EA failures of the given test in the
+# baseline window. Override in tests.
+count_baseline_failures() {
+  local class="$1" name="$2" baseline_days="$3"
+  local esc_name=${name//\"/\\\"}
+  estc ci-stats list-failures \
+    --class "$class" \
+    --query-string "name.keyword:\"$esc_name\" AND NOT build.tags:\"$EA_TAG\"" \
+    --from "now-${baseline_days}d" --size 1 2>&1 \
+    | awk '/^Failures:[[:space:]]+[0-9]+/ { print $2; exit }'
+}
+
+# Reads `list-failures` output on stdin and emits unique tab-separated
+# "class<TAB>name" lines, sorted.
+parse_test_pairs() {
+  awk '
+    /^  Class:[[:space:]]/ { sub(/^  Class:[[:space:]]+/, ""); c = $0 }
+    /^  Test:[[:space:]]/  { sub(/^  Test:[[:space:]]+/, "");  print c "\t" $0 }
+  ' | sort -u
+}
+
+# Emits the markdown report. Args: recent_hours baseline_days threshold
+# candidates_block inherited_block
+render_report() {
+  local recent_hours="$1" baseline_days="$2" inherited_threshold="$3"
+  local candidates="$4" inherited="$5"
+  local cand_count inh_count
+  cand_count=$(printf '%s' "$candidates" | grep -c '^- ' || true)
+  inh_count=$(printf '%s' "$inherited" | grep -c '^- ' || true)
+
+  cat <<MARKDOWN
+## EA failure classification
+
+Window: last ${recent_hours}h of \`${EA_TAG}\` failures vs ${baseline_days}d baseline of non-EA failures on \`main\`.
+Inherited threshold: ≥${inherited_threshold} non-EA failure(s).
+
+### EA-specific candidates (${cand_count})
+
+Failed on EA but **no** non-EA failures in the baseline window — investigate these.
+
+${candidates:-_(none)_}
+
+<details>
+<summary>Inherited from main (${inh_count}) — click to expand</summary>
+
+These also fail on regular CI lanes; likely existing flaky/broken tests, not EA-specific.
+
+${inherited:-_(none)_}
+
+</details>
+MARKDOWN
+}
+
+emit_annotation() {
+  local style="$1" body="$2"
+  if [[ -n "${BUILDKITE_BUILD_ID:-}" ]]; then
+    printf '%s\n' "$body" \
+      | buildkite-agent annotate \
+          --context "ea-failure-classification" \
+          --style "$style"
+  else
+    printf '%s\n' "$body"
+  fi
+}
+
+main() {
+  local recent_hours="${EA_CLASSIFY_RECENT_HOURS:-26}"
+  local baseline_days="${EA_CLASSIFY_BASELINE_DAYS:-14}"
+  local inherited_threshold="${EA_CLASSIFY_INHERITED_THRESHOLD:-1}"
+
+  # Graceful fallback when running in CI before ci-stats credentials are wired
+  # up. Lets us validate the pipeline integration end-to-end without full
+  # functionality.
+  if ! command -v estc >/dev/null 2>&1; then
+    log "estc CLI not available; emitting placeholder annotation."
+    emit_annotation info "## EA failure classification
+
+_Pipeline integration in place. Awaiting ci-stats read credentials in CI to enable classification — see \`.buildkite/scripts/ea-classify-failures.sh\` header._"
+    return 0
+  fi
+
+  log "[1/3] Fetching EA failures from the last ${recent_hours}h..."
+  local ea_out
+  ea_out=$(fetch_ea_failures "$recent_hours")
+
+  log "[2/3] Parsing failures..."
+  local tests
+  tests=$(printf '%s\n' "$ea_out" | parse_test_pairs)
+
+  if [[ -z "$tests" ]]; then
+    log "No EA failures found in the last ${recent_hours}h."
+    return 0
+  fi
+
+  local total
+  total=$(printf '%s\n' "$tests" | wc -l | tr -d ' ')
+  log "[3/3] Classifying $total unique tests against ${baseline_days}d baseline..."
+
+  local candidates="" inherited="" i=0
+  while IFS=$'\t' read -r class name; do
+    i=$((i+1))
+    log "  [$i/$total] $class.$name"
+    local count
+    count=$(count_baseline_failures "$class" "$name" "$baseline_days")
+    count=${count:-0}
+    if [[ "$count" -ge "$inherited_threshold" ]]; then
+      inherited+="- \`${class}.${name}\` — ${count} non-EA fails / ${baseline_days}d"$'\n'
+    else
+      candidates+="- \`${class}.${name}\` — 0 non-EA fails / ${baseline_days}d"$'\n'
+    fi
+  done <<< "$tests"
+
+  local body style="info"
+  body=$(render_report "$recent_hours" "$baseline_days" "$inherited_threshold" "$candidates" "$inherited")
+  if [[ -n "$candidates" ]]; then
+    style="warning"
+  fi
+  emit_annotation "$style" "$body"
+}
+
+# Run main only when executed directly, so the test file can source this and
+# override fetch_ea_failures / count_baseline_failures with stubs.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.buildkite/scripts/ea-classify-failures.test.sh
+++ b/.buildkite/scripts/ea-classify-failures.test.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# Fixture test for ea-classify-failures.sh. Stubs the two data-fetching
+# functions (fetch_ea_failures, count_baseline_failures) so the parsing and
+# classification logic can be exercised without hitting ci-stats.
+#
+# Run from anywhere:
+#   .buildkite/scripts/ea-classify-failures.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ea-classify-failures.sh
+source "$SCRIPT_DIR/ea-classify-failures.sh"
+
+failures=0
+expect() {
+  local label="$1" haystack="$2" needle="$3"
+  if grep -qF -- "$needle" <<< "$haystack"; then
+    echo "  ok: $label"
+  else
+    echo "  FAIL: $label" >&2
+    echo "    expected to find: $needle" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# --- parse_test_pairs ---
+echo "test: parse_test_pairs extracts unique class/name pairs"
+fixture=$(cat <<'EOF'
+Failures: 3 total, showing 3 most recent
+
+[2026-05-08 09:19:14] branch=main  tags=[CI, elasticsearch-periodic-java-ea, main]
+  Class:  com.example.AlphaTests
+  Test:   testInherited
+  Task:   :foo:test
+
+[2026-05-08 09:19:13] branch=main  tags=[CI, elasticsearch-periodic-java-ea, main]
+  Class:  com.example.AlphaTests
+  Test:   testInherited
+  Task:   :foo:test
+
+[2026-05-08 09:19:12] branch=main  tags=[CI, elasticsearch-periodic-java-ea, main]
+  Class:  com.example.BetaTests
+  Test:   testEaSpecific
+  Task:   :bar:test
+EOF
+)
+parsed=$(printf '%s\n' "$fixture" | parse_test_pairs)
+expect "AlphaTests pair present" "$parsed" $'com.example.AlphaTests\ttestInherited'
+expect "BetaTests pair present"  "$parsed" $'com.example.BetaTests\ttestEaSpecific'
+got_count=$(printf '%s\n' "$parsed" | wc -l | tr -d ' ')
+if [[ "$got_count" != "2" ]]; then
+  echo "  FAIL: expected 2 unique pairs after dedup, got $got_count" >&2
+  failures=$((failures + 1))
+else
+  echo "  ok: dedups to 2 unique pairs"
+fi
+
+# --- main: classification end-to-end with stubbed I/O ---
+echo "test: main classifies into candidates vs inherited buckets"
+
+# These stubs are invoked indirectly by main; suppress "never invoked" warnings.
+# shellcheck disable=SC2317,SC2329
+fetch_ea_failures() {
+  cat <<'EOF'
+Failures: 2 total, showing 2 most recent
+
+[2026-05-08 09:19:14] branch=main  tags=[CI, elasticsearch-periodic-java-ea, main]
+  Class:  com.example.AlphaTests
+  Test:   testInherited
+  Task:   :foo:test
+
+[2026-05-08 09:19:13] branch=main  tags=[CI, elasticsearch-periodic-java-ea, main]
+  Class:  com.example.BetaTests
+  Test:   testEaSpecific
+  Task:   :bar:test
+EOF
+}
+
+# AlphaTests has non-EA history (=> inherited); BetaTests has none (=> candidate).
+# shellcheck disable=SC2317,SC2329
+count_baseline_failures() {
+  local class="$1"
+  case "$class" in
+    *AlphaTests) echo 5 ;;
+    *BetaTests)  echo 0 ;;
+    *)           echo 0 ;;
+  esac
+}
+
+# Unset BUILDKITE_BUILD_ID so main prints the body to stdout instead of trying
+# to call buildkite-agent annotate.
+unset BUILDKITE_BUILD_ID
+output=$(main 2>/dev/null)
+
+expect "shows 1 candidate count"           "$output" "EA-specific candidates (1)"
+expect "shows 1 inherited count"           "$output" "Inherited from main (1)"
+expect "BetaTests listed as candidate"     "$output" "BetaTests.testEaSpecific\` — 0 non-EA fails"
+expect "AlphaTests listed as inherited"    "$output" "AlphaTests.testInherited\` — 5 non-EA fails"
+expect "candidates section before details" "$output" "### EA-specific candidates"
+
+# --- main: empty fetch yields no report ---
+echo "test: main exits cleanly when there are no EA failures"
+# shellcheck disable=SC2317,SC2329
+fetch_ea_failures() { echo "Failures: 0 total, showing 0 most recent"; }
+output=$(main 2>/dev/null)
+if [[ -n "$output" ]]; then
+  echo "  FAIL: expected no stdout when there are no EA failures, got:" >&2
+  echo "$output" >&2
+  failures=$((failures + 1))
+else
+  echo "  ok: empty stdout when no EA failures"
+fi
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+  echo "$failures assertion(s) failed" >&2
+  exit 1
+fi
+echo "all tests passed"


### PR DESCRIPTION
Adds a final post-build step to elasticsearch-periodic-java-ea that classifies each run's failed tests into EA-specific candidates vs failures inherited from main, and posts the result as a Buildkite annotation. 

Today the pipeline is reliably red but every recurring failure also reproduces on stock-JDK lanes, so a genuine EA SDK bug would be invisible under the noise. This is a local prototype: data is fetched via the estc CLI for now, and the in-CI path falls back to a placeholder annotation pending vault credentials for ci-stats,at which point swapping two helper functions for curl finishes the job. Includes a fixture-driven shell test.