### PR TITLE
Revert "Remove obsolete ClusterStateSecretsMetadata"

### DIFF
--- a/x-pack/plugin/secure-settings/src/main/java/org/elasticsearch/xpack/stateless/settings/secure/ClusterStateSecretsMetadata.java
+++ b/x-pack/plugin/secure-settings/src/main/java/org/elasticsearch/xpack/stateless/settings/secure/ClusterStateSecretsMetadata.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.settings.secure;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.cluster.AbstractNamedDiffable;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.NamedDiff;
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ToXContent;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Non-secret metadata for cluster secrets (legacy).
+ *
+ * <p>This class is no longer written to cluster state. It is retained solely so that
+ * upgraded nodes can still deserialize cluster state from non-upgraded masters during
+ * a rolling upgrade. {@link ReservedClusterSecretsAction} actively removes it when present.
+ *
+ * TODO Delete this class and its {@code NamedWriteableRegistry} entries once all nodes have been upgraded (ES-13910).
+ *
+ * @deprecated No longer in use; retained for rolling-upgrade deserialization compatibility.
+ */
+@Deprecated
+public class ClusterStateSecretsMetadata extends AbstractNamedDiffable<ClusterState.Custom> implements ClusterState.Custom {
+
+    /**
+     * The name for this data class
+     *
+     * <p>This name will be used to identify this {@link org.elasticsearch.common.io.stream.NamedWriteable} in cluster
+     * state. See {@link #getWriteableName()}.
+     */
+    public static final String TYPE = "file_secure_settings_metadata";
+
+    private final boolean success;
+    private final long version;
+    private final List<String> errorStackTrace;
+
+    private ClusterStateSecretsMetadata(boolean success, long version, List<String> errorStackTrace) {
+        this.success = success;
+        this.version = version;
+        this.errorStackTrace = errorStackTrace == null ? List.of() : errorStackTrace;
+    }
+
+    public ClusterStateSecretsMetadata(StreamInput in) throws IOException {
+        this.success = in.readBoolean();
+        this.version = in.readLong();
+        this.errorStackTrace = in.readStringCollectionAsList();
+    }
+
+    public static ClusterStateSecretsMetadata createSuccessful(long version) {
+        return new ClusterStateSecretsMetadata(true, version, List.of());
+    }
+
+    public static ClusterStateSecretsMetadata createError(long version, List<String> errorStackTrace) {
+        return new ClusterStateSecretsMetadata(false, version, errorStackTrace);
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public List<String> getErrorStackTrace() {
+        return errorStackTrace;
+    }
+
+    @Override
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
+        return Iterators.single((builder, params) -> {
+            builder.field("success", this.success);
+            builder.field("version", this.version);
+            if (errorStackTrace.isEmpty() == false) {
+                builder.stringListField("stack_trace", errorStackTrace);
+            }
+            return builder;
+        });
+    }
+
+    @Override
+    public String getWriteableName() {
+        return TYPE;
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersion.minimumCompatible();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(success);
+        out.writeLong(version);
+        out.writeStringCollection(errorStackTrace);
+    }
+
+    public static NamedDiff<ClusterState.Custom> readDiffFrom(StreamInput in) throws IOException {
+        return readDiffFrom(ClusterState.Custom.class, TYPE, in);
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterStateSecretsMetadata{"
+            + "success="
+            + success
+            + ", version="
+            + version
+            + ", errorStackTrace="
+            + errorStackTrace
+            + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClusterStateSecretsMetadata that = (ClusterStateSecretsMetadata) o;
+        return success == that.success && version == that.version && Objects.equals(errorStackTrace, that.errorStackTrace);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(success, errorStackTrace, version);
+    }
+}

--- a/x-pack/plugin/secure-settings/src/main/java/org/elasticsearch/xpack/stateless/settings/secure/ReservedClusterSecretsAction.java
+++ b/x-pack/plugin/secure-settings/src/main/java/org/elasticsearch/xpack/stateless/settings/secure/ReservedClusterSecretsAction.java
@@ -38,16 +38,23 @@ public class ReservedClusterSecretsAction implements ReservedClusterStateHandler
         ClusterState.Builder builder = ClusterState.builder(clusterState);
         builder.putCustom(ClusterSecrets.TYPE, newSecrets);
 
+        // Actively remove legacy metadata from cluster state if present.
+        builder.removeCustom(ClusterStateSecretsMetadata.TYPE);
+
         return new TransformState(builder.build(), newSecrets.getSettings().getSettingNames());
     }
 
     @Override
     public ClusterState remove(TransformState prevState) {
         ClusterState clusterState = prevState.state();
-        if (clusterState.custom(ClusterSecrets.TYPE) == null) {
+        if (clusterState.custom(ClusterSecrets.TYPE) == null && clusterState.custom(ClusterStateSecretsMetadata.TYPE) == null) {
             return clusterState;
         }
-        return ClusterState.builder(clusterState).removeCustom(ClusterSecrets.TYPE).build();
+        return ClusterState.builder(clusterState)
+            .removeCustom(ClusterSecrets.TYPE)
+            // Actively remove legacy metadata from cluster state if present.
+            .removeCustom(ClusterStateSecretsMetadata.TYPE)
+            .build();
     }
 
     @Override

--- a/x-pack/plugin/secure-settings/src/main/java/org/elasticsearch/xpack/stateless/settings/secure/SecureSettingsPlugin.java
+++ b/x-pack/plugin/secure-settings/src/main/java/org/elasticsearch/xpack/stateless/settings/secure/SecureSettingsPlugin.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.stateless.settings.secure;
 
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.NamedDiff;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ReloadablePlugin;
 import org.elasticsearch.plugins.internal.ReloadAwarePlugin;
@@ -27,5 +30,18 @@ public class SecureSettingsPlugin extends Plugin implements ReloadAwarePlugin {
     @Override
     public void setReloadCallback(ReloadablePlugin reloadablePlugin) {
         this.clusterStateSecretsListener.setReloadCallback(reloadablePlugin);
+    }
+
+    /**
+     * Retained for rolling-upgrade compatibility so upgraded nodes can deserialize cluster state
+     * from non-upgraded masters that still contain {@link ClusterStateSecretsMetadata}.
+     * TODO Remove once all nodes are upgraded (ES-13910).
+     */
+    @Override
+    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return List.of(
+            new NamedWriteableRegistry.Entry(ClusterState.Custom.class, ClusterStateSecretsMetadata.TYPE, ClusterStateSecretsMetadata::new),
+            new NamedWriteableRegistry.Entry(NamedDiff.class, ClusterStateSecretsMetadata.TYPE, ClusterStateSecretsMetadata::readDiffFrom)
+        );
     }
 }

--- a/x-pack/plugin/secure-settings/src/test/java/org/elasticsearch/xpack/stateless/settings/secure/ClusterStateSecretsMetadataTests.java
+++ b/x-pack/plugin/secure-settings/src/test/java/org/elasticsearch/xpack/stateless/settings/secure/ClusterStateSecretsMetadataTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.stateless.settings.secure;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.AbstractNamedWriteableTestCase;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ClusterStateSecretsMetadataTests extends AbstractNamedWriteableTestCase<ClusterStateSecretsMetadata> {
+
+    public void testToXContentChunkedSuccess() throws Exception {
+        ClusterStateSecretsMetadata metadata = ClusterStateSecretsMetadata.createSuccessful(1L);
+        XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+        builder.startObject();
+        metadata.toXContentChunked(EMPTY_PARAMS).forEachRemaining(xcontent -> {
+            try {
+                xcontent.toXContent(builder, EMPTY_PARAMS);
+            } catch (IOException e) {
+                logger.error(e.getMessage(), e);
+                fail(e.getMessage());
+            }
+        });
+        builder.endObject();
+        Map<String, Object> xContentMap = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
+
+        assertThat(xContentMap.size(), equalTo(2));
+        assertThat(xContentMap.get("success"), equalTo(true));
+        assertThat(xContentMap.get("version"), equalTo(1));
+        assertThat(xContentMap.get("stack_trace"), nullValue());
+    }
+
+    public void testToXContentChunkedFailure() throws Exception {
+        ClusterStateSecretsMetadata metadata = ClusterStateSecretsMetadata.createError(-1L, List.of("line1\n", "line2\n"));
+        XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+        builder.startObject();
+        metadata.toXContentChunked(EMPTY_PARAMS).forEachRemaining(xcontent -> {
+            try {
+                xcontent.toXContent(builder, EMPTY_PARAMS);
+            } catch (IOException e) {
+                logger.error(e.getMessage(), e);
+                fail(e.getMessage());
+            }
+        });
+        builder.endObject();
+        Map<String, Object> xContentMap = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
+
+        assertThat(xContentMap.size(), equalTo(3));
+        assertThat(xContentMap.get("success"), equalTo(false));
+        assertThat(xContentMap.get("version"), equalTo(-1));
+        assertThat(xContentMap.get("stack_trace"), equalTo(List.of("line1\n", "line2\n")));
+    }
+
+    public void testSerializeSuccess() throws Exception {
+        ClusterStateSecretsMetadata metadata = ClusterStateSecretsMetadata.createSuccessful(1L);
+        final BytesStreamOutput out = new BytesStreamOutput();
+        metadata.writeTo(out);
+        final ClusterStateSecretsMetadata fromStream = new ClusterStateSecretsMetadata(out.bytes().streamInput());
+
+        assertThat(fromStream, equalTo(metadata));
+    }
+
+    public void testSerializeError() throws Exception {
+        ClusterStateSecretsMetadata metadata = ClusterStateSecretsMetadata.createError(-1L, List.of("line1\n", "line2\n"));
+        final BytesStreamOutput out = new BytesStreamOutput();
+        metadata.writeTo(out);
+        final ClusterStateSecretsMetadata fromStream = new ClusterStateSecretsMetadata(out.bytes().streamInput());
+
+        assertThat(fromStream, equalTo(metadata));
+    }
+
+    @Override
+    protected ClusterStateSecretsMetadata createTestInstance() {
+        if (randomBoolean()) {
+            return ClusterStateSecretsMetadata.createSuccessful(randomLong());
+        }
+        return ClusterStateSecretsMetadata.createError(randomLong(), randomList(0, 10, () -> randomAlphaOfLength(10)));
+    }
+
+    @Override
+    protected ClusterStateSecretsMetadata mutateInstance(ClusterStateSecretsMetadata instance) throws IOException {
+        if (randomBoolean()) {
+            // change success to failure
+            if (instance.isSuccess()) {
+                return ClusterStateSecretsMetadata.createError(instance.getVersion(), randomList(0, 10, () -> randomAlphaOfLength(10)));
+            }
+            return ClusterStateSecretsMetadata.createSuccessful(instance.getVersion());
+        }
+        if (instance.isSuccess()) {
+            return ClusterStateSecretsMetadata.createSuccessful(randomValueOtherThan(instance.getVersion(), ESTestCase::randomLong));
+        }
+        return ClusterStateSecretsMetadata.createError(
+            randomValueOtherThan(instance.getVersion(), ESTestCase::randomLong),
+            instance.getErrorStackTrace()
+        );
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(
+            List.of(
+                new NamedWriteableRegistry.Entry(
+                    ClusterStateSecretsMetadata.class,
+                    ClusterStateSecretsMetadata.TYPE,
+                    ClusterStateSecretsMetadata::new
+                )
+            )
+        );
+    }
+
+    @Override
+    protected Class<ClusterStateSecretsMetadata> categoryClass() {
+        return ClusterStateSecretsMetadata.class;
+    }
+}


### PR DESCRIPTION
Reverts elastic/elasticsearch#148221

Apparently https://github.com/elastic/elasticsearch/compare/main...revert-148221-statelessOnPrem/cleanupClusterStateSecretsMetadata?expand=1#diff-fdccc3d583ca52671e9bfea7a0689d38bad30b1f02322276e61b2c740a71b6adR41-R43 wasn't sufficient to ensure removal of the legacy ClusterStateSecretsMetadata from cluster state.