### PR TITLE
Add config.name mapping to fleet-agents index

### DIFF
--- a/docs/changelog/148703.yaml
+++ b/docs/changelog/148703.yaml
@@ -1,0 +1,5 @@
+area: Infra/Plugins
+issues: []
+pr: 148703
+summary: Add `config.name` mapping to fleet-agents index
+type: enhancement

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -448,6 +448,9 @@
                 "properties": {
                   "description": {
                     "type": "keyword"
+                  },
+                  "name": {
+                    "type": "keyword"
                   }
                 }
               },

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -72,7 +72,7 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     private static final String MAPPING_VERSION_VARIABLE = "fleet.version";
     private static final List<String> ALLOWED_PRODUCTS = List.of("kibana", "fleet");
     private static final int FLEET_ACTIONS_MAPPINGS_VERSION = 2;
-    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 9;
+    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 10;
     private static final int FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION = 3;
     private static final int FLEET_SECRETS_MAPPINGS_VERSION = 1;
     private static final int FLEET_POLICIES_MAPPINGS_VERSION = 2;


### PR DESCRIPTION
## Summary

Adds `config.name` as a `keyword` field under `non_identifying_attributes.config` in the `.fleet-agents` index mapping and bumps `FLEET_AGENTS_MAPPINGS_VERSION` from 9 to 10.

Follow-up to #145824, which added the initial OpAMP metadata mappings.

Relates: https://github.com/elastic/ingest-dev/issues/7689

## Test plan

- [ ] Verify mapping version bump (9 → 10) triggers index template update
- [ ] Confirm `config.name` is indexed as a keyword and queryable/aggregatable via the passthrough on `non_identifying_attributes`