### PR TITLE
Updating `ecs@mappings` to include new flattened `gen_ai` fields

### DIFF
--- a/docs/changelog/148674.yaml
+++ b/docs/changelog/148674.yaml
@@ -1,0 +1,5 @@
+area: Data streams
+issues: []
+pr: 148674
+summary: Updating `ecs@mappings` to include new flattened `gen_ai` fields
+type: feature

--- a/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
@@ -207,7 +207,13 @@
             "path_match": [
               "*structured_data",
               "*exports",
-              "*imports"
+              "*imports",
+              "*gen_ai.system_instructions",
+              "*gen_ai.input.messages",
+              "*gen_ai.output.messages",
+              "*gen_ai.tool.definitions",
+              "*gen_ai.tool.call.arguments",
+              "*gen_ai.tool.call.result"
             ],
             "match_mapping_type": "object"
           }

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -33,11 +33,11 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 19;
+    public static final int REGISTRY_VERSION = 20;
 
     // The computed checksum of all templates and components that are registered in this registry.
     // This is used by a test to ensure that REGISTRY_VERSION is updated when any of the components change.
-    static final String COMPUTED_CHECKSUM = "228d8ef7";
+    static final String COMPUTED_CHECKSUM = "c42ed95a";
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
     public static final Setting<Boolean> STACK_TEMPLATES_ENABLED = Setting.boolSetting(


### PR DESCRIPTION
Following up on https://github.com/elastic/ecs/pull/2532.
