### PR TITLE
Fix DLS docs: .enum sub-field references to .keyword

### DIFF
--- a/docs/reference/search-connectors/es-connectors-known-issues.md
+++ b/docs/reference/search-connectors/es-connectors-known-issues.md
@@ -121,6 +121,17 @@ The connector service has the following known issues:
     As a result, true document volume will be under-reported by a factor of 1024.
 
 
+* **DLS queries fail to match documents for content indices created on 9.0+**
+
+    The DLS query template stored in access control documents (`.search-acl-filter-*` indices) references the sub-field `_allow_access_control.enum`. This sub-field was created by a custom dynamic mapping template that was [removed in connectors v9.0.0](https://github.com/elastic/connectors/pull/3013). Under Elasticsearch's default dynamic mapping, the correct sub-field is `_allow_access_control.keyword`. As a result, DLS-protected documents are silently filtered out — users see no results for documents that have access control set.
+
+    **Affected versions**: 9.0.0+, for any content index created after upgrading. Indices created before 9.0 are not affected because the old mapping is preserved.
+
+    **Workaround**: After fetching the DLS query from the access control document, replace `_allow_access_control.enum` with `_allow_access_control.keyword` before using it in an API key role descriptor.
+
+    **Fix**: Tracked in [elastic/connectors#4005](https://github.com/elastic/connectors/issues/4005). After the fix is deployed, re-run an **access control sync** so the corrected query template is written to the `.search-acl-filter-*` documents.
+
+
 ## Individual connector known issues [es-connectors-known-issues-specific]
 
 Individual connectors may have additional known issues. Refer to [each connector’s reference documentation](/reference/search-connectors/index.md) for connector-specific known issues.

--- a/docs/reference/search-connectors/es-dls-e2e-guide.md
+++ b/docs/reference/search-connectors/es-dls-e2e-guide.md
@@ -108,7 +108,7 @@ The access control index will contain documents similar to this example:
               },
               {
                 "terms": {
-                  "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                  "_allow_access_control.keyword": {{#toJson}}access_control{{/toJson}}
                 }
               }
             ]
@@ -121,6 +121,10 @@ The access control index will contain documents similar to this example:
 }
 ```
 % NOTCONSOLE
+
+::::{note}
+These examples use `_allow_access_control.keyword`, which is the default sub-field created by Elasticsearch's dynamic mapping for text fields. If you have defined a custom mapping for `_allow_access_control` (for example, mapping it directly as `keyword`), adjust the field name in the `terms` query accordingly.
+::::
 
 This document contains the Elasticsearch query that describes which documents the user `john@example.com` has access to. The access control information is stored in the `access_control` field. In this case the user has access only to documents that contain `"john@example.co"` or `"Engineering Members"` in the `_allow_access_control` field.
 
@@ -166,7 +170,7 @@ POST /_security/api_key
                     },
                     {
                       "terms": {
-                        "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                        "_allow_access_control.keyword": {{#toJson}}access_control{{/toJson}}
                       }
                     }
                   ]

--- a/docs/reference/search-connectors/es-dls-overview.md
+++ b/docs/reference/search-connectors/es-dls-overview.md
@@ -44,7 +44,7 @@ Note the following details about content documents and syncs:
 
 1. Remember that for DLS to work, your **content documents** must have access control fields that match the criteria defined in your access control documents. [Content documents](#es-dls-overview-content-documents) contain the actual content your users will search for. If a content document does not have access control fields, there will be no restrictions on who can view it.
 2. When a user searches for content, the access control documents determine which content the user is allowed to view.
-3. At *search* time documents without the `_allow_access_control` field or with allowed values in `_allow_access_control.enum` will be returned in the search results. The logic for determining whether a document has access control enabled is based on the presence or values of the `_allow_access_control*` fields.
+3. At *search* time documents without the `_allow_access_control` field or with allowed values in `_allow_access_control.keyword` will be returned in the search results. The logic for determining whether a document has access control enabled is based on the presence or values of the `_allow_access_control` field.
 4. Run **Content** syncs to sync your third party data source to Elasticsearch. A specific field (or fields) within these documents correlates with the query parameters in the access control documents enabling document-level security (DLS).
 
 ::::{note}


### PR DESCRIPTION
## Summary

- Fix DLS query examples to use `_allow_access_control.keyword` instead of `_allow_access_control.enum`
- Add a note that the exact sub-field depends on index mapping configuration
- Add known issue entry for the corresponding connector bug

The `.enum` sub-field was created by a custom dynamic mapping template in the connectors service that was removed in v9.0.0 (elastic/connectors#3013). Under Elasticsearch's default dynamic mapping, string fields get a `.keyword` sub-field. The outdated `.enum` references cause DLS queries to silently match zero documents.

**Files changed:**
- `docs/reference/search-connectors/es-dls-overview.md` — fix `.enum` reference in prose
- `docs/reference/search-connectors/es-dls-e2e-guide.md` — fix `.enum` in two query examples, add mapping note
- `docs/reference/search-connectors/es-connectors-known-issues.md` — add known issue entry

Connector-side fix tracked in elastic/connectors#4005 / elastic/connectors#4006.

## Test plan

- [ ] Verify docs render correctly
- [ ] Verify known issue links resolve
