### PR TITLE
Mute DatasetRewriterTests pending investigation of #148666

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -575,3 +575,5 @@ tests:
 - class: org.elasticsearch.xpack.stateless.reshard.StatelessReshardMixedOperationsIT
   method: testMixedOperationsDuringSplit
   issue: https://github.com/elastic/elasticsearch/issues/148809
+- class: org.elasticsearch.xpack.esql.datasources.DatasetRewriterTests
+  issue: https://github.com/elastic/elasticsearch/issues/148666


### PR DESCRIPTION
Class-level mute of `DatasetRewriterTests` while #148666 is investigated.

**Symptom**

In `release-tests` (`-Dbuild.snapshot=false`), `DatasetRewriter.rewrite()` returns its input `UnresolvedRelation` unchanged when called from inside the test body. 20 of 29 tests fail — every test that expects a rewrite. The 9 that pass are exactly the ones that expect a no-op (no-rewrite path: `testNoDatasetsLeavesPlanUnchanged`, the remote-cluster bail-out tests, `testFastPathSkipsResolverWhenNoPatternCouldMatchDataset`, etc.).

**Not reproducible locally**

JDK 21 and JDK 26 (Oracle EA, ARM64), same seed/locale/timezone, `-Dbuild.snapshot=false`: the class cleanly skips via the `@Before assumeTrue(ESQL_EXTERNAL_DATASOURCES_FEATURE_FLAG.isEnabled())` guard (locally the flag is off when `build.snapshot=false`). With the flag explicitly forced on, the test passes — even running the full `:x-pack:plugin:esql:test` suite. The failure only manifests in CI's `release-tests` JVM environment, where the feature flag is observed as on inside `@Before` (test runs) but the rewriter's runtime behavior matches the off path.

**Why mute, not fix**

Without a local repro I can't validate a fix. Muting is the right move to unblock `release-tests` while the root cause is found; a follow-up PR can land the real fix once we have a reproducer. Issue #148666 tracks the investigation.