### PR TITLE
Fix ArrayIndexOutOfBoundsException in centroid grouping evaluateFinal

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidPointAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidPointAggregator.java
@@ -123,7 +123,7 @@ abstract class CentroidPointAggregator {
         try (BytesRefBlock.Builder builder = ctx.blockFactory().newBytesRefBlockBuilder(selected.getPositionCount())) {
             for (int i = 0; i < selected.getPositionCount(); i++) {
                 int si = selected.getInt(i);
-                if (state.hasValue(si) && si < state.xValues.size()) {
+                if (si < state.xValues.size() && state.hasValue(si)) {
                     BytesRef result = state.encodeCentroidResult(si);
                     builder.appendBytesRef(result);
                 } else {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidShapeAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidShapeAggregator.java
@@ -147,7 +147,7 @@ abstract class CentroidShapeAggregator {
         try (BytesRefBlock.Builder builder = ctx.blockFactory().newBytesRefBlockBuilder(selected.getPositionCount())) {
             for (int i = 0; i < selected.getPositionCount(); i++) {
                 int si = selected.getInt(i);
-                if (state.hasValue(si) && si < state.xValues.size()) {
+                if (si < state.xValues.size() && state.hasValue(si)) {
                     BytesRef result = state.encodeCentroidResult(si);
                     builder.appendBytesRef(result);
                 } else {


### PR DESCRIPTION
### Summary

`evaluateFinal` for grouping centroids used `state.hasValue(si) && si < state.xValues.size()`. `hasValue(si)` called `counts.get(si)` before the bounds check. When `selected` contained a group id outside the current array size (e.g. index 136 with length 129), this caused an `ArrayIndexOutOfBoundsException` during hash aggregation finish (see [#141318](https://github.com/elastic/elasticsearch/issues/141318)).

### Changes

- Reorder the condition to `si < state.xValues.size() && state.hasValue(si)` in `CentroidPointAggregator` and the same pattern in `CentroidShapeAggregator`.
- Out-of-range group ids now follow the same path as empty groups: append null, consistent with `evaluateIntermediate` which already guards with `group < state.xValues.size()`.

### Related

Closes #141318