### PR TITLE
[8.19] Fix FsBlobContainer.moveBlobAtomic fallback on CIFS filesystems (#148777)

### DIFF
--- a/docs/changelog/148777.yaml
+++ b/docs/changelog/148777.yaml
@@ -1,0 +1,6 @@
+area: Distributed
+issues:
+ - 148811
+pr: 148777
+summary: Fix `FsBlobContainer.moveBlobAtomic` fallback on CIFS filesystems
+type: bug

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -48,6 +48,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystemException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -375,6 +376,15 @@ public class FsBlobContainer extends AbstractBlobContainer {
         try {
             Files.createLink(targetBlobPath, sourceBlobPath);
         } catch (UnsupportedOperationException e) {
+            fallbackMoveAtomically.accept(targetBlobPath, sourceBlobPath);
+            return;
+        } catch (FileSystemException e) {
+            // In some filesystems (e.g., CIFS) the Files.createLink() does not throw UnsupportedOperationException (as Javadoc says) but
+            // FileSystemException instead. To handle this, we fall back to the no-hard-link operation. This is an indirect check
+            // that assumes that direct FileSystemExceptions instance creation is rare, and it indicates a lack of support for hard links.
+            if (e.getClass() != FileSystemException.class) {
+                throw e;
+            }
             fallbackMoveAtomically.accept(targetBlobPath, sourceBlobPath);
             return;
         }

--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -34,6 +34,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.CopyOption;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -333,6 +334,21 @@ public class FsBlobContainerTests extends ESTestCase {
             }
         }.getFileSystem(null);
         PathUtilsForTesting.installMock(noOverwriteFs);
+        try {
+            checkAtomicWrite();
+        } finally {
+            PathUtilsForTesting.installMock(fileSystem);
+        }
+    }
+
+    public void testAtomicWriteHardLinkThrowsFileSystemException() throws IOException {
+        final var noHardLinkFs = new FilterFileSystemProvider("nohardlinkfs://", fileSystem) {
+            @Override
+            public void createLink(Path link, Path existing) throws IOException {
+                throw new FileSystemException(link.toString(), existing.toString(), "hard links not supported");
+            }
+        }.getFileSystem(null);
+        PathUtilsForTesting.installMock(noHardLinkFs);
         try {
             checkAtomicWrite();
         } finally {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix FsBlobContainer.moveBlobAtomic fallback on CIFS filesystems (#148777)