### PR TITLE
Fix TranslogReplicatorTests#testTranslogBytesAreSyncedWhenReachingSizeThreshold

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -506,9 +506,6 @@ tests:
 - class: org.elasticsearch.compute.data.BlockAccountingTests
   method: testBytesRefVector
   issue: https://github.com/elastic/elasticsearch/issues/148481
-- class: org.elasticsearch.xpack.stateless.engine.translog.TranslogReplicatorTests
-  method: testTranslogBytesAreSyncedWhenReachingSizeThreshold
-  issue: https://github.com/elastic/elasticsearch/issues/148545
 - class: org.elasticsearch.xpack.stateless.engine.SoftDeletesRetentionIT
   method: testRetentionLeasesIgnoredForSoftDeletesPolicy
   issue: https://github.com/elastic/elasticsearch/issues/148557

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicatorTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicatorTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
@@ -459,9 +460,10 @@ public class TranslogReplicatorTests extends ESTestCase {
         ObjectStoreService objectStoreService = mockObjectStoreService(compoundFiles);
         StatelessClusterConsistencyService consistencyService = mockConsistencyService();
 
+        final var taskQueue = new DeterministicTaskQueue(random());
         int threshold = randomIntBetween(128, 512);
         TranslogReplicator translogReplicator = new TranslogReplicator(
-            threadPool,
+            taskQueue.getThreadPool(),
             Settings.builder()
                 .put(TranslogReplicator.FLUSH_INTERVAL_SETTING.getKey(), TimeValue.timeValueDays(1))
                 .put(TranslogReplicator.FLUSH_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(threshold))
@@ -486,18 +488,16 @@ public class TranslogReplicatorTests extends ESTestCase {
             bytes += s.length();
         }
 
-        Translog.Location location = new Translog.Location(0, 0, 0);
         long currentLocation = 0;
         seqNo = 0;
         for (Translog.Serialized s : serialized) {
-            location = new Translog.Location(0, currentLocation, s.length());
+            Translog.Location location = new Translog.Location(0, currentLocation, s.length());
             translogReplicator.add(shardId, s, seqNo++, location);
             currentLocation += s.length();
         }
 
-        PlainActionFuture<Void> future = new PlainActionFuture<>();
-        translogReplicator.sync(shardId, location, future);
-        future.actionGet();
+        // There should be a flush in the queue now, run it
+        taskQueue.runAllTasks();
 
         assertThat(compoundFiles.size(), equalTo(Math.toIntExact(translogReplicator.getMaxUploadedFile() + 1)));
         Translog.Operation[] expectedOperations = operations.toArray(new Translog.Operation[0]);

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicatorTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicatorTests.java
@@ -478,6 +478,8 @@ public class TranslogReplicatorTests extends ESTestCase {
         ArrayList<Translog.Serialized> serialized = new ArrayList<>();
         int bytes = 0;
         int seqNo = 0;
+        // Stop as soon as we're at, or have exceeded the threshold. We don't want to reintroduce
+        // the race from https://github.com/elastic/elasticsearch/issues/148545
         while (bytes < threshold) {
             Translog.Operation operation = generateOperation(seqNo++);
             operations.add(operation);

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicatorTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicatorTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
@@ -460,10 +459,9 @@ public class TranslogReplicatorTests extends ESTestCase {
         ObjectStoreService objectStoreService = mockObjectStoreService(compoundFiles);
         StatelessClusterConsistencyService consistencyService = mockConsistencyService();
 
-        final var taskQueue = new DeterministicTaskQueue(random());
         int threshold = randomIntBetween(128, 512);
         TranslogReplicator translogReplicator = new TranslogReplicator(
-            taskQueue.getThreadPool(),
+            threadPool,
             Settings.builder()
                 .put(TranslogReplicator.FLUSH_INTERVAL_SETTING.getKey(), TimeValue.timeValueDays(1))
                 .put(TranslogReplicator.FLUSH_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(threshold))
@@ -480,7 +478,7 @@ public class TranslogReplicatorTests extends ESTestCase {
         ArrayList<Translog.Serialized> serialized = new ArrayList<>();
         int bytes = 0;
         int seqNo = 0;
-        while (bytes <= threshold) {
+        while (bytes < threshold) {
             Translog.Operation operation = generateOperation(seqNo++);
             operations.add(operation);
             Translog.Serialized s = serializeOperations(new Translog.Operation[] { operation })[0];
@@ -488,16 +486,18 @@ public class TranslogReplicatorTests extends ESTestCase {
             bytes += s.length();
         }
 
+        Translog.Location location = new Translog.Location(0, 0, 0);
         long currentLocation = 0;
         seqNo = 0;
         for (Translog.Serialized s : serialized) {
-            Translog.Location location = new Translog.Location(0, currentLocation, s.length());
+            location = new Translog.Location(0, currentLocation, s.length());
             translogReplicator.add(shardId, s, seqNo++, location);
             currentLocation += s.length();
         }
 
-        // There should be a flush in the queue now, run it
-        taskQueue.runAllTasks();
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        translogReplicator.sync(shardId, location, future);
+        safeGet(future);
 
         assertThat(compoundFiles.size(), equalTo(Math.toIntExact(translogReplicator.getMaxUploadedFile() + 1)));
         Translog.Operation[] expectedOperations = operations.toArray(new Translog.Operation[0]);


### PR DESCRIPTION
As soon as the size threshold is reached or breached, the `TranslogReplicator` dispatches a `FlushTask`. If that `FlushTask` starts before we attempt the next `TranslogReplicator#add` call, we'll create a new buffer which will be nowhere near full. This will mean the subsequent call to `TranslogReplicator#sync` will hang indefinitely because `minimumIntervalExhausted` is not true.

This is only possible because we keep adding operations while the byte size is <= the threshold, this leaves the possibility that we add one more operation after the flush is triggered. If we stop adding operations in the event the threshold is reached (and don't exceed it), the flush will be triggered, and there is no risk of creating a new buffer while that's happening.

This test has been around a while, but there is no need to backport the fix because it was previously serverless code.

Fixes #148545
