### PR TITLE
Fix SharedBlobCacheWarmingServiceTests.testIdLookupPreWarming test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -557,9 +557,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.MlDailyMaintenanceServiceIT
   method: testTriggerCloseIdleJobsWithStoppedDatafeeds
   issue: https://github.com/elastic/elasticsearch/issues/148758
-- class: org.elasticsearch.xpack.stateless.cache.SharedBlobCacheWarmingServiceTests
-  method: testIdLookupPreWarming
-  issue: https://github.com/elastic/elasticsearch/issues/148760
 - class: org.elasticsearch.xpack.stateless.recovery.IndexingShardRelocationIT
   method: testRelocateIndexingShardWithActionFailures
   issue: https://github.com/elastic/elasticsearch/issues/148782

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java
@@ -1282,9 +1282,7 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
                     // when the 16-byte Lucene footer straddles a region boundary).
                     int firstUncachedRegion = lastHeaderRegion + 1;
                     // footer occupies [fileLength - footerLength, fileLength); use its start region as the guard
-                    int footerStartRegion = node.sharedCacheService.getRegion(
-                        loc.offset() + loc.fileLength() - CodecUtil.footerLength()
-                    );
+                    int footerStartRegion = node.sharedCacheService.getRegion(loc.offset() + loc.fileLength() - CodecUtil.footerLength());
                     if (firstUncachedRegion < footerStartRegion) {
                         long uncachedRegionStart = (long) firstUncachedRegion * regionSize;
                         assertFalse(

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.stateless.cache;
 
+import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
@@ -1276,10 +1277,15 @@ public class SharedBlobCacheWarmingServiceTests extends ESTestCase {
                             cacheFile.tryRead(ByteBuffer.allocate(Math.toIntExact(readEnd - readStart)), readStart)
                         );
                     }
-                    // The region immediately after the header should NOT be cached, but we must skip the footer region.
+                    // The region immediately after the header should NOT be cached, but we must skip
+                    // any region covered by the footer (which may start one region before the file's last region
+                    // when the 16-byte Lucene footer straddles a region boundary).
                     int firstUncachedRegion = lastHeaderRegion + 1;
-                    int footerRegion = node.sharedCacheService.getEndingRegion(loc.offset() + loc.fileLength());
-                    if (firstUncachedRegion < footerRegion) {
+                    // footer occupies [fileLength - footerLength, fileLength); use its start region as the guard
+                    int footerStartRegion = node.sharedCacheService.getRegion(
+                        loc.offset() + loc.fileLength() - CodecUtil.footerLength()
+                    );
+                    if (firstUncachedRegion < footerStartRegion) {
                         long uncachedRegionStart = (long) firstUncachedRegion * regionSize;
                         assertFalse(
                             fileName + " region " + firstUncachedRegion + " (after header) should NOT be cached",


### PR DESCRIPTION
The test assertion is validating whether only the region containing the `.tim` file footer, assuming the footer always fits a single region.

Unfortunately, in some cases the footer spans two regions (last and second last) - e.g. 4 first bytes in the last region, but 12 bytes are in the second last. 

This is a valid case (not an issue), so we should just accept that.

The fix is about taking the header size into account when calculating the footer start region instead of assuming it's the last one.

Closes: #148760