### PR TITLE
[9.4] ES|QL: disallow casting to snapshot-only type (#148813)

### DIFF
--- a/docs/changelog/148813.yaml
+++ b/docs/changelog/148813.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 147867
+pr: 148813
+summary: Disallow casting to snapshot-only type
+type: bug

--- a/docs/reference/query-languages/esql/kibana/definition/inline_cast.json
+++ b/docs/reference/query-languages/esql/kibana/definition/inline_cast.json
@@ -7,7 +7,6 @@
   "date" : "to_datetime",
   "date_nanos" : "to_date_nanos",
   "date_period" : "to_dateperiod",
-  "date_range" : "to_date_range",
   "datetime" : "to_datetime",
   "dense_vector" : "to_dense_vector",
   "double" : "to_double",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -634,6 +634,15 @@ public class EsqlFunctionRegistry {
         return false;
     }
 
+    private static final Set<Class<? extends Function>> SNAPSHOT_FUNCTION_CLASSES = Arrays.stream(snapshotFunctions())
+        .flatMap(Arrays::stream)
+        .map(FunctionDefinition::clazz)
+        .collect(Collectors.toUnmodifiableSet());
+
+    public static boolean isSnapshotOnly(Class<? extends Function> functionClass) {
+        return SNAPSHOT_FUNCTION_CLASSES.contains(functionClass);
+    }
+
     public static String normalizeName(String name) {
         return name.toLowerCase(Locale.ROOT);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -16,6 +16,7 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
+import org.elasticsearch.Build;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.regex.Regex;
@@ -797,6 +798,9 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
         }
         Expression expr = expression(parseTree);
         var convertFunction = converterToFactory.apply(source, expr, ConfigurationAware.CONFIGURATION_MARKER);
+        if (Build.current().isSnapshot() == false && EsqlFunctionRegistry.isSnapshotOnly(convertFunction.getClass())) {
+            throw new ParsingException(source, "Unsupported conversion to type [{}]", dataType);
+        }
         return convertFunction;
     }
 
@@ -804,7 +808,7 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
     public DataType visitToDataType(EsqlBaseParser.ToDataTypeContext ctx) {
         String typeName = visitIdentifier(ctx.identifier());
         DataType dataType = DataType.fromNameOrAlias(typeName);
-        if (dataType == DataType.UNSUPPORTED) {
+        if (dataType == DataType.UNSUPPORTED || dataType.supportedVersion().supportedLocally() == false) {
             throw new ParsingException(source(ctx), "Unknown data type named [{}]", typeName);
         }
         return dataType;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -2594,6 +2594,15 @@ public class StatementParserTests extends AbstractStatementParserTests {
         expectError("ROW (1+2)::doesnotexist", "line 1:12: Unknown data type named [doesnotexist]");
     }
 
+    public void testInlineConvertToSnapshotOnlyType() {
+        assumeFalse("date_range is exposed on snapshot builds", Build.current().isSnapshot());
+        expectError(
+            "ROW str = \"2020-01-01T00:00:00.000Z..2021-01-01T00:00:00.000Z\" | EVAL range = str::date_range",
+            "Unknown data type named [date_range]"
+        );
+        expectError("ROW range = \"x\"::date_range", "Unknown data type named [date_range]");
+    }
+
     public void testLookup() {
         String query = "ROW a = 1 | LOOKUP_🐔 t ON j";
         if (Build.current().isSnapshot() == false) {


### PR DESCRIPTION
Backports the following commits to 9.4:
 - ES|QL: disallow casting to snapshot-only type (#148813)