### PR TITLE
ESQL: Load results in order

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
@@ -738,7 +738,7 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
         request.setJsonEntity(Strings.toString(body));
 
         Response response = client().performRequest(request);
-        Map<String, Object> responseMap = responseAsMap(response);
+        Map<String, Object> responseMap = responseAsOrderedMap(response);
         HttpHost coordinatorHost = response.getHost();
         NodeInfo coordinator = allNodeToInfo().values().stream().filter(n -> n.boundAddress().contains(coordinatorHost)).findFirst().get();
         TransportVersion coordinatorVersion = coordinator.version();

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
 import org.elasticsearch.compute.data.LongRangeBlockBuilder;
@@ -26,6 +27,8 @@ import org.elasticsearch.logging.Logger;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.test.ListMatcher;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
@@ -590,13 +593,8 @@ public final class CsvAssert {
                 x -> EsqlDataTypeConverter.dateRangeToString((LongRangeBlockBuilder.LongRange) x)
             );
             case FLATTENED -> {
-                // Parse expected JSON string to Map so comparison with actual is order-independent
-                String json = (String) expectedValue;
-                try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, json)) {
-                    yield parser.map();
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
+                // Keep expected as a string so comparison with actual is order-sensitive
+                yield expectedValue;
             }
             case INTEGER, LONG, DOUBLE, FLOAT, HALF_FLOAT, SCALED_FLOAT, KEYWORD, TEXT, SEMANTIC_TEXT, IP_RANGE, JSON, NULL, BOOLEAN,
                 DENSE_VECTOR, TDIGEST, UNSUPPORTED -> expectedValue;
@@ -621,19 +619,21 @@ public final class CsvAssert {
                 x -> DEFAULT_DATE_NANOS_FORMATTER.formatNanos(DEFAULT_DATE_NANOS_FORMATTER.parseNanos((String) x))
             );
             case FLATTENED -> {
-                if (actualValue instanceof Map<?, ?>) {
-                    // REST test: value was deserialized as a Map from the JSON response
-                    yield actualValue;
+                if (actualValue instanceof Map<?, ?> map) {
+                    // REST test: serialize the Map preserving its natural key iteration order so
+                    // the comparison is order-sensitive (a LinkedHashMap from JSON deserialization
+                    // preserves the server's key order).
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> typedMap = (Map<String, Object>) map;
+                    try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+                        builder.map(typedMap);
+                        yield BytesReference.bytes(builder).utf8ToString();
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
                 }
-                // CsvIT: value is a JSON string from the block loader
-                try (
-                    XContentParser parser = XContentType.JSON.xContent()
-                        .createParser(XContentParserConfiguration.EMPTY, (String) actualValue)
-                ) {
-                    yield parser.map();
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
+                // CsvIT: value is already a JSON string from the block loader — compare directly
+                yield actualValue;
             }
             default -> actualValue;
         };

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -592,12 +592,8 @@ public final class CsvAssert {
                 LongRangeBlockBuilder.LongRange.class,
                 x -> EsqlDataTypeConverter.dateRangeToString((LongRangeBlockBuilder.LongRange) x)
             );
-            case FLATTENED -> {
-                // Keep expected as a string so comparison with actual is order-sensitive
-                yield expectedValue;
-            }
             case INTEGER, LONG, DOUBLE, FLOAT, HALF_FLOAT, SCALED_FLOAT, KEYWORD, TEXT, SEMANTIC_TEXT, IP_RANGE, JSON, NULL, BOOLEAN,
-                DENSE_VECTOR, TDIGEST, UNSUPPORTED -> expectedValue;
+                DENSE_VECTOR, TDIGEST, UNSUPPORTED, FLATTENED -> expectedValue;
         };
     }
 
@@ -620,9 +616,8 @@ public final class CsvAssert {
             );
             case FLATTENED -> {
                 if (actualValue instanceof Map<?, ?> map) {
-                    // REST test: serialize the Map preserving its natural key iteration order so
-                    // the comparison is order-sensitive (a LinkedHashMap from JSON deserialization
-                    // preserves the server's key order).
+                    // REST tests come back as a LinkedHashMap and our assertions are json strings.
+                    // So we convert to json strings. This preserves order *because* of the LinkedHashMap.
                     @SuppressWarnings("unchecked")
                     Map<String, Object> typedMap = (Map<String, Object>) map;
                     try (XContentBuilder builder = XContentFactory.jsonBuilder()) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -1448,7 +1448,7 @@ public final class EsqlTestUtils {
         try (InputStream content = entity.getContent()) {
             XContentType xContentType = XContentType.fromMediaType(entity.getContentType().getValue());
             assertEquals(expectedContentType, xContentType);
-            return XContentHelper.convertToMap(xContentType.xContent(), content, false /* ordered */);
+            return XContentHelper.convertToMap(xContentType.xContent(), content, true /* ordered */);
         }
     }
 


### PR DESCRIPTION
I'm about to start asserting on the load order from `flattened` fields but ESQL doesn't load in order at all so I can't! This gets ESQL's tests to load in order so I can make those assertions. I've split it out because it has a huge blast radius and I want to deal with any odd failures it causes on their own.
