### PR TITLE
Reduce the amount of memory used by TranslogReplicator#BlobTranslogFile

### DIFF
--- a/docs/changelog/148881.yaml
+++ b/docs/changelog/148881.yaml
@@ -1,0 +1,5 @@
+area: Engine
+issues: []
+pr: 148881
+summary: Reduce the amount of memory used by `TranslogReplicator#BlobTranslogFile`
+type: enhancement

--- a/x-pack/plugin/stateless/build.gradle
+++ b/x-pack/plugin/stateless/build.gradle
@@ -24,6 +24,8 @@ dependencies {
   compileOnly project(xpackModule('core'))
   compileOnly project(xpackModule('blob-cache'))
 
+  implementation 'com.carrotsearch:hppc:0.8.1'
+
   testImplementation project(':test:framework')
   testImplementation testArtifact(project(xpackModule('searchable-snapshots')))
   testImplementation 'com.amazonaws:aws-java-sdk-core:1.12.684'

--- a/x-pack/plugin/stateless/src/main/java/module-info.java
+++ b/x-pack/plugin/stateless/src/main/java/module-info.java
@@ -23,6 +23,7 @@ module org.elasticsearch.xpack.stateless {
 
     requires org.apache.logging.log4j;
     requires org.apache.lucene.core;
+    requires hppc;
 
     exports org.elasticsearch.xpack.stateless
         to

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBuffer.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBuffer.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.stateless.engine.translog;
 
+import com.carrotsearch.hppc.ObjectLongHashMap;
+
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
@@ -27,7 +29,6 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 public class NodeTranslogBuffer implements Releasable {
 
@@ -154,13 +155,14 @@ public class NodeTranslogBuffer implements Releasable {
                 CompositeBytesReference.of(headerStream.bytes(), compoundTranslogStream.bytes()),
                 () -> Releasables.close(headerStream, compoundTranslogStream)
             );
-            Map<ShardId, TranslogMetadata.Operations> operations = metadata.entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().operations()));
+
+            ObjectLongHashMap<ShardId> totalOps = new ObjectLongHashMap<>(metadata.size());
+            metadata.forEach((key, value) -> totalOps.put(key, value.operations().totalOps()));
+
             TranslogReplicator.CompoundTranslogMetadata compoundMetadata = new TranslogReplicator.CompoundTranslogMetadata(
                 Strings.format("%019d", generation),
                 generation,
-                operations,
+                totalOps,
                 syncedLocations
             );
 

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/ShardSyncState.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/ShardSyncState.java
@@ -229,7 +229,7 @@ class ShardSyncState {
             referencedTranslogFileOffsets = new int[translogFiles.size()];
             int i = 0;
             for (TranslogReplicator.BlobTranslogFile referencedFile : translogFiles.values()) {
-                estimatedOps += referencedFile.operations().get(shardId).totalOps();
+                estimatedOps += referencedFile.getTotalOps(shardId);
                 referencedTranslogFileOffsets[i] = Math.toIntExact(generation - referencedFile.generation());
                 assert referencedTranslogFileOffsets[i] > 0 : generation + " " + referencedFile.generation();
                 ++i;

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicator.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicator.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.stateless.engine.translog;
 
+import com.carrotsearch.hppc.ObjectLongHashMap;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.AlreadyClosedException;
@@ -489,7 +491,7 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
     public record CompoundTranslogMetadata(
         String name,
         long generation,
-        Map<ShardId, TranslogMetadata.Operations> operations,
+        ObjectLongHashMap<ShardId> totalOps,
         Map<ShardId, ShardSyncState.SyncMarker> syncedLocations
     ) {}
 
@@ -606,21 +608,18 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
 
         private final long generation;
         private final String blobName;
-        private final Map<ShardId, TranslogMetadata.Operations> operations;
+        // ObjectLongHashMap allows us to avoid using Long wrappers and HashMap$Node which can account for a significant amount of memory,
+        // when the number of shards and BlobTranslogFiles are high.
+        private final ObjectLongHashMap<ShardId> totalOps;
         private final Set<ShardId> includedShards;
 
         private volatile boolean safeForDelete = true;
         private ArrayList<ShardId> unsafeForDeleteShards = null;
 
-        BlobTranslogFile(
-            long generation,
-            String blobName,
-            Map<ShardId, TranslogMetadata.Operations> operations,
-            Set<ShardId> includedShards
-        ) {
+        BlobTranslogFile(long generation, String blobName, ObjectLongHashMap<ShardId> totalOps, Set<ShardId> includedShards) {
             this.generation = generation;
             this.blobName = blobName;
-            this.operations = operations;
+            this.totalOps = totalOps;
             this.includedShards = includedShards;
         }
 
@@ -632,8 +631,8 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
             return blobName;
         }
 
-        public Map<ShardId, TranslogMetadata.Operations> operations() {
-            return operations;
+        public long getTotalOps(ShardId shardId) {
+            return this.totalOps.get(shardId);
         }
 
         @Override
@@ -673,8 +672,8 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
                 + generation
                 + ", blobName='"
                 + blobName
-                + "', operations="
-                + operations
+                + "', totalOps="
+                + totalOps
                 + ", includedShards="
                 + includedShards
                 + '}';
@@ -686,7 +685,7 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
         private final TranslogReplicator.CompoundTranslogMetadata metadata;
 
         private BlobTranslogFileImpl(CompoundTranslogMetadata metadata) {
-            super(metadata.generation(), metadata.name(), metadata.operations(), metadata.syncedLocations().keySet());
+            super(metadata.generation(), metadata.name(), metadata.totalOps(), metadata.syncedLocations().keySet());
             this.metadata = metadata;
         }
 
@@ -715,7 +714,7 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
                 BlobTranslogFileImpl translogFile = uploadTranslogTask.translogFile;
                 CompoundTranslogMetadata metadata = uploadTranslogTask.translog.metadata();
                 for (Map.Entry<ShardId, ShardSyncState.SyncMarker> entry : metadata.syncedLocations().entrySet()) {
-                    assert translogFile.operations().get(entry.getKey()).totalOps() > 0;
+                    assert translogFile.getTotalOps(entry.getKey()) > 0;
                     ShardSyncState shardSyncState = shardSyncStates.get(entry.getKey());
                     // If the shard sync state has been deregistered we can just ignore
                     if (shardSyncState != null) {

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBufferTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBufferTests.java
@@ -91,8 +91,8 @@ public class NodeTranslogBufferTests extends ESTestCase {
 
         assertTrue(translogBuffer.writeToBuffer(activeShard, operation, 1, new Translog.Location(0, 0, operation.length())));
         TranslogReplicator.CompoundTranslog translog = translogBuffer.complete(0, Set.of(activeShard));
-        assertThat(translog.metadata().operations().keySet(), hasItems(activeShardId));
-        assertThat(translog.metadata().operations().size(), equalTo(1));
+        assertTrue(translog.metadata().totalOps().containsKey(activeShardId));
+        assertThat(translog.metadata().totalOps().size(), equalTo(1));
         assertThat(translog.metadata().syncedLocations().keySet(), hasItems(activeShardId));
         assertThat(translog.metadata().syncedLocations().size(), equalTo(1));
     }
@@ -112,8 +112,9 @@ public class NodeTranslogBufferTests extends ESTestCase {
         assertTrue(translogBuffer.writeToBuffer(activeShard, serialized(new byte[60]), 1, new Translog.Location(0, 0, 100)));
 
         TranslogReplicator.CompoundTranslog translog = translogBuffer.complete(0, Set.of(activeShard, activeButNoBufferedDataShard));
-        assertThat(translog.metadata().operations().keySet(), hasItems(activeShardId, activeButNoBufferedShardId));
-        assertThat(translog.metadata().operations().size(), equalTo(2));
+        assertTrue(translog.metadata().totalOps().containsKey(activeShardId));
+        assertTrue(translog.metadata().totalOps().containsKey(activeButNoBufferedShardId));
+        assertThat(translog.metadata().totalOps().size(), equalTo(2));
         assertThat(translog.metadata().syncedLocations().keySet(), hasItems(activeShardId));
         assertThat(translog.metadata().syncedLocations().size(), equalTo(1));
     }
@@ -134,8 +135,8 @@ public class NodeTranslogBufferTests extends ESTestCase {
         assertTrue(translogBuffer.writeToBuffer(activeShard, serialized(new byte[90]), 1, new Translog.Location(0, 0, 100)));
 
         TranslogReplicator.CompoundTranslog translog = translogBuffer.complete(0, Set.of(activeShard, closedShard));
-        assertThat(translog.metadata().operations().keySet(), hasItems(activeShardId));
-        assertThat(translog.metadata().operations().size(), equalTo(1));
+        assertTrue(translog.metadata().totalOps().containsKey(activeShardId));
+        assertThat(translog.metadata().totalOps().size(), equalTo(1));
         assertThat(translog.metadata().syncedLocations().keySet(), hasItems(activeShardId));
         assertThat(translog.metadata().syncedLocations().size(), equalTo(1));
     }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/ShardSyncStateTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/ShardSyncStateTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.stateless.engine.translog;
 
+import com.carrotsearch.hppc.ObjectLongHashMap;
+
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -19,7 +21,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
@@ -40,7 +41,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            Map.of(shardId, new TranslogMetadata.Operations(1, 2, 1)),
+            totalOps(shardId, 1),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -64,6 +65,12 @@ public class ShardSyncStateTests extends ESTestCase {
         assertFalse(activeTranslogFile.hasReferences());
     }
 
+    private static ObjectLongHashMap<ShardId> totalOps(ShardId shardId, long value) {
+        ObjectLongHashMap<ShardId> totalOps = new ObjectLongHashMap<>(1);
+        totalOps.put(shardId, value);
+        return totalOps;
+    }
+
     public void testActiveTranslogFileIsReferencedInNextSync() throws IOException {
         ShardId shardId = new ShardId(new Index("name", "uuid"), 0);
         long primaryTerm = randomLongBetween(0, 20);
@@ -71,12 +78,7 @@ public class ShardSyncStateTests extends ESTestCase {
 
         shardSyncState.markSyncStarting(
             primaryTerm,
-            new TranslogReplicator.BlobTranslogFile(
-                1,
-                "",
-                Map.of(shardId, new TranslogMetadata.Operations(1, 2, 1)),
-                Collections.singleton(shardId)
-            ) {
+            new TranslogReplicator.BlobTranslogFile(1, "", totalOps(shardId, 1), Collections.singleton(shardId)) {
                 @Override
                 protected void closeInternal() {}
             }
@@ -84,12 +86,7 @@ public class ShardSyncStateTests extends ESTestCase {
 
         shardSyncState.markSyncStarting(
             primaryTerm,
-            new TranslogReplicator.BlobTranslogFile(
-                2,
-                "",
-                Map.of(shardId, new TranslogMetadata.Operations(1, 3, 2)),
-                Collections.singleton(shardId)
-            ) {
+            new TranslogReplicator.BlobTranslogFile(2, "", totalOps(shardId, 2), Collections.singleton(shardId)) {
                 @Override
                 protected void closeInternal() {}
             }
@@ -100,12 +97,7 @@ public class ShardSyncStateTests extends ESTestCase {
         assertThat(directory.referencedTranslogFileOffsets(), equalTo(new int[] { 3, 2 }));
         shardSyncState.markSyncStarting(
             primaryTerm,
-            new TranslogReplicator.BlobTranslogFile(
-                4,
-                "",
-                Map.of(shardId, new TranslogMetadata.Operations(1, 2, 1)),
-                Collections.singleton(shardId)
-            ) {
+            new TranslogReplicator.BlobTranslogFile(4, "", totalOps(shardId, 1), Collections.singleton(shardId)) {
                 @Override
                 protected void closeInternal() {}
             }
@@ -118,12 +110,7 @@ public class ShardSyncStateTests extends ESTestCase {
         assertThat(directory2.referencedTranslogFileOffsets(), equalTo(new int[] { 4, 3, 1 }));
         shardSyncState.markSyncStarting(
             primaryTerm,
-            new TranslogReplicator.BlobTranslogFile(
-                5,
-                "",
-                Map.of(shardId, new TranslogMetadata.Operations(1, 2, 1)),
-                Collections.singleton(shardId)
-            ) {
+            new TranslogReplicator.BlobTranslogFile(5, "", totalOps(shardId, 1), Collections.singleton(shardId)) {
                 @Override
                 protected void closeInternal() {}
             }
@@ -146,7 +133,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            Map.of(shardId, new TranslogMetadata.Operations(1, 2, 1)),
+            totalOps(shardId, 1),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -179,7 +166,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            Map.of(shardId, new TranslogMetadata.Operations(1, 2, 1)),
+            totalOps(shardId, 1),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -207,7 +194,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            Map.of(shardId, new TranslogMetadata.Operations(1, 2, 1)),
+            totalOps(shardId, 1),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -237,7 +224,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            Map.of(shardId, new TranslogMetadata.Operations(0, 4, 4)),
+            totalOps(shardId, 4),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -270,7 +257,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            Map.of(shardId, new TranslogMetadata.Operations(0, 3, 3)),
+            totalOps(shardId, 3),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -314,7 +301,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            Map.of(shardId, new TranslogMetadata.Operations(0, 3, 3)),
+            totalOps(shardId, 3),
             Collections.singleton(shardId)
         ) {
             @Override


### PR DESCRIPTION
The heapdumps of the OOM errors that impacted multiple ESQL tests showed that most of the memory was consumed by TranslogMetadata$Operations and the HashMap$Node containing them.

The patch replace the use of the Operations instances by long primitives, reducing the memory usage for an Operation object from 40 bytes to 8 bytes. It also use ObjectLongHashMap instead of HashMap, eliminating the 32 bytes of the HashMap$Node object. Those changes should reduce the original cost from 72 bytes to ~8 bytes. For the cases where we had 3 millions of objects it should reduce the memory usage from 216MB to 24MB.