### PR TITLE
Typo: Update connector name from Teams to Zoom

### DIFF
--- a/docs/reference/search-connectors/es-connectors-zoom.md
+++ b/docs/reference/search-connectors/es-connectors-zoom.md
@@ -100,7 +100,7 @@ Refer to the [{{es}} API documentation](https://www.elastic.co/docs/api/doc/elas
 
 ### Usage [es-connectors-zoom-client-connector-usage]
 
-To use this connector in the UI, select the **Teams** tile when creating a new connector under **Search → Connectors**.
+To use this connector in the UI, select the **Zoom** tile when creating a new connector under **Search → Connectors**.
 
 If you’re already familiar with how connectors work, you can also use the [Connector APIs](https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-connector).
 


### PR DESCRIPTION
[Docs page for Zoom connector](https://www.elastic.co/docs/reference/search-connectors/es-connectors-zoom) incorrectly mentions the Teams connector. 