### PR TITLE
Mute ParquetRsDiscoverSplitRangesStatsTests and NativeLoaderTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -544,3 +544,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.parquet.ParquetRsFormatSpecIT
   method: test {csv-spec:external-basic.evalComputedColumn [S3]}
   issue: https://github.com/elastic/elasticsearch/issues/148655
+- class: org.elasticsearch.xpack.esql.datasource.parquet.parquetrs.NativeLoaderTests
+  method: testLoad
+  issue: https://github.com/elastic/elasticsearch/issues/148693

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -547,3 +547,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.datasource.parquet.parquetrs.NativeLoaderTests
   method: testLoad
   issue: https://github.com/elastic/elasticsearch/issues/148693
+- class: org.elasticsearch.xpack.esql.datasource.parquet.parquetrs.ParquetRsDiscoverSplitRangesStatsTests
+  method: testDiscoverSplitRangesIncludesColumnMinMax
+  issue: https://github.com/elastic/elasticsearch/issues/148698


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/issues/148693 and #148698