### PR TITLE
Grant `cluster:monitor/xpack/info` to internal CPS user

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.tasks.TaskCancellationService;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.core.action.XPackInfoAction;
 import org.elasticsearch.xpack.core.ilm.action.ILMActions;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.support.MetadataUtils;
@@ -318,7 +319,8 @@ public class InternalUsers {
                 "cluster:internal:data/read/esql/open_exchange",
                 "cluster:internal:data/read/esql/exchange",
                 "cluster:internal/remote_cluster/nodes",
-                "cluster:admin/serverless/autoscaling/get_serverless_autoscaling_metrics" },
+                "cluster:admin/serverless/autoscaling/get_serverless_autoscaling_metrics",
+                XPackInfoAction.NAME },
             null,
             null,
             null,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
@@ -396,7 +396,8 @@ public class InternalUsersTests extends ESTestCase {
             TaskCancellationService.REMOTE_CLUSTER_BAN_PARENT_ACTION_NAME,
             TaskCancellationService.REMOTE_CLUSTER_CANCEL_CHILD_ACTION_NAME,
             "cluster:internal:data/read/esql/open_exchange",
-            "cluster:internal:data/read/esql/exchange"
+            "cluster:internal:data/read/esql/exchange",
+            XPackInfoAction.NAME
         );
 
         for (String clusterAction : allowedClusterActions) {
@@ -406,7 +407,7 @@ public class InternalUsersTests extends ESTestCase {
         checkClusterAccess(
             crossProjectSearchUser,
             role,
-            randomFrom(ClusterStateAction.NAME, XPackInfoAction.NAME, TransportService.HANDSHAKE_ACTION_NAME),
+            randomFrom(ClusterStateAction.NAME, TransportService.HANDSHAKE_ACTION_NAME),
             false
         );
 


### PR DESCRIPTION
Granting `cluster:monitor/xpack/info` to the internal CPS user.
We need this because ML's cross-project datafeeds calls
`cluster:monitor/xpack/info` on linked projects to detect the
remote license tier before issuing searches.