### PR TITLE
[9.4] Default PromQL and Prometheus discovery APIs to metrics-* (#148489, #148770)

### DIFF
--- a/docs/changelog/148489.yaml
+++ b/docs/changelog/148489.yaml
@@ -1,0 +1,5 @@
+area: PromQL
+issues: []
+pr: 148489
+summary: Default PromQL index to metrics-*
+type: bug

--- a/docs/changelog/148770.yaml
+++ b/docs/changelog/148770.yaml
@@ -1,0 +1,5 @@
+area: PromQL
+issues: []
+pr: 148770
+summary: Default Prometheus discovery APIs to metrics-*
+type: bug

--- a/x-pack/plugin/esql/qa/testFixtures/src/test/java/org/elasticsearch/xpack/esql/EsqlTestUtilsTests.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/test/java/org/elasticsearch/xpack/esql/EsqlTestUtilsTests.java
@@ -41,7 +41,7 @@ public class EsqlTestUtilsTests extends ESTestCase {
     public void testPromQLDefaultIndex() {
         assertThat(
             EsqlTestUtils.addRemoteIndices("PROMQL step=1m (avg(baz))", Set.of(), false),
-            equalTo("PROMQL index=*:*,* step=1m (avg(baz))")
+            equalTo("PROMQL index=*:metrics-*,metrics-* step=1m (avg(baz))")
         );
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -116,6 +116,7 @@ import static org.elasticsearch.xpack.esql.core.util.StringUtils.WILDCARD;
 import static org.elasticsearch.xpack.esql.parser.ParserUtils.typedParsing;
 import static org.elasticsearch.xpack.esql.parser.ParserUtils.visitList;
 import static org.elasticsearch.xpack.esql.plan.logical.Enrich.Mode;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * Translates what we get back from Antlr into the data structures the rest of the planner steps will act on.  Generally speaking, things
@@ -1495,7 +1496,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
         Duration step = null;
         Integer buckets = null;
         Duration scrapeInterval = Duration.ofMinutes(1);
-        IndexPattern indexPattern = new IndexPattern(source, "*");
+        IndexPattern indexPattern = new IndexPattern(source, DEFAULT_PROMQL_INDEX_PATTERN);
 
         Set<String> paramsSeen = new HashSet<>();
         for (EsqlBaseParser.PromqlParamContext paramCtx : ctx.promqlParam()) {
@@ -1631,8 +1632,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
             }
             throw new ParsingException(source(ctx), "Parameter [{}] for index must be a string", ctx.NAMED_OR_POSITIONAL_PARAM().getText());
         } else if (ctx.promqlIndexPattern().isEmpty()) {
-            // Default to all indices if no index pattern is provided
-            return new IndexPattern(source(ctx), "*");
+            return new IndexPattern(source(ctx), DEFAULT_PROMQL_INDEX_PATTERN);
         } else {
             return new IndexPattern(source(ctx), visitPromqlIndexPattern(ctx.promqlIndexPattern()));
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -55,6 +55,11 @@ public class PromqlCommand extends UnaryPlan
         TimestampBoundsAware.OfLogicalPlan {
 
     /**
+     * Default index expression for embedded PromQL when no {@code index=} option is provided.
+     */
+    public static final String DEFAULT_PROMQL_INDEX_PATTERN = "metrics-*";
+
+    /**
      * The name of the column containing the step value (aka time bucket) in range queries.
      */
     private static final String STEP_COLUMN_NAME = "step";

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -211,6 +211,7 @@ import static org.elasticsearch.xpack.esql.optimizer.rules.logical.DeduplicateAg
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules.TransformDirection.DOWN;
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules.TransformDirection.UP;
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneColumnsTests.assertCommonIncompatibleDataTypesEsRelation;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.contains;
@@ -11226,13 +11227,13 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
     }
 
     public void testPromqlWithoutExplicitIndex() {
-        var testAnalyzer = EsqlTestUtils.analyzer().addIndex("*", "k8s-mappings.json", IndexMode.TIME_SERIES);
+        var testAnalyzer = EsqlTestUtils.analyzer().addIndex(DEFAULT_PROMQL_INDEX_PATTERN, "k8s-mappings.json", IndexMode.TIME_SERIES);
         var plan = logicalOptimizerWithLatestVersion.optimize(testAnalyzer.query("PROMQL step=5m avg(rate(network.total_bytes_in[5m]))"));
         assertNotNull(plan);
     }
 
     public void testPromqlWithoutExplicitIndexAndGrouping() {
-        var testAnalyzer = EsqlTestUtils.analyzer().addIndex("*", "k8s-mappings.json", IndexMode.TIME_SERIES);
+        var testAnalyzer = EsqlTestUtils.analyzer().addIndex(DEFAULT_PROMQL_INDEX_PATTERN, "k8s-mappings.json", IndexMode.TIME_SERIES);
         var plan = logicalOptimizerWithLatestVersion.optimize(
             testAnalyzer.query("PROMQL step=5m avg(rate(network.total_bytes_in[5m])) by (cluster)")
         );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/promql/PromqlParserTests.java
@@ -263,6 +263,13 @@ public class PromqlParserTests extends ESTestCase {
         assertThat(promql.end().value(), nullValue());
     }
 
+    public void testRangeQueryWithoutIndexUsesDefaultMetricsPattern() {
+        PromqlCommand promql = parse("PROMQL step=5m avg(foo)");
+        List<UnresolvedRelation> unresolvedRelations = promql.collect(UnresolvedRelation.class);
+        assertThat(unresolvedRelations, hasSize(1));
+        assertThat(unresolvedRelations.getFirst().indexPattern().indexPattern(), equalTo(PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN));
+    }
+
     public void testRangeQueryBucketsRequiresPositiveInteger() {
         ParsingException e = assertThrows(ParsingException.class, () -> parse("PROMQL index=test buckets=0 (avg(foo))"));
         assertThat(e.getMessage(), containsString("Invalid value [0] for parameter [buckets], expected a positive integer"));

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusInstantQueryRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusInstantQueryRestAction.java
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * REST handler for the Prometheus {@code GET /api/v1/query} instant query endpoint.
@@ -71,7 +72,7 @@ public class PrometheusInstantQueryRestAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         String query = getRequiredParam(request, QUERY_PARAM);
-        String index = request.param(INDEX_PARAM, "*");
+        String index = request.param(INDEX_PARAM, DEFAULT_PROMQL_INDEX_PATTERN);
         int limit = request.paramAsInt(LIMIT_PARAM, DEFAULT_LIMIT);
 
         String timeStr = request.param(TIME_PARAM);

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusLabelValuesRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusLabelValuesRestAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.parser.promql.PromqlParserUtils;
 import org.elasticsearch.xpack.esql.plan.EsqlStatement;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -25,6 +26,7 @@ import java.util.List;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * REST handler for the Prometheus {@code GET /_prometheus/api/v1/label/{name}/values} and
@@ -41,6 +43,9 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
  * <p>When a label name is absent from all index mappings ESQL returns a {@code "Unknown column"}
  * BAD_REQUEST error. The response listener converts that into an empty {@code data:[]} success
  * response, which is the correct Prometheus behaviour for a label that has no values.
+ *
+ * <p>When the path omits {@code {index}} and no {@code index} query parameter is set, the index
+ * expression defaults to {@link PromqlCommand#DEFAULT_PROMQL_INDEX_PATTERN} (same as PromQL query APIs).
  */
 @ServerlessScope(Scope.PUBLIC)
 public class PrometheusLabelValuesRestAction extends BaseRestHandler {
@@ -71,7 +76,7 @@ public class PrometheusLabelValuesRestAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String rawName = request.param("name");
         String labelName = PrometheusLabelNameUtils.decodeLabelName(rawName);
-        String index = request.param(INDEX_PARAM, "*");
+        String index = request.param(INDEX_PARAM, DEFAULT_PROMQL_INDEX_PATTERN);
 
         List<String> matchSelectors = request.repeatedParamAsList(MATCH_PARAM);
 

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusLabelsRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusLabelsRestAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.parser.promql.PromqlParserUtils;
 import org.elasticsearch.xpack.esql.plan.EsqlStatement;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -25,12 +26,14 @@ import java.util.List;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * REST handler for the Prometheus {@code GET /api/v1/labels} endpoint.
  * Returns the sorted list of label names across all matching time series.
  * The optional {@code {index}} path parameter restricts the query to a specific index pattern;
- * when omitted, all indices ({@code "*"}) are searched.
+ * when omitted, the index expression defaults to {@link PromqlCommand#DEFAULT_PROMQL_INDEX_PATTERN}
+ * (same as PromQL query APIs).
  * Only GET is supported. POST with {@code application/x-www-form-urlencoded} bodies is rejected
  * at the HTTP layer as a CSRF safeguard before this handler is ever reached — see
  * {@code RestController#isContentTypeDisallowed}.
@@ -74,7 +77,7 @@ public class PrometheusLabelsRestAction extends BaseRestHandler {
         // limit+1 sentinel to detect and report truncation.
         int limit = request.paramAsInt(LIMIT_PARAM, DEFAULT_LIMIT);
 
-        String index = request.param(INDEX_PARAM, "*");
+        String index = request.param(INDEX_PARAM, DEFAULT_PROMQL_INDEX_PATTERN);
         LogicalPlan plan = PrometheusLabelsPlanBuilder.buildPlan(index, matchSelectors, start, end, limit);
         EsqlStatement statement = new EsqlStatement(plan, List.of());
         PreparedEsqlQueryRequest esqlRequest = PreparedEsqlQueryRequest.sync(statement, "prometheus_labels");

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryRangeRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryRangeRestAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.plan.EsqlStatement;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * REST handler for the Prometheus {@code GET /api/v1/query_range} endpoint.
@@ -56,7 +57,7 @@ public class PrometheusQueryRangeRestAction extends BaseRestHandler {
         String start = getRequiredParam(request, START_PARAM);
         String end = getRequiredParam(request, END_PARAM);
         String step = getRequiredParam(request, PrometheusQueryResponseListener.STEP_PARAM);
-        String index = request.param(INDEX_PARAM, "*");
+        String index = request.param(INDEX_PARAM, DEFAULT_PROMQL_INDEX_PATTERN);
         int limit = request.paramAsInt(LIMIT_PARAM, DEFAULT_LIMIT);
 
         EsqlStatement statement = PromqlQueryPlanBuilder.buildStatement(query, index, start, end, step);

--- a/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusSeriesRestAction.java
+++ b/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusSeriesRestAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.parser.promql.PromqlParserUtils;
 import org.elasticsearch.xpack.esql.plan.EsqlStatement;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -25,6 +26,7 @@ import java.util.List;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
 
 /**
  * REST handler for the Prometheus {@code GET /api/v1/series} endpoint.
@@ -32,6 +34,9 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
  * Only GET is supported. POST with {@code application/x-www-form-urlencoded} bodies is rejected
  * at the HTTP layer as a CSRF safeguard before this handler is ever reached — see
  * {@code RestController#isContentTypeDisallowed}.
+ *
+ * <p>When the path omits {@code {index}} and no {@code index} query parameter is set, the index
+ * expression defaults to {@link PromqlCommand#DEFAULT_PROMQL_INDEX_PATTERN} (same as PromQL query APIs).
  */
 @ServerlessScope(Scope.PUBLIC)
 public class PrometheusSeriesRestAction extends BaseRestHandler {
@@ -75,7 +80,7 @@ public class PrometheusSeriesRestAction extends BaseRestHandler {
         // limit+1 sentinel to detect and report truncation.
         int limit = request.paramAsInt(LIMIT_PARAM, DEFAULT_LIMIT);
 
-        String index = request.param(INDEX_PARAM, "*");
+        String index = request.param(INDEX_PARAM, DEFAULT_PROMQL_INDEX_PATTERN);
         LogicalPlan plan = PrometheusSeriesPlanBuilder.buildPlan(index, matchSelectors, start, end, limit);
         EsqlStatement statement = new EsqlStatement(plan, List.of());
         PreparedEsqlQueryRequest esqlRequest = PreparedEsqlQueryRequest.sync(statement, "prometheus_series");

--- a/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryRestActionTests.java
+++ b/x-pack/plugin/prometheus/src/test/java/org/elasticsearch/xpack/prometheus/rest/PrometheusQueryRestActionTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.prometheus.rest;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.client.NoOpNodeClient;
+import org.elasticsearch.test.rest.FakeRestChannel;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.esql.action.EsqlQueryAction;
+import org.elasticsearch.xpack.esql.action.PreparedEsqlQueryRequest;
+import org.elasticsearch.xpack.esql.plan.logical.UnresolvedRelation;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand.DEFAULT_PROMQL_INDEX_PATTERN;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertSame;
+
+public class PrometheusQueryRestActionTests extends ESTestCase {
+
+    private ThreadPool threadPool;
+    private CapturingNodeClient client;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = createThreadPool();
+        client = new CapturingNodeClient(threadPool);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        terminate(threadPool);
+    }
+
+    public void testInstantQueryDefaultsToMetricsIndexPattern() throws Exception {
+        var request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(
+            Map.of("query", "up", "time", "2026-01-01T00:00:00Z")
+        ).build();
+
+        new PrometheusInstantQueryRestAction().handleRequest(request, new FakeRestChannel(request, false), client);
+
+        assertThat(capturedIndexPattern(), equalTo(DEFAULT_PROMQL_INDEX_PATTERN));
+    }
+
+    public void testQueryRangeDefaultsToMetricsIndexPattern() throws Exception {
+        var request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(
+            Map.of("query", "up", "start", "2026-01-01T00:00:00Z", "end", "2026-01-01T01:00:00Z", "step", "1m")
+        ).build();
+
+        new PrometheusQueryRangeRestAction().handleRequest(request, new FakeRestChannel(request, false), client);
+
+        assertThat(capturedIndexPattern(), equalTo(DEFAULT_PROMQL_INDEX_PATTERN));
+    }
+
+    private String capturedIndexPattern() {
+        assertNotNull(client.capturedRequest);
+        return client.capturedRequest.statement().plan().collect(UnresolvedRelation.class).getFirst().indexPattern().indexPattern();
+    }
+
+    private static class CapturingNodeClient extends NoOpNodeClient {
+        private PreparedEsqlQueryRequest capturedRequest;
+
+        CapturingNodeClient(ThreadPool threadPool) {
+            super(threadPool);
+        }
+
+        @Override
+        public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+            ActionType<Response> action,
+            Request request,
+            ActionListener<Response> listener
+        ) {
+            assertSame(EsqlQueryAction.INSTANCE, action);
+            capturedRequest = (PreparedEsqlQueryRequest) request;
+        }
+    }
+}


### PR DESCRIPTION
# Backport

This backports the following from `main` to `9.4`:

- #148489
- #148770

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)