### PR TITLE
Reset offset/length in BytesRefBlockHash

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -139,6 +139,8 @@ final class BytesRefBlockHash extends BlockHash {
             }
             for (int i = 0; i < PREFETCH_BATCH; i++) {
                 batchKeys[i].bytes = BytesRef.EMPTY_BYTES;
+                batchKeys[i].offset = 0;
+                batchKeys[i].length = 0;
             }
             prefetchBarrier.consume(dummy);
             return builder.build();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -152,6 +152,8 @@ $if(BytesRef)$
             }
             for (int i = 0; i < PREFETCH_BATCH; i++) {
                 batchKeys[i].bytes = BytesRef.EMPTY_BYTES;
+                batchKeys[i].offset = 0;
+                batchKeys[i].length = 0;
             }
             prefetchBarrier.consume(dummy);
             return builder.build();


### PR DESCRIPTION
We should reset offset/length after each batch to keep all fields of a BytesRef consistent.