### PR TITLE
prevent flakey test behavior

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -407,9 +407,6 @@ tests:
 - class: org.elasticsearch.search.aggregations.metrics.LargeTopHitsIT
   method: test500Queries
   issue: https://github.com/elastic/elasticsearch/issues/148056
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
-  issue: https://github.com/elastic/elasticsearch/issues/148096
 - class: org.elasticsearch.xpack.stateless.StatelessHollowIndexShardsIT
   method: testStressWithRelocationFailures
   issue: https://github.com/elastic/elasticsearch/issues/148129

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mtermvectors/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mtermvectors/10_basic.yml
@@ -19,6 +19,14 @@ setup:
   - do:
       indices.refresh: {}
 
+  # In mixed-cluster BWC tests, the rebalancer may relocate shards after node
+  # upgrades. A request hitting a recovering shard copy returns empty term
+  # vectors. Wait for no relocating shards before proceeding.
+  - do:
+      cluster.health:
+        index: testidx
+        wait_for_no_relocating_shards: true
+
 ---
 "Basic tests for multi termvector get":
 


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/148096

It's difficult to reproduce this but does seem to recur ever yearish.  The best current guess is that the test itself is still flakey and occasionally gets into race conditions before the cluster really can be queried.  Then we wind up querying it and getting back null data, missing docs. 