### PR TITLE
Add Error Coverage Tests for MatchPharse, KNN, TOP_SNIPPETS, CHUNK, and DECAY 

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
@@ -307,7 +307,6 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.VarianceErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.VarianceOverTimeErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.aggregate.WeightedAvgErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.fulltext.MatchPhraseErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.grouping.BucketErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.grouping.TBucketErrorTests is missing")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
@@ -331,7 +331,6 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.TopSnippetsErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.util.DelayErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.util.DelayTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.vector.KnnErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.vector.MagnitudeErrorTests is missing")
         );
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
@@ -328,7 +328,6 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.ChunkErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.ContainsErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.TopSnippetsErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.util.DelayErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.util.DelayTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.vector.MagnitudeErrorTests is missing")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
@@ -326,7 +326,6 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvUnionErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.nulls.CoalesceErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.ChunkErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.ContainsErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.util.DelayErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.util.DelayTests is missing")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
@@ -325,7 +325,6 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvSortErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvUnionErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.nulls.CoalesceErrorTests is missing")
-                .item("org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.string.ContainsErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.util.DelayErrorTests is missing")
                 .item("org.elasticsearch.xpack.esql.expression.function.scalar.util.DelayTests is missing")

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseErrorTests.java
@@ -53,7 +53,7 @@ public class MatchPhraseErrorTests extends ErrorsForCasesWithoutExamplesTestCase
     protected Expression build(Source source, List<Expression> args) {
         MatchPhrase matchPhrase = new MatchPhrase(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null);
         // We need to add the QueryBuilder to the match_phrase expression, as it is used to implement equals() and hashCode() and
-        // thus test the serialization methods. But we can only do this if the parameters make sense .
+        // thus test the serialization methods. But we can only do this if the parameters make sense.
         if (args.get(0) instanceof FieldAttribute && args.get(1).foldable()) {
             QueryBuilder queryBuilder = TRANSLATOR_HANDLER.asQuery(LucenePushdownPredicates.DEFAULT, matchPhrase).toQueryBuilder();
             matchPhrase = (MatchPhrase) matchPhrase.replaceQueryBuilder(queryBuilder);
@@ -86,7 +86,7 @@ public class MatchPhraseErrorTests extends ErrorsForCasesWithoutExamplesTestCase
                     + "] cannot be null, received []";
             }
             if (validDataTypeAtPosition(signature.get(i), i) == false) {
-                // Map expressions have different error messages
+                // Map expressions have different error messages.
                 if (i == 2) {
                     return format(null, "third argument of [{}] must be a map expression, received []", sourceForSignature(signature));
                 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhraseErrorTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.fulltext;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
+import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
+import org.hamcrest.Matcher;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
+import static org.elasticsearch.xpack.esql.expression.function.fulltext.SingleFieldFullTextFunction.expectedTypesAsString;
+import static org.elasticsearch.xpack.esql.planner.TranslatorHandler.TRANSLATOR_HANDLER;
+import static org.hamcrest.Matchers.equalTo;
+
+public class MatchPhraseErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
+
+    @Override
+    protected List<TestCaseSupplier> cases() {
+        return paramsToSuppliers(MatchPhraseTests.parameters());
+    }
+
+    @Override
+    protected Stream<List<DataType>> testCandidates(List<TestCaseSupplier> cases, Set<List<DataType>> valid) {
+        Set<List<DataType>> validWithAcceptedTypes = new HashSet<>(valid);
+        for (DataType fieldDataType : MatchPhrase.FIELD_DATA_TYPES) {
+            for (DataType queryDataType : MatchPhrase.QUERY_DATA_TYPES) {
+                validWithAcceptedTypes.add(List.of(fieldDataType, queryDataType));
+                validWithAcceptedTypes.add(List.of(fieldDataType, queryDataType, DataType.UNSUPPORTED));
+            }
+        }
+        return super.testCandidates(cases, validWithAcceptedTypes);
+    }
+
+    @Override
+    protected Expression build(Source source, List<Expression> args) {
+        MatchPhrase matchPhrase = new MatchPhrase(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null);
+        // We need to add the QueryBuilder to the match_phrase expression, as it is used to implement equals() and hashCode() and
+        // thus test the serialization methods. But we can only do this if the parameters make sense .
+        if (args.get(0) instanceof FieldAttribute && args.get(1).foldable()) {
+            QueryBuilder queryBuilder = TRANSLATOR_HANDLER.asQuery(LucenePushdownPredicates.DEFAULT, matchPhrase).toQueryBuilder();
+            matchPhrase = (MatchPhrase) matchPhrase.replaceQueryBuilder(queryBuilder);
+        }
+        return matchPhrase;
+    }
+
+    @Override
+    protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
+        return equalTo(
+            errorMessageStringForMatchPhrase(
+                validPerPosition,
+                signature,
+                (l, p) -> p == 0 ? expectedTypesAsString(MatchPhrase.FIELD_DATA_TYPES) : expectedTypesAsString(MatchPhrase.QUERY_DATA_TYPES)
+            )
+        );
+    }
+
+    private static String errorMessageStringForMatchPhrase(
+        List<Set<DataType>> validPerPosition,
+        List<DataType> signature,
+        AbstractFunctionTestCase.PositionalErrorMessageSupplier positionalErrorMessageSupplier
+    ) {
+        for (int i = 0; i < signature.size(); i++) {
+            // Need to check for nulls and bad parameters in order
+            if (signature.get(i) == DataType.NULL && i > 0) {
+                return TypeResolutions.ParamOrdinal.fromIndex(i).name().toLowerCase(Locale.ROOT)
+                    + " argument of ["
+                    + sourceForSignature(signature)
+                    + "] cannot be null, received []";
+            }
+            if (validDataTypeAtPosition(signature.get(i), i) == false) {
+                // Map expressions have different error messages
+                if (i == 2) {
+                    return format(null, "third argument of [{}] must be a map expression, received []", sourceForSignature(signature));
+                }
+                break;
+            }
+        }
+
+        return typeErrorMessage(true, validPerPosition, signature, positionalErrorMessageSupplier);
+    }
+
+    private static boolean validDataTypeAtPosition(DataType dataType, int position) {
+        return switch (position) {
+            case 0 -> MatchPhrase.FIELD_DATA_TYPES.contains(dataType);
+            case 1 -> MatchPhrase.QUERY_DATA_TYPES.contains(dataType);
+            case 2 -> dataType == DataType.UNSUPPORTED;
+            default -> false;
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayErrorTests.java
@@ -8,15 +8,15 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.score;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.MapExpression;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.hamcrest.Matcher;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -33,31 +33,34 @@ public class DecayErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Stream<List<DataType>> testCandidates(List<TestCaseSupplier> cases, Set<List<DataType>> valid) {
-        Set<List<DataType>> validWithAcceptedTypes = new HashSet<>(valid);
-        // The valid origin and scale types depend on the value type, so expand beyond the examples in DecayTests.
-        for (DataType valueDataType : DataType.types()) {
-            if (validValueType(valueDataType) == false) {
+        return Stream.concat(super.testCandidates(cases, valid), threeArgCandidates());
+    }
+
+    private static Stream<List<DataType>> threeArgCandidates() {
+        List<DataType> universe = AbstractFunctionTestCase.validFunctionParameters().toList();
+        List<List<DataType>> result = new ArrayList<>();
+        for (DataType value : universe) {
+            if (validValueType(value) == false) {
+                // Invalid value types are already covered by the 4-arity sweep.
                 continue;
             }
-            for (DataType originDataType : DataType.types()) {
-                if (validOriginType(valueDataType, originDataType) == false) {
-                    continue;
-                }
-                for (DataType scaleDataType : DataType.types()) {
-                    if (validScaleType(valueDataType, scaleDataType)) {
-                        validWithAcceptedTypes.add(List.of(valueDataType, originDataType, scaleDataType, DataType.SOURCE));
+            for (DataType origin : universe) {
+                for (DataType scale : universe) {
+                    // Only emit combinations that produce an origin- or scale-related error.
+                    if (validOriginType(value, origin) && validScaleType(value, scale)) {
+                        continue;
                     }
+                    result.add(List.of(value, origin, scale));
                 }
             }
         }
-        return super.testCandidates(cases, validWithAcceptedTypes);
+        // Mirror the framework's NULL de-duplication: at most one NULL per signature.
+        return result.stream().filter(sig -> sig.stream().filter(t -> t == DataType.NULL).count() <= 1);
     }
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        // DecayTests marks options as SOURCE, but Decay's resolver expects an actual MapExpression.
-        Expression options = args.get(3).dataType() == DataType.SOURCE ? new MapExpression(source, List.of()) : args.get(3);
-        return new Decay(source, args.get(0), args.get(1), args.get(2), options);
+        return new Decay(source, args.get(0), args.get(1), args.get(2), args.size() > 3 ? args.get(3) : null);
     }
 
     @Override
@@ -69,7 +72,7 @@ public class DecayErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
         DataType valueDataType = signature.get(0);
         DataType originDataType = signature.get(1);
         DataType scaleDataType = signature.get(2);
-        DataType optionsDataType = signature.get(3);
+        DataType optionsDataType = signature.size() > 3 ? signature.get(3) : null;
 
         if (valueDataType == DataType.NULL) {
             return nullTypeError(signature, 0);
@@ -79,10 +82,12 @@ public class DecayErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
         }
 
         // Options are resolved before origin/scale compatibility, so mirror that order here.
-        if (optionsDataType == DataType.NULL) {
-            return nullTypeError(signature, 3);
-        }
-        if (optionsDataType != DataType.SOURCE) {
+        if (optionsDataType != null) {
+            if (optionsDataType == DataType.NULL) {
+                return nullTypeError(signature, 3);
+            }
+            // No 4-arity candidate ever has DataType.SOURCE at position 3 (validFunctionParameters
+            // excludes it), so the only error reachable here is "must be a map expression".
             return "fourth argument of [" + sourceForSignature(signature) + "] must be a map expression, received []";
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/DecayErrorTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.score;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.MapExpression;
+import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.hamcrest.Matcher;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class DecayErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
+
+    @Override
+    protected List<TestCaseSupplier> cases() {
+        return paramsToSuppliers(DecayTests.parameters());
+    }
+
+    @Override
+    protected Stream<List<DataType>> testCandidates(List<TestCaseSupplier> cases, Set<List<DataType>> valid) {
+        Set<List<DataType>> validWithAcceptedTypes = new HashSet<>(valid);
+        // The valid origin and scale types depend on the value type, so expand beyond the examples in DecayTests.
+        for (DataType valueDataType : DataType.types()) {
+            if (validValueType(valueDataType) == false) {
+                continue;
+            }
+            for (DataType originDataType : DataType.types()) {
+                if (validOriginType(valueDataType, originDataType) == false) {
+                    continue;
+                }
+                for (DataType scaleDataType : DataType.types()) {
+                    if (validScaleType(valueDataType, scaleDataType)) {
+                        validWithAcceptedTypes.add(List.of(valueDataType, originDataType, scaleDataType, DataType.SOURCE));
+                    }
+                }
+            }
+        }
+        return super.testCandidates(cases, validWithAcceptedTypes);
+    }
+
+    @Override
+    protected Expression build(Source source, List<Expression> args) {
+        // DecayTests marks options as SOURCE, but Decay's resolver expects an actual MapExpression.
+        Expression options = args.get(3).dataType() == DataType.SOURCE ? new MapExpression(source, List.of()) : args.get(3);
+        return new Decay(source, args.get(0), args.get(1), args.get(2), options);
+    }
+
+    @Override
+    protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
+        return equalTo(errorMessageStringForDecay(signature));
+    }
+
+    private static String errorMessageStringForDecay(List<DataType> signature) {
+        DataType valueDataType = signature.get(0);
+        DataType originDataType = signature.get(1);
+        DataType scaleDataType = signature.get(2);
+        DataType optionsDataType = signature.get(3);
+
+        if (valueDataType == DataType.NULL) {
+            return nullTypeError(signature, 0);
+        }
+        if (validValueType(valueDataType) == false) {
+            return typeError(signature, 0, "numeric, date or spatial point");
+        }
+
+        // Options are resolved before origin/scale compatibility, so mirror that order here.
+        if (optionsDataType == DataType.NULL) {
+            return nullTypeError(signature, 3);
+        }
+        if (optionsDataType != DataType.SOURCE) {
+            return "fourth argument of [" + sourceForSignature(signature) + "] must be a map expression, received []";
+        }
+
+        if (originDataType == DataType.NULL) {
+            return nullTypeError(signature, 1);
+        }
+        if (validOriginType(valueDataType, originDataType) == false) {
+            return typeError(signature, 1, originTypeDescription(valueDataType));
+        }
+
+        if (scaleDataType == DataType.NULL) {
+            return nullTypeError(signature, 2);
+        }
+        if (validScaleType(valueDataType, scaleDataType) == false) {
+            return typeError(signature, 2, scaleTypeDescription(valueDataType));
+        }
+
+        throw new IllegalStateException(
+            "Can't generate error message for these types, you probably need a custom signature = " + signature
+        );
+    }
+
+    private static boolean validValueType(DataType dataType) {
+        return dataType.isNumeric() || dataType.isDate() || DataType.isSpatialPoint(dataType);
+    }
+
+    private static boolean validOriginType(DataType valueDataType, DataType originDataType) {
+        if (DataType.isSpatialPoint(valueDataType)) {
+            return DataType.isSpatialPoint(originDataType);
+        }
+        if (DataType.isMillisOrNanos(valueDataType)) {
+            return DataType.isMillisOrNanos(originDataType);
+        }
+        return originDataType.isNumeric();
+    }
+
+    private static boolean validScaleType(DataType valueDataType, DataType scaleDataType) {
+        if (DataType.isSpatialPoint(valueDataType)) {
+            return DataType.isGeoPoint(valueDataType) ? DataType.isString(scaleDataType) : scaleDataType.isNumeric();
+        }
+        if (DataType.isMillisOrNanos(valueDataType)) {
+            return DataType.isTimeDuration(scaleDataType);
+        }
+        return scaleDataType.isNumeric();
+    }
+
+    private static String originTypeDescription(DataType valueDataType) {
+        if (DataType.isSpatialPoint(valueDataType)) {
+            return "spatial point";
+        }
+        if (DataType.isMillisOrNanos(valueDataType)) {
+            return "datetime or date_nanos";
+        }
+        return "numeric";
+    }
+
+    private static String scaleTypeDescription(DataType valueDataType) {
+        if (DataType.isSpatialPoint(valueDataType)) {
+            return DataType.isGeoPoint(valueDataType) ? "keyword or text" : "numeric";
+        }
+        if (DataType.isMillisOrNanos(valueDataType)) {
+            return "time_duration";
+        }
+        return "numeric";
+    }
+
+    private static String nullTypeError(List<DataType> signature, int position) {
+        return ordinal(position) + "argument of [" + sourceForSignature(signature) + "] cannot be null, received []";
+    }
+
+    private static String typeError(List<DataType> signature, int position, String expectedTypeString) {
+        return ordinal(position)
+            + "argument of ["
+            + sourceForSignature(signature)
+            + "] must be ["
+            + expectedTypeString
+            + "], found value [] type ["
+            + signature.get(position).typeName()
+            + "]";
+    }
+
+    private static String ordinal(int position) {
+        return TypeResolutions.ParamOrdinal.fromIndex(position).name().toLowerCase(Locale.ROOT) + " ";
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ChunkErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ChunkErrorTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.hamcrest.Matcher;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ChunkErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
+
+    @Override
+    protected List<TestCaseSupplier> cases() {
+        return paramsToSuppliers(ChunkTests.parameters());
+    }
+
+    @Override
+    protected Stream<List<DataType>> testCandidates(List<TestCaseSupplier> cases, Set<List<DataType>> valid) {
+        Set<List<DataType>> validWithAcceptedTypes = new HashSet<>(valid);
+        validWithAcceptedTypes.add(List.of(DataType.NULL));
+        validWithAcceptedTypes.add(List.of(DataType.NULL, DataType.UNSUPPORTED));
+        for (DataType fieldDataType : DataType.stringTypes()) {
+            if (DataType.UNDER_CONSTRUCTION.contains(fieldDataType)) {
+                continue;
+            }
+            validWithAcceptedTypes.add(List.of(fieldDataType));
+            validWithAcceptedTypes.add(List.of(fieldDataType, DataType.UNSUPPORTED));
+        }
+        return super.testCandidates(cases, validWithAcceptedTypes);
+    }
+
+    @Override
+    protected Expression build(Source source, List<Expression> args) {
+        return new Chunk(source, args.get(0), args.size() > 1 ? args.get(1) : null);
+    }
+
+    @Override
+    protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
+        return equalTo(errorMessageStringForChunk(validPerPosition, signature));
+    }
+
+    private static String errorMessageStringForChunk(List<Set<DataType>> validPerPosition, List<DataType> signature) {
+        if (validDataTypeAtPosition(signature.get(0), 0) == false) {
+            return typeErrorMessage(true, validPerPosition, signature, (v, p) -> "string");
+        }
+        return "invalid chunking_settings, found []";
+    }
+
+    private static boolean validDataTypeAtPosition(DataType dataType, int position) {
+        return switch (position) {
+            case 0 -> DataType.isString(dataType) || dataType == DataType.NULL;
+            case 1 -> dataType == DataType.UNSUPPORTED;
+            default -> false;
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippetsErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippetsErrorTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.hamcrest.Matcher;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TopSnippetsErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
+
+    @Override
+    protected List<TestCaseSupplier> cases() {
+        return paramsToSuppliers(TopSnippetsTests.parameters());
+    }
+
+    @Override
+    protected Stream<List<DataType>> testCandidates(List<TestCaseSupplier> cases, Set<List<DataType>> valid) {
+        Set<List<DataType>> validWithAcceptedTypes = new HashSet<>(valid);
+        for (DataType fieldDataType : DataType.stringTypes()) {
+            if (DataType.UNDER_CONSTRUCTION.contains(fieldDataType)) {
+                continue;
+            }
+            for (DataType queryDataType : DataType.stringTypes()) {
+                if (DataType.UNDER_CONSTRUCTION.contains(queryDataType)) {
+                    continue;
+                }
+                validWithAcceptedTypes.add(List.of(fieldDataType, queryDataType));
+                validWithAcceptedTypes.add(List.of(fieldDataType, queryDataType, DataType.UNSUPPORTED));
+            }
+        }
+        return super.testCandidates(cases, validWithAcceptedTypes).filter(sig -> false == sig.contains(DataType.NULL));
+    }
+
+    @Override
+    protected Expression build(Source source, List<Expression> args) {
+        return new TopSnippets(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null);
+    }
+
+    @Override
+    protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
+        return equalTo(errorMessageStringForTopSnippets(validPerPosition, signature));
+    }
+
+    private static String errorMessageStringForTopSnippets(List<Set<DataType>> validPerPosition, List<DataType> signature) {
+        for (int i = 0; i < signature.size(); i++) {
+            if (validDataTypeAtPosition(signature.get(i), i) == false) {
+                // Map expressions have different error messages.
+                if (i == 2) {
+                    return format(null, "third argument of [{}] must be a map expression, received []", sourceForSignature(signature));
+                }
+                break;
+            }
+        }
+        return typeErrorMessage(true, validPerPosition, signature, (v, p) -> "string");
+    }
+
+    private static boolean validDataTypeAtPosition(DataType dataType, int position) {
+        return switch (position) {
+            case 0, 1 -> DataType.isString(dataType);
+            case 2 -> dataType == DataType.UNSUPPORTED;
+            default -> false;
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/KnnErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/KnnErrorTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.vector;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
+import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
+import static org.hamcrest.Matchers.equalTo;
+
+public class KnnErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
+
+    @Override
+    protected List<TestCaseSupplier> cases() {
+        return paramsToSuppliers(KnnTests.parameters());
+    }
+
+    @Override
+    protected Expression build(Source source, List<Expression> args) {
+        return new Knn(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null, null, null, List.of());
+    }
+
+    @Override
+    protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
+        return equalTo(
+            errorMessageStringForKnn(validPerPosition, signature, (l, p) -> p == 0 ? "dense_vector, null, text" : "dense_vector")
+        );
+    }
+
+    private static String errorMessageStringForKnn(
+        List<Set<DataType>> validPerPosition,
+        List<DataType> signature,
+        AbstractFunctionTestCase.PositionalErrorMessageSupplier positionalErrorMessageSupplier
+    ) {
+        for (int i = 0; i < signature.size(); i++) {
+            // Need to check for nulls and bad parameters in order
+            if (signature.get(i) == DataType.NULL && i > 0) {
+                return TypeResolutions.ParamOrdinal.fromIndex(i).name().toLowerCase(Locale.ROOT)
+                    + " argument of ["
+                    + sourceForSignature(signature)
+                    + "] cannot be null, received []";
+            }
+            if (validPerPosition.get(i).contains(signature.get(i)) == false) {
+                // Map expressions have different error messages
+                if (i == 2) {
+                    return format(null, "third argument of [{}] must be a map expression, received []", sourceForSignature(signature));
+                }
+                break;
+            }
+        }
+
+        return typeErrorMessage(true, validPerPosition, signature, positionalErrorMessageSupplier);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/KnnErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/KnnErrorTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.expression.function.vector;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
@@ -19,6 +18,8 @@ import org.hamcrest.Matcher;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.hamcrest.Matchers.equalTo;
@@ -31,15 +32,19 @@ public class KnnErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
     }
 
     @Override
+    protected Stream<List<DataType>> testCandidates(List<TestCaseSupplier> cases, Set<List<DataType>> valid) {
+        // Don't test null, as it is not allowed but the expected message is not a type error - so we check it separately in VerifierTests
+        return super.testCandidates(cases, valid).filter(sig -> false == sig.contains(DataType.NULL));
+    }
+
+    @Override
     protected Expression build(Source source, List<Expression> args) {
         return new Knn(source, args.get(0), args.get(1), args.size() > 2 ? args.get(2) : null, null, null, List.of());
     }
 
     @Override
     protected Matcher<String> expectedTypeErrorMatcher(List<Set<DataType>> validPerPosition, List<DataType> signature) {
-        return equalTo(
-            errorMessageStringForKnn(validPerPosition, signature, (l, p) -> p == 0 ? "dense_vector, null, text" : "dense_vector")
-        );
+        return equalTo(errorMessageStringForKnn(validPerPosition, signature, (types, position) -> expectedTypesAsString(types)));
     }
 
     private static String errorMessageStringForKnn(
@@ -48,15 +53,8 @@ public class KnnErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
         AbstractFunctionTestCase.PositionalErrorMessageSupplier positionalErrorMessageSupplier
     ) {
         for (int i = 0; i < signature.size(); i++) {
-            // Need to check for nulls and bad parameters in order
-            if (signature.get(i) == DataType.NULL && i > 0) {
-                return TypeResolutions.ParamOrdinal.fromIndex(i).name().toLowerCase(Locale.ROOT)
-                    + " argument of ["
-                    + sourceForSignature(signature)
-                    + "] cannot be null, received []";
-            }
             if (validPerPosition.get(i).contains(signature.get(i)) == false) {
-                // Map expressions have different error messages
+                // Map expressions have different error messages.
                 if (i == 2) {
                     return format(null, "third argument of [{}] must be a map expression, received []", sourceForSignature(signature));
                 }
@@ -65,5 +63,13 @@ public class KnnErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
         }
 
         return typeErrorMessage(true, validPerPosition, signature, positionalErrorMessageSupplier);
+    }
+
+    /**
+     * Format a set of accepted types the same way Knn's resolver does
+     * (see {@code SingleFieldFullTextFunction#expectedTypesAsString}): lowercase, sorted, comma-separated.
+     */
+    private static String expectedTypesAsString(Set<DataType> dataTypes) {
+        return dataTypes.stream().map(t -> t.name().toLowerCase(Locale.ROOT)).sorted().collect(Collectors.joining(", "));
     }
 }


### PR DESCRIPTION
## Related Issues
Closes #147961

## Summary

- Add error coverage for `MatchPharse`, `KNN`, `TOP_SNIPPETS`, `CHUNK`, and `DECAY` ES|QL functions.
- Remove the newly covered error test classes from `EsqlFunctionRegistryTests` expected-missing list.
