### PR TITLE
Slices: enable doc values in _routing's doc_values mapping attribute

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -358,7 +358,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             MetadataFieldMapper.Builder routingBuilder = metadataBuilders.get(RoutingFieldMapper.NAME);
             if (routingBuilder instanceof RoutingFieldMapper.Builder builder) {
                 builder.required.setValue(true);
-                builder.docValues.setValue(true);
             }
         }
         return metadataBuilders;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -94,7 +94,8 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
 
     public static final TypeParser PARSER = new ConfigurableTypeParser(c -> {
         var indexMode = c.getIndexSettings().getMode();
-        return new Builder(indexMode == IndexMode.COLUMNAR || indexMode == IndexMode.COLUMNAR_LOGSDB);
+        boolean slicesEnabled = c.getIndexSettings().isSliceEnabled();
+        return new Builder(slicesEnabled || indexMode == IndexMode.COLUMNAR || indexMode == IndexMode.COLUMNAR_LOGSDB);
     });
 
     /**


### PR DESCRIPTION
Instead of enabling doc values via `MapperService`.

A follow up from #148488