### PR TITLE
Fix Docker CLI resolution on Windows

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerSupportService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerSupportService.java
@@ -304,25 +304,47 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
         return values;
     }
 
+    // visible for testing
+    static Optional<String> resolveDockerExecutableFromPath(String pathEnv, String separator, List<String> executableNames) {
+        if (pathEnv == null || pathEnv.isEmpty()) {
+            return Optional.empty();
+        }
+
+        for (String dir : pathEnv.split(separator)) {
+            for (String executableName : executableNames) {
+                File candidate = new File(dir.trim(), executableName);
+                if (candidate.isFile() && candidate.canExecute()) {
+                    return Optional.of(candidate.getAbsolutePath());
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static List<String> dockerExecutableNames() {
+        return OS.current() == OS.WINDOWS ? List.of("docker.exe", "docker") : List.of("docker");
+    }
+
     /**
      * Resolves the Docker executable so it can be found even when PATH is minimal (e.g. Gradle
      * workers or IDE). Searches PATH first for an executable named "docker", then falls back to
-     * {@link #DOCKER_BINARIES}. Use this when invoking docker from tasks so the binary is found
-     * regardless of worker environment.
+     * {@link #DOCKER_BINARIES}. On Windows, prefers "docker.exe" because an extensionless Docker
+     * shim may not be executable by CreateProcess. Use this when invoking docker from tasks so the
+     * binary is found regardless of worker environment.
      *
      * @return the absolute path to the Docker CLI if found and executable, otherwise "docker".
      */
     public String getResolvedDockerExecutable() {
-        String pathEnv = System.getenv("PATH");
-        if (pathEnv != null && pathEnv.isEmpty() == false) {
-            String separator = System.getProperty("path.separator", ":");
-            for (String dir : pathEnv.split(separator)) {
-                File candidate = new File(dir.trim(), "docker");
-                if (candidate.isFile() && candidate.canExecute()) {
-                    return candidate.getAbsolutePath();
-                }
-            }
+        Optional<String> resolvedFromPath = resolveDockerExecutableFromPath(
+            System.getenv("PATH"),
+            System.getProperty("path.separator", ":"),
+            dockerExecutableNames()
+        );
+        if (resolvedFromPath.isPresent()) {
+            return resolvedFromPath.get();
         }
+
         for (String path : DOCKER_BINARIES) {
             File f = new File(path);
             if (f.isFile() && f.canExecute()) {

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/docker/DockerSupportServiceTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/docker/DockerSupportServiceTests.java
@@ -10,12 +10,18 @@ package org.elasticsearch.gradle.internal.docker;
 
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.elasticsearch.gradle.internal.docker.DockerSupportService.deriveId;
 import static org.elasticsearch.gradle.internal.docker.DockerSupportService.parseOsRelease;
+import static org.elasticsearch.gradle.internal.docker.DockerSupportService.resolveDockerExecutableFromPath;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -95,5 +101,24 @@ public class DockerSupportServiceTests {
         osRelease.put("VERSION_ID", "6.10");
 
         assertThat("ol-6.10", equalTo(deriveId(osRelease)));
+    }
+
+    @Test
+    public void testWindowsDockerExeIsPreferredOverExtensionlessDocker() throws IOException {
+        final Path dockerBin = Files.createTempDirectory("docker-bin");
+        final Path docker = dockerBin.resolve("docker");
+        final Path dockerExe = dockerBin.resolve("docker.exe");
+        Files.createFile(docker);
+        Files.createFile(dockerExe);
+        docker.toFile().setExecutable(true);
+        dockerExe.toFile().setExecutable(true);
+
+        Optional<String> resolved = resolveDockerExecutableFromPath(
+            dockerBin.toString(),
+            File.pathSeparator,
+            List.of("docker.exe", "docker")
+        );
+
+        assertThat(resolved.orElseThrow(), equalTo(dockerExe.toFile().getAbsolutePath()));
     }
 }


### PR DESCRIPTION
Fixes Docker CLI resolution on Windows when Docker Desktop's extensionless `docker` shim is found before `docker.exe` on PATH.

`DockerSupportService#getResolvedDockerExecutable()` previously searched PATH for an executable named `docker`.
On Windows, Docker Desktop may expose both:

```text
C:\Program Files\Docker\Docker\resources\bin\docker
C:\Program Files\Docker\Docker\resources\bin\docker.exe
````

When the extensionless `docker` file is selected, Gradle fails while probing Docker availability:

```text
CreateProcess error=193, %1 is not a valid Win32 application
```

This change prefers `docker.exe` before `docker` on Windows while preserving the existing `docker` lookup behavior on non-Windows platforms.

Testing:

```text
./gradlew :build-tools-internal:test --tests "org.elasticsearch.gradle.internal.docker.DockerSupportServiceTests"
./gradlew :build-tools-internal:precommit
```

Manually verified on Windows with Docker Desktop:

```text
./gradlew :distribution:archives:linux-tar:assemble
```
