### PR TITLE
ESQL:DS: fix CSV splits generation

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -785,8 +785,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
             }
         } else if (context.recordAligned()) {
             // Non-first split that the caller guarantees starts on a record boundary
-            // (e.g. streaming-parallel chunks sliced on \n). No partial line to drop, no header
-            // to parse — use the pre-bound schema directly.
+            // (e.g. streaming-parallel chunks sliced on record boundaries). No partial line to
+            // drop, no header to parse — use the pre-bound schema directly.
             effectiveSchema = resolvedSchema;
         } else {
             // Non-first byte-range split (e.g. bzip2 / zstd-indexed macro-split). The leading

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -48,7 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * Architecture:
  * <ol>
  *   <li>A segmentator thread reads the decompressed stream into byte buffers from a pool</li>
- *   <li>Each buffer is split at the last record boundary (newline) to form a complete chunk</li>
+ *   <li>Each buffer is split at the last record boundary to form a complete chunk</li>
  *   <li>Chunks are dispatched to parser threads via a bounded queue</li>
  *   <li>Parser threads parse each chunk independently using the format reader</li>
  *   <li>Results are yielded in chunk order via per-slot page queues</li>
@@ -428,15 +428,16 @@ public final class StreamingParallelParsingCoordinator {
                         // first split; otherwise CSV-style readers re-run header inference on data
                         // rows. NDJSON does not have a header, so the readers ignore firstSplit.
                         // - lastSplit: the segmentator only dispatches a chunk after locating its
-                        // trailing \n via findLastNewline (or grows the buffer until one is found),
-                        // so the chunk's final byte is always a record terminator. The original
-                        // chunk.last flag was set only on the EOF chunk, leaving every interior
-                        // chunk wrapped in TrimLastPartialLineInputStream's per-byte tail scan —
-                        // pure overhead on already-aligned data. Setting lastSplit=true everywhere
-                        // lets line-oriented readers (NDJSON) skip that scan.
-                        // - recordAligned: the segmentator slices on \n carry-over so each chunk
-                        // starts exactly on a record boundary; readers can skip the "drop leading
-                        // partial line" workaround used for byte-range macro-splits.
+                        // trailing record boundary via findLastRecordBoundary (or grows the buffer
+                        // until one is found), so the chunk's final byte is always a record
+                        // terminator. The original chunk.last flag was set only on the EOF chunk,
+                        // leaving every interior chunk wrapped in TrimLastPartialLineInputStream's
+                        // per-byte tail scan — pure overhead on already-aligned data. Setting
+                        // lastSplit=true everywhere lets line-oriented readers (NDJSON) skip that
+                        // scan.
+                        // - recordAligned: the segmentator slices on record-boundary carry-over so
+                        // each chunk starts exactly on a record boundary; readers can skip the
+                        // "drop leading partial line" workaround used for byte-range macro-splits.
                         FormatReadContext ctx = FormatReadContext.builder()
                             .projectedColumns(projectedColumns)
                             .batchSize(batchSize)
@@ -510,19 +511,12 @@ public final class StreamingParallelParsingCoordinator {
             int lastBoundary = -1;
             int pos = 0;
             while (pos < length) {
-                long consumed;
-                try {
-                    consumed = r.findNextRecordBoundary(new ByteArrayInputStream(buf, pos, length - pos));
-                } catch (IOException e) {
-                    logger.trace("findNextRecordBoundary failed at pos [{}]; falling back to last known boundary", pos, e);
-                    break;
-                }
+                long consumed = r.findNextRecordBoundary(new ByteArrayInputStream(buf, pos, length - pos));
                 if (consumed < 0) {
                     break;
                 }
                 assert consumed <= Integer.MAX_VALUE : "consumed [" + consumed + "] exceeds int range";
                 pos += (int) consumed;
-                // pos now points to the first byte of the next record; the boundary (the \n) is at pos-1
                 lastBoundary = pos - 1;
             }
             return lastBoundary;
@@ -560,6 +554,13 @@ public final class StreamingParallelParsingCoordinator {
          * least one <em>record</em> boundary (as determined by {@link #findLastRecordBoundary}).
          * Multi-line quoted fields may contain {@code \n} bytes that are not record boundaries; this
          * method avoids splitting in the middle of such a field.
+         * <p>
+         * The inner loop uses {@link #growUntilNewline} (raw {@code \n} scan) intentionally: a
+         * record boundary always coincides with a {@code \n}, so growing to the next raw
+         * {@code \n} is the minimum I/O needed before re-checking with the quote-aware
+         * {@link #findLastRecordBoundary}. For quoted fields with embedded {@code \n}, the
+         * raw scan stops too early and the boundary check returns {@code -1}, causing another
+         * growth iteration — correct, just not single-pass.
          *
          * @return a {@link GrowResult} carrying both the grown buffer and the pre-computed boundary
          *         index, so callers can avoid a redundant {@link #findLastRecordBoundary} rescan

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -263,9 +263,10 @@ public final class StreamingParallelParsingCoordinator {
                             // {@link #growUntilNewline} only copies from {@code buf}; the original pool buffer
                             // is independent of {@code grown} and must be returned to the pool here so the
                             // pool does not leak one entry per oversized record.
-                            byte[] grown = growUntilRecordBoundary(stream, buf, totalBytes, chunkSize);
+                            GrowResult result = growUntilRecordBoundary(stream, buf, totalBytes, chunkSize);
                             recycleBuffer(buf);
-                            int grownNewline = findLastRecordBoundary(grown, grown.length);
+                            byte[] grown = result.buffer();
+                            int grownNewline = result.boundary();
                             if (grownNewline < 0) {
                                 if (chunkIndex == 0) {
                                     bindSchemaFromFirstChunk(grown, grown.length);
@@ -513,11 +514,13 @@ public final class StreamingParallelParsingCoordinator {
                 try {
                     consumed = r.findNextRecordBoundary(new ByteArrayInputStream(buf, pos, length - pos));
                 } catch (IOException e) {
+                    logger.trace("findNextRecordBoundary failed at pos [{}]; falling back to last known boundary", pos, e);
                     break;
                 }
                 if (consumed < 0) {
                     break;
                 }
+                assert consumed <= Integer.MAX_VALUE : "consumed [" + consumed + "] exceeds int range";
                 pos += (int) consumed;
                 // pos now points to the first byte of the next record; the boundary (the \n) is at pos-1
                 lastBoundary = pos - 1;
@@ -550,23 +553,28 @@ public final class StreamingParallelParsingCoordinator {
             }
         }
 
+        private record GrowResult(byte[] buffer, int boundary) {}
+
         /**
          * Like {@link #growUntilNewline} but keeps growing until the accumulated buffer contains at
          * least one <em>record</em> boundary (as determined by {@link #findLastRecordBoundary}).
          * Multi-line quoted fields may contain {@code \n} bytes that are not record boundaries; this
          * method avoids splitting in the middle of such a field.
+         *
+         * @return a {@link GrowResult} carrying both the grown buffer and the pre-computed boundary
+         *         index, so callers can avoid a redundant {@link #findLastRecordBoundary} rescan
          */
-        private byte[] growUntilRecordBoundary(InputStream stream, byte[] existing, int existingLen, int growBy) throws IOException {
+        private GrowResult growUntilRecordBoundary(InputStream stream, byte[] existing, int existingLen, int growBy) throws IOException {
             byte[] buf = existing;
             int len = existingLen;
             while (true) {
                 byte[] grown = growUntilNewline(stream, buf, len, growBy);
                 if (grown.length == len) {
-                    return grown;
+                    return new GrowResult(grown, -1);
                 }
                 int boundary = findLastRecordBoundary(grown, grown.length);
                 if (boundary >= 0) {
-                    return grown;
+                    return new GrowResult(grown, boundary);
                 }
                 buf = grown;
                 len = grown.length;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
@@ -244,7 +245,7 @@ public final class StreamingParallelParsingCoordinator {
                     int totalBytes = offset + Math.max(bytesRead, 0);
                     boolean isEof = bytesRead < 0 || totalBytes < buf.length;
 
-                    int lastNewline = findLastNewline(buf, totalBytes);
+                    int lastNewline = findLastRecordBoundary(buf, totalBytes);
 
                     if (lastNewline < 0) {
                         if (isEof) {
@@ -262,9 +263,9 @@ public final class StreamingParallelParsingCoordinator {
                             // {@link #growUntilNewline} only copies from {@code buf}; the original pool buffer
                             // is independent of {@code grown} and must be returned to the pool here so the
                             // pool does not leak one entry per oversized record.
-                            byte[] grown = growUntilNewline(stream, buf, totalBytes, chunkSize);
+                            byte[] grown = growUntilRecordBoundary(stream, buf, totalBytes, chunkSize);
                             recycleBuffer(buf);
-                            int grownNewline = findLastNewline(grown, grown.length);
+                            int grownNewline = findLastRecordBoundary(grown, grown.length);
                             if (grownNewline < 0) {
                                 if (chunkIndex == 0) {
                                     bindSchemaFromFirstChunk(grown, grown.length);
@@ -491,6 +492,39 @@ public final class StreamingParallelParsingCoordinator {
             return -1;
         }
 
+        /**
+         * Finds the last <em>record</em> boundary in {@code buf[0..length)}, which for formats
+         * with multi-line quoted fields (CSV) may differ from the last {@code \n}.
+         * <p>
+         * Scans forward through the buffer using {@link SegmentableFormatReader#findNextRecordBoundary}
+         * so that newlines inside quoted fields are correctly skipped. Returns the index of the last
+         * byte that belongs to a complete record (i.e. the position of the terminating {@code \n}),
+         * or {@code -1} if no record boundary exists in the buffer.
+         */
+        private int findLastRecordBoundary(byte[] buf, int length) throws IOException {
+            SegmentableFormatReader r = reader;
+            if (r == null) {
+                return findLastNewline(buf, length);
+            }
+            int lastBoundary = -1;
+            int pos = 0;
+            while (pos < length) {
+                long consumed;
+                try {
+                    consumed = r.findNextRecordBoundary(new ByteArrayInputStream(buf, pos, length - pos));
+                } catch (IOException e) {
+                    break;
+                }
+                if (consumed < 0) {
+                    break;
+                }
+                pos += (int) consumed;
+                // pos now points to the first byte of the next record; the boundary (the \n) is at pos-1
+                lastBoundary = pos - 1;
+            }
+            return lastBoundary;
+        }
+
         private static byte[] growUntilNewline(InputStream stream, byte[] existing, int existingLen, int growBy) throws IOException {
             byte[] grown = new byte[existingLen + growBy];
             System.arraycopy(existing, 0, grown, 0, existingLen);
@@ -504,7 +538,6 @@ public final class StreamingParallelParsingCoordinator {
                     }
                     return Arrays.copyOf(grown, offset);
                 }
-                // Check for newline in the newly read bytes
                 for (int i = offset; i < offset + n; i++) {
                     if (grown[i] == '\n') {
                         return Arrays.copyOf(grown, offset + n);
@@ -514,6 +547,29 @@ public final class StreamingParallelParsingCoordinator {
                 if (offset >= grown.length) {
                     grown = Arrays.copyOf(grown, grown.length + growBy);
                 }
+            }
+        }
+
+        /**
+         * Like {@link #growUntilNewline} but keeps growing until the accumulated buffer contains at
+         * least one <em>record</em> boundary (as determined by {@link #findLastRecordBoundary}).
+         * Multi-line quoted fields may contain {@code \n} bytes that are not record boundaries; this
+         * method avoids splitting in the middle of such a field.
+         */
+        private byte[] growUntilRecordBoundary(InputStream stream, byte[] existing, int existingLen, int growBy) throws IOException {
+            byte[] buf = existing;
+            int len = existingLen;
+            while (true) {
+                byte[] grown = growUntilNewline(stream, buf, len, growBy);
+                if (grown.length == len) {
+                    return grown;
+                }
+                int boundary = findLastRecordBoundary(grown, grown.length);
+                if (boundary >= 0) {
+                    return grown;
+                }
+                buf = grown;
+                len = grown.length;
             }
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/AsyncExternalSourceOperatorFactoryTests.java
@@ -2409,6 +2409,18 @@ public class AsyncExternalSourceOperatorFactoryTests extends ESTestCase {
         when(inner.defaultErrorPolicy()).thenReturn(ErrorPolicy.STRICT);
         when(inner.metadata(any())).thenReturn(null);
         when(inner.read(any(), any())).thenReturn(emptyPageIterator());
+        when(inner.findNextRecordBoundary(any())).thenAnswer(invocation -> {
+            InputStream in = invocation.getArgument(0);
+            long consumed = 0;
+            int b;
+            while ((b = in.read()) != -1) {
+                consumed++;
+                if (b == '\n') {
+                    return consumed;
+                }
+            }
+            return -1L;
+        });
         return inner;
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -797,6 +797,9 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             int first = stream.read();
             if (first == -1) return -1;
             consumed++;
+            if (first == '\n') {
+                return consumed;
+            }
             boolean inQuotes = (first == '"');
             int b;
             while ((b = stream.read()) != -1) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -772,6 +772,10 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
      * starts with {@code "}, the record ends at the closing {@code "} followed by {@code \n}
      * (embedded {@code \n} are literal). {@link #findNextRecordBoundary} mirrors this quoting
      * convention so the streaming coordinator splits chunks at real record boundaries.
+     * <p>
+     * <b>Limitation:</b> escaped quotes ({@code ""}) are not handled; {@code "} is treated as a
+     * simple open/close toggle. This is sufficient for testing the coordinator's chunk-splitting
+     * logic but does not model full RFC 4180 quoting.
      */
     private static class QuoteAwareLineFormatReader implements SegmentableFormatReader, NoConfigFormatReader {
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -356,6 +356,175 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
     }
 
     /**
+     * Content with multi-line quoted fields where the embedded {@code \n} falls exactly on a chunk
+     * boundary must not split the logical record across two parser-thread chunks.
+     * <p>
+     * Uses a tiny chunk size (64 bytes) so the quoted field's inner newline is almost certain to
+     * land on a chunk boundary at some offset; the test verifies every record is delivered intact.
+     */
+    public void testMultiLineQuotedFieldsAcrossChunkBoundaries() throws Exception {
+        // 50 records, some with multi-line quoted fields containing embedded \n
+        StringBuilder sb = new StringBuilder();
+        int recordCount = 0;
+        for (int i = 0; i < 50; i++) {
+            if (i % 5 == 0) {
+                sb.append("\"multi\nline-").append(String.format(java.util.Locale.ROOT, "%04d", i)).append("\"\n");
+            } else {
+                sb.append("simple-").append(String.format(java.util.Locale.ROOT, "%04d", i)).append('\n');
+            }
+            recordCount++;
+        }
+        byte[] bytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+        ExecutorService executor = Executors.newFixedThreadPool(6);
+        try {
+            // chunkSize=64 forces many splits; quoted \n must not become a chunk boundary
+            QuoteAwareLineFormatReader reader = new QuoteAwareLineFormatReader(64);
+            List<String> allLines = collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(
+                    reader,
+                    new ByteArrayInputStream(bytes),
+                    List.of("line"),
+                    50,
+                    4,
+                    executor,
+                    ErrorPolicy.STRICT
+                )
+            );
+
+            assertEquals(recordCount, allLines.size());
+            int multiLineCount = 0;
+            for (String line : allLines) {
+                if (line.startsWith("multi\nline-")) {
+                    multiLineCount++;
+                }
+            }
+            assertEquals("every 5th record is multi-line", 10, multiLineCount);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * When the chunk size is smaller than a single multi-line record (no record boundary in the
+     * initial buffer), the coordinator must grow the buffer until it finds a real record boundary.
+     */
+    public void testGrowUntilRecordBoundaryForOversizedQuotedField() throws Exception {
+        // One giant multi-line quoted field that is larger than the chunk size, followed by a
+        // normal record. The coordinator must grow past the first \n inside the quoted field.
+        StringBuilder sb = new StringBuilder();
+        sb.append("\"");
+        // ~200 bytes of quoted content with embedded \n every 40 chars
+        for (int i = 0; i < 5; i++) {
+            sb.append("chunk-of-text-that-is-about-forty-bytes!");
+            if (i < 4) sb.append('\n');
+        }
+        sb.append("\"\n");
+        sb.append("trailing-record\n");
+
+        byte[] bytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+        ExecutorService executor = Executors.newFixedThreadPool(6);
+        try {
+            // Chunk size smaller than the first record → forces growUntilRecordBoundary
+            QuoteAwareLineFormatReader reader = new QuoteAwareLineFormatReader(64);
+            List<String> allLines = collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(
+                    reader,
+                    new ByteArrayInputStream(bytes),
+                    List.of("line"),
+                    50,
+                    4,
+                    executor,
+                    ErrorPolicy.STRICT
+                )
+            );
+
+            assertEquals(2, allLines.size());
+            assertTrue("first record should contain embedded newlines", allLines.get(0).contains("\n"));
+            assertEquals("trailing-record", allLines.get(1));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * A large stream where every Nth record has a multi-line quoted field: verifies order
+     * preservation and correct record count end-to-end under realistic parallelism.
+     */
+    public void testLargeStreamWithInterspersedMultiLineRecords() throws Exception {
+        int totalRecords = 2000;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < totalRecords; i++) {
+            if (i % 7 == 0) {
+                sb.append("\"quoted\nrecord-").append(String.format(java.util.Locale.ROOT, "%04d", i)).append("\"\n");
+            } else {
+                sb.append("plain-").append(String.format(java.util.Locale.ROOT, "%04d", i)).append('\n');
+            }
+        }
+        byte[] bytes = sb.toString().getBytes(StandardCharsets.UTF_8);
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        try {
+            QuoteAwareLineFormatReader reader = new QuoteAwareLineFormatReader(512);
+            List<String> allLines = collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(
+                    reader,
+                    new ByteArrayInputStream(bytes),
+                    List.of("line"),
+                    100,
+                    6,
+                    executor,
+                    ErrorPolicy.STRICT
+                )
+            );
+
+            assertEquals(totalRecords, allLines.size());
+            for (int i = 0; i < totalRecords; i++) {
+                String line = allLines.get(i);
+                if (i % 7 == 0) {
+                    String expected = "quoted\nrecord-" + String.format(java.util.Locale.ROOT, "%04d", i);
+                    assertEquals("record " + i, expected, line);
+                } else {
+                    String expected = "plain-" + String.format(java.util.Locale.ROOT, "%04d", i);
+                    assertEquals("record " + i, expected, line);
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * When all records are simple (no quoting), the quote-aware boundary finder must behave
+     * identically to the naive newline finder — regression guard.
+     */
+    public void testQuoteAwareReaderWithNoQuotedFieldsMatchesNaiveBehavior() throws Exception {
+        int lineCount = 500;
+        String content = buildContent(lineCount);
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        ExecutorService executor = Executors.newFixedThreadPool(6);
+        try {
+            QuoteAwareLineFormatReader reader = new QuoteAwareLineFormatReader(256);
+            List<String> allLines = collectLines(
+                StreamingParallelParsingCoordinator.parallelRead(
+                    reader,
+                    new ByteArrayInputStream(bytes),
+                    List.of("line"),
+                    50,
+                    4,
+                    executor,
+                    ErrorPolicy.STRICT
+                )
+            );
+
+            assertEquals(lineCount, allLines.size());
+            for (int i = 0; i < lineCount; i++) {
+                assertEquals("line-" + String.format(java.util.Locale.ROOT, "%04d", i), allLines.get(i));
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
      * A minimal format reader that treats each line as a record, producing one keyword block per page.
      * <p>
      * Tracks {@link #metadataCalls}, {@link #boundReadCalls}, and {@link #unboundReadCalls} per
@@ -589,6 +758,144 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
         @Override
         public List<String> fileExtensions() {
             return List.of();
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * A format reader that supports {@code "}-quoted multi-line fields, modelling the CSV case
+     * where a {@code \n} inside {@code "..."} is part of the field value, not a record boundary.
+     * <p>
+     * The format is trivial: each record is one "field" terminated by {@code \n}. If the field
+     * starts with {@code "}, the record ends at the closing {@code "} followed by {@code \n}
+     * (embedded {@code \n} are literal). {@link #findNextRecordBoundary} mirrors this quoting
+     * convention so the streaming coordinator splits chunks at real record boundaries.
+     */
+    private static class QuoteAwareLineFormatReader implements SegmentableFormatReader, NoConfigFormatReader {
+
+        private final long minSegment;
+        private final List<Attribute> resolvedSchema;
+
+        QuoteAwareLineFormatReader(long minSegment) {
+            this(minSegment, null);
+        }
+
+        private QuoteAwareLineFormatReader(long minSegment, List<Attribute> resolvedSchema) {
+            this.minSegment = minSegment;
+            this.resolvedSchema = resolvedSchema;
+        }
+
+        @Override
+        public long findNextRecordBoundary(InputStream stream) throws IOException {
+            long consumed = 0;
+            int first = stream.read();
+            if (first == -1) return -1;
+            consumed++;
+            boolean inQuotes = (first == '"');
+            int b;
+            while ((b = stream.read()) != -1) {
+                consumed++;
+                if (inQuotes) {
+                    if (b == '"') {
+                        inQuotes = false;
+                    }
+                } else if (b == '\n') {
+                    return consumed;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public long minimumSegmentSize() {
+            return minSegment;
+        }
+
+        @Override
+        public SourceMetadata metadata(StorageObject object) {
+            List<Attribute> schema = List.of(
+                new ReferenceAttribute(Source.EMPTY, null, "line", DataType.KEYWORD, Nullability.TRUE, null, false)
+            );
+            return new SimpleSourceMetadata(schema, formatName(), object.path().toString());
+        }
+
+        @Override
+        public FormatReader withSchema(List<Attribute> schema) {
+            return new QuoteAwareLineFormatReader(minSegment, schema);
+        }
+
+        @Override
+        public CloseableIterator<Page> read(StorageObject object, FormatReadContext context) throws IOException {
+            InputStream stream = object.newStream();
+            List<String> records = new ArrayList<>();
+            StringBuilder current = new StringBuilder();
+            boolean inQuotes = false;
+
+            int b;
+            while ((b = stream.read()) != -1) {
+                char c = (char) b;
+                if (inQuotes) {
+                    if (c == '"') {
+                        inQuotes = false;
+                    } else {
+                        current.append(c);
+                    }
+                } else if (c == '"' && current.length() == 0) {
+                    inQuotes = true;
+                } else if (c == '\n') {
+                    if (current.length() > 0) {
+                        records.add(current.toString());
+                    }
+                    current.setLength(0);
+                } else {
+                    current.append(c);
+                }
+            }
+            if (current.length() > 0) {
+                records.add(current.toString());
+            }
+
+            List<Page> pages = new ArrayList<>();
+            int batchSize = context.batchSize();
+            for (int start = 0; start < records.size(); start += batchSize) {
+                int end = Math.min(start + batchSize, records.size());
+                int count = end - start;
+                try (var builder = TEST_BLOCK_FACTORY.newBytesRefBlockBuilder(count)) {
+                    for (int i = start; i < end; i++) {
+                        builder.appendBytesRef(new BytesRef(records.get(i)));
+                    }
+                    pages.add(new Page(count, builder.build()));
+                }
+            }
+
+            return new CloseableIterator<>() {
+                int idx = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return idx < pages.size();
+                }
+
+                @Override
+                public Page next() {
+                    return pages.get(idx++);
+                }
+
+                @Override
+                public void close() {}
+            };
+        }
+
+        @Override
+        public String formatName() {
+            return "quote-aware-line";
+        }
+
+        @Override
+        public List<String> fileExtensions() {
+            return List.of(".txt");
         }
 
         @Override


### PR DESCRIPTION
This corrects the CSV splits generation to account for quoted cells containing line breaks.
