### PR TITLE
[9.4] Add config.name mapping to fleet-agents index (#148703)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -445,6 +445,9 @@
                 "properties": {
                   "description": {
                     "type": "keyword"
+                  },
+                  "name": {
+                    "type": "keyword"
                   }
                 }
               },

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -72,7 +72,7 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     private static final String MAPPING_VERSION_VARIABLE = "fleet.version";
     private static final List<String> ALLOWED_PRODUCTS = List.of("kibana", "fleet");
     private static final int FLEET_ACTIONS_MAPPINGS_VERSION = 2;
-    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 8;
+    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 9;
     private static final int FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION = 3;
     private static final int FLEET_SECRETS_MAPPINGS_VERSION = 1;
     private static final int FLEET_POLICIES_MAPPINGS_VERSION = 2;


### PR DESCRIPTION
Backport of #148703 to `9.4`.

## Summary

Adds `config.name` as a `keyword` field under `non_identifying_attributes.config` in the `.fleet-agents` index mapping and bumps `FLEET_AGENTS_MAPPINGS_VERSION` from 8 to 9 on this branch.

Relates: https://github.com/elastic/ingest-dev/issues/7689