### PR TITLE
[8.19] Pass CircuitBreakingException through SearchExecutionContext#toQuery (#148607)

### DIFF
--- a/docs/changelog/148607.yaml
+++ b/docs/changelog/148607.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 148607
+summary: Pass `CircuitBreakingException` through `SearchExecutionContext#toQuery`
+type: bug

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/AccountableQueryCircuitBreakerIT.java
@@ -209,7 +209,7 @@ public class AccountableQueryCircuitBreakerIT extends ESIntegTestCase {
         );
 
         SearchRequestBuilder searchRequest = client().prepareSearch(INDEX_NAME).setQuery(query);
-        assertFailures(searchRequest, RestStatus.BAD_REQUEST, containsString("Data too large"));
+        assertFailures(searchRequest, RestStatus.TOO_MANY_REQUESTS, containsString("Data too large"));
         assertThat("Request circuit breaker should have tripped", getRequestBreakerTrippedCount(), greaterThanOrEqualTo(1L));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -436,7 +436,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
         SearchRequestBuilder searchRequest = client().prepareSearch("cb-query-test").setQuery(boolQuery);
         // This is one of the cases where a CB-trip does not translate into a 429, but instead a 400, because the query is rejected
         // at construction time, before it is executed
-        assertFailures(searchRequest, RestStatus.BAD_REQUEST, containsString("Data too large"));
+        assertFailures(searchRequest, RestStatus.TOO_MANY_REQUESTS, containsString("Data too large"));
 
         NodesStatsResponse stats = client().admin().cluster().prepareNodesStats().setBreaker(true).get();
         long queryConstructionBreaks = 0;

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.Nullable;
@@ -587,7 +588,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
                 query = Queries.newMatchNoDocsQuery("No query left after rewrite.");
             }
             return new ParsedQuery(query, copyNamedQueries());
-        } catch (QueryShardException | ParsingException e) {
+        } catch (QueryShardException | ParsingException | CircuitBreakingException e) {
             throw e;
         } catch (Exception e) {
             throw new QueryShardException(this, "failed to create query: {}", e, e.getMessage());


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Pass CircuitBreakingException through SearchExecutionContext#toQuery (#148607)