### PR TITLE
Default Prometheus discovery APIs to metrics-*

### DIFF
--- a/docs/changelog/148770.yaml
+++ b/docs/changelog/148770.yaml
@@ -1,0 +1,5 @@
+area: PromQL
+issues: []
+pr: 148770
+summary: Default Prometheus discovery APIs to metrics-*
+type: bug

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusLabelValuesRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusLabelValuesRestAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.parser.promql.PromqlParserUtils;
 import org.elasticsearch.xpack.esql.plan.EsqlStatement;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -25,6 +26,7 @@ import java.util.List;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * REST handler for the Prometheus {@code GET /_prometheus/api/v1/label/{name}/values} and
@@ -41,6 +43,9 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
  * <p>When a label name is absent from all index mappings ESQL returns a {@code "Unknown column"}
  * BAD_REQUEST error. The response listener converts that into an empty {@code data:[]} success
  * response, which is the correct Prometheus behaviour for a label that has no values.
+ *
+ * <p>When the path omits {@code {index}} and no {@code index} query parameter is set, the index
+ * expression defaults to {@link PromqlCommand#DEFAULT_PROMQL_INDEX_PATTERN} (same as PromQL query APIs).
  */
 @ServerlessScope(Scope.PUBLIC)
 public class PrometheusLabelValuesRestAction extends BaseRestHandler {
@@ -71,7 +76,7 @@ public class PrometheusLabelValuesRestAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String rawName = request.param("name");
         String labelName = PrometheusLabelNameUtils.decodeLabelName(rawName);
-        String index = request.param(INDEX_PARAM, "*");
+        String index = request.param(INDEX_PARAM, DEFAULT_PROMQL_INDEX_PATTERN);
 
         List<String> matchSelectors = request.repeatedParamAsList(MATCH_PARAM);
 

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusLabelsRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusLabelsRestAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.parser.promql.PromqlParserUtils;
 import org.elasticsearch.xpack.esql.plan.EsqlStatement;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -25,12 +26,14 @@ import java.util.List;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * REST handler for the Prometheus {@code GET /api/v1/labels} endpoint.
  * Returns the sorted list of label names across all matching time series.
  * The optional {@code {index}} path parameter restricts the query to a specific index pattern;
- * when omitted, all indices ({@code "*"}) are searched.
+ * when omitted, the index expression defaults to {@link PromqlCommand#DEFAULT_PROMQL_INDEX_PATTERN}
+ * (same as PromQL query APIs).
  * Only GET is supported. POST with {@code application/x-www-form-urlencoded} bodies is rejected
  * at the HTTP layer as a CSRF safeguard before this handler is ever reached — see
  * {@code RestController#isContentTypeDisallowed}.
@@ -74,7 +77,7 @@ public class PrometheusLabelsRestAction extends BaseRestHandler {
         // limit+1 sentinel to detect and report truncation.
         int limit = request.paramAsInt(LIMIT_PARAM, DEFAULT_LIMIT);
 
-        String index = request.param(INDEX_PARAM, "*");
+        String index = request.param(INDEX_PARAM, DEFAULT_PROMQL_INDEX_PATTERN);
         LogicalPlan plan = PrometheusLabelsPlanBuilder.buildPlan(index, matchSelectors, start, end, limit);
         EsqlStatement statement = new EsqlStatement(plan, List.of());
         PreparedEsqlQueryRequest esqlRequest = PreparedEsqlQueryRequest.sync(statement, "prometheus_labels");

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusMetadataRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusMetadataRestAction.java
@@ -16,17 +16,21 @@ import org.elasticsearch.xpack.esql.action.EsqlQueryAction;
 import org.elasticsearch.xpack.esql.action.PreparedEsqlQueryRequest;
 import org.elasticsearch.xpack.esql.plan.EsqlStatement;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * REST handler for the Prometheus {@code GET /_prometheus/api/v1/metadata} and
  * {@code GET /_prometheus/{index}/api/v1/metadata} endpoints.
  * Returns metric metadata (type, help, unit) for scraped metrics.
  * Uses the {@code METRICS_INFO} ES|QL command as data source.
+ * When the path omits {@code {index}} and no {@code index} query parameter is set, the index
+ * expression defaults to {@link PromqlCommand#DEFAULT_PROMQL_INDEX_PATTERN} (same as PromQL query APIs).
  */
 @ServerlessScope(Scope.PUBLIC)
 public class PrometheusMetadataRestAction extends BaseRestHandler {
@@ -50,7 +54,7 @@ public class PrometheusMetadataRestAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        String index = request.param(INDEX_PARAM, "*");
+        String index = request.param(INDEX_PARAM, DEFAULT_PROMQL_INDEX_PATTERN);
         String metric = request.param(METRIC_PARAM);
         int limit = request.paramAsInt(LIMIT_PARAM, DEFAULT_LIMIT);
         int limitPerMetric = request.paramAsInt(LIMIT_PER_METRIC_PARAM, DEFAULT_LIMIT);

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusSeriesRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusSeriesRestAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.parser.promql.PromqlParserUtils;
 import org.elasticsearch.xpack.esql.plan.EsqlStatement;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -25,6 +26,7 @@ import java.util.List;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * REST handler for the Prometheus {@code GET /api/v1/series} endpoint.
@@ -32,6 +34,9 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
  * Only GET is supported. POST with {@code application/x-www-form-urlencoded} bodies is rejected
  * at the HTTP layer as a CSRF safeguard before this handler is ever reached — see
  * {@code RestController#isContentTypeDisallowed}.
+ *
+ * <p>When the path omits {@code {index}} and no {@code index} query parameter is set, the index
+ * expression defaults to {@link PromqlCommand#DEFAULT_PROMQL_INDEX_PATTERN} (same as PromQL query APIs).
  */
 @ServerlessScope(Scope.PUBLIC)
 public class PrometheusSeriesRestAction extends BaseRestHandler {
@@ -75,7 +80,7 @@ public class PrometheusSeriesRestAction extends BaseRestHandler {
         // limit+1 sentinel to detect and report truncation.
         int limit = request.paramAsInt(LIMIT_PARAM, DEFAULT_LIMIT);
 
-        String index = request.param(INDEX_PARAM, "*");
+        String index = request.param(INDEX_PARAM, DEFAULT_PROMQL_INDEX_PATTERN);
         LogicalPlan plan = PrometheusSeriesPlanBuilder.buildPlan(index, matchSelectors, start, end, limit);
         EsqlStatement statement = new EsqlStatement(plan, List.of());
         PreparedEsqlQueryRequest esqlRequest = PreparedEsqlQueryRequest.sync(statement, "prometheus_series");


### PR DESCRIPTION
Prometheus `metadata`, `labels`, `label/{name}/values`, and `series` REST handlers previously defaulted the index expression to `*` while `query` and `query_range` already used `PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN` (`metrics-*`).

This change aligns discovery endpoints with the query APIs so path-less requests stay scoped to metrics indices by default. Operators who need a broader scope can still pass an explicit `{index}` path segment or an `index` query parameter (for example `index=*`).