### PR TITLE
[Test] Fix StatelessIndexCommitListenerIT.testRefIsNotReleasedUponNotificationFailure

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -497,9 +497,6 @@ tests:
 - class: org.elasticsearch.xpack.dlm.frozen.DLMFrozenTransitionIT
   method: testEndToEndFrozenTransition
   issue: https://github.com/elastic/elasticsearch/issues/148467
-- class: org.elasticsearch.xpack.stateless.StatelessIndexCommitListenerIT
-  method: testRefIsNotReleasedUponNotificationFailure
-  issue: https://github.com/elastic/elasticsearch/issues/148471
 - class: org.elasticsearch.xpack.stateless.cache.SearchCommitPrefetcherIT
   method: testCommitPrefetching
   issue: https://github.com/elastic/elasticsearch/issues/148476

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessIndexCommitListenerIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessIndexCommitListenerIT.java
@@ -24,6 +24,8 @@ import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.xpack.stateless.commits.CommitBCCResolver;
 import org.elasticsearch.xpack.stateless.commits.IndexEngineLocalReaderListener;
 import org.elasticsearch.xpack.stateless.commits.StatelessCommitService;
+import org.elasticsearch.xpack.stateless.engine.IndexEngine;
+import org.elasticsearch.xpack.stateless.engine.IndexEngineTestUtils;
 import org.elasticsearch.xpack.stateless.engine.PrimaryTermAndGeneration;
 import org.elasticsearch.xpack.stateless.recovery.RegisterCommitResponse;
 import org.junit.After;
@@ -256,7 +258,9 @@ public class StatelessIndexCommitListenerIT extends AbstractStatelessPluginInteg
 
     @After
     public void teardownTest() {
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        if (indexName != null) {
+            assertAcked(client().admin().indices().prepareDelete(indexName));
+        }
         indexNode = null;
         searchNode = null;
         indexName = null;
@@ -420,8 +424,15 @@ public class StatelessIndexCommitListenerIT extends AbstractStatelessPluginInteg
             // Wait until the shard is marked as failed and then reallocated so we can
             // release the new commits once it becomes green again.
             ensureGreen(indexName);
+
+            // Delete the index to close shards and prevent new commits from being created
+            // before releasing retained commits, avoiding a race condition.
+            final var engine = asInstanceOf(IndexEngine.class, findIndexShard(indexName).withEngine(e -> e));
+            assertAcked(indicesAdmin().prepareDelete(indexName));
+            IndexEngineTestUtils.awaitClose(engine);
         } finally {
             plugin.listRetainedCommits(shardId).forEach(this::releaseCommit);
+            indexName = null;
         }
     }
 

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessIndexCommitListenerIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessIndexCommitListenerIT.java
@@ -431,8 +431,11 @@ public class StatelessIndexCommitListenerIT extends AbstractStatelessPluginInteg
             assertAcked(indicesAdmin().prepareDelete(indexName));
             IndexEngineTestUtils.awaitClose(engine);
         } finally {
-            plugin.listRetainedCommits(shardId).forEach(this::releaseCommit);
-            indexName = null;
+            try {
+                plugin.listRetainedCommits(shardId).forEach(this::releaseCommit);
+            } finally {
+                indexName = null;
+            }
         }
     }
 


### PR DESCRIPTION
After the cluster got red and the shard is reassigned, the cluster gets green again and the new commits are released, before the test index is finally deleted by the teardowntest() method.

If a commit is created just after the commits are released in the finally block, then the commit is retained after the test and causes the
 leak listener to complain.

Fixed the test by deleting the test index and waiting for the engine to be closed after rebuilt, and then close any retained commit.

Closes #148471
