### PR TITLE
[9.3] Migrate to log4j2 annotation processor for plugins (#136983)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/tsdb/TSDBDocValuesMergeBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/codec/tsdb/TSDBDocValuesMergeBenchmark.java
@@ -64,7 +64,6 @@ import java.util.function.Supplier;
 public class TSDBDocValuesMergeBenchmark {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging();
         LogConfigurator.setNodeName("test");
     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/indices/common/MappingParsingBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/indices/common/MappingParsingBenchmark.java
@@ -64,7 +64,6 @@ import java.util.concurrent.TimeUnit;
 public class MappingParsingBenchmark {
     static {
         // For Elasticsearch900Lucene101Codec:
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging();
         LogConfigurator.setNodeName("test");
     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerJDKFloat32Benchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerJDKFloat32Benchmark.java
@@ -43,7 +43,6 @@ public class VectorScorerJDKFloat32Benchmark {
 
     static {
         NodeNamePatternConverter.setGlobalNodeName("foo");
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerJDKInt7uBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerJDKInt7uBenchmark.java
@@ -41,7 +41,6 @@ public class VectorScorerJDKInt7uBenchmark {
 
     static {
         NodeNamePatternConverter.setGlobalNodeName("foo");
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/OptimizedTextBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/xcontent/OptimizedTextBenchmark.java
@@ -53,7 +53,6 @@ import java.util.concurrent.TimeUnit;
 public class OptimizedTextBenchmark {
     static {
         // For Elasticsearch900Lucene101Codec:
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging();
         LogConfigurator.setNodeName("test");
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -98,7 +98,7 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
             // TODO Discuss moving compileOptions.getCompilerArgs() to use provider api with Gradle team.
             List<String> compilerArgs = compileOptions.getCompilerArgs();
             compilerArgs.add("-Werror");
-            compilerArgs.add("-Xlint:all,-path,-serial,-options,-deprecation,-try,-removal");
+            compilerArgs.add("-Xlint:all,-path,-serial,-options,-deprecation,-try,-removal,-processing");
             compilerArgs.add("-Xdoclint:all");
             compilerArgs.add("-Xdoclint:-missing");
             compileOptions.setEncoding("UTF-8");

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/initialization/DynamicInstrumentationUtils.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/initialization/DynamicInstrumentationUtils.java
@@ -29,7 +29,6 @@ public class DynamicInstrumentationUtils {
      * or alternatively the system property `es.entitlements.dump`.
      */
     public static void main(String[] args) throws Exception {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging();
 
         var path = requireNonNull(args.length > 0 ? args[0] : System.getProperty("es.entitlements.dump"), "destination for dump required");

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/CagraParameterTranslationTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/CagraParameterTranslationTests.java
@@ -28,7 +28,6 @@ import static java.util.Locale.ROOT;
 public class CagraParameterTranslationTests extends ESTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging();
     }
 

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQVectorsFormatTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswSQVectorsFormatTests.java
@@ -29,7 +29,6 @@ import static org.elasticsearch.test.ESTestCase.randomFrom;
 public class ES92GpuHnswSQVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsFormatTests.java
+++ b/libs/gpu-codec/src/test/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsFormatTests.java
@@ -27,7 +27,6 @@ import static org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat.DEFAULT_MAX_C
 public class ES92GpuHnswVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/VectorSimilarityFunctionsTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/VectorSimilarityFunctionsTests.java
@@ -26,7 +26,6 @@ public abstract class VectorSimilarityFunctionsTests extends ESTestCase {
 
     static {
         NodeNamePatternConverter.setGlobalNodeName("foo");
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/VectorSystemPropertyTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/VectorSystemPropertyTests.java
@@ -75,7 +75,6 @@ public class VectorSystemPropertyTests extends ESTestCase {
 
         public class Test {
             static {
-                LogConfigurator.loadLog4jPlugins();
                 LogConfigurator.configureESLogging(); // native access requires logging to be initialized
             }
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -51,7 +51,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.matchesRegex;
-import static org.hamcrest.Matchers.startsWith;
 
 public class EvilLoggerTests extends ESTestCase {
 
@@ -249,7 +248,7 @@ public class EvilLoggerTests extends ESTestCase {
         final int expectedLogLines = 3;
         assertThat(events, hasSize(expectedLogLines + stackTraceLength));
         for (int i = 0; i < expectedLogLines; i++) {
-            assertThat("Contents of [" + path + "] are wrong", events.get(i), startsWith("[" + getTestName() + "]" + prefix + " test"));
+            assertThat("Contents of [" + path + "] are wrong", events.get(i), endsWith(prefix + " test"));
         }
     }
 

--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -63,7 +63,6 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
 
     static {
         // normally done by ESTestCase, but need here because spawner depends on logging
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging();
         MockLog.init();
     }

--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
@@ -69,8 +69,6 @@ public class KnnIndexTester {
     static final Logger logger;
 
     static {
-        LogConfigurator.loadLog4jPlugins();
-
         // necessary otherwise the es.logger.level system configuration in build.gradle is ignored
         ProcessInfo pinfo = ProcessInfo.fromSystem();
         Map<String, String> sysprops = pinfo.sysprops();

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -67,6 +67,8 @@ dependencies {
   // logging
   api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   api "org.apache.logging.log4j:log4j-core:${versions.log4j}"
+  annotationProcessor "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+  annotationProcessor "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 
   // access to native functions
   implementation project(':libs:native')

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFact
 import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.config.builder.impl.DefaultConfigurationBuilder;
 import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
-import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfiguration;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationBuilder;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory;
@@ -151,13 +150,6 @@ public class LogConfigurator {
     }
 
     /**
-     * Load logging plugins so we can have {@code node_name} in the pattern.
-     */
-    public static void loadLog4jPlugins() {
-        PluginManager.addPackage(LogConfigurator.class.getPackage().getName());
-    }
-
-    /**
      * Sets the cluster name. This is called before logging is configured.
      */
     public static void setClusterName(String clusterName) {
@@ -200,8 +192,6 @@ public class LogConfigurator {
         Objects.requireNonNull(settings);
         Objects.requireNonNull(configsPath);
         Objects.requireNonNull(logsPath);
-
-        loadLog4jPlugins();
 
         setLogConfigurationSystemProperty(logsPath, settings);
         // we initialize the status logger immediately otherwise Log4j will complain when we try to get the context

--- a/server/src/test/java/org/elasticsearch/index/codec/storedfields/TSDBStoredFieldsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/storedfields/TSDBStoredFieldsFormatTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.mapper.IdFieldMapper;
 public class TSDBStoredFieldsFormatTests extends BaseStoredFieldsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormatTests.java
@@ -57,7 +57,6 @@ public class ES87TSDBDocValuesFormatTests extends BaseDocValuesFormatTestCase {
     private static final int NUM_DOCS = 10;
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging();
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/BQVectorUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/BQVectorUtilsTests.java
@@ -20,8 +20,13 @@
 package org.elasticsearch.index.codec.vectors;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.elasticsearch.common.logging.LogConfigurator;
 
 public class BQVectorUtilsTests extends LuceneTestCase {
+
+    static {
+        LogConfigurator.configureESLogging(); // native access requires logging to be initialized
+    }
 
     public static int popcount(byte[] a, int aOffset, byte[] b, int length) {
         int res = 0;

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseHnswBFloat16VectorsFormatTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseHnswBFloat16VectorsFormatTestCase.java
@@ -45,7 +45,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 public abstract class BaseHnswBFloat16VectorsFormatTestCase extends BaseBFloat16KnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseHnswVectorsFormatTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseHnswVectorsFormatTestCase.java
@@ -46,7 +46,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 public abstract class BaseHnswVectorsFormatTestCase extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseKnnBitVectorsFormatTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/BaseKnnBitVectorsFormatTestCase.java
@@ -37,7 +37,6 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 public abstract class BaseKnnBitVectorsFormatTestCase extends BaseIndexFileFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/ES813FlatVectorFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/ES813FlatVectorFormatTests.java
@@ -31,7 +31,6 @@ import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
 public class ES813FlatVectorFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/ES813Int8FlatVectorFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/ES813Int8FlatVectorFormatTests.java
@@ -31,7 +31,6 @@ import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
 public class ES813Int8FlatVectorFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/ES814HnswScalarQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/ES814HnswScalarQuantizedVectorsFormatTests.java
@@ -45,7 +45,6 @@ import static org.hamcrest.Matchers.hasEntry;
 public class ES814HnswScalarQuantizedVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQBFloat16VectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQBFloat16VectorsFormatTests.java
@@ -35,7 +35,6 @@ import static org.hamcrest.Matchers.equalTo;
 public class ES920DiskBBQBFloat16VectorsFormatTests extends BaseBFloat16KnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsFormatTests.java
@@ -62,7 +62,6 @@ import static org.hamcrest.Matchers.hasToString;
 public class ES920DiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQBFloat16VectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQBFloat16VectorsFormatTests.java
@@ -36,7 +36,6 @@ import static org.hamcrest.Matchers.equalTo;
 public class ESNextDiskBBQBFloat16VectorsFormatTests extends BaseBFloat16KnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
@@ -68,7 +68,6 @@ import static org.hamcrest.Matchers.oneOf;
 public class ESNextDiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
     KnnVectorsFormat format;

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es816/ES816BinaryFlatVectorsScorerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es816/ES816BinaryFlatVectorsScorerTests.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 public class ES816BinaryFlatVectorsScorerTests extends LuceneTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es816/ES816BinaryQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es816/ES816BinaryQuantizedVectorsFormatTests.java
@@ -71,7 +71,6 @@ import static org.hamcrest.Matchers.oneOf;
 public class ES816BinaryQuantizedVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsFormatTests.java
@@ -77,7 +77,6 @@ import static org.hamcrest.Matchers.oneOf;
 public class ES818BinaryQuantizedVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93BinaryQuantizedBFloat16VectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93BinaryQuantizedBFloat16VectorsFormatTests.java
@@ -68,7 +68,6 @@ import static org.hamcrest.Matchers.oneOf;
 public class ES93BinaryQuantizedBFloat16VectorsFormatTests extends BaseBFloat16KnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93BinaryQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93BinaryQuantizedVectorsFormatTests.java
@@ -77,7 +77,6 @@ import static org.hamcrest.Matchers.oneOf;
 public class ES93BinaryQuantizedVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93FlatBFloat16VectorFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93FlatBFloat16VectorFormatTests.java
@@ -36,7 +36,6 @@ import static org.hamcrest.Matchers.hasEntry;
 public class ES93FlatBFloat16VectorFormatTests extends BaseBFloat16KnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93FlatVectorFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93FlatVectorFormatTests.java
@@ -35,7 +35,6 @@ import static org.hamcrest.Matchers.hasEntry;
 public class ES93FlatVectorFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93ScalarQuantizedBFloat16VectorFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93ScalarQuantizedBFloat16VectorFormatTests.java
@@ -39,7 +39,6 @@ import static org.hamcrest.Matchers.hasEntry;
 public class ES93ScalarQuantizedBFloat16VectorFormatTests extends BaseBFloat16KnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93ScalarQuantizedVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/es93/ES93ScalarQuantizedVectorsFormatTests.java
@@ -37,7 +37,6 @@ import static org.hamcrest.Matchers.hasEntry;
 public class ES93ScalarQuantizedVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/zstd/Zstd814BestCompressionStoredFieldsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/zstd/Zstd814BestCompressionStoredFieldsFormatTests.java
@@ -11,9 +11,14 @@ package org.elasticsearch.index.codec.zstd;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.tests.index.BaseStoredFieldsFormatTestCase;
+import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.index.codec.Elasticsearch92Lucene103Codec;
 
 public class Zstd814BestCompressionStoredFieldsFormatTests extends BaseStoredFieldsFormatTestCase {
+
+    static {
+        LogConfigurator.configureESLogging(); // native access requires logging to be initialized
+    }
 
     private final Codec codec = new Elasticsearch92Lucene103Codec(Zstd814StoredFieldsFormat.Mode.BEST_COMPRESSION);
 

--- a/server/src/test/java/org/elasticsearch/index/codec/zstd/Zstd814BestSpeedStoredFieldsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/zstd/Zstd814BestSpeedStoredFieldsFormatTests.java
@@ -11,9 +11,14 @@ package org.elasticsearch.index.codec.zstd;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.tests.index.BaseStoredFieldsFormatTestCase;
+import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.index.codec.Elasticsearch92Lucene103Codec;
 
 public class Zstd814BestSpeedStoredFieldsFormatTests extends BaseStoredFieldsFormatTestCase {
+
+    static {
+        LogConfigurator.configureESLogging(); // native access requires logging to be initialized
+    }
 
     private final Codec codec = new Elasticsearch92Lucene103Codec(Zstd814StoredFieldsFormat.Mode.BEST_SPEED);
 

--- a/server/src/test/java/org/elasticsearch/index/store/AsyncDirectIODirectoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/AsyncDirectIODirectoryTests.java
@@ -49,7 +49,6 @@ import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 public class AsyncDirectIODirectoryTests extends BaseDirectoryTestCase {
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractDiversifyingChildrenIVFKnnVectorQueryTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractDiversifyingChildrenIVFKnnVectorQueryTestCase.java
@@ -77,7 +77,6 @@ abstract class AbstractDiversifyingChildrenIVFKnnVectorQueryTestCase extends Luc
     }
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
 

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractIVFKnnVectorQueryTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractIVFKnnVectorQueryTestCase.java
@@ -90,7 +90,6 @@ abstract class AbstractIVFKnnVectorQueryTestCase extends LuceneTestCase {
     static final float EPSILON = 0.001f;
 
     static {
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging(); // native access requires logging to be initialized
     }
     KnnVectorsFormat format;

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -298,7 +298,6 @@ public abstract class ESTestCase extends LuceneTestCase {
         TEST_WORKER_VM_ID = System.getProperty(TEST_WORKER_SYS_PROPERTY, DEFAULT_TEST_WORKER_ID);
         setTestSysProps(random);
         // TODO: consolidate logging initialization for tests so it all occurs in logconfigurator
-        LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging();
         MockLog.init();
 

--- a/x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlDataLoader.java
+++ b/x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlDataLoader.java
@@ -13,13 +13,11 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
-import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -36,8 +34,6 @@ public class EqlDataLoader {
     private static final String PROPERTIES_FILENAME = "config.properties";
 
     public static void main(String[] args) throws IOException {
-        // Need to setup the log configuration properly to avoid messages when creating a new RestClient
-        PluginManager.addPackage(LogConfigurator.class.getPackage().getName());
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("admin", "admin-password"));
         try (

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -16,7 +16,6 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -55,6 +54,15 @@ import static org.elasticsearch.xpack.esql.CsvTestUtils.multiValuesAwareCsvToStr
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.reader;
 
 public class CsvTestsDataLoader {
+
+    static {
+        // Ensure the logging factory is initialized before the static logger field below. When running standalone (via main() or
+        // Gradle's loadCsvSpecData task), nothing has initialized the ES logging system before this class is loaded.
+        LogConfigurator.configureESLogging();
+    }
+
+    private static final Logger logger = LogManager.getLogger(CsvTestsDataLoader.class);
+
     private static final int BULK_DATA_SIZE = 100_000;
     private static final TestDataset EMPLOYEES = new TestDataset("employees", "mapping-default.json", "employees.csv").noSubfields();
     private static final TestDataset EMPLOYEES_INCOMPATIBLE = new TestDataset(
@@ -322,7 +330,6 @@ public class CsvTestsDataLoader {
      */
     public static void main(String[] args) throws IOException {
         // Need to setup the log configuration properly to avoid messages when creating a new RestClient
-        PluginManager.addPackage(LogConfigurator.class.getPackage().getName());
         LogConfigurator.configureESLogging();
 
         String protocol = "http";

--- a/x-pack/plugin/esql/tools/src/main/java/org/elasticsearch/xpack/esql/tools/ProfileParser.java
+++ b/x-pack/plugin/esql/tools/src/main/java/org/elasticsearch/xpack/esql/tools/ProfileParser.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -30,7 +29,6 @@ import java.util.Map;
 public class ProfileParser {
 
     public static void main(String[] args) throws IOException {
-        PluginManager.addPackage(LogConfigurator.class.getPackage().getName());
         LogConfigurator.configureESLogging();
         Logger logger = LogManager.getLogger(ProfileParser.class);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Migrate to log4j2 annotation processor for plugins (#136983)](https://github.com/elastic/elasticsearch/pull/136983)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)