### PR TITLE
ESQL: Fix capability in test (#148269)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -279,9 +279,6 @@ tests:
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=cluster.info/20_info_http/Cluster HTTP Info}
   issue: https://github.com/elastic/elasticsearch/issues/147753
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/50_index_patterns/_index LIKE with overly complex pattern}
-  issue: https://github.com/elastic/elasticsearch/issues/148134
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/148339

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/50_index_patterns.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/50_index_patterns.yml
@@ -404,7 +404,7 @@ same_name_different_type_same_family:
         - method: POST
           path: /_query
           parameters: [ method, path, parameters, capabilities ]
-          capabilities: [ fix_index_like_question_mark_wildcard ]
+          capabilities: [ fix_index_like_question_mark_wildcard, handle_determinization_complexity ]
       reason: "determinization complexity for _index LIKE not handled until fix"
   - do:
       indices.create:


### PR DESCRIPTION
We need *both* the `fix_index_like_question_mark_wildcard`, and `handle_determinization_complexity` capabilities to assert the error message.

Closes #148134
