### PR TITLE
ES|QL|DS: Downgrade target architecture from AVX512 to AVX2

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet-rs/native/.cargo/config.toml
+++ b/x-pack/plugin/esql-datasource-parquet-rs/native/.cargo/config.toml
@@ -5,10 +5,13 @@ rustflags = ["-C", "target-cpu=native"]
 
 # Cross-compilation targets: override [build] when --target is used.
 # x86-64-v3 = AVX2 baseline (Haswell+, all modern cloud x86 instances)
-# skylake_avx512 = AVX512 baseline
+# x86-64-v4 = AVX512 baseline
 # See rustc --target x86_64-unknown-linux-gnu --print target-cpus
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=skylake_avx512"]
+# Target AVX2. First-generation GCE instances (n1 series) use a mixed set of CPUs, some not supporting AVX512
+# TODO: if benchmarks show a difference, we may add an additional target for x86-64-v4
+# and select at start time by sniffing CPU capabilities.
+rustflags = ["-C", "target-cpu=x86-64-v3"]
 
 # neoverse-n1 = AWS Graviton2/3 baseline (most aarch64 cloud instances)
 # neoverse-n2 = AWS Graviton4/5


### PR DESCRIPTION
CI randomly fails with this message:

```
Execution failed for task ':x-pack:plugin:esql-datasource-parquet-rs:test' (registered by plugin 'org.gradle.jvm-test-suite').
> Test process encountered an unexpected problem.
  > Process 'Gradle Test Executor 75' finished with non-zero exit value 134 (this value may indicate that the process was terminated with the SIGABRT signal)
```

A common characteristic of these failures is that they happen on GCE n1-standard-32 instances. These first-generation instances [use a variety of CPUs](https://docs.cloud.google.com/compute/docs/general-purpose-machines#n1_machines), some of which do not support AVX512.

This PR downgrades the x86_64 build of the Rust Parquet library to use AVX2 as a baseline.