### PR TITLE
Tweak testThrottlingMetrics for stability

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
@@ -209,10 +209,10 @@ public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
 
     public void testThrottlingMetrics() throws Exception {
         final String indexName = randomIdentifier();
-        final int numShards = randomIntBetween(1, 10);
+        final int numShards = randomIntBetween(1, 3);
         final int numReplicas = randomIntBetween(0, 1);
         createIndex(indexName, numShards, numReplicas);
-        indexRandom(true, indexName, randomIntBetween(100, 120));
+        indexRandom(true, indexName, randomIntBetween(10, 50));
 
         // Create a repository with restrictive throttling settings
         final String repositoryName = randomIdentifier();
@@ -221,8 +221,8 @@ public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
             ByteSizeValue.ofKb(2)
         )
             .put(BlobStoreRepository.MAX_RESTORE_BYTES_PER_SEC.getKey(), ByteSizeValue.ofKb(2))
-            // Small chunk size ensures we don't get stuck throttling for too long
-            .put("chunk_size", ByteSizeValue.ofBytes(100));
+            // Small chunk size ensures we don't get stuck throttling for too long. But we don't want to overwhelm with too many chunks.
+            .put("chunk_size", ByteSizeValue.ofBytes(1000));
         createRepository(repositoryName, "mock", repositorySettings, false);
 
         final String snapshotName = randomIdentifier();


### PR DESCRIPTION
Tweak the configuration of SnapshotMetricsIT testThrottlingMetrics to make it more stable and less likely to timeout of a CI machine.

The problem was that the test created too many chunks causing uploads take too long cumulatively. This caused snapshot creation to take over 10s resulting is timeout of safeGet. For that we increase the chunk size. Additionally, we also saw timeouts during restore caused by slow diagnostic checks. For that we decrease the number of shards and docs. Neither change should affect test coverage.

Confirmed stability by running the test 10k times on a loaded machine.

Closes elastic/elasticsearch#147954