### PR TITLE
Slices: enable required by default via RoutingFieldMapper instead of MapperService

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -354,12 +354,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
                 metadataBuilders.put(builder.leafName(), builder);
             }
         }
-        if (indexSettings.isSliceEnabled()) {
-            MetadataFieldMapper.Builder routingBuilder = metadataBuilders.get(RoutingFieldMapper.NAME);
-            if (routingBuilder instanceof RoutingFieldMapper.Builder builder) {
-                builder.required.setValue(true);
-            }
-        }
         return metadataBuilders;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -55,24 +55,23 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
     public static final NodeFeature ROUTING_AS_DOC_VALUES = new NodeFeature("mapper.routing_as_doc_values");
     public static final NodeFeature ROUTING_AS_DOC_VALUES_BY_DEFAULT = new NodeFeature("mapper.routing_as_doc_values_by_default");
 
-    public static class Defaults {
-        public static final boolean REQUIRED = false;
-    }
-
     private static RoutingFieldMapper toType(FieldMapper in) {
         return (RoutingFieldMapper) in;
     }
 
     public static class Builder extends MetadataFieldMapper.Builder {
 
-        final Parameter<Boolean> required = Parameter.boolParam("required", false, m -> toType(m).required, Defaults.REQUIRED);
+        final Parameter<Boolean> required;
         final Parameter<Boolean> docValues;
 
+        final boolean requiredByDefault;
         final boolean docValuesEnabledByDefault;
 
-        Builder(boolean docValuesEnabledByDefault) {
+        Builder(boolean requiredByDefault, boolean docValuesEnabledByDefault) {
             super(NAME);
+            this.requiredByDefault = requiredByDefault;
             this.docValuesEnabledByDefault = docValuesEnabledByDefault;
+            this.required = Parameter.boolParam("required", false, m -> toType(m).required, requiredByDefault);
             this.docValues = Parameter.boolParam("doc_values", false, m -> toType(m).docValues, docValuesEnabledByDefault);
         }
 
@@ -88,14 +87,14 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
 
         @Override
         public RoutingFieldMapper build() {
-            return RoutingFieldMapper.get(required.getValue(), docValuesEnabledByDefault, docValues.getValue());
+            return RoutingFieldMapper.get(requiredByDefault, required.getValue(), docValuesEnabledByDefault, docValues.getValue());
         }
     }
 
     public static final TypeParser PARSER = new ConfigurableTypeParser(c -> {
         var indexMode = c.getIndexSettings().getMode();
         boolean slicesEnabled = c.getIndexSettings().isSliceEnabled();
-        return new Builder(slicesEnabled || indexMode == IndexMode.COLUMNAR || indexMode == IndexMode.COLUMNAR_LOGSDB);
+        return new Builder(slicesEnabled, slicesEnabled || indexMode == IndexMode.COLUMNAR || indexMode == IndexMode.COLUMNAR_LOGSDB);
     });
 
     /**
@@ -285,6 +284,11 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
     private final boolean required;
 
     /**
+     * Whether routing is required by default
+     */
+    private final boolean requiredByDefault;
+
+    /**
      * Whether routing values are stored as sorted doc values instead of stored fields.
      */
     private final boolean docValues;
@@ -294,29 +298,50 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
      */
     private final boolean docValuesEnabledByDefault;
 
-    private static final RoutingFieldMapper REQUIRED_STORED = new RoutingFieldMapper(true, false, false);
-    private static final RoutingFieldMapper NOT_REQUIRED_STORED = new RoutingFieldMapper(false, false, false);
-    private static final RoutingFieldMapper REQUIRED_DOC_VALUES = new RoutingFieldMapper(true, false, true);
-    private static final RoutingFieldMapper REQUIRED_DOC_VALUES_ENABLED_BY_DEFAULT = new RoutingFieldMapper(true, true, true);
-    private static final RoutingFieldMapper NOT_REQUIRED_DOC_VALUES = new RoutingFieldMapper(false, false, true);
-    private static final RoutingFieldMapper NOT_REQUIRED_DOC_VALUES_ENABLED_BY_DEFAULT = new RoutingFieldMapper(false, true, true);
+    static final RoutingFieldMapper REQUIRED_STORED = new RoutingFieldMapper(true, false, false, false);
+    static final RoutingFieldMapper NOT_REQUIRED_STORED = new RoutingFieldMapper(false, false, false, false);
+    static final RoutingFieldMapper REQUIRED_DEFAULT_STORED = new RoutingFieldMapper(false, true, false, false);
+    static final RoutingFieldMapper REQUIRED_DOC_VALUES = new RoutingFieldMapper(true, false, false, true);
+    static final RoutingFieldMapper REQUIRED_DOC_VALUES_DEFAULT = new RoutingFieldMapper(true, false, true, true);
+    static final RoutingFieldMapper NOT_REQUIRED_DOC_VALUES = new RoutingFieldMapper(false, false, false, true);
+    static final RoutingFieldMapper REQUIRED_DEFAULT_DOC_VALUES = new RoutingFieldMapper(false, true, false, true);
+    static final RoutingFieldMapper NOT_REQUIRED_DOC_VALUES_DEFAULT = new RoutingFieldMapper(false, false, true, true);
+    static final RoutingFieldMapper REQUIRED__DEFAULT_DOC_VALUES_DEFAULT = new RoutingFieldMapper(false, false, true, true);
 
     private static final Map<String, NamedAnalyzer> ANALYZERS = Map.of(NAME, Lucene.KEYWORD_ANALYZER);
 
-    public static RoutingFieldMapper get(boolean required, boolean docValuesEnabledByDefault, boolean docValues) {
+    public static RoutingFieldMapper get(
+        boolean requiredByDefault,
+        boolean required,
+        boolean docValuesEnabledByDefault,
+        boolean docValues
+    ) {
         if (docValues) {
             if (required) {
-                return docValuesEnabledByDefault ? REQUIRED_DOC_VALUES_ENABLED_BY_DEFAULT : REQUIRED_DOC_VALUES;
+                if (docValuesEnabledByDefault) {
+                    return REQUIRED_DOC_VALUES_DEFAULT;
+                } else {
+                    return REQUIRED_DOC_VALUES;
+                }
             } else {
-                return docValuesEnabledByDefault ? NOT_REQUIRED_DOC_VALUES_ENABLED_BY_DEFAULT : NOT_REQUIRED_DOC_VALUES;
+                if (docValuesEnabledByDefault) {
+                    return requiredByDefault ? REQUIRED__DEFAULT_DOC_VALUES_DEFAULT : NOT_REQUIRED_DOC_VALUES_DEFAULT;
+                } else {
+                    return requiredByDefault ? REQUIRED_DEFAULT_DOC_VALUES : NOT_REQUIRED_DOC_VALUES;
+                }
             }
         }
-        return required ? REQUIRED_STORED : NOT_REQUIRED_STORED;
+        if (required) {
+            return REQUIRED_STORED;
+        } else {
+            return requiredByDefault ? REQUIRED_DEFAULT_STORED : NOT_REQUIRED_STORED;
+        }
     }
 
-    private RoutingFieldMapper(boolean required, boolean docValuesEnabledByDefault, boolean docValues) {
+    private RoutingFieldMapper(boolean required, boolean requiredByDefault, boolean docValuesEnabledByDefault, boolean docValues) {
         super(docValues ? DOC_VALUES_FIELD_TYPE : FIELD_TYPE);
         this.required = required;
+        this.requiredByDefault = requiredByDefault;
         this.docValues = docValues;
         this.docValuesEnabledByDefault = docValuesEnabledByDefault;
     }
@@ -363,6 +388,6 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(docValuesEnabledByDefault).init(this);
+        return new Builder(requiredByDefault, docValuesEnabledByDefault).init(this);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -45,6 +45,7 @@ import org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class RoutingFieldMapper extends MetadataFieldMapper {
@@ -87,7 +88,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
 
         @Override
         public RoutingFieldMapper build() {
-            return RoutingFieldMapper.get(requiredByDefault, required.getValue(), docValuesEnabledByDefault, docValues.getValue());
+            return InstancesLookup.lookup(requiredByDefault, required.getValue(), docValuesEnabledByDefault, docValues.getValue());
         }
     }
 
@@ -298,45 +299,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
      */
     private final boolean docValuesEnabledByDefault;
 
-    static final RoutingFieldMapper REQUIRED_STORED = new RoutingFieldMapper(true, false, false, false);
-    static final RoutingFieldMapper NOT_REQUIRED_STORED = new RoutingFieldMapper(false, false, false, false);
-    static final RoutingFieldMapper REQUIRED_DEFAULT_STORED = new RoutingFieldMapper(false, true, false, false);
-    static final RoutingFieldMapper REQUIRED_DOC_VALUES = new RoutingFieldMapper(true, false, false, true);
-    static final RoutingFieldMapper REQUIRED_DOC_VALUES_DEFAULT = new RoutingFieldMapper(true, false, true, true);
-    static final RoutingFieldMapper NOT_REQUIRED_DOC_VALUES = new RoutingFieldMapper(false, false, false, true);
-    static final RoutingFieldMapper REQUIRED_DEFAULT_DOC_VALUES = new RoutingFieldMapper(false, true, false, true);
-    static final RoutingFieldMapper NOT_REQUIRED_DOC_VALUES_DEFAULT = new RoutingFieldMapper(false, false, true, true);
-    static final RoutingFieldMapper REQUIRED__DEFAULT_DOC_VALUES_DEFAULT = new RoutingFieldMapper(false, false, true, true);
-
     private static final Map<String, NamedAnalyzer> ANALYZERS = Map.of(NAME, Lucene.KEYWORD_ANALYZER);
-
-    public static RoutingFieldMapper get(
-        boolean requiredByDefault,
-        boolean required,
-        boolean docValuesEnabledByDefault,
-        boolean docValues
-    ) {
-        if (docValues) {
-            if (required) {
-                if (docValuesEnabledByDefault) {
-                    return REQUIRED_DOC_VALUES_DEFAULT;
-                } else {
-                    return REQUIRED_DOC_VALUES;
-                }
-            } else {
-                if (docValuesEnabledByDefault) {
-                    return requiredByDefault ? REQUIRED__DEFAULT_DOC_VALUES_DEFAULT : NOT_REQUIRED_DOC_VALUES_DEFAULT;
-                } else {
-                    return requiredByDefault ? REQUIRED_DEFAULT_DOC_VALUES : NOT_REQUIRED_DOC_VALUES;
-                }
-            }
-        }
-        if (required) {
-            return REQUIRED_STORED;
-        } else {
-            return requiredByDefault ? REQUIRED_DEFAULT_STORED : NOT_REQUIRED_STORED;
-        }
-    }
 
     private RoutingFieldMapper(boolean required, boolean requiredByDefault, boolean docValuesEnabledByDefault, boolean docValues) {
         super(docValues ? DOC_VALUES_FIELD_TYPE : FIELD_TYPE);
@@ -389,5 +352,39 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
     @Override
     public FieldMapper.Builder getMergeBuilder() {
         return new Builder(requiredByDefault, docValuesEnabledByDefault).init(this);
+    }
+
+    static class InstancesLookup {
+
+        private record Key(boolean requiredByDefault, boolean required, boolean docValuesEnabledByDefault, boolean docValues) {}
+
+        final static Map<Key, RoutingFieldMapper> INSTANCES = new HashMap<>(16);
+
+        static {
+            for (boolean required : new boolean[] { true, false }) {
+                for (boolean requiredByDefault : new boolean[] { true, false }) {
+                    for (boolean docValuesEnabled : new boolean[] { true, false }) {
+                        for (boolean docValuesEnabledByDefault : new boolean[] { true, false }) {
+                            INSTANCES.put(
+                                new Key(requiredByDefault, required, docValuesEnabledByDefault, docValuesEnabled),
+                                new RoutingFieldMapper(required, requiredByDefault, required, docValuesEnabledByDefault)
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        static RoutingFieldMapper lookup(
+            boolean requiredByDefault,
+            boolean required,
+            boolean docValuesEnabledByDefault,
+            boolean docValues
+        ) {
+            var key = new Key(requiredByDefault, required, docValuesEnabledByDefault, docValues);
+            var routingFieldMapper = INSTANCES.get(key);
+            assert routingFieldMapper != null;
+            return routingFieldMapper;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -354,11 +354,11 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         return new Builder(requiredByDefault, docValuesEnabledByDefault).init(this);
     }
 
-    static class InstancesLookup {
+    static final class InstancesLookup {
 
         private record Key(boolean requiredByDefault, boolean required, boolean docValuesEnabledByDefault, boolean docValues) {}
 
-        final static Map<Key, RoutingFieldMapper> INSTANCES = new HashMap<>(16);
+        static final Map<Key, RoutingFieldMapper> INSTANCES = new HashMap<>(16);
 
         static {
             for (boolean required : new boolean[] { true, false }) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -301,7 +301,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
 
     private static final Map<String, NamedAnalyzer> ANALYZERS = Map.of(NAME, Lucene.KEYWORD_ANALYZER);
 
-    private RoutingFieldMapper(boolean required, boolean requiredByDefault, boolean docValuesEnabledByDefault, boolean docValues) {
+    private RoutingFieldMapper(boolean requiredByDefault, boolean required, boolean docValuesEnabledByDefault, boolean docValues) {
         super(docValues ? DOC_VALUES_FIELD_TYPE : FIELD_TYPE);
         this.required = required;
         this.requiredByDefault = requiredByDefault;
@@ -367,7 +367,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
                         for (boolean docValuesEnabledByDefault : new boolean[] { true, false }) {
                             INSTANCES.put(
                                 new Key(requiredByDefault, required, docValuesEnabledByDefault, docValuesEnabled),
-                                new RoutingFieldMapper(required, requiredByDefault, docValuesEnabledByDefault, docValuesEnabled)
+                                new RoutingFieldMapper(requiredByDefault, required, docValuesEnabledByDefault, docValuesEnabled)
                             );
                         }
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -367,7 +367,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
                         for (boolean docValuesEnabledByDefault : new boolean[] { true, false }) {
                             INSTANCES.put(
                                 new Key(requiredByDefault, required, docValuesEnabledByDefault, docValuesEnabled),
-                                new RoutingFieldMapper(required, requiredByDefault, required, docValuesEnabledByDefault)
+                                new RoutingFieldMapper(required, requiredByDefault, docValuesEnabledByDefault, docValuesEnabled)
                             );
                         }
                     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldMapperTests.java
@@ -152,6 +152,59 @@ public class RoutingFieldMapperTests extends MetadataMapperTestCase {
         assertEquals("no routing fields when routing value is absent", 0, doc.rootDoc().getFields("_routing").size());
     }
 
+    public void testBuilderReturnsExpectedSingleton() {
+        // docValues = false (routing stored as a stored field)
+        {
+            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, false);
+            assertSame(RoutingFieldMapper.NOT_REQUIRED_STORED, builder.build());
+        }
+        {
+            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(true, false);
+            builder.required.setValue(false);
+            assertSame(RoutingFieldMapper.REQUIRED_DEFAULT_STORED, builder.build());
+        }
+        {
+            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, false);
+            builder.required.setValue(true);
+            assertSame(RoutingFieldMapper.REQUIRED_STORED, builder.build());
+        }
+
+        // docValues = true, docValuesEnabledByDefault = false
+        {
+            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, false);
+            builder.docValues.setValue(true);
+            assertSame(RoutingFieldMapper.NOT_REQUIRED_DOC_VALUES, builder.build());
+        }
+        {
+            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(true, false);
+            builder.required.setValue(false);
+            builder.docValues.setValue(true);
+            assertSame(RoutingFieldMapper.REQUIRED_DEFAULT_DOC_VALUES, builder.build());
+        }
+        {
+            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, false);
+            builder.required.setValue(true);
+            builder.docValues.setValue(true);
+            assertSame(RoutingFieldMapper.REQUIRED_DOC_VALUES, builder.build());
+        }
+
+        // docValues = true, docValuesEnabledByDefault = true
+        {
+            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, true);
+            assertSame(RoutingFieldMapper.NOT_REQUIRED_DOC_VALUES_DEFAULT, builder.build());
+        }
+        {
+            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(true, true);
+            builder.required.setValue(false);
+            assertSame(RoutingFieldMapper.REQUIRED__DEFAULT_DOC_VALUES_DEFAULT, builder.build());
+        }
+        {
+            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, true);
+            builder.required.setValue(true);
+            assertSame(RoutingFieldMapper.REQUIRED_DOC_VALUES_DEFAULT, builder.build());
+        }
+    }
+
     public void testFetchDocValuesRoutingFieldValue() throws IOException {
         MapperService mapperService = createMapperService(topMapping(b -> b.startObject("_routing").field("doc_values", true).endObject()));
         withLuceneIndex(

--- a/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RoutingFieldMapperTests.java
@@ -153,56 +153,43 @@ public class RoutingFieldMapperTests extends MetadataMapperTestCase {
     }
 
     public void testBuilderReturnsExpectedSingleton() {
-        // docValues = false (routing stored as a stored field)
-        {
-            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, false);
-            assertSame(RoutingFieldMapper.NOT_REQUIRED_STORED, builder.build());
-        }
-        {
-            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(true, false);
-            builder.required.setValue(false);
-            assertSame(RoutingFieldMapper.REQUIRED_DEFAULT_STORED, builder.build());
-        }
-        {
-            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, false);
-            builder.required.setValue(true);
-            assertSame(RoutingFieldMapper.REQUIRED_STORED, builder.build());
-        }
+        for (boolean requiredByDefault : new boolean[] { false, true }) {
+            for (boolean docValuesEnabledByDefault : new boolean[] { false, true }) {
+                for (boolean required : new boolean[] { false, true }) {
+                    for (boolean docValues : new boolean[] { false, true }) {
+                        String desc = "requiredByDefault="
+                            + requiredByDefault
+                            + " docValuesEnabledByDefault="
+                            + docValuesEnabledByDefault
+                            + " required="
+                            + required
+                            + " docValues="
+                            + docValues;
 
-        // docValues = true, docValuesEnabledByDefault = false
-        {
-            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, false);
-            builder.docValues.setValue(true);
-            assertSame(RoutingFieldMapper.NOT_REQUIRED_DOC_VALUES, builder.build());
+                        RoutingFieldMapper first = buildRoutingMapper(requiredByDefault, docValuesEnabledByDefault, required, docValues);
+                        RoutingFieldMapper second = buildRoutingMapper(requiredByDefault, docValuesEnabledByDefault, required, docValues);
+                        assertSame(desc + " (two builds should return the same singleton)", first, second);
+                        assertSame(
+                            desc + " (build must match InstancesLookup)",
+                            RoutingFieldMapper.InstancesLookup.lookup(requiredByDefault, required, docValuesEnabledByDefault, docValues),
+                            first
+                        );
+                    }
+                }
+            }
         }
-        {
-            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(true, false);
-            builder.required.setValue(false);
-            builder.docValues.setValue(true);
-            assertSame(RoutingFieldMapper.REQUIRED_DEFAULT_DOC_VALUES, builder.build());
-        }
-        {
-            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, false);
-            builder.required.setValue(true);
-            builder.docValues.setValue(true);
-            assertSame(RoutingFieldMapper.REQUIRED_DOC_VALUES, builder.build());
-        }
+    }
 
-        // docValues = true, docValuesEnabledByDefault = true
-        {
-            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, true);
-            assertSame(RoutingFieldMapper.NOT_REQUIRED_DOC_VALUES_DEFAULT, builder.build());
-        }
-        {
-            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(true, true);
-            builder.required.setValue(false);
-            assertSame(RoutingFieldMapper.REQUIRED__DEFAULT_DOC_VALUES_DEFAULT, builder.build());
-        }
-        {
-            RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(false, true);
-            builder.required.setValue(true);
-            assertSame(RoutingFieldMapper.REQUIRED_DOC_VALUES_DEFAULT, builder.build());
-        }
+    private static RoutingFieldMapper buildRoutingMapper(
+        boolean requiredByDefault,
+        boolean docValuesEnabledByDefault,
+        boolean required,
+        boolean docValues
+    ) {
+        RoutingFieldMapper.Builder builder = new RoutingFieldMapper.Builder(requiredByDefault, docValuesEnabledByDefault);
+        builder.required.setValue(required);
+        builder.docValues.setValue(docValues);
+        return builder.build();
     }
 
     public void testFetchDocValuesRoutingFieldValue() throws IOException {


### PR DESCRIPTION
Follow up from #148773. This requires a bit more work because:
* For meta field mappers we return singleton instances to reduce jvm heap usage by mappers.
* For defaults, we use Parameter's defaults, this to avoid serializing mapping attributes in places where it is not needed. Or in this case avoid serializing `_routing: {required: true}`.

These seem like minor optimizations, but in large clusters these things do matter.