### PR TITLE
ESQL: Fix flaky OOM test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -524,9 +524,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeRandomMappingIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/148190
-- class: org.elasticsearch.xpack.esql.enrich.LookupFromIndexServiceResponseTests
-  method: testReceiverReleasesAlreadyReadPagesOnBreakerTrip
-  issue: https://github.com/elastic/elasticsearch/issues/148605
 - class: org.elasticsearch.xpack.ml.integration.ForecastIT
   method: testOverflowToDisk
   issue: https://github.com/elastic/elasticsearch/issues/148606

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexServiceResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexServiceResponseTests.java
@@ -236,7 +236,7 @@ public class LookupFromIndexServiceResponseTests extends AbstractWireSerializing
             sender.decRef();
         }
 
-        BlockFactory receiverFactory = blockFactory(ByteSizeValue.ofBytes(pagesHeapBytes / 2));
+        BlockFactory receiverFactory = blockFactory(ByteSizeValue.ofBytes(pagesHeapBytes / 4));
         try (StreamInput in = new NamedWriteableAwareStreamInput(wireBytes.streamInput(), new NamedWriteableRegistry(List.of()))) {
             in.setTransportVersion(TransportVersion.current());
             expectThrows(CircuitBreakingException.class, () -> new LookupFromIndexService.LookupResponse(in, receiverFactory));


### PR DESCRIPTION
Dead simple: reduce the total allocated memory by half.

Tested locally a few thousands time to see there are no failures this time.

Closes #148605.