### PR TITLE
[One workflow] Align workflows system data stream mappings with Kibana schema

### DIFF
--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -48,9 +48,9 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
 
     private static final String KIBANA_WORKFLOWS_VERSION_VARIABLE = "kibana.workflows.version";
 
-    private static final int WORKFLOWS_EVENTS_MAPPINGS_VERSION = 2;
+    private static final int WORKFLOWS_EVENTS_MAPPINGS_VERSION = 3;
 
-    private static final int WORKFLOWS_EXECUTION_LOGS_MAPPINGS_VERSION = 1;
+    private static final int WORKFLOWS_EXECUTION_LOGS_MAPPINGS_VERSION = 2;
 
     /** Log data stream registered in {@link #workflowsEventsSystemDataStreamDescriptor()}. */
     public static final String WORKFLOWS_EVENTS_DATA_STREAM_NAME = ".workflows-events";

--- a/modules/kibana/src/main/resources/org/elasticsearch/kibana/workflows-events.json
+++ b/modules/kibana/src/main/resources/org/elasticsearch/kibana/workflows-events.json
@@ -18,15 +18,34 @@
         "version": "${kibana.workflows.version}",
         "managed_index_mappings_version": ${kibana.workflows.events.managed.index.version}
       },
-      "dynamic": true,
+      "dynamic": false,
       "properties": {
         "@timestamp": {
           "type": "date"
+        },
+        "eventId": {
+          "type": "keyword"
+        },
+        "triggerId": {
+          "type": "keyword"
+        },
+        "spaceId": {
+          "type": "keyword"
+        },
+        "subscriptions": {
+          "type": "keyword"
+        },
+        "sourceExecutionId": {
+          "type": "keyword"
+        },
+        "payload": {
+          "type": "object",
+          "properties": {}
         }
       }
     }
   },
   "composed_of": [],
   "priority": 200,
-  "version": 2
+  "version": 3
 }

--- a/modules/kibana/src/main/resources/org/elasticsearch/kibana/workflows-execution-data-stream-logs.json
+++ b/modules/kibana/src/main/resources/org/elasticsearch/kibana/workflows-execution-data-stream-logs.json
@@ -18,15 +18,39 @@
         "version": "${kibana.workflows.version}",
         "managed_index_mappings_version": ${kibana.workflows.execution.logs.managed.index.version}
       },
-      "dynamic": true,
+      "dynamic": false,
       "properties": {
         "@timestamp": {
           "type": "date"
+        },
+        "spaceId": {
+          "type": "keyword"
+        },
+        "level": {
+          "type": "keyword"
+        },
+        "workflow": {
+          "type": "object",
+          "dynamic": false,
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "execution_id": {
+              "type": "keyword"
+            },
+            "step_id": {
+              "type": "keyword"
+            },
+            "step_execution_id": {
+              "type": "keyword"
+            }
+          }
         }
       }
     }
   },
   "composed_of": [],
   "priority": 200,
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/148871

## Summary

Fixes mapping definition drift for workflows system data streams: composable templates shipped with the `kibana` module previously used `dynamic: true` and only `@timestamp`, while kibana repo declared `dynamic: false` and explicit fields. elasticsearch is the source of truth for these streams; templates now match the intended schema so persisted `_mapping` matches product expectations.

### Behaviour / rollout

- **New data streams** pick up the new mapping from creation.
- **Existing streams**: the **current write index** keeps its prior mapping until **rollover**; after rollover (with all nodes on this build), the new write index uses the updated template. Older backing indices are unchanged (acceptable for this fix).

### Follow-up (Kibana repo)

Remove or narrow duplicate full `MappingsDefinition` objects for these streams; keep TypeScript document types and point contributors at the JSON resources in this repository.

### Verification

`GET /.workflows-events/_mapping` and `GET /.workflows-execution-data-stream-logs/_mapping` should show `dynamic: false`, expected properties, and updated `managed_index_mappings_version`.