### PR TITLE
Ensure that test polygons are valid for lucene tesselator

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -536,9 +536,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.StatelessBatchedBehavioursIT
   method: testGenerationalFileBlobReferenceIsRetainedCorrectly
   issue: https://github.com/elastic/elasticsearch/issues/148723
-- class: org.elasticsearch.xpack.spatial.index.query.GeoShapeWithDocValuesQueryTests
-  method: testQueryRandomGeoCollection
-  issue: https://github.com/elastic/elasticsearch/issues/148727
 - class: org.elasticsearch.index.mapper.ArrayObjectsLimitIT
   method: testDynamicSettingUpdateAffectsSubsequentDocuments
   issue: https://github.com/elastic/elasticsearch/issues/148745

--- a/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
@@ -89,8 +89,18 @@ public class GeometryTestUtils {
         }
     }
 
+    /**
+     * Returns a Lucene polygon with non-zero area, so its vertices are not all collinear and the polygon
+     * survives {@link org.apache.lucene.geo.Tessellator}. Lucene's {@code GeoTestUtil.nextPolygon} on its
+     * own occasionally returns degenerate polygons; callers that hand the result to the geo_shape indexer
+     * should use this wrapper.
+     */
+    public static org.apache.lucene.geo.Polygon nextLucenePolygon() {
+        return randomValueOtherThanMany(p -> area(p) == 0, GeoTestUtil::nextPolygon);
+    }
+
     public static Polygon randomPolygon(boolean hasAlt) {
-        org.apache.lucene.geo.Polygon lucenePolygon = randomValueOtherThanMany(p -> area(p) == 0, GeoTestUtil::nextPolygon);
+        org.apache.lucene.geo.Polygon lucenePolygon = nextLucenePolygon();
         if (lucenePolygon.numHoles() > 0) {
             org.apache.lucene.geo.Polygon[] luceneHoles = lucenePolygon.getHoles();
             List<LinearRing> holes = new ArrayList<>();

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryTestCase.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.search.geo;
 
-import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.geo.GeoJson;
@@ -201,7 +200,7 @@ public abstract class GeoShapeQueryTestCase extends BaseShapeQueryTestCase<GeoSh
     }
 
     protected Polygon nextPolygon() {
-        org.apache.lucene.geo.Polygon randomPoly = GeoTestUtil.nextPolygon();
+        org.apache.lucene.geo.Polygon randomPoly = GeometryTestUtils.nextLucenePolygon();
         return new Polygon(new LinearRing(randomPoly.getPolyLons(), randomPoly.getPolyLats()));
     }
 


### PR DESCRIPTION
This removes polygons with only colinear points, by testing the polygon area. We already did this in some tests, and this fix expands the usage to a known flaky tests suite.

Fixes #148727
