### PR TITLE
Add remote fetch physical nodes, operators, and service substrate.

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/PlanWritables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/PlanWritables.java
@@ -45,6 +45,7 @@ import org.elasticsearch.xpack.esql.plan.logical.local.ImmediateLocalSupplier;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
+import org.elasticsearch.xpack.esql.plan.physical.EmitRemoteFetchHandleExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
@@ -64,6 +65,8 @@ import org.elasticsearch.xpack.esql.plan.physical.MetricsInfoExec;
 import org.elasticsearch.xpack.esql.plan.physical.MvExpandExec;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.RegisteredDomainExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.SampleExec;
 import org.elasticsearch.xpack.esql.plan.physical.SampledAggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ShowExec;
@@ -134,6 +137,7 @@ public class PlanWritables {
             CompletionExec.ENTRY,
             DissectExec.ENTRY,
             EnrichExec.ENTRY,
+            EmitRemoteFetchHandleExec.ENTRY,
             EsSourceExec.ENTRY,
             EvalExec.ENTRY,
             ExchangeExec.ENTRY,
@@ -150,6 +154,8 @@ public class PlanWritables {
             LocalSourceExec.ENTRY,
             MvExpandExec.ENTRY,
             ProjectExec.ENTRY,
+            RemoteFetchExec.ENTRY,
+            RemoteFetchSourceExec.ENTRY,
             RerankExec.ENTRY,
             SampleExec.ENTRY,
             SampledAggregateExec.ENTRY,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EmitRemoteFetchHandleExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EmitRemoteFetchHandleExec.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Replaces the local-only {@code _doc} column with a transport-safe remote fetch handle before the final exchange.
+ */
+public class EmitRemoteFetchHandleExec extends UnaryExec {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "EmitRemoteFetchHandleExec",
+        EmitRemoteFetchHandleExec::new
+    );
+
+    private final Attribute sourceAttribute;
+    private final Attribute handleAttribute;
+    private List<Attribute> lazyOutput;
+
+    public EmitRemoteFetchHandleExec(Source source, PhysicalPlan child, Attribute sourceAttribute, Attribute handleAttribute) {
+        super(source, child);
+        this.sourceAttribute = sourceAttribute;
+        this.handleAttribute = handleAttribute;
+    }
+
+    private EmitRemoteFetchHandleExec(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(PhysicalPlan.class),
+            in.readNamedWriteable(Attribute.class),
+            in.readNamedWriteable(Attribute.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeNamedWriteable(sourceAttribute);
+        out.writeNamedWriteable(handleAttribute);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected NodeInfo<EmitRemoteFetchHandleExec> info() {
+        return NodeInfo.create(this, EmitRemoteFetchHandleExec::new, child(), sourceAttribute, handleAttribute);
+    }
+
+    @Override
+    public EmitRemoteFetchHandleExec replaceChild(PhysicalPlan newChild) {
+        return new EmitRemoteFetchHandleExec(source(), newChild, sourceAttribute, handleAttribute);
+    }
+
+    @Override
+    protected AttributeSet computeReferences() {
+        return AttributeSet.of(sourceAttribute);
+    }
+
+    public Attribute sourceAttribute() {
+        return sourceAttribute;
+    }
+
+    public Attribute handleAttribute() {
+        return handleAttribute;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        if (lazyOutput == null) {
+            lazyOutput = new ArrayList<>(child().output().size());
+            for (Attribute attribute : child().output()) {
+                lazyOutput.add(attribute.equals(sourceAttribute) ? handleAttribute : attribute);
+            }
+        }
+        return lazyOutput;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(child(), sourceAttribute, handleAttribute);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        EmitRemoteFetchHandleExec other = (EmitRemoteFetchHandleExec) obj;
+        return Objects.equals(child(), other.child())
+            && Objects.equals(sourceAttribute, other.sourceAttribute)
+            && Objects.equals(handleAttribute, other.handleAttribute);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RemoteFetchExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RemoteFetchExec.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Fetches deferred fields on the coordinator from remote shard owners using a transport-safe handle.
+ */
+public class RemoteFetchExec extends UnaryExec implements EstimatesRowSize {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "RemoteFetchExec",
+        RemoteFetchExec::new
+    );
+
+    private final Attribute handleAttribute;
+    private final List<Attribute> attributesToFetch;
+    private final List<Attribute> fetchedOutputAttributes;
+    private final PhysicalPlan pushdownPlan;
+    private List<Attribute> lazyOutput;
+
+    public RemoteFetchExec(
+        Source source,
+        PhysicalPlan child,
+        Attribute handleAttribute,
+        List<Attribute> attributesToFetch,
+        List<Attribute> fetchedOutputAttributes,
+        PhysicalPlan pushdownPlan
+    ) {
+        super(source, child);
+        this.handleAttribute = handleAttribute;
+        this.attributesToFetch = List.copyOf(attributesToFetch);
+        this.fetchedOutputAttributes = List.copyOf(fetchedOutputAttributes);
+        this.pushdownPlan = pushdownPlan;
+    }
+
+    private RemoteFetchExec(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(PhysicalPlan.class),
+            in.readNamedWriteable(Attribute.class),
+            in.readNamedWriteableCollectionAsList(Attribute.class),
+            in.readNamedWriteableCollectionAsList(Attribute.class),
+            in.readOptionalNamedWriteable(PhysicalPlan.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeNamedWriteable(handleAttribute);
+        out.writeNamedWriteableCollection(attributesToFetch);
+        out.writeNamedWriteableCollection(fetchedOutputAttributes);
+        out.writeOptionalNamedWriteable(pushdownPlan);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected NodeInfo<RemoteFetchExec> info() {
+        return NodeInfo.create(
+            this,
+            RemoteFetchExec::new,
+            child(),
+            handleAttribute,
+            attributesToFetch,
+            fetchedOutputAttributes,
+            pushdownPlan
+        );
+    }
+
+    @Override
+    public RemoteFetchExec replaceChild(PhysicalPlan newChild) {
+        return new RemoteFetchExec(source(), newChild, handleAttribute, attributesToFetch, fetchedOutputAttributes, pushdownPlan);
+    }
+
+    @Override
+    protected AttributeSet computeReferences() {
+        return AttributeSet.of(handleAttribute);
+    }
+
+    public Attribute handleAttribute() {
+        return handleAttribute;
+    }
+
+    public List<Attribute> attributesToFetch() {
+        return attributesToFetch;
+    }
+
+    public PhysicalPlan pushdownPlan() {
+        return pushdownPlan;
+    }
+
+    public List<Attribute> fetchedOutputAttributes() {
+        return fetchedOutputAttributes;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        if (lazyOutput == null) {
+            List<Attribute> childOutput = child().output();
+            List<Attribute> fetchedOutput = fetchedOutputAttributes();
+            lazyOutput = new ArrayList<>(childOutput.size() + fetchedOutput.size());
+            lazyOutput.addAll(childOutput);
+            lazyOutput.addAll(fetchedOutput);
+        }
+        return lazyOutput;
+    }
+
+    @Override
+    public PhysicalPlan estimateRowSize(State state) {
+        state.add(true, attributesToFetch);
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(child(), handleAttribute, attributesToFetch, fetchedOutputAttributes, pushdownPlan);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RemoteFetchExec other = (RemoteFetchExec) obj;
+        return Objects.equals(child(), other.child())
+            && Objects.equals(handleAttribute, other.handleAttribute)
+            && Objects.equals(attributesToFetch, other.attributesToFetch)
+            && Objects.equals(fetchedOutputAttributes, other.fetchedOutputAttributes)
+            && Objects.equals(pushdownPlan, other.pushdownPlan);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RemoteFetchSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RemoteFetchSourceExec.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Leaf source used to compile remote-fetch post-fetch pushdown fragments.
+ */
+public class RemoteFetchSourceExec extends LeafExec {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "RemoteFetchSourceExec",
+        RemoteFetchSourceExec::new
+    );
+
+    private final List<Attribute> output;
+
+    public RemoteFetchSourceExec(Source source, List<Attribute> output) {
+        super(source);
+        this.output = List.copyOf(output);
+    }
+
+    private RemoteFetchSourceExec(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), in.readNamedWriteableCollectionAsList(Attribute.class));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteableCollection(output);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected NodeInfo<RemoteFetchSourceExec> info() {
+        return NodeInfo.create(this, RemoteFetchSourceExec::new, output);
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return output;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(output);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RemoteFetchSourceExec other = (RemoteFetchSourceExec) obj;
+        return Objects.equals(output, other.output);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchBatchOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchBatchOperator.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.BatchMetadata;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.IndexedByShardId;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Server-side batch operator for remote fetch over bidirectional exchange.
+ * Consumes one handles page per batch and emits one or more fetched pages
+ * carrying the same batch id.
+ */
+final class RemoteFetchBatchOperator implements Operator {
+    private final List<RemoteFetchService.FetchField> fields;
+    private final IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts;
+    private final PlannerSettings plannerSettings;
+    private final RemoteFetchService remoteFetchService;
+    private final PhysicalPlan pushdownPlan;
+    private final Deque<Page> outputQueue = new ArrayDeque<>();
+    private boolean finished;
+    private Exception failure;
+
+    RemoteFetchBatchOperator(
+        List<RemoteFetchService.FetchField> fields,
+        IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts,
+        PlannerSettings plannerSettings,
+        PhysicalPlan pushdownPlan,
+        RemoteFetchService remoteFetchService
+    ) {
+        this.fields = List.copyOf(fields);
+        this.shardContexts = shardContexts;
+        this.plannerSettings = plannerSettings;
+        this.pushdownPlan = pushdownPlan;
+        this.remoteFetchService = remoteFetchService;
+    }
+
+    @Override
+    public boolean needsInput() {
+        return finished == false && failure == null;
+    }
+
+    @Override
+    public void addInput(Page page) {
+        if (failure != null) {
+            page.releaseBlocks();
+            return;
+        }
+        try {
+            BatchMetadata metadata = page.batchMetadata();
+            if (metadata == null) {
+                throw new IllegalStateException("remote fetch batch page missing metadata");
+            }
+            List<RemoteFetchHandle> handles = decodeHandles(page);
+            List<Page> fetched = remoteFetchService.executeFetchForExchange(handles, fields, shardContexts, plannerSettings);
+            fetched = remoteFetchService.executePushdownForExchange(fetched, pushdownPlan, shardContexts);
+            enqueueWithBatchMetadata(metadata.batchId(), fetched);
+        } catch (Exception e) {
+            failure = e;
+        } finally {
+            page.releaseBlocks();
+        }
+    }
+
+    @Override
+    public void finish() {
+        finished = true;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return (finished || failure != null) && outputQueue.isEmpty();
+    }
+
+    @Override
+    public boolean canProduceMoreDataWithoutExtraInput() {
+        return outputQueue.isEmpty() == false || failure != null;
+    }
+
+    @Override
+    public Page getOutput() {
+        if (failure != null) {
+            Exception e = failure;
+            failure = null;
+            if (e instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new IllegalStateException("remote fetch batch operator failed", e);
+        }
+        return outputQueue.pollFirst();
+    }
+
+    @Override
+    public void close() {
+        for (Page page : outputQueue) {
+            Releasables.closeExpectNoException(page::releaseBlocks);
+        }
+        outputQueue.clear();
+    }
+
+    private static List<RemoteFetchHandle> decodeHandles(Page page) {
+        if (page.getBlockCount() != 1) {
+            throw new IllegalStateException("expected a single handle block but got [" + page.getBlockCount() + "]");
+        }
+        BytesRefBlock handlesBlock = (BytesRefBlock) page.getBlock(0);
+        List<RemoteFetchHandle> handles = new ArrayList<>(page.getPositionCount());
+        BytesRef scratch = new BytesRef();
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            if (handlesBlock.isNull(position)) {
+                throw new IllegalStateException("remote fetch handle block cannot contain nulls");
+            }
+            if (handlesBlock.getValueCount(position) != 1) {
+                throw new IllegalStateException("remote fetch handle block must have exactly one value per row");
+            }
+            handles.add(RemoteFetchHandle.fromBytesRef(handlesBlock.getBytesRef(handlesBlock.getFirstValueIndex(position), scratch)));
+        }
+        return handles;
+    }
+
+    private void enqueueWithBatchMetadata(long batchId, List<Page> fetchedPages) {
+        if (fetchedPages.isEmpty()) {
+            outputQueue.add(Page.createBatchMarkerPage(batchId, 0));
+            return;
+        }
+        int pageIndex = 0;
+        for (Page fetchedPage : fetchedPages) {
+            Block[] blocks = new Block[fetchedPage.getBlockCount()];
+            for (int i = 0; i < blocks.length; i++) {
+                blocks[i] = fetchedPage.getBlock(i);
+                blocks[i].incRef();
+            }
+            boolean isLast = pageIndex == fetchedPages.size() - 1;
+            outputQueue.add(new Page(new BatchMetadata(batchId, pageIndex, isLast), blocks));
+            pageIndex++;
+            fetchedPage.releaseBlocks();
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandle.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandle.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * Serializable row handle for coordinator-driven remote fetch.
+ * <p>
+ * The existing {@code _doc} column is intentionally local-only because {@code DocBlock}s do not cross a transport
+ * boundary. This handle captures the minimum routing information needed to revisit a document on its owning node
+ * after the coordinator has already narrowed the candidate set.
+ */
+public record RemoteFetchHandle(String nodeId, String sessionId, int shard, int segment, int doc) implements Writeable {
+    public static final Writeable.Reader<RemoteFetchHandle> READER = RemoteFetchHandle::new;
+
+    public RemoteFetchHandle {
+        Objects.requireNonNull(nodeId, "nodeId");
+        Objects.requireNonNull(sessionId, "sessionId");
+        if (shard < 0) {
+            throw new IllegalArgumentException("shard must be non-negative");
+        }
+        if (segment < 0) {
+            throw new IllegalArgumentException("segment must be non-negative");
+        }
+        if (doc < 0) {
+            throw new IllegalArgumentException("doc must be non-negative");
+        }
+    }
+
+    public RemoteFetchHandle(StreamInput in) throws IOException {
+        this(in.readString(), in.readString(), in.readVInt(), in.readVInt(), in.readVInt());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(nodeId);
+        out.writeString(sessionId);
+        out.writeVInt(shard);
+        out.writeVInt(segment);
+        out.writeVInt(doc);
+    }
+
+    /**
+     * Encodes the handle into a transport-safe {@link BytesRef} so it can be carried through regular page blocks.
+     */
+    public BytesRef toBytesRef() {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            writeTo(out);
+            return BytesRef.deepCopyOf(out.bytes().toBytesRef());
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to encode remote fetch handle", e);
+        }
+    }
+
+    public static RemoteFetchHandle fromBytesRef(BytesRef bytesRef) {
+        try (StreamInput in = StreamInput.wrap(BytesRef.deepCopyOf(bytesRef).bytes)) {
+            return new RemoteFetchHandle(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to decode remote fetch handle", e);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleOperator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DocBlock;
+import org.elasticsearch.compute.data.DocVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.AbstractPageMappingOperator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Releasables;
+
+import java.util.Arrays;
+
+/**
+ * Encodes local {@code _doc} references into transport-safe remote fetch handles.
+ */
+public final class RemoteFetchHandleOperator extends AbstractPageMappingOperator {
+    public record Factory(String nodeId, String sessionId, int docChannel) implements OperatorFactory {
+        @Override
+        public Operator get(DriverContext driverContext) {
+            return new RemoteFetchHandleOperator(driverContext, nodeId, sessionId, docChannel);
+        }
+
+        @Override
+        public String describe() {
+            return "RemoteFetchHandleOperator[channel=" + docChannel + "]";
+        }
+    }
+
+    private final DriverContext driverContext;
+    private final String nodeId;
+    private final String sessionId;
+    private final int docChannel;
+
+    RemoteFetchHandleOperator(DriverContext driverContext, String nodeId, String sessionId, int docChannel) {
+        this.driverContext = driverContext;
+        this.nodeId = nodeId;
+        this.sessionId = sessionId;
+        this.docChannel = docChannel;
+    }
+
+    @Override
+    protected Page process(Page page) {
+        Block[] blocks = new Block[page.getBlockCount()];
+        boolean success = false;
+        try (BytesRefBlock.Builder handleBuilder = driverContext.blockFactory().newBytesRefBlockBuilder(page.getPositionCount())) {
+            DocVector docVector = ((DocBlock) page.getBlock(docChannel)).asVector();
+            BytesRef scratch = new BytesRef();
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                handleBuilder.appendBytesRef(
+                    new RemoteFetchHandle(
+                        nodeId,
+                        sessionId,
+                        docVector.shards().getInt(position),
+                        docVector.segments().getInt(position),
+                        docVector.docs().getInt(position)
+                    ).toBytesRef()
+                );
+            }
+            for (int block = 0; block < blocks.length; block++) {
+                if (block == docChannel) {
+                    blocks[block] = handleBuilder.build();
+                } else {
+                    blocks[block] = page.getBlock(block);
+                    blocks[block].incRef();
+                }
+            }
+            Page output = new Page(page.getPositionCount(), blocks);
+            success = true;
+            return output;
+        } finally {
+            page.releaseBlocks();
+            if (success == false) {
+                Releasables.closeExpectNoException(Releasables.wrap(Arrays.asList(blocks)));
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteFetchHandleOperator[channel=" + docChannel + "]";
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchOperator.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.AsyncOperator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.session.Configuration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+record RemoteFetchResult(Page inputPage, int[] groupByPosition, int[] offsetByPosition, List<GroupPages> pagesByGroup) {
+    static RemoteFetchResult passthrough(Page inputPage) {
+        return new RemoteFetchResult(inputPage, null, null, null);
+    }
+
+    boolean isPassthrough() {
+        return groupByPosition == null;
+    }
+}
+
+record GroupPages(List<Page> pages, boolean hasPositionMapping) {}
+
+/**
+ * Fetches deferred fields from the owning data nodes after the coordinator has narrowed the candidate set.
+ */
+public final class RemoteFetchOperator extends AsyncOperator<RemoteFetchResult> {
+    public interface Client extends Releasable {
+        void fetchAsync(String nodeId, RemoteFetchService.Request request, ActionListener<List<Page>> listener);
+
+        @Override
+        default void close() {}
+    }
+
+    @FunctionalInterface
+    public interface ClientFactory {
+        Client create();
+    }
+
+    public record Factory(
+        int handleChannel,
+        List<RemoteFetchService.FetchField> requestFields,
+        List<Attribute> outputFields,
+        PhysicalPlan pushdownPlan,
+        Configuration configuration,
+        int maxOutstandingRequests,
+        ThreadContext threadContext,
+        ClientFactory clientFactory
+    ) implements OperatorFactory {
+        @Override
+        public Operator get(DriverContext driverContext) {
+            return new RemoteFetchOperator(
+                driverContext,
+                threadContext,
+                handleChannel,
+                requestFields,
+                outputFields,
+                pushdownPlan,
+                configuration,
+                maxOutstandingRequests,
+                clientFactory.create()
+            );
+        }
+
+        @Override
+        public String describe() {
+            return "RemoteFetchOperator[channel=" + handleChannel + ", requestFields=" + requestFields + "]";
+        }
+    }
+
+    private record TargetSession(String nodeId, String sessionId) {}
+
+    private static final class Group {
+        private final TargetSession target;
+        private final List<RemoteFetchHandle> handles = new ArrayList<>();
+
+        private Group(TargetSession target) {
+            this.target = target;
+        }
+    }
+
+    private final DriverContext driverContext;
+    private final int handleChannel;
+    private final List<RemoteFetchService.FetchField> requestFields;
+    private final List<Attribute> outputFields;
+    private final PhysicalPlan pushdownPlan;
+    private final Configuration configuration;
+    private final Client client;
+
+    RemoteFetchOperator(
+        DriverContext driverContext,
+        ThreadContext threadContext,
+        int handleChannel,
+        List<RemoteFetchService.FetchField> requestFields,
+        List<Attribute> outputFields,
+        PhysicalPlan pushdownPlan,
+        Configuration configuration,
+        int maxOutstandingRequests,
+        Client client
+    ) {
+        super(driverContext, threadContext, maxOutstandingRequests);
+        this.driverContext = driverContext;
+        this.handleChannel = handleChannel;
+        this.requestFields = List.copyOf(requestFields);
+        this.outputFields = List.copyOf(outputFields);
+        this.pushdownPlan = pushdownPlan;
+        this.configuration = configuration;
+        this.client = client;
+    }
+
+    @Override
+    protected void performAsync(Page inputPage, ActionListener<RemoteFetchResult> listener) {
+        if (inputPage.getPositionCount() == 0 || outputFields.isEmpty()) {
+            listener.onResponse(RemoteFetchResult.passthrough(inputPage));
+            return;
+        }
+
+        GroupedHandles groupedHandles = decodeHandles(inputPage);
+        if (groupedHandles.groups().isEmpty()) {
+            listener.onResponse(RemoteFetchResult.passthrough(inputPage));
+            return;
+        }
+
+        inputPage.allowPassingToDifferentDriver();
+        AtomicBoolean completed = new AtomicBoolean();
+        AtomicInteger remaining = new AtomicInteger(groupedHandles.groups().size());
+        List<GroupPages> pagesByGroup = new ArrayList<>(groupedHandles.groups().size());
+        for (int i = 0; i < groupedHandles.groups().size(); i++) {
+            pagesByGroup.add(null);
+        }
+
+        for (int groupIndex = 0; groupIndex < groupedHandles.groups().size(); groupIndex++) {
+            Group group = groupedHandles.groups().get(groupIndex);
+            RemoteFetchService.Request request = new RemoteFetchService.Request(
+                group.target.sessionId(),
+                requestFields,
+                group.handles,
+                pushdownPlan,
+                configuration
+            );
+            final int currentGroup = groupIndex;
+            client.fetchAsync(group.target.nodeId(), request, ActionListener.wrap(pages -> {
+                pages.forEach(Page::allowPassingToDifferentDriver);
+                if (completed.get()) {
+                    releasePages(pages);
+                    return;
+                }
+                final boolean hasPositionMapping;
+                try {
+                    hasPositionMapping = validateFetchedPages(group, pages);
+                } catch (Exception e) {
+                    releasePages(pages);
+                    if (completed.compareAndSet(false, true)) {
+                        releasePagesByGroup(pagesByGroup);
+                        listener.onFailure(e);
+                    }
+                    return;
+                }
+                pagesByGroup.set(currentGroup, new GroupPages(pages, hasPositionMapping));
+                if (remaining.decrementAndGet() == 0 && completed.compareAndSet(false, true)) {
+                    listener.onResponse(
+                        new RemoteFetchResult(inputPage, groupedHandles.groupByPosition(), groupedHandles.offsetByPosition(), pagesByGroup)
+                    );
+                }
+            }, e -> {
+                if (completed.compareAndSet(false, true)) {
+                    releasePagesByGroup(pagesByGroup);
+                    listener.onFailure(e);
+                }
+            }));
+        }
+    }
+
+    @Override
+    protected void releaseFetchedOnAnyThread(RemoteFetchResult result) {
+        releasePageOnAnyThread(result.inputPage());
+        releasePagesByGroup(result.pagesByGroup());
+    }
+
+    @Override
+    protected void doClose() {
+        client.close();
+    }
+
+    @Override
+    public Page getOutput() {
+        RemoteFetchResult fetched = fetchFromBuffer();
+        if (fetched == null) {
+            return null;
+        }
+        if (fetched.isPassthrough()) {
+            return fetched.inputPage();
+        }
+        return mergeFetchedPage(fetched.inputPage(), fetched.groupByPosition(), fetched.offsetByPosition(), fetched.pagesByGroup());
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteFetchOperator[channel=" + handleChannel + ", requestFields=" + requestFields + "]";
+    }
+
+    private GroupedHandles decodeHandles(Page inputPage) {
+        BytesRefBlock handlesBlock = (BytesRefBlock) inputPage.getBlock(handleChannel);
+        Map<TargetSession, Integer> groupLookup = new LinkedHashMap<>();
+        List<Group> groups = new ArrayList<>();
+        int[] groupByPosition = new int[inputPage.getPositionCount()];
+        int[] offsetByPosition = new int[inputPage.getPositionCount()];
+        BytesRef scratch = new BytesRef();
+
+        for (int position = 0; position < inputPage.getPositionCount(); position++) {
+            if (handlesBlock.isNull(position)) {
+                throw new IllegalStateException("remote fetch handle column cannot contain nulls");
+            }
+            if (handlesBlock.getValueCount(position) != 1) {
+                throw new IllegalStateException("remote fetch handle column must contain exactly one handle per row");
+            }
+            RemoteFetchHandle handle = RemoteFetchHandle.fromBytesRef(
+                handlesBlock.getBytesRef(handlesBlock.getFirstValueIndex(position), scratch)
+            );
+            TargetSession target = new TargetSession(handle.nodeId(), handle.sessionId());
+            Integer groupIndex = groupLookup.get(target);
+            if (groupIndex == null) {
+                groupIndex = groups.size();
+                groupLookup.put(target, groupIndex);
+                groups.add(new Group(target));
+            }
+            Group group = groups.get(groupIndex);
+            groupByPosition[position] = groupIndex;
+            offsetByPosition[position] = group.handles.size();
+            group.handles.add(handle);
+        }
+        return new GroupedHandles(groups, groupByPosition, offsetByPosition);
+    }
+
+    private boolean validateFetchedPages(Group group, List<Page> pages) {
+        int positions = 0;
+        Boolean hasPositionMapping = null;
+        for (Page page : pages) {
+            boolean pageHasPosition = page.getBlockCount() == outputFields.size() + 1;
+            if (page.getBlockCount() != outputFields.size() && pageHasPosition == false) {
+                throw new IllegalStateException(
+                    "remote fetch returned ["
+                        + page.getBlockCount()
+                        + "] columns but expected ["
+                        + outputFields.size()
+                        + "] or ["
+                        + (outputFields.size() + 1)
+                        + "]"
+                );
+            }
+            if (hasPositionMapping == null) {
+                hasPositionMapping = pageHasPosition;
+            } else if (hasPositionMapping != pageHasPosition) {
+                throw new IllegalStateException("remote fetch returned inconsistent page schemas for a single target group");
+            }
+            positions += page.getPositionCount();
+        }
+        if (Boolean.TRUE.equals(hasPositionMapping) == false && positions != group.handles.size()) {
+            throw new IllegalStateException("remote fetch returned [" + positions + "] rows but expected [" + group.handles.size() + "]");
+        }
+        return Boolean.TRUE.equals(hasPositionMapping);
+    }
+
+    private Page mergeFetchedPage(Page inputPage, int[] groupByPosition, int[] offsetByPosition, List<GroupPages> pagesByGroup) {
+        if (pagesByGroup.stream().anyMatch(g -> g != null && g.hasPositionMapping())) {
+            return mergeFetchedPageWithFiltering(inputPage, groupByPosition, offsetByPosition, pagesByGroup);
+        }
+        Block[] outputBlocks = new Block[inputPage.getBlockCount() + outputFields.size()];
+        Block.Builder[] builders = new Block.Builder[outputFields.size()];
+        boolean success = false;
+        try {
+            for (int block = 0; block < inputPage.getBlockCount(); block++) {
+                outputBlocks[block] = inputPage.getBlock(block);
+                outputBlocks[block].incRef();
+            }
+            for (int field = 0; field < outputFields.size(); field++) {
+                builders[field] = PlannerUtils.toElementType(outputFields.get(field).dataType())
+                    .newBlockBuilder(inputPage.getPositionCount(), driverContext.blockFactory());
+                for (int position = 0; position < inputPage.getPositionCount(); position++) {
+                    List<Page> fetchedPages = pagesByGroup.get(groupByPosition[position]).pages();
+                    copyFetchedPosition(builders[field], fetchedPages, field, offsetByPosition[position]);
+                }
+                outputBlocks[inputPage.getBlockCount() + field] = builders[field].build();
+            }
+            Page output = new Page(inputPage.getPositionCount(), outputBlocks);
+            success = true;
+            return output;
+        } finally {
+            inputPage.releaseBlocks();
+            releasePagesByGroup(pagesByGroup);
+            Releasables.closeExpectNoException(Releasables.wrap(Arrays.asList(builders)));
+            if (success == false) {
+                Releasables.closeExpectNoException(Releasables.wrap(Arrays.asList(outputBlocks)));
+            }
+        }
+    }
+
+    private Page mergeFetchedPageWithFiltering(
+        Page inputPage,
+        int[] groupByPosition,
+        int[] offsetByPosition,
+        List<GroupPages> pagesByGroup
+    ) {
+        List<Map<Integer, FetchedRowRef>> groupMappings = buildGroupMappings(pagesByGroup);
+        List<Integer> originalPositions = new ArrayList<>(inputPage.getPositionCount());
+        List<FetchedRowRef> keptRows = new ArrayList<>(inputPage.getPositionCount());
+        for (int position = 0; position < inputPage.getPositionCount(); position++) {
+            int group = groupByPosition[position];
+            int offset = offsetByPosition[position];
+            FetchedRowRef rowRef = groupMappings.get(group).get(offset);
+            if (rowRef != null) {
+                originalPositions.add(position);
+                keptRows.add(rowRef);
+            }
+        }
+        Block[] outputBlocks = new Block[inputPage.getBlockCount() + outputFields.size()];
+        Block.Builder[] builders = new Block.Builder[outputBlocks.length];
+        boolean success = false;
+        try {
+            for (int i = 0; i < inputPage.getBlockCount(); i++) {
+                builders[i] = inputPage.getBlock(i).elementType().newBlockBuilder(originalPositions.size(), driverContext.blockFactory());
+            }
+            for (int i = 0; i < outputFields.size(); i++) {
+                builders[inputPage.getBlockCount() + i] = PlannerUtils.toElementType(outputFields.get(i).dataType())
+                    .newBlockBuilder(originalPositions.size(), driverContext.blockFactory());
+            }
+            for (int i = 0; i < originalPositions.size(); i++) {
+                int inputPos = originalPositions.get(i);
+                for (int block = 0; block < inputPage.getBlockCount(); block++) {
+                    builders[block].copyFrom(inputPage.getBlock(block), inputPos, inputPos + 1);
+                }
+                FetchedRowRef rowRef = keptRows.get(i);
+                Page fetchedPage = pagesByGroup.get(rowRef.group()).pages().get(rowRef.pageIndex());
+                for (int field = 0; field < outputFields.size(); field++) {
+                    builders[inputPage.getBlockCount() + field].copyFrom(
+                        fetchedPage.getBlock(field),
+                        rowRef.position(),
+                        rowRef.position() + 1
+                    );
+                }
+            }
+            for (int i = 0; i < outputBlocks.length; i++) {
+                outputBlocks[i] = builders[i].build();
+            }
+            Page output = new Page(originalPositions.size(), outputBlocks);
+            success = true;
+            return output;
+        } finally {
+            inputPage.releaseBlocks();
+            releasePagesByGroup(pagesByGroup);
+            Releasables.closeExpectNoException(Releasables.wrap(Arrays.asList(builders)));
+            if (success == false) {
+                Releasables.closeExpectNoException(Releasables.wrap(Arrays.asList(outputBlocks)));
+            }
+        }
+    }
+
+    private static List<Map<Integer, FetchedRowRef>> buildGroupMappings(List<GroupPages> pagesByGroup) {
+        List<Map<Integer, FetchedRowRef>> mappings = new ArrayList<>(pagesByGroup.size());
+        for (int group = 0; group < pagesByGroup.size(); group++) {
+            GroupPages groupPages = pagesByGroup.get(group);
+            Map<Integer, FetchedRowRef> mapping = new HashMap<>();
+            if (groupPages != null) {
+                List<Page> pages = groupPages.pages();
+                if (groupPages.hasPositionMapping()) {
+                    for (int pageIndex = 0; pageIndex < pages.size(); pageIndex++) {
+                        Page page = pages.get(pageIndex);
+                        IntBlock positionBlock = page.getBlock(page.getBlockCount() - 1);
+                        for (int row = 0; row < page.getPositionCount(); row++) {
+                            mapping.put(positionBlock.getInt(row), new FetchedRowRef(group, pageIndex, row));
+                        }
+                    }
+                } else {
+                    int runningOffset = 0;
+                    for (int pageIndex = 0; pageIndex < pages.size(); pageIndex++) {
+                        Page page = pages.get(pageIndex);
+                        for (int row = 0; row < page.getPositionCount(); row++) {
+                            mapping.put(runningOffset++, new FetchedRowRef(group, pageIndex, row));
+                        }
+                    }
+                }
+            }
+            mappings.add(mapping);
+        }
+        return mappings;
+    }
+
+    private static void copyFetchedPosition(Block.Builder builder, List<Page> fetchedPages, int fieldIndex, int flattenedPosition) {
+        int position = flattenedPosition;
+        for (Page page : fetchedPages) {
+            if (position < page.getPositionCount()) {
+                builder.copyFrom(page.getBlock(fieldIndex), position, position + 1);
+                return;
+            }
+            position -= page.getPositionCount();
+        }
+        throw new IllegalStateException("remote fetch response did not contain the expected row");
+    }
+
+    private static void releasePagesByGroup(List<GroupPages> pagesByGroup) {
+        for (GroupPages group : pagesByGroup) {
+            releasePages(group == null ? null : group.pages());
+        }
+    }
+
+    private static void releasePages(List<Page> pages) {
+        if (pages != null) {
+            for (Page page : pages) {
+                Releasables.closeExpectNoException(page::releaseBlocks);
+            }
+        }
+    }
+
+    private record GroupedHandles(List<Group> groups, int[] groupByPosition, int[] offsetByPosition) {}
+
+    private record FetchedRowRef(int group, int pageIndex, int position) {}
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchService.java
@@ -1,0 +1,1028 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ChannelActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.compute.data.BatchMetadata;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockStreamInput;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DocVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.IndexedByShardId;
+import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator.EvalOperatorFactory;
+import org.elasticsearch.compute.operator.FilterOperator.FilterOperatorFactory;
+import org.elasticsearch.compute.operator.IsBlockedResult;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.operator.ProjectOperator.ProjectOperatorFactory;
+import org.elasticsearch.compute.operator.exchange.BidirectionalBatchExchangeClient;
+import org.elasticsearch.compute.operator.exchange.BidirectionalBatchExchangeServer;
+import org.elasticsearch.compute.operator.exchange.ExchangeService;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.AbstractTransportRequest;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportRequestHandler;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.action.EsqlQueryAction;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchSourceExec;
+import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.planner.Layout;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.session.Configuration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Internal transport service that fetches field values for coordinator-selected rows from the owning data node.
+ * <p>
+ * This is the transport half of the remote late-materialization prototype. It intentionally works on a narrow v1
+ * contract: a batch of {@link RemoteFetchHandle}s plus a list of plain field specifications to load.
+ */
+public final class RemoteFetchService {
+    private static final String ACTION_PREFIX = EsqlQueryAction.NAME + "/remote_fetch";
+    static final String RELEASE_ACTION_NAME = ACTION_PREFIX + "/release";
+    static final String EXCHANGE_SETUP_ACTION_NAME = ACTION_PREFIX + "/exchange_setup";
+
+    private static final Logger logger = LogManager.getLogger(RemoteFetchService.class);
+    private static final AtomicLong exchangeIdGenerator = new AtomicLong();
+
+    private final ClusterService clusterService;
+    private final TransportService transportService;
+    private final ExchangeService exchangeService;
+    private final BigArrays bigArrays;
+    private final BlockFactory blockFactory;
+    private final PlannerSettings.Holder plannerSettings;
+    private final LocalCircuitBreaker.SizeSettings localBreakerSettings;
+    private final RetainedSearchContextsRegistry retainedSearchContexts = new RetainedSearchContextsRegistry();
+
+    RemoteFetchService(TransportActionServices transportActionServices, BigArrays bigArrays, BlockFactory blockFactory) {
+        this.clusterService = transportActionServices.clusterService();
+        this.transportService = transportActionServices.transportService();
+        this.exchangeService = transportActionServices.exchangeService();
+        this.bigArrays = bigArrays;
+        this.blockFactory = blockFactory;
+        this.plannerSettings = transportActionServices.plannerSettings();
+        this.localBreakerSettings = new LocalCircuitBreaker.SizeSettings(clusterService.getSettings());
+        transportService.registerRequestHandler(
+            RELEASE_ACTION_NAME,
+            transportService.getThreadPool().executor(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME),
+            ReleaseRequest::new,
+            new ReleaseTransportHandler()
+        );
+        transportService.registerRequestHandler(
+            EXCHANGE_SETUP_ACTION_NAME,
+            transportService.getThreadPool().executor(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME),
+            ExchangeSetupRequest::new,
+            new ExchangeSetupTransportHandler()
+        );
+    }
+
+    RetainedSearchContextsRegistry.Registration retainSearchContexts(String sessionId, AcquiredSearchContexts searchContexts) {
+        return retainedSearchContexts.register(sessionId, searchContexts);
+    }
+
+    void releaseAsync(DiscoveryNode targetNode, String sessionId, ActionListener<Void> listener) {
+        transportService.sendRequest(
+            targetNode,
+            RELEASE_ACTION_NAME,
+            new ReleaseRequest(sessionId),
+            TransportRequestOptions.EMPTY,
+            new ActionListenerResponseHandler<>(
+                listener.map(ignored -> null),
+                in -> ActionResponse.Empty.INSTANCE,
+                transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
+            )
+        );
+    }
+
+    public ThreadContext threadContext() {
+        return transportService.getThreadPool().getThreadContext();
+    }
+
+    public RemoteFetchOperator.Client newBatchExchangeClient(CancellableTask parentTask) {
+        return new BatchExchangeFetchClient(parentTask);
+    }
+
+    private Page buildHandlesPage(List<RemoteFetchHandle> handles, long batchId) {
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(handles.size())) {
+            for (RemoteFetchHandle handle : handles) {
+                builder.appendBytesRef(handle.toBytesRef());
+            }
+            return new Page(new BatchMetadata(batchId, 0, true), builder.build());
+        }
+    }
+
+    private static Page stripBatchMetadata(Page page) {
+        Block[] blocks = new Block[page.getBlockCount()];
+        for (int i = 0; i < blocks.length; i++) {
+            blocks[i] = page.getBlock(i);
+            blocks[i].incRef();
+        }
+        return new Page(page.getPositionCount(), blocks);
+    }
+
+    private static Configuration readConfiguration(StreamInput in) throws IOException {
+        return new Configuration(
+            // TODO make Configuration Releasable
+            new BlockStreamInput(
+                in,
+                BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker(CircuitBreaker.REQUEST)).build()
+            )
+        );
+    }
+
+    TrackedSessions trackedSessions() {
+        return new TrackedSessions(this);
+    }
+
+    private final class BatchExchangeFetchClient implements RemoteFetchOperator.Client {
+        private final CancellableTask parentTask;
+        private final Executor executor = transportService.getThreadPool().executor(ThreadPool.Names.SEARCH);
+        private final Map<TargetSession, TargetState> targets = new HashMap<>();
+        private volatile boolean closed;
+
+        private BatchExchangeFetchClient(CancellableTask parentTask) {
+            this.parentTask = parentTask;
+        }
+
+        @Override
+        public void fetchAsync(String nodeId, Request request, ActionListener<List<Page>> listener) {
+            if (closed) {
+                listener.onFailure(new IllegalStateException("remote fetch exchange client is closed"));
+                return;
+            }
+            TargetSession target = new TargetSession(nodeId, request.sessionId());
+            final TargetState state;
+            synchronized (this) {
+                state = targets.computeIfAbsent(
+                    target,
+                    t -> createTargetState(t, request.fields(), request.pushdownPlan(), request.configuration())
+                );
+            }
+            ActionListener<List<Page>> cleanupListener = ActionListener.wrap(listener::onResponse, e -> {
+                removeTargetState(target, state);
+                listener.onFailure(e);
+            });
+            executor.execute(() -> state.fetch(request, cleanupListener));
+        }
+
+        @Override
+        public void close() {
+            Map<TargetSession, TargetState> states;
+            synchronized (this) {
+                if (closed) {
+                    return;
+                }
+                closed = true;
+                states = new HashMap<>(targets);
+                targets.clear();
+            }
+            for (TargetState state : states.values()) {
+                state.close();
+            }
+        }
+
+        private TargetState createTargetState(
+            TargetSession target,
+            List<FetchField> fields,
+            PhysicalPlan pushdownPlan,
+            Configuration configuration
+        ) {
+            DiscoveryNode node = clusterService.state().nodes().get(target.nodeId());
+            if (node == null) {
+                throw new IllegalStateException("remote fetch target node [" + target.nodeId() + "] not found");
+            }
+            BidirectionalBatchExchangeClient.ServerSetupCallback setupCallback = (
+                serverNode,
+                clientToServerId,
+                serverToClientId,
+                setupListener) -> {
+                ExchangeSetupRequest setupRequest = new ExchangeSetupRequest(
+                    target.sessionId(),
+                    fields,
+                    pushdownPlan,
+                    configuration,
+                    clientToServerId,
+                    serverToClientId
+                );
+                transportService.sendChildRequest(
+                    serverNode,
+                    EXCHANGE_SETUP_ACTION_NAME,
+                    setupRequest,
+                    parentTask,
+                    TransportRequestOptions.EMPTY,
+                    new ActionListenerResponseHandler<>(
+                        setupListener.map(ignored -> (String) null),
+                        in -> ActionResponse.Empty.INSTANCE,
+                        transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
+                    )
+                );
+            };
+            BidirectionalBatchExchangeClient client = new BidirectionalBatchExchangeClient(
+                target.sessionId() + "/remote-fetch/" + exchangeIdGenerator.incrementAndGet(),
+                exchangeService,
+                transportService.getThreadPool().executor(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME),
+                Math.max(1, fields.size() + 1),
+                transportService,
+                parentTask,
+                ActionListener.noop(),
+                clusterService.getSettings(),
+                setupCallback,
+                null,
+                1,
+                () -> node
+            );
+            return new TargetState(client, fields, pushdownPlan, configuration);
+        }
+
+        private void removeTargetState(TargetSession target, TargetState expectedState) {
+            boolean removed;
+            synchronized (this) {
+                removed = targets.remove(target, expectedState);
+            }
+            if (removed) {
+                expectedState.close();
+            }
+        }
+    }
+
+    private final class TargetState {
+        private final BidirectionalBatchExchangeClient client;
+        private final List<FetchField> fields;
+        private final PhysicalPlan pushdownPlan;
+        private final Configuration configuration;
+        private final AtomicLong batchIdGenerator = new AtomicLong();
+        private final Object lock = new Object();
+        private boolean closed;
+
+        private TargetState(
+            BidirectionalBatchExchangeClient client,
+            List<FetchField> fields,
+            PhysicalPlan pushdownPlan,
+            Configuration configuration
+        ) {
+            this.client = client;
+            this.fields = List.copyOf(fields);
+            this.pushdownPlan = pushdownPlan;
+            this.configuration = configuration;
+        }
+
+        void fetch(Request request, ActionListener<List<Page>> listener) {
+            synchronized (lock) {
+                try {
+                    if (closed) {
+                        throw new IllegalStateException("remote fetch target state is closed");
+                    }
+                    if (fields.equals(request.fields()) == false) {
+                        throw new IllegalStateException("remote fetch fields differ for reused target session channel");
+                    }
+                    if (Objects.equals(pushdownPlan, request.pushdownPlan()) == false) {
+                        throw new IllegalStateException("remote fetch pushdown plan differs for reused target session channel");
+                    }
+                    if (configuration.equals(request.configuration()) == false) {
+                        throw new IllegalStateException("remote fetch configuration differs for reused target session channel");
+                    }
+                    long batchId = batchIdGenerator.incrementAndGet();
+                    Page handlesPage = buildHandlesPage(request.handles(), batchId);
+                    client.sendPage(handlesPage);
+                    listener.onResponse(collectFetchedPagesForBatch(client, batchId));
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                }
+            }
+        }
+
+        void close() {
+            synchronized (lock) {
+                if (closed) {
+                    return;
+                }
+                closed = true;
+                try {
+                    client.finish();
+                    client.finishCollectingResponseHeaders();
+                    client.close();
+                } catch (Exception e) {
+                    logger.debug("failed to close remote fetch target state", e);
+                }
+            }
+        }
+    }
+
+    private record TargetSession(String nodeId, String sessionId) {}
+
+    private List<Page> collectFetchedPagesForBatch(BidirectionalBatchExchangeClient client, long batchId) throws Exception {
+        List<Page> pages = new ArrayList<>();
+        boolean completed = false;
+        while (completed == false) {
+            Page page = client.pollPage();
+            if (page != null) {
+                try {
+                    BatchMetadata metadata = page.batchMetadata();
+                    if (metadata == null || metadata.batchId() != batchId) {
+                        throw new IllegalStateException("received unexpected batch metadata while awaiting batch [" + batchId + "]");
+                    }
+                    if (page.getPositionCount() > 0) {
+                        pages.add(stripBatchMetadata(page));
+                    }
+                    if (metadata.isLastPageInBatch()) {
+                        client.markBatchCompleted(batchId);
+                        completed = true;
+                    }
+                } finally {
+                    page.releaseBlocks();
+                }
+                continue;
+            }
+            Exception failure = client.getPrimaryFailure();
+            if (failure != null) {
+                throw failure;
+            }
+            IsBlockedResult blocked = client.waitUntilPageReady();
+            if (blocked.listener().isDone() == false) {
+                PlainActionFuture<Void> waitFuture = new PlainActionFuture<>();
+                blocked.listener().addListener(waitFuture);
+                FutureUtils.get(waitFuture);
+            }
+        }
+        return pages;
+    }
+
+    int retainedSessions() {
+        return retainedSearchContexts.retainedSessions();
+    }
+
+    boolean isRegistered(String sessionId) {
+        return retainedSearchContexts.isRegistered(sessionId);
+    }
+
+    private void releaseSession(String sessionId) {
+        retainedSearchContexts.closeRegistration(sessionId);
+    }
+
+    private void releaseBestEffort(DiscoveryNode targetNode, String sessionId) {
+        releaseAsync(targetNode, sessionId, ActionListener.wrap(ignored -> {}, e -> {
+            logger.debug("failed to release retained remote fetch session [{}] on node [{}]", sessionId, targetNode.getId(), e);
+        }));
+    }
+
+    private void startExchangeFetchServer(ExchangeSetupRequest request, CancellableTask task, ActionListener<Void> listener) {
+        final RetainedSearchContextsRegistry.Lease lease;
+        try {
+            lease = retainedSearchContexts.acquire(request.sessionId());
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
+        final DiscoveryNode clientNode;
+        try {
+            clientNode = determineClientNode(task);
+        } catch (Exception e) {
+            lease.close();
+            listener.onFailure(e);
+            return;
+        }
+        final PlannerSettings settings = plannerSettings.get();
+        final IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts = lease.searchContexts()
+            .map(ComputeSearchContext::shardContext);
+        final LocalCircuitBreaker localBreaker = new LocalCircuitBreaker(
+            blockFactory.breaker(),
+            localBreakerSettings.overReservedBytes(),
+            localBreakerSettings.maxOverReservedBytes()
+        );
+        final DriverContext driverContext = new DriverContext(
+            bigArrays,
+            blockFactory.newChildFactory(localBreaker),
+            localBreakerSettings,
+            "remote_fetch_exchange"
+        );
+        final BidirectionalBatchExchangeServer server = new BidirectionalBatchExchangeServer(
+            request.clientToServerId(),
+            request.clientToServerId(),
+            request.serverToClientId(),
+            exchangeService,
+            transportService.getThreadPool().executor(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME),
+            Math.max(1, request.fields().size()),
+            transportService,
+            task,
+            clientNode,
+            clusterService.getSettings()
+        );
+        final Releasable releasable = Releasables.wrap(server, lease, localBreaker);
+        List<Operator> intermediate = List.of(
+            new RemoteFetchBatchOperator(request.fields(), shardContexts, settings, request.pushdownPlan(), this)
+        );
+        server.startWithOperators(
+            driverContext,
+            transportService.getThreadPool().getThreadContext(),
+            intermediate,
+            clusterService.getClusterName().value(),
+            releasable,
+            listener
+        );
+    }
+
+    private DiscoveryNode determineClientNode(CancellableTask task) {
+        if (task == null) {
+            throw new IllegalStateException("cannot determine remote fetch exchange client node: task is null");
+        }
+        if (task.getParentTaskId().isSet() == false) {
+            throw new IllegalStateException("cannot determine remote fetch exchange client node: parent task is not set");
+        }
+        String nodeId = task.getParentTaskId().getNodeId();
+        DiscoveryNode node = clusterService.state().nodes().get(nodeId);
+        if (node == null) {
+            throw new IllegalStateException("remote fetch exchange client node [" + nodeId + "] not found");
+        }
+        return node;
+    }
+
+    List<Page> executeFetchForExchange(
+        List<RemoteFetchHandle> handles,
+        List<FetchField> fields,
+        IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts,
+        PlannerSettings settings
+    ) {
+        List<ValuesSourceReaderOperator.FieldInfo> fieldInfos = buildFieldInfos(fields, shardContexts, settings);
+        IndexedByShardId<ValuesSourceReaderOperator.ShardContext> readerContexts = shardContexts.map(
+            c -> new ValuesSourceReaderOperator.ShardContext(
+                c.searcher().getIndexReader(),
+                c::newSourceLoader,
+                c.storedFieldsSequentialProportion()
+            )
+        );
+        return executeFetch(handles, fieldInfos, readerContexts, bigArrays, blockFactory, localBreakerSettings, settings);
+    }
+
+    List<Page> executePushdownForExchange(
+        List<Page> pages,
+        PhysicalPlan pushdownPlan,
+        IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts
+    ) {
+        if (pushdownPlan == null || pages.isEmpty()) {
+            return pages;
+        }
+        List<Page> current = appendPositionColumn(pages);
+        List<Operator.OperatorFactory> factories = new ArrayList<>();
+        compilePushdownFactories(pushdownPlan, factories, shardContexts);
+        for (Operator.OperatorFactory factory : factories) {
+            List<Page> next = new ArrayList<>();
+            Operator operator = factory.get(new DriverContext(bigArrays, blockFactory, localBreakerSettings, "remote_fetch_pushdown"));
+            try {
+                for (Page page : current) {
+                    operator.addInput(page);
+                    Page output;
+                    while ((output = operator.getOutput()) != null) {
+                        output.allowPassingToDifferentDriver();
+                        next.add(output);
+                    }
+                }
+                operator.finish();
+                Page output;
+                while ((output = operator.getOutput()) != null) {
+                    output.allowPassingToDifferentDriver();
+                    next.add(output);
+                }
+            } finally {
+                operator.close();
+            }
+            current = next;
+        }
+        return current;
+    }
+
+    private List<Page> appendPositionColumn(List<Page> pages) {
+        List<Page> withPosition = new ArrayList<>(pages.size());
+        int position = 0;
+        for (Page page : pages) {
+            try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(page.getPositionCount())) {
+                for (int row = 0; row < page.getPositionCount(); row++) {
+                    builder.appendInt(position++);
+                }
+                withPosition.add(page.appendBlock(builder.build()));
+            }
+        }
+        return withPosition;
+    }
+
+    private Layout compilePushdownFactories(
+        PhysicalPlan plan,
+        List<Operator.OperatorFactory> factories,
+        IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts
+    ) {
+        if (plan instanceof RemoteFetchSourceExec sourceExec) {
+            Layout.Builder builder = new Layout.Builder();
+            builder.append(sourceExec.output());
+            return builder.build();
+        }
+        if (plan instanceof EvalExec evalExec) {
+            Layout childLayout = compilePushdownFactories(evalExec.child(), factories, shardContexts);
+            Layout.Builder builder = childLayout.builder();
+            for (Alias field : evalExec.fields()) {
+                factories.add(
+                    new EvalOperatorFactory(EvalMapper.toEvaluator(FoldContext.small(), field.child(), childLayout, shardContexts))
+                );
+                builder.append(field.toAttribute());
+            }
+            return builder.build();
+        }
+        if (plan instanceof FilterExec filterExec) {
+            Layout childLayout = compilePushdownFactories(filterExec.child(), factories, shardContexts);
+            factories.add(
+                new FilterOperatorFactory(EvalMapper.toEvaluator(FoldContext.small(), filterExec.condition(), childLayout, shardContexts))
+            );
+            return childLayout;
+        }
+        if (plan instanceof ProjectExec projectExec) {
+            Layout childLayout = compilePushdownFactories(projectExec.child(), factories, shardContexts);
+            List<Integer> projectionList = new ArrayList<>(projectExec.projections().size());
+            Layout.Builder builder = new Layout.Builder();
+            for (NamedExpression projection : projectExec.projections()) {
+                NameId inputId = projection instanceof Alias alias ? ((NamedExpression) alias.child()).id() : projection.id();
+                Layout.ChannelAndType input = childLayout.get(inputId);
+                if (input == null) {
+                    throw new IllegalStateException("can't find pushdown input for [" + projection + "]");
+                }
+                projectionList.add(input.channel());
+                builder.append(projection);
+            }
+            factories.add(new ProjectOperatorFactory(projectionList));
+            return builder.build();
+        }
+        throw new IllegalStateException("unsupported remote fetch pushdown plan [" + plan.getClass().getSimpleName() + "]");
+    }
+
+    static List<ValuesSourceReaderOperator.FieldInfo> buildFieldInfos(
+        List<FetchField> fields,
+        IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts,
+        PlannerSettings plannerSettings
+    ) {
+        List<ValuesSourceReaderOperator.FieldInfo> fieldInfos = new ArrayList<>(fields.size());
+        for (FetchField field : fields) {
+            fieldInfos.add(
+                new ValuesSourceReaderOperator.FieldInfo(
+                    field.fieldName(),
+                    PlannerUtils.toElementType(field.dataType()),
+                    false,
+                    (warningsMode, shardIdx) -> {
+                        BlockLoader loader = shardContexts.get(shardIdx)
+                            .blockLoader(
+                                field.fieldName(),
+                                field.dataType() == DataType.UNSUPPORTED,
+                                MappedFieldType.FieldExtractPreference.NONE,
+                                null,
+                                null,
+                                plannerSettings.blockLoaderSizeOrdinals(),
+                                plannerSettings.blockLoaderSizeScript()
+                            );
+                        return ValuesSourceReaderOperator.load(loader);
+                    }
+                )
+            );
+        }
+        return fieldInfos;
+    }
+
+    static List<Page> executeFetch(
+        List<RemoteFetchHandle> handles,
+        List<ValuesSourceReaderOperator.FieldInfo> fieldInfos,
+        IndexedByShardId<ValuesSourceReaderOperator.ShardContext> shardContexts,
+        BigArrays bigArrays,
+        BlockFactory blockFactory,
+        LocalCircuitBreaker.SizeSettings localBreakerSettings,
+        PlannerSettings plannerSettings
+    ) {
+        if (handles.isEmpty()) {
+            return List.of();
+        }
+        if (fieldInfos.isEmpty()) {
+            throw new IllegalArgumentException("remote fetch requires at least one field");
+        }
+
+        final LocalCircuitBreaker localBreaker = new LocalCircuitBreaker(
+            blockFactory.breaker(),
+            localBreakerSettings.overReservedBytes(),
+            localBreakerSettings.maxOverReservedBytes()
+        );
+        final DriverContext driverContext = new DriverContext(
+            bigArrays,
+            blockFactory.newChildFactory(localBreaker),
+            localBreakerSettings,
+            "remote_fetch"
+        );
+        final Operator operator = new ValuesSourceReaderOperator.Factory(
+            plannerSettings.valuesLoadingJumboSize(),
+            fieldInfos,
+            shardContexts,
+            fieldInfos.size() <= plannerSettings.reuseColumnLoadersThreshold(),
+            0,
+            plannerSettings.sourceReservationFactor(),
+            plannerSettings.docSequenceBytesRefFieldThreshold()
+        ).get(driverContext);
+        final int[] projection = new int[fieldInfos.size()];
+        for (int i = 0; i < projection.length; i++) {
+            projection[i] = i + 1;
+        }
+        Page inputPage = inputPage(driverContext.blockFactory(), handles);
+        boolean releaseInputPage = true;
+        boolean success = false;
+        List<Page> outputPages = new ArrayList<>();
+        try {
+            operator.addInput(inputPage);
+            releaseInputPage = false;
+            operator.finish();
+            while (operator.isFinished() == false) {
+                Page page = operator.getOutput();
+                if (page == null) {
+                    throw new IllegalStateException("remote fetch operator stalled without producing output");
+                }
+                Page projected = page.projectBlocks(projection);
+                page.releaseBlocks();
+                projected.allowPassingToDifferentDriver();
+                outputPages.add(projected);
+            }
+            success = true;
+            return outputPages;
+        } finally {
+            Releasables.closeExpectNoException(operator, localBreaker);
+            if (releaseInputPage) {
+                inputPage.releaseBlocks();
+            }
+            if (success == false) {
+                Releasables.closeExpectNoException(Releasables.wrap(Iterators.map(outputPages.iterator(), page -> page::releaseBlocks)));
+            }
+        }
+    }
+
+    static Page inputPage(BlockFactory blockFactory, List<RemoteFetchHandle> handles) {
+        try (DocVector.FixedBuilder builder = DocVector.newFixedBuilder(blockFactory, handles.size())) {
+            for (RemoteFetchHandle handle : handles) {
+                builder.append(handle.shard(), handle.segment(), handle.doc());
+            }
+            return new Page(builder.build(DocVector.config()).asBlock());
+        }
+    }
+
+    public static final class FetchField implements Writeable {
+        private final String fieldName;
+        private final DataType dataType;
+
+        public FetchField(String fieldName, DataType dataType) {
+            this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
+            this.dataType = Objects.requireNonNull(dataType, "dataType");
+        }
+
+        FetchField(StreamInput in) throws IOException {
+            this(in.readString(), DataType.fromTypeName(in.readString()));
+        }
+
+        public String fieldName() {
+            return fieldName;
+        }
+
+        public DataType dataType() {
+            return dataType;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(fieldName);
+            out.writeString(dataType.typeName());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj instanceof FetchField == false) {
+                return false;
+            }
+            FetchField other = (FetchField) obj;
+            return fieldName.equals(other.fieldName) && dataType == other.dataType;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fieldName, dataType);
+        }
+
+        @Override
+        public String toString() {
+            return fieldName + ":" + dataType.typeName();
+        }
+    }
+
+    public static final class Request extends AbstractTransportRequest {
+        private final String sessionId;
+        private final List<FetchField> fields;
+        private final List<RemoteFetchHandle> handles;
+        private final PhysicalPlan pushdownPlan;
+        private final Configuration configuration;
+
+        public Request(String sessionId, List<FetchField> fields, List<RemoteFetchHandle> handles, Configuration configuration) {
+            this(sessionId, fields, handles, null, configuration);
+        }
+
+        public Request(
+            String sessionId,
+            List<FetchField> fields,
+            List<RemoteFetchHandle> handles,
+            PhysicalPlan pushdownPlan,
+            Configuration configuration
+        ) {
+            this.sessionId = Objects.requireNonNull(sessionId, "sessionId");
+            this.fields = List.copyOf(fields);
+            this.handles = List.copyOf(handles);
+            this.pushdownPlan = pushdownPlan;
+            this.configuration = Objects.requireNonNull(configuration, "configuration");
+        }
+
+        Request(StreamInput in) throws IOException {
+            super(in);
+            this.sessionId = in.readString();
+            this.fields = in.readCollectionAsList(FetchField::new);
+            this.handles = in.readCollectionAsList(RemoteFetchHandle.READER);
+            this.configuration = readConfiguration(in);
+            PlanStreamInput pin = new PlanStreamInput(in, in.namedWriteableRegistry(), configuration);
+            this.pushdownPlan = pin.readOptionalNamedWriteable(PhysicalPlan.class);
+        }
+
+        String sessionId() {
+            return sessionId;
+        }
+
+        List<FetchField> fields() {
+            return fields;
+        }
+
+        List<RemoteFetchHandle> handles() {
+            return handles;
+        }
+
+        PhysicalPlan pushdownPlan() {
+            return pushdownPlan;
+        }
+
+        Configuration configuration() {
+            return configuration;
+        }
+
+        void validateForNode(String localNodeId) {
+            if (fields.isEmpty()) {
+                throw new IllegalArgumentException("remote fetch requires at least one field");
+            }
+            for (RemoteFetchHandle handle : handles) {
+                if (sessionId.equals(handle.sessionId()) == false) {
+                    throw new IllegalArgumentException(
+                        "remote fetch request session [" + sessionId + "] does not match handle session [" + handle.sessionId() + "]"
+                    );
+                }
+                if (localNodeId.equals(handle.nodeId()) == false) {
+                    throw new IllegalArgumentException(
+                        "remote fetch handle node [" + handle.nodeId() + "] does not match local node [" + localNodeId + "]"
+                    );
+                }
+            }
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(sessionId);
+            out.writeCollection(fields);
+            out.writeCollection(handles);
+            configuration.writeTo(out);
+            new PlanStreamOutput(out, configuration).writeOptionalNamedWriteable(pushdownPlan);
+        }
+
+        @Override
+        public String toString() {
+            return "RemoteFetchRequest[session=" + sessionId + ", fields=" + fields + ", handles=" + handles.size() + "]";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj instanceof Request == false) {
+                return false;
+            }
+            Request other = (Request) obj;
+            return sessionId.equals(other.sessionId)
+                && fields.equals(other.fields)
+                && handles.equals(other.handles)
+                && Objects.equals(pushdownPlan, other.pushdownPlan)
+                && configuration.equals(other.configuration);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(sessionId, fields, handles, pushdownPlan, configuration);
+        }
+    }
+
+    static final class ReleaseRequest extends AbstractTransportRequest {
+        private final String sessionId;
+
+        ReleaseRequest(String sessionId) {
+            this.sessionId = Objects.requireNonNull(sessionId, "sessionId");
+        }
+
+        ReleaseRequest(StreamInput in) throws IOException {
+            super(in);
+            this.sessionId = in.readString();
+        }
+
+        String sessionId() {
+            return sessionId;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(sessionId);
+        }
+    }
+
+    static final class ExchangeSetupRequest extends AbstractTransportRequest {
+        private final String sessionId;
+        private final List<FetchField> fields;
+        private final PhysicalPlan pushdownPlan;
+        private final Configuration configuration;
+        private final String clientToServerId;
+        private final String serverToClientId;
+
+        ExchangeSetupRequest(
+            String sessionId,
+            List<FetchField> fields,
+            PhysicalPlan pushdownPlan,
+            Configuration configuration,
+            String clientToServerId,
+            String serverToClientId
+        ) {
+            this.sessionId = Objects.requireNonNull(sessionId);
+            this.fields = List.copyOf(fields);
+            this.pushdownPlan = pushdownPlan;
+            this.configuration = Objects.requireNonNull(configuration);
+            this.clientToServerId = Objects.requireNonNull(clientToServerId);
+            this.serverToClientId = Objects.requireNonNull(serverToClientId);
+        }
+
+        ExchangeSetupRequest(StreamInput in) throws IOException {
+            super(in);
+            this.sessionId = in.readString();
+            this.fields = in.readCollectionAsList(FetchField::new);
+            this.configuration = readConfiguration(in);
+            PlanStreamInput pin = new PlanStreamInput(in, in.namedWriteableRegistry(), configuration);
+            this.pushdownPlan = pin.readOptionalNamedWriteable(PhysicalPlan.class);
+            this.clientToServerId = in.readString();
+            this.serverToClientId = in.readString();
+        }
+
+        String sessionId() {
+            return sessionId;
+        }
+
+        List<FetchField> fields() {
+            return fields;
+        }
+
+        PhysicalPlan pushdownPlan() {
+            return pushdownPlan;
+        }
+
+        Configuration configuration() {
+            return configuration;
+        }
+
+        String clientToServerId() {
+            return clientToServerId;
+        }
+
+        String serverToClientId() {
+            return serverToClientId;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(sessionId);
+            out.writeCollection(fields);
+            configuration.writeTo(out);
+            new PlanStreamOutput(out, configuration).writeOptionalNamedWriteable(pushdownPlan);
+            out.writeString(clientToServerId);
+            out.writeString(serverToClientId);
+        }
+    }
+
+    private class ReleaseTransportHandler implements TransportRequestHandler<ReleaseRequest> {
+        @Override
+        public void messageReceived(ReleaseRequest request, TransportChannel channel, Task task) throws Exception {
+            releaseSession(request.sessionId());
+            channel.sendResponse(ActionResponse.Empty.INSTANCE);
+        }
+    }
+
+    private class ExchangeSetupTransportHandler implements TransportRequestHandler<ExchangeSetupRequest> {
+        @Override
+        public void messageReceived(ExchangeSetupRequest request, TransportChannel channel, Task task) {
+            startExchangeFetchServer(
+                request,
+                (CancellableTask) task,
+                new ChannelActionListener<>(channel).map(ignored -> ActionResponse.Empty.INSTANCE)
+            );
+        }
+    }
+
+    static final class TrackedSessions implements Releasable {
+        private final RemoteFetchService remoteFetchService;
+        private final List<TrackedSession> sessions = new ArrayList<>();
+        private boolean closed;
+
+        private TrackedSessions(RemoteFetchService remoteFetchService) {
+            this.remoteFetchService = remoteFetchService;
+        }
+
+        synchronized void track(DiscoveryNode targetNode, String sessionId) {
+            if (closed) {
+                remoteFetchService.releaseBestEffort(targetNode, sessionId);
+                return;
+            }
+            sessions.add(new TrackedSession(targetNode, sessionId));
+        }
+
+        @Override
+        public void close() {
+            List<TrackedSession> tracked;
+            synchronized (this) {
+                if (closed) {
+                    return;
+                }
+                closed = true;
+                tracked = List.copyOf(sessions);
+                sessions.clear();
+            }
+            for (TrackedSession session : tracked) {
+                remoteFetchService.releaseBestEffort(session.targetNode(), session.sessionId());
+            }
+        }
+    }
+
+    private record TrackedSession(DiscoveryNode targetNode, String sessionId) {}
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleOperatorTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DocBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.test.ESTestCase;
+
+public class RemoteFetchHandleOperatorTests extends ESTestCase {
+    public void testEncodesDocColumnIntoRemoteFetchHandles() {
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TestBlockFactory.getNonBreakingInstance(), null);
+        Page input = null;
+        Page output = null;
+        try (
+            DocBlock.Builder docBuilder = DocBlock.newBlockBuilder(driverContext.blockFactory(), 2);
+            IntBlock.Builder sortBuilder = driverContext.blockFactory().newIntBlockBuilder(2);
+            RemoteFetchHandleOperator operator = new RemoteFetchHandleOperator(driverContext, "node-a", "session-a", 0)
+        ) {
+            docBuilder.appendShard(1).appendSegment(2).appendDoc(10);
+            docBuilder.appendShard(3).appendSegment(4).appendDoc(20);
+            sortBuilder.appendInt(100);
+            sortBuilder.appendInt(200);
+            input = new Page(docBuilder.build(), sortBuilder.build());
+
+            operator.addInput(input);
+            input = null;
+            output = operator.getOutput();
+
+            BytesRefBlock handles = output.getBlock(0);
+            assertEquals(2, handles.getPositionCount());
+            assertEquals(new RemoteFetchHandle("node-a", "session-a", 1, 2, 10), decode(handles, 0));
+            assertEquals(new RemoteFetchHandle("node-a", "session-a", 3, 4, 20), decode(handles, 1));
+
+            IntBlock sortValues = output.getBlock(1);
+            assertEquals(100, sortValues.getInt(0));
+            assertEquals(200, sortValues.getInt(1));
+        } finally {
+            if (input != null) {
+                input.releaseBlocks();
+            }
+            if (output != null) {
+                output.releaseBlocks();
+            }
+        }
+    }
+
+    private static RemoteFetchHandle decode(BytesRefBlock handles, int position) {
+        BytesRef scratch = new BytesRef();
+        return RemoteFetchHandle.fromBytesRef(handles.getBytesRef(handles.getFirstValueIndex(position), scratch));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class RemoteFetchHandleTests extends ESTestCase {
+    public void testBytesRefRoundTrip() {
+        RemoteFetchHandle handle = randomHandle();
+
+        BytesRef encoded = handle.toBytesRef();
+
+        assertEquals(handle, RemoteFetchHandle.fromBytesRef(encoded));
+    }
+
+    public void testWriteableRoundTrip() throws IOException {
+        RemoteFetchHandle handle = randomHandle();
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            handle.writeTo(out);
+            try (StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes)) {
+                assertEquals(handle, RemoteFetchHandle.READER.read(in));
+            }
+        }
+    }
+
+    public void testRejectsNegativeShard() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new RemoteFetchHandle(randomAlphaOfLength(8), randomAlphaOfLength(8), -1, 0, 0)
+        );
+        assertEquals("shard must be non-negative", e.getMessage());
+    }
+
+    public void testRejectsNegativeSegment() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new RemoteFetchHandle(randomAlphaOfLength(8), randomAlphaOfLength(8), 0, -1, 0)
+        );
+        assertEquals("segment must be non-negative", e.getMessage());
+    }
+
+    public void testRejectsNegativeDoc() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new RemoteFetchHandle(randomAlphaOfLength(8), randomAlphaOfLength(8), 0, 0, -1)
+        );
+        assertEquals("doc must be non-negative", e.getMessage());
+    }
+
+    private RemoteFetchHandle randomHandle() {
+        return new RemoteFetchHandle(
+            randomAlphaOfLengthBetween(5, 12),
+            randomAlphaOfLengthBetween(5, 16),
+            randomIntBetween(0, 1024),
+            randomIntBetween(0, 4096),
+            randomIntBetween(0, 1 << 20)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchOperatorTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.capabilities.ConfigurationAware;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RemoteFetchOperatorTests extends ESTestCase {
+    public void testFetchesAcrossNodesAndReassemblesInInputOrder() {
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TestBlockFactory.getNonBreakingInstance(), null);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        List<RemoteFetchService.FetchField> fields = List.of(
+            new RemoteFetchService.FetchField("salary", DataType.INTEGER),
+            new RemoteFetchService.FetchField("name", DataType.KEYWORD)
+        );
+        List<Attribute> outputFields = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "salary", DataType.INTEGER),
+            new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD)
+        );
+        AtomicInteger requests = new AtomicInteger();
+        RemoteFetchOperator.Client client = (nodeId, request, listener) -> {
+            requests.incrementAndGet();
+            switch (nodeId) {
+                case "node-a" -> {
+                    assertEquals("session-a", request.sessionId());
+                    assertEquals(List.of(11, 33), request.handles().stream().map(RemoteFetchHandle::doc).toList());
+                    listener.onResponse(List.of(page(driverContext, 10, "a"), page(driverContext, 30, "c")));
+                }
+                case "node-b" -> {
+                    assertEquals("session-b", request.sessionId());
+                    assertEquals(List.of(22), request.handles().stream().map(RemoteFetchHandle::doc).toList());
+                    listener.onResponse(List.of(page(driverContext, 20, "b")));
+                }
+                default -> listener.onFailure(new IllegalStateException("unexpected node [" + nodeId + "]"));
+            }
+        };
+
+        Page input = null;
+        Page output = null;
+        try (
+            RemoteFetchOperator operator = new RemoteFetchOperator(
+                driverContext,
+                threadContext,
+                0,
+                fields,
+                outputFields,
+                null,
+                ConfigurationAware.CONFIGURATION_MARKER,
+                2,
+                client
+            )
+        ) {
+            input = new Page(handles(driverContext), carry(driverContext));
+            operator.addInput(input);
+            input = null;
+            output = operator.getOutput();
+
+            assertNotNull(output);
+            assertEquals(4, output.getBlockCount());
+            assertEquals(2, requests.get());
+
+            IntBlock carryValues = output.getBlock(1);
+            assertEquals(100, carryValues.getInt(0));
+            assertEquals(200, carryValues.getInt(1));
+            assertEquals(300, carryValues.getInt(2));
+
+            IntBlock fetchedInts = output.getBlock(2);
+            assertEquals(10, fetchedInts.getInt(0));
+            assertEquals(20, fetchedInts.getInt(1));
+            assertEquals(30, fetchedInts.getInt(2));
+
+            BytesRefBlock fetchedStrings = output.getBlock(3);
+            assertEquals("a", utf8(fetchedStrings, 0));
+            assertEquals("b", utf8(fetchedStrings, 1));
+            assertEquals("c", utf8(fetchedStrings, 2));
+        } finally {
+            if (input != null) {
+                input.releaseBlocks();
+            }
+            if (output != null) {
+                output.releaseBlocks();
+            }
+        }
+    }
+
+    private static Page page(DriverContext driverContext, int intValue, String stringValue) {
+        try (
+            IntBlock.Builder intBuilder = driverContext.blockFactory().newIntBlockBuilder(1);
+            BytesRefBlock.Builder stringBuilder = driverContext.blockFactory().newBytesRefBlockBuilder(1)
+        ) {
+            intBuilder.appendInt(intValue);
+            stringBuilder.appendBytesRef(new BytesRef(stringValue));
+            return new Page(intBuilder.build(), stringBuilder.build());
+        }
+    }
+
+    private static BytesRefBlock handles(DriverContext driverContext) {
+        try (BytesRefBlock.Builder builder = driverContext.blockFactory().newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new RemoteFetchHandle("node-a", "session-a", 1, 0, 11).toBytesRef());
+            builder.appendBytesRef(new RemoteFetchHandle("node-b", "session-b", 2, 0, 22).toBytesRef());
+            builder.appendBytesRef(new RemoteFetchHandle("node-a", "session-a", 1, 0, 33).toBytesRef());
+            return builder.build();
+        }
+    }
+
+    private static IntBlock carry(DriverContext driverContext) {
+        try (IntBlock.Builder builder = driverContext.blockFactory().newIntBlockBuilder(3)) {
+            builder.appendInt(100);
+            builder.appendInt(200);
+            builder.appendInt(300);
+            return builder.build();
+        }
+    }
+
+    private static String utf8(BytesRefBlock block, int position) {
+        return block.getBytesRef(block.getFirstValueIndex(position), new BytesRef()).utf8ToString();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchServiceRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchServiceRequestTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.ConfigurationTestUtils.randomConfiguration;
+
+public class RemoteFetchServiceRequestTests extends AbstractWireSerializingTestCase<RemoteFetchService.Request> {
+    @Override
+    protected Writeable.Reader<RemoteFetchService.Request> instanceReader() {
+        return RemoteFetchService.Request::new;
+    }
+
+    @Override
+    protected RemoteFetchService.Request createTestInstance() {
+        return new RemoteFetchService.Request(
+            randomAlphaOfLengthBetween(5, 12),
+            randomList(1, 5, this::randomField),
+            randomList(0, 8, this::randomHandle),
+            randomConfiguration()
+        );
+    }
+
+    @Override
+    protected RemoteFetchService.Request mutateInstance(RemoteFetchService.Request instance) throws IOException {
+        return switch (between(0, 3)) {
+            case 0 -> new RemoteFetchService.Request(
+                randomAlphaOfLengthBetween(5, 12),
+                instance.fields(),
+                instance.handles(),
+                instance.configuration()
+            );
+            case 1 -> new RemoteFetchService.Request(
+                instance.sessionId(),
+                randomList(1, 5, this::randomField),
+                instance.handles(),
+                instance.configuration()
+            );
+            case 2 -> new RemoteFetchService.Request(
+                instance.sessionId(),
+                instance.fields(),
+                randomList(0, 8, this::randomHandle),
+                instance.configuration()
+            );
+            default -> new RemoteFetchService.Request(
+                instance.sessionId(),
+                instance.fields(),
+                instance.handles(),
+                randomValueOtherThan(instance.configuration(), org.elasticsearch.xpack.esql.ConfigurationTestUtils::randomConfiguration)
+            );
+        };
+    }
+
+    private RemoteFetchService.FetchField randomField() {
+        DataType dataType = randomFrom(DataType.KEYWORD, DataType.LONG, DataType.INTEGER, DataType.DOUBLE, DataType.BOOLEAN, DataType.TEXT);
+        return new RemoteFetchService.FetchField(randomAlphaOfLengthBetween(3, 10), dataType);
+    }
+
+    private RemoteFetchHandle randomHandle() {
+        return new RemoteFetchHandle(
+            randomAlphaOfLengthBetween(5, 12),
+            randomAlphaOfLengthBetween(5, 12),
+            randomIntBetween(0, 32),
+            randomIntBetween(0, 16),
+            randomIntBetween(0, 4096)
+        );
+    }
+
+    public void testValidateRejectsEmptyFields() {
+        RemoteFetchService.Request request = new RemoteFetchService.Request(
+            "session-1",
+            List.of(),
+            List.of(new RemoteFetchHandle("node-1", "session-1", 0, 0, 0)),
+            randomConfiguration()
+        );
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> request.validateForNode("node-1"));
+        assertEquals("remote fetch requires at least one field", e.getMessage());
+    }
+
+    public void testValidateRejectsSessionMismatch() {
+        RemoteFetchService.Request request = new RemoteFetchService.Request(
+            "session-1",
+            List.of(new RemoteFetchService.FetchField("field", DataType.KEYWORD)),
+            List.of(new RemoteFetchHandle("node-1", "session-2", 0, 0, 0)),
+            randomConfiguration()
+        );
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> request.validateForNode("node-1"));
+        assertEquals("remote fetch request session [session-1] does not match handle session [session-2]", e.getMessage());
+    }
+
+    public void testValidateRejectsNodeMismatch() {
+        RemoteFetchService.Request request = new RemoteFetchService.Request(
+            "session-1",
+            List.of(new RemoteFetchService.FetchField("field", DataType.KEYWORD)),
+            List.of(new RemoteFetchHandle("node-2", "session-1", 0, 0, 0)),
+            randomConfiguration()
+        );
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> request.validateForNode("node-1"));
+        assertEquals("remote fetch handle node [node-2] does not match local node [node-1]", e.getMessage());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchServiceTests.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DocBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.IndexedByShardIdFromSingleton;
+import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
+import org.elasticsearch.compute.test.NoOpReleasable;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.SourceLoader;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.search.internal.AliasFilter;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.ConfigurationTestUtils;
+import org.elasticsearch.xpack.esql.SerializationTestUtils;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchSourceExec;
+import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.session.Configuration;
+import org.junit.After;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class RemoteFetchServiceTests extends MapperServiceTestCase {
+    private Directory directory;
+    private IndexReader reader;
+    private BlockFactory blockFactory;
+
+    public void testInputPagePreservesHandleCoordinates() {
+        blockFactory = blockFactory();
+        List<RemoteFetchHandle> handles = List.of(
+            new RemoteFetchHandle("node-1", "session-1", 3, 7, 11),
+            new RemoteFetchHandle("node-1", "session-1", 5, 13, 17)
+        );
+
+        Page page = RemoteFetchService.inputPage(blockFactory, handles);
+        try {
+            DocBlock docBlock = page.getBlock(0);
+            assertThat(docBlock.asVector().shards().getInt(0), equalTo(3));
+            assertThat(docBlock.asVector().segments().getInt(0), equalTo(7));
+            assertThat(docBlock.asVector().docs().getInt(0), equalTo(11));
+            assertThat(docBlock.asVector().shards().getInt(1), equalTo(5));
+            assertThat(docBlock.asVector().segments().getInt(1), equalTo(13));
+            assertThat(docBlock.asVector().docs().getInt(1), equalTo(17));
+        } finally {
+            page.releaseBlocks();
+        }
+    }
+
+    public void testExecuteFetchLoadsRequestedFieldsInHandleOrder() throws Exception {
+        blockFactory = blockFactory();
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("k").field("type", "keyword").endObject();
+            b.startObject("n").field("type", "long").endObject();
+        }));
+
+        directory = newDirectory();
+        try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig())) {
+            addDoc(writer, "k0", 10);
+            addDoc(writer, "k1", 20);
+            addDoc(writer, "k2", 30);
+        }
+        reader = DirectoryReader.open(directory);
+
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(mapperService, null);
+        EsPhysicalOperationProviders.DefaultShardContext fetchShardContext = new EsPhysicalOperationProviders.DefaultShardContext(
+            0,
+            new NoOpReleasable(),
+            searchExecutionContext,
+            AliasFilter.EMPTY
+        );
+        List<ValuesSourceReaderOperator.FieldInfo> fieldInfos = RemoteFetchService.buildFieldInfos(
+            List.of(new RemoteFetchService.FetchField("k", DataType.KEYWORD), new RemoteFetchService.FetchField("n", DataType.LONG)),
+            new IndexedByShardIdFromSingleton<>(fetchShardContext),
+            PlannerSettings.DEFAULTS
+        );
+
+        List<Page> pages = RemoteFetchService.executeFetch(
+            List.of(
+                new RemoteFetchHandle("node-1", "session-1", 0, 0, 2),
+                new RemoteFetchHandle("node-1", "session-1", 0, 0, 0),
+                new RemoteFetchHandle("node-1", "session-1", 0, 0, 1)
+            ),
+            fieldInfos,
+            new IndexedByShardIdFromSingleton<>(
+                new ValuesSourceReaderOperator.ShardContext(reader, sourcePaths -> SourceLoader.FROM_STORED_SOURCE, 0.2)
+            ),
+            BigArrays.NON_RECYCLING_INSTANCE,
+            blockFactory,
+            LocalCircuitBreaker.SizeSettings.DEFAULT_SETTINGS,
+            PlannerSettings.DEFAULTS
+        );
+
+        try {
+            assertThat(pages.size(), equalTo(1));
+            Page page = pages.getFirst();
+            BytesRef scratch = new BytesRef();
+            assertThat(page.getBlockCount(), equalTo(2));
+            assertThat(
+                page.<org.elasticsearch.compute.data.BytesRefBlock>getBlock(0).getBytesRef(0, scratch).utf8ToString(),
+                equalTo("k2")
+            );
+            assertThat(
+                page.<org.elasticsearch.compute.data.BytesRefBlock>getBlock(0).getBytesRef(1, scratch).utf8ToString(),
+                equalTo("k0")
+            );
+            assertThat(
+                page.<org.elasticsearch.compute.data.BytesRefBlock>getBlock(0).getBytesRef(2, scratch).utf8ToString(),
+                equalTo("k1")
+            );
+            assertThat(page.<org.elasticsearch.compute.data.LongBlock>getBlock(1).getLong(0), equalTo(30L));
+            assertThat(page.<org.elasticsearch.compute.data.LongBlock>getBlock(1).getLong(1), equalTo(10L));
+            assertThat(page.<org.elasticsearch.compute.data.LongBlock>getBlock(1).getLong(2), equalTo(20L));
+        } finally {
+            Releasables.closeExpectNoException(Releasables.wrap(Iterators.map(pages.iterator(), page -> page::releaseBlocks)));
+        }
+    }
+
+    public void testExecutePushdownForExchangeSupportsFilterExec() {
+        blockFactory = blockFactory();
+        RemoteFetchService remoteFetchService = newRemoteFetchService(blockFactory);
+        ReferenceAttribute fetchedAttribute = new ReferenceAttribute(Source.EMPTY, null, "n", DataType.LONG);
+        ReferenceAttribute positionAttribute = new ReferenceAttribute(
+            Source.EMPTY,
+            null,
+            RemoteFetchPlanner.REMOTE_FETCH_POSITION_NAME,
+            DataType.INTEGER
+        );
+        PhysicalPlan pushdownPlan = new FilterExec(
+            Source.EMPTY,
+            new RemoteFetchSourceExec(Source.EMPTY, List.of(fetchedAttribute, positionAttribute)),
+            new GreaterThan(Source.EMPTY, fetchedAttribute, new Literal(Source.EMPTY, 15L, DataType.LONG))
+        );
+        Page inputPage;
+        try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(3)) {
+            builder.appendLong(10L);
+            builder.appendLong(20L);
+            builder.appendLong(30L);
+            inputPage = new Page(builder.build());
+        }
+
+        List<Page> outputPages = remoteFetchService.executePushdownForExchange(
+            List.of(inputPage),
+            pushdownPlan,
+            new IndexedByShardIdFromSingleton<>(
+                Mockito.mock(EsPhysicalOperationProviders.ShardContext.class, Mockito.withSettings().stubOnly())
+            )
+        );
+
+        try {
+            assertThat(outputPages.size(), equalTo(1));
+            Page output = outputPages.getFirst();
+            assertThat(output.getPositionCount(), equalTo(2));
+            assertThat(output.getBlockCount(), equalTo(2));
+            assertThat(output.<LongBlock>getBlock(0).getLong(0), equalTo(20L));
+            assertThat(output.<LongBlock>getBlock(0).getLong(1), equalTo(30L));
+            assertThat(output.<IntBlock>getBlock(1).getInt(0), equalTo(1));
+            assertThat(output.<IntBlock>getBlock(1).getInt(1), equalTo(2));
+        } finally {
+            Releasables.closeExpectNoException(Releasables.wrap(Iterators.map(outputPages.iterator(), page -> page::releaseBlocks)));
+        }
+    }
+
+    public void testExchangeSetupRequestRoundTripsPushdownPlanWithFieldAttributes() throws IOException {
+        FieldAttribute fieldAttribute = new FieldAttribute(
+            Source.EMPTY,
+            "n",
+            new EsField("n", DataType.LONG, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+        );
+        Configuration configuration = ConfigurationTestUtils.randomConfiguration();
+        PhysicalPlan pushdownPlan = new RemoteFetchSourceExec(Source.EMPTY, List.of(fieldAttribute));
+        RemoteFetchService.ExchangeSetupRequest request = new RemoteFetchService.ExchangeSetupRequest(
+            "session-1",
+            List.of(new RemoteFetchService.FetchField("n", DataType.LONG)),
+            pushdownPlan,
+            configuration,
+            "clientToServer-1",
+            "serverToClient-1"
+        );
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            request.writeTo(out);
+            try (
+                StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), SerializationTestUtils.writableRegistry())
+            ) {
+                RemoteFetchService.ExchangeSetupRequest copy = new RemoteFetchService.ExchangeSetupRequest(in);
+                assertThat(copy.sessionId(), equalTo("session-1"));
+                assertThat(copy.fields(), equalTo(List.of(new RemoteFetchService.FetchField("n", DataType.LONG))));
+                assertThat(copy.pushdownPlan() instanceof RemoteFetchSourceExec, equalTo(true));
+                assertThat(copy.configuration(), equalTo(configuration));
+                assertThat(copy.clientToServerId(), equalTo("clientToServer-1"));
+                assertThat(copy.serverToClientId(), equalTo("serverToClient-1"));
+            }
+        }
+    }
+
+    private static RemoteFetchService newRemoteFetchService(BlockFactory blockFactory) {
+        ClusterService clusterService = Mockito.mock(ClusterService.class, Mockito.withSettings().stubOnly());
+        Mockito.when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        ThreadPool threadPool = Mockito.mock(ThreadPool.class, Mockito.withSettings().stubOnly());
+        Mockito.when(threadPool.executor(Mockito.anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        TransportService transportService = Mockito.mock(TransportService.class, Mockito.withSettings().stubOnly());
+        Mockito.when(transportService.getThreadPool()).thenReturn(threadPool);
+        PlannerSettings.Holder plannerSettings = Mockito.mock(PlannerSettings.Holder.class, Mockito.withSettings().stubOnly());
+        Mockito.when(plannerSettings.get()).thenReturn(PlannerSettings.DEFAULTS);
+        return new RemoteFetchService(
+            new TransportActionServices(
+                transportService,
+                null,
+                null,
+                clusterService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                plannerSettings,
+                null
+            ),
+            blockFactory.bigArrays(),
+            blockFactory
+        );
+    }
+
+    private static void addDoc(IndexWriter writer, String keyword, long number) throws IOException {
+        Document document = new Document();
+        document.add(new SortedDocValuesField("k", new BytesRef(keyword)));
+        document.add(new NumericDocValuesField("n", number));
+        writer.addDocument(document);
+    }
+
+    private BlockFactory blockFactory() {
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(4)).withCircuitBreaking();
+        return BlockFactory.builder(bigArrays).build();
+    }
+
+    @After
+    public void tearDownResources() throws Exception {
+        IOUtils.close(reader, directory);
+        if (blockFactory != null) {
+            assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+            assertThat(blockFactory.breaker().getTrippedCount(), equalTo(0L));
+            assertThat(blockFactory.breaker().getName(), equalTo(CircuitBreaker.REQUEST));
+        }
+        MockBigArrays.ensureAllArraysAreReleased();
+        super.tearDown();
+    }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Introduce the core execution primitives and request/service machinery used to fetch late-materialized fields from retained contexts.

Made-with: Cursor