### PR TITLE
Fix loadSuites to tolerate suite missing in some classpath roots

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -389,7 +389,12 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
                     }
                 }
             }
-            assert found : "Path " + strPath + " does not exist in any YAML test root: " + Arrays.toString(roots);
+            // The empty string is the "include everything" sentinel used by the default
+            // createParameters() entry point. It is legitimately allowed to resolve to
+            // nothing - e.g. a yamlRestCompatTest task whose project has no compat tests
+            // at all, so the classpath exposes no rest-api-spec/test root. Only enforce
+            // the typo guard for explicit, non-empty user-supplied suite paths.
+            assert strPath.isEmpty() || found : "Path " + strPath + " does not exist in any YAML test root: " + Arrays.toString(roots);
         }
         return files;
     }

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -349,12 +349,29 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
     /** Find all yaml suites that match the given list of paths from the root test path. */
     // pkg private for tests
     static Map<String, Set<Path>> loadSuites(String... paths) throws Exception {
-        Map<String, Set<Path>> files = new HashMap<>();
         Path[] roots = ClasspathUtils.findFilePaths(ESClientYamlSuiteTestCase.class.getClassLoader(), TESTS_PATH);
-        for (Path root : roots) {
-            for (String strPath : paths) {
+        return loadSuites(roots, paths);
+    }
+
+    /**
+     * Find all yaml suites that match the given list of paths under the supplied {@code roots}.
+     *
+     * A yamlRestTest task can have more than one root on its classpath: the project's own
+     * {@code src/yamlRestTest/resources/rest-api-spec/test} resources, plus the output of
+     * {@code copyYamlTestsTask} (in {@code build/restResources/yamlTests}) that may pull in
+     * tests from sibling projects. A given user-specified suite path normally only lives in
+     * one of those roots, so requiring it to exist in every root produces spurious failures.
+     * Instead, require each path to be resolvable as a directory or {@code .yml} file in at
+     * least one root, and just skip roots where it isn't present.
+     */
+    static Map<String, Set<Path>> loadSuites(Path[] roots, String... paths) throws Exception {
+        Map<String, Set<Path>> files = new HashMap<>();
+        for (String strPath : paths) {
+            boolean found = false;
+            for (Path root : roots) {
                 Path path = root.resolve(strPath);
                 if (Files.isDirectory(path)) {
+                    found = true;
                     try (var filesStream = Files.walk(path)) {
                         filesStream.forEach(file -> {
                             if (file.toString().endsWith(".yml")) {
@@ -365,11 +382,14 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
                         });
                     }
                 } else {
-                    path = root.resolve(strPath + ".yml");
-                    assert Files.exists(path) : "Path " + path + " does not exist in YAML test root";
-                    addSuite(root, path, files);
+                    Path ymlPath = root.resolve(strPath + ".yml");
+                    if (Files.exists(ymlPath)) {
+                        found = true;
+                        addSuite(root, ymlPath, files);
+                    }
                 }
             }
+            assert found : "Path " + strPath + " does not exist in any YAML test root: " + Arrays.toString(roots);
         }
         return files;
     }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseTests.java
@@ -138,6 +138,25 @@ public class ESClientYamlSuiteTestCaseTests extends ESTestCase {
         assertThat(paths, equalTo(Set.of(rootA.resolve("logging/10_usage.yml"), rootB.resolve("logging/10_usage.yml"))));
     }
 
+    /**
+     * Projects whose yamlRestCompatTest task has no compat tests at all (e.g. {@code modules/user-agent})
+     * expose zero {@code rest-api-spec/test} roots on the test JVM classpath, but the test class still
+     * calls {@code createParameters()} with the default empty path. That must produce an empty parameter
+     * set, not an {@code AssertionError} - JUnit Parameterized treats it as zero candidates and the test
+     * class becomes a no-op. The typo guard must not fire for the "include everything" sentinel.
+     */
+    public void testLoadEmptyPathWithNoRootsReturnsEmpty() throws Exception {
+        // given: no classpath roots at all (mirrors a project with no yaml tests)
+        Path[] roots = new Path[0];
+
+        // when: loading with the default "include everything" sentinel
+        Map<String, Set<Path>> yamlSuites = ESClientYamlSuiteTestCase.loadSuites(roots, "");
+
+        // then: an empty result is returned without firing the typo guard
+        assertThat(yamlSuites, notNullValue());
+        assertThat(yamlSuites.isEmpty(), equalTo(true));
+    }
+
     public void testLoadMissingSuiteFailsWithDescriptiveError() throws Exception {
         // given: a single empty root, so the requested suite cannot resolve anywhere
         Path root = createTempDir();

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseTests.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.greaterThan;
@@ -66,6 +67,90 @@ public class ESClientYamlSuiteTestCaseTests extends ESTestCase {
         Path dir = createTempDir();
         Path file = dir.resolve("test_loading.yml");
         Files.createFile(file);
+    }
+
+    /**
+     * A yamlRestTest task can expose more than one {@code rest-api-spec/test} root on its
+     * classpath (e.g. its own source set output and {@code copyYamlTestsTask} output). A
+     * user-specified suite path typically lives in only one of those roots, so
+     * {@link ESClientYamlSuiteTestCase#loadSuites(Path[], String...)} must not require the
+     * path to be present in every root - existence in at least one root is enough. This
+     * regression reproduces the {@code AssertionError: ... does not exist in YAML test root}
+     * seen by {@code repeat-changed-tests} once {@code tests.rest.suite.<task>} routing
+     * was wired up.
+     */
+    public void testLoadSingleSuiteAcrossMultipleRoots() throws Exception {
+        // given: two roots, only one of which contains the requested suite. The other root has
+        // unrelated content so it is non-empty (mirrors copyYamlTestsTask output in real builds).
+        Path rootWithSuite = createTempDir();
+        Path suiteDir = rootWithSuite.resolve("logging");
+        Files.createDirectories(suiteDir);
+        Files.writeString(suiteDir.resolve("10_usage.yml"), "---\n\"placeholder\":\n  - do: { ping: {} }\n");
+
+        Path rootWithoutSuite = createTempDir();
+        Path otherDir = rootWithoutSuite.resolve("other");
+        Files.createDirectories(otherDir);
+        Files.writeString(otherDir.resolve("10_other.yml"), "---\n\"placeholder\":\n  - do: { ping: {} }\n");
+
+        // when: loading the suite from the multi-root classpath
+        Map<String, Set<Path>> yamlSuites = ESClientYamlSuiteTestCase.loadSuites(
+            new Path[] { rootWithSuite, rootWithoutSuite },
+            "logging/10_usage"
+        );
+
+        // then: the suite is found despite being absent from the second root
+        assertSingleFile(yamlSuites, "logging", "10_usage.yml");
+
+        // when: roots are passed in the reverse order
+        yamlSuites = ESClientYamlSuiteTestCase.loadSuites(new Path[] { rootWithoutSuite, rootWithSuite }, "logging/10_usage");
+
+        // then: the result is identical; root order must not matter
+        assertSingleFile(yamlSuites, "logging", "10_usage.yml");
+    }
+
+    /**
+     * If a suite path resolves under more than one root (e.g. the project's own source set output
+     * and the {@code copyYamlTestsTask} output both contain a same-named file), the loader registers
+     * both {@link Path}s under the same group key. Downstream the suite is parsed and executed once
+     * per copy, and {@code addSuite} emits a "duplicate test name" warning. This documents the
+     * status quo - the multi-root tolerance added for the missing-from-one-root case does not
+     * change how same-named copies are handled.
+     */
+    public void testLoadSingleSuitePresentInBothRoots() throws Exception {
+        // given: the same suite file exists under both roots
+        Path rootA = createTempDir();
+        Path rootB = createTempDir();
+        for (Path root : new Path[] { rootA, rootB }) {
+            Path suiteDir = root.resolve("logging");
+            Files.createDirectories(suiteDir);
+            Files.writeString(suiteDir.resolve("10_usage.yml"), "---\n\"placeholder\":\n  - do: { ping: {} }\n");
+        }
+
+        // when: loading the suite
+        Map<String, Set<Path>> yamlSuites = ESClientYamlSuiteTestCase.loadSuites(new Path[] { rootA, rootB }, "logging/10_usage");
+
+        // then: both absolute paths are registered under the same group, so downstream the suite
+        // will be parsed and executed once per copy (and addSuite logs a duplicate-name warning)
+        assertThat(yamlSuites, notNullValue());
+        assertThat(yamlSuites.keySet(), equalTo(Set.of("logging")));
+        Set<Path> paths = yamlSuites.get("logging");
+        assertThat("both root copies should be registered", paths.size(), equalTo(2));
+        assertThat(paths, equalTo(Set.of(rootA.resolve("logging/10_usage.yml"), rootB.resolve("logging/10_usage.yml"))));
+    }
+
+    public void testLoadMissingSuiteFailsWithDescriptiveError() throws Exception {
+        // given: a single empty root, so the requested suite cannot resolve anywhere
+        Path root = createTempDir();
+
+        // when: loading a suite path that exists in none of the roots
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> ESClientYamlSuiteTestCase.loadSuites(new Path[] { root }, "missing/never_exists")
+        );
+
+        // then: the typo-guard assertion fires and names both the missing path and the roots searched
+        assertThat(error.getMessage(), containsString("missing/never_exists"));
+        assertThat(error.getMessage(), containsString("does not exist in any YAML test root"));
     }
 
     private static void assertSingleFile(Map<String, Set<Path>> yamlSuites, String dirName, String fileName) {


### PR DESCRIPTION
## Summary

`ESClientYamlSuiteTestCase.loadSuites` requires a user-specified `tests.rest.suite` path to resolve in **every** classpath root for the `yamlRestTest` task. A yamlRestTest task typically has two such roots:

- `build/resources/yamlRestTest/rest-api-spec/test/` — the project's own source set output.
- `build/restResources/yamlTests/rest-api-spec/test/` — `copyYamlTestsTask` output for tests imported from sibling projects.

A given single-suite path normally lives in just one of those, so the assertion at `loadSuites:369` fires at whichever root doesn't happen to contain it:

```
java.lang.AssertionError: Path .../build/restResources/yamlTests/rest-api-spec/test/logging/10_usage.yml does not exist in YAML test root
    at ESClientYamlSuiteTestCase.loadSuites(ESClientYamlSuiteTestCase.java:369)
    at ESClientYamlSuiteTestCase.createParameters(ESClientYamlSuiteTestCase.java:305)
    ...
    at XPackRestIT.parameters(XPackRestIT.java:66)
```

This was a latent flaw (the assertion dates back to #95095, 2023). It became reachable when #148200 enabled per-task scoping via `tests.rest.suite.<task path>` from `repeat-changed-tests` cross-project batches. #148087 (Stas's `_xpack/usage` logging tracking) is the first PR to exercise a single-suite path under a multi-root x-pack yamlRestTest project and hit it — the `repeat-changed-tests` step soft-fails.

## Changes

- `ESClientYamlSuiteTestCase.loadSuites`: invert the loop ordering and promote the existence check from per-root to per-path. Each `tests.rest.suite` path must resolve in at least one root; roots that don't contain it are silently skipped. The typo-guard assertion is preserved — it now fires only when the path is missing from every root, with a clearer message that lists all roots searched.
- A package-private overload `loadSuites(Path[] roots, String... paths)` is extracted so the multi-root behaviour can be unit-tested.
- Three regression tests in `ESClientYamlSuiteTestCaseTests`:
  - `testLoadSingleSuiteAcrossMultipleRoots` — the original failure mode; also covers root-order independence.
  - `testLoadSingleSuitePresentInBothRoots` — documents the unchanged duplicate-on-classpath behaviour (both copies registered, downstream `addSuite` warns).
  - `testLoadMissingSuiteFailsWithDescriptiveError` — confirms the typo guard still fires and includes the new descriptive message.

## Test plan

- [x] `:test:yaml-rest-runner:test --tests ESClientYamlSuiteTestCaseTests` — pass.
- [x] `:test:yaml-rest-runner:spotlessJavaCheck` — clean.
- [x] End-to-end reproducer: `./gradlew :x-pack:plugin:yamlRestTest --rerun -Dtests.rest.suite.:x-pack:plugin:yamlRestTest=logging/10_usage` with #148087's YAML file applied on top — fails on `main` with the original AssertionError, succeeds on this branch.
- [x] Genuine-typo path: same command with a non-existent suite name — still fails with the new descriptive message listing all roots.
