### PR TITLE
ESQL: Flattened support for COALESCE and IS NULL

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -850,6 +850,14 @@ public class RestEsqlIT extends RestEsqlTestCase {
                   "type": "Point",
                   "coordinates": [-77.03653, 38.897676]
                 }
+                """),
+            Map.entry(DataType.FLATTENED, """
+                {
+                  "foo": "a",
+                  "o": {
+                    "bar": "b"
+                  }
+                }
                 """)
         );
         if (EsqlCapabilities.Cap.AGGREGATE_METRIC_DOUBLE_V0.isEnabled()) {
@@ -874,7 +882,9 @@ public class RestEsqlIT extends RestEsqlTestCase {
         shouldBeSupported.remove(DataType.DATE_RANGE);
         shouldBeSupported.remove(DataType.TDIGEST);
         shouldBeSupported.remove(DataType.HISTOGRAM);
-        shouldBeSupported.remove(DataType.FLATTENED); // TO_STRING not yet supported for flattened
+        if (EsqlCapabilities.Cap.FLATTENED_DATATYPE.isEnabled() == false) {
+            shouldBeSupported.remove(DataType.FLATTENED);
+        }
         if (EsqlCapabilities.Cap.AGGREGATE_METRIC_DOUBLE_V0.isEnabled() == false) {
             shouldBeSupported.remove(DataType.AGGREGATE_METRIC_DOUBLE);
         }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -64,7 +64,6 @@ import org.elasticsearch.tdigest.Centroid;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.transport.RemoteTransportException;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.analytics.mapper.EncodedTDigest;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -95,6 +95,7 @@ import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
+import org.elasticsearch.xpack.esql.expression.function.FlattenedCases;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StGeohash;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StGeohex;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StGeotile;
@@ -1188,7 +1189,7 @@ public final class EsqlTestUtils {
                     throw new UncheckedIOException(e);
                 }
             }
-            case FLATTENED -> randomFlattenedValue();
+            case FLATTENED -> FlattenedCases.RANDOM.get();
             case TSID_DATA_TYPE -> randomTsId().toBytesRef();
             case HISTOGRAM -> randomHistogram();
             case DENSE_VECTOR -> Arrays.asList(randomArray(10, 10, i -> new Float[10], ESTestCase::randomFloat));
@@ -1294,47 +1295,6 @@ public final class EsqlTestUtils {
             case 2 -> new Version(between(0, 100) + "." + between(0, 100) + "." + between(0, 100));
             default -> throw new IllegalArgumentException();
         };
-    }
-
-    /**
-     * Build a random {@link BytesRef} that mimics what {@code RootFlattenedDocValuesBlockLoader}
-     * produces: a JSON object whose leaf values are always strings (flattened doc values store
-     * everything as strings), where dotted keys are reconstructed as nested objects and
-     * multi-valued keys become string arrays.
-     */
-    private static BytesRef randomFlattenedValue() {
-        try {
-            XContentBuilder builder = JsonXContent.contentBuilder().startObject();
-            int numFields = between(1, 5);
-            for (int i = 0; i < numFields; i++) {
-                String key = randomAlphaOfLength(between(3, 8));
-                switch (between(0, 2)) {
-                    case 0 -> {
-                        // Nested object, as produced from a dotted key like "parent.child"
-                        builder.startObject(key);
-                        builder.field(randomAlphaOfLength(between(3, 8)), randomAlphaOfLength(between(5, 15)));
-                        builder.endObject();
-                    }
-                    case 1 -> {
-                        // Array of strings, as produced from a multi-valued flattened field
-                        int numValues = between(2, 4);
-                        builder.startArray(key);
-                        for (int j = 0; j < numValues; j++) {
-                            builder.value(randomAlphaOfLength(between(5, 15)));
-                        }
-                        builder.endArray();
-                    }
-                    default -> {
-                        // Simple string field
-                        builder.field(key, randomAlphaOfLength(between(5, 15)));
-                    }
-                }
-            }
-            builder.endObject();
-            return BytesReference.bytes(builder).toBytesRef();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 
     static BytesReference randomTsId() {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/FlattenedCases.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/expression/function/FlattenedCases.java
@@ -25,7 +25,7 @@ import static org.elasticsearch.test.ESTestCase.randomIntBetween;
  * Shared suppliers for {@link DataType#FLATTENED} test cases,
  * used by both {@link TestCaseSupplier} and {@link MultiRowTestCaseSupplier}.
  */
-class FlattenedCases {
+public class FlattenedCases {
     static final Supplier<BytesRef> EMPTY = json(b -> {});
     static final Supplier<BytesRef> SINGLE_KEY = json(b -> b.field(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20)));
     static final Supplier<BytesRef> MULTI_KEY = json(b -> {
@@ -45,7 +45,7 @@ class FlattenedCases {
             b.endObject();
         }
     });
-    static final Supplier<BytesRef> RANDOM = () -> randomFrom(EMPTY, SINGLE_KEY, MULTI_KEY, OBJECT).get();
+    public static final Supplier<BytesRef> RANDOM = () -> randomFrom(EMPTY, SINGLE_KEY, MULTI_KEY, OBJECT).get();
 
     private static Supplier<BytesRef> json(CheckedConsumer<XContentBuilder, IOException> body) {
         return () -> {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/flattened.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/flattened.csv-spec
@@ -72,3 +72,57 @@ FROM flattened_otel_logs
 @timestamp:date          | first_part:keyword
 2020-01-01T00:02:48.461Z | "{""rally.message_size"":""192"""
 ;
+
+coalesce
+required_capability: flattened_datatype
+required_capability: fn_coalesce_flattened
+
+FROM flattened_otel_logs
+| WHERE @timestamp == "2020-01-01T00:02:48.461Z"
+| EVAL c = COALESCE(attributes, resource.attributes)
+| KEEP @timestamp, c
+;
+
+@timestamp:date          | c:flattened
+2020-01-01T00:02:48.461Z | "{""rally.message_size"":""192"",""type"":""beats""}"
+;
+
+coalesceNullFirst
+required_capability: flattened_datatype
+required_capability: fn_coalesce_flattened
+
+FROM flattened_otel_logs
+| WHERE @timestamp == "2020-01-01T00:02:48.461Z"
+| EVAL c = COALESCE(null, attributes)
+| KEEP @timestamp, c
+;
+
+@timestamp:date          | c:flattened
+2020-01-01T00:02:48.461Z | "{""rally.message_size"":""192"",""type"":""beats""}"
+;
+
+isNull
+required_capability: flattened_datatype
+
+FROM flattened_otel_logs
+| WHERE @timestamp == "2020-01-01T00:02:48.461Z"
+| EVAL n = attributes IS NULL
+| KEEP @timestamp, n
+;
+
+@timestamp:date          | n:boolean
+2020-01-01T00:02:48.461Z | false
+;
+
+isNotNull
+required_capability: flattened_datatype
+
+FROM flattened_otel_logs
+| WHERE @timestamp == "2020-01-01T00:02:48.461Z"
+| EVAL n = attributes IS NOT NULL
+| KEEP @timestamp, n
+;
+
+@timestamp:date          | n:boolean
+2020-01-01T00:02:48.461Z | true
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/Coalesce.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/Coalesce.java
@@ -42,6 +42,7 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Coalesce", Coalesce::new);
     public static final FunctionDefinition DEFINITION = FunctionDefinition.def(Coalesce.class)
         .unaryVariadic(Coalesce::new)
+        .capabilities("flattened")
         .name("coalesce");
 
     private DataType dataType;
@@ -54,6 +55,7 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
             "date_nanos",
             "date",
             "dense_vector",
+            "flattened",
             "histogram",
             "geo_point",
             "geo_shape",
@@ -81,6 +83,7 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
                 "date_nanos",
                 "date",
                 "dense_vector",
+                "flattened",
                 "histogram",
                 "geo_point",
                 "geo_shape",
@@ -106,6 +109,7 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
                 "date_nanos",
                 "date",
                 "dense_vector",
+                "flattened",
                 "histogram",
                 "geo_point",
                 "geo_shape",
@@ -221,14 +225,14 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
                 toEvaluator,
                 children()
             );
-            case KEYWORD, TEXT, CARTESIAN_POINT, CARTESIAN_SHAPE, HISTOGRAM, GEO_POINT, GEO_SHAPE, IP, VERSION -> CoalesceBytesRefEvaluator
-                .toEvaluator(toEvaluator, children());
+            case KEYWORD, TEXT, CARTESIAN_POINT, CARTESIAN_SHAPE, FLATTENED, HISTOGRAM, GEO_POINT, GEO_SHAPE, IP, VERSION ->
+                CoalesceBytesRefEvaluator.toEvaluator(toEvaluator, children());
             case EXPONENTIAL_HISTOGRAM -> CoalesceExponentialHistogramEvaluator.toEvaluator(toEvaluator, children());
             case TDIGEST -> CoalesceTDigestEvaluator.toEvaluator(toEvaluator, children());
             case DENSE_VECTOR -> CoalesceFloatEvaluator.toEvaluator(toEvaluator, children());
             case NULL -> ConstantEvaluators.CONSTANT_NULL_FACTORY;
             case UNSUPPORTED, SHORT, BYTE, DATE_PERIOD, OBJECT, DOC_DATA_TYPE, SOURCE, TIME_DURATION, FLOAT, HALF_FLOAT, TSID_DATA_TYPE,
-                SCALED_FLOAT, PARTIAL_AGG, AGGREGATE_METRIC_DOUBLE, DATE_RANGE, FLATTENED -> throw new UnsupportedOperationException(
+                SCALED_FLOAT, PARTIAL_AGG, AGGREGATE_METRIC_DOUBLE, DATE_RANGE -> throw new UnsupportedOperationException(
                     dataType() + " can't be coalesced"
                 );
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNotNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNotNull.java
@@ -47,6 +47,7 @@ public class IsNotNull extends UnaryScalarFunction implements EvaluatorMapper, N
         operator = "IS NOT NULL",
         returnType = {
             "double",
+            "flattened",
             "integer",
             "long",
             "date_nanos",
@@ -67,6 +68,7 @@ public class IsNotNull extends UnaryScalarFunction implements EvaluatorMapper, N
             description = "Value to check. It can be a single- or multi-valued column or an expression.",
             type = {
                 "double",
+                "flattened",
                 "integer",
                 "long",
                 "date_nanos",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNull.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/nulls/IsNull.java
@@ -44,6 +44,7 @@ public class IsNull extends UnaryScalarFunction implements EvaluatorMapper, Nega
         operator = "IS NULL",
         returnType = {
             "double",
+            "flattened",
             "integer",
             "long",
             "date_nanos",
@@ -63,6 +64,7 @@ public class IsNull extends UnaryScalarFunction implements EvaluatorMapper, Nega
             description = "Value to check. It can be a single- or multi-valued column or an expression.",
             type = {
                 "double",
+                "flattened",
                 "integer",
                 "long",
                 "date_nanos",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
+import org.elasticsearch.xpack.esql.expression.function.FlattenedCases;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
@@ -178,6 +179,19 @@ public class CoalesceTests extends AbstractScalarFunctionTestCase {
                 "CoalesceFloatEagerEvaluator[values=[Attribute[channel=0], Attribute[channel=1]]]",
                 DataType.DENSE_VECTOR,
                 equalTo(firstVector == null ? secondVector : firstVector)
+            );
+        }));
+        noNullsSuppliers.add(new TestCaseSupplier(List.of(DataType.FLATTENED, DataType.FLATTENED), () -> {
+            BytesRef first = randomBoolean() ? null : FlattenedCases.RANDOM.get();
+            BytesRef second = FlattenedCases.RANDOM.get();
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(first, DataType.FLATTENED, "first"),
+                    new TestCaseSupplier.TypedData(second, DataType.FLATTENED, "second")
+                ),
+                "CoalesceBytesRefEagerEvaluator[values=[Attribute[channel=0], Attribute[channel=1]]]",
+                DataType.FLATTENED,
+                equalTo(first == null ? second : first)
             );
         }));
         List<TestCaseSupplier> suppliers = new ArrayList<>(noNullsSuppliers);


### PR DESCRIPTION
Adds flattened field suppor for COALESCE and IS NULL and updates the testing infrastructure based on feedback from #14827.
