### PR TITLE
Fix UOE in CanMatch empty-shards skipped-by-cluster map

### DIFF
--- a/docs/changelog/148754.yaml
+++ b/docs/changelog/148754.yaml
@@ -1,0 +1,5 @@
+pr: 148754
+summary: Fix UOE in CanMatch empty-shards skipped-by-cluster map
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -163,7 +163,8 @@ final class CanMatchPreFilterSearchPhase {
         boolean includeSkippedShardsInIterators
     ) {
         if (shardsIts.isEmpty()) {
-            return SubscribableListener.newSucceeded(new CanMatchResult(Collections.emptyList(), Collections.emptyMap()));
+            // Must be mutable: callers fold per-cluster skip counts into this map via Map#merge.
+            return SubscribableListener.newSucceeded(new CanMatchResult(Collections.emptyList(), new HashMap<>()));
         }
         final SubscribableListener<CanMatchResult> listener = new SubscribableListener<>();
         long phaseStartTimeInNanos = System.nanoTime();

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -202,6 +202,49 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
     }
 
     /**
+     * Empty shard iterators short-circuit the phase without contacting any nodes, but the returned
+     * {@link CanMatchPreFilterSearchPhase.CanMatchResult#skippedByClusterAlias()} map must still be mutable:
+     * callers (e.g. {@code TransportSearchAction} and {@code TransportOpenPointInTimeAction}) fold per-cluster
+     * skipped-shard counts from remotes into it via {@link Map#merge}. Returning
+     * {@link Collections#emptyMap()} here triggers {@link UnsupportedOperationException} in those callers.
+     */
+    public void testEmptyShardIteratorsReturnsMutableSkippedByClusterAlias() {
+        final TransportSearchAction.SearchTimeProvider timeProvider = new TransportSearchAction.SearchTimeProvider(
+            0,
+            System.nanoTime(),
+            System::nanoTime
+        );
+        SearchTransportService searchTransportService = new SearchTransportService(null, null, null);
+        AtomicReference<CanMatchPreFilterSearchPhase.CanMatchResult> result = new AtomicReference<>();
+        SubscribableListener<CanMatchPreFilterSearchPhase.CanMatchResult> listener = CanMatchPreFilterSearchPhase.execute(
+            logger,
+            searchTransportService,
+            (clusterAlias, node) -> null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
+            new SearchRequest().allowPartialSearchResults(true),
+            Collections.emptyList(),
+            timeProvider,
+            null,
+            false,
+            EMPTY_CONTEXT_PROVIDER,
+            new SearchResponseMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
+            Map.of(),
+            randomBoolean()
+        );
+        listener.addListener(ActionTestUtils.assertNoFailureListener(result::set));
+        assertNotNull("phase should complete synchronously for empty shard iterators", result.get());
+        assertEquals(0, result.get().iterators().size());
+
+        // Caller pattern from TransportOpenPointInTimeAction and TransportSearchAction: fold non-empty per-cluster
+        // skip counts (as produced by search_shards round-trip) into the can-match result map. This must not throw.
+        Map<String, Integer> incomingSkips = Map.of("remote_a", 3, LOCAL_CLUSTER_GROUP_KEY, 0);
+        incomingSkips.forEach((cluster, count) -> result.get().skippedByClusterAlias().merge(cluster, count, Integer::sum));
+        assertEquals(Map.of("remote_a", 3, LOCAL_CLUSTER_GROUP_KEY, 0), result.get().skippedByClusterAlias());
+    }
+
+    /**
      * When {@code includeSkippedShardsInIterators} is {@code true} (as for peers before
      * {@link SearchShardsResponse#SEARCH_SHARDS_NUM_SKIPPED2}), skipped shards must appear as iterators with
      * {@link SearchShardIterator#skip()} true and{@link CanMatchPreFilterSearchPhase.CanMatchResult#skippedByClusterAlias()} must stay


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch-serverless/issues/6640 once it propagates into Serverless.
Also c.f. https://elasticco.atlassian.net/browse/ES-14789.

AI-assisted PR.

## Summary

`CanMatchPreFilterSearchPhase.execute` short-circuits when the
incoming shard iterators list is empty:

```java
if (shardsIts.isEmpty()) {
    return SubscribableListener.newSucceeded(
        new CanMatchResult(Collections.emptyList(), Collections.emptyMap())
    );
}
```

`Collections.emptyMap()` is **immutable**, but both callers
(`TransportSearchAction#AsyncSearchActionProvider.runNewSearchPhase`
at `TransportSearchAction.java:2173` and
`TransportOpenPointInTimeAction$OpenPointInTimePhase.runNewSearchPhase`
at `TransportOpenPointInTimeAction.java:344`) then fold the per-cluster
skip counts from the `search_shards` round-trip into that map via
`Map#merge`:

```java
skippedByClusterAlias.forEach(
    (cluster, count) -> canMatchResult.skippedByClusterAlias().merge(cluster, count, Integer::sum)
);
```

That throws `UnsupportedOperationException` from
`Collections$EmptyMap.merge` whenever the incoming counts map has any
entry — which happens whenever any remote returned a response from
`search_shards` (the map is populated with one entry per remote even
when its skipped count is `0`, see `TransportSearchAction.java:712-715`).

In practice this is reachable from an EQL search (`_eql/search`
internally opens a PIT) against a project that has cross-cluster /
cross-project remotes but no matching local shards — exactly the
scenario reported on a Serverless project hitting this with a 500.

The bug was introduced by #144801 (which re-applied #142170 after
its earlier revert in #144438), when the `CanMatchResult` was changed
to carry a per-cluster `skippedByClusterAlias` map. The empty-shards
short-circuit hardcoded `Collections.emptyMap()` but the new call
sites mutate it.

## Fix

Make the empty-path map mutable (`new HashMap<>()`). Smallest viable
change; defends against any future caller assuming the map is
mutable. Allocation is one tiny HashMap on a path that is already
returning a `CanMatchResult` so the cost is negligible.

## Test plan

- [x] New `testEmptyShardIteratorsReturnsMutableSkippedByClusterAlias`
      in `CanMatchPreFilterSearchPhaseTests` reproduces the exact
      `UnsupportedOperationException` against the unfixed code and
      passes with the fix applied. Verified by toggling the source
      fix on/off and re-running.
- [x] `./gradlew :server:test --tests
      'org.elasticsearch.action.search.CanMatchPreFilterSearchPhaseTests'`
      passes (full class, not just the new test).
- [x] `./gradlew :server:spotlessApply` clean.