### PR TITLE
Fix file handle leak in Lucene90CompoundEntriesReaderTests on Windows (part2)

### DIFF
--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/Lucene90CompoundEntriesReaderTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/Lucene90CompoundEntriesReaderTests.java
@@ -46,10 +46,10 @@ public class Lucene90CompoundEntriesReaderTests extends ESTestCase {
             try (var compoundReader = si.getCodec().compoundFormat().getCompoundReader(directory, si)) {
                 actualSegmentEntries = Set.of(compoundReader.listAll());
             }
-            var parsedSegmentEntries = prependSegmentName(
-                si.name,
-                Lucene90CompoundEntriesReader.readEntries(directory.openInput(si.name + ".cfe", IOContext.DEFAULT)).keySet()
-            );
+            Set<String> parsedSegmentEntries;
+            try (var cfeInput = directory.openInput(si.name + ".cfe", IOContext.DEFAULT)) {
+                parsedSegmentEntries = prependSegmentName(si.name, Lucene90CompoundEntriesReader.readEntries(cfeInput).keySet());
+            }
 
             assertThat(parsedSegmentEntries, equalTo(actualSegmentEntries));
         }


### PR DESCRIPTION
This fix partially addressed issue https://github.com/elastic/elasticsearch/pull/148316.
But there are more files to close.

Closes https://github.com/elastic/elasticsearch/issues/147958