### PR TITLE
ES|QL Preserve Ordinal blocks through filter()

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -28,6 +28,8 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -668,6 +670,42 @@ final class ParquetPushedExpressions {
      * and the multi-stage single-expression path).
      */
     WordMask evaluateFilter(
+        Map<String, Block> predicateBlocks,
+        int rowCount,
+        WordMask reusable,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
+        // The dictionary fast paths in evaluateExpression walk getDictionaryVector() directly.
+        // OrdinalBytesRefBlocks produced by filter()/slice()/keepMask() share the source dictionary
+        // and may carry phantom entries (not referenced by any ord); compact those once up front so
+        // the per-expression evaluators stay phantom-agnostic. The Parquet column reader produces
+        // blocks with needsCompaction()==false today, so this loop is a no-op on the hot path.
+        // dictCache is bypassed whenever we compact: a given Expression's match bitmap is indexed by
+        // dict ord, and per-batch compaction in the same row group can produce different ord layouts.
+        Map<String, Block> effectiveBlocks = predicateBlocks;
+        List<Releasable> toClose = null;
+        for (Map.Entry<String, Block> entry : predicateBlocks.entrySet()) {
+            if (entry.getValue() instanceof OrdinalBytesRefBlock obb && obb.needsCompaction()) {
+                if (toClose == null) {
+                    effectiveBlocks = new HashMap<>(predicateBlocks);
+                    toClose = new ArrayList<>(2);
+                }
+                OrdinalBytesRefBlock compacted = obb.compact();
+                effectiveBlocks.put(entry.getKey(), compacted);
+                toClose.add(compacted);
+            }
+        }
+        Map<Expression, boolean[]> effectiveCache = toClose == null ? dictCache : null;
+        try {
+            return doEvaluateFilter(effectiveBlocks, rowCount, reusable, effectiveCache);
+        } finally {
+            if (toClose != null) {
+                Releasables.close(toClose);
+            }
+        }
+    }
+
+    private WordMask doEvaluateFilter(
         Map<String, Block> predicateBlocks,
         int rowCount,
         WordMask reusable,

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -28,7 +28,6 @@ import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeBytesRef;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeInt;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.swisshash.BytesRefSwissHash;
-import java.util.Arrays;
 // end generated imports
 
 /**
@@ -174,25 +173,44 @@ final class BytesRefBlockHash extends BlockHash {
     }
 
     /**
-     * Sentinel for "this dictionary ord has not yet been hashed into the global hash on this page".
-     * Stored in the per-page {@code localToGlobal} array; replaced with the real group id (always
-     * non-negative because of {@link BlockHash#hashOrdToGroupNullReserved}) on first touch.
-     */
-    private static final int UNSEEN = -1;
-
-    /**
      * Lazily hashes the dictionary entry at {@code ord} into the global hash on first visit and
      * returns the cached group id thereafter. Dictionary entries that no rows reference are never
      * looked up, so phantom entries left over by {@code filter()}/{@code slice()}/{@code keepMask()}
      * (which share the dictionary across the filtered block) are not promoted to groups.
+     * <p>
+     * The cache stores {@code groupId + 1} so that the zero-initialized {@code int[]} doubles as
+     * the "unseen" sentinel without an explicit {@link java.util.Arrays#fill} pass — group ids are
+     * always {@code >= 0} because of {@link BlockHash#hashOrdToGroupNullReserved}.
      */
     private int groupForOrd(int ord, BytesRefVector dict, int[] localToGlobal, BytesRef scratch) {
         int g = localToGlobal[ord];
-        if (g == UNSEEN) {
-            g = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch))));
+        if (g == 0) {
+            g = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch)))) + 1;
             localToGlobal[ord] = g;
         }
-        return g;
+        return g - 1;
+    }
+
+    /**
+     * Eager counterpart of {@link #groupForOrd}: hashes every dictionary entry up front into a
+     * primitive {@code int[]} indexed by ord. Used on the no-phantoms path so the per-row inner
+     * loop is a single primitive array access instead of a virtual call into an {@link IntVector}.
+     * <p>
+     * Routes the prefill through {@link #add(BytesRefVector)} so the {@link BytesRefSwissHash}
+     * prefetch path (batched bucket prefetching) still applies — that's where most of this
+     * method's time goes for high-cardinality dictionaries; profiling showed dropping it cost
+     * ~20-30% on URL-grouping workloads. We then copy into a primitive {@code int[]} so the
+     * per-row inner loop avoids the {@code IntVector.getInt} virtual call.
+     */
+    private int[] eagerDictGroupIds(BytesRefVector dict) {
+        int dictSize = dict.getPositionCount();
+        int[] cache = new int[dictSize];
+        try (var hashOrds = add(dict)) {
+            for (int o = 0; o < dictSize; o++) {
+                cache[o] = hashOrds.getInt(o);
+            }
+        }
+        return cache;
     }
 
     private IntVector addOrdinalsVector(OrdinalBytesRefVector inputBlock) {
@@ -204,18 +222,26 @@ final class BytesRefBlockHash extends BlockHash {
             int groupId = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch))));
             return blockFactory.newConstantIntVector(groupId, inputOrds.getPositionCount());
         }
-        // The lazy path costs a measurable branch+load per row on dense Parquet pages where every dict
-        // entry is referenced; only take it when phantoms are actually
-        // possible (filter()/slice()/keepMask() flagged the block as needing compaction).
+        // The lazy path costs an extra zero-check + subtraction per row on dense Parquet pages where
+        // every dict entry is referenced; only take it when phantoms are actually possible
+        // (filter()/slice()/keepMask() flagged the block as needing compaction).
         return inputBlock.needsCompaction() ? addOrdinalsVectorLazy(inputOrds, dict) : addOrdinalsVectorEager(inputOrds, dict);
     }
 
     private IntVector addOrdinalsVectorEager(IntVector inputOrds, BytesRefVector dict) {
-        try (var hashOrds = add(dict); var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
-            for (int p = 0; p < inputOrds.getPositionCount(); p++) {
-                builder.appendInt(hashOrds.getInt(inputOrds.getInt(p)));
+        long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
+        try {
+            int[] dictGroupIds = eagerDictGroupIds(dict);
+            int positions = inputOrds.getPositionCount();
+            try (var builder = blockFactory.newIntVectorFixedBuilder(positions)) {
+                for (int p = 0; p < positions; p++) {
+                    builder.appendInt(dictGroupIds[inputOrds.getInt(p)]);
+                }
+                return builder.build();
             }
-            return builder.build();
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
     }
 
@@ -225,9 +251,9 @@ final class BytesRefBlockHash extends BlockHash {
         blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
         try {
             int[] localToGlobal = new int[dict.getPositionCount()];
-            Arrays.fill(localToGlobal, UNSEEN);
-            try (var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
-                for (int p = 0; p < inputOrds.getPositionCount(); p++) {
+            int positions = inputOrds.getPositionCount();
+            try (var builder = blockFactory.newIntVectorFixedBuilder(positions)) {
+                for (int p = 0; p < positions; p++) {
                     builder.appendInt(groupForOrd(inputOrds.getInt(p), dict, localToGlobal, scratch));
                 }
                 return builder.build();
@@ -244,31 +270,37 @@ final class BytesRefBlockHash extends BlockHash {
 
     private IntBlock addOrdinalsBlockEager(OrdinalBytesRefBlock inputBlock) {
         BytesRefVector dict = inputBlock.getDictionaryVector();
-        try (
-            IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);
-            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount());
-            IntVector hashOrds = add(dict)
-        ) {
-            for (int p = 0; p < inputOrds.getPositionCount(); p++) {
-                int valueCount = inputOrds.getValueCount(p);
-                int firstIndex = inputOrds.getFirstValueIndex(p);
-                switch (valueCount) {
-                    case 0 -> {
-                        builder.appendInt(0);
-                        seenNull = true;
-                    }
-                    case 1 -> builder.appendInt(hashOrds.getInt(inputOrds.getInt(firstIndex)));
-                    default -> {
-                        int end = firstIndex + valueCount;
-                        builder.beginPositionEntry();
-                        for (int i = firstIndex; i < end; i++) {
-                            builder.appendInt(hashOrds.getInt(inputOrds.getInt(i)));
+        long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
+        try {
+            int[] dictGroupIds = eagerDictGroupIds(dict);
+            try (
+                IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);
+                IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount())
+            ) {
+                for (int p = 0; p < inputOrds.getPositionCount(); p++) {
+                    int valueCount = inputOrds.getValueCount(p);
+                    int firstIndex = inputOrds.getFirstValueIndex(p);
+                    switch (valueCount) {
+                        case 0 -> {
+                            builder.appendInt(0);
+                            seenNull = true;
                         }
-                        builder.endPositionEntry();
+                        case 1 -> builder.appendInt(dictGroupIds[inputOrds.getInt(firstIndex)]);
+                        default -> {
+                            int end = firstIndex + valueCount;
+                            builder.beginPositionEntry();
+                            for (int i = firstIndex; i < end; i++) {
+                                builder.appendInt(dictGroupIds[inputOrds.getInt(i)]);
+                            }
+                            builder.endPositionEntry();
+                        }
                     }
                 }
+                return builder.build();
             }
-            return builder.build();
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
     }
 
@@ -278,7 +310,6 @@ final class BytesRefBlockHash extends BlockHash {
         blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
         try {
             int[] localToGlobal = new int[dict.getPositionCount()];
-            Arrays.fill(localToGlobal, UNSEEN);
             BytesRef scratch = new BytesRef();
             try (
                 IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -198,30 +198,56 @@ final class BytesRefBlockHash extends BlockHash {
     private IntVector addOrdinalsVector(OrdinalBytesRefVector inputBlock) {
         IntVector inputOrds = inputBlock.getOrdinalsVector();
         BytesRefVector dict = inputBlock.getDictionaryVector();
-        BytesRef scratch = new BytesRef();
         if (inputOrds.isConstant()) {
+            BytesRef scratch = new BytesRef();
             int ord = inputOrds.getInt(0);
             int groupId = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch))));
             return blockFactory.newConstantIntVector(groupId, inputOrds.getPositionCount());
         }
-        int[] localToGlobal = new int[dict.getPositionCount()];
-        Arrays.fill(localToGlobal, UNSEEN);
-        try (var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
+        // The lazy path costs a measurable branch+load per row on dense Parquet pages where every dict
+        // entry is referenced; only take it when phantoms are actually
+        // possible (filter()/slice()/keepMask() flagged the block as needing compaction).
+        return inputBlock.needsCompaction() ? addOrdinalsVectorLazy(inputOrds, dict) : addOrdinalsVectorEager(inputOrds, dict);
+    }
+
+    private IntVector addOrdinalsVectorEager(IntVector inputOrds, BytesRefVector dict) {
+        try (var hashOrds = add(dict); var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
             for (int p = 0; p < inputOrds.getPositionCount(); p++) {
-                builder.appendInt(groupForOrd(inputOrds.getInt(p), dict, localToGlobal, scratch));
+                builder.appendInt(hashOrds.getInt(inputOrds.getInt(p)));
             }
             return builder.build();
         }
     }
 
-    private IntBlock addOrdinalsBlock(OrdinalBytesRefBlock inputBlock) {
-        BytesRefVector dict = inputBlock.getDictionaryVector();
-        int[] localToGlobal = new int[dict.getPositionCount()];
-        Arrays.fill(localToGlobal, UNSEEN);
+    private IntVector addOrdinalsVectorLazy(IntVector inputOrds, BytesRefVector dict) {
         BytesRef scratch = new BytesRef();
+        long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
+        try {
+            int[] localToGlobal = new int[dict.getPositionCount()];
+            Arrays.fill(localToGlobal, UNSEEN);
+            try (var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
+                for (int p = 0; p < inputOrds.getPositionCount(); p++) {
+                    builder.appendInt(groupForOrd(inputOrds.getInt(p), dict, localToGlobal, scratch));
+                }
+                return builder.build();
+            }
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
+        }
+    }
+
+    private IntBlock addOrdinalsBlock(OrdinalBytesRefBlock inputBlock) {
+        // See addOrdinalsVector for the rationale behind this split.
+        return inputBlock.needsCompaction() ? addOrdinalsBlockLazy(inputBlock) : addOrdinalsBlockEager(inputBlock);
+    }
+
+    private IntBlock addOrdinalsBlockEager(OrdinalBytesRefBlock inputBlock) {
+        BytesRefVector dict = inputBlock.getDictionaryVector();
         try (
             IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);
-            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount())
+            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount());
+            IntVector hashOrds = add(dict)
         ) {
             for (int p = 0; p < inputOrds.getPositionCount(); p++) {
                 int valueCount = inputOrds.getValueCount(p);
@@ -231,18 +257,56 @@ final class BytesRefBlockHash extends BlockHash {
                         builder.appendInt(0);
                         seenNull = true;
                     }
-                    case 1 -> builder.appendInt(groupForOrd(inputOrds.getInt(firstIndex), dict, localToGlobal, scratch));
+                    case 1 -> builder.appendInt(hashOrds.getInt(inputOrds.getInt(firstIndex)));
                     default -> {
                         int end = firstIndex + valueCount;
                         builder.beginPositionEntry();
                         for (int i = firstIndex; i < end; i++) {
-                            builder.appendInt(groupForOrd(inputOrds.getInt(i), dict, localToGlobal, scratch));
+                            builder.appendInt(hashOrds.getInt(inputOrds.getInt(i)));
                         }
                         builder.endPositionEntry();
                     }
                 }
             }
             return builder.build();
+        }
+    }
+
+    private IntBlock addOrdinalsBlockLazy(OrdinalBytesRefBlock inputBlock) {
+        BytesRefVector dict = inputBlock.getDictionaryVector();
+        long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
+        try {
+            int[] localToGlobal = new int[dict.getPositionCount()];
+            Arrays.fill(localToGlobal, UNSEEN);
+            BytesRef scratch = new BytesRef();
+            try (
+                IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);
+                IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount())
+            ) {
+                for (int p = 0; p < inputOrds.getPositionCount(); p++) {
+                    int valueCount = inputOrds.getValueCount(p);
+                    int firstIndex = inputOrds.getFirstValueIndex(p);
+                    switch (valueCount) {
+                        case 0 -> {
+                            builder.appendInt(0);
+                            seenNull = true;
+                        }
+                        case 1 -> builder.appendInt(groupForOrd(inputOrds.getInt(firstIndex), dict, localToGlobal, scratch));
+                        default -> {
+                            int end = firstIndex + valueCount;
+                            builder.beginPositionEntry();
+                            for (int i = firstIndex; i < end; i++) {
+                                builder.appendInt(groupForOrd(inputOrds.getInt(i), dict, localToGlobal, scratch));
+                            }
+                            builder.endPositionEntry();
+                        }
+                    }
+                }
+                return builder.build();
+            }
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -16,12 +16,6 @@ import org.elasticsearch.common.util.BytesRefHashTable;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.BytesRefVector;
-import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
@@ -34,7 +28,7 @@ import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeBytesRef;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeInt;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.swisshash.BytesRefSwissHash;
-import java.util.BitSet;
+import java.util.Arrays;
 // end generated imports
 
 /**
@@ -179,28 +173,55 @@ final class BytesRefBlockHash extends BlockHash {
         return ReleasableIterator.single(lookup(vector));
     }
 
+    /**
+     * Sentinel for "this dictionary ord has not yet been hashed into the global hash on this page".
+     * Stored in the per-page {@code localToGlobal} array; replaced with the real group id (always
+     * non-negative because of {@link BlockHash#hashOrdToGroupNullReserved}) on first touch.
+     */
+    private static final int UNSEEN = -1;
+
+    /**
+     * Lazily hashes the dictionary entry at {@code ord} into the global hash on first visit and
+     * returns the cached group id thereafter. Dictionary entries that no rows reference are never
+     * looked up, so phantom entries left over by {@code filter()}/{@code slice()}/{@code keepMask()}
+     * (which share the dictionary across the filtered block) are not promoted to groups.
+     */
+    private int groupForOrd(int ord, BytesRefVector dict, int[] localToGlobal, BytesRef scratch) {
+        int g = localToGlobal[ord];
+        if (g == UNSEEN) {
+            g = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch))));
+            localToGlobal[ord] = g;
+        }
+        return g;
+    }
+
     private IntVector addOrdinalsVector(OrdinalBytesRefVector inputBlock) {
         IntVector inputOrds = inputBlock.getOrdinalsVector();
-        try (var hashOrds = add(inputBlock.getDictionaryVector())) {
-            if (inputOrds.isConstant()) {
-                int ord = hashOrds.getInt(inputOrds.getInt(0));
-                return blockFactory.newConstantIntVector(ord, inputOrds.getPositionCount());
+        BytesRefVector dict = inputBlock.getDictionaryVector();
+        BytesRef scratch = new BytesRef();
+        if (inputOrds.isConstant()) {
+            int ord = inputOrds.getInt(0);
+            int groupId = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch))));
+            return blockFactory.newConstantIntVector(groupId, inputOrds.getPositionCount());
+        }
+        int[] localToGlobal = new int[dict.getPositionCount()];
+        Arrays.fill(localToGlobal, UNSEEN);
+        try (var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
+            for (int p = 0; p < inputOrds.getPositionCount(); p++) {
+                builder.appendInt(groupForOrd(inputOrds.getInt(p), dict, localToGlobal, scratch));
             }
-            try (var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
-                for (int p = 0; p < inputOrds.getPositionCount(); p++) {
-                    int ord = hashOrds.getInt(inputOrds.getInt(p));
-                    builder.appendInt(ord);
-                }
-                return builder.build();
-            }
+            return builder.build();
         }
     }
 
     private IntBlock addOrdinalsBlock(OrdinalBytesRefBlock inputBlock) {
+        BytesRefVector dict = inputBlock.getDictionaryVector();
+        int[] localToGlobal = new int[dict.getPositionCount()];
+        Arrays.fill(localToGlobal, UNSEEN);
+        BytesRef scratch = new BytesRef();
         try (
             IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);
-            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount());
-            IntVector hashOrds = add(inputBlock.getDictionaryVector())
+            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount())
         ) {
             for (int p = 0; p < inputOrds.getPositionCount(); p++) {
                 int valueCount = inputOrds.getValueCount(p);
@@ -210,17 +231,12 @@ final class BytesRefBlockHash extends BlockHash {
                         builder.appendInt(0);
                         seenNull = true;
                     }
-                    case 1 -> {
-                        int ord = hashOrds.getInt(inputOrds.getInt(firstIndex));
-                        builder.appendInt(ord);
-                    }
+                    case 1 -> builder.appendInt(groupForOrd(inputOrds.getInt(firstIndex), dict, localToGlobal, scratch));
                     default -> {
-                        int start = firstIndex;
                         int end = firstIndex + valueCount;
                         builder.beginPositionEntry();
-                        for (int i = start; i < end; i++) {
-                            int ord = hashOrds.getInt(inputOrds.getInt(i));
-                            builder.appendInt(ord);
+                        for (int i = firstIndex; i < end; i++) {
+                            builder.appendInt(groupForOrd(inputOrds.getInt(i), dict, localToGlobal, scratch));
                         }
                         builder.endPositionEntry();
                     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation.blockhash;
 
 // begin generated imports
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
@@ -16,24 +15,14 @@ import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.BytesRefVector;
-import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
-import org.elasticsearch.compute.data.OrdinalBytesRefVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupe;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeDouble;
-import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeInt;
 import org.elasticsearch.core.ReleasableIterator;
-import java.util.BitSet;
 // end generated imports
 
 /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation.blockhash;
 
 // begin generated imports
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
@@ -16,24 +15,12 @@ import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.BytesRefVector;
-import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.DoubleVector;
-import org.elasticsearch.compute.data.IntBlock;
-import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
-import org.elasticsearch.compute.data.OrdinalBytesRefVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupe;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeInt;
-import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeInt;
 import org.elasticsearch.core.ReleasableIterator;
-import java.util.BitSet;
 // end generated imports
 
 /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.aggregation.blockhash;
 
 // begin generated imports
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
@@ -16,24 +15,14 @@ import org.elasticsearch.common.util.LongHashTable;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.BytesRefVector;
-import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
-import org.elasticsearch.compute.data.OrdinalBytesRefVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupe;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeLong;
-import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeInt;
 import org.elasticsearch.core.ReleasableIterator;
-import java.util.BitSet;
 // end generated imports
 
 /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregators.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregators.java
@@ -16,9 +16,12 @@ import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
-import org.elasticsearch.core.Releasables;
+
+import java.util.Arrays;
 
 final class ValuesBytesRefAggregators {
+    private static final int UNSEEN = -1;
+
     static GroupingAggregatorFunction.AddInput wrapAddInput(
         GroupingAggregatorFunction.AddInput delegate,
         ValuesBytesRefAggregator.GroupingState state,
@@ -28,7 +31,11 @@ final class ValuesBytesRefAggregators {
         if (valuesOrdinal == null) {
             return delegate;
         }
-        final IntVector hashIds = hashDict(state, valuesOrdinal.getDictionaryVector());
+        final BytesRefVector dict = valuesOrdinal.getDictionaryVector();
+        // Lazy ord-to-hashId cache. Phantom dictionary entries (left over from filter()/slice()/keepMask())
+        // are never visited because no row references them, so they never enter state.bytes.
+        final int[] hashIds = newLazyHashIds(dict.getPositionCount());
+        final BytesRef scratch = new BytesRef();
         IntBlock ordinalIds = valuesOrdinal.getOrdinalsBlock();
         return new GroupingAggregatorFunction.AddInput() {
             @Override
@@ -47,7 +54,7 @@ final class ValuesBytesRefAggregators {
                         int valuesStart = ordinalIds.getFirstValueIndex(groupPosition + positionOffset);
                         int valuesEnd = valuesStart + ordinalIds.getValueCount(groupPosition + positionOffset);
                         for (int v = valuesStart; v < valuesEnd; v++) {
-                            state.addValueOrdinal(groupId, hashIds.getInt(ordinalIds.getInt(v)));
+                            state.addValueOrdinal(groupId, lazyHashId(ordinalIds.getInt(v), dict, hashIds, scratch, state));
                         }
                     }
                 }
@@ -69,7 +76,7 @@ final class ValuesBytesRefAggregators {
                         int valuesStart = ordinalIds.getFirstValueIndex(groupPosition + positionOffset);
                         int valuesEnd = valuesStart + ordinalIds.getValueCount(groupPosition + positionOffset);
                         for (int v = valuesStart; v < valuesEnd; v++) {
-                            state.addValueOrdinal(groupId, hashIds.getInt(ordinalIds.getInt(v)));
+                            state.addValueOrdinal(groupId, lazyHashId(ordinalIds.getInt(v), dict, hashIds, scratch, state));
                         }
                     }
                 }
@@ -77,12 +84,12 @@ final class ValuesBytesRefAggregators {
 
             @Override
             public void add(int positionOffset, IntVector groupIds) {
-                addOrdinalInputBlock(state, positionOffset, groupIds, ordinalIds, hashIds);
+                addOrdinalInputBlock(state, positionOffset, groupIds, ordinalIds, dict, hashIds, scratch);
             }
 
             @Override
             public void close() {
-                Releasables.close(hashIds, delegate);
+                delegate.close();
             }
         };
     }
@@ -96,7 +103,9 @@ final class ValuesBytesRefAggregators {
         if (valuesOrdinal == null) {
             return delegate;
         }
-        final IntVector hashIds = hashDict(state, valuesOrdinal.getDictionaryVector());
+        final BytesRefVector dict = valuesOrdinal.getDictionaryVector();
+        final int[] hashIds = newLazyHashIds(dict.getPositionCount());
+        final BytesRef scratch = new BytesRef();
         var ordinalIds = valuesOrdinal.getOrdinalsVector();
         return new GroupingAggregatorFunction.AddInput() {
             @Override
@@ -109,7 +118,8 @@ final class ValuesBytesRefAggregators {
                     int groupEnd = groupStart + groupIds.getValueCount(groupPosition);
                     for (int g = groupStart; g < groupEnd; g++) {
                         int groupId = groupIds.getInt(g);
-                        state.addValueOrdinal(groupId, hashIds.getInt(ordinalIds.getInt(groupPosition + positionOffset)));
+                        int ord = ordinalIds.getInt(groupPosition + positionOffset);
+                        state.addValueOrdinal(groupId, lazyHashId(ord, dict, hashIds, scratch, state));
                     }
                 }
             }
@@ -124,32 +134,42 @@ final class ValuesBytesRefAggregators {
                     int groupEnd = groupStart + groupIds.getValueCount(groupPosition);
                     for (int g = groupStart; g < groupEnd; g++) {
                         int groupId = groupIds.getInt(g);
-                        state.addValueOrdinal(groupId, hashIds.getInt(ordinalIds.getInt(groupPosition + positionOffset)));
+                        int ord = ordinalIds.getInt(groupPosition + positionOffset);
+                        state.addValueOrdinal(groupId, lazyHashId(ord, dict, hashIds, scratch, state));
                     }
                 }
             }
 
             @Override
             public void add(int positionOffset, IntVector groupIds) {
-                addOrdinalInputVector(state, positionOffset, groupIds, ordinalIds, hashIds);
+                addOrdinalInputVector(state, positionOffset, groupIds, ordinalIds, dict, hashIds, scratch);
             }
 
             @Override
             public void close() {
-                Releasables.close(hashIds, delegate);
+                delegate.close();
             }
         };
     }
 
-    static IntVector hashDict(ValuesBytesRefAggregator.GroupingState state, BytesRefVector dict) {
-        BytesRef scratch = new BytesRef();
-        try (var hashIdsBuilder = dict.blockFactory().newIntVectorFixedBuilder(dict.getPositionCount())) {
-            for (int p = 0; p < dict.getPositionCount(); p++) {
-                final long hashId = BlockHash.hashOrdToGroup(state.bytes.add(dict.getBytesRef(p, scratch)));
-                hashIdsBuilder.appendInt(Math.toIntExact(hashId));
-            }
-            return hashIdsBuilder.build();
+    /**
+     * Returns a per-page lazy ord-to-hashId cache, sized by the dictionary and pre-filled with
+     * {@link #UNSEEN}. Entries are populated by {@link #lazyHashId} on first reference, so phantom
+     * dictionary entries that no row touches never enter {@code state.bytes}.
+     */
+    static int[] newLazyHashIds(int dictSize) {
+        int[] cache = new int[dictSize];
+        Arrays.fill(cache, UNSEEN);
+        return cache;
+    }
+
+    static int lazyHashId(int ord, BytesRefVector dict, int[] cache, BytesRef scratch, ValuesBytesRefAggregator.GroupingState state) {
+        int v = cache[ord];
+        if (v == UNSEEN) {
+            v = Math.toIntExact(BlockHash.hashOrdToGroup(state.bytes.add(dict.getBytesRef(ord, scratch))));
+            cache[ord] = v;
         }
+        return v;
     }
 
     static void addOrdinalInputBlock(
@@ -157,7 +177,9 @@ final class ValuesBytesRefAggregators {
         int positionOffset,
         IntVector groupIds,
         IntBlock ordinalIds,
-        IntVector hashIds
+        BytesRefVector dict,
+        int[] hashIds,
+        BytesRef scratch
     ) {
         for (int p = 0; p < groupIds.getPositionCount(); p++) {
             final int groupId = groupIds.getInt(p);
@@ -166,7 +188,7 @@ final class ValuesBytesRefAggregators {
             final int end = start + ordinalIds.getValueCount(valuePosition);
             for (int i = start; i < end; i++) {
                 int ord = ordinalIds.getInt(i);
-                state.addValueOrdinal(groupId, hashIds.getInt(ord));
+                state.addValueOrdinal(groupId, lazyHashId(ord, dict, hashIds, scratch, state));
             }
         }
     }
@@ -176,22 +198,25 @@ final class ValuesBytesRefAggregators {
         int positionOffset,
         IntVector groupIds,
         IntVector ordinalIds,
-        IntVector hashIds
+        BytesRefVector dict,
+        int[] hashIds,
+        BytesRef scratch
     ) {
-        if (groupIds.isConstant() && hashIds.isConstant()) {
-            state.addValueOrdinal(groupIds.getInt(0), hashIds.getInt(0));
+        if (groupIds.isConstant() && ordinalIds.isConstant()) {
+            int ord = ordinalIds.getInt(0);
+            state.addValueOrdinal(groupIds.getInt(0), lazyHashId(ord, dict, hashIds, scratch, state));
             return;
         }
         int lastGroup = groupIds.getInt(0);
         int lastOrd = ordinalIds.getInt(positionOffset);
-        state.addValueOrdinal(lastGroup, hashIds.getInt(lastOrd));
+        state.addValueOrdinal(lastGroup, lazyHashId(lastOrd, dict, hashIds, scratch, state));
         for (int p = 1; p < groupIds.getPositionCount(); p++) {
             final int nextGroup = groupIds.getInt(p);
             final int nextOrd = ordinalIds.getInt(p + positionOffset);
             if (nextGroup != lastGroup || nextOrd != lastOrd) {
                 lastGroup = nextGroup;
                 lastOrd = nextOrd;
-                state.addValueOrdinal(lastGroup, hashIds.getInt(lastOrd));
+                state.addValueOrdinal(lastGroup, lazyHashId(lastOrd, dict, hashIds, scratch, state));
             }
         }
     }
@@ -212,13 +237,13 @@ final class ValuesBytesRefAggregators {
             }
         }
         if (dict != null && dict.getPositionCount() < groupIds.getPositionCount()) {
-            try (var hashIds = hashDict(state, dict)) {
-                IntVector ordinalsVector = ordinals.asVector();
-                if (ordinalsVector != null) {
-                    addOrdinalInputVector(state, positionOffset, groupIds, ordinalsVector, hashIds);
-                } else {
-                    addOrdinalInputBlock(state, positionOffset, groupIds, ordinals, hashIds);
-                }
+            final int[] hashIds = newLazyHashIds(dict.getPositionCount());
+            final BytesRef scratch = new BytesRef();
+            IntVector ordinalsVector = ordinals.asVector();
+            if (ordinalsVector != null) {
+                addOrdinalInputVector(state, positionOffset, groupIds, ordinalsVector, dict, hashIds, scratch);
+            } else {
+                addOrdinalInputBlock(state, positionOffset, groupIds, ordinals, dict, hashIds, scratch);
             }
         } else {
             final BytesRef scratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregators.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregators.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.IntArrayBlock;
@@ -32,66 +33,82 @@ final class ValuesBytesRefAggregators {
             return delegate;
         }
         final BytesRefVector dict = valuesOrdinal.getDictionaryVector();
-        // Lazy ord-to-hashId cache. Phantom dictionary entries (left over from filter()/slice()/keepMask())
-        // are never visited because no row references them, so they never enter state.bytes.
-        final int[] hashIds = newLazyHashIds(dict.getPositionCount());
-        final BytesRef scratch = new BytesRef();
-        IntBlock ordinalIds = valuesOrdinal.getOrdinalsBlock();
-        return new GroupingAggregatorFunction.AddInput() {
-            @Override
-            public void add(int positionOffset, IntArrayBlock groupIds) {
-                for (int groupPosition = 0; groupPosition < groupIds.getPositionCount(); groupPosition++) {
-                    if (groupIds.isNull(groupPosition)) {
-                        continue;
-                    }
-                    int groupStart = groupIds.getFirstValueIndex(groupPosition);
-                    int groupEnd = groupStart + groupIds.getValueCount(groupPosition);
-                    for (int g = groupStart; g < groupEnd; g++) {
-                        int groupId = groupIds.getInt(g);
-                        if (ordinalIds.isNull(groupPosition + positionOffset)) {
+        final BlockFactory blockFactory = dict.blockFactory();
+        final long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "ValuesBytesRefAggregator");
+        boolean success = false;
+        try {
+            // Ord-to-hashId cache. When phantoms are possible (needsCompaction()==true) we leave entries
+            // at UNSEEN and let lazyHashId fill them on first reference, so phantom dict entries never
+            // enter state.bytes. When no phantoms are possible (the dense Parquet path) we pre-hash the
+            // whole dictionary up front, so the per-row UNSEEN branch in lazyHashId is always predicted
+            // not-taken — restoring the old eager fast path for clickbench-style dense aggregations.
+            final int[] hashIds = valuesOrdinal.needsCompaction() ? newLazyHashIds(dict.getPositionCount()) : eagerHashIds(state, dict);
+            final BytesRef scratch = new BytesRef();
+            final IntBlock ordinalIds = valuesOrdinal.getOrdinalsBlock();
+            GroupingAggregatorFunction.AddInput result = new GroupingAggregatorFunction.AddInput() {
+                @Override
+                public void add(int positionOffset, IntArrayBlock groupIds) {
+                    for (int groupPosition = 0; groupPosition < groupIds.getPositionCount(); groupPosition++) {
+                        if (groupIds.isNull(groupPosition)) {
                             continue;
                         }
-                        int valuesStart = ordinalIds.getFirstValueIndex(groupPosition + positionOffset);
-                        int valuesEnd = valuesStart + ordinalIds.getValueCount(groupPosition + positionOffset);
-                        for (int v = valuesStart; v < valuesEnd; v++) {
-                            state.addValueOrdinal(groupId, lazyHashId(ordinalIds.getInt(v), dict, hashIds, scratch, state));
+                        int groupStart = groupIds.getFirstValueIndex(groupPosition);
+                        int groupEnd = groupStart + groupIds.getValueCount(groupPosition);
+                        for (int g = groupStart; g < groupEnd; g++) {
+                            int groupId = groupIds.getInt(g);
+                            if (ordinalIds.isNull(groupPosition + positionOffset)) {
+                                continue;
+                            }
+                            int valuesStart = ordinalIds.getFirstValueIndex(groupPosition + positionOffset);
+                            int valuesEnd = valuesStart + ordinalIds.getValueCount(groupPosition + positionOffset);
+                            for (int v = valuesStart; v < valuesEnd; v++) {
+                                state.addValueOrdinal(groupId, lazyHashId(ordinalIds.getInt(v), dict, hashIds, scratch, state));
+                            }
                         }
                     }
                 }
-            }
 
-            @Override
-            public void add(int positionOffset, IntBigArrayBlock groupIds) {
-                for (int groupPosition = 0; groupPosition < groupIds.getPositionCount(); groupPosition++) {
-                    if (groupIds.isNull(groupPosition)) {
-                        continue;
-                    }
-                    int groupStart = groupIds.getFirstValueIndex(groupPosition);
-                    int groupEnd = groupStart + groupIds.getValueCount(groupPosition);
-                    for (int g = groupStart; g < groupEnd; g++) {
-                        int groupId = groupIds.getInt(g);
-                        if (ordinalIds.isNull(groupPosition + positionOffset)) {
+                @Override
+                public void add(int positionOffset, IntBigArrayBlock groupIds) {
+                    for (int groupPosition = 0; groupPosition < groupIds.getPositionCount(); groupPosition++) {
+                        if (groupIds.isNull(groupPosition)) {
                             continue;
                         }
-                        int valuesStart = ordinalIds.getFirstValueIndex(groupPosition + positionOffset);
-                        int valuesEnd = valuesStart + ordinalIds.getValueCount(groupPosition + positionOffset);
-                        for (int v = valuesStart; v < valuesEnd; v++) {
-                            state.addValueOrdinal(groupId, lazyHashId(ordinalIds.getInt(v), dict, hashIds, scratch, state));
+                        int groupStart = groupIds.getFirstValueIndex(groupPosition);
+                        int groupEnd = groupStart + groupIds.getValueCount(groupPosition);
+                        for (int g = groupStart; g < groupEnd; g++) {
+                            int groupId = groupIds.getInt(g);
+                            if (ordinalIds.isNull(groupPosition + positionOffset)) {
+                                continue;
+                            }
+                            int valuesStart = ordinalIds.getFirstValueIndex(groupPosition + positionOffset);
+                            int valuesEnd = valuesStart + ordinalIds.getValueCount(groupPosition + positionOffset);
+                            for (int v = valuesStart; v < valuesEnd; v++) {
+                                state.addValueOrdinal(groupId, lazyHashId(ordinalIds.getInt(v), dict, hashIds, scratch, state));
+                            }
                         }
                     }
                 }
-            }
 
-            @Override
-            public void add(int positionOffset, IntVector groupIds) {
-                addOrdinalInputBlock(state, positionOffset, groupIds, ordinalIds, dict, hashIds, scratch);
-            }
+                @Override
+                public void add(int positionOffset, IntVector groupIds) {
+                    addOrdinalInputBlock(state, positionOffset, groupIds, ordinalIds, dict, hashIds, scratch);
+                }
 
-            @Override
-            public void close() {
-                delegate.close();
+                @Override
+                public void close() {
+                    blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
+                    delegate.close();
+                }
+            };
+            success = true;
+            return result;
+        } finally {
+            if (success == false) {
+                blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
             }
-        };
+        }
     }
 
     static GroupingAggregatorFunction.AddInput wrapAddInput(
@@ -104,52 +121,66 @@ final class ValuesBytesRefAggregators {
             return delegate;
         }
         final BytesRefVector dict = valuesOrdinal.getDictionaryVector();
-        final int[] hashIds = newLazyHashIds(dict.getPositionCount());
-        final BytesRef scratch = new BytesRef();
-        var ordinalIds = valuesOrdinal.getOrdinalsVector();
-        return new GroupingAggregatorFunction.AddInput() {
-            @Override
-            public void add(int positionOffset, IntArrayBlock groupIds) {
-                for (int groupPosition = 0; groupPosition < groupIds.getPositionCount(); groupPosition++) {
-                    if (groupIds.isNull(groupPosition)) {
-                        continue;
-                    }
-                    int groupStart = groupIds.getFirstValueIndex(groupPosition);
-                    int groupEnd = groupStart + groupIds.getValueCount(groupPosition);
-                    for (int g = groupStart; g < groupEnd; g++) {
-                        int groupId = groupIds.getInt(g);
-                        int ord = ordinalIds.getInt(groupPosition + positionOffset);
-                        state.addValueOrdinal(groupId, lazyHashId(ord, dict, hashIds, scratch, state));
-                    }
-                }
-            }
-
-            @Override
-            public void add(int positionOffset, IntBigArrayBlock groupIds) {
-                for (int groupPosition = 0; groupPosition < groupIds.getPositionCount(); groupPosition++) {
-                    if (groupIds.isNull(groupPosition)) {
-                        continue;
-                    }
-                    int groupStart = groupIds.getFirstValueIndex(groupPosition);
-                    int groupEnd = groupStart + groupIds.getValueCount(groupPosition);
-                    for (int g = groupStart; g < groupEnd; g++) {
-                        int groupId = groupIds.getInt(g);
-                        int ord = ordinalIds.getInt(groupPosition + positionOffset);
-                        state.addValueOrdinal(groupId, lazyHashId(ord, dict, hashIds, scratch, state));
+        final BlockFactory blockFactory = dict.blockFactory();
+        final long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "ValuesBytesRefAggregator");
+        boolean success = false;
+        try {
+            // See the BytesRefBlock overload for the rationale behind this conditional.
+            final int[] hashIds = valuesOrdinal.needsCompaction() ? newLazyHashIds(dict.getPositionCount()) : eagerHashIds(state, dict);
+            final BytesRef scratch = new BytesRef();
+            final IntVector ordinalIds = valuesOrdinal.getOrdinalsVector();
+            GroupingAggregatorFunction.AddInput result = new GroupingAggregatorFunction.AddInput() {
+                @Override
+                public void add(int positionOffset, IntArrayBlock groupIds) {
+                    for (int groupPosition = 0; groupPosition < groupIds.getPositionCount(); groupPosition++) {
+                        if (groupIds.isNull(groupPosition)) {
+                            continue;
+                        }
+                        int groupStart = groupIds.getFirstValueIndex(groupPosition);
+                        int groupEnd = groupStart + groupIds.getValueCount(groupPosition);
+                        for (int g = groupStart; g < groupEnd; g++) {
+                            int groupId = groupIds.getInt(g);
+                            int ord = ordinalIds.getInt(groupPosition + positionOffset);
+                            state.addValueOrdinal(groupId, lazyHashId(ord, dict, hashIds, scratch, state));
+                        }
                     }
                 }
-            }
 
-            @Override
-            public void add(int positionOffset, IntVector groupIds) {
-                addOrdinalInputVector(state, positionOffset, groupIds, ordinalIds, dict, hashIds, scratch);
-            }
+                @Override
+                public void add(int positionOffset, IntBigArrayBlock groupIds) {
+                    for (int groupPosition = 0; groupPosition < groupIds.getPositionCount(); groupPosition++) {
+                        if (groupIds.isNull(groupPosition)) {
+                            continue;
+                        }
+                        int groupStart = groupIds.getFirstValueIndex(groupPosition);
+                        int groupEnd = groupStart + groupIds.getValueCount(groupPosition);
+                        for (int g = groupStart; g < groupEnd; g++) {
+                            int groupId = groupIds.getInt(g);
+                            int ord = ordinalIds.getInt(groupPosition + positionOffset);
+                            state.addValueOrdinal(groupId, lazyHashId(ord, dict, hashIds, scratch, state));
+                        }
+                    }
+                }
 
-            @Override
-            public void close() {
-                delegate.close();
+                @Override
+                public void add(int positionOffset, IntVector groupIds) {
+                    addOrdinalInputVector(state, positionOffset, groupIds, ordinalIds, dict, hashIds, scratch);
+                }
+
+                @Override
+                public void close() {
+                    blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
+                    delegate.close();
+                }
+            };
+            success = true;
+            return result;
+        } finally {
+            if (success == false) {
+                blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
             }
-        };
+        }
     }
 
     /**
@@ -160,6 +191,20 @@ final class ValuesBytesRefAggregators {
     static int[] newLazyHashIds(int dictSize) {
         int[] cache = new int[dictSize];
         Arrays.fill(cache, UNSEEN);
+        return cache;
+    }
+
+    /**
+     * Eager counterpart used when the input block guarantees no phantom dictionary entries: every
+     * dict entry is hashed up front, so subsequent {@link #lazyHashId} calls hit on the first
+     * cache load and the {@code v == UNSEEN} branch becomes a predicted-not-taken no-op.
+     */
+    static int[] eagerHashIds(ValuesBytesRefAggregator.GroupingState state, BytesRefVector dict) {
+        int[] cache = new int[dict.getPositionCount()];
+        BytesRef scratch = new BytesRef();
+        for (int p = 0; p < dict.getPositionCount(); p++) {
+            cache[p] = Math.toIntExact(BlockHash.hashOrdToGroup(state.bytes.add(dict.getBytesRef(p, scratch))));
+        }
         return cache;
     }
 
@@ -229,21 +274,31 @@ final class ValuesBytesRefAggregators {
     ) {
         BytesRefVector dict = null;
         IntBlock ordinals = null;
+        boolean needsCompaction = false;
         {
             final OrdinalBytesRefBlock asOrdinals = values.asOrdinals();
             if (asOrdinals != null) {
                 dict = asOrdinals.getDictionaryVector();
                 ordinals = asOrdinals.getOrdinalsBlock();
+                needsCompaction = asOrdinals.needsCompaction();
             }
         }
         if (dict != null && dict.getPositionCount() < groupIds.getPositionCount()) {
-            final int[] hashIds = newLazyHashIds(dict.getPositionCount());
-            final BytesRef scratch = new BytesRef();
-            IntVector ordinalsVector = ordinals.asVector();
-            if (ordinalsVector != null) {
-                addOrdinalInputVector(state, positionOffset, groupIds, ordinalsVector, dict, hashIds, scratch);
-            } else {
-                addOrdinalInputBlock(state, positionOffset, groupIds, ordinals, dict, hashIds, scratch);
+            final BlockFactory blockFactory = dict.blockFactory();
+            final long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+            blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "ValuesBytesRefAggregator");
+            try {
+                // See wrapAddInput for the rationale behind the eager/lazy split.
+                final int[] hashIds = needsCompaction ? newLazyHashIds(dict.getPositionCount()) : eagerHashIds(state, dict);
+                final BytesRef scratch = new BytesRef();
+                IntVector ordinalsVector = ordinals.asVector();
+                if (ordinalsVector != null) {
+                    addOrdinalInputVector(state, positionOffset, groupIds, ordinalsVector, dict, hashIds, scratch);
+                } else {
+                    addOrdinalInputBlock(state, positionOffset, groupIds, ordinals, dict, hashIds, scratch);
+                }
+            } finally {
+                blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
             }
         } else {
             final BytesRef scratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregators.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ValuesBytesRefAggregators.java
@@ -18,10 +18,7 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 
-import java.util.Arrays;
-
 final class ValuesBytesRefAggregators {
-    private static final int UNSEEN = -1;
 
     static GroupingAggregatorFunction.AddInput wrapAddInput(
         GroupingAggregatorFunction.AddInput delegate,
@@ -38,11 +35,13 @@ final class ValuesBytesRefAggregators {
         blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "ValuesBytesRefAggregator");
         boolean success = false;
         try {
-            // Ord-to-hashId cache. When phantoms are possible (needsCompaction()==true) we leave entries
-            // at UNSEEN and let lazyHashId fill them on first reference, so phantom dict entries never
-            // enter state.bytes. When no phantoms are possible (the dense Parquet path) we pre-hash the
-            // whole dictionary up front, so the per-row UNSEEN branch in lazyHashId is always predicted
-            // not-taken — restoring the old eager fast path for clickbench-style dense aggregations.
+            // Ord-to-hashId cache. Entries store {@code hashId + 1}, so the zero-initialized array
+            // doubles as the "unseen" sentinel. When phantoms are possible (needsCompaction()==true)
+            // we leave the array zeroed and let lazyHashId fill entries on first reference, so
+            // phantom dict entries never enter state.bytes. When no phantoms are possible (the dense
+            // Parquet path) we pre-hash the whole dictionary up front, so the per-row zero-check in
+            // lazyHashId is always predicted not-taken — restoring the old eager fast path for
+            // clickbench-style dense aggregations.
             final int[] hashIds = valuesOrdinal.needsCompaction() ? newLazyHashIds(dict.getPositionCount()) : eagerHashIds(state, dict);
             final BytesRef scratch = new BytesRef();
             final IntBlock ordinalIds = valuesOrdinal.getOrdinalsBlock();
@@ -184,37 +183,37 @@ final class ValuesBytesRefAggregators {
     }
 
     /**
-     * Returns a per-page lazy ord-to-hashId cache, sized by the dictionary and pre-filled with
-     * {@link #UNSEEN}. Entries are populated by {@link #lazyHashId} on first reference, so phantom
-     * dictionary entries that no row touches never enter {@code state.bytes}.
+     * Returns a per-page lazy ord-to-hashId cache, sized by the dictionary. Entries are populated by
+     * {@link #lazyHashId} on first reference, so phantom dictionary entries that no row touches never
+     * enter {@code state.bytes}. The cache stores {@code hashId + 1}; the JVM's zero-init makes
+     * {@code 0} the implicit "unseen" sentinel without an explicit fill.
      */
     static int[] newLazyHashIds(int dictSize) {
-        int[] cache = new int[dictSize];
-        Arrays.fill(cache, UNSEEN);
-        return cache;
+        return new int[dictSize];
     }
 
     /**
      * Eager counterpart used when the input block guarantees no phantom dictionary entries: every
-     * dict entry is hashed up front, so subsequent {@link #lazyHashId} calls hit on the first
-     * cache load and the {@code v == UNSEEN} branch becomes a predicted-not-taken no-op.
+     * dict entry is hashed up front (storing {@code hashId + 1}), so subsequent {@link #lazyHashId}
+     * calls hit on the first cache load and the {@code v == 0} branch becomes a predicted-not-taken
+     * no-op.
      */
     static int[] eagerHashIds(ValuesBytesRefAggregator.GroupingState state, BytesRefVector dict) {
         int[] cache = new int[dict.getPositionCount()];
         BytesRef scratch = new BytesRef();
         for (int p = 0; p < dict.getPositionCount(); p++) {
-            cache[p] = Math.toIntExact(BlockHash.hashOrdToGroup(state.bytes.add(dict.getBytesRef(p, scratch))));
+            cache[p] = Math.toIntExact(BlockHash.hashOrdToGroup(state.bytes.add(dict.getBytesRef(p, scratch)))) + 1;
         }
         return cache;
     }
 
     static int lazyHashId(int ord, BytesRefVector dict, int[] cache, BytesRef scratch, ValuesBytesRefAggregator.GroupingState state) {
         int v = cache[ord];
-        if (v == UNSEEN) {
-            v = Math.toIntExact(BlockHash.hashOrdToGroup(state.bytes.add(dict.getBytesRef(ord, scratch))));
+        if (v == 0) {
+            v = Math.toIntExact(BlockHash.hashOrdToGroup(state.bytes.add(dict.getBytesRef(ord, scratch)))) + 1;
             cache[ord] = v;
         }
-        return v;
+        return v - 1;
     }
 
     static void addOrdinalInputBlock(

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/TimeSeriesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/TimeSeriesBlockHash.java
@@ -30,6 +30,8 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
+import java.util.Arrays;
+
 /**
  * An optimized block hash that receives two blocks: tsid and timestamp, which are sorted.
  * Since the incoming data is sorted, this block hash checks tsid ordinals to avoid redundant
@@ -154,19 +156,18 @@ public final class TimeSeriesBlockHash extends BlockHash {
         long acquiredBytes = (long) Integer.BYTES * (ordinalsLength + dictLength);
         blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "TimeSeriesBlockHash");
         try {
+            // Lazy ord-to-tsid cache. Phantom dictionary entries (left over from filter()/slice()/keepMask())
+            // are never visited because no row references them, and therefore never enter tsidHash.
             final int[] dictOrds = new int[dictLength];
-            for (int p = 0; p < dictLength; p++) {
-                BytesRef v = dictVector.getBytesRef(p, scratch);
-                dictOrds[p] = Math.toIntExact(hashOrdToGroup(tsidHash.add(v)));
-            }
+            Arrays.fill(dictOrds, UNSEEN);
             final int[] groupIds = new int[ordinalsLength];
-            int prevTsid = dictOrds[ordinalsVector.getInt(0)];
+            int prevTsid = lazyTsid(dictOrds, dictVector, ordinalsVector.getInt(0));
             long prevTimestamp = timestamps.getLong(0);
             int prevGroupId = Math.toIntExact(hashOrdToGroup(finalHash.add(prevTsid, prevTimestamp)));
             groupIds[0] = prevGroupId;
             for (int p = 1; p < ordinalsLength; p++) {
                 final long timestamp = timestamps.getLong(p);
-                int tsid = dictOrds[ordinalsVector.getInt(p)];
+                int tsid = lazyTsid(dictOrds, dictVector, ordinalsVector.getInt(p));
                 if (tsid != prevTsid || timestamp != prevTimestamp) {
                     prevTimestamp = timestamp;
                     prevGroupId = Math.toIntExact(hashOrdToGroup(finalHash.add(tsid, prevTimestamp)));
@@ -181,6 +182,17 @@ public final class TimeSeriesBlockHash extends BlockHash {
         } finally {
             blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
+    }
+
+    private static final int UNSEEN = -1;
+
+    private int lazyTsid(int[] cache, BytesRefVector dict, int dictOrd) {
+        int tsid = cache[dictOrd];
+        if (tsid == UNSEEN) {
+            tsid = Math.toIntExact(hashOrdToGroup(tsidHash.add(dict.getBytesRef(dictOrd, scratch))));
+            cache[dictOrd] = tsid;
+        }
+        return tsid;
     }
 
     private void addVector(BytesRefVector tsidVector, LongVector timestamps, GroupingAggregatorFunction.AddInput addInput) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/TimeSeriesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/TimeSeriesBlockHash.java
@@ -30,8 +30,6 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
-import java.util.Arrays;
-
 /**
  * An optimized block hash that receives two blocks: tsid and timestamp, which are sorted.
  * Since the incoming data is sorted, this block hash checks tsid ordinals to avoid redundant
@@ -158,8 +156,8 @@ public final class TimeSeriesBlockHash extends BlockHash {
         try {
             // Lazy ord-to-tsid cache. Phantom dictionary entries (left over from filter()/slice()/keepMask())
             // are never visited because no row references them, and therefore never enter tsidHash.
+            // Entries store {@code tsid + 1}; the zero-init array doubles as the "unseen" sentinel.
             final int[] dictOrds = new int[dictLength];
-            Arrays.fill(dictOrds, UNSEEN);
             final int[] groupIds = new int[ordinalsLength];
             int prevTsid = lazyTsid(dictOrds, dictVector, ordinalsVector.getInt(0));
             long prevTimestamp = timestamps.getLong(0);
@@ -184,15 +182,13 @@ public final class TimeSeriesBlockHash extends BlockHash {
         }
     }
 
-    private static final int UNSEEN = -1;
-
     private int lazyTsid(int[] cache, BytesRefVector dict, int dictOrd) {
         int tsid = cache[dictOrd];
-        if (tsid == UNSEEN) {
-            tsid = Math.toIntExact(hashOrdToGroup(tsidHash.add(dict.getBytesRef(dictOrd, scratch))));
+        if (tsid == 0) {
+            tsid = Math.toIntExact(hashOrdToGroup(tsidHash.add(dict.getBytesRef(dictOrd, scratch)))) + 1;
             cache[dictOrd] = tsid;
         }
-        return tsid;
+        return tsid - 1;
     }
 
     private void addVector(BytesRefVector tsidVector, LongVector timestamps, GroupingAggregatorFunction.AddInput addInput) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -38,7 +38,6 @@ $endif$
 import org.elasticsearch.core.ReleasableIterator;
 $if(BytesRef)$
 import org.elasticsearch.swisshash.BytesRefSwissHash;
-import java.util.Arrays;
 $endif$
 // end generated imports
 
@@ -200,25 +199,44 @@ $endif$
 
 $if(BytesRef)$
     /**
-     * Sentinel for "this dictionary ord has not yet been hashed into the global hash on this page".
-     * Stored in the per-page {@code localToGlobal} array; replaced with the real group id (always
-     * non-negative because of {@link BlockHash#hashOrdToGroupNullReserved}) on first touch.
-     */
-    private static final int UNSEEN = -1;
-
-    /**
      * Lazily hashes the dictionary entry at {@code ord} into the global hash on first visit and
      * returns the cached group id thereafter. Dictionary entries that no rows reference are never
      * looked up, so phantom entries left over by {@code filter()}/{@code slice()}/{@code keepMask()}
      * (which share the dictionary across the filtered block) are not promoted to groups.
+     * <p>
+     * The cache stores {@code groupId + 1} so that the zero-initialized {@code int[]} doubles as
+     * the "unseen" sentinel without an explicit {@link java.util.Arrays#fill} pass — group ids are
+     * always {@code >= 0} because of {@link BlockHash#hashOrdToGroupNullReserved}.
      */
     private int groupForOrd(int ord, BytesRefVector dict, int[] localToGlobal, BytesRef scratch) {
         int g = localToGlobal[ord];
-        if (g == UNSEEN) {
-            g = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch))));
+        if (g == 0) {
+            g = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch)))) + 1;
             localToGlobal[ord] = g;
         }
-        return g;
+        return g - 1;
+    }
+
+    /**
+     * Eager counterpart of {@link #groupForOrd}: hashes every dictionary entry up front into a
+     * primitive {@code int[]} indexed by ord. Used on the no-phantoms path so the per-row inner
+     * loop is a single primitive array access instead of a virtual call into an {@link IntVector}.
+     * <p>
+     * Routes the prefill through {@link #add(BytesRefVector)} so the {@link BytesRefSwissHash}
+     * prefetch path (batched bucket prefetching) still applies — that's where most of this
+     * method's time goes for high-cardinality dictionaries; profiling showed dropping it cost
+     * ~20-30% on URL-grouping workloads. We then copy into a primitive {@code int[]} so the
+     * per-row inner loop avoids the {@code IntVector.getInt} virtual call.
+     */
+    private int[] eagerDictGroupIds(BytesRefVector dict) {
+        int dictSize = dict.getPositionCount();
+        int[] cache = new int[dictSize];
+        try (var hashOrds = add(dict)) {
+            for (int o = 0; o < dictSize; o++) {
+                cache[o] = hashOrds.getInt(o);
+            }
+        }
+        return cache;
     }
 
     private IntVector addOrdinalsVector(OrdinalBytesRefVector inputBlock) {
@@ -230,18 +248,26 @@ $if(BytesRef)$
             int groupId = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch))));
             return blockFactory.newConstantIntVector(groupId, inputOrds.getPositionCount());
         }
-        // The lazy path costs a measurable branch+load per row on dense Parquet pages where every dict
-        // entry is referenced (clickbench q16/q17/q18/q34); only take it when phantoms are actually
-        // possible (filter()/slice()/keepMask() flagged the block as needing compaction).
+        // The lazy path costs an extra zero-check + subtraction per row on dense Parquet pages where
+        // every dict entry is referenced; only take it when phantoms are actually possible
+        // (filter()/slice()/keepMask() flagged the block as needing compaction).
         return inputBlock.needsCompaction() ? addOrdinalsVectorLazy(inputOrds, dict) : addOrdinalsVectorEager(inputOrds, dict);
     }
 
     private IntVector addOrdinalsVectorEager(IntVector inputOrds, BytesRefVector dict) {
-        try (var hashOrds = add(dict); var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
-            for (int p = 0; p < inputOrds.getPositionCount(); p++) {
-                builder.appendInt(hashOrds.getInt(inputOrds.getInt(p)));
+        long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
+        try {
+            int[] dictGroupIds = eagerDictGroupIds(dict);
+            int positions = inputOrds.getPositionCount();
+            try (var builder = blockFactory.newIntVectorFixedBuilder(positions)) {
+                for (int p = 0; p < positions; p++) {
+                    builder.appendInt(dictGroupIds[inputOrds.getInt(p)]);
+                }
+                return builder.build();
             }
-            return builder.build();
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
     }
 
@@ -251,9 +277,9 @@ $if(BytesRef)$
         blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
         try {
             int[] localToGlobal = new int[dict.getPositionCount()];
-            Arrays.fill(localToGlobal, UNSEEN);
-            try (var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
-                for (int p = 0; p < inputOrds.getPositionCount(); p++) {
+            int positions = inputOrds.getPositionCount();
+            try (var builder = blockFactory.newIntVectorFixedBuilder(positions)) {
+                for (int p = 0; p < positions; p++) {
                     builder.appendInt(groupForOrd(inputOrds.getInt(p), dict, localToGlobal, scratch));
                 }
                 return builder.build();
@@ -270,31 +296,37 @@ $if(BytesRef)$
 
     private IntBlock addOrdinalsBlockEager(OrdinalBytesRefBlock inputBlock) {
         BytesRefVector dict = inputBlock.getDictionaryVector();
-        try (
-            IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);
-            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount());
-            IntVector hashOrds = add(dict)
-        ) {
-            for (int p = 0; p < inputOrds.getPositionCount(); p++) {
-                int valueCount = inputOrds.getValueCount(p);
-                int firstIndex = inputOrds.getFirstValueIndex(p);
-                switch (valueCount) {
-                    case 0 -> {
-                        builder.appendInt(0);
-                        seenNull = true;
-                    }
-                    case 1 -> builder.appendInt(hashOrds.getInt(inputOrds.getInt(firstIndex)));
-                    default -> {
-                        int end = firstIndex + valueCount;
-                        builder.beginPositionEntry();
-                        for (int i = firstIndex; i < end; i++) {
-                            builder.appendInt(hashOrds.getInt(inputOrds.getInt(i)));
+        long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
+        try {
+            int[] dictGroupIds = eagerDictGroupIds(dict);
+            try (
+                IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);
+                IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount())
+            ) {
+                for (int p = 0; p < inputOrds.getPositionCount(); p++) {
+                    int valueCount = inputOrds.getValueCount(p);
+                    int firstIndex = inputOrds.getFirstValueIndex(p);
+                    switch (valueCount) {
+                        case 0 -> {
+                            builder.appendInt(0);
+                            seenNull = true;
                         }
-                        builder.endPositionEntry();
+                        case 1 -> builder.appendInt(dictGroupIds[inputOrds.getInt(firstIndex)]);
+                        default -> {
+                            int end = firstIndex + valueCount;
+                            builder.beginPositionEntry();
+                            for (int i = firstIndex; i < end; i++) {
+                                builder.appendInt(dictGroupIds[inputOrds.getInt(i)]);
+                            }
+                            builder.endPositionEntry();
+                        }
                     }
                 }
+                return builder.build();
             }
-            return builder.build();
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
     }
 
@@ -304,7 +336,6 @@ $if(BytesRef)$
         blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
         try {
             int[] localToGlobal = new int[dict.getPositionCount()];
-            Arrays.fill(localToGlobal, UNSEEN);
             BytesRef scratch = new BytesRef();
             try (
                 IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -8,7 +8,9 @@
 package org.elasticsearch.compute.aggregation.blockhash;
 
 // begin generated imports
+$if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
+$endif$
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
@@ -16,27 +18,28 @@ import org.elasticsearch.common.util.$Hash$Table;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.BytesRefVector;
-import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.DoubleVector;
+$if(int)$
+$else$
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
+$endif$
+$if(BytesRef)$
 import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 import org.elasticsearch.compute.data.OrdinalBytesRefVector;
+$endif$
 import org.elasticsearch.compute.data.$Type$Block;
 import org.elasticsearch.compute.data.$Type$Vector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupe;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupe$Type$;
+$if(BytesRef)$
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeInt;
+$endif$
 import org.elasticsearch.core.ReleasableIterator;
 $if(BytesRef)$
 import org.elasticsearch.swisshash.BytesRefSwissHash;
+import java.util.Arrays;
 $endif$
-import java.util.BitSet;
 // end generated imports
 
 /**
@@ -196,28 +199,55 @@ $endif$
     }
 
 $if(BytesRef)$
+    /**
+     * Sentinel for "this dictionary ord has not yet been hashed into the global hash on this page".
+     * Stored in the per-page {@code localToGlobal} array; replaced with the real group id (always
+     * non-negative because of {@link BlockHash#hashOrdToGroupNullReserved}) on first touch.
+     */
+    private static final int UNSEEN = -1;
+
+    /**
+     * Lazily hashes the dictionary entry at {@code ord} into the global hash on first visit and
+     * returns the cached group id thereafter. Dictionary entries that no rows reference are never
+     * looked up, so phantom entries left over by {@code filter()}/{@code slice()}/{@code keepMask()}
+     * (which share the dictionary across the filtered block) are not promoted to groups.
+     */
+    private int groupForOrd(int ord, BytesRefVector dict, int[] localToGlobal, BytesRef scratch) {
+        int g = localToGlobal[ord];
+        if (g == UNSEEN) {
+            g = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch))));
+            localToGlobal[ord] = g;
+        }
+        return g;
+    }
+
     private IntVector addOrdinalsVector(OrdinalBytesRefVector inputBlock) {
         IntVector inputOrds = inputBlock.getOrdinalsVector();
-        try (var hashOrds = add(inputBlock.getDictionaryVector())) {
-            if (inputOrds.isConstant()) {
-                int ord = hashOrds.getInt(inputOrds.getInt(0));
-                return blockFactory.newConstantIntVector(ord, inputOrds.getPositionCount());
+        BytesRefVector dict = inputBlock.getDictionaryVector();
+        BytesRef scratch = new BytesRef();
+        if (inputOrds.isConstant()) {
+            int ord = inputOrds.getInt(0);
+            int groupId = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch))));
+            return blockFactory.newConstantIntVector(groupId, inputOrds.getPositionCount());
+        }
+        int[] localToGlobal = new int[dict.getPositionCount()];
+        Arrays.fill(localToGlobal, UNSEEN);
+        try (var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
+            for (int p = 0; p < inputOrds.getPositionCount(); p++) {
+                builder.appendInt(groupForOrd(inputOrds.getInt(p), dict, localToGlobal, scratch));
             }
-            try (var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
-                for (int p = 0; p < inputOrds.getPositionCount(); p++) {
-                    int ord = hashOrds.getInt(inputOrds.getInt(p));
-                    builder.appendInt(ord);
-                }
-                return builder.build();
-            }
+            return builder.build();
         }
     }
 
     private IntBlock addOrdinalsBlock(OrdinalBytesRefBlock inputBlock) {
+        BytesRefVector dict = inputBlock.getDictionaryVector();
+        int[] localToGlobal = new int[dict.getPositionCount()];
+        Arrays.fill(localToGlobal, UNSEEN);
+        BytesRef scratch = new BytesRef();
         try (
             IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);
-            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount());
-            IntVector hashOrds = add(inputBlock.getDictionaryVector())
+            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount())
         ) {
             for (int p = 0; p < inputOrds.getPositionCount(); p++) {
                 int valueCount = inputOrds.getValueCount(p);
@@ -227,17 +257,12 @@ $if(BytesRef)$
                         builder.appendInt(0);
                         seenNull = true;
                     }
-                    case 1 -> {
-                        int ord = hashOrds.getInt(inputOrds.getInt(firstIndex));
-                        builder.appendInt(ord);
-                    }
+                    case 1 -> builder.appendInt(groupForOrd(inputOrds.getInt(firstIndex), dict, localToGlobal, scratch));
                     default -> {
-                        int start = firstIndex;
                         int end = firstIndex + valueCount;
                         builder.beginPositionEntry();
-                        for (int i = start; i < end; i++) {
-                            int ord = hashOrds.getInt(inputOrds.getInt(i));
-                            builder.appendInt(ord);
+                        for (int i = firstIndex; i < end; i++) {
+                            builder.appendInt(groupForOrd(inputOrds.getInt(i), dict, localToGlobal, scratch));
                         }
                         builder.endPositionEntry();
                     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -224,30 +224,56 @@ $if(BytesRef)$
     private IntVector addOrdinalsVector(OrdinalBytesRefVector inputBlock) {
         IntVector inputOrds = inputBlock.getOrdinalsVector();
         BytesRefVector dict = inputBlock.getDictionaryVector();
-        BytesRef scratch = new BytesRef();
         if (inputOrds.isConstant()) {
+            BytesRef scratch = new BytesRef();
             int ord = inputOrds.getInt(0);
             int groupId = Math.toIntExact(hashOrdToGroupNullReserved(hash.add(dict.getBytesRef(ord, scratch))));
             return blockFactory.newConstantIntVector(groupId, inputOrds.getPositionCount());
         }
-        int[] localToGlobal = new int[dict.getPositionCount()];
-        Arrays.fill(localToGlobal, UNSEEN);
-        try (var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
+        // The lazy path costs a measurable branch+load per row on dense Parquet pages where every dict
+        // entry is referenced (clickbench q16/q17/q18/q34); only take it when phantoms are actually
+        // possible (filter()/slice()/keepMask() flagged the block as needing compaction).
+        return inputBlock.needsCompaction() ? addOrdinalsVectorLazy(inputOrds, dict) : addOrdinalsVectorEager(inputOrds, dict);
+    }
+
+    private IntVector addOrdinalsVectorEager(IntVector inputOrds, BytesRefVector dict) {
+        try (var hashOrds = add(dict); var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
             for (int p = 0; p < inputOrds.getPositionCount(); p++) {
-                builder.appendInt(groupForOrd(inputOrds.getInt(p), dict, localToGlobal, scratch));
+                builder.appendInt(hashOrds.getInt(inputOrds.getInt(p)));
             }
             return builder.build();
         }
     }
 
-    private IntBlock addOrdinalsBlock(OrdinalBytesRefBlock inputBlock) {
-        BytesRefVector dict = inputBlock.getDictionaryVector();
-        int[] localToGlobal = new int[dict.getPositionCount()];
-        Arrays.fill(localToGlobal, UNSEEN);
+    private IntVector addOrdinalsVectorLazy(IntVector inputOrds, BytesRefVector dict) {
         BytesRef scratch = new BytesRef();
+        long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
+        try {
+            int[] localToGlobal = new int[dict.getPositionCount()];
+            Arrays.fill(localToGlobal, UNSEEN);
+            try (var builder = blockFactory.newIntVectorBuilder(inputOrds.getPositionCount())) {
+                for (int p = 0; p < inputOrds.getPositionCount(); p++) {
+                    builder.appendInt(groupForOrd(inputOrds.getInt(p), dict, localToGlobal, scratch));
+                }
+                return builder.build();
+            }
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
+        }
+    }
+
+    private IntBlock addOrdinalsBlock(OrdinalBytesRefBlock inputBlock) {
+        // See addOrdinalsVector for the rationale behind this split.
+        return inputBlock.needsCompaction() ? addOrdinalsBlockLazy(inputBlock) : addOrdinalsBlockEager(inputBlock);
+    }
+
+    private IntBlock addOrdinalsBlockEager(OrdinalBytesRefBlock inputBlock) {
+        BytesRefVector dict = inputBlock.getDictionaryVector();
         try (
             IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);
-            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount())
+            IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount());
+            IntVector hashOrds = add(dict)
         ) {
             for (int p = 0; p < inputOrds.getPositionCount(); p++) {
                 int valueCount = inputOrds.getValueCount(p);
@@ -257,18 +283,56 @@ $if(BytesRef)$
                         builder.appendInt(0);
                         seenNull = true;
                     }
-                    case 1 -> builder.appendInt(groupForOrd(inputOrds.getInt(firstIndex), dict, localToGlobal, scratch));
+                    case 1 -> builder.appendInt(hashOrds.getInt(inputOrds.getInt(firstIndex)));
                     default -> {
                         int end = firstIndex + valueCount;
                         builder.beginPositionEntry();
                         for (int i = firstIndex; i < end; i++) {
-                            builder.appendInt(groupForOrd(inputOrds.getInt(i), dict, localToGlobal, scratch));
+                            builder.appendInt(hashOrds.getInt(inputOrds.getInt(i)));
                         }
                         builder.endPositionEntry();
                     }
                 }
             }
             return builder.build();
+        }
+    }
+
+    private IntBlock addOrdinalsBlockLazy(OrdinalBytesRefBlock inputBlock) {
+        BytesRefVector dict = inputBlock.getDictionaryVector();
+        long acquiredBytes = (long) Integer.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "BytesRefBlockHash");
+        try {
+            int[] localToGlobal = new int[dict.getPositionCount()];
+            Arrays.fill(localToGlobal, UNSEEN);
+            BytesRef scratch = new BytesRef();
+            try (
+                IntBlock inputOrds = new MultivalueDedupeInt(inputBlock.getOrdinalsBlock()).dedupeToBlockAdaptive(blockFactory);
+                IntBlock.Builder builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount())
+            ) {
+                for (int p = 0; p < inputOrds.getPositionCount(); p++) {
+                    int valueCount = inputOrds.getValueCount(p);
+                    int firstIndex = inputOrds.getFirstValueIndex(p);
+                    switch (valueCount) {
+                        case 0 -> {
+                            builder.appendInt(0);
+                            seenNull = true;
+                        }
+                        case 1 -> builder.appendInt(groupForOrd(inputOrds.getInt(firstIndex), dict, localToGlobal, scratch));
+                        default -> {
+                            int end = firstIndex + valueCount;
+                            builder.beginPositionEntry();
+                            for (int i = firstIndex; i < end; i++) {
+                                builder.appendInt(groupForOrd(inputOrds.getInt(i), dict, localToGlobal, scratch));
+                            }
+                            builder.endPositionEntry();
+                        }
+                    }
+                }
+                return builder.build();
+            }
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
     }
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -108,34 +108,21 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
 
     @Override
     public BytesRefBlock filter(boolean mayContainDuplicates, int... positions) {
-        // Do not build a filtered block using the same dictionary, because dictionary entries that are not referenced
-        // may reappear when hashing the dictionary in BlockHash.
-        // TODO: merge this BytesRefArrayBlock#filter
-        final OrdinalBytesRefVector vector = asVector();
-        if (vector != null) {
-            return vector.filter(mayContainDuplicates, positions).asBlock();
-        }
-        BytesRef scratch = new BytesRef();
-        try (BytesRefBlock.Builder builder = blockFactory().newBytesRefBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendBytesRef(getBytesRef(getFirstValueIndex(pos), scratch));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendBytesRef(getBytesRef(first + c, scratch));
-                    }
-                    builder.endPositionEntry();
-                }
+        // Share the dictionary with the filtered block. Dictionary entries that are no longer referenced
+        // by any ordinal must be ignored by consumers; the consumer-side fast paths (e.g.
+        // BytesRefBlockHash#addOrdinals*, DistinctByOperator, BytesRefTopNBlockHash) drive their work off
+        // the ordinals and never iterate the dictionary, so phantom entries are never observed.
+        OrdinalBytesRefBlock result = null;
+        IntBlock filteredOrdinals = ordinals.filter(mayContainDuplicates, positions);
+        try {
+            result = new OrdinalBytesRefBlock(filteredOrdinals, bytes);
+            bytes.incRef();
+        } finally {
+            if (result == null) {
+                filteredOrdinals.close();
             }
-            return builder.mvOrdering(mvOrdering()).build();
         }
+        return result;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -79,6 +79,29 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
     }
 
     /**
+     * Returns a freshly allocated boolean array of length {@code getDictionaryVector().getPositionCount()}
+     * where {@code result[ord]} is {@code true} iff {@code ord} is referenced by at least one non-null
+     * ordinal in this block. Useful for consumers that want to skip phantom dictionary entries (left over
+     * by {@code filter()}/{@code slice()}/{@code keepMask()}) without paying the cost of a full
+     * {@link #compact()} that also remaps the ordinals.
+     */
+    public boolean[] referencedDictionaryEntries() {
+        boolean[] referenced = new boolean[bytes.getPositionCount()];
+        int positionCount = ordinals.getPositionCount();
+        for (int p = 0; p < positionCount; p++) {
+            if (ordinals.isNull(p)) {
+                continue;
+            }
+            int start = ordinals.getFirstValueIndex(p);
+            int end = start + ordinals.getValueCount(p);
+            for (int i = start; i < end; i++) {
+                referenced[ordinals.getInt(i)] = true;
+            }
+        }
+        return referenced;
+    }
+
+    /**
      * Returns a block whose dictionary is guaranteed to contain only entries referenced by at least one
      * ordinal. If {@link #needsCompaction()} is {@code false}, returns {@code this} (with an extra ref).
      * If a walk of the ordinals discovers every dictionary entry is referenced, returns a wrapper around
@@ -91,21 +114,11 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
             return this;
         }
         int dictSize = bytes.getPositionCount();
-        boolean[] referenced = new boolean[dictSize];
+        boolean[] referenced = referencedDictionaryEntries();
         int referencedCount = 0;
-        int positionCount = ordinals.getPositionCount();
-        for (int p = 0; p < positionCount; p++) {
-            if (ordinals.isNull(p)) {
-                continue;
-            }
-            int start = ordinals.getFirstValueIndex(p);
-            int end = start + ordinals.getValueCount(p);
-            for (int i = start; i < end; i++) {
-                int ord = ordinals.getInt(i);
-                if (referenced[ord] == false) {
-                    referenced[ord] = true;
-                    referencedCount++;
-                }
+        for (int oldOrd = 0; oldOrd < dictSize; oldOrd++) {
+            if (referenced[oldOrd]) {
+                referencedCount++;
             }
         }
         if (referencedCount == dictSize) {
@@ -113,6 +126,7 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
             bytes.incRef();
             return new OrdinalBytesRefBlock(ordinals, bytes, false);
         }
+        int positionCount = ordinals.getPositionCount();
         int[] remap = new int[dictSize];
         BytesRefVector compactBytes = null;
         IntBlock remappedOrds = null;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -25,10 +25,23 @@ import java.io.IOException;
 public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted implements BytesRefBlock {
     private final IntBlock ordinals;
     private final BytesRefVector bytes;
+    /**
+     * When {@code true}, {@link #bytes} may contain entries that are not referenced by any ordinal
+     * ("phantom" entries) introduced by ops that share the dictionary across blocks (e.g. {@link #filter},
+     * {@link #keepMask}, {@link #slice}). Consumers that walk the dictionary directly should call
+     * {@link #compact()} first; ordinal-driven consumers naturally ignore phantoms. Always {@code false}
+     * for blocks built fresh from a builder or read from the wire.
+     */
+    private final boolean needsCompaction;
 
     public OrdinalBytesRefBlock(IntBlock ordinals, BytesRefVector bytes) {
+        this(ordinals, bytes, false);
+    }
+
+    public OrdinalBytesRefBlock(IntBlock ordinals, BytesRefVector bytes, boolean needsCompaction) {
         this.ordinals = ordinals;
         this.bytes = bytes;
+        this.needsCompaction = needsCompaction;
     }
 
     static OrdinalBytesRefBlock readOrdinalBlock(BlockFactory blockFactory, BlockStreamInput in) throws IOException {
@@ -47,8 +60,101 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
     }
 
     void writeOrdinalBlock(StreamOutput out) throws IOException {
-        ordinals.writeTo(out);
-        bytes.writeTo(out);
+        // Always serialize a phantom-free dictionary: the wire format is unchanged, but receivers
+        // (including older versions) walk the dictionary directly and would observe phantoms if we
+        // shipped them. compact() is a no-op when no phantoms are present.
+        try (OrdinalBytesRefBlock c = compact()) {
+            c.ordinals.writeTo(out);
+            c.bytes.writeTo(out);
+        }
+    }
+
+    /**
+     * Returns {@code true} if this block's dictionary may contain entries that are not referenced by any
+     * ordinal. Such phantom entries arise when ops like {@link #filter}, {@link #keepMask}, or {@link #slice}
+     * share the dictionary with the source block.
+     */
+    public boolean needsCompaction() {
+        return needsCompaction;
+    }
+
+    /**
+     * Returns a block whose dictionary is guaranteed to contain only entries referenced by at least one
+     * ordinal. If {@link #needsCompaction()} is {@code false}, returns {@code this} (with an extra ref).
+     * If a walk of the ordinals discovers every dictionary entry is referenced, returns a wrapper around
+     * the same children with the flag cleared (no copy). Otherwise builds a compact dictionary and a
+     * remapped ordinals block. The returned block must be closed by the caller.
+     */
+    public OrdinalBytesRefBlock compact() {
+        if (needsCompaction == false) {
+            incRef();
+            return this;
+        }
+        int dictSize = bytes.getPositionCount();
+        boolean[] referenced = new boolean[dictSize];
+        int referencedCount = 0;
+        int positionCount = ordinals.getPositionCount();
+        for (int p = 0; p < positionCount; p++) {
+            if (ordinals.isNull(p)) {
+                continue;
+            }
+            int start = ordinals.getFirstValueIndex(p);
+            int end = start + ordinals.getValueCount(p);
+            for (int i = start; i < end; i++) {
+                int ord = ordinals.getInt(i);
+                if (referenced[ord] == false) {
+                    referenced[ord] = true;
+                    referencedCount++;
+                }
+            }
+        }
+        if (referencedCount == dictSize) {
+            ordinals.incRef();
+            bytes.incRef();
+            return new OrdinalBytesRefBlock(ordinals, bytes, false);
+        }
+        int[] remap = new int[dictSize];
+        BytesRefVector compactBytes = null;
+        IntBlock remappedOrds = null;
+        try (BytesRefVector.Builder dictBuilder = blockFactory().newBytesRefVectorBuilder(referencedCount)) {
+            BytesRef scratch = new BytesRef();
+            int newOrd = 0;
+            for (int oldOrd = 0; oldOrd < dictSize; oldOrd++) {
+                if (referenced[oldOrd]) {
+                    dictBuilder.appendBytesRef(bytes.getBytesRef(oldOrd, scratch));
+                    remap[oldOrd] = newOrd++;
+                } else {
+                    remap[oldOrd] = -1;
+                }
+            }
+            compactBytes = dictBuilder.build();
+            try (IntBlock.Builder ordsBuilder = blockFactory().newIntBlockBuilder(positionCount)) {
+                for (int p = 0; p < positionCount; p++) {
+                    if (ordinals.isNull(p)) {
+                        ordsBuilder.appendNull();
+                        continue;
+                    }
+                    int valueCount = ordinals.getValueCount(p);
+                    int start = ordinals.getFirstValueIndex(p);
+                    if (valueCount == 1) {
+                        ordsBuilder.appendInt(remap[ordinals.getInt(start)]);
+                    } else {
+                        ordsBuilder.beginPositionEntry();
+                        for (int i = start; i < start + valueCount; i++) {
+                            ordsBuilder.appendInt(remap[ordinals.getInt(i)]);
+                        }
+                        ordsBuilder.endPositionEntry();
+                    }
+                }
+                remappedOrds = ordsBuilder.mvOrdering(ordinals.mvOrdering()).build();
+            }
+            OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(remappedOrds, compactBytes, false);
+            remappedOrds = null;
+            compactBytes = null;
+            return result;
+        } finally {
+            Releasables.closeExpectNoException(remappedOrds, compactBytes);
+        }
     }
 
     /**
@@ -66,6 +172,11 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
         return ordinals;
     }
 
+    /**
+     * Returns the underlying dictionary vector. When {@link #needsCompaction()} is {@code true} the
+     * dictionary may contain phantom entries that are not referenced by any ordinal; callers that walk
+     * the dictionary directly should call {@link #compact()} first.
+     */
     public BytesRefVector getDictionaryVector() {
         return bytes;
     }
@@ -84,7 +195,7 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
     public OrdinalBytesRefVector asVector() {
         IntVector vector = ordinals.asVector();
         if (vector != null) {
-            return new OrdinalBytesRefVector(vector, bytes);
+            return new OrdinalBytesRefVector(vector, bytes, needsCompaction);
         } else {
             return null;
         }
@@ -103,19 +214,17 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
         }
         IntBlock slicedOrdinals = ordinals.slice(beginInclusive, endExclusive);
         bytes.incRef();
-        return new OrdinalBytesRefBlock(slicedOrdinals, bytes);
+        return new OrdinalBytesRefBlock(slicedOrdinals, bytes, true);
     }
 
     @Override
     public BytesRefBlock filter(boolean mayContainDuplicates, int... positions) {
-        // Share the dictionary with the filtered block. Dictionary entries that are no longer referenced
-        // by any ordinal must be ignored by consumers; the consumer-side fast paths (e.g.
-        // BytesRefBlockHash#addOrdinals*, DistinctByOperator, BytesRefTopNBlockHash) drive their work off
-        // the ordinals and never iterate the dictionary, so phantom entries are never observed.
+        // Share the dictionary with the filtered block; the result is flagged needsCompaction so the wire
+        // boundary (and any consumer that walks the dictionary directly) can compact away phantoms.
         OrdinalBytesRefBlock result = null;
         IntBlock filteredOrdinals = ordinals.filter(mayContainDuplicates, positions);
         try {
-            result = new OrdinalBytesRefBlock(filteredOrdinals, bytes);
+            result = new OrdinalBytesRefBlock(filteredOrdinals, bytes, true);
             bytes.incRef();
         } finally {
             if (result == null) {
@@ -138,10 +247,12 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
             }
             return (BytesRefBlock) blockFactory().newConstantNullBlock(getPositionCount());
         }
+        // Same shared-dictionary contract as filter(): mark needsCompaction so phantoms are stripped at
+        // the wire boundary or by downstream callers that walk the dictionary directly.
         OrdinalBytesRefBlock result = null;
         IntBlock filteredOrdinals = ordinals.keepMask(mask);
         try {
-            result = new OrdinalBytesRefBlock(filteredOrdinals, bytes);
+            result = new OrdinalBytesRefBlock(filteredOrdinals, bytes, true);
             bytes.incRef();
         } finally {
             if (result == null) {
@@ -163,7 +274,7 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
         try {
             copiedOrdinals = ordinals.deepCopy(blockFactory);
             copiedBytes = bytes.deepCopy(blockFactory);
-            OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(copiedOrdinals, copiedBytes);
+            OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(copiedOrdinals, copiedBytes, needsCompaction);
             copiedOrdinals = null;
             copiedBytes = null;
             return result;
@@ -253,7 +364,7 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
         OrdinalBytesRefBlock result = null;
         IntBlock expandedOrdinals = ordinals.expand();
         try {
-            result = new OrdinalBytesRefBlock(expandedOrdinals, bytes);
+            result = new OrdinalBytesRefBlock(expandedOrdinals, bytes, needsCompaction);
             bytes.incRef();
         } finally {
             if (result == null) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -87,6 +87,17 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
      */
     public boolean[] referencedDictionaryEntries() {
         boolean[] referenced = new boolean[bytes.getPositionCount()];
+        // Fast path for dense ordinals (no nulls, single-valued positions) — overwhelmingly common
+        // for blocks produced by filter()/keepMask()/slice(), which is precisely the source of
+        // phantoms this method is here to detect.
+        IntVector ordsVector = ordinals.asVector();
+        if (ordsVector != null) {
+            int positionCount = ordsVector.getPositionCount();
+            for (int p = 0; p < positionCount; p++) {
+                referenced[ordsVector.getInt(p)] = true;
+            }
+            return referenced;
+        }
         int positionCount = ordinals.getPositionCount();
         for (int p = 0; p < positionCount; p++) {
             if (ordinals.isNull(p)) {
@@ -115,22 +126,16 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
         }
         int dictSize = bytes.getPositionCount();
         boolean[] referenced = referencedDictionaryEntries();
-        int referencedCount = 0;
-        for (int oldOrd = 0; oldOrd < dictSize; oldOrd++) {
-            if (referenced[oldOrd]) {
-                referencedCount++;
-            }
-        }
-        if (referencedCount == dictSize) {
-            ordinals.incRef();
-            bytes.incRef();
-            return new OrdinalBytesRefBlock(ordinals, bytes, false);
-        }
         int positionCount = ordinals.getPositionCount();
         int[] remap = new int[dictSize];
         BytesRefVector compactBytes = null;
         IntBlock remappedOrds = null;
-        try (BytesRefVector.Builder dictBuilder = blockFactory().newBytesRefVectorBuilder(referencedCount)) {
+        // Single dictionary pass: build `remap` and the compact dictionary together. When `newOrd`
+        // ends up equal to `dictSize`, the flag was conservatively set but no phantoms exist —
+        // discard the freshly built (identical) dictionary and reuse the source children. Builder
+        // is sized to `dictSize` (an upper bound) rather than the exact referenced count so we
+        // don't need a separate counting pass; over-allocation is bounded by the dictionary size.
+        try (BytesRefVector.Builder dictBuilder = blockFactory().newBytesRefVectorBuilder(dictSize)) {
             BytesRef scratch = new BytesRef();
             int newOrd = 0;
             for (int oldOrd = 0; oldOrd < dictSize; oldOrd++) {
@@ -140,6 +145,11 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
                 } else {
                     remap[oldOrd] = -1;
                 }
+            }
+            if (newOrd == dictSize) {
+                ordinals.incRef();
+                bytes.incRef();
+                return new OrdinalBytesRefBlock(ordinals, bytes, false);
             }
             compactBytes = dictBuilder.build();
             try (IntBlock.Builder ordsBuilder = blockFactory().newIntBlockBuilder(positionCount)) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -243,12 +243,17 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
 
     @Override
     public BytesRefBlock filter(boolean mayContainDuplicates, int... positions) {
-        // Share the dictionary with the filtered block; the result is flagged needsCompaction so the wire
-        // boundary (and any consumer that walks the dictionary directly) can compact away phantoms.
+        // Share the dictionary with the filtered block. By default we flag needsCompaction so the
+        // wire boundary and dictionary-walking consumers can strip phantoms. If positions is a
+        // permutation of the source (no duplicates, same length) every source row survives and no
+        // new phantoms are introduced — propagate the source's flag instead of forcing true.
+        boolean filteredNeedsCompaction = (mayContainDuplicates == false && positions.length == ordinals.getPositionCount())
+            ? needsCompaction
+            : true;
         OrdinalBytesRefBlock result = null;
         IntBlock filteredOrdinals = ordinals.filter(mayContainDuplicates, positions);
         try {
-            result = new OrdinalBytesRefBlock(filteredOrdinals, bytes, true);
+            result = new OrdinalBytesRefBlock(filteredOrdinals, bytes, filteredNeedsCompaction);
             bytes.incRef();
         } finally {
             if (result == null) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -95,22 +95,13 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
         }
         int dictSize = bytes.getPositionCount();
         boolean[] referenced = referencedDictionaryEntries();
-        int referencedCount = 0;
-        for (int oldOrd = 0; oldOrd < dictSize; oldOrd++) {
-            if (referenced[oldOrd]) {
-                referencedCount++;
-            }
-        }
-        if (referencedCount == dictSize) {
-            ordinals.incRef();
-            bytes.incRef();
-            return new OrdinalBytesRefVector(ordinals, bytes, false);
-        }
         int positionCount = ordinals.getPositionCount();
         int[] remap = new int[dictSize];
         BytesRefVector compactBytes = null;
         IntVector remappedOrds = null;
-        try (BytesRefVector.Builder dictBuilder = blockFactory().newBytesRefVectorBuilder(referencedCount)) {
+        // See OrdinalBytesRefBlock#compact for why this single-pass build + post-check is preferred
+        // over a separate counting pass.
+        try (BytesRefVector.Builder dictBuilder = blockFactory().newBytesRefVectorBuilder(dictSize)) {
             BytesRef scratch = new BytesRef();
             int newOrd = 0;
             for (int oldOrd = 0; oldOrd < dictSize; oldOrd++) {
@@ -120,6 +111,11 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
                 } else {
                     remap[oldOrd] = -1;
                 }
+            }
+            if (newOrd == dictSize) {
+                ordinals.incRef();
+                bytes.incRef();
+                return new OrdinalBytesRefVector(ordinals, bytes, false);
             }
             compactBytes = dictBuilder.build();
             try (IntVector.Builder ordsBuilder = blockFactory().newIntVectorFixedBuilder(positionCount)) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -26,10 +26,19 @@ import java.io.IOException;
 public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted implements BytesRefVector {
     private final IntVector ordinals;
     private final BytesRefVector bytes;
+    /**
+     * See {@link OrdinalBytesRefBlock#needsCompaction()}.
+     */
+    private final boolean needsCompaction;
 
     public OrdinalBytesRefVector(IntVector ordinals, BytesRefVector bytes) {
+        this(ordinals, bytes, false);
+    }
+
+    public OrdinalBytesRefVector(IntVector ordinals, BytesRefVector bytes, boolean needsCompaction) {
         this.ordinals = ordinals;
         this.bytes = bytes;
+        this.needsCompaction = needsCompaction;
     }
 
     static OrdinalBytesRefVector readOrdinalVector(BlockFactory blockFactory, StreamInput in) throws IOException {
@@ -48,8 +57,74 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
     }
 
     void writeOrdinalVector(StreamOutput out) throws IOException {
-        ordinals.writeTo(out);
-        bytes.writeTo(out);
+        // Always serialize a phantom-free dictionary; see OrdinalBytesRefBlock#writeOrdinalBlock.
+        try (OrdinalBytesRefVector c = compact()) {
+            c.ordinals.writeTo(out);
+            c.bytes.writeTo(out);
+        }
+    }
+
+    /**
+     * See {@link OrdinalBytesRefBlock#needsCompaction()}.
+     */
+    public boolean needsCompaction() {
+        return needsCompaction;
+    }
+
+    /**
+     * Vector counterpart of {@link OrdinalBytesRefBlock#compact()}. Returns {@code this} (with an extra
+     * ref) when no compaction is needed; otherwise returns a new vector with a phantom-free dictionary
+     * and remapped ordinals. The returned vector must be closed by the caller.
+     */
+    public OrdinalBytesRefVector compact() {
+        if (needsCompaction == false) {
+            incRef();
+            return this;
+        }
+        int dictSize = bytes.getPositionCount();
+        boolean[] referenced = new boolean[dictSize];
+        int referencedCount = 0;
+        int positionCount = ordinals.getPositionCount();
+        for (int p = 0; p < positionCount; p++) {
+            int ord = ordinals.getInt(p);
+            if (referenced[ord] == false) {
+                referenced[ord] = true;
+                referencedCount++;
+            }
+        }
+        if (referencedCount == dictSize) {
+            ordinals.incRef();
+            bytes.incRef();
+            return new OrdinalBytesRefVector(ordinals, bytes, false);
+        }
+        int[] remap = new int[dictSize];
+        BytesRefVector compactBytes = null;
+        IntVector remappedOrds = null;
+        try (BytesRefVector.Builder dictBuilder = blockFactory().newBytesRefVectorBuilder(referencedCount)) {
+            BytesRef scratch = new BytesRef();
+            int newOrd = 0;
+            for (int oldOrd = 0; oldOrd < dictSize; oldOrd++) {
+                if (referenced[oldOrd]) {
+                    dictBuilder.appendBytesRef(bytes.getBytesRef(oldOrd, scratch));
+                    remap[oldOrd] = newOrd++;
+                } else {
+                    remap[oldOrd] = -1;
+                }
+            }
+            compactBytes = dictBuilder.build();
+            try (IntVector.Builder ordsBuilder = blockFactory().newIntVectorFixedBuilder(positionCount)) {
+                for (int p = 0; p < positionCount; p++) {
+                    ordsBuilder.appendInt(remap[ordinals.getInt(p)]);
+                }
+                remappedOrds = ordsBuilder.build();
+            }
+            OrdinalBytesRefVector result = new OrdinalBytesRefVector(remappedOrds, compactBytes, false);
+            remappedOrds = null;
+            compactBytes = null;
+            return result;
+        } finally {
+            Releasables.closeExpectNoException(remappedOrds, compactBytes);
+        }
     }
 
     /**
@@ -87,7 +162,7 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
 
     @Override
     public OrdinalBytesRefBlock asBlock() {
-        return new OrdinalBytesRefBlock(ordinals.asBlock(), bytes);
+        return new OrdinalBytesRefBlock(ordinals.asBlock(), bytes, needsCompaction);
     }
 
     @Override
@@ -99,20 +174,21 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
         return ordinals;
     }
 
+    /**
+     * See {@link OrdinalBytesRefBlock#getDictionaryVector()} for the phantom-entries contract.
+     */
     public BytesRefVector getDictionaryVector() {
         return bytes;
     }
 
     @Override
     public BytesRefVector filter(boolean mayContainDuplicates, int... positions) {
-        // Share the dictionary with the filtered vector. Dictionary entries that are no longer referenced
-        // by any ordinal must be ignored by consumers; the consumer-side fast paths (e.g.
-        // BytesRefBlockHash#addOrdinals*, DistinctByOperator, BytesRefTopNBlockHash) drive their work off
-        // the ordinals and never iterate the dictionary, so phantom entries are never observed.
+        // Share the dictionary with the filtered vector; flagged needsCompaction so phantoms are stripped
+        // at the wire boundary or by consumers that walk the dictionary directly.
         OrdinalBytesRefVector result = null;
         IntVector filteredOrdinals = ordinals.filter(mayContainDuplicates, positions);
         try {
-            result = new OrdinalBytesRefVector(filteredOrdinals, bytes);
+            result = new OrdinalBytesRefVector(filteredOrdinals, bytes, true);
             bytes.incRef();
         } finally {
             if (result == null) {
@@ -139,7 +215,7 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
         }
         IntVector slicedOrdinals = ordinals.slice(beginInclusive, endExclusive);
         bytes.incRef();
-        return new OrdinalBytesRefVector(slicedOrdinals, bytes);
+        return new OrdinalBytesRefVector(slicedOrdinals, bytes, true);
     }
 
     @Override
@@ -149,7 +225,7 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
         try {
             copiedOrdinals = ordinals.deepCopy(blockFactory);
             copiedBytes = bytes.deepCopy(blockFactory);
-            OrdinalBytesRefVector result = new OrdinalBytesRefVector(copiedOrdinals, copiedBytes);
+            OrdinalBytesRefVector result = new OrdinalBytesRefVector(copiedOrdinals, copiedBytes, needsCompaction);
             copiedOrdinals = null;
             copiedBytes = null;
             return result;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -189,12 +189,16 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
 
     @Override
     public BytesRefVector filter(boolean mayContainDuplicates, int... positions) {
-        // Share the dictionary with the filtered vector; flagged needsCompaction so phantoms are stripped
-        // at the wire boundary or by consumers that walk the dictionary directly.
+        // See OrdinalBytesRefBlock#filter: a no-duplicates filter whose length matches the source is a
+        // permutation, so no rows are dropped and we can propagate the source's flag rather than
+        // forcing true.
+        boolean filteredNeedsCompaction = (mayContainDuplicates == false && positions.length == ordinals.getPositionCount())
+            ? needsCompaction
+            : true;
         OrdinalBytesRefVector result = null;
         IntVector filteredOrdinals = ordinals.filter(mayContainDuplicates, positions);
         try {
-            result = new OrdinalBytesRefVector(filteredOrdinals, bytes, true);
+            result = new OrdinalBytesRefVector(filteredOrdinals, bytes, filteredNeedsCompaction);
             bytes.incRef();
         } finally {
             if (result == null) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -72,6 +72,18 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
     }
 
     /**
+     * Vector counterpart of {@link OrdinalBytesRefBlock#referencedDictionaryEntries()}.
+     */
+    public boolean[] referencedDictionaryEntries() {
+        boolean[] referenced = new boolean[bytes.getPositionCount()];
+        int positionCount = ordinals.getPositionCount();
+        for (int p = 0; p < positionCount; p++) {
+            referenced[ordinals.getInt(p)] = true;
+        }
+        return referenced;
+    }
+
+    /**
      * Vector counterpart of {@link OrdinalBytesRefBlock#compact()}. Returns {@code this} (with an extra
      * ref) when no compaction is needed; otherwise returns a new vector with a phantom-free dictionary
      * and remapped ordinals. The returned vector must be closed by the caller.
@@ -82,13 +94,10 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
             return this;
         }
         int dictSize = bytes.getPositionCount();
-        boolean[] referenced = new boolean[dictSize];
+        boolean[] referenced = referencedDictionaryEntries();
         int referencedCount = 0;
-        int positionCount = ordinals.getPositionCount();
-        for (int p = 0; p < positionCount; p++) {
-            int ord = ordinals.getInt(p);
-            if (referenced[ord] == false) {
-                referenced[ord] = true;
+        for (int oldOrd = 0; oldOrd < dictSize; oldOrd++) {
+            if (referenced[oldOrd]) {
                 referencedCount++;
             }
         }
@@ -97,6 +106,7 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
             bytes.incRef();
             return new OrdinalBytesRefVector(ordinals, bytes, false);
         }
+        int positionCount = ordinals.getPositionCount();
         int[] remap = new int[dictSize];
         BytesRefVector compactBytes = null;
         IntVector remappedOrds = null;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -105,15 +105,21 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
 
     @Override
     public BytesRefVector filter(boolean mayContainDuplicates, int... positions) {
-        // Do not build a filtered block using the same dictionary, because dictionary entries that are not referenced
-        // may reappear when hashing the dictionary in BlockHash.
-        final BytesRef scratch = new BytesRef();
-        try (BytesRefVector.Builder builder = blockFactory().newBytesRefVectorBuilder(positions.length)) {
-            for (int p : positions) {
-                builder.appendBytesRef(getBytesRef(p, scratch));
+        // Share the dictionary with the filtered vector. Dictionary entries that are no longer referenced
+        // by any ordinal must be ignored by consumers; the consumer-side fast paths (e.g.
+        // BytesRefBlockHash#addOrdinals*, DistinctByOperator, BytesRefTopNBlockHash) drive their work off
+        // the ordinals and never iterate the dictionary, so phantom entries are never observed.
+        OrdinalBytesRefVector result = null;
+        IntVector filteredOrdinals = ordinals.filter(mayContainDuplicates, positions);
+        try {
+            result = new OrdinalBytesRefVector(filteredOrdinals, bytes);
+            bytes.incRef();
+        } finally {
+            if (result == null) {
+                filteredOrdinals.close();
             }
-            return builder.build();
         }
+        return result;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DistinctByOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DistinctByOperator.java
@@ -100,31 +100,41 @@ public class DistinctByOperator extends AbstractPageMappingOperator {
     }
 
     /**
-     * Fast path for ordinal vectors (no nulls): hash only the dictionary entries,
-     * then filter positions using cheap integer ordinal lookups.
+     * Fast path for ordinal vectors (no nulls): walk rows once, looking up only the dictionary
+     * entries that are actually referenced. A per-page {@code seenInPage} boolean[] keeps
+     * {@link #seenKeys} from being asked about the same ord twice within the page. Dictionary
+     * entries that no row references are never read, so values left over by a shared dictionary
+     * (after {@code filter}/{@code slice}/{@code keepMask}) do not pollute the cross-page hash.
      */
     private Page processOrdinalsVector(Page page, OrdinalBytesRefVector ordinals) {
-        boolean[] skipOrdinal = hashDictionary(ordinals.getDictionaryVector());
+        BytesRefVector dict = ordinals.getDictionaryVector();
         IntVector ords = ordinals.getOrdinalsVector();
+        boolean[] seenInPage = new boolean[dict.getPositionCount()];
+        BytesRef scratch = new BytesRef();
         int rowCount = 0;
         int[] positions = new int[page.getPositionCount()];
         for (int p = 0; p < ords.getPositionCount(); p++) {
             int ord = ords.getInt(p);
-            if (skipOrdinal[ord] == false) {
+            if (seenInPage[ord]) {
+                continue;
+            }
+            seenInPage[ord] = true;
+            if (seenKeys.add(dict.getBytesRef(ord, scratch)) >= 0) {
                 positions[rowCount++] = p;
-                skipOrdinal[ord] = true;
             }
         }
         return filteredPage(page, positions, rowCount);
     }
 
     /**
-     * Fast path for ordinal blocks (may contain nulls): hash only the dictionary entries,
-     * then filter positions using cheap integer ordinal lookups, skipping null positions.
+     * Fast path for ordinal blocks (may contain nulls): like {@link #processOrdinalsVector}, but
+     * skips null positions. Dictionary entries that no row references are never read.
      */
     private Page processOrdinalsBlock(Page page, OrdinalBytesRefBlock ordinals) {
-        boolean[] skipOrdinal = hashDictionary(ordinals.getDictionaryVector());
+        BytesRefVector dict = ordinals.getDictionaryVector();
         IntBlock ords = ordinals.getOrdinalsBlock();
+        boolean[] seenInPage = new boolean[dict.getPositionCount()];
+        BytesRef scratch = new BytesRef();
         int rowCount = 0;
         int[] positions = new int[page.getPositionCount()];
         for (int p = 0; p < ords.getPositionCount(); p++) {
@@ -132,25 +142,15 @@ public class DistinctByOperator extends AbstractPageMappingOperator {
                 continue;
             }
             int ord = ords.getInt(ords.getFirstValueIndex(p));
-            if (skipOrdinal[ord] == false) {
+            if (seenInPage[ord]) {
+                continue;
+            }
+            seenInPage[ord] = true;
+            if (seenKeys.add(dict.getBytesRef(ord, scratch)) >= 0) {
                 positions[rowCount++] = p;
-                skipOrdinal[ord] = true;
             }
         }
         return filteredPage(page, positions, rowCount);
-    }
-
-    /**
-     * Adds all dictionary entries to {@link #seenKeys} and returns a boolean array
-     * indexed by ordinal: {@code true} means the key was already present (skip it).
-     */
-    private boolean[] hashDictionary(BytesRefVector dictionary) {
-        BytesRef scratch = new BytesRef();
-        boolean[] skip = new boolean[dictionary.getPositionCount()];
-        for (int d = 0; d < dictionary.getPositionCount(); d++) {
-            skip[d] = seenKeys.add(dictionary.getBytesRef(d, scratch)) < 0;
-        }
-        return skip;
     }
 
     private static Page filteredPage(Page page, int[] positions, int rowCount) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DistinctByOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/DistinctByOperator.java
@@ -43,10 +43,12 @@ public class DistinctByOperator extends AbstractPageMappingOperator {
     }
 
     private final int keyChannel;
+    private final BlockFactory blockFactory;
     private final BytesRefHashTable seenKeys;
 
     public DistinctByOperator(int keyChannel, BlockFactory blockFactory) {
         this.keyChannel = keyChannel;
+        this.blockFactory = blockFactory;
         this.seenKeys = HashImplFactory.newBytesRefHash(blockFactory);
     }
 
@@ -109,21 +111,27 @@ public class DistinctByOperator extends AbstractPageMappingOperator {
     private Page processOrdinalsVector(Page page, OrdinalBytesRefVector ordinals) {
         BytesRefVector dict = ordinals.getDictionaryVector();
         IntVector ords = ordinals.getOrdinalsVector();
-        boolean[] seenInPage = new boolean[dict.getPositionCount()];
-        BytesRef scratch = new BytesRef();
-        int rowCount = 0;
-        int[] positions = new int[page.getPositionCount()];
-        for (int p = 0; p < ords.getPositionCount(); p++) {
-            int ord = ords.getInt(p);
-            if (seenInPage[ord]) {
-                continue;
+        long acquiredBytes = (long) Byte.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "DistinctByOperator");
+        try {
+            boolean[] seenInPage = new boolean[dict.getPositionCount()];
+            BytesRef scratch = new BytesRef();
+            int rowCount = 0;
+            int[] positions = new int[page.getPositionCount()];
+            for (int p = 0; p < ords.getPositionCount(); p++) {
+                int ord = ords.getInt(p);
+                if (seenInPage[ord]) {
+                    continue;
+                }
+                seenInPage[ord] = true;
+                if (seenKeys.add(dict.getBytesRef(ord, scratch)) >= 0) {
+                    positions[rowCount++] = p;
+                }
             }
-            seenInPage[ord] = true;
-            if (seenKeys.add(dict.getBytesRef(ord, scratch)) >= 0) {
-                positions[rowCount++] = p;
-            }
+            return filteredPage(page, positions, rowCount);
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
-        return filteredPage(page, positions, rowCount);
     }
 
     /**
@@ -133,24 +141,30 @@ public class DistinctByOperator extends AbstractPageMappingOperator {
     private Page processOrdinalsBlock(Page page, OrdinalBytesRefBlock ordinals) {
         BytesRefVector dict = ordinals.getDictionaryVector();
         IntBlock ords = ordinals.getOrdinalsBlock();
-        boolean[] seenInPage = new boolean[dict.getPositionCount()];
-        BytesRef scratch = new BytesRef();
-        int rowCount = 0;
-        int[] positions = new int[page.getPositionCount()];
-        for (int p = 0; p < ords.getPositionCount(); p++) {
-            if (ords.isNull(p)) {
-                continue;
+        long acquiredBytes = (long) Byte.BYTES * dict.getPositionCount();
+        blockFactory.breaker().addEstimateBytesAndMaybeBreak(acquiredBytes, "DistinctByOperator");
+        try {
+            boolean[] seenInPage = new boolean[dict.getPositionCount()];
+            BytesRef scratch = new BytesRef();
+            int rowCount = 0;
+            int[] positions = new int[page.getPositionCount()];
+            for (int p = 0; p < ords.getPositionCount(); p++) {
+                if (ords.isNull(p)) {
+                    continue;
+                }
+                int ord = ords.getInt(ords.getFirstValueIndex(p));
+                if (seenInPage[ord]) {
+                    continue;
+                }
+                seenInPage[ord] = true;
+                if (seenKeys.add(dict.getBytesRef(ord, scratch)) >= 0) {
+                    positions[rowCount++] = p;
+                }
             }
-            int ord = ords.getInt(ords.getFirstValueIndex(p));
-            if (seenInPage[ord]) {
-                continue;
-            }
-            seenInPage[ord] = true;
-            if (seenKeys.add(dict.getBytesRef(ord, scratch)) >= 0) {
-                positions[rowCount++] = p;
-            }
+            return filteredPage(page, positions, rowCount);
+        } finally {
+            blockFactory.breaker().addWithoutBreaking(-acquiredBytes);
         }
-        return filteredPage(page, positions, rowCount);
     }
 
     private static Page filteredPage(Page page, int[] positions, int rowCount) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperator.java
@@ -45,6 +45,13 @@ public final class EnrichQuerySourceOperator extends SourceOperator {
     private final Page originalPage;
     private final BlockOptimization blockOptimization;
     private Page optimizedPage;
+    /**
+     * In {@link BlockOptimization#DICTIONARY} mode, marks dictionary entries actually referenced by an
+     * ordinal in {@link #originalPage}. Phantom dict entries (left over by upstream {@code filter()}/
+     * {@code slice()}/{@code keepMask()}) sit at unreferenced positions and we skip Lucene queries for
+     * them in {@link #nextQuery()} / {@link #processBulkQueries}. {@code null} until the first call.
+     */
+    private boolean[] referencedDictionaryEntries;
     private int queryPosition = -1;
     private final IndexedByShardId<? extends ShardContext> shardContexts;
     private final ShardContext shardContext;
@@ -122,6 +129,20 @@ public final class EnrichQuerySourceOperator extends SourceOperator {
      */
     public Page getInputPage() {
         return getInputPageInternal();
+    }
+
+    /**
+     * Lazily computes (and caches) which dictionary positions are actually referenced by some ordinal
+     * in {@link #originalPage}. Returns {@code null} when not in DICTIONARY mode (no phantoms possible).
+     */
+    private boolean[] referencedDictionaryEntries() {
+        if (blockOptimization != BlockOptimization.DICTIONARY) {
+            return null;
+        }
+        if (referencedDictionaryEntries == null) {
+            referencedDictionaryEntries = BlockOptimization.extractOrdinalBlock(originalPage).referencedDictionaryEntries();
+        }
+        return referencedDictionaryEntries;
     }
 
     @Override
@@ -209,9 +230,14 @@ public final class EnrichQuerySourceOperator extends SourceOperator {
             bulkKeywordLookup.initializeCaches(indexReader);
         }
 
+        boolean[] referenced = referencedDictionaryEntries();
         int totalMatches = 0;
         do {
             if (queryPosition >= queryList.getPositionCount(inputPage)) break;
+            if (referenced != null && referenced[queryPosition] == false) {
+                queryPosition++;
+                continue;
+            }
 
             final int matches = bulkKeywordLookup.processQuery(
                 inputPage,
@@ -260,7 +286,12 @@ public final class EnrichQuerySourceOperator extends SourceOperator {
     private Query nextQuery() {
         ++queryPosition;
         Page inputPage = getInputPageInternal();
+        boolean[] referenced = referencedDictionaryEntries();
         while (isFinished() == false) {
+            if (referenced != null && referenced[queryPosition] == false) {
+                ++queryPosition;
+                continue;
+            }
             Query query = queryList.getQuery(queryPosition, inputPage, searchExecutionContext);
             if (query != null) {
                 return query;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperator.java
@@ -49,9 +49,12 @@ public final class EnrichQuerySourceOperator extends SourceOperator {
      * In {@link BlockOptimization#DICTIONARY} mode, marks dictionary entries actually referenced by an
      * ordinal in {@link #originalPage}. Phantom dict entries (left over by upstream {@code filter()}/
      * {@code slice()}/{@code keepMask()}) sit at unreferenced positions and we skip Lucene queries for
-     * them in {@link #nextQuery()} / {@link #processBulkQueries}. {@code null} until the first call.
+     * them in {@link #nextQuery()} / {@link #processBulkQueries}. {@code null} when phantoms are
+     * impossible (non-DICTIONARY mode, or source block has {@code needsCompaction() == false}).
      */
     private boolean[] referencedDictionaryEntries;
+    /** True once {@link #referencedDictionaryEntries()} has run; allows caching the {@code null} result. */
+    private boolean referencedDictionaryEntriesComputed;
     private int queryPosition = -1;
     private final IndexedByShardId<? extends ShardContext> shardContexts;
     private final ShardContext shardContext;
@@ -133,15 +136,25 @@ public final class EnrichQuerySourceOperator extends SourceOperator {
 
     /**
      * Lazily computes (and caches) which dictionary positions are actually referenced by some ordinal
-     * in {@link #originalPage}. Returns {@code null} when not in DICTIONARY mode (no phantoms possible).
+     * in {@link #originalPage}. Returns {@code null} when phantoms cannot exist — either because we
+     * are not in DICTIONARY mode, or because the source ordinal block has {@code needsCompaction()
+     * == false}, meaning every dictionary entry is referenced by construction. Avoiding the scan in
+     * the no-phantoms case is the whole point: it would walk every ordinal only to produce an
+     * all-true array.
      */
     private boolean[] referencedDictionaryEntries() {
+        if (referencedDictionaryEntriesComputed) {
+            return referencedDictionaryEntries;
+        }
+        referencedDictionaryEntriesComputed = true;
         if (blockOptimization != BlockOptimization.DICTIONARY) {
             return null;
         }
-        if (referencedDictionaryEntries == null) {
-            referencedDictionaryEntries = BlockOptimization.extractOrdinalBlock(originalPage).referencedDictionaryEntries();
+        OrdinalBytesRefBlock ordinalBlock = BlockOptimization.extractOrdinalBlock(originalPage);
+        if (ordinalBlock.needsCompaction() == false) {
+            return null;
         }
+        referencedDictionaryEntries = ordinalBlock.referencedDictionaryEntries();
         return referencedDictionaryEntries;
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -470,11 +470,13 @@ public class BlockHashTests extends BlockHashTestCase {
                     assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 4)));
                     assertKeys(ordsAndKeys.keys(), "item-2", "item-1", "item-4", "item-3");
                 } else {
+                    // Lazy hashing adds dictionary entries in first-visit (input ord) order rather
+                    // than dictionary order: ords 1, 0, 3, 2 -> "item-2", "item-1", "item-4", "item-3".
                     assertThat(ordsAndKeys.description(), startsWith("BytesRefBlockHash{channel=0, entries=4, size="));
                     assertThat(ordsAndKeys.description(), endsWith("b, seenNull=false}"));
-                    assertOrds(ordsAndKeys.ords(), 2, 1, 4, 2, 4, 1, 3, 4);
+                    assertOrds(ordsAndKeys.ords(), 1, 2, 3, 1, 3, 2, 4, 3);
                     assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(1, 5)));
-                    assertKeys(ordsAndKeys.keys(), "item-1", "item-2", "item-3", "item-4");
+                    assertKeys(ordsAndKeys.keys(), "item-2", "item-1", "item-4", "item-3");
                 }
             }, new OrdinalBytesRefVector(ords.build(), bytes.build()).asBlock());
         }
@@ -567,6 +569,75 @@ public class BlockHashTests extends BlockHashTestCase {
                     assertKeys(ordsAndKeys.keys(), null, "foo", "bar", "bort");
                 }
                 assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 4)));
+            }, new OrdinalBytesRefBlock(ords.build(), bytes.build()));
+        }
+    }
+
+    public void testOrdinalsWithUnreferencedDictionaryEntriesVector() {
+        // Dictionary entries 1 and 3 are intentionally never referenced. With shared dictionaries on
+        // filter()/slice()/keepMask(), these can leak in to BytesRefBlockHash and must not become groups.
+        try (
+            IntVector.Builder ords = blockFactory.newIntVectorFixedBuilder(5);
+            BytesRefVector.Builder bytes = blockFactory.newBytesRefVectorBuilder(4)
+        ) {
+            ords.appendInt(0);
+            ords.appendInt(2);
+            ords.appendInt(0);
+            ords.appendInt(2);
+            ords.appendInt(2);
+            bytes.appendBytesRef(new BytesRef("a"));
+            bytes.appendBytesRef(new BytesRef("phantom-1"));
+            bytes.appendBytesRef(new BytesRef("b"));
+            bytes.appendBytesRef(new BytesRef("phantom-2"));
+
+            hash(ordsAndKeys -> {
+                if (forcePackedHash) {
+                    assertThat(ordsAndKeys.description(), startsWith("PackedValuesBlockHash{groups=[0:BYTES_REF], entries=2, size="));
+                    assertOrds(ordsAndKeys.ords(), 0, 1, 0, 1, 1);
+                    assertKeys(ordsAndKeys.keys(), "a", "b");
+                    assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 2)));
+                } else {
+                    assertThat(ordsAndKeys.description(), startsWith("BytesRefBlockHash{channel=0, entries=2, size="));
+                    assertThat(ordsAndKeys.description(), endsWith("b, seenNull=false}"));
+                    assertOrds(ordsAndKeys.ords(), 1, 2, 1, 2, 2);
+                    assertKeys(ordsAndKeys.keys(), "a", "b");
+                    assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(1, 3)));
+                }
+            }, new OrdinalBytesRefVector(ords.build(), bytes.build()).asBlock());
+        }
+    }
+
+    public void testOrdinalsWithUnreferencedDictionaryEntriesBlock() {
+        // As above, but with nulls and multi-value positions exercising addOrdinalsBlock.
+        try (
+            IntBlock.Builder ords = blockFactory.newIntBlockBuilder(5);
+            BytesRefVector.Builder bytes = blockFactory.newBytesRefVectorBuilder(4)
+        ) {
+            ords.appendInt(0);
+            ords.appendNull();
+            ords.beginPositionEntry();
+            ords.appendInt(0);
+            ords.appendInt(2);
+            ords.endPositionEntry();
+            ords.appendInt(2);
+            bytes.appendBytesRef(new BytesRef("a"));
+            bytes.appendBytesRef(new BytesRef("phantom-1"));
+            bytes.appendBytesRef(new BytesRef("b"));
+            bytes.appendBytesRef(new BytesRef("phantom-2"));
+
+            hash(ordsAndKeys -> {
+                if (forcePackedHash) {
+                    assertThat(ordsAndKeys.description(), startsWith("PackedValuesBlockHash{groups=[0:BYTES_REF], entries=3, size="));
+                    assertOrds(ordsAndKeys.ords(), new int[] { 0 }, new int[] { 1 }, new int[] { 0, 2 }, new int[] { 2 });
+                    assertKeys(ordsAndKeys.keys(), "a", null, "b");
+                    assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 3)));
+                } else {
+                    assertThat(ordsAndKeys.description(), startsWith("BytesRefBlockHash{channel=0, entries=2, size="));
+                    assertThat(ordsAndKeys.description(), endsWith("b, seenNull=true}"));
+                    assertOrds(ordsAndKeys.ords(), new int[] { 1 }, new int[] { 0 }, new int[] { 1, 2 }, new int[] { 2 });
+                    assertKeys(ordsAndKeys.keys(), null, "a", "b");
+                    assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 3)));
+                }
             }, new OrdinalBytesRefBlock(ords.build(), bytes.build()));
         }
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -470,13 +470,11 @@ public class BlockHashTests extends BlockHashTestCase {
                     assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 4)));
                     assertKeys(ordsAndKeys.keys(), "item-2", "item-1", "item-4", "item-3");
                 } else {
-                    // Lazy hashing adds dictionary entries in first-visit (input ord) order rather
-                    // than dictionary order: ords 1, 0, 3, 2 -> "item-2", "item-1", "item-4", "item-3".
                     assertThat(ordsAndKeys.description(), startsWith("BytesRefBlockHash{channel=0, entries=4, size="));
                     assertThat(ordsAndKeys.description(), endsWith("b, seenNull=false}"));
-                    assertOrds(ordsAndKeys.ords(), 1, 2, 3, 1, 3, 2, 4, 3);
+                    assertOrds(ordsAndKeys.ords(), 2, 1, 4, 2, 4, 1, 3, 4);
                     assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(1, 5)));
-                    assertKeys(ordsAndKeys.keys(), "item-2", "item-1", "item-4", "item-3");
+                    assertKeys(ordsAndKeys.keys(), "item-1", "item-2", "item-3", "item-4");
                 }
             }, new OrdinalBytesRefVector(ords.build(), bytes.build()).asBlock());
         }
@@ -603,7 +601,7 @@ public class BlockHashTests extends BlockHashTestCase {
                     assertKeys(ordsAndKeys.keys(), "a", "b");
                     assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(1, 3)));
                 }
-            }, new OrdinalBytesRefVector(ords.build(), bytes.build()).asBlock());
+            }, new OrdinalBytesRefVector(ords.build(), bytes.build(), true).asBlock());
         }
     }
 
@@ -638,7 +636,7 @@ public class BlockHashTests extends BlockHashTestCase {
                     assertKeys(ordsAndKeys.keys(), null, "a", "b");
                     assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 3)));
                 }
-            }, new OrdinalBytesRefBlock(ords.build(), bytes.build()));
+            }, new OrdinalBytesRefBlock(ords.build(), bytes.build(), true));
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -53,7 +53,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -1729,7 +1728,8 @@ public class BasicBlockTests extends ESTestCase {
                     masks[i] = randomIntBetween(0, positionCount - 1);
                 }
                 try (var filtered = block.filter(true, masks)) {
-                    assertThat(filtered, not(instanceOf(OrdinalBytesRefBlock.class)));
+                    assertThat(filtered, instanceOf(OrdinalBytesRefBlock.class));
+                    assertThat(((OrdinalBytesRefBlock) filtered).getDictionaryVector(), sameInstance(block.getDictionaryVector()));
                 }
                 assertSliceFullRange(block);
                 assertSliceOrdinalBytesRefBlock(block, 0, 0);
@@ -1767,7 +1767,8 @@ public class BasicBlockTests extends ESTestCase {
                     masks[i] = randomIntBetween(0, positionCount - 1);
                 }
                 try (var filtered = vector.filter(true, masks)) {
-                    assertThat(filtered, not(instanceOf(OrdinalBytesRefVector.class)));
+                    assertThat(filtered, instanceOf(OrdinalBytesRefVector.class));
+                    assertThat(((OrdinalBytesRefVector) filtered).getDictionaryVector(), sameInstance(vector.getDictionaryVector()));
                 }
                 assertSliceFullRange(vector);
                 assertSliceOrdinalBytesRefVector(vector, 0, 0);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -1729,7 +1729,26 @@ public class BasicBlockTests extends ESTestCase {
                 }
                 try (var filtered = block.filter(true, masks)) {
                     assertThat(filtered, instanceOf(OrdinalBytesRefBlock.class));
-                    assertThat(((OrdinalBytesRefBlock) filtered).getDictionaryVector(), sameInstance(block.getDictionaryVector()));
+                    OrdinalBytesRefBlock filteredOrdinal = (OrdinalBytesRefBlock) filtered;
+                    assertThat(filteredOrdinal.needsCompaction(), is(true));
+                    BytesRef expected = new BytesRef();
+                    BytesRef actual = new BytesRef();
+                    for (int i = 0; i < masks.length; i++) {
+                        if (block.isNull(masks[i])) {
+                            assertThat(filteredOrdinal.isNull(i), is(true));
+                            continue;
+                        }
+                        assertThat(filteredOrdinal.isNull(i), is(false));
+                        assertThat(filteredOrdinal.getValueCount(i), equalTo(block.getValueCount(masks[i])));
+                        int srcStart = block.getFirstValueIndex(masks[i]);
+                        int dstStart = filteredOrdinal.getFirstValueIndex(i);
+                        for (int v = 0; v < block.getValueCount(masks[i]); v++) {
+                            assertThat(
+                                filteredOrdinal.getBytesRef(dstStart + v, actual),
+                                equalTo(block.getBytesRef(srcStart + v, expected))
+                            );
+                        }
+                    }
                 }
                 assertSliceFullRange(block);
                 assertSliceOrdinalBytesRefBlock(block, 0, 0);
@@ -1768,7 +1787,13 @@ public class BasicBlockTests extends ESTestCase {
                 }
                 try (var filtered = vector.filter(true, masks)) {
                     assertThat(filtered, instanceOf(OrdinalBytesRefVector.class));
-                    assertThat(((OrdinalBytesRefVector) filtered).getDictionaryVector(), sameInstance(vector.getDictionaryVector()));
+                    OrdinalBytesRefVector filteredOrdinal = (OrdinalBytesRefVector) filtered;
+                    assertThat(filteredOrdinal.needsCompaction(), is(true));
+                    BytesRef expected = new BytesRef();
+                    BytesRef actual = new BytesRef();
+                    for (int i = 0; i < masks.length; i++) {
+                        assertThat(filteredOrdinal.getBytesRef(i, actual), equalTo(vector.getBytesRef(masks[i], expected)));
+                    }
                 }
                 assertSliceFullRange(vector);
                 assertSliceOrdinalBytesRefVector(vector, 0, 0);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/OrdinalBytesRefCompactTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/OrdinalBytesRefCompactTests.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.core.Releasables;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class OrdinalBytesRefCompactTests extends SerializationTestCase {
+
+    public void testCompactOnCleanBlockReturnsSelf() {
+        try (OrdinalBytesRefBlock block = buildBlockWithPhantoms(false)) {
+            assertThat(block.needsCompaction(), is(false));
+            try (OrdinalBytesRefBlock compact = block.compact()) {
+                assertThat(compact, sameInstance(block));
+                assertThat(compact.needsCompaction(), is(false));
+            }
+        }
+    }
+
+    public void testCompactOnFilteredBlockProducesPhantomFreeDict() {
+        // Dictionary: a, phantom-1, b, phantom-2, c. Ords reference 0, 2, 4 only.
+        try (
+            BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(5);
+            IntBlock.Builder ordsBuilder = blockFactory.newIntBlockBuilder(4)
+        ) {
+            dictBuilder.appendBytesRef(new BytesRef("a"));
+            dictBuilder.appendBytesRef(new BytesRef("phantom-1"));
+            dictBuilder.appendBytesRef(new BytesRef("b"));
+            dictBuilder.appendBytesRef(new BytesRef("phantom-2"));
+            dictBuilder.appendBytesRef(new BytesRef("c"));
+            ordsBuilder.appendInt(0);
+            ordsBuilder.appendNull();
+            ordsBuilder.appendInt(2);
+            ordsBuilder.appendInt(4);
+            try (OrdinalBytesRefBlock block = new OrdinalBytesRefBlock(ordsBuilder.build(), dictBuilder.build(), true)) {
+                try (OrdinalBytesRefBlock compact = block.compact()) {
+                    assertThat(compact.needsCompaction(), is(false));
+                    assertThat(compact.getDictionaryVector().getPositionCount(), equalTo(3));
+                    BytesRef scratch = new BytesRef();
+                    assertThat(compact.getDictionaryVector().getBytesRef(0, scratch).utf8ToString(), equalTo("a"));
+                    assertThat(compact.getDictionaryVector().getBytesRef(1, scratch).utf8ToString(), equalTo("b"));
+                    assertThat(compact.getDictionaryVector().getBytesRef(2, scratch).utf8ToString(), equalTo("c"));
+
+                    assertThat(compact.isNull(0), is(false));
+                    assertThat(compact.getBytesRef(0, scratch).utf8ToString(), equalTo("a"));
+                    assertThat(compact.isNull(1), is(true));
+                    assertThat(compact.getBytesRef(2, scratch).utf8ToString(), equalTo("b"));
+                    assertThat(compact.getBytesRef(3, scratch).utf8ToString(), equalTo("c"));
+                }
+            }
+        }
+    }
+
+    public void testCompactWhenAllReferencedReturnsSameChildren() {
+        // Flag is true but ordinals happen to reference every dict entry: short-circuit, no copy.
+        try (
+            BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(2);
+            IntBlock.Builder ordsBuilder = blockFactory.newIntBlockBuilder(3)
+        ) {
+            dictBuilder.appendBytesRef(new BytesRef("a"));
+            dictBuilder.appendBytesRef(new BytesRef("b"));
+            ordsBuilder.appendInt(0);
+            ordsBuilder.appendInt(1);
+            ordsBuilder.appendInt(0);
+            IntBlock ords = ordsBuilder.build();
+            BytesRefVector dict = dictBuilder.build();
+            try (OrdinalBytesRefBlock block = new OrdinalBytesRefBlock(ords, dict, true)) {
+                try (OrdinalBytesRefBlock compact = block.compact()) {
+                    assertThat(compact, not(sameInstance(block)));
+                    assertThat(compact.needsCompaction(), is(false));
+                    assertThat(compact.getOrdinalsBlock(), sameInstance(ords));
+                    assertThat(compact.getDictionaryVector(), sameInstance(dict));
+                }
+            }
+        }
+    }
+
+    public void testFilterThenCompactValuesMatch() {
+        try (
+            BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(4);
+            IntVector.Builder ordsBuilder = blockFactory.newIntVectorBuilder(6)
+        ) {
+            for (int i = 0; i < 4; i++) {
+                dictBuilder.appendBytesRef(new BytesRef("v" + i));
+            }
+            int[] sourceOrds = new int[] { 0, 3, 1, 2, 0, 3 };
+            for (int o : sourceOrds) {
+                ordsBuilder.appendInt(o);
+            }
+            try (OrdinalBytesRefVector source = new OrdinalBytesRefVector(ordsBuilder.build(), dictBuilder.build())) {
+                int[] keep = new int[] { 1, 4, 5 }; // values v3, v0, v3
+                try (BytesRefVector filtered = source.filter(true, keep)) {
+                    OrdinalBytesRefVector ord = (OrdinalBytesRefVector) filtered;
+                    assertThat(ord.needsCompaction(), is(true));
+                    try (OrdinalBytesRefVector compact = ord.compact()) {
+                        assertThat(compact.needsCompaction(), is(false));
+                        // Only dictionary entries 0 and 3 are referenced.
+                        assertThat(compact.getDictionaryVector().getPositionCount(), equalTo(2));
+                        BytesRef scratch = new BytesRef();
+                        assertThat(compact.getBytesRef(0, scratch).utf8ToString(), equalTo("v3"));
+                        assertThat(compact.getBytesRef(1, scratch).utf8ToString(), equalTo("v0"));
+                        assertThat(compact.getBytesRef(2, scratch).utf8ToString(), equalTo("v3"));
+                    }
+                }
+            }
+        }
+    }
+
+    public void testSerializeRoundTripCompactsBlockDictionary() throws IOException {
+        // Dense ordinal block (12 values, 5-entry dict with 2 phantoms) -> the wire path picks
+        // the SERIALIZE_BLOCK_ORDINAL branch, which is where we want compaction to happen.
+        try (OrdinalBytesRefBlock block = buildDenseBlockWithPhantoms()) {
+            assertThat(block.needsCompaction(), is(true));
+            assertThat(block.isDense(), is(true));
+            assertThat(block.getDictionaryVector().getPositionCount(), equalTo(5));
+            try (BytesRefBlock deser = serializeDeserializeBlock((BytesRefBlock) block)) {
+                OrdinalBytesRefBlock ord = deser.asOrdinals();
+                assertNotNull("expected dictionary-encoded block on the wire", ord);
+                assertThat(ord.needsCompaction(), is(false));
+                assertThat(ord.getDictionaryVector().getPositionCount(), equalTo(3));
+                BytesRef scratch = new BytesRef();
+                assertThat(ord.getDictionaryVector().getBytesRef(0, scratch).utf8ToString(), equalTo("a"));
+                assertThat(ord.getDictionaryVector().getBytesRef(1, scratch).utf8ToString(), equalTo("b"));
+                assertThat(ord.getDictionaryVector().getBytesRef(2, scratch).utf8ToString(), equalTo("c"));
+                // Original ords were [0, null, 2, 4, 0, 0, 2, 0, 4, 4, 2, 0]; remapped to
+                // [0, null, 1, 2, 0, 0, 1, 0, 2, 2, 1, 0].
+                assertThat(ord.isNull(1), is(true));
+                assertThat(ord.getBytesRef(0, scratch).utf8ToString(), equalTo("a"));
+                assertThat(ord.getBytesRef(2, scratch).utf8ToString(), equalTo("b"));
+                assertThat(ord.getBytesRef(3, scratch).utf8ToString(), equalTo("c"));
+                assertThat(ord.getBytesRef(8, scratch).utf8ToString(), equalTo("c"));
+            }
+        }
+    }
+
+    public void testSerializeRoundTripCompactsVectorDictionary() throws IOException {
+        try (OrdinalBytesRefVector vector = buildDenseVectorWithPhantoms()) {
+            assertThat(vector.needsCompaction(), is(true));
+            assertThat(vector.isDense(), is(true));
+            assertThat(vector.getDictionaryVector().getPositionCount(), equalTo(4));
+            try (BytesRefBlock deser = serializeDeserializeBlock((BytesRefBlock) vector.asBlock())) {
+                OrdinalBytesRefBlock ord = deser.asOrdinals();
+                assertNotNull("expected dictionary-encoded block on the wire", ord);
+                assertThat(ord.needsCompaction(), is(false));
+                assertThat(ord.getDictionaryVector().getPositionCount(), equalTo(2));
+                BytesRef scratch = new BytesRef();
+                assertThat(ord.getDictionaryVector().getBytesRef(0, scratch).utf8ToString(), equalTo("a"));
+                assertThat(ord.getDictionaryVector().getBytesRef(1, scratch).utf8ToString(), equalTo("c"));
+            }
+        }
+    }
+
+    public void testCompactVectorOnCleanReturnsSelf() {
+        try (OrdinalBytesRefVector vector = buildVectorWithPhantoms(false)) {
+            assertThat(vector.needsCompaction(), is(false));
+            try (OrdinalBytesRefVector compact = vector.compact()) {
+                assertThat(compact, sameInstance(vector));
+            }
+        }
+    }
+
+    public void testCompactVectorPhantomFreeDict() {
+        try (OrdinalBytesRefVector vector = buildVectorWithPhantoms(true)) {
+            assertThat(vector.needsCompaction(), is(true));
+            try (OrdinalBytesRefVector compact = vector.compact()) {
+                assertThat(compact.needsCompaction(), is(false));
+                assertThat(compact.getDictionaryVector().getPositionCount(), equalTo(2));
+                BytesRef scratch = new BytesRef();
+                assertThat(compact.getBytesRef(0, scratch).utf8ToString(), equalTo("a"));
+                assertThat(compact.getBytesRef(1, scratch).utf8ToString(), equalTo("c"));
+                assertThat(compact.getBytesRef(2, scratch).utf8ToString(), equalTo("a"));
+            }
+        }
+    }
+
+    public void testCompactVectorAllReferencedReturnsSameChildren() {
+        try (
+            BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(2);
+            IntVector.Builder ordsBuilder = blockFactory.newIntVectorBuilder(3)
+        ) {
+            dictBuilder.appendBytesRef(new BytesRef("a"));
+            dictBuilder.appendBytesRef(new BytesRef("b"));
+            ordsBuilder.appendInt(0);
+            ordsBuilder.appendInt(1);
+            ordsBuilder.appendInt(0);
+            IntVector ords = ordsBuilder.build();
+            BytesRefVector dict = dictBuilder.build();
+            try (OrdinalBytesRefVector vector = new OrdinalBytesRefVector(ords, dict, true)) {
+                try (OrdinalBytesRefVector compact = vector.compact()) {
+                    assertThat(compact, not(sameInstance(vector)));
+                    assertThat(compact.needsCompaction(), is(false));
+                    assertThat(compact.getOrdinalsVector(), sameInstance(ords));
+                    assertThat(compact.getDictionaryVector(), sameInstance(dict));
+                }
+            }
+        }
+    }
+
+    /**
+     * Builds a block whose dictionary always has exactly five entries [a, phantom-1, b, phantom-2, c]
+     * and whose ordinals reference 0, null, 2, 4. When {@code needsCompaction} is true the result is
+     * flagged for compaction; otherwise the (correct but ill-conformed) flag stays false to test the
+     * no-op path.
+     */
+    private OrdinalBytesRefBlock buildBlockWithPhantoms(boolean needsCompaction) {
+        BytesRefVector dict = null;
+        IntBlock ords = null;
+        try (
+            BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(5);
+            IntBlock.Builder ordsBuilder = blockFactory.newIntBlockBuilder(4)
+        ) {
+            dictBuilder.appendBytesRef(new BytesRef("a"));
+            dictBuilder.appendBytesRef(new BytesRef("phantom-1"));
+            dictBuilder.appendBytesRef(new BytesRef("b"));
+            dictBuilder.appendBytesRef(new BytesRef("phantom-2"));
+            dictBuilder.appendBytesRef(new BytesRef("c"));
+            ordsBuilder.appendInt(0);
+            ordsBuilder.appendNull();
+            ordsBuilder.appendInt(2);
+            ordsBuilder.appendInt(4);
+            dict = dictBuilder.build();
+            ords = ordsBuilder.build();
+            OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(ords, dict, needsCompaction);
+            ords = null;
+            dict = null;
+            return result;
+        } finally {
+            Releasables.closeExpectNoException(ords, dict);
+        }
+    }
+
+    /**
+     * Same dictionary as {@link #buildBlockWithPhantoms} but with enough ordinals to satisfy
+     * {@link OrdinalBytesRefBlock#isDense()}, so the wire path actually picks the ordinal branch.
+     */
+    private OrdinalBytesRefBlock buildDenseBlockWithPhantoms() {
+        BytesRefVector dict = null;
+        IntBlock ords = null;
+        try (
+            BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(5);
+            IntBlock.Builder ordsBuilder = blockFactory.newIntBlockBuilder(12)
+        ) {
+            dictBuilder.appendBytesRef(new BytesRef("a"));
+            dictBuilder.appendBytesRef(new BytesRef("phantom-1"));
+            dictBuilder.appendBytesRef(new BytesRef("b"));
+            dictBuilder.appendBytesRef(new BytesRef("phantom-2"));
+            dictBuilder.appendBytesRef(new BytesRef("c"));
+            int[] sequence = new int[] { 0, -1, 2, 4, 0, 0, 2, 0, 4, 4, 2, 0 };
+            for (int o : sequence) {
+                if (o < 0) {
+                    ordsBuilder.appendNull();
+                } else {
+                    ordsBuilder.appendInt(o);
+                }
+            }
+            dict = dictBuilder.build();
+            ords = ordsBuilder.build();
+            OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(ords, dict, true);
+            ords = null;
+            dict = null;
+            return result;
+        } finally {
+            Releasables.closeExpectNoException(ords, dict);
+        }
+    }
+
+    /**
+     * Same dictionary as {@link #buildVectorWithPhantoms} but dense.
+     */
+    private OrdinalBytesRefVector buildDenseVectorWithPhantoms() {
+        BytesRefVector dict = null;
+        IntVector ords = null;
+        try (
+            BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(4);
+            IntVector.Builder ordsBuilder = blockFactory.newIntVectorBuilder(10)
+        ) {
+            dictBuilder.appendBytesRef(new BytesRef("a"));
+            dictBuilder.appendBytesRef(new BytesRef("phantom"));
+            dictBuilder.appendBytesRef(new BytesRef("b"));
+            dictBuilder.appendBytesRef(new BytesRef("c"));
+            for (int o : new int[] { 0, 3, 0, 0, 3, 0, 3, 0, 3, 0 }) {
+                ordsBuilder.appendInt(o);
+            }
+            dict = dictBuilder.build();
+            ords = ordsBuilder.build();
+            OrdinalBytesRefVector result = new OrdinalBytesRefVector(ords, dict, true);
+            ords = null;
+            dict = null;
+            return result;
+        } finally {
+            Releasables.closeExpectNoException(ords, dict);
+        }
+    }
+
+    /**
+     * Builds a vector with dictionary [a, phantom, b, c] and ordinals 0, 3, 0 (so phantom and "b" are
+     * unreferenced).
+     */
+    private OrdinalBytesRefVector buildVectorWithPhantoms(boolean needsCompaction) {
+        BytesRefVector dict = null;
+        IntVector ords = null;
+        try (
+            BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(4);
+            IntVector.Builder ordsBuilder = blockFactory.newIntVectorBuilder(3)
+        ) {
+            dictBuilder.appendBytesRef(new BytesRef("a"));
+            dictBuilder.appendBytesRef(new BytesRef("phantom"));
+            dictBuilder.appendBytesRef(new BytesRef("b"));
+            dictBuilder.appendBytesRef(new BytesRef("c"));
+            ordsBuilder.appendInt(0);
+            ordsBuilder.appendInt(3);
+            ordsBuilder.appendInt(0);
+            dict = dictBuilder.build();
+            ords = ordsBuilder.build();
+            OrdinalBytesRefVector result = new OrdinalBytesRefVector(ords, dict, needsCompaction);
+            ords = null;
+            dict = null;
+            return result;
+        } finally {
+            Releasables.closeExpectNoException(ords, dict);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DistinctByOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DistinctByOperatorTests.java
@@ -10,7 +10,12 @@ package org.elasticsearch.compute.operator;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.test.OperatorTestCase;
 import org.hamcrest.Matcher;
@@ -354,6 +359,121 @@ public class DistinctByOperatorTests extends OperatorTestCase {
                 assertThat(outputValues.getLong(0), equalTo(0L));
 
                 output.releaseBlocks();
+            }
+        }
+    }
+
+    /**
+     * Regression coverage for the shared-dictionary contract: a value that is present in page A's
+     * dictionary but is not referenced by any row of page A must NOT poison the cross-page hash.
+     * In page B, a row that legitimately references that value must still be emitted.
+     */
+    public void testOrdinalUnreferencedDictionaryEntryAcrossPagesVector() {
+        BlockFactory blockFactory = driverContext().blockFactory();
+        try (DistinctByOperator op = new DistinctByOperator(0, blockFactory)) {
+            // Page 1: dictionary has [a, phantom], but rows reference only ord 0 ("a").
+            BytesRefVector dict1;
+            try (BytesRefVector.Builder b = blockFactory.newBytesRefVectorBuilder(2)) {
+                b.appendBytesRef(new BytesRef("a"));
+                b.appendBytesRef(new BytesRef("phantom"));
+                dict1 = b.build();
+            }
+            IntVector ords1;
+            try (IntVector.Builder o = blockFactory.newIntVectorFixedBuilder(3)) {
+                o.appendInt(0);
+                o.appendInt(0);
+                o.appendInt(0);
+                ords1 = o.build();
+            }
+            Page output1 = null;
+            try {
+                op.addInput(new Page(new OrdinalBytesRefVector(ords1, dict1).asBlock()));
+                output1 = op.getOutput();
+                assertThat(Objects.requireNonNull(output1).getPositionCount(), equalTo(1));
+                BytesRefBlock keyBlock = output1.getBlock(0);
+                assertThat(keyBlock.getBytesRef(0, new BytesRef()).utf8ToString(), equalTo("a"));
+            } finally {
+                if (output1 != null) {
+                    output1.releaseBlocks();
+                }
+            }
+
+            // Page 2: row references "phantom". Must be emitted (phantom was never inserted into seenKeys).
+            BytesRefVector dict2;
+            try (BytesRefVector.Builder b = blockFactory.newBytesRefVectorBuilder(1)) {
+                b.appendBytesRef(new BytesRef("phantom"));
+                dict2 = b.build();
+            }
+            IntVector ords2;
+            try (IntVector.Builder o = blockFactory.newIntVectorFixedBuilder(1)) {
+                o.appendInt(0);
+                ords2 = o.build();
+            }
+            Page output2 = null;
+            try {
+                op.addInput(new Page(new OrdinalBytesRefVector(ords2, dict2).asBlock()));
+                output2 = op.getOutput();
+                assertThat(Objects.requireNonNull(output2).getPositionCount(), equalTo(1));
+                BytesRefBlock keyBlock = output2.getBlock(0);
+                assertThat(keyBlock.getBytesRef(0, new BytesRef()).utf8ToString(), equalTo("phantom"));
+            } finally {
+                if (output2 != null) {
+                    output2.releaseBlocks();
+                }
+            }
+        }
+    }
+
+    public void testOrdinalUnreferencedDictionaryEntryAcrossPagesBlock() {
+        BlockFactory blockFactory = driverContext().blockFactory();
+        try (DistinctByOperator op = new DistinctByOperator(0, blockFactory)) {
+            // Page 1: dictionary has [a, phantom], block has a null + two refs to ord 0.
+            BytesRefVector dict1;
+            try (BytesRefVector.Builder b = blockFactory.newBytesRefVectorBuilder(2)) {
+                b.appendBytesRef(new BytesRef("a"));
+                b.appendBytesRef(new BytesRef("phantom"));
+                dict1 = b.build();
+            }
+            IntBlock ords1;
+            try (IntBlock.Builder o = blockFactory.newIntBlockBuilder(3)) {
+                o.appendInt(0);
+                o.appendNull();
+                o.appendInt(0);
+                ords1 = o.build();
+            }
+            Page output1 = null;
+            try {
+                op.addInput(new Page(new OrdinalBytesRefBlock(ords1, dict1)));
+                output1 = op.getOutput();
+                assertThat(Objects.requireNonNull(output1).getPositionCount(), equalTo(1));
+            } finally {
+                if (output1 != null) {
+                    output1.releaseBlocks();
+                }
+            }
+
+            // Page 2: legitimate "phantom" row must be emitted.
+            BytesRefVector dict2;
+            try (BytesRefVector.Builder b = blockFactory.newBytesRefVectorBuilder(1)) {
+                b.appendBytesRef(new BytesRef("phantom"));
+                dict2 = b.build();
+            }
+            IntBlock ords2;
+            try (IntBlock.Builder o = blockFactory.newIntBlockBuilder(1)) {
+                o.appendInt(0);
+                ords2 = o.build();
+            }
+            Page output2 = null;
+            try {
+                op.addInput(new Page(new OrdinalBytesRefBlock(ords2, dict2)));
+                output2 = op.getOutput();
+                assertThat(Objects.requireNonNull(output2).getPositionCount(), equalTo(1));
+                BytesRefBlock keyBlock = output2.getBlock(0);
+                assertThat(keyBlock.getBytesRef(0, new BytesRef()).utf8ToString(), equalTo("phantom"));
+            } finally {
+                if (output2 != null) {
+                    output2.releaseBlocks();
+                }
             }
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/internal/InternalPacks.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/internal/InternalPacks.java
@@ -32,9 +32,14 @@ final class InternalPacks {
         if (vector != null) {
             OrdinalBytesRefVector ordinals = vector.asOrdinals();
             if (ordinals != null) {
-                var encoded = packBytesVector(driverContext, ordinals.getDictionaryVector());
-                ordinals.getOrdinalsVector().incRef();
-                return new OrdinalBytesRefVector(ordinals.getOrdinalsVector(), encoded).asBlock();
+                // Compact away phantom dictionary entries (left over by filter()/slice()/keepMask())
+                // before encoding, so we don't waste work encoding values no row references and don't
+                // propagate phantoms into the new ordinal block we hand back.
+                try (OrdinalBytesRefVector compact = ordinals.compact()) {
+                    var encoded = packBytesVector(driverContext, compact.getDictionaryVector());
+                    compact.getOrdinalsVector().incRef();
+                    return new OrdinalBytesRefVector(compact.getOrdinalsVector(), encoded).asBlock();
+                }
             } else {
                 return packBytesVector(driverContext, vector).asBlock();
             }


### PR DESCRIPTION
Closes elastic/esql-planning#691


