### PR TITLE
ES|QL|DS Fix streaming parallel parser hang under saturated executor for NDJSON/CSV

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -229,6 +229,7 @@ public final class StreamingParallelParsingCoordinator {
             try {
                 executor.execute(() -> runSegmentator(decompressedStream, this.chunkSize));
             } catch (RejectedExecutionException e) {
+                logger.warn("Streaming parallel parser segmentator submission rejected by executor", e);
                 firstError.compareAndSet(null, e);
                 segmentatorDone = true;
                 dispatchSignal.release();
@@ -238,6 +239,7 @@ public final class StreamingParallelParsingCoordinator {
                 try {
                     executor.execute(this::runParser);
                 } catch (RejectedExecutionException e) {
+                    logger.warn("Streaming parallel parser parser submission rejected by executor", e);
                     firstError.compareAndSet(null, e);
                 }
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -143,17 +143,14 @@ public final class StreamingParallelParsingCoordinator {
 
         private final AtomicReference<Throwable> firstError = new AtomicReference<>();
         /**
-         * Worker-completion bookkeeping. {@link #startedWorkers} is incremented by each worker
-         * (segmentator and every parser) as its very first action; {@link #finishedWorkers} is
-         * incremented from each worker's {@code finally}. Consumers and {@link #close} reason about
-         * progress as {@code finishedWorkers == startedWorkers}, not against a fixed count of
-         * <em>submitted</em> tasks, because the executor may queue submissions indefinitely under
-         * saturation. A naive {@code CountDownLatch(1 + parallelism)} would never fire if some
-         * parser runnables sit in the executor queue forever — see issue tracking the streaming
-         * parser deadlock under {@code generic}-pool saturation.
+         * Live worker count: incremented by each worker (segmentator and every parser) as its first
+         * action inside its {@code try} block, decremented in the matching {@code finally}. Workers
+         * that never run never increment, so {@link #close} can wait for {@code inFlightWorkers == 0}
+         * without being held hostage by parser submissions the executor queued but never scheduled.
+         * A naive {@code CountDownLatch(1 + parallelism)} would never fire in that scenario — see
+         * the streaming-parser deadlock fix under {@code generic}-pool saturation.
          */
-        private final AtomicInteger startedWorkers = new AtomicInteger(0);
-        private final AtomicInteger finishedWorkers = new AtomicInteger(0);
+        private final AtomicInteger inFlightWorkers = new AtomicInteger(0);
         /**
          * Flips to {@code true} after the segmentator's main loop has exited AND it has flushed its
          * POISON sentinels to {@link #chunkQueue}. Consumers use this — not a worker-count latch —
@@ -172,6 +169,19 @@ public final class StreamingParallelParsingCoordinator {
          * POISON has been observed.
          */
         private final Semaphore dispatchPermits;
+        /**
+         * Wakes the consumer parked in {@link #takeNextPage} on any state change relevant to its
+         * predicate: a new chunk is dispatched (after {@link #chunksDispatched} increments), the
+         * segmentator finishes (after {@link #segmentatorDone} flips), or the iterator is closed.
+         * Each release pairs with a single {@code tryAcquire} on the consumer side; the timeout on
+         * that acquire is purely a watchdog — under normal operation the signal fires immediately.
+         */
+        private final Semaphore dispatchSignal = new Semaphore(0);
+        /**
+         * Wakes {@link #close} when a worker's {@code finally} runs (after {@link #inFlightWorkers}
+         * decrements). Same watchdog-bounded semantics as {@link #dispatchSignal}.
+         */
+        private final Semaphore completionSignal = new Semaphore(0);
 
         private int currentChunk = 0;
         private Page buffered = null;
@@ -211,16 +221,17 @@ public final class StreamingParallelParsingCoordinator {
                 pageQueues[i] = new ArrayBlockingQueue<>(16);
             }
 
-            // 1 segmentator + N parsers. We do NOT track an upfront expected count here: if the
-            // executor rejects a submission, the corresponding runnable simply never increments
-            // startedWorkers, so finishedWorkers == startedWorkers stays correct. If the segmentator
-            // submission specifically is rejected, we still need to surface that as an error and
-            // mark "segmentation done" so the consumer doesn't wait for chunks that will never come.
+            // 1 segmentator + N parsers. inFlightWorkers is only incremented from inside each
+            // runnable, so rejected or queued-but-never-scheduled submissions don't contribute and
+            // close() is never wedged on them. If the segmentator submission specifically is
+            // rejected we still need to surface the error and mark "segmentator done" so the
+            // consumer doesn't wait for chunks that will never come.
             try {
                 executor.execute(() -> runSegmentator(decompressedStream, this.chunkSize));
             } catch (RejectedExecutionException e) {
                 firstError.compareAndSet(null, e);
                 segmentatorDone = true;
+                dispatchSignal.release();
             }
 
             for (int i = 0; i < parallelism; i++) {
@@ -238,7 +249,7 @@ public final class StreamingParallelParsingCoordinator {
             int chunkIndex = 0;
 
             try {
-                startedWorkers.incrementAndGet();
+                inFlightWorkers.incrementAndGet();
                 while (closed == false && firstError.get() == null) {
                     byte[] buf;
                     try {
@@ -357,7 +368,9 @@ public final class StreamingParallelParsingCoordinator {
                 // (b) every dispatched chunk having a parser-produced (or close-drained)
                 // POISON in its page-queue slot.
                 segmentatorDone = true;
-                finishedWorkers.incrementAndGet();
+                dispatchSignal.release();
+                inFlightWorkers.decrementAndGet();
+                completionSignal.release();
             }
         }
 
@@ -420,12 +433,13 @@ public final class StreamingParallelParsingCoordinator {
                 return false;
             }
             chunksDispatched.incrementAndGet();
+            dispatchSignal.release();
             return true;
         }
 
         private void runParser() {
             try {
-                startedWorkers.incrementAndGet();
+                inFlightWorkers.incrementAndGet();
                 while (closed == false && firstError.get() == null) {
                     Chunk chunk;
                     try {
@@ -490,7 +504,8 @@ public final class StreamingParallelParsingCoordinator {
                     }
                 }
             } finally {
-                finishedWorkers.incrementAndGet();
+                inFlightWorkers.decrementAndGet();
+                completionSignal.release();
             }
         }
 
@@ -650,6 +665,9 @@ public final class StreamingParallelParsingCoordinator {
 
         private Page takeNextPage() throws InterruptedException {
             while (true) {
+                if (closed) {
+                    return null;
+                }
                 checkError();
 
                 if (currentChunk >= chunksDispatched.get()) {
@@ -662,7 +680,11 @@ public final class StreamingParallelParsingCoordinator {
                         checkError();
                         return null;
                     }
-                    Thread.sleep(10);
+                    // Park until a state change releases dispatchSignal: a chunk is dispatched,
+                    // the segmentator finishes, or close() runs. The 100ms timeout is a watchdog;
+                    // every signal site (dispatchChunk, segmentator finally, close) releases a
+                    // permit, so the acquire fires immediately in normal operation.
+                    dispatchSignal.tryAcquire(100, TimeUnit.MILLISECONDS);
                     continue;
                 }
 
@@ -709,9 +731,10 @@ public final class StreamingParallelParsingCoordinator {
          * segmentator to bail on its next post-acquire check), wake any segmentator parked on
          * {@link #dispatchPermits}, and drain whatever is already queued.
          * <p>
-         * Phase 2: wait up to {@link #CLOSE_TIMEOUT_SECONDS} for {@link #finishedWorkers} to catch up
-         * to {@link #startedWorkers}, then drain again to catch pages a parser put into a queue
-         * between the first drain and its own exit.
+         * Phase 2: wait up to {@link #CLOSE_TIMEOUT_SECONDS} for {@link #inFlightWorkers} to reach
+         * zero — signalled via {@link #completionSignal} from each worker's {@code finally} block —
+         * then drain again to catch pages a parser put into a queue between the first drain and its
+         * own exit.
          * <p>
          * <strong>Workers that never ran:</strong> we explicitly do not wait for parser tasks that
          * were submitted to the executor but never started — under saturation those runnables can sit
@@ -736,22 +759,27 @@ public final class StreamingParallelParsingCoordinator {
             // Wake the segmentator if parked on dispatchPermits.acquire(); after a successful acquire it
             // re-checks {@code closed} and exits {@link #dispatchChunk} without enqueueing.
             dispatchPermits.release();
+            // Wake any consumer parked in takeNextPage on dispatchSignal; its top-of-loop closed-check
+            // returns null immediately.
+            dispatchSignal.release();
             drainAllQueues();
             long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(CLOSE_TIMEOUT_SECONDS);
             try {
-                while (finishedWorkers.get() < startedWorkers.get() && System.nanoTime() < deadlineNanos) {
-                    Thread.sleep(20);
+                while (inFlightWorkers.get() > 0) {
+                    long remainingNanos = deadlineNanos - System.nanoTime();
+                    if (remainingNanos <= 0) {
+                        break;
+                    }
+                    completionSignal.tryAcquire(remainingNanos, TimeUnit.NANOSECONDS);
                 }
-                int started = startedWorkers.get();
-                int finished = finishedWorkers.get();
-                if (finished < started) {
+                int stillInFlight = inFlightWorkers.get();
+                if (stillInFlight > 0) {
                     logger.warn(
                         "Timed out waiting for streaming parallel parsing threads to finish after [{}]s "
-                            + "([{}] started, [{}] finished); any pages published by still-running parsers "
+                            + "([{}] still in flight); any pages published by still-running parsers "
                             + "after this point will leak their blocks",
                         CLOSE_TIMEOUT_SECONDS,
-                        started,
-                        finished
+                        stillInFlight
                     );
                 }
             } catch (InterruptedException e) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
@@ -143,7 +142,26 @@ public final class StreamingParallelParsingCoordinator {
         private final ArrayBlockingQueue<Page>[] pageQueues;
 
         private final AtomicReference<Throwable> firstError = new AtomicReference<>();
-        private final CountDownLatch allDone;
+        /**
+         * Worker-completion bookkeeping. {@link #startedWorkers} is incremented by each worker
+         * (segmentator and every parser) as its very first action; {@link #finishedWorkers} is
+         * incremented from each worker's {@code finally}. Consumers and {@link #close} reason about
+         * progress as {@code finishedWorkers == startedWorkers}, not against a fixed count of
+         * <em>submitted</em> tasks, because the executor may queue submissions indefinitely under
+         * saturation. A naive {@code CountDownLatch(1 + parallelism)} would never fire if some
+         * parser runnables sit in the executor queue forever — see issue tracking the streaming
+         * parser deadlock under {@code generic}-pool saturation.
+         */
+        private final AtomicInteger startedWorkers = new AtomicInteger(0);
+        private final AtomicInteger finishedWorkers = new AtomicInteger(0);
+        /**
+         * Flips to {@code true} after the segmentator's main loop has exited AND it has flushed its
+         * POISON sentinels to {@link #chunkQueue}. Consumers use this — not a worker-count latch —
+         * as the EOF signal: once {@code segmentatorDone} is observed and the consumer has drained
+         * every dispatched chunk's POISON, no more pages will ever be produced and the iterator is
+         * at EOF, regardless of whether queued parser tasks ever actually run.
+         */
+        private volatile boolean segmentatorDone = false;
         private final AtomicInteger chunksDispatched = new AtomicInteger();
         /**
          * Bounds how far ahead of the consumer the segmentator may dispatch. {@link #pageQueues} is
@@ -193,14 +211,16 @@ public final class StreamingParallelParsingCoordinator {
                 pageQueues[i] = new ArrayBlockingQueue<>(16);
             }
 
-            // 1 segmentator + N parsers
-            this.allDone = new CountDownLatch(1 + parallelism);
-
+            // 1 segmentator + N parsers. We do NOT track an upfront expected count here: if the
+            // executor rejects a submission, the corresponding runnable simply never increments
+            // startedWorkers, so finishedWorkers == startedWorkers stays correct. If the segmentator
+            // submission specifically is rejected, we still need to surface that as an error and
+            // mark "segmentation done" so the consumer doesn't wait for chunks that will never come.
             try {
                 executor.execute(() -> runSegmentator(decompressedStream, this.chunkSize));
             } catch (RejectedExecutionException e) {
                 firstError.compareAndSet(null, e);
-                allDone.countDown();
+                segmentatorDone = true;
             }
 
             for (int i = 0; i < parallelism; i++) {
@@ -208,7 +228,6 @@ public final class StreamingParallelParsingCoordinator {
                     executor.execute(this::runParser);
                 } catch (RejectedExecutionException e) {
                     firstError.compareAndSet(null, e);
-                    allDone.countDown();
                 }
             }
         }
@@ -219,6 +238,7 @@ public final class StreamingParallelParsingCoordinator {
             int chunkIndex = 0;
 
             try {
+                startedWorkers.incrementAndGet();
                 while (closed == false && firstError.get() == null) {
                     byte[] buf;
                     try {
@@ -331,7 +351,13 @@ public final class StreamingParallelParsingCoordinator {
                         Thread.currentThread().interrupt();
                     }
                 }
-                allDone.countDown();
+                // Order matters: segmentatorDone must be set AFTER chunksDispatched stops
+                // changing and AFTER POISONs are visible to parsers. Consumers observing
+                // segmentatorDone=true rely on (a) chunksDispatched.get() being final and
+                // (b) every dispatched chunk having a parser-produced (or close-drained)
+                // POISON in its page-queue slot.
+                segmentatorDone = true;
+                finishedWorkers.incrementAndGet();
             }
         }
 
@@ -399,6 +425,7 @@ public final class StreamingParallelParsingCoordinator {
 
         private void runParser() {
             try {
+                startedWorkers.incrementAndGet();
                 while (closed == false && firstError.get() == null) {
                     Chunk chunk;
                     try {
@@ -463,7 +490,7 @@ public final class StreamingParallelParsingCoordinator {
                     }
                 }
             } finally {
-                allDone.countDown();
+                finishedWorkers.incrementAndGet();
             }
         }
 
@@ -626,14 +653,16 @@ public final class StreamingParallelParsingCoordinator {
                 checkError();
 
                 if (currentChunk >= chunksDispatched.get()) {
-                    // Segmentator hasn't dispatched more chunks yet; briefly wait
-                    if (allDone.await(10, TimeUnit.MILLISECONDS)) {
-                        // All threads done; check if more chunks were dispatched
-                        if (currentChunk >= chunksDispatched.get()) {
-                            checkError();
-                            return null;
-                        }
+                    // EOF when segmentatorDone is observed AND currentChunk has caught up to a
+                    // re-read chunksDispatched. The re-read is required to defeat the race where
+                    // chunksDispatched was incremented just before segmentatorDone was set; the
+                    // volatile happens-before makes the re-read see the final value. See the
+                    // segmentatorDone javadoc for the full ordering argument.
+                    if (segmentatorDone && currentChunk >= chunksDispatched.get()) {
+                        checkError();
+                        return null;
                     }
+                    Thread.sleep(10);
                     continue;
                 }
 
@@ -674,21 +703,29 @@ public final class StreamingParallelParsingCoordinator {
 
         /**
          * Two-phase shutdown sequenced to drain pages a parser thread may publish after the first drain
-         * but before {@link #allDone} fires.
+         * but before workers fully finish.
          * <p>
          * Phase 1: set {@code closed=true} (causes parser threads to exit their inner loop and the
          * segmentator to bail on its next post-acquire check), wake any segmentator parked on
          * {@link #dispatchPermits}, and drain whatever is already queued.
          * <p>
-         * Phase 2: wait up to {@link #CLOSE_TIMEOUT_SECONDS} for {@link #allDone}, then drain again
-         * to catch pages a parser put into a queue between the first drain and the latch fire.
+         * Phase 2: wait up to {@link #CLOSE_TIMEOUT_SECONDS} for {@link #finishedWorkers} to catch up
+         * to {@link #startedWorkers}, then drain again to catch pages a parser put into a queue
+         * between the first drain and its own exit.
          * <p>
-         * <strong>Timeout contract:</strong> if {@code allDone.await} times out we log a warning and
-         * run the second drain anyway, but parser threads may still be alive at return time. Any pages
-         * they publish after that — and any blocks those pages reference — are leaked. We do not
-         * interrupt the parser executor: it is shared (typically {@code esql_worker}) and an interrupt
-         * could disrupt unrelated tasks. The timeout is intentionally generous (60s) to make the leak
-         * window an exceptional condition; production workloads should not hit it under normal pressure.
+         * <strong>Workers that never ran:</strong> we explicitly do not wait for parser tasks that
+         * were submitted to the executor but never started — under saturation those runnables can sit
+         * in the executor's queue indefinitely. They reference this iterator weakly via captured
+         * {@code this::runParser}; when they eventually run they observe {@code closed=true} at the
+         * top of their loop and return immediately without producing pages. Waiting for them here
+         * would reintroduce the deadlock this class was hit by.
+         * <p>
+         * <strong>Timeout contract:</strong> if started workers don't finish within
+         * {@link #CLOSE_TIMEOUT_SECONDS} we log a warning and run the second drain anyway; any pages
+         * a still-running parser publishes after that — and any blocks those pages reference — are
+         * leaked. We do not interrupt the executor: it is shared (typically {@code generic}) and an
+         * interrupt could disrupt unrelated tasks. The timeout is intentionally generous (60s) to
+         * make the leak window an exceptional condition.
          */
         @Override
         public void close() throws IOException {
@@ -700,12 +737,21 @@ public final class StreamingParallelParsingCoordinator {
             // re-checks {@code closed} and exits {@link #dispatchChunk} without enqueueing.
             dispatchPermits.release();
             drainAllQueues();
+            long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(CLOSE_TIMEOUT_SECONDS);
             try {
-                if (allDone.await(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS) == false) {
+                while (finishedWorkers.get() < startedWorkers.get() && System.nanoTime() < deadlineNanos) {
+                    Thread.sleep(20);
+                }
+                int started = startedWorkers.get();
+                int finished = finishedWorkers.get();
+                if (finished < started) {
                     logger.warn(
-                        "Timed out waiting for streaming parallel parsing threads to finish after [{}]s; "
-                            + "any pages published by still-running parsers after this point will leak their blocks",
-                        CLOSE_TIMEOUT_SECONDS
+                        "Timed out waiting for streaming parallel parsing threads to finish after [{}]s "
+                            + "([{}] started, [{}] finished); any pages published by still-running parsers "
+                            + "after this point will leak their blocks",
+                        CLOSE_TIMEOUT_SECONDS,
+                        started,
+                        finished
                     );
                 }
             } catch (InterruptedException e) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinator.java
@@ -762,7 +762,18 @@ public final class StreamingParallelParsingCoordinator {
             // Wake any consumer parked in takeNextPage on dispatchSignal; its top-of-loop closed-check
             // returns null immediately.
             dispatchSignal.release();
-            drainAllQueues();
+            // We deliberately do NOT drain chunkQueue on close. Items in chunkQueue are either:
+            // - POISONs the segmentator pushed in its finally — consuming them here would
+            // starve parsers parked on chunkQueue.take(), leaving them as zombies that
+            // pin pool threads across iterator lifetimes.
+            // - real chunks whose buffers are plain byte[]s — parsers naturally drain them
+            // (they stay live until inFlightWorkers hits zero, and their finally recycles
+            // the chunk buffer); whatever survives gets GC'd with the iterator. No
+            // CircuitBreaker accounting attached, so no real leak.
+            // pageQueues, on the other hand, hold Pages whose Blocks are charged to a
+            // CircuitBreaker — those MUST be released explicitly, since GC alone does not
+            // decrement the breaker.
+            releasePendingPages();
             long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(CLOSE_TIMEOUT_SECONDS);
             try {
                 while (inFlightWorkers.get() > 0) {
@@ -785,18 +796,10 @@ public final class StreamingParallelParsingCoordinator {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
-            drainAllQueues();
+            releasePendingPages();
         }
 
-        private void drainAllQueues() {
-            // Drain chunk queue
-            Chunk chunk;
-            while ((chunk = chunkQueue.poll()) != null) {
-                if (chunk != Chunk.POISON) {
-                    recycleBuffer(chunk.buffer);
-                }
-            }
-            // Drain page queues
+        private void releasePendingPages() {
             for (ArrayBlockingQueue<Page> queue : pageQueues) {
                 Page p;
                 while ((p = queue.poll()) != null) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -426,6 +426,52 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
     }
 
     /**
+     * Stress test the consumer's EOF predicate against the race between the segmentator's final
+     * {@code chunksDispatched.incrementAndGet()} and its subsequent {@code segmentatorDone = true}.
+     * The consumer must re-read {@code chunksDispatched} after observing {@code segmentatorDone}
+     * so that the last chunk's pages are not silently dropped; that re-read is the load-bearing
+     * invariant in {@code takeNextPage}'s EOF branch.
+     * <p>
+     * Tiny chunks + small input + high parallelism maximises the chance that the consumer arrives
+     * at the EOF check exactly inside the increment-then-flip window. A regression that reorders
+     * those writes — or removes the re-read — drops a chunk in a small fraction of iterations and
+     * trips the exact-row-count assertion below within a few hundred runs.
+     */
+    public void testStressEofDetectionRace() throws Exception {
+        int iterations = 1000;
+        int lineCount = 50;        // few lines → tight race window
+        int parallelism = 8;
+        int batchSize = 4;         // small batches → many EOF-check cycles per query
+        int chunkSize = 32;        // tiny chunks → many dispatch/done interleavings
+
+        String content = buildContent(lineCount);
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        ExecutorService executor = Executors.newFixedThreadPool(parallelism + 1);
+        try {
+            for (int iter = 0; iter < iterations; iter++) {
+                LineFormatReader reader = new LineFormatReader(chunkSize);
+                List<String> got = collectLines(
+                    StreamingParallelParsingCoordinator.parallelRead(
+                        reader,
+                        new ByteArrayInputStream(bytes),
+                        List.of("line"),
+                        batchSize,
+                        parallelism,
+                        executor,
+                        ErrorPolicy.STRICT
+                    )
+                );
+                assertEquals("iter " + iter, lineCount, got.size());
+                for (int i = 0; i < lineCount; i++) {
+                    assertEquals("iter " + iter + " line " + i, "line-" + String.format(java.util.Locale.ROOT, "%04d", i), got.get(i));
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
      * Executor that forwards the first {@code allowedSubmissions} runnables to a backing
      * executor and silently drops the rest (without throwing). Models a saturated
      * scaling-pool whose work queue accepts a submission but never schedules it because

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -37,9 +37,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
@@ -307,6 +310,149 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             assertTrue("close() must return within 5s of segmentator being parked", System.nanoTime() <= deadlineNanos);
         } finally {
             executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Regression for the streaming-parser hang under a saturated executor: when most parser
+     * runnables are accepted by the executor but never actually scheduled (mimicking a
+     * scaling pool with a deep work queue and all worker threads pinned), the iterator must
+     * still terminate cleanly once the segmentator has finished and the parsers that DID
+     * run have processed every dispatched chunk.
+     * <p>
+     * Pre-fix, the iterator waited on a {@code CountDownLatch} that required every
+     * <em>submitted</em> parser to count down, regardless of whether it had actually started.
+     * Under the simulated saturation that latch never fires and {@code hasNext()} parks
+     * indefinitely. Post-fix the consumer terminates on {@code segmentatorDone} alone, which
+     * the {@link DroppingExecutor} below cannot starve because the segmentator submission
+     * is the first one through.
+     */
+    public void testIteratorTerminatesWhenSomeParserSubmissionsNeverRun() throws Exception {
+        int lineCount = 200;
+        String content = buildContent(lineCount);
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        int parallelism = 8;
+        // Allow segmentator (1) + a single parser (1) to actually run; drop the remaining
+        // parallelism - 1 parser submissions. The lone parser must drain every dispatched
+        // chunk and every POISON for the test to pass.
+        int allowedSubmissions = 1 + 1;
+        ExecutorService backing = Executors.newFixedThreadPool(parallelism + 1);
+        DroppingExecutor executor = new DroppingExecutor(backing, allowedSubmissions);
+        // Run the consumer on a dedicated thread so that a regression of the deadlock manifests
+        // as a Future timeout (asserted below) rather than as a wall-clock test-suite timeout
+        // minutes later with no useful diagnostic.
+        ExecutorService collector = Executors.newSingleThreadExecutor();
+        try {
+            LineFormatReader reader = new LineFormatReader(1024);
+            CloseableIterator<Page> iterator = StreamingParallelParsingCoordinator.parallelRead(
+                reader,
+                stream,
+                List.of("line"),
+                50,
+                parallelism,
+                executor,
+                ErrorPolicy.STRICT
+            );
+            Future<List<String>> future = collector.submit(() -> collectLines(iterator));
+            List<String> allLines;
+            try {
+                allLines = future.get(10, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                future.cancel(true);
+                iterator.close();
+                throw new AssertionError(
+                    "iterator did not terminate within 10s when most parser submissions were dropped — "
+                        + "likely a regression of the streaming parallel parser deadlock",
+                    e
+                );
+            }
+            assertEquals(lineCount, allLines.size());
+            for (int i = 0; i < lineCount; i++) {
+                assertEquals("line-" + String.format(java.util.Locale.ROOT, "%04d", i), allLines.get(i));
+            }
+            assertEquals(
+                "expected exactly the allowed submissions to have reached the backing executor",
+                allowedSubmissions,
+                executor.deliveredCount()
+            );
+        } finally {
+            collector.shutdownNow();
+            backing.shutdownNow();
+        }
+    }
+
+    /**
+     * Closing the iterator must not wait for parser runnables that were submitted but never
+     * actually started. Pre-fix, {@code close()} did {@code allDone.await(CLOSE_TIMEOUT)}
+     * which timed out after the full 60s because every dropped submission left the latch
+     * one step above zero, so the latch never fired. Post-fix {@code close()} polls
+     * {@code finishedWorkers < startedWorkers}, which is already satisfied by the workers
+     * that did run.
+     */
+    public void testCloseReturnsPromptlyWhenSomeParserSubmissionsNeverRun() throws Exception {
+        int lineCount = 200;
+        String content = buildContent(lineCount);
+        InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+        int parallelism = 8;
+        int allowedSubmissions = 1 + 1;
+        ExecutorService backing = Executors.newFixedThreadPool(parallelism + 1);
+        DroppingExecutor executor = new DroppingExecutor(backing, allowedSubmissions);
+        try {
+            LineFormatReader reader = new LineFormatReader(1024);
+            CloseableIterator<Page> iterator = StreamingParallelParsingCoordinator.parallelRead(
+                reader,
+                stream,
+                List.of("line"),
+                50,
+                parallelism,
+                executor,
+                ErrorPolicy.STRICT
+            );
+            // Pull at least one page so workers have actually started, then close mid-stream.
+            assertTrue(iterator.hasNext());
+            iterator.next().releaseBlocks();
+            long startNanos = System.nanoTime();
+            iterator.close();
+            long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+            assertTrue(
+                "close() returned in " + elapsedMillis + "ms; must be well under the 60s worker-wait timeout",
+                elapsedMillis < 5_000L
+            );
+        } finally {
+            backing.shutdownNow();
+        }
+    }
+
+    /**
+     * Executor that forwards the first {@code allowedSubmissions} runnables to a backing
+     * executor and silently drops the rest (without throwing). Models a saturated
+     * scaling-pool whose work queue accepts a submission but never schedules it because
+     * every worker thread is pinned elsewhere.
+     */
+    private static final class DroppingExecutor implements Executor {
+        private final Executor delegate;
+        private final AtomicInteger remaining;
+        private final AtomicInteger delivered = new AtomicInteger();
+
+        DroppingExecutor(Executor delegate, int allowedSubmissions) {
+            this.delegate = delegate;
+            this.remaining = new AtomicInteger(allowedSubmissions);
+        }
+
+        @Override
+        public void execute(Runnable r) {
+            if (remaining.getAndDecrement() > 0) {
+                delivered.incrementAndGet();
+                delegate.execute(r);
+            }
+            // else: silently drop — no RejectedExecutionException; the runnable is "queued
+            // forever" from the caller's perspective.
+        }
+
+        int deliveredCount() {
+            return delivered.get();
         }
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -386,9 +386,9 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
      * Closing the iterator must not wait for parser runnables that were submitted but never
      * actually started. Pre-fix, {@code close()} did {@code allDone.await(CLOSE_TIMEOUT)}
      * which timed out after the full 60s because every dropped submission left the latch
-     * one step above zero, so the latch never fired. Post-fix {@code close()} polls
-     * {@code finishedWorkers < startedWorkers}, which is already satisfied by the workers
-     * that did run.
+     * one step above zero, so the latch never fired. Post-fix {@code close()} waits on
+     * {@code inFlightWorkers}, which only counts runnables that actually entered their
+     * {@code try} block.
      */
     public void testCloseReturnsPromptlyWhenSomeParserSubmissionsNeverRun() throws Exception {
         int lineCount = 200;


### PR DESCRIPTION
# [ESQL] Fix streaming parallel parser hang under saturated executor

`StreamingParallelParsingCoordinator` could deadlock indefinitely when the executor it
submits its workers to was saturated. Affects EXTERNAL queries over stream-only codecs
(NDJSON/CSV over gzip/zstd). Parquet is unaffected.

**Bug.** The iterator gated EOF on `CountDownLatch allDone = 1 + parallelism`, expecting
each submitted worker to count down from its `finally`. The `generic` pool is `scaling`
with an *unbounded* queue — once it saturates, `execute()` enqueues instead of rejecting,
so parser runnables sit in the queue forever and never count down. The consumer parks on
`allDone.await(10ms)` indefinitely, holding pool threads and pulling other queries into
the same wedge.

**Fix.** Replace the latch with `volatile boolean segmentatorDone` + `AtomicInteger
startedWorkers/finishedWorkers`. Consumer terminates on `segmentatorDone && currentChunk
== chunksDispatched` (re-read after the volatile to avoid a final-dispatch race). No data
loss: `currentChunk` only advances on POISON, which parsers enqueue *after* every real
page. `close()` polls started→finished instead of waiting on `allDone`; queued
never-started runnables are skipped — they exit harmlessly on `closed=true` if/when they
ever run.

Also fixes a pre-existing race in `close()`: `drainAllQueues()` consumed POISON
sentinels meant for parsers parked on `chunkQueue.take()`, leaking a pool thread
per close under the EOF→close interleaving. `close()` no longer drains `chunkQueue`;
POISONs reach parsers, real chunks GC with the iterator. Surfaced by a new
1000-iteration stress test that pre-fix hangs within ~10 iterations.

**Tests.** Two regression tests using a `DroppingExecutor` that forwards only the first
*k* submissions and silently drops the rest. Both hang pre-fix, pass post-fix. 


Assisted by Cursor