### PR TITLE
[8.19] [Transform] Only run next search once (#148268) (#148868)

### DIFF
--- a/docs/changelog/148268.yaml
+++ b/docs/changelog/148268.yaml
@@ -1,0 +1,6 @@
+area: Transform
+issues:
+ - 147716
+pr: 148268
+summary: Only run next search once
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.Scheduler;
@@ -616,7 +617,18 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
 
             if (executionDelay.duration() > 0) {
                 logger.debug("throttling job [{}], wait for {} ({} {})", getJobId(), executionDelay, currentMaxDocsPerSecond, lastDocCount);
-                scheduledNextSearch = new ScheduledRunnable(threadPool, executionDelay, () -> triggerNextSearch(executionDelay.getNanos()));
+                try {
+                    scheduledNextSearch = new ScheduledRunnable(
+                        threadPool,
+                        executionDelay,
+                        () -> triggerNextSearch(executionDelay.getNanos())
+                    );
+                } catch (EsRejectedExecutionException e) {
+                    if (e.isExecutorShutdown()) {
+                        return;
+                    }
+                    throw e;
+                }
 
                 // corner case: if meanwhile stop() has been called or state persistence has been requested: fast forward, run search now
                 if (getState().equals(IndexerState.STOPPING) || triggerSaveState()) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -792,7 +792,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         logger.debug("[{}] updating persistent state of transform to [{}].", transformConfig.getId(), state.toString());
 
         // we might need to call the save state listeners, but do not want to stop rolling
-        persistStateWithAutoStop(state, ActionListener.wrap(r -> {
+        persistStateWithAutoStop(state, ActionListener.runAfter(ActionListener.wrap(r -> {
             try {
                 if (saveStateListenersAtTheMomentOfCalling != null) {
                     ActionListener.onResponse(saveStateListenersAtTheMomentOfCalling, r);
@@ -802,7 +802,6 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                 logger.warn(msg, onResponseException);
             } finally {
                 lastSaveStateMilliseconds = TimeUnit.NANOSECONDS.toMillis(getTimeNanos());
-                next.run();
             }
         }, e -> {
             try {
@@ -812,10 +811,8 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
             } catch (Exception onFailureException) {
                 String msg = LoggerMessageFormat.format("[{}] failed notifying saveState listeners, ignoring.", getJobId());
                 logger.warn(msg, onFailureException);
-            } finally {
-                next.run();
             }
-        }));
+        }), next));
     }
 
     private void persistStateWithAutoStop(TransformState state, ActionListener<Void> listener) {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [Transform] Only run next search once (#148268) (#148868)