### PR TITLE
ES|QL: lift findLastRecordBoundary onto SegmentableFormatReader SPI

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -48,6 +48,7 @@ import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -823,13 +824,8 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     /**
-     * Quote-aware backward boundary scan: drives {@link #findNextRecordBoundary} over fresh
-     * {@link java.io.ByteArrayInputStream} slices and returns the offset of the last terminator
-     * byte. Reuses the existing quote-state logic in {@link #findNextRecordBoundaryQuotedFieldsOnly}
-     * and {@link #findNextRecordBoundaryBracketCommaMvc} rather than duplicating it.
-     * <p>
-     * NDJSON keeps the default backward-{@code \n} scan from the SPI; only CSV/TSV with embedded
-     * newlines in quoted fields needs this override.
+     * Drives {@link #findNextRecordBoundary} forward through the buffer and returns the offset of
+     * the last terminator byte, so newlines inside quoted/bracketed cells are correctly skipped.
      */
     @Override
     public int findLastRecordBoundary(byte[] buf, int length) throws IOException {
@@ -839,7 +835,7 @@ public class CsvFormatReader implements SegmentableFormatReader {
         int lastBoundary = -1;
         int cumulative = 0;
         while (cumulative < length) {
-            java.io.ByteArrayInputStream bis = new java.io.ByteArrayInputStream(buf, cumulative, length - cumulative);
+            ByteArrayInputStream bis = new ByteArrayInputStream(buf, cumulative, length - cumulative);
             long consumed = findNextRecordBoundary(bis);
             if (consumed < 0) {
                 return lastBoundary;

--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -823,6 +823,34 @@ public class CsvFormatReader implements SegmentableFormatReader {
     }
 
     /**
+     * Quote-aware backward boundary scan: drives {@link #findNextRecordBoundary} over fresh
+     * {@link java.io.ByteArrayInputStream} slices and returns the offset of the last terminator
+     * byte. Reuses the existing quote-state logic in {@link #findNextRecordBoundaryQuotedFieldsOnly}
+     * and {@link #findNextRecordBoundaryBracketCommaMvc} rather than duplicating it.
+     * <p>
+     * NDJSON keeps the default backward-{@code \n} scan from the SPI; only CSV/TSV with embedded
+     * newlines in quoted fields needs this override.
+     */
+    @Override
+    public int findLastRecordBoundary(byte[] buf, int length) throws IOException {
+        if (length <= 0) {
+            return -1;
+        }
+        int lastBoundary = -1;
+        int cumulative = 0;
+        while (cumulative < length) {
+            java.io.ByteArrayInputStream bis = new java.io.ByteArrayInputStream(buf, cumulative, length - cumulative);
+            long consumed = findNextRecordBoundary(bis);
+            if (consumed < 0) {
+                return lastBoundary;
+            }
+            cumulative += Math.toIntExact(consumed);
+            lastBoundary = cumulative - 1;
+        }
+        return lastBoundary;
+    }
+
+    /**
      * Upper bound for {@link BufferedInputStream#mark(int)} while probing bracket MVC cells during record-boundary
      * scans. Matches {@link CsvFormatOptions#maxFieldSize()} so an unclosed bracket cell cannot invalidate the mark
      * before we reset and treat {@code [} as a literal byte.

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -2648,11 +2648,6 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     // --- findLastRecordBoundary tests ---
-    // findLastRecordBoundary is the SPI hook used by the streaming-parallel coordinator to choose
-    // chunk cut points. It must skip newlines inside quoted/bracketed cells; otherwise multi-MiB
-    // CSV reads with embedded newlines split chunks mid-record and parser threads throw
-    // "Unclosed quoted field". The default in SegmentableFormatReader is a backward `\n` scan
-    // (correct for NDJSON, preserves its O(1) fast path); CSV/TSV must override.
 
     public void testFindLastRecordBoundarySimpleTwoLines() throws IOException {
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
@@ -2664,7 +2659,6 @@ public class CsvFormatReaderTests extends ESTestCase {
     public void testFindLastRecordBoundarySingleTrailingLineNoTerminator() throws IOException {
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
         byte[] data = "a,b\nc,d".getBytes(StandardCharsets.UTF_8);
-        // Last terminator is the \n after "a,b"; "c,d" is incomplete and must be carried over.
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(3, boundary);
     }
@@ -2675,37 +2669,30 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testFindLastRecordBoundaryAllInsideQuotedField() throws IOException {
+        // Unterminated quoted cell: no boundary; caller must grow.
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
-        // Buffer is entirely the inside of an unterminated quoted cell. There is no record
-        // boundary anywhere within it — the caller must grow the buffer to keep reading.
         byte[] data = "\"line one\nline two\nline three\n".getBytes(StandardCharsets.UTF_8);
         assertEquals(-1, reader.findLastRecordBoundary(data, data.length));
     }
 
     public void testFindLastRecordBoundarySkipsEmbeddedNewlineInQuotedField() throws IOException {
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
-        // Two records: one with an embedded \n inside a quoted cell, one plain. The boundary
-        // returned must point at the \n that terminates the plain record (offset = full length - 1),
-        // NOT at any of the embedded \n bytes inside the quoted field.
         byte[] data = "\"row1\nwith\nembedded\",a\nrow2,b\n".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(data.length - 1, boundary);
     }
 
     public void testFindLastRecordBoundaryEmbeddedNewlineFollowedByUnterminatedTail() throws IOException {
+        // Complete row, then an unterminated quoted field whose closing quote is in the next chunk.
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
-        // Production shape: a complete row, then a quoted field with an embedded \n whose closing
-        // quote is presumably in the next chunk. The boundary must point at the \n terminating the
-        // first record; the unterminated bytes must be carried over.
         byte[] data = "row1,a\n\"row2 starts here\nstill inside quote".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals("row1,a\n".length() - 1, boundary);
     }
 
     public void testFindLastRecordBoundaryRespectsBracketMvc() throws IOException {
+        // Embedded \n inside [..] must not be a boundary.
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
-        // Two records: one with embedded \n inside a [..] MVC cell, one plain. Bracket-aware path
-        // must not cut inside the bracket cell.
         byte[] data = "a,[v1\nv2\nv3],b\nrow2,plain,c\n".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(data.length - 1, boundary);
@@ -2713,7 +2700,6 @@ public class CsvFormatReaderTests extends ESTestCase {
 
     public void testFindLastRecordBoundaryLengthSubsetOfBuffer() throws IOException {
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
-        // Buffer has trailing garbage past `length` that must be ignored — the scan must respect length.
         byte[] body = "a,b\nc,d\n".getBytes(StandardCharsets.UTF_8);
         byte[] padded = new byte[body.length + 64];
         System.arraycopy(body, 0, padded, 0, body.length);
@@ -2724,8 +2710,6 @@ public class CsvFormatReaderTests extends ESTestCase {
 
     public void testFindLastRecordBoundaryCRLF() throws IOException {
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
-        // A CRLF-terminated stream must report the offset of the trailing \n of the last record, not the \r.
-        // Mirrors testFindNextRecordBoundaryCRLF on the backward-scan side.
         byte[] data = "a,b\r\nc,d\r\n".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(data.length - 1, boundary);
@@ -2733,11 +2717,8 @@ public class CsvFormatReaderTests extends ESTestCase {
     }
 
     public void testFindLastRecordBoundaryDoubledQuoteEscape() throws IOException {
+        // RFC 4180: "" is a literal quote inside a quoted field, not close-then-reopen.
         CsvFormatReader reader = new CsvFormatReader(blockFactory);
-        // RFC 4180 doubled-quote escape inside a quoted field: each {@code ""} is a literal quote,
-        // not a close-then-reopen. A scan that flipped quote state on every {@code "} would
-        // prematurely exit the quoted region and report a boundary inside the field; verify the
-        // final \n is selected instead.
         byte[] data = "\"value with \"\"escaped\"\" quotes\"\nrest\n".getBytes(StandardCharsets.UTF_8);
         int boundary = reader.findLastRecordBoundary(data, data.length);
         assertEquals(data.length - 1, boundary);

--- a/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-csv/src/test/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReaderTests.java
@@ -2647,6 +2647,103 @@ public class CsvFormatReaderTests extends ESTestCase {
         assertEquals("before,[not\n".length(), boundary);
     }
 
+    // --- findLastRecordBoundary tests ---
+    // findLastRecordBoundary is the SPI hook used by the streaming-parallel coordinator to choose
+    // chunk cut points. It must skip newlines inside quoted/bracketed cells; otherwise multi-MiB
+    // CSV reads with embedded newlines split chunks mid-record and parser threads throw
+    // "Unclosed quoted field". The default in SegmentableFormatReader is a backward `\n` scan
+    // (correct for NDJSON, preserves its O(1) fast path); CSV/TSV must override.
+
+    public void testFindLastRecordBoundarySimpleTwoLines() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] data = "a,b\nc,d\n".getBytes(StandardCharsets.UTF_8);
+        int boundary = reader.findLastRecordBoundary(data, data.length);
+        assertEquals(data.length - 1, boundary);
+    }
+
+    public void testFindLastRecordBoundarySingleTrailingLineNoTerminator() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        byte[] data = "a,b\nc,d".getBytes(StandardCharsets.UTF_8);
+        // Last terminator is the \n after "a,b"; "c,d" is incomplete and must be carried over.
+        int boundary = reader.findLastRecordBoundary(data, data.length);
+        assertEquals(3, boundary);
+    }
+
+    public void testFindLastRecordBoundaryEmpty() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        assertEquals(-1, reader.findLastRecordBoundary(new byte[0], 0));
+    }
+
+    public void testFindLastRecordBoundaryAllInsideQuotedField() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        // Buffer is entirely the inside of an unterminated quoted cell. There is no record
+        // boundary anywhere within it — the caller must grow the buffer to keep reading.
+        byte[] data = "\"line one\nline two\nline three\n".getBytes(StandardCharsets.UTF_8);
+        assertEquals(-1, reader.findLastRecordBoundary(data, data.length));
+    }
+
+    public void testFindLastRecordBoundarySkipsEmbeddedNewlineInQuotedField() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        // Two records: one with an embedded \n inside a quoted cell, one plain. The boundary
+        // returned must point at the \n that terminates the plain record (offset = full length - 1),
+        // NOT at any of the embedded \n bytes inside the quoted field.
+        byte[] data = "\"row1\nwith\nembedded\",a\nrow2,b\n".getBytes(StandardCharsets.UTF_8);
+        int boundary = reader.findLastRecordBoundary(data, data.length);
+        assertEquals(data.length - 1, boundary);
+    }
+
+    public void testFindLastRecordBoundaryEmbeddedNewlineFollowedByUnterminatedTail() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        // Production shape: a complete row, then a quoted field with an embedded \n whose closing
+        // quote is presumably in the next chunk. The boundary must point at the \n terminating the
+        // first record; the unterminated bytes must be carried over.
+        byte[] data = "row1,a\n\"row2 starts here\nstill inside quote".getBytes(StandardCharsets.UTF_8);
+        int boundary = reader.findLastRecordBoundary(data, data.length);
+        assertEquals("row1,a\n".length() - 1, boundary);
+    }
+
+    public void testFindLastRecordBoundaryRespectsBracketMvc() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        // Two records: one with embedded \n inside a [..] MVC cell, one plain. Bracket-aware path
+        // must not cut inside the bracket cell.
+        byte[] data = "a,[v1\nv2\nv3],b\nrow2,plain,c\n".getBytes(StandardCharsets.UTF_8);
+        int boundary = reader.findLastRecordBoundary(data, data.length);
+        assertEquals(data.length - 1, boundary);
+    }
+
+    public void testFindLastRecordBoundaryLengthSubsetOfBuffer() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        // Buffer has trailing garbage past `length` that must be ignored — the scan must respect length.
+        byte[] body = "a,b\nc,d\n".getBytes(StandardCharsets.UTF_8);
+        byte[] padded = new byte[body.length + 64];
+        System.arraycopy(body, 0, padded, 0, body.length);
+        Arrays.fill(padded, body.length, padded.length, (byte) 0xff);
+        int boundary = reader.findLastRecordBoundary(padded, body.length);
+        assertEquals(body.length - 1, boundary);
+    }
+
+    public void testFindLastRecordBoundaryCRLF() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        // A CRLF-terminated stream must report the offset of the trailing \n of the last record, not the \r.
+        // Mirrors testFindNextRecordBoundaryCRLF on the backward-scan side.
+        byte[] data = "a,b\r\nc,d\r\n".getBytes(StandardCharsets.UTF_8);
+        int boundary = reader.findLastRecordBoundary(data, data.length);
+        assertEquals(data.length - 1, boundary);
+        assertEquals('\n', data[boundary]);
+    }
+
+    public void testFindLastRecordBoundaryDoubledQuoteEscape() throws IOException {
+        CsvFormatReader reader = new CsvFormatReader(blockFactory);
+        // RFC 4180 doubled-quote escape inside a quoted field: each {@code ""} is a literal quote,
+        // not a close-then-reopen. A scan that flipped quote state on every {@code "} would
+        // prematurely exit the quoted region and report a boundary inside the field; verify the
+        // final \n is selected instead.
+        byte[] data = "\"value with \"\"escaped\"\" quotes\"\nrest\n".getBytes(StandardCharsets.UTF_8);
+        int boundary = reader.findLastRecordBoundary(data, data.length);
+        assertEquals(data.length - 1, boundary);
+        assertEquals('\n', data[boundary]);
+    }
+
     public void testBracketAwareLeadingWhitespaceBeforeBracketOpensMvc() throws IOException {
         String csv = "prefix:keyword,mid:keyword,suffix:keyword\nx,  [[37]],y\n";
         StorageObject object = createStorageObject(csv);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
@@ -245,7 +244,7 @@ public final class StreamingParallelParsingCoordinator {
                     int totalBytes = offset + Math.max(bytesRead, 0);
                     boolean isEof = bytesRead < 0 || totalBytes < buf.length;
 
-                    int lastNewline = findLastRecordBoundary(buf, totalBytes);
+                    int lastNewline = reader.findLastRecordBoundary(buf, totalBytes);
 
                     if (lastNewline < 0) {
                         if (isEof) {
@@ -485,43 +484,6 @@ public final class StreamingParallelParsingCoordinator {
             return totalRead;
         }
 
-        private static int findLastNewline(byte[] buf, int length) {
-            for (int i = length - 1; i >= 0; i--) {
-                if (buf[i] == '\n') {
-                    return i;
-                }
-            }
-            return -1;
-        }
-
-        /**
-         * Finds the last <em>record</em> boundary in {@code buf[0..length)}, which for formats
-         * with multi-line quoted fields (CSV) may differ from the last {@code \n}.
-         * <p>
-         * Scans forward through the buffer using {@link SegmentableFormatReader#findNextRecordBoundary}
-         * so that newlines inside quoted fields are correctly skipped. Returns the index of the last
-         * byte that belongs to a complete record (i.e. the position of the terminating {@code \n}),
-         * or {@code -1} if no record boundary exists in the buffer.
-         */
-        private int findLastRecordBoundary(byte[] buf, int length) throws IOException {
-            SegmentableFormatReader r = reader;
-            if (r == null) {
-                return findLastNewline(buf, length);
-            }
-            int lastBoundary = -1;
-            int pos = 0;
-            while (pos < length) {
-                long consumed = r.findNextRecordBoundary(new ByteArrayInputStream(buf, pos, length - pos));
-                if (consumed < 0) {
-                    break;
-                }
-                assert consumed <= Integer.MAX_VALUE : "consumed [" + consumed + "] exceeds int range";
-                pos += (int) consumed;
-                lastBoundary = pos - 1;
-            }
-            return lastBoundary;
-        }
-
         private static byte[] growUntilNewline(InputStream stream, byte[] existing, int existingLen, int growBy) throws IOException {
             byte[] grown = new byte[existingLen + growBy];
             System.arraycopy(existing, 0, grown, 0, existingLen);
@@ -551,19 +513,19 @@ public final class StreamingParallelParsingCoordinator {
 
         /**
          * Like {@link #growUntilNewline} but keeps growing until the accumulated buffer contains at
-         * least one <em>record</em> boundary (as determined by {@link #findLastRecordBoundary}).
+         * least one record boundary (as determined by {@link SegmentableFormatReader#findLastRecordBoundary}).
          * Multi-line quoted fields may contain {@code \n} bytes that are not record boundaries; this
          * method avoids splitting in the middle of such a field.
          * <p>
          * The inner loop uses {@link #growUntilNewline} (raw {@code \n} scan) intentionally: a
          * record boundary always coincides with a {@code \n}, so growing to the next raw
-         * {@code \n} is the minimum I/O needed before re-checking with the quote-aware
-         * {@link #findLastRecordBoundary}. For quoted fields with embedded {@code \n}, the
-         * raw scan stops too early and the boundary check returns {@code -1}, causing another
-         * growth iteration — correct, just not single-pass.
+         * {@code \n} is the minimum I/O needed before re-checking with the quote-aware SPI method.
+         * For quoted fields with embedded {@code \n}, the raw scan stops too early and the
+         * boundary check returns {@code -1}, causing another growth iteration — correct, just
+         * not single-pass.
          *
          * @return a {@link GrowResult} carrying both the grown buffer and the pre-computed boundary
-         *         index, so callers can avoid a redundant {@link #findLastRecordBoundary} rescan
+         *         index, so callers can avoid a redundant boundary rescan
          */
         private GrowResult growUntilRecordBoundary(InputStream stream, byte[] existing, int existingLen, int growBy) throws IOException {
             byte[] buf = existing;
@@ -573,7 +535,7 @@ public final class StreamingParallelParsingCoordinator {
                 if (grown.length == len) {
                     return new GrowResult(grown, -1);
                 }
-                int boundary = findLastRecordBoundary(grown, grown.length);
+                int boundary = reader.findLastRecordBoundary(grown, grown.length);
                 if (boundary >= 0) {
                     return new GrowResult(grown, boundary);
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SegmentableFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SegmentableFormatReader.java
@@ -62,4 +62,28 @@ public interface SegmentableFormatReader extends FormatReader {
     default long minimumSegmentSize() {
         return 1024 * 1024;
     }
+
+    /**
+     * Returns the offset of the byte that terminates the latest complete record within
+     * {@code buf[0..length)}, or {@code -1} if no complete record terminates inside the buffer.
+     * Used by streaming-parallel chunkers to slice on a record boundary; bytes after the offset
+     * are carried into the next chunk.
+     * <p>
+     * <b>Open-tail contract:</b> when the tail is mid-record (e.g. an unterminated quoted cell),
+     * implementations MUST return the offset of the last complete record that <em>precedes</em>
+     * the open region (or {@code -1} if none). Returning an offset inside the open region would
+     * dispatch a malformed chunk.
+     * <p>
+     * Default: backward scan for {@code \n} — correct for NDJSON and other line-oriented formats
+     * with no embedded newlines; O(1) when the buffer ends near a boundary. Formats with embedded
+     * newlines inside quoted fields (CSV/TSV) must override to track quote state.
+     */
+    default int findLastRecordBoundary(byte[] buf, int length) throws IOException {
+        for (int i = length - 1; i >= 0; i--) {
+            if (buf[i] == '\n') {
+                return i;
+            }
+        }
+        return -1;
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -815,6 +815,29 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             return -1;
         }
 
+        /**
+         * Quote-aware override: drives {@link #findNextRecordBoundary} forward through the buffer.
+         * Bypasses the SPI default (backward {@code \n} scan) because embedded {@code \n} bytes
+         * inside {@code "..."} must not be treated as record terminators.
+         */
+        @Override
+        public int findLastRecordBoundary(byte[] buf, int length) throws IOException {
+            if (length <= 0) {
+                return -1;
+            }
+            int lastBoundary = -1;
+            int cumulative = 0;
+            while (cumulative < length) {
+                long consumed = findNextRecordBoundary(new java.io.ByteArrayInputStream(buf, cumulative, length - cumulative));
+                if (consumed < 0) {
+                    return lastBoundary;
+                }
+                cumulative += Math.toIntExact(consumed);
+                lastBoundary = cumulative - 1;
+            }
+            return lastBoundary;
+        }
+
         @Override
         public long minimumSegmentSize() {
             return minSegment;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -828,7 +828,7 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             int lastBoundary = -1;
             int cumulative = 0;
             while (cumulative < length) {
-                long consumed = findNextRecordBoundary(new java.io.ByteArrayInputStream(buf, cumulative, length - cumulative));
+                long consumed = findNextRecordBoundary(new ByteArrayInputStream(buf, cumulative, length - cumulative));
                 if (consumed < 0) {
                     return lastBoundary;
                 }


### PR DESCRIPTION
## Summary

`StreamingParallelParsingCoordinator` slices the decompressed input stream into ~1 MiB chunks for parallel parsing, and uses `findLastRecordBoundary(byte[], int)` to choose a quote-aware chunk cut point. The merged fix in #148724 placed that method as a private member of `StreamingParallelIterator`, calling `findNextRecordBoundary` for every format including NDJSON. That forces NDJSON's chunker to do an O(N) forward walk allocating a `ByteArrayInputStream` per record, instead of the previous O(1) backward `\n` scan.

This PR lifts `findLastRecordBoundary` onto the `SegmentableFormatReader` SPI with a default backward-`\n` scan. `CsvFormatReader` overrides with the forward walk driving its existing quote-state machinery. NDJSON inherits the default and keeps its fast path; the coordinator becomes format-agnostic again.

Functionally equivalent to #148724 on the CSV side — same correctness, same bracket-MVC and embedded-newline handling. The difference is layering: the format-specific knowledge moves to the format reader, and formats that don't need it pay no cost.

## Change

- `SegmentableFormatReader.findLastRecordBoundary(byte[] buf, int length)` — new default method on the SPI. Default impl: backward scan for `\n`. Javadoc spells out the "open-tail contract": when the buffer ends mid-record, implementations must return the offset of the last complete record's terminator that precedes the open region (or `-1` if none).
- `CsvFormatReader.findLastRecordBoundary` — `@Override` that drives `findNextRecordBoundary` forward through fresh `ByteArrayInputStream` slices, reusing the existing quote-aware logic (`findNextRecordBoundaryQuotedFieldsOnly` and `findNextRecordBoundaryBracketCommaMvc`) rather than duplicating it.
- `StreamingParallelIterator` — calls `reader.findLastRecordBoundary(...)` instead of its own private method. The private `findLastNewline` and `findLastRecordBoundary` methods are deleted (the SPI's default is the same backward-`\n` scan).
- `growUntilRecordBoundary` — now calls `reader.findLastRecordBoundary(...)` for its boundary check.

## Test plan

- 10 isolated unit tests in `CsvFormatReaderTests` exercising the new SPI override directly at the byte-array level: simple two-record case, unterminated trailing record, empty buffer, all-inside-quoted (no boundary), embedded-newline-in-quote skipped, mixed plain + unterminated quoted tail, bracket MVC, length-subset of buffer, CRLF terminators, RFC 4180 doubled-quote escape.
- The existing end-to-end coordinator tests from #148724 (`testMultiLineQuotedFieldsAcrossChunkBoundaries`, `testGrowUntilRecordBoundaryForOversizedQuotedField`, `testLargeStreamWithInterspersedMultiLineRecords`, `testQuoteAwareReaderWithNoQuotedFieldsMatchesNaiveBehavior`) all pass with the test stub overriding `findLastRecordBoundary` to drive its quote-aware `findNextRecordBoundary`.
- NDJSON tests stay green — it inherits the default backward-`\n` scan, same behavior as before #148724.
