### PR TITLE
[9.4] Make streaming fetch chunk size cluster-dynamic (#148705)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -571,6 +571,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         SearchService.QUERY_PHASE_PARALLEL_COLLECTION_ENABLED,
         SearchService.FETCH_PHASE_CHUNKED_ENABLED,
         SearchService.FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS,
+        SearchService.FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES,
         SearchService.MEMORY_ACCOUNTING_BUFFER_SIZE,
         ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING,
         ThreadPool.LATE_TIME_INTERVAL_WARN_THRESHOLD_SETTING,

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -277,6 +277,15 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Property.NodeScope
     );
 
+    public static final Setting<ByteSizeValue> FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES = Setting.byteSizeSetting(
+        "search.fetch_phase_chunked_target_chunk_bytes",
+        ByteSizeValue.of(1, ByteSizeUnit.MB),
+        ByteSizeValue.of(256, ByteSizeUnit.KB),
+        ByteSizeValue.of(64, ByteSizeUnit.MB),
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
     public static final Setting<Integer> MAX_OPEN_SCROLL_CONTEXT = Setting.intSetting(
         "search.max_open_scroll_context",
         500,
@@ -372,6 +381,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     private volatile boolean enableQueryPhaseParallelCollection;
     private volatile boolean enableFetchPhaseChunked;
     private volatile int fetchPhaseMaxInFlightChunks;
+    private volatile int fetchPhaseTargetChunkBytes;
 
     private volatile long defaultKeepAlive;
 
@@ -476,11 +486,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         batchQueryPhase = BATCHED_QUERY_PHASE.get(settings);
         enableFetchPhaseChunked = FETCH_PHASE_CHUNKED_ENABLED.get(settings);
         fetchPhaseMaxInFlightChunks = FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS.get(settings);
+        fetchPhaseTargetChunkBytes = Math.toIntExact(FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES.get(settings).getBytes());
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED, this::setEnableQueryPhaseParallelCollection);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(FETCH_PHASE_CHUNKED_ENABLED, this::setEnableFetchPhaseChunked);
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS, this::setFetchPhaseMaxInFlightChunks);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES, this::setFetchPhaseTargetChunkBytes);
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(BATCHED_QUERY_PHASE, bulkExecuteQueryPhase -> this.batchQueryPhase = bulkExecuteQueryPhase);
         memoryAccountingBufferSize = MEMORY_ACCOUNTING_BUFFER_SIZE.get(settings).getBytes();
@@ -531,6 +544,10 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     private void setFetchPhaseMaxInFlightChunks(int fetchPhaseMaxInFlightChunks) {
         this.fetchPhaseMaxInFlightChunks = fetchPhaseMaxInFlightChunks;
+    }
+
+    private void setFetchPhaseTargetChunkBytes(ByteSizeValue byteSizeValue) {
+        this.fetchPhaseTargetChunkBytes = Math.toIntExact(byteSizeValue.getBytes());
     }
 
     private static void validateKeepAlives(TimeValue defaultKeepAlive, TimeValue maxKeepAlive) {
@@ -1170,6 +1187,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                         null,
                         writer,
                         fetchPhaseMaxInFlightChunks,
+                        fetchPhaseTargetChunkBytes,
                         searchExecutor,
                         newFetchBuildListener(opsListener, searchContext, startTime, closeOnce),
                         newFetchCompletionListener(listener, fetchResult)

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
@@ -91,7 +92,7 @@ public final class FetchPhase {
     public void execute(SearchContext context, int[] docIdsToLoad, RankDocShardInfo rankDocs) {
         // Synchronous wrapper for backward compatibility,
         PlainActionFuture<Void> future = new PlainActionFuture<>();
-        execute(context, docIdsToLoad, rankDocs, null, null, null, null, null, future);
+        execute(context, docIdsToLoad, rankDocs, null, null, null, null, null, null, future);
         try {
             future.actionGet();
         } catch (UncategorizedExecutionException e) {
@@ -112,7 +113,7 @@ public final class FetchPhase {
     public void execute(SearchContext context, int[] docIdsToLoad, RankDocShardInfo rankDocs, @Nullable IntConsumer memoryChecker) {
         // Synchronous wrapper for backward compatibility,
         PlainActionFuture<Void> future = new PlainActionFuture<>();
-        execute(context, docIdsToLoad, rankDocs, memoryChecker, null, null, null, null, future);
+        execute(context, docIdsToLoad, rankDocs, memoryChecker, null, null, null, null, null, future);
         try {
             future.actionGet();
         } catch (UncategorizedExecutionException e) {
@@ -135,6 +136,10 @@ public final class FetchPhase {
      * @param rankDocs ranking information
      * @param memoryChecker optional callback for memory tracking, may be {@code null}
      * @param writer optional chunk writer for streaming mode, may be {@code null}
+     * @param maxInFlightChunks optional override for the maximum concurrent in-flight chunks in streaming mode; when {@code null}
+     *                          the value is resolved from {@link SearchService#FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS}.
+     * @param targetChunkBytes  optional override for the target chunk size in bytes in streaming mode; when {@code null} the
+     *                          value is resolved from {@link SearchService#FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES}.
      * @param continuationExecutor executor for dispatching chunk production after ACK-driven continuation in streaming mode.
      *                             When a chunk ACK arrives on a network thread, this executor ensures the next chunk is produced
      *                             on a search thread rather than inline on the network thread. Required when {@code writer} is
@@ -157,6 +162,7 @@ public final class FetchPhase {
         @Nullable IntConsumer memoryChecker,
         @Nullable FetchPhaseResponseChunk.Writer writer,
         @Nullable Integer maxInFlightChunks,
+        @Nullable Integer targetChunkBytes,
         @Nullable Executor continuationExecutor,
         @Nullable ActionListener<Void> buildListener,
         ActionListener<Void> listener
@@ -212,20 +218,36 @@ public final class FetchPhase {
             buildSearchHits(context, docIdsToLoad, docsIterator, resolvedBuildListener, hitsListener);
         } else {
             assert continuationExecutor != null : "continuationExecutor is required in streaming mode";
-            int resolvedMaxInFlightChunks = maxInFlightChunks != null
-                ? maxInFlightChunks
-                : SearchService.FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS.get(context.getSearchExecutionContext().getIndexSettings().getSettings());
+            var settings = context.getSearchExecutionContext().getIndexSettings().getSettings();
             buildSearchHitsStreaming(
                 context,
                 docIdsToLoad,
                 docsIterator,
                 writer,
-                resolvedMaxInFlightChunks,
+                resolveMaxInFlightChunks(maxInFlightChunks, settings),
+                resolveTargetChunkBytes(targetChunkBytes, settings),
                 continuationExecutor,
                 resolvedBuildListener,
                 hitsListener
             );
         }
+    }
+
+    /**
+     * Resolves the streaming-fetch max in-flight chunk count. Explicit caller overrides win; otherwise the value is read
+     * from the (potentially cluster-overridden) {@link SearchService#FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS} setting.
+     */
+    static int resolveMaxInFlightChunks(@Nullable Integer override, Settings settings) {
+        return override != null ? override : SearchService.FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS.get(settings);
+    }
+
+    /**
+     * Resolves the streaming-fetch target chunk size in bytes. Explicit caller overrides win; otherwise the value is read
+     * from the (potentially cluster-overridden) {@link SearchService#FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES} setting so
+     * cluster-level changes are honoured rather than always falling back to the hard-coded default.
+     */
+    static int resolveTargetChunkBytes(@Nullable Integer override, Settings settings) {
+        return override != null ? override : Math.toIntExact(SearchService.FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES.get(settings).getBytes());
     }
 
     private static class PreloadedSourceProvider implements SourceProvider {
@@ -446,6 +468,7 @@ public final class FetchPhase {
         StreamingFetchPhaseDocsIterator docsIterator,
         FetchPhaseResponseChunk.Writer writer,
         int maxInFlightChunks,
+        int targetChunkBytes,
         Executor continuationExecutor,
         ActionListener<Void> buildListener,
         ActionListener<SearchHitsWithSizeBytes> listener
@@ -454,8 +477,6 @@ public final class FetchPhase {
         final AtomicReference<ReleasableBytesReference> lastChunkBytesRef = new AtomicReference<>();
         final AtomicLong lastChunkHitCountRef = new AtomicLong(0);
         final AtomicLong lastChunkSequenceStartRef = new AtomicLong(-1);
-
-        final int targetChunkBytes = StreamingFetchPhaseDocsIterator.DEFAULT_TARGET_CHUNK_BYTES;
 
         // RefCountingListener tracks chunk ACKs in streaming mode.
         // Each chunk calls acquire() to get a listener, which is completed when the ACK arrives.

--- a/server/src/main/java/org/elasticsearch/search/fetch/StreamingFetchPhaseDocsIterator.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/StreamingFetchPhaseDocsIterator.java
@@ -71,12 +71,6 @@ import java.util.function.Supplier;
 abstract class StreamingFetchPhaseDocsIterator extends FetchPhaseDocsIterator {
 
     /**
-     * Default target chunk size in bytes (256KB).
-     * Chunks may slightly exceed this as we complete the current hit before checking.
-     */
-    static final int DEFAULT_TARGET_CHUNK_BYTES = 256 * 1024;
-
-    /**
      * Asynchronous iteration using {@link ThrottledIterator} for streaming mode.
      *
      * @param shardTarget         the shard being fetched from

--- a/server/src/test/java/org/elasticsearch/search/fetch/FetchPhaseDocsIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/FetchPhaseDocsIteratorTests.java
@@ -216,6 +216,42 @@ public class FetchPhaseDocsIteratorTests extends ESTestCase {
         assertThat(SearchService.FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS.get(Settings.EMPTY), equalTo(3));
     }
 
+    public void testFetchPhaseTargetChunkBytesSettingIsReadCorrectly() {
+        Settings customSettings = Settings.builder().put(SearchService.FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES.getKey(), "2mb").build();
+        assertThat(SearchService.FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES.get(customSettings), equalTo(ByteSizeValue.ofMb(2)));
+        assertThat(SearchService.FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES.get(Settings.EMPTY), equalTo(ByteSizeValue.ofMb(1)));
+    }
+
+    public void testResolveMaxInFlightChunksPrefersExplicitOverride() {
+        Settings settings = Settings.builder().put(SearchService.FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS.getKey(), 7).build();
+        assertThat(FetchPhase.resolveMaxInFlightChunks(2, settings), equalTo(2));
+    }
+
+    public void testResolveMaxInFlightChunksFallsBackToClusterSettingWhenNoOverride() {
+        Settings settings = Settings.builder().put(SearchService.FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS.getKey(), 7).build();
+        assertThat(FetchPhase.resolveMaxInFlightChunks(null, settings), equalTo(7));
+    }
+
+    public void testResolveMaxInFlightChunksFallsBackToDefaultWhenNoOverrideAndNoClusterSetting() {
+        int expectedDefault = SearchService.FETCH_PHASE_MAX_IN_FLIGHT_CHUNKS.getDefault(Settings.EMPTY);
+        assertThat(FetchPhase.resolveMaxInFlightChunks(null, Settings.EMPTY), equalTo(expectedDefault));
+    }
+
+    public void testResolveTargetChunkBytesPrefersExplicitOverride() {
+        Settings settings = Settings.builder().put(SearchService.FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES.getKey(), "4mb").build();
+        assertThat(FetchPhase.resolveTargetChunkBytes(123_456, settings), equalTo(123_456));
+    }
+
+    public void testResolveTargetChunkBytesFallsBackToClusterSettingWhenNoOverride() {
+        Settings settings = Settings.builder().put(SearchService.FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES.getKey(), "4mb").build();
+        assertThat(FetchPhase.resolveTargetChunkBytes(null, settings), equalTo(Math.toIntExact(ByteSizeValue.ofMb(4).getBytes())));
+    }
+
+    public void testResolveTargetChunkBytesFallsBackToDefaultWhenNoOverrideAndNoClusterSetting() {
+        int expectedDefault = Math.toIntExact(SearchService.FETCH_PHASE_CHUNKED_TARGET_CHUNK_BYTES.getDefault(Settings.EMPTY).getBytes());
+        assertThat(FetchPhase.resolveTargetChunkBytes(null, Settings.EMPTY), equalTo(expectedDefault));
+    }
+
     public void testIterateAsyncSingleDocument() throws Exception {
         LuceneDocs docs = createDocs(1, false);
         CircuitBreaker circuitBreaker = newLimitedBreaker(ByteSizeValue.ofBytes(Long.MAX_VALUE));


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Make streaming fetch chunk size cluster-dynamic (#148705)