### PR TITLE
ESQL:DS: remove duplicated method

### DIFF
--- a/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
+++ b/x-pack/plugin/esql-datasource-csv/src/main/java/org/elasticsearch/xpack/esql/datasource/csv/CsvFormatReader.java
@@ -48,7 +48,6 @@ import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -821,29 +820,6 @@ public class CsvFormatReader implements SegmentableFormatReader {
         int markLimit = recordBoundaryMarkLimit();
         long maxMvcSuffixBytes = Math.max(0L, markLimit - 1L);
         return findNextRecordBoundaryBracketCommaMvc(bis, markLimit, maxMvcSuffixBytes);
-    }
-
-    /**
-     * Drives {@link #findNextRecordBoundary} forward through the buffer and returns the offset of
-     * the last terminator byte, so newlines inside quoted/bracketed cells are correctly skipped.
-     */
-    @Override
-    public int findLastRecordBoundary(byte[] buf, int length) throws IOException {
-        if (length <= 0) {
-            return -1;
-        }
-        int lastBoundary = -1;
-        int cumulative = 0;
-        while (cumulative < length) {
-            ByteArrayInputStream bis = new ByteArrayInputStream(buf, cumulative, length - cumulative);
-            long consumed = findNextRecordBoundary(bis);
-            if (consumed < 0) {
-                return lastBoundary;
-            }
-            cumulative += Math.toIntExact(consumed);
-            lastBoundary = cumulative - 1;
-        }
-        return lastBoundary;
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SegmentableFormatReader.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/spi/SegmentableFormatReader.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasources.spi;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -74,16 +75,27 @@ public interface SegmentableFormatReader extends FormatReader {
      * the open region (or {@code -1} if none). Returning an offset inside the open region would
      * dispatch a malformed chunk.
      * <p>
-     * Default: backward scan for {@code \n} — correct for NDJSON and other line-oriented formats
-     * with no embedded newlines; O(1) when the buffer ends near a boundary. Formats with embedded
-     * newlines inside quoted fields (CSV/TSV) must override to track quote state.
+     * Default: drives {@link #findNextRecordBoundary} forward through the buffer, so embedded
+     * newlines inside quoted fields are handled correctly by any implementation that tracks
+     * quote state in its boundary scanner. A sub-stream is created per record because
+     * {@code findNextRecordBoundary} implementations may read beyond the returned boundary
+     * (e.g. via internal bulk-read buffers); each sub-stream is a lightweight view into the
+     * same backing array with no data copying.
      */
     default int findLastRecordBoundary(byte[] buf, int length) throws IOException {
-        for (int i = length - 1; i >= 0; i--) {
-            if (buf[i] == '\n') {
-                return i;
-            }
+        if (length <= 0) {
+            return -1;
         }
-        return -1;
+        int lastBoundary = -1;
+        int cumulative = 0;
+        while (cumulative < length) {
+            long consumed = findNextRecordBoundary(new ByteArrayInputStream(buf, cumulative, length - cumulative));
+            if (consumed < 0) {
+                return lastBoundary;
+            }
+            cumulative += Math.toIntExact(consumed);
+            lastBoundary = cumulative - 1;
+        }
+        return lastBoundary;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/StreamingParallelParsingCoordinatorTests.java
@@ -815,29 +815,6 @@ public class StreamingParallelParsingCoordinatorTests extends ESTestCase {
             return -1;
         }
 
-        /**
-         * Quote-aware override: drives {@link #findNextRecordBoundary} forward through the buffer.
-         * Bypasses the SPI default (backward {@code \n} scan) because embedded {@code \n} bytes
-         * inside {@code "..."} must not be treated as record terminators.
-         */
-        @Override
-        public int findLastRecordBoundary(byte[] buf, int length) throws IOException {
-            if (length <= 0) {
-                return -1;
-            }
-            int lastBoundary = -1;
-            int cumulative = 0;
-            while (cumulative < length) {
-                long consumed = findNextRecordBoundary(new ByteArrayInputStream(buf, cumulative, length - cumulative));
-                if (consumed < 0) {
-                    return lastBoundary;
-                }
-                cumulative += Math.toIntExact(consumed);
-                lastBoundary = cumulative - 1;
-            }
-            return lastBoundary;
-        }
-
         @Override
         public long minimumSegmentSize() {
             return minSegment;


### PR DESCRIPTION
This removes the duplication of `findLastRecordBoundar` from `StreamingParallelParsingCoordinatorTests` and `CsvFormatReader`, using the (updated) one in `SegmentableFormatReader`.
