### PR TITLE
[9.4] Fix UOE in CanMatch empty-shards skipped-by-cluster map (#148754)

### DIFF
--- a/docs/changelog/148754.yaml
+++ b/docs/changelog/148754.yaml
@@ -1,0 +1,5 @@
+pr: 148754
+summary: Fix UOE in CanMatch empty-shards skipped-by-cluster map
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -163,7 +163,8 @@ final class CanMatchPreFilterSearchPhase {
         boolean includeSkippedShardsInIterators
     ) {
         if (shardsIts.isEmpty()) {
-            return SubscribableListener.newSucceeded(new CanMatchResult(Collections.emptyList(), Collections.emptyMap()));
+            // Must be mutable: callers fold per-cluster skip counts into this map via Map#merge.
+            return SubscribableListener.newSucceeded(new CanMatchResult(Collections.emptyList(), new HashMap<>()));
         }
         final SubscribableListener<CanMatchResult> listener = new SubscribableListener<>();
         long phaseStartTimeInNanos = System.nanoTime();

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -202,6 +202,49 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
     }
 
     /**
+     * Empty shard iterators short-circuit the phase without contacting any nodes, but the returned
+     * {@link CanMatchPreFilterSearchPhase.CanMatchResult#skippedByClusterAlias()} map must still be mutable:
+     * callers (e.g. {@code TransportSearchAction} and {@code TransportOpenPointInTimeAction}) fold per-cluster
+     * skipped-shard counts from remotes into it via {@link Map#merge}. Returning
+     * {@link Collections#emptyMap()} here triggers {@link UnsupportedOperationException} in those callers.
+     */
+    public void testEmptyShardIteratorsReturnsMutableSkippedByClusterAlias() {
+        final TransportSearchAction.SearchTimeProvider timeProvider = new TransportSearchAction.SearchTimeProvider(
+            0,
+            System.nanoTime(),
+            System::nanoTime
+        );
+        SearchTransportService searchTransportService = new SearchTransportService(null, null, null);
+        AtomicReference<CanMatchPreFilterSearchPhase.CanMatchResult> result = new AtomicReference<>();
+        SubscribableListener<CanMatchPreFilterSearchPhase.CanMatchResult> listener = CanMatchPreFilterSearchPhase.execute(
+            logger,
+            searchTransportService,
+            (clusterAlias, node) -> null,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
+            new SearchRequest().allowPartialSearchResults(true),
+            Collections.emptyList(),
+            timeProvider,
+            null,
+            false,
+            EMPTY_CONTEXT_PROVIDER,
+            new SearchResponseMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
+            Map.of(),
+            randomBoolean()
+        );
+        listener.addListener(ActionTestUtils.assertNoFailureListener(result::set));
+        assertNotNull("phase should complete synchronously for empty shard iterators", result.get());
+        assertEquals(0, result.get().iterators().size());
+
+        // Caller pattern from TransportOpenPointInTimeAction and TransportSearchAction: fold non-empty per-cluster
+        // skip counts (as produced by search_shards round-trip) into the can-match result map. This must not throw.
+        Map<String, Integer> incomingSkips = Map.of("remote_a", 3, LOCAL_CLUSTER_GROUP_KEY, 0);
+        incomingSkips.forEach((cluster, count) -> result.get().skippedByClusterAlias().merge(cluster, count, Integer::sum));
+        assertEquals(Map.of("remote_a", 3, LOCAL_CLUSTER_GROUP_KEY, 0), result.get().skippedByClusterAlias());
+    }
+
+    /**
      * When {@code includeSkippedShardsInIterators} is {@code true} (as for peers before
      * {@link SearchShardsResponse#SEARCH_SHARDS_NUM_SKIPPED2}), skipped shards must appear as iterators with
      * {@link SearchShardIterator#skip()} true and{@link CanMatchPreFilterSearchPhase.CanMatchResult#skippedByClusterAlias()} must stay


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix UOE in CanMatch empty-shards skipped-by-cluster map (#148754)