### PR TITLE
Include running time in GET /_nodes/shutdown

### DIFF
--- a/docs/changelog/148817.yaml
+++ b/docs/changelog/148817.yaml
@@ -1,0 +1,5 @@
+area: Infra/Node Lifecycle
+issues: []
+pr: 148817
+summary: Include running time in GET /_nodes/shutdown
+type: enhancement

--- a/docs/changelog/148817.yaml
+++ b/docs/changelog/148817.yaml
@@ -1,5 +1,0 @@
-area: Infra/Node Lifecycle
-issues: []
-pr: 148817
-summary: Include running time in GET /_nodes/shutdown
-type: enhancement

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/SingleNodeShutdownStatus.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/SingleNodeShutdownStatus.java
@@ -19,12 +19,14 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.function.LongSupplier;
 
 import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.chunk;
 import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.endObject;
@@ -37,6 +39,7 @@ public class SingleNodeShutdownStatus implements Writeable, ChunkedToXContentObj
     private final ShutdownPersistentTasksStatus persistentTasksStatus;
     private final ShutdownPluginsStatus pluginsStatus;
     private final ShutdownShardSnapshotsStatus shardSnapshotsStatus;
+    private final LongSupplier currentTimeMillis;
 
     private static final ParseField STATUS = new ParseField("status");
     private static final ParseField SHARD_MIGRATION_FIELD = new ParseField("shard_migration");
@@ -44,6 +47,7 @@ public class SingleNodeShutdownStatus implements Writeable, ChunkedToXContentObj
     private static final ParseField PLUGINS_STATUS = new ParseField("plugins");
     private static final ParseField SHARD_SNAPSHOTS_FIELD = new ParseField("shard_snapshots");
     private static final ParseField TARGET_NODE_NAME_FIELD = new ParseField("target_node_name");
+    private static final ParseField SHUTDOWN_RUNNING_TIME = new ParseField("shutdown_running_time");
 
     public SingleNodeShutdownStatus(
         SingleNodeShutdownMetadata metadata,
@@ -52,11 +56,23 @@ public class SingleNodeShutdownStatus implements Writeable, ChunkedToXContentObj
         ShutdownPluginsStatus pluginsStatus,
         ShutdownShardSnapshotsStatus shardSnapshotsStatus
     ) {
+        this(metadata, shardMigrationStatus, persistentTasksStatus, pluginsStatus, shardSnapshotsStatus, System::currentTimeMillis);
+    }
+
+    SingleNodeShutdownStatus(
+        SingleNodeShutdownMetadata metadata,
+        ShutdownShardMigrationStatus shardMigrationStatus,
+        ShutdownPersistentTasksStatus persistentTasksStatus,
+        ShutdownPluginsStatus pluginsStatus,
+        ShutdownShardSnapshotsStatus shardSnapshotsStatus,
+        LongSupplier currentTimeMillis
+    ) {
         this.metadata = Objects.requireNonNull(metadata, "metadata must not be null");
         this.shardMigrationStatus = Objects.requireNonNull(shardMigrationStatus, "shard migration status must not be null");
         this.persistentTasksStatus = Objects.requireNonNull(persistentTasksStatus, "persistent task status must not be null");
         this.pluginsStatus = Objects.requireNonNull(pluginsStatus, "plugin status must not be null");
         this.shardSnapshotsStatus = Objects.requireNonNull(shardSnapshotsStatus, "shard snapshots status must not be null");
+        this.currentTimeMillis = Objects.requireNonNull(currentTimeMillis, "currentTimeMillis() func must not be null");
     }
 
     public SingleNodeShutdownStatus(StreamInput in) throws IOException {
@@ -65,6 +81,7 @@ public class SingleNodeShutdownStatus implements Writeable, ChunkedToXContentObj
         this.persistentTasksStatus = new ShutdownPersistentTasksStatus(in);
         this.pluginsStatus = new ShutdownPluginsStatus(in);
         this.shardSnapshotsStatus = ShutdownShardSnapshotsStatus.readFrom(in);
+        this.currentTimeMillis = System::currentTimeMillis;
     }
 
     @Override
@@ -145,7 +162,11 @@ public class SingleNodeShutdownStatus implements Writeable, ChunkedToXContentObj
                 SingleNodeShutdownMetadata.STARTED_AT_READABLE_FIELD,
                 metadata.getStartedAtMillis()
             );
-            builder.field(STATUS.getPreferredName(), overallStatus());
+            var overallStatus = overallStatus();
+            builder.field(STATUS.getPreferredName(), overallStatus);
+            if (overallStatus != SingleNodeShutdownMetadata.Status.COMPLETE) {
+                builder.field(SHUTDOWN_RUNNING_TIME.getPreferredName(), getCurrentRunningTime());
+            }
             return builder;
         }), ChunkedToXContentHelper.field(SHARD_MIGRATION_FIELD.getPreferredName(), shardMigrationStatus, params), chunk((builder, p) -> {
             builder.field(PERSISTENT_TASKS_FIELD.getPreferredName(), persistentTasksStatus);
@@ -162,5 +183,15 @@ public class SingleNodeShutdownStatus implements Writeable, ChunkedToXContentObj
             }
             return builder;
         }), endObject());
+    }
+
+    private TimeValue getCurrentRunningTime() {
+        long durationMillis = currentTimeMillis.getAsLong() - metadata.getStartedAtMillis();
+        // System.currentTimeMillis(), used for time measurement here, is not necessarily a monotonic function, it might go back in time
+        // when e.g. system clock changes
+        if (durationMillis < 0) {
+            durationMillis = 0;
+        }
+        return TimeValue.timeValueMillis(durationMillis);
     }
 }

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusResponseTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/GetShutdownStatusResponseTests.java
@@ -14,20 +14,28 @@ import org.elasticsearch.cluster.metadata.ShutdownShardSnapshotsStatus;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata.Type.RESTART;
 import static org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata.Type.SIGTERM;
+import static org.elasticsearch.common.xcontent.ChunkedToXContent.wrapAsToXContent;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 
 public class GetShutdownStatusResponseTests extends AbstractWireSerializingTestCase<GetShutdownStatusAction.Response> {
     @Override
@@ -74,8 +82,9 @@ public class GetShutdownStatusResponseTests extends AbstractWireSerializingTestC
         final var status = randomStatus();
         final int persistentTasksRemaining = randomIntBetween(0, 10);
         final int autoReassignRemaining = randomIntBetween(0, persistentTasksRemaining);
+        final var nodeShutdownMetadata = randomNodeShutdownMetadata();
         return new SingleNodeShutdownStatus(
-            randomNodeShutdownMetadata(),
+            nodeShutdownMetadata,
             new ShutdownShardMigrationStatus(status, randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()),
             status == SingleNodeShutdownMetadata.Status.NOT_STARTED
                 ? ShutdownPersistentTasksStatus.notStarted()
@@ -83,7 +92,8 @@ public class GetShutdownStatusResponseTests extends AbstractWireSerializingTestC
             new ShutdownPluginsStatus(randomBoolean()),
             status == SingleNodeShutdownMetadata.Status.NOT_STARTED
                 ? ShutdownShardSnapshotsStatus.NOT_STARTED
-                : ShutdownShardSnapshotsStatus.fromShardCounts(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong())
+                : ShutdownShardSnapshotsStatus.fromShardCounts(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()),
+            () -> nodeShutdownMetadata.getStartedAtMillis() + 1_000L
         );
     }
 
@@ -116,6 +126,60 @@ public class GetShutdownStatusResponseTests extends AbstractWireSerializingTestC
         );
     }
 
+    public void testRunningTimeEmittedWhileInProgress() throws IOException {
+        final var metadata = randomNodeShutdownMetadata();
+        final var shardMigrationStatus = new ShutdownShardMigrationStatus(SingleNodeShutdownMetadata.Status.IN_PROGRESS, 0, 0, 0);
+        final var persistentTasksStatus = ShutdownPersistentTasksStatus.fromRemainingTasks(1, 1);
+        final var pluginsStatus = new ShutdownPluginsStatus(false);
+
+        var singleNodeStatus = new SingleNodeShutdownStatus(
+            metadata,
+            shardMigrationStatus,
+            persistentTasksStatus,
+            pluginsStatus,
+            ShutdownShardSnapshotsStatus.fromShardCounts(between(0, 100), between(0, 100), between(1, 100)),
+            () -> metadata.getStartedAtMillis() + 2500L
+        );
+
+        assertThat(toJsonMap(singleNodeStatus), hasEntry("shutdown_running_time", "2.5s"));
+    }
+
+    public void testRunningTimeOmittedWhenComplete() throws IOException {
+        final var metadata = randomNodeShutdownMetadata();
+        final var shardMigrationStatus = new ShutdownShardMigrationStatus(SingleNodeShutdownMetadata.Status.COMPLETE, 0, 0, 0);
+        final var persistentTasksStatus = ShutdownPersistentTasksStatus.fromRemainingTasks(0, 0);
+        final var pluginsStatus = new ShutdownPluginsStatus(true);
+
+        var singleNodeStatus = new SingleNodeShutdownStatus(
+            metadata,
+            shardMigrationStatus,
+            persistentTasksStatus,
+            pluginsStatus,
+            ShutdownShardSnapshotsStatus.fromShardCounts(between(0, 100), between(0, 100), 0),
+            () -> metadata.getStartedAtMillis() + 2500L
+        );
+
+        assertThat(toJsonMap(singleNodeStatus), not(hasKey("shutdown_running_time")));
+    }
+
+    public void testRunningTimeIsClampedWhenClockRegresses() throws IOException {
+        final var metadata = randomNodeShutdownMetadata();
+        final var shardMigrationStatus = new ShutdownShardMigrationStatus(SingleNodeShutdownMetadata.Status.IN_PROGRESS, 0, 0, 0);
+        final var persistentTasksStatus = ShutdownPersistentTasksStatus.fromRemainingTasks(1, 1);
+        final var pluginsStatus = new ShutdownPluginsStatus(false);
+
+        var singleNodeStatus = new SingleNodeShutdownStatus(
+            metadata,
+            shardMigrationStatus,
+            persistentTasksStatus,
+            pluginsStatus,
+            ShutdownShardSnapshotsStatus.fromShardCounts(between(0, 100), between(0, 100), between(1, 100)),
+            () -> metadata.getStartedAtMillis() - 1L
+        );
+
+        assertThat(toJsonMap(singleNodeStatus), hasEntry("shutdown_running_time", "0s"));
+    }
+
     public void testSerializationBwc() throws IOException {
         final var oldVersion = TransportVersionUtils.getPreviousVersion(ShutdownShardSnapshotsStatus.SHUTDOWN_SHARD_SNAPSHOTS_STATUS);
         final BytesStreamOutput out = new BytesStreamOutput();
@@ -139,5 +203,12 @@ public class GetShutdownStatusResponseTests extends AbstractWireSerializingTestC
 
     public static SingleNodeShutdownMetadata.Status randomStatus() {
         return randomFrom(new ArrayList<>(EnumSet.allOf(SingleNodeShutdownMetadata.Status.class)));
+    }
+
+    private Map<String, Object> toJsonMap(ChunkedToXContent chunkedToXContent) throws IOException {
+        var xContent = wrapAsToXContent(chunkedToXContent);
+        try (var parser = createParser(xContent.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))) {
+            return parser.map();
+        }
     }
 }


### PR DESCRIPTION
This is the first part of the #139544 issue.

For non-`COMPLETED` node shutdowns, include a new
`shutdown_running_time` property in the `GET` response containing the amount of time the shutdown has been in progress.