### PR TITLE
Wire remote fetch planner and coordinator-side orchestration

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/PlanWritables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/PlanWritables.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.esql.plan.logical.local.ImmediateLocalSupplier;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
+import org.elasticsearch.xpack.esql.plan.physical.EmitRemoteFetchHandleExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
@@ -65,6 +66,8 @@ import org.elasticsearch.xpack.esql.plan.physical.MetricsInfoExec;
 import org.elasticsearch.xpack.esql.plan.physical.MvExpandExec;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.RegisteredDomainExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.SampleExec;
 import org.elasticsearch.xpack.esql.plan.physical.SampledAggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ShowExec;
@@ -137,6 +140,7 @@ public class PlanWritables {
             CompletionExec.ENTRY,
             DissectExec.ENTRY,
             EnrichExec.ENTRY,
+            EmitRemoteFetchHandleExec.ENTRY,
             EsSourceExec.ENTRY,
             EvalExec.ENTRY,
             ExchangeExec.ENTRY,
@@ -153,6 +157,8 @@ public class PlanWritables {
             LocalSourceExec.ENTRY,
             MvExpandExec.ENTRY,
             ProjectExec.ENTRY,
+            RemoteFetchExec.ENTRY,
+            RemoteFetchSourceExec.ENTRY,
             RerankExec.ENTRY,
             SampleExec.ENTRY,
             SampledAggregateExec.ENTRY,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EmitRemoteFetchHandleExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EmitRemoteFetchHandleExec.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Replaces the local-only {@code _doc} column with a transport-safe remote fetch handle before the final exchange.
+ */
+public class EmitRemoteFetchHandleExec extends UnaryExec {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "EmitRemoteFetchHandleExec",
+        EmitRemoteFetchHandleExec::new
+    );
+
+    private final Attribute sourceAttribute;
+    private final Attribute handleAttribute;
+    private List<Attribute> lazyOutput;
+
+    public EmitRemoteFetchHandleExec(Source source, PhysicalPlan child, Attribute sourceAttribute, Attribute handleAttribute) {
+        super(source, child);
+        this.sourceAttribute = sourceAttribute;
+        this.handleAttribute = handleAttribute;
+    }
+
+    private EmitRemoteFetchHandleExec(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(PhysicalPlan.class),
+            in.readNamedWriteable(Attribute.class),
+            in.readNamedWriteable(Attribute.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeNamedWriteable(sourceAttribute);
+        out.writeNamedWriteable(handleAttribute);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected NodeInfo<EmitRemoteFetchHandleExec> info() {
+        return NodeInfo.create(this, EmitRemoteFetchHandleExec::new, child(), sourceAttribute, handleAttribute);
+    }
+
+    @Override
+    public EmitRemoteFetchHandleExec replaceChild(PhysicalPlan newChild) {
+        return new EmitRemoteFetchHandleExec(source(), newChild, sourceAttribute, handleAttribute);
+    }
+
+    @Override
+    protected AttributeSet computeReferences() {
+        return AttributeSet.of(sourceAttribute);
+    }
+
+    public Attribute sourceAttribute() {
+        return sourceAttribute;
+    }
+
+    public Attribute handleAttribute() {
+        return handleAttribute;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        if (lazyOutput == null) {
+            lazyOutput = new ArrayList<>(child().output().size());
+            for (Attribute attribute : child().output()) {
+                lazyOutput.add(attribute.equals(sourceAttribute) ? handleAttribute : attribute);
+            }
+        }
+        return lazyOutput;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(child(), sourceAttribute, handleAttribute);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        EmitRemoteFetchHandleExec other = (EmitRemoteFetchHandleExec) obj;
+        return Objects.equals(child(), other.child())
+            && Objects.equals(sourceAttribute, other.sourceAttribute)
+            && Objects.equals(handleAttribute, other.handleAttribute);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RemoteFetchExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RemoteFetchExec.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Fetches deferred fields on the coordinator from remote shard owners using a transport-safe handle.
+ */
+public class RemoteFetchExec extends UnaryExec implements EstimatesRowSize {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "RemoteFetchExec",
+        RemoteFetchExec::new
+    );
+
+    private final Attribute handleAttribute;
+    private final List<Attribute> attributesToFetch;
+    private final List<Attribute> fetchedOutputAttributes;
+    private final PhysicalPlan pushdownPlan;
+    private List<Attribute> lazyOutput;
+
+    public RemoteFetchExec(
+        Source source,
+        PhysicalPlan child,
+        Attribute handleAttribute,
+        List<Attribute> attributesToFetch,
+        List<Attribute> fetchedOutputAttributes,
+        PhysicalPlan pushdownPlan
+    ) {
+        super(source, child);
+        this.handleAttribute = handleAttribute;
+        this.attributesToFetch = List.copyOf(attributesToFetch);
+        this.fetchedOutputAttributes = List.copyOf(fetchedOutputAttributes);
+        this.pushdownPlan = pushdownPlan;
+    }
+
+    private RemoteFetchExec(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            in.readNamedWriteable(PhysicalPlan.class),
+            in.readNamedWriteable(Attribute.class),
+            in.readNamedWriteableCollectionAsList(Attribute.class),
+            in.readNamedWriteableCollectionAsList(Attribute.class),
+            in.readOptionalNamedWriteable(PhysicalPlan.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteable(child());
+        out.writeNamedWriteable(handleAttribute);
+        out.writeNamedWriteableCollection(attributesToFetch);
+        out.writeNamedWriteableCollection(fetchedOutputAttributes);
+        out.writeOptionalNamedWriteable(pushdownPlan);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected NodeInfo<RemoteFetchExec> info() {
+        return NodeInfo.create(
+            this,
+            RemoteFetchExec::new,
+            child(),
+            handleAttribute,
+            attributesToFetch,
+            fetchedOutputAttributes,
+            pushdownPlan
+        );
+    }
+
+    @Override
+    public RemoteFetchExec replaceChild(PhysicalPlan newChild) {
+        return new RemoteFetchExec(source(), newChild, handleAttribute, attributesToFetch, fetchedOutputAttributes, pushdownPlan);
+    }
+
+    @Override
+    protected AttributeSet computeReferences() {
+        return AttributeSet.of(handleAttribute);
+    }
+
+    public Attribute handleAttribute() {
+        return handleAttribute;
+    }
+
+    public List<Attribute> attributesToFetch() {
+        return attributesToFetch;
+    }
+
+    public PhysicalPlan pushdownPlan() {
+        return pushdownPlan;
+    }
+
+    public List<Attribute> fetchedOutputAttributes() {
+        return fetchedOutputAttributes;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        if (lazyOutput == null) {
+            List<Attribute> childOutput = child().output();
+            List<Attribute> fetchedOutput = fetchedOutputAttributes();
+            lazyOutput = new ArrayList<>(childOutput.size() + fetchedOutput.size());
+            lazyOutput.addAll(childOutput);
+            lazyOutput.addAll(fetchedOutput);
+        }
+        return lazyOutput;
+    }
+
+    @Override
+    public PhysicalPlan estimateRowSize(State state) {
+        state.add(true, attributesToFetch);
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(child(), handleAttribute, attributesToFetch, fetchedOutputAttributes, pushdownPlan);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RemoteFetchExec other = (RemoteFetchExec) obj;
+        return Objects.equals(child(), other.child())
+            && Objects.equals(handleAttribute, other.handleAttribute)
+            && Objects.equals(attributesToFetch, other.attributesToFetch)
+            && Objects.equals(fetchedOutputAttributes, other.fetchedOutputAttributes)
+            && Objects.equals(pushdownPlan, other.pushdownPlan);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RemoteFetchSourceExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/RemoteFetchSourceExec.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Leaf source used to compile remote-fetch post-fetch pushdown fragments.
+ */
+public class RemoteFetchSourceExec extends LeafExec {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        PhysicalPlan.class,
+        "RemoteFetchSourceExec",
+        RemoteFetchSourceExec::new
+    );
+
+    private final List<Attribute> output;
+
+    public RemoteFetchSourceExec(Source source, List<Attribute> output) {
+        super(source);
+        this.output = List.copyOf(output);
+    }
+
+    private RemoteFetchSourceExec(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), in.readNamedWriteableCollectionAsList(Attribute.class));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        out.writeNamedWriteableCollection(output);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected NodeInfo<RemoteFetchSourceExec> info() {
+        return NodeInfo.create(this, RemoteFetchSourceExec::new, output);
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return output;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(output);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RemoteFetchSourceExec other = (RemoteFetchSourceExec) obj;
+        return Objects.equals(output, other.output);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -75,11 +75,9 @@ import org.elasticsearch.compute.operator.topn.TopNEncoder;
 import org.elasticsearch.compute.operator.topn.TopNOperator;
 import org.elasticsearch.compute.operator.topn.TopNOperator.TopNOperatorFactory;
 import org.elasticsearch.core.Assertions;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexMode;
-import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
@@ -140,6 +138,7 @@ import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.ChangePointExec;
 import org.elasticsearch.xpack.esql.plan.physical.CompoundOutputEvalExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
+import org.elasticsearch.xpack.esql.plan.physical.EmitRemoteFetchHandleExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsStatsQueryExec;
@@ -166,6 +165,7 @@ import org.elasticsearch.xpack.esql.plan.physical.OutputExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.RegisteredDomainExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchExec;
 import org.elasticsearch.xpack.esql.plan.physical.SampleExec;
 import org.elasticsearch.xpack.esql.plan.physical.ShowExec;
 import org.elasticsearch.xpack.esql.plan.physical.SparklineGenerateEmptyBucketsExec;
@@ -180,12 +180,16 @@ import org.elasticsearch.xpack.esql.plan.physical.inference.CompletionExec;
 import org.elasticsearch.xpack.esql.plan.physical.inference.RerankExec;
 import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders.ShardContext;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.elasticsearch.xpack.esql.plugin.RemoteFetchHandleOperator;
+import org.elasticsearch.xpack.esql.plugin.RemoteFetchOperator;
+import org.elasticsearch.xpack.esql.plugin.RemoteFetchService;
 import org.elasticsearch.xpack.esql.score.ScoreMapper;
 import org.elasticsearch.xpack.esql.session.Configuration;
 import org.elasticsearch.xpack.esql.session.EsqlCCSUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -226,10 +230,12 @@ public class LocalExecutionPlanner {
     private final Supplier<ExchangeSink> exchangeSinkSupplier;
     private final EnrichLookupService enrichLookupService;
     private final LookupFromIndexService lookupFromIndexService;
+    private final RemoteFetchService remoteFetchService;
     private final InferenceService inferenceService;
     private final UserAgentParserRegistry userAgentParserRegistry;
     private final PhysicalOperationProviders physicalOperationProviders;
     private final OperatorFactoryRegistry operatorFactoryRegistry;
+    private final String localNodeId;
 
     public LocalExecutionPlanner(
         String sessionId,
@@ -248,6 +254,46 @@ public class LocalExecutionPlanner {
         PhysicalOperationProviders physicalOperationProviders,
         OperatorFactoryRegistry operatorFactoryRegistry
     ) {
+        this(
+            sessionId,
+            clusterAlias,
+            parentTask,
+            bigArrays,
+            blockFactory,
+            settings,
+            configuration,
+            exchangeSourceSupplier,
+            exchangeSinkSupplier,
+            enrichLookupService,
+            lookupFromIndexService,
+            null,
+            inferenceService,
+            userAgentParserRegistry,
+            physicalOperationProviders,
+            operatorFactoryRegistry,
+            null
+        );
+    }
+
+    public LocalExecutionPlanner(
+        String sessionId,
+        String clusterAlias,
+        CancellableTask parentTask,
+        BigArrays bigArrays,
+        BlockFactory blockFactory,
+        Settings settings,
+        Configuration configuration,
+        Supplier<ExchangeSource> exchangeSourceSupplier,
+        Supplier<ExchangeSink> exchangeSinkSupplier,
+        EnrichLookupService enrichLookupService,
+        LookupFromIndexService lookupFromIndexService,
+        RemoteFetchService remoteFetchService,
+        InferenceService inferenceService,
+        UserAgentParserRegistry userAgentParserRegistry,
+        PhysicalOperationProviders physicalOperationProviders,
+        OperatorFactoryRegistry operatorFactoryRegistry,
+        String localNodeId
+    ) {
 
         this.sessionId = sessionId;
         this.clusterAlias = clusterAlias;
@@ -260,10 +306,12 @@ public class LocalExecutionPlanner {
         this.exchangeSinkSupplier = exchangeSinkSupplier;
         this.enrichLookupService = enrichLookupService;
         this.lookupFromIndexService = lookupFromIndexService;
+        this.remoteFetchService = remoteFetchService;
         this.inferenceService = inferenceService;
         this.userAgentParserRegistry = userAgentParserRegistry;
         this.physicalOperationProviders = physicalOperationProviders;
         this.operatorFactoryRegistry = operatorFactoryRegistry;
+        this.localNodeId = localNodeId;
     }
 
     /**
@@ -288,8 +336,7 @@ public class LocalExecutionPlanner {
             plannerSettings,
             timeSeries,
             settings,
-            shardContexts,
-            physicalOperationProviders.analysisRegistry()
+            shardContexts
         );
 
         // workaround for https://github.com/elastic/elasticsearch/issues/99782
@@ -327,6 +374,10 @@ public class LocalExecutionPlanner {
             return planFieldExtractNode(fieldExtractExec, context);
         } else if (node instanceof ExternalFieldExtractExec extExtract) {
             return planExternalFieldExtract(extExtract, context);
+        } else if (node instanceof EmitRemoteFetchHandleExec emitRemoteFetchHandleExec) {
+            return planRemoteFetchHandleNode(emitRemoteFetchHandleExec, context);
+        } else if (node instanceof RemoteFetchExec remoteFetchExec) {
+            return planRemoteFetchNode(remoteFetchExec, context);
         } else if (node instanceof ExchangeExec exchangeExec) {
             return planExchange(exchangeExec, context);
         } else if (node instanceof TopNExec topNExec) {
@@ -470,7 +521,7 @@ public class LocalExecutionPlanner {
         source = source.with(
             new ColumnExtractOperator.Factory(
                 types,
-                EvalMapper.toEvaluator(context.foldCtx(), coe.input(), layout, context.analysisRegistry()),
+                EvalMapper.toEvaluator(context.foldCtx(), coe.input(), layout),
                 new CompoundOutputEvaluator.Factory(coe.input().dataType(), coe.source(), provider)
             ),
             layout
@@ -483,12 +534,7 @@ public class LocalExecutionPlanner {
         String inferenceId = BytesRefs.toString(completion.inferenceId().fold(context.foldCtx()));
         Map<String, Object> taskSettings = completion.taskSettings().toFoldedMap(context.foldCtx());
         Layout outputLayout = source.layout.builder().append(completion.targetField()).build();
-        ExpressionEvaluator.Factory promptEvaluatorFactory = EvalMapper.toEvaluator(
-            context.foldCtx(),
-            completion.prompt(),
-            source.layout,
-            context.analysisRegistry()
-        );
+        ExpressionEvaluator.Factory promptEvaluatorFactory = EvalMapper.toEvaluator(context.foldCtx(), completion.prompt(), source.layout);
 
         return source.with(
             new CompletionOperator.Factory(inferenceService, inferenceId, promptEvaluatorFactory, taskSettings, completion.timeout()),
@@ -626,6 +672,54 @@ public class LocalExecutionPlanner {
         return source.with(factory, newLayout);
     }
 
+    private PhysicalOperation planRemoteFetchHandleNode(
+        EmitRemoteFetchHandleExec emitRemoteFetchHandleExec,
+        LocalExecutionPlannerContext context
+    ) {
+        if (localNodeId == null) {
+            throw new IllegalStateException("remote fetch handle emission requires the local node id");
+        }
+        PhysicalOperation source = plan(emitRemoteFetchHandleExec.child(), context);
+        int docChannel = source.layout.get(emitRemoteFetchHandleExec.sourceAttribute().id()).channel();
+        Layout outputLayout = replaceLayoutAttribute(
+            source.layout,
+            emitRemoteFetchHandleExec.sourceAttribute(),
+            emitRemoteFetchHandleExec.handleAttribute()
+        );
+        return source.with(new RemoteFetchHandleOperator.Factory(localNodeId, sessionId, docChannel), outputLayout);
+    }
+
+    private PhysicalOperation planRemoteFetchNode(RemoteFetchExec remoteFetchExec, LocalExecutionPlannerContext context) {
+        if (remoteFetchService == null) {
+            throw new IllegalStateException("remote fetch planning requires a remote fetch service");
+        }
+        if (parentTask == null) {
+            throw new IllegalStateException("remote fetch planning requires a cancellable parent task");
+        }
+        PhysicalOperation source = plan(remoteFetchExec.child(), context);
+        int handleChannel = source.layout.get(remoteFetchExec.handleAttribute().id()).channel();
+        List<RemoteFetchService.FetchField> requestFields = remoteFetchExec.attributesToFetch().stream().map(attribute -> {
+            String fieldName = attribute instanceof FieldAttribute fieldAttribute ? fieldAttribute.fieldName().string() : attribute.name();
+            return new RemoteFetchService.FetchField(fieldName, attribute.dataType());
+        }).toList();
+        Layout.Builder outputLayoutBuilder = source.layout.builder();
+        outputLayoutBuilder.append(remoteFetchExec.fetchedOutputAttributes());
+        Layout outputLayout = outputLayoutBuilder.build();
+        return source.with(
+            new RemoteFetchOperator.Factory(
+                handleChannel,
+                requestFields,
+                remoteFetchExec.fetchedOutputAttributes(),
+                remoteFetchExec.pushdownPlan(),
+                configuration,
+                Math.max(1, context.queryPragmas().concurrentExchangeClients()),
+                remoteFetchService.threadContext(),
+                () -> remoteFetchService.newBatchExchangeClient(parentTask)
+            ),
+            outputLayout
+        );
+    }
+
     private PhysicalOperation planOutput(OutputExec outputExec, LocalExecutionPlannerContext context) {
         PhysicalOperation source = plan(outputExec.child(), context);
         var output = outputExec.output();
@@ -662,6 +756,20 @@ public class LocalExecutionPlanner {
         } : Function.identity();
 
         return transformer;
+    }
+
+    private static Layout replaceLayoutAttribute(Layout inputLayout, Attribute oldAttribute, Attribute newAttribute) {
+        Layout.Builder builder = new Layout.Builder();
+        for (Layout.ChannelSet channel : inputLayout.inverse()) {
+            var ids = new HashSet<>(channel.nameIds());
+            if (ids.remove(oldAttribute.id())) {
+                ids.add(newAttribute.id());
+                builder.append(new Layout.ChannelSet(ids, newAttribute.dataType()));
+            } else {
+                builder.append(new Layout.ChannelSet(ids, channel.type()));
+            }
+        }
+        return builder.build();
     }
 
     private PhysicalOperation planExchange(ExchangeExec exchangeExec, LocalExecutionPlannerContext context) {
@@ -801,13 +909,7 @@ public class LocalExecutionPlanner {
         PhysicalOperation source = plan(eval.child(), context);
 
         for (Alias field : eval.fields()) {
-            var evaluatorSupplier = EvalMapper.toEvaluator(
-                context.foldCtx(),
-                field.child(),
-                source.layout,
-                context.shardContexts,
-                context.analysisRegistry()
-            );
+            var evaluatorSupplier = EvalMapper.toEvaluator(context.foldCtx(), field.child(), source.layout, context.shardContexts);
             Layout.Builder layout = source.layout.builder();
             layout.append(field.toAttribute());
             source = source.with(new EvalOperatorFactory(evaluatorSupplier), layout.build());
@@ -828,7 +930,7 @@ public class LocalExecutionPlanner {
         source = source.with(
             new StringExtractOperator.StringExtractOperatorFactory(
                 patternNames,
-                EvalMapper.toEvaluator(context.foldCtx(), expr, layout, context.analysisRegistry()),
+                EvalMapper.toEvaluator(context.foldCtx(), expr, layout),
                 () -> (input) -> dissect.parser().parser().parse(input)
             ),
             layout
@@ -860,7 +962,7 @@ public class LocalExecutionPlanner {
         source = source.with(
             new ColumnExtractOperator.Factory(
                 types,
-                EvalMapper.toEvaluator(context.foldCtx(), grok.inputExpression(), layout, context.analysisRegistry()),
+                EvalMapper.toEvaluator(context.foldCtx(), grok.inputExpression(), layout),
                 new GrokEvaluatorExtracter.Factory(grok.pattern().grok(), grok.pattern().pattern(), fieldToPos, fieldToType)
             ),
             layout
@@ -901,7 +1003,7 @@ public class LocalExecutionPlanner {
 
         List<ExpressionEvaluator.Factory> rerankFieldsEvaluators = rerank.rerankFields()
             .stream()
-            .map(rerankField -> EvalMapper.toEvaluator(context.foldCtx(), rerankField.child(), source.layout, context.analysisRegistry()))
+            .map(rerankField -> EvalMapper.toEvaluator(context.foldCtx(), rerankField.child(), source.layout))
             .toList();
 
         assert rerankFieldsEvaluators.size() > 0 : "rerank expression evaluators must not be empty";
@@ -1542,15 +1644,7 @@ public class LocalExecutionPlanner {
         PhysicalOperation source = plan(filter.child(), context);
         // TODO: should this be extracted into a separate eval block?
         PhysicalOperation filterOperation = source.with(
-            new FilterOperatorFactory(
-                EvalMapper.toEvaluator(
-                    context.foldCtx(),
-                    filter.condition(),
-                    source.layout,
-                    context.shardContexts,
-                    context.analysisRegistry()
-                )
-            ),
+            new FilterOperatorFactory(EvalMapper.toEvaluator(context.foldCtx(), filter.condition(), source.layout, context.shardContexts)),
             source.layout
         );
         // Add ScoreOperator only on data nodes. Data nodes are able to calculate scores running queries on the resulting docs.
@@ -1817,8 +1911,7 @@ public class LocalExecutionPlanner {
         PlannerSettings plannerSettings,
         boolean timeSeries,
         Settings settings,
-        IndexedByShardId<? extends ShardContext> shardContexts,
-        @Nullable AnalysisRegistry analysisRegistry
+        IndexedByShardId<? extends ShardContext> shardContexts
     ) {
         void addDriverFactory(DriverFactory driverFactory) {
             driverFactories.add(driverFactory);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerSettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerSettings.java
@@ -89,6 +89,18 @@ public class PlannerSettings {
     );
 
     /**
+     * Enables the prototype substrate for coordinator-side remote fetch after a distributed TopN narrowing phase.
+     * This setting is intentionally separate from {@link #REDUCTION_LATE_MATERIALIZATION} so the new cross-node
+     * continuation path can be developed and tested without changing the existing late-materialization behavior.
+     */
+    public static final Setting<Boolean> REMOTE_FETCH_LATE_MATERIALIZATION = Setting.boolSetting(
+        "esql.remote_fetch_late_materialization",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
      * Circuit breaker space reserved for each script {@link BlockLoader.Reader}. The default
      * is pretty poor estimate for the overhead of the script, but it'll do for now. We're
      * estimating 100kb for loading ordinals from doc values and 2kb for loading numbers from
@@ -238,6 +250,7 @@ public class PlannerSettings {
             LUCENE_TOPN_LIMIT,
             INTERMEDIATE_LOCAL_RELATION_MAX_SIZE,
             REDUCTION_LATE_MATERIALIZATION,
+            REMOTE_FETCH_LATE_MATERIALIZATION,
             PARTIAL_AGGREGATION_EMIT_KEYS_THRESHOLD,
             PARTIAL_AGGREGATION_EMIT_UNIQUENESS_THRESHOLD,
             REUSE_COLUMN_LOADERS_THRESHOLD,
@@ -266,6 +279,10 @@ public class PlannerSettings {
             clusterSettings.initializeAndWatch(
                 INTERMEDIATE_LOCAL_RELATION_MAX_SIZE,
                 v -> settings.updateAndGet(s -> s.intermediateLocalRelationMaxSize(v))
+            );
+            clusterSettings.initializeAndWatch(
+                REMOTE_FETCH_LATE_MATERIALIZATION,
+                v -> settings.updateAndGet(s -> s.remoteFetchLateMaterialization(v))
             );
             clusterSettings.initializeAndWatch(
                 PARTIAL_AGGREGATION_EMIT_KEYS_THRESHOLD,
@@ -307,6 +324,7 @@ public class PlannerSettings {
     private final ByteSizeValue valuesLoadingJumboSize;
     private final int luceneTopNLimit;
     private final ByteSizeValue intermediateLocalRelationMaxSize;
+    private final boolean remoteFetchLateMaterialization;
     private final int partialEmitKeysThreshold;
     private final double partialEmitUniquenessThreshold;
     private final int reuseColumnLoadersThreshold;
@@ -327,6 +345,7 @@ public class PlannerSettings {
         VALUES_LOADING_JUMBO_SIZE.get(Settings.EMPTY),
         LUCENE_TOPN_LIMIT.getDefault(Settings.EMPTY),
         INTERMEDIATE_LOCAL_RELATION_MAX_SIZE.getDefault(Settings.EMPTY),
+        REMOTE_FETCH_LATE_MATERIALIZATION.getDefault(Settings.EMPTY),
         PARTIAL_AGGREGATION_EMIT_KEYS_THRESHOLD.getDefault(Settings.EMPTY),
         PARTIAL_AGGREGATION_EMIT_UNIQUENESS_THRESHOLD.getDefault(Settings.EMPTY),
         REUSE_COLUMN_LOADERS_THRESHOLD.getDefault(Settings.EMPTY),
@@ -348,6 +367,7 @@ public class PlannerSettings {
         ByteSizeValue valuesLoadingJumboSize,
         int luceneTopNLimit,
         ByteSizeValue intermediateLocalRelationMaxSize,
+        boolean remoteFetchLateMaterialization,
         int partialEmitKeysThreshold,
         double partialEmitUniquenessThreshold,
         int reuseColumnLoadersThreshold,
@@ -364,6 +384,7 @@ public class PlannerSettings {
         this.valuesLoadingJumboSize = valuesLoadingJumboSize;
         this.luceneTopNLimit = luceneTopNLimit;
         this.intermediateLocalRelationMaxSize = intermediateLocalRelationMaxSize;
+        this.remoteFetchLateMaterialization = remoteFetchLateMaterialization;
         this.partialEmitKeysThreshold = partialEmitKeysThreshold;
         this.partialEmitUniquenessThreshold = partialEmitUniquenessThreshold;
         this.reuseColumnLoadersThreshold = reuseColumnLoadersThreshold;
@@ -383,6 +404,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -407,6 +429,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -431,6 +454,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -469,6 +493,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -486,6 +511,31 @@ public class PlannerSettings {
         return intermediateLocalRelationMaxSize;
     }
 
+    public PlannerSettings remoteFetchLateMaterialization(boolean remoteFetchLateMaterialization) {
+        return new PlannerSettings(
+            defaultDataPartitioning,
+            docsThresholdForAutoPartitioning,
+            valuesLoadingJumboSize,
+            luceneTopNLimit,
+            intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
+            partialEmitKeysThreshold,
+            partialEmitUniquenessThreshold,
+            reuseColumnLoadersThreshold,
+            blockLoaderSizeOrdinals,
+            blockLoaderSizeScript,
+            maxKeywordSortFields,
+            sourceReservationFactor,
+            bytesRefRamOverestimateThreshold,
+            bytesRefRamOverestimateFactor,
+            docSequenceBytesRefFieldThreshold
+        );
+    }
+
+    public boolean remoteFetchLateMaterialization() {
+        return remoteFetchLateMaterialization;
+    }
+
     public PlannerSettings partialEmitKeysThreshold(int partialEmitKeysThreshold) {
         return new PlannerSettings(
             defaultDataPartitioning,
@@ -493,6 +543,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -517,6 +568,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -541,6 +593,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -572,6 +625,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -599,6 +653,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -626,6 +681,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -650,6 +706,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -674,6 +731,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -698,6 +756,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -722,6 +781,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,
@@ -746,6 +806,7 @@ public class PlannerSettings {
             valuesLoadingJumboSize,
             luceneTopNLimit,
             intermediateLocalRelationMaxSize,
+            remoteFetchLateMaterialization,
             partialEmitKeysThreshold,
             partialEmitUniquenessThreshold,
             reuseColumnLoadersThreshold,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
@@ -301,7 +301,8 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                         configuration,
                         configuration.newFoldContext(),
                         exchangeSource::createExchangeSource,
-                        () -> exchangeSink.createExchangeSink(() -> {})
+                        () -> exchangeSink.createExchangeSink(() -> {}),
+                        false
                     ),
                     coordinatorPlan,
                     computeService.plannerSettings().get(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ClusterComputeHandler.java
@@ -323,6 +323,7 @@ final class ClusterComputeHandler implements TransportRequestHandler<ClusterComp
                     originalIndices,
                     exchangeSource,
                     cancelQueryOnFailure,
+                    null,
                     computeListener.acquireCompute().map(r -> {
                         finalResponse.set(r);
                         return r.getCompletionInfo();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeContext.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeContext.java
@@ -25,7 +25,8 @@ record ComputeContext(
     Configuration configuration,
     FoldContext foldCtx,
     Supplier<ExchangeSource> exchangeSourceSupplier,
-    Supplier<ExchangeSink> exchangeSinkSupplier
+    Supplier<ExchangeSink> exchangeSinkSupplier,
+    boolean retainSearchContexts
 ) {
     IndexedByShardId<? extends SearchExecutionContext> searchExecutionContexts() {
         return searchContexts.map(s -> s.searchContext().getSearchExecutionContext());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -170,6 +170,7 @@ public class ComputeService {
     private final DriverTaskRunner driverRunner;
     private final EnrichLookupService enrichLookupService;
     private final LookupFromIndexService lookupFromIndexService;
+    private final RemoteFetchService remoteFetchService;
     private final InferenceService inferenceService;
     private final UserAgentParserRegistry userAgentParserRegistry;
     private final ClusterService clusterService;
@@ -203,6 +204,7 @@ public class ComputeService {
         this.driverRunner = new DriverTaskRunner(transportService, searchExecutor);
         this.enrichLookupService = enrichLookupService;
         this.lookupFromIndexService = lookupFromIndexService;
+        this.remoteFetchService = new RemoteFetchService(transportActionServices, this.bigArrays, blockFactory);
         this.inferenceService = transportActionServices.inferenceService();
         this.userAgentParserRegistry = transportActionServices.userAgentParserRegistry();
         this.clusterService = transportActionServices.clusterService();
@@ -230,6 +232,10 @@ public class ComputeService {
 
     PlannerSettings.Holder plannerSettings() {
         return plannerSettings;
+    }
+
+    RemoteFetchService remoteFetchService() {
+        return remoteFetchService;
     }
 
     FormatReaderRegistry formatReaderRegistry() {
@@ -519,7 +525,8 @@ public class ComputeService {
             configuration,
             foldContext,
             mainExchangeSource::createExchangeSource,
-            null
+            null,
+            false
         );
 
         Runnable cancelQueryOnFailure = cancelQueryOnFailure(rootTask);
@@ -748,7 +755,8 @@ public class ComputeService {
                 configuration,
                 foldContext,
                 null,
-                exchangeSinkSupplier
+                exchangeSinkSupplier,
+                false
             );
             updateShardCountForCoordinatorOnlyQuery(execInfo);
             try (
@@ -866,7 +874,8 @@ public class ComputeService {
                             configuration,
                             foldContext,
                             exchangeSource::createExchangeSource,
-                            exchangeSinkSupplier
+                            exchangeSinkSupplier,
+                            false
                         ),
                         coordinatorPlan,
                         plannerSettings.get(),
@@ -1010,7 +1019,8 @@ public class ComputeService {
                     configuration,
                     foldContext,
                     exchangeSource::createExchangeSource,
-                    exchangeSinkSupplier
+                    exchangeSinkSupplier,
+                    false
                 ),
                 coordinatorPlan,
                 plannerSettings.get(),
@@ -1132,7 +1142,8 @@ public class ComputeService {
         PlanTimeProfile planTimeProfile,
         ActionListener<DriverCompletionInfo> listener
     ) {
-        var shardContexts = context.searchContexts().map(ComputeSearchContext::shardContext);
+        var shardContexts = context.searchContexts()
+            .map(context.retainSearchContexts() ? ComputeSearchContext::newDetachedShardContext : ComputeSearchContext::shardContext);
         EsPhysicalOperationProviders physicalOperationProviders = new EsPhysicalOperationProviders(
             context.foldCtx(),
             shardContexts,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -102,6 +102,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -810,6 +811,25 @@ public class ComputeService {
             listener.onFailure(new IllegalStateException(error));
             return;
         }
+        RemoteFetchService.TrackedSessions trackedRemoteFetchSessions = null;
+        boolean supportsRemoteFetchRetainedContexts = clusterService.state()
+            .getMinTransportVersion()
+            .supports(DataNodeRequest.ESQL_REMOTE_FETCH_RETAINED_CONTEXTS);
+        if (plannerSettings.get().remoteFetchLateMaterialization()
+            && supportsRemoteFetchRetainedContexts
+            && dataNodePlan instanceof ExchangeSinkExec exchangeSinkExec
+            && clusterToConcreteIndices.size() == 1
+            && clusterToConcreteIndices.containsKey(LOCAL_CLUSTER)) {
+            Optional<PhysicalPlan> remoteFetchCoordinatorPlan = RemoteFetchPlanner.planCoordinatorTopN(
+                stats -> new LocalPhysicalOptimizerContext(plannerSettings.get(), flags, configuration, foldContext, stats),
+                coordinatorPlan,
+                exchangeSinkExec
+            );
+            if (remoteFetchCoordinatorPlan.isPresent()) {
+                coordinatorPlan = remoteFetchCoordinatorPlan.get();
+                trackedRemoteFetchSessions = remoteFetchService.trackedSessions();
+            }
+        }
         Map<String, OriginalIndices> clusterToOriginalIndices = getIndices(resolvedPlan, EsRelation::originalIndices);
         var localOriginalIndices = clusterToOriginalIndices.remove(LOCAL_CLUSTER);
         var localConcreteIndices = clusterToConcreteIndices.remove(LOCAL_CLUSTER);
@@ -820,6 +840,9 @@ public class ComputeService {
          */
         List<Attribute> outputAttributes = resolvedPlan.output();
         var exchangeSource = new ExchangeSourceHandler(configuration.pragmas().exchangeBufferSize(), searchExecutor);
+        if (trackedRemoteFetchSessions != null) {
+            listener = ActionListener.runBefore(listener, trackedRemoteFetchSessions::close);
+        }
         listener = ActionListener.runBefore(listener, () -> exchangeService.removeExchangeSourceHandler(sessionId));
         exchangeService.addExchangeSourceHandler(sessionId, exchangeSource);
         try (
@@ -897,6 +920,7 @@ public class ComputeService {
                             localOriginalIndices,
                             exchangeSource,
                             cancelQueryOnFailure,
+                            trackedRemoteFetchSessions,
                             ActionListener.wrap(r -> {
                                 localClusterWasInterrupted.set(execInfo.isStopped());
                                 execInfo.swapCluster(
@@ -1164,10 +1188,12 @@ public class ComputeService {
                 context.exchangeSinkSupplier(),
                 enrichLookupService,
                 lookupFromIndexService,
+                remoteFetchService,
                 inferenceService,
                 userAgentParserRegistry,
                 physicalOperationProviders,
-                operatorFactoryRegistry
+                operatorFactoryRegistry,
+                clusterService.localNode().getId()
             );
 
             LOGGER.debug("Received physical plan for {}:\n{}", context.description(), plan);
@@ -1321,10 +1347,39 @@ public class ComputeService {
         boolean reduceNodeLateMaterialization,
         PlanTimeProfile planTimeProfile
     ) {
+        return reductionPlan(
+            plannerSettings,
+            flags,
+            configuration,
+            foldCtx,
+            originalPlan,
+            runNodeLevelReduction,
+            reduceNodeLateMaterialization,
+            false,
+            planTimeProfile
+        );
+    }
+
+    public static ReductionPlan reductionPlan(
+        PlannerSettings plannerSettings,
+        EsqlFlags flags,
+        Configuration configuration,
+        FoldContext foldCtx,
+        ExchangeSinkExec originalPlan,
+        boolean runNodeLevelReduction,
+        boolean reduceNodeLateMaterialization,
+        boolean remoteFetchLateMaterialization,
+        PlanTimeProfile planTimeProfile
+    ) {
         long startTime = planTimeProfile == null ? 0 : System.nanoTime();
         PhysicalPlan source = new ExchangeSourceExec(originalPlan.source(), originalPlan.output(), originalPlan.isIntermediateAgg());
-        ReductionPlan passThroughReduction = new ReductionPlan(originalPlan.replaceChild(source), originalPlan);
-        if (reduceNodeLateMaterialization == false && runNodeLevelReduction == false) {
+        // Just send out everything through a single exchange as a fallback
+        ReductionPlan passThroughReduction = new ReductionPlan(
+            originalPlan.replaceChild(source),
+            originalPlan,
+            LocalPhysicalOptimization.ENABLED
+        );
+        if (remoteFetchLateMaterialization == false && reduceNodeLateMaterialization == false && runNodeLevelReduction == false) {
             return passThroughReduction;
         }
 
@@ -1335,6 +1390,10 @@ public class ComputeService {
 
         // The default plan is just the exchange source piped directly into the exchange sink.
         ReductionPlan reductionPlan = switch (PlannerUtils.reductionPlan(originalPlan)) {
+            case PlannerUtils.TopNReduction ignored when remoteFetchLateMaterialization -> RemoteFetchPlanner.planReduceDriverTopN(
+                stats -> new LocalPhysicalOptimizerContext(plannerSettings, flags, configuration, foldCtx, stats),
+                originalPlan
+            ).orElseThrow(() -> new IllegalStateException("remote fetch late materialization was selected but planning failed"));
             case PlannerUtils.TopNReduction topN when reduceNodeLateMaterialization ->
                 // In the case of TopN, the source output type is replaced since we're pulling the FieldExtractExec to the reduction node,
                 // so essentially we are splitting the TopNExec into two parts, similar to other aggregations, but unlike other

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -120,6 +120,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         OriginalIndices originalIndices,
         ExchangeSourceHandler exchangeSource,
         Runnable runOnTaskFailure,
+        RemoteFetchService.TrackedSessions remoteFetchSessions,
         ActionListener<ComputeResponse> outListener
     ) {
         Integer maxConcurrentNodesPerCluster = PlanConcurrencyCalculator.INSTANCE.calculateNodesConcurrency(dataNodePlan, configuration);
@@ -196,6 +197,11 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                                 .equals(connection.getNode().getId());
                             boolean enableReduceNodeLateMaterialization = EsqlCapabilities.Cap.ENABLE_REDUCE_NODE_LATE_MATERIALIZATION
                                 .isEnabled();
+                            boolean supportsRetainedSearchContexts = connection.getTransportVersion()
+                                .supports(DataNodeRequest.ESQL_REMOTE_FETCH_RETAINED_CONTEXTS);
+                            boolean retainSearchContexts = remoteFetchSessions != null
+                                && computeService.plannerSettings().get().remoteFetchLateMaterialization()
+                                && supportsRetainedSearchContexts;
                             var dataNodeRequest = new DataNodeRequest(
                                 childSessionId,
                                 configuration,
@@ -210,8 +216,11 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                                 // work as the final driver.
                                 queryPragmas.nodeLevelReduction() && sameNodeAsCoordinator == false,
                                 queryPragmas.nodeLevelReduction() && enableReduceNodeLateMaterialization,
-                                false
+                                retainSearchContexts
                             );
+                            if (retainSearchContexts) {
+                                remoteFetchSessions.track(connection.getNode(), nodeReduceSessionId(childSessionId));
+                            }
                             transportService.sendChildRequest(
                                 connection,
                                 ComputeService.DATA_ACTION_NAME,
@@ -787,6 +796,7 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                 plan,
                 request.runNodeLevelReduction(),
                 request.reductionLateMaterialization(),
+                request.retainSearchContexts(),
                 planTimeProfile
             );
         } else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeComputeHandler.java
@@ -566,7 +566,8 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                         configuration,
                         configuration.newFoldContext(),
                         null,
-                        () -> exchangeSink.createExchangeSink(pagesProduced::incrementAndGet)
+                        () -> exchangeSink.createExchangeSink(pagesProduced::incrementAndGet),
+                        request.retainSearchContexts()
                     );
                     computeService.runCompute(
                         parentTask,
@@ -732,7 +733,8 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                         request.configuration(),
                         new FoldContext(request.pragmas().foldLimit().getBytes()),
                         exchangeSource::createExchangeSource,
-                        () -> externalSink.createExchangeSink(() -> {})
+                        () -> externalSink.createExchangeSink(() -> {}),
+                        request.retainSearchContexts()
                     ),
                     reducePlan,
                     plannerSettings,
@@ -792,8 +794,9 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             return;
         }
         final String sessionId = request.sessionId();
+        final String nodeReduceSessionId = nodeReduceSessionId(sessionId);
         request = new DataNodeRequest(
-            sessionId + "[n]", // internal session
+            nodeReduceSessionId, // internal session
             request.configuration(),
             request.clusterAlias(),
             request.shards(),
@@ -809,6 +812,26 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
         // the sender doesn't support retry on shard failures, so we need to fail fast here.
         final boolean failFastOnShardFailures = supportShardLevelRetryFailure(channel.getVersion()) == false;
         var computeSearchContexts = new AcquiredSearchContexts(request.shards().size());
+        ActionListener<DataNodeComputeResponse> responseListener;
+        if (request.retainSearchContexts()) {
+            final RetainedSearchContextsRegistry.Handle retainedSearchContexts;
+            try {
+                retainedSearchContexts = computeService.remoteFetchService()
+                    .retainSearchContexts(nodeReduceSessionId, computeSearchContexts);
+            } catch (Exception e) {
+                computeSearchContexts.close();
+                listener.onFailure(e);
+                return;
+            }
+            ((CancellableTask) task).addListener(retainedSearchContexts::close);
+            responseListener = ActionListener.wrap(listener::onResponse, e -> {
+                try (retainedSearchContexts) {
+                    listener.onFailure(e);
+                }
+            });
+        } else {
+            responseListener = ActionListener.releaseAfter(listener, computeSearchContexts);
+        }
         runComputeOnDataNode(
             (CancellableTask) task,
             sessionId,
@@ -818,8 +841,12 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
             computeSearchContexts,
             computeService.plannerSettings().get(),
             planTimeProfile,
-            ActionListener.releaseAfter(listener, computeSearchContexts)
+            responseListener
         );
+    }
+
+    private static String nodeReduceSessionId(String sessionId) {
+        return sessionId + "[n]";
     }
 
     private void handleExternalSourceRequest(
@@ -881,7 +908,8 @@ final class DataNodeComputeHandler implements TransportRequestHandler<DataNodeRe
                     configuration,
                     configuration.newFoldContext(),
                     null,
-                    () -> externalSink.createExchangeSink(() -> {})
+                    () -> externalSink.createExchangeSink(() -> {}),
+                    false
                 );
                 computeService.runCompute(
                     task,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ReductionPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ReductionPlan.java
@@ -17,4 +17,8 @@ import org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec;
  * @param dataNodePlan The plan to be executed on the data driver. This may contain a
  * {@link org.elasticsearch.xpack.esql.plan.physical.FragmentExec}.
  */
-public record ReductionPlan(ExchangeSinkExec nodeReducePlan, ExchangeSinkExec dataNodePlan) {}
+public record ReductionPlan(ExchangeSinkExec nodeReducePlan, ExchangeSinkExec dataNodePlan, LocalPhysicalOptimization localOptimization) {
+    public ReductionPlan(ExchangeSinkExec nodeReducePlan, ExchangeSinkExec dataNodePlan) {
+        this(nodeReducePlan, dataNodePlan, LocalPhysicalOptimization.ENABLED);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchBatchOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchBatchOperator.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.BatchMetadata;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.IndexedByShardId;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Server-side batch operator for remote fetch over bidirectional exchange.
+ * Consumes one handles page per batch and emits one or more fetched pages
+ * carrying the same batch ID.
+ */
+final class RemoteFetchBatchOperator implements Operator {
+    private final List<RemoteFetchService.FetchField> fields;
+    private final IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts;
+    private final PlannerSettings plannerSettings;
+    private final RemoteFetchService remoteFetchService;
+    private final PhysicalPlan pushdownPlan;
+    private final Deque<Page> outputQueue = new ArrayDeque<>();
+    private boolean finished;
+    private Exception failure;
+
+    RemoteFetchBatchOperator(
+        List<RemoteFetchService.FetchField> fields,
+        IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts,
+        PlannerSettings plannerSettings,
+        PhysicalPlan pushdownPlan,
+        RemoteFetchService remoteFetchService
+    ) {
+        this.fields = List.copyOf(fields);
+        this.shardContexts = shardContexts;
+        this.plannerSettings = plannerSettings;
+        this.pushdownPlan = pushdownPlan;
+        this.remoteFetchService = remoteFetchService;
+    }
+
+    @Override
+    public boolean needsInput() {
+        return finished == false && failure == null;
+    }
+
+    @Override
+    public void addInput(Page page) {
+        try {
+            if (failure != null) {
+                return;
+            }
+            BatchMetadata metadata = page.batchMetadata();
+            if (metadata == null) {
+                throw new IllegalStateException("remote fetch batch page missing metadata");
+            }
+            List<RemoteFetchHandle> handles = decodeHandles(page);
+            List<Page> fetched = remoteFetchService.executeFetchForExchange(handles, fields, shardContexts, plannerSettings);
+            fetched = remoteFetchService.executePushdownForExchange(fetched, pushdownPlan, shardContexts);
+            enqueueWithBatchMetadata(metadata.batchId(), fetched);
+        } catch (Exception e) {
+            failure = e;
+        } finally {
+            page.releaseBlocks();
+        }
+    }
+
+    @Override
+    public void finish() {
+        finished = true;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return (finished || failure != null) && outputQueue.isEmpty();
+    }
+
+    @Override
+    public boolean canProduceMoreDataWithoutExtraInput() {
+        return outputQueue.isEmpty() == false || failure != null;
+    }
+
+    @Override
+    public Page getOutput() {
+        if (failure == null) {
+            return outputQueue.pollFirst();
+        }
+        Exception e = failure;
+        failure = null;
+        if (e instanceof RuntimeException re) {
+            throw re;
+        }
+        throw new IllegalStateException("remote fetch batch operator failed", e);
+    }
+
+    @Override
+    public void close() {
+        for (Page page : outputQueue) {
+            Releasables.closeExpectNoException(page::releaseBlocks);
+        }
+        outputQueue.clear();
+    }
+
+    private static List<RemoteFetchHandle> decodeHandles(Page page) {
+        if (page.getBlockCount() != 1) {
+            throw new IllegalStateException("expected a single handle block but got [" + page.getBlockCount() + "]");
+        }
+        BytesRefBlock handlesBlock = page.getBlock(0);
+        List<RemoteFetchHandle> handles = new ArrayList<>(page.getPositionCount());
+        BytesRef scratch = new BytesRef();
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            if (handlesBlock.isNull(position)) {
+                throw new IllegalStateException("remote fetch handle block cannot contain nulls");
+            }
+            if (handlesBlock.getValueCount(position) != 1) {
+                throw new IllegalStateException("remote fetch handle block must have exactly one value per row");
+            }
+            handles.add(RemoteFetchHandle.fromBytesRef(handlesBlock.getBytesRef(handlesBlock.getFirstValueIndex(position), scratch)));
+        }
+        return handles;
+    }
+
+    private void enqueueWithBatchMetadata(long batchId, List<Page> fetchedPages) {
+        if (fetchedPages.isEmpty()) {
+            outputQueue.add(Page.createBatchMarkerPage(batchId, 0));
+            return;
+        }
+        int pageIndex = 0;
+        try {
+            for (Page fetchedPage : fetchedPages) {
+                Block[] blocks = new Block[fetchedPage.getBlockCount()];
+                for (int i = 0; i < blocks.length; i++) {
+                    blocks[i] = fetchedPage.getBlock(i);
+                    blocks[i].incRef();
+                }
+                boolean isLast = pageIndex == fetchedPages.size() - 1;
+                outputQueue.add(new Page(new BatchMetadata(batchId, pageIndex, isLast), blocks));
+                pageIndex++;
+            }
+        } finally {
+            for (Page fetchedPage : fetchedPages) {
+                fetchedPage.releaseBlocks();
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandle.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandle.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+
+/**
+ * Serializable row handle for coordinator-driven remote fetch.
+ * <p>
+ * {@code DocBlock} references (shard ordinal, segment, doc) are only meaningful on the node that produced them —
+ * a coordinator receiving pages from multiple data nodes cannot resolve those local ordinals back to the original
+ * shard. This handle pairs the doc triple with the originating node and session so the coordinator can route a
+ * fetch request back to the owning node after narrowing the candidate set.
+ */
+public record RemoteFetchHandle(String nodeId, String sessionId, int shard, int segment, int doc) implements Writeable {
+    public static final Writeable.Reader<RemoteFetchHandle> READER = RemoteFetchHandle::new;
+
+    public RemoteFetchHandle {
+        Objects.requireNonNull(nodeId, "nodeId");
+        Objects.requireNonNull(sessionId, "sessionId");
+        if (shard < 0) {
+            throw new IllegalArgumentException("shard must be non-negative");
+        }
+        if (segment < 0) {
+            throw new IllegalArgumentException("segment must be non-negative");
+        }
+        if (doc < 0) {
+            throw new IllegalArgumentException("doc must be non-negative");
+        }
+    }
+
+    public RemoteFetchHandle(StreamInput in) throws IOException {
+        this(in.readString(), in.readString(), in.readVInt(), in.readVInt(), in.readVInt());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(nodeId);
+        out.writeString(sessionId);
+        out.writeVInt(shard);
+        out.writeVInt(segment);
+        out.writeVInt(doc);
+    }
+
+    /**
+     * Encodes the handle into a transport-safe {@link BytesRef} so it can be carried through regular page blocks.
+     */
+    public BytesRef toBytesRef() {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            writeTo(out);
+            return BytesRef.deepCopyOf(out.bytes().toBytesRef());
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to encode remote fetch handle", e);
+        }
+    }
+
+    public static RemoteFetchHandle fromBytesRef(BytesRef bytesRef) {
+        try (StreamInput in = StreamInput.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length)) {
+            return new RemoteFetchHandle(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to decode remote fetch handle", e);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleOperator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DocBlock;
+import org.elasticsearch.compute.data.DocVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.AbstractPageMappingOperator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Releasables;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * Encodes local {@code _doc} references into transport-safe remote fetch handles.
+ */
+public final class RemoteFetchHandleOperator extends AbstractPageMappingOperator {
+    public record Factory(String nodeId, String sessionId, int docChannel) implements OperatorFactory {
+        @Override
+        public Operator get(DriverContext driverContext) {
+            return new RemoteFetchHandleOperator(driverContext, nodeId, sessionId, docChannel);
+        }
+
+        @Override
+        public String describe() {
+            return "RemoteFetchHandleOperator[channel=" + docChannel + "]";
+        }
+    }
+
+    private final DriverContext driverContext;
+    private final String nodeId;
+    private final String sessionId;
+    private final int docChannel;
+
+    RemoteFetchHandleOperator(DriverContext driverContext, String nodeId, String sessionId, int docChannel) {
+        this.driverContext = driverContext;
+        this.nodeId = nodeId;
+        this.sessionId = sessionId;
+        this.docChannel = docChannel;
+    }
+
+    @Override
+    protected Page process(Page page) {
+        Block[] blocks = new Block[page.getBlockCount()];
+        boolean success = false;
+        try (
+            BytesRefBlock.Builder handleBuilder = driverContext.blockFactory().newBytesRefBlockBuilder(page.getPositionCount());
+            BytesStreamOutput scratch = new BytesStreamOutput()
+        ) {
+            DocVector docVector = ((DocBlock) page.getBlock(docChannel)).asVector();
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                scratch.reset();
+                try {
+                    scratch.writeString(nodeId);
+                    scratch.writeString(sessionId);
+                    scratch.writeVInt(docVector.shards().getInt(position));
+                    scratch.writeVInt(docVector.segments().getInt(position));
+                    scratch.writeVInt(docVector.docs().getInt(position));
+                } catch (IOException e) {
+                    throw new UncheckedIOException("failed to encode remote fetch handle", e);
+                }
+                handleBuilder.appendBytesRef(scratch.bytes().toBytesRef());
+            }
+            for (int block = 0; block < blocks.length; block++) {
+                if (block == docChannel) {
+                    blocks[block] = handleBuilder.build();
+                } else {
+                    blocks[block] = page.getBlock(block);
+                    blocks[block].incRef();
+                }
+            }
+            Page output = new Page(page.getPositionCount(), blocks);
+            success = true;
+            return output;
+        } finally {
+            page.releaseBlocks();
+            if (success == false) {
+                Releasables.closeExpectNoException(blocks);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteFetchHandleOperator[channel=" + docChannel + "]";
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchOperator.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.AsyncOperator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.session.Configuration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Fetches deferred fields from the owning data nodes after the coordinator has narrowed the candidate set.
+ */
+public final class RemoteFetchOperator extends AsyncOperator<RemoteFetchOperator.RemoteFetchResult> {
+    record RemoteFetchResult(Page inputPage, int[] groupByPosition, int[] offsetByPosition, List<GroupPages> pagesByGroup) {
+        RemoteFetchResult {
+            if ((groupByPosition == null) != (offsetByPosition == null) || (groupByPosition == null) != (pagesByGroup == null)) {
+                throw new IllegalArgumentException("groupByPosition, offsetByPosition, and pagesByGroup must all be null or all non-null");
+            }
+        }
+
+        static RemoteFetchResult passthrough(Page inputPage) {
+            return new RemoteFetchResult(inputPage, null, null, null);
+        }
+
+        boolean isPassthrough() {
+            return groupByPosition == null;
+        }
+    }
+
+    record GroupPages(List<Page> pages, boolean hasPositionMapping) {}
+
+    @FunctionalInterface
+    public interface Client extends Releasable {
+        void fetchAsync(String nodeId, RemoteFetchService.Request request, ActionListener<List<Page>> listener);
+
+        @Override
+        default void close() {}
+    }
+
+    @FunctionalInterface
+    public interface ClientFactory {
+        Client create();
+    }
+
+    public record Factory(
+        int handleChannel,
+        List<RemoteFetchService.FetchField> requestFields,
+        List<Attribute> outputFields,
+        PhysicalPlan pushdownPlan,
+        Configuration configuration,
+        int maxOutstandingRequests,
+        ThreadContext threadContext,
+        ClientFactory clientFactory
+    ) implements OperatorFactory {
+        @Override
+        public Operator get(DriverContext driverContext) {
+            return new RemoteFetchOperator(
+                driverContext,
+                threadContext,
+                handleChannel,
+                requestFields,
+                outputFields,
+                pushdownPlan,
+                configuration,
+                maxOutstandingRequests,
+                clientFactory.create()
+            );
+        }
+
+        @Override
+        public String describe() {
+            return "RemoteFetchOperator[channel=" + handleChannel + ", requestFields=" + requestFields + "]";
+        }
+    }
+
+    private record TargetSession(String nodeId, String sessionId) {}
+
+    private static final class Group {
+        private final TargetSession target;
+        private final List<RemoteFetchHandle> handles = new ArrayList<>();
+
+        private Group(TargetSession target) {
+            this.target = target;
+        }
+    }
+
+    private final DriverContext driverContext;
+    private final int handleChannel;
+    private final List<RemoteFetchService.FetchField> requestFields;
+    private final List<Attribute> outputFields;
+    private final PhysicalPlan pushdownPlan;
+    private final Configuration configuration;
+    private final Client client;
+
+    RemoteFetchOperator(
+        DriverContext driverContext,
+        ThreadContext threadContext,
+        int handleChannel,
+        List<RemoteFetchService.FetchField> requestFields,
+        List<Attribute> outputFields,
+        PhysicalPlan pushdownPlan,
+        Configuration configuration,
+        int maxOutstandingRequests,
+        Client client
+    ) {
+        super(driverContext, threadContext, maxOutstandingRequests);
+        this.driverContext = driverContext;
+        this.handleChannel = handleChannel;
+        this.requestFields = List.copyOf(requestFields);
+        this.outputFields = List.copyOf(outputFields);
+        this.pushdownPlan = pushdownPlan;
+        this.configuration = configuration;
+        this.client = client;
+    }
+
+    @Override
+    protected void performAsync(Page inputPage, ActionListener<RemoteFetchResult> listener) {
+        if (inputPage.getPositionCount() == 0 || outputFields.isEmpty()) {
+            listener.onResponse(RemoteFetchResult.passthrough(inputPage));
+            return;
+        }
+
+        GroupedHandles groupedHandles = decodeHandles(inputPage);
+        if (groupedHandles.groups().isEmpty()) {
+            listener.onResponse(RemoteFetchResult.passthrough(inputPage));
+            return;
+        }
+
+        inputPage.allowPassingToDifferentDriver();
+        AtomicBoolean completed = new AtomicBoolean();
+        int numGroups = groupedHandles.groups().size();
+        AtomicInteger remaining = new AtomicInteger(numGroups);
+        List<GroupPages> pagesByGroup = Arrays.asList(new GroupPages[numGroups]);
+
+        for (int groupIndex = 0; groupIndex < numGroups; groupIndex++) {
+            Group group = groupedHandles.groups().get(groupIndex);
+            RemoteFetchService.Request request = new RemoteFetchService.Request(
+                group.target.sessionId(),
+                requestFields,
+                group.handles,
+                pushdownPlan,
+                configuration
+            );
+            final int currentGroup = groupIndex;
+            client.fetchAsync(group.target.nodeId(), request, ActionListener.wrap(pages -> {
+                pages.forEach(Page::allowPassingToDifferentDriver);
+                if (completed.get()) {
+                    releasePages(pages);
+                    return;
+                }
+                final boolean hasPositionMapping;
+                try {
+                    hasPositionMapping = validateFetchedPages(group, pages);
+                } catch (Exception e) {
+                    releasePages(pages);
+                    failAndRelease(completed, pagesByGroup, listener, e);
+                    return;
+                }
+                pagesByGroup.set(currentGroup, new GroupPages(pages, hasPositionMapping));
+                if (remaining.decrementAndGet() == 0 && completed.compareAndSet(false, true)) {
+                    listener.onResponse(
+                        new RemoteFetchResult(inputPage, groupedHandles.groupByPosition(), groupedHandles.offsetByPosition(), pagesByGroup)
+                    );
+                }
+            }, e -> failAndRelease(completed, pagesByGroup, listener, e)));
+        }
+    }
+
+    @Override
+    protected void releaseFetchedOnAnyThread(RemoteFetchResult result) {
+        releasePageOnAnyThread(result.inputPage());
+        if (result.pagesByGroup() != null) {
+            releasePagesByGroup(result.pagesByGroup());
+        }
+    }
+
+    @Override
+    protected void doClose() {
+        client.close();
+    }
+
+    private static void failAndRelease(
+        AtomicBoolean completed,
+        List<GroupPages> pagesByGroup,
+        ActionListener<RemoteFetchResult> listener,
+        Exception e
+    ) {
+        if (completed.compareAndSet(false, true)) {
+            releasePagesByGroup(pagesByGroup);
+            listener.onFailure(e);
+        }
+    }
+
+    @Override
+    public Page getOutput() {
+        RemoteFetchResult fetched = fetchFromBuffer();
+        if (fetched == null) {
+            return null;
+        }
+        if (fetched.isPassthrough()) {
+            return fetched.inputPage();
+        }
+        return mergeFetchedPage(fetched.inputPage(), fetched.groupByPosition(), fetched.offsetByPosition(), fetched.pagesByGroup());
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteFetchOperator[channel=" + handleChannel + ", requestFields=" + requestFields + "]";
+    }
+
+    private GroupedHandles decodeHandles(Page inputPage) {
+        BytesRefBlock handlesBlock = inputPage.getBlock(handleChannel);
+        Map<TargetSession, Integer> groupLookup = new LinkedHashMap<>();
+        List<Group> groups = new ArrayList<>();
+        int[] groupByPosition = new int[inputPage.getPositionCount()];
+        int[] offsetByPosition = new int[inputPage.getPositionCount()];
+        BytesRef scratch = new BytesRef();
+
+        for (int position = 0; position < inputPage.getPositionCount(); position++) {
+            if (handlesBlock.isNull(position)) {
+                throw new IllegalStateException("remote fetch handle column cannot contain nulls");
+            }
+            if (handlesBlock.getValueCount(position) != 1) {
+                throw new IllegalStateException("remote fetch handle column must contain exactly one handle per row");
+            }
+            RemoteFetchHandle handle = RemoteFetchHandle.fromBytesRef(
+                handlesBlock.getBytesRef(handlesBlock.getFirstValueIndex(position), scratch)
+            );
+            TargetSession target = new TargetSession(handle.nodeId(), handle.sessionId());
+            Integer groupIndex = groupLookup.get(target);
+            if (groupIndex == null) {
+                groupIndex = groups.size();
+                groupLookup.put(target, groupIndex);
+                groups.add(new Group(target));
+            }
+            Group group = groups.get(groupIndex);
+            groupByPosition[position] = groupIndex;
+            offsetByPosition[position] = group.handles.size();
+            group.handles.add(handle);
+        }
+        return new GroupedHandles(groups, groupByPosition, offsetByPosition);
+    }
+
+    /**
+     * Validates pages returned by a single fetch group and determines the response schema.
+     * <p>
+     * Pages may contain exactly {@code outputFields.size()} columns (plain fetch) or one extra trailing column
+     * carrying an original-position mapping (pushdown with filtering). All pages in a group must use the same
+     * schema. For the plain-fetch case the total row count must equal the number of handles sent; for the
+     * position-mapped case rows may be fewer (filtered) so only the schema is checked.
+     *
+     * @return {@code true} if the pages carry an extra position-mapping column, {@code false} otherwise
+     * @throws IllegalStateException on column count mismatch, inconsistent schemas, or unexpected row counts
+     */
+    private boolean validateFetchedPages(Group group, List<Page> pages) {
+        int positions = 0;
+        Boolean hasPositionMapping = null;
+        for (Page page : pages) {
+            boolean pageHasPosition = page.getBlockCount() == outputFields.size() + 1;
+            if (page.getBlockCount() != outputFields.size() && pageHasPosition == false) {
+                throw new IllegalStateException(
+                    "remote fetch returned ["
+                        + page.getBlockCount()
+                        + "] columns but expected ["
+                        + outputFields.size()
+                        + "] or ["
+                        + (outputFields.size() + 1)
+                        + "]"
+                );
+            }
+            if (pageHasPosition && (page.getBlock(page.getBlockCount() - 1) instanceof IntBlock == false)) {
+                throw new IllegalStateException(
+                    "remote fetch position-mapping column must be an IntBlock but was ["
+                        + page.getBlock(page.getBlockCount() - 1).getClass().getSimpleName()
+                        + "]"
+                );
+            }
+            if (hasPositionMapping == null) {
+                hasPositionMapping = pageHasPosition;
+            } else if (hasPositionMapping != pageHasPosition) {
+                throw new IllegalStateException("remote fetch returned inconsistent page schemas for a single target group");
+            }
+            positions += page.getPositionCount();
+        }
+        if (Boolean.TRUE.equals(hasPositionMapping) == false && positions != group.handles.size()) {
+            throw new IllegalStateException("remote fetch returned [" + positions + "] rows but expected [" + group.handles.size() + "]");
+        }
+        return Boolean.TRUE.equals(hasPositionMapping);
+    }
+
+    private Page mergeFetchedPage(Page inputPage, int[] groupByPosition, int[] offsetByPosition, List<GroupPages> pagesByGroup) {
+        if (pagesByGroup.stream().anyMatch(g -> g != null && g.hasPositionMapping())) {
+            return mergeFetchedPageWithFiltering(inputPage, groupByPosition, offsetByPosition, pagesByGroup);
+        }
+        Block[] outputBlocks = new Block[inputPage.getBlockCount() + outputFields.size()];
+        Block.Builder[] builders = new Block.Builder[outputFields.size()];
+        boolean success = false;
+        try {
+            for (int block = 0; block < inputPage.getBlockCount(); block++) {
+                outputBlocks[block] = inputPage.getBlock(block);
+                outputBlocks[block].incRef();
+            }
+            for (int field = 0; field < outputFields.size(); field++) {
+                builders[field] = PlannerUtils.toElementType(outputFields.get(field).dataType())
+                    .newBlockBuilder(inputPage.getPositionCount(), driverContext.blockFactory());
+                for (int position = 0; position < inputPage.getPositionCount(); position++) {
+                    List<Page> fetchedPages = pagesByGroup.get(groupByPosition[position]).pages();
+                    copyFetchedPosition(builders[field], fetchedPages, field, offsetByPosition[position]);
+                }
+                outputBlocks[inputPage.getBlockCount() + field] = builders[field].build();
+            }
+            Page output = new Page(inputPage.getPositionCount(), outputBlocks);
+            success = true;
+            return output;
+        } finally {
+            inputPage.releaseBlocks();
+            releasePagesByGroup(pagesByGroup);
+            Releasables.closeExpectNoException(builders);
+            if (success == false) {
+                Releasables.closeExpectNoException(outputBlocks);
+            }
+        }
+    }
+
+    /**
+     * Merges fetched pages when a server-side pushdown filter may have dropped rows. The fetched pages carry an
+     * extra trailing column with original-position indices so we can match surviving rows back to the coordinator's
+     * input page. Rows whose position is absent from the fetch response are omitted from the output.
+     */
+    private Page mergeFetchedPageWithFiltering(
+        Page inputPage,
+        int[] groupByPosition,
+        int[] offsetByPosition,
+        List<GroupPages> pagesByGroup
+    ) {
+        // Build a per-group lookup from original handle offset -> (pageIndex, row) in the fetched pages
+        List<Map<Integer, FetchedRowRef>> groupMappings = buildGroupMappings(pagesByGroup);
+
+        // Walk the input positions and keep only those that survived the pushdown filter
+        List<Integer> originalPositions = new ArrayList<>(inputPage.getPositionCount());
+        List<FetchedRowRef> keptRows = new ArrayList<>(inputPage.getPositionCount());
+        for (int position = 0; position < inputPage.getPositionCount(); position++) {
+            int group = groupByPosition[position];
+            int offset = offsetByPosition[position];
+            FetchedRowRef rowRef = groupMappings.get(group).get(offset);
+            if (rowRef != null) {
+                originalPositions.add(position);
+                keptRows.add(rowRef);
+            }
+        }
+
+        // Rebuild: copy kept input columns + append fetched field columns, both filtered to surviving rows
+        Block[] outputBlocks = new Block[inputPage.getBlockCount() + outputFields.size()];
+        Block.Builder[] builders = new Block.Builder[outputBlocks.length];
+        boolean success = false;
+        try {
+            for (int i = 0; i < inputPage.getBlockCount(); i++) {
+                builders[i] = inputPage.getBlock(i).elementType().newBlockBuilder(originalPositions.size(), driverContext.blockFactory());
+            }
+            for (int i = 0; i < outputFields.size(); i++) {
+                builders[inputPage.getBlockCount() + i] = PlannerUtils.toElementType(outputFields.get(i).dataType())
+                    .newBlockBuilder(originalPositions.size(), driverContext.blockFactory());
+            }
+            for (int i = 0; i < originalPositions.size(); i++) {
+                int inputPos = originalPositions.get(i);
+                for (int block = 0; block < inputPage.getBlockCount(); block++) {
+                    builders[block].copyFrom(inputPage.getBlock(block), inputPos, inputPos + 1);
+                }
+                FetchedRowRef rowRef = keptRows.get(i);
+                Page fetchedPage = pagesByGroup.get(rowRef.group()).pages().get(rowRef.pageIndex());
+                for (int field = 0; field < outputFields.size(); field++) {
+                    builders[inputPage.getBlockCount() + field].copyFrom(
+                        fetchedPage.getBlock(field),
+                        rowRef.position(),
+                        rowRef.position() + 1
+                    );
+                }
+            }
+            for (int i = 0; i < outputBlocks.length; i++) {
+                outputBlocks[i] = builders[i].build();
+            }
+            Page output = new Page(originalPositions.size(), outputBlocks);
+            success = true;
+            return output;
+        } finally {
+            inputPage.releaseBlocks();
+            releasePagesByGroup(pagesByGroup);
+            Releasables.closeExpectNoException(builders);
+            if (success == false) {
+                Releasables.closeExpectNoException(outputBlocks);
+            }
+        }
+    }
+
+    private static List<Map<Integer, FetchedRowRef>> buildGroupMappings(List<GroupPages> pagesByGroup) {
+        List<Map<Integer, FetchedRowRef>> mappings = new ArrayList<>(pagesByGroup.size());
+        for (int group = 0; group < pagesByGroup.size(); group++) {
+            GroupPages groupPages = pagesByGroup.get(group);
+            Map<Integer, FetchedRowRef> mapping = new HashMap<>();
+            if (groupPages != null) {
+                List<Page> pages = groupPages.pages();
+                if (groupPages.hasPositionMapping()) {
+                    for (int pageIndex = 0; pageIndex < pages.size(); pageIndex++) {
+                        Page page = pages.get(pageIndex);
+                        IntBlock positionBlock = page.getBlock(page.getBlockCount() - 1);
+                        for (int row = 0; row < page.getPositionCount(); row++) {
+                            int pos = positionBlock.getInt(row);
+                            FetchedRowRef prev = mapping.put(pos, new FetchedRowRef(group, pageIndex, row));
+                            if (prev != null) {
+                                throw new IllegalStateException("remote fetch returned duplicate position [" + pos + "]");
+                            }
+                        }
+                    }
+                } else {
+                    int runningOffset = 0;
+                    for (int pageIndex = 0; pageIndex < pages.size(); pageIndex++) {
+                        Page page = pages.get(pageIndex);
+                        for (int row = 0; row < page.getPositionCount(); row++) {
+                            mapping.put(runningOffset++, new FetchedRowRef(group, pageIndex, row));
+                        }
+                    }
+                }
+            }
+            mappings.add(mapping);
+        }
+        return mappings;
+    }
+
+    private static void copyFetchedPosition(Block.Builder builder, List<Page> fetchedPages, int fieldIndex, int flattenedPosition) {
+        int position = flattenedPosition;
+        for (Page page : fetchedPages) {
+            if (position < page.getPositionCount()) {
+                builder.copyFrom(page.getBlock(fieldIndex), position, position + 1);
+                return;
+            }
+            position -= page.getPositionCount();
+        }
+        throw new IllegalStateException("remote fetch response did not contain the expected row");
+    }
+
+    private static void releasePagesByGroup(List<GroupPages> pagesByGroup) {
+        for (GroupPages group : pagesByGroup) {
+            releasePages(group == null ? null : group.pages());
+        }
+    }
+
+    private static void releasePages(List<Page> pages) {
+        if (pages != null) {
+            Releasables.closeExpectNoException(Releasables.wrap(pages));
+        }
+    }
+
+    private record GroupedHandles(List<Group> groups, int[] groupByPosition, int[] offsetByPosition) {}
+
+    private record FetchedRowRef(int group, int pageIndex, int position) {}
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchPlanner.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.InsertFieldExtraction;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ReplaceSourceAttributes;
+import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.plan.physical.EmitRemoteFetchHandleExec;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.EstimatesRowSize;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
+import org.elasticsearch.xpack.esql.plan.physical.LimitExec;
+import org.elasticsearch.xpack.esql.plan.physical.OutputExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.TopNExec;
+import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
+import org.elasticsearch.xpack.esql.planner.mapper.LocalMapper;
+import org.elasticsearch.xpack.esql.stats.SearchStats;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Planner helpers for the distributed remote fetch prototype on the linear TopN family.
+ */
+final class RemoteFetchPlanner {
+    static final String REMOTE_FETCH_HANDLE_NAME = "_remote_fetch_handle";
+    static final String REMOTE_FETCH_POSITION_NAME = "_remote_fetch_position";
+
+    static Optional<PhysicalPlan> planCoordinatorTopN(
+        Function<SearchStats, LocalPhysicalOptimizerContext> contextFactory,
+        PhysicalPlan coordinatorPlan,
+        ExchangeSinkExec originalDataPlan
+    ) {
+        PlanningInfo info = analyze(contextFactory, originalDataPlan).orElse(null);
+        if (info == null) {
+            return Optional.empty();
+        }
+        return rewriteCoordinatorPlan(coordinatorPlan, info);
+    }
+
+    static Optional<ReductionPlan> planReduceDriverTopN(
+        Function<SearchStats, LocalPhysicalOptimizerContext> contextFactory,
+        ExchangeSinkExec originalPlan
+    ) {
+        PlanningInfo info = analyze(contextFactory, originalPlan).orElse(null);
+        if (info == null) {
+            return Optional.empty();
+        }
+
+        LogicalPlan withAddedDocToRelation = info.topN().transformUp(EsRelation.class, r -> {
+            if (r.indexMode() == IndexMode.LOOKUP) {
+                return r;
+            }
+            List<Attribute> attributes = CollectionUtils.prependToCopy(info.docAttribute(), r.output());
+            return r.withAttributes(attributes);
+        });
+        if (withAddedDocToRelation.output().stream().noneMatch(EsQueryExec::isDocAttribute)) {
+            return Optional.empty();
+        }
+
+        Project updatedFragment = new Project(Source.EMPTY, withAddedDocToRelation, info.carryAttributes());
+        FragmentExec updatedFragmentExec = info.fragmentExec().withFragment(updatedFragment);
+        ExchangeSinkExec updatedDataPlan = originalPlan.replaceChildAndUpdateOutput(updatedFragmentExec);
+
+        PhysicalPlan reductionPlan = toPhysical(updatedFragment, info.context()).transformDown(
+            TopNExec.class,
+            topNExec -> topNExec.replaceChild(new ExchangeSourceExec(info.topN().source(), info.carryAttributes(), false)).withSortedInput()
+        );
+        PhysicalPlan sizedReductionPlan = EstimatesRowSize.estimateRowSize(updatedFragmentExec.estimatedRowSize(), reductionPlan);
+        PhysicalPlan encodedReductionPlan = new EmitRemoteFetchHandleExec(
+            Source.EMPTY,
+            sizedReductionPlan,
+            info.docAttribute(),
+            info.handleAttribute()
+        );
+        ExchangeSinkExec nodeReducePlan = new ExchangeSinkExec(
+            originalPlan.source(),
+            info.externalOutput(),
+            originalPlan.isIntermediateAgg(),
+            encodedReductionPlan
+        );
+        return Optional.of(new ReductionPlan(nodeReducePlan, updatedDataPlan, LocalPhysicalOptimization.DISABLED));
+    }
+
+    private static Optional<PlanningInfo> analyze(
+        Function<SearchStats, LocalPhysicalOptimizerContext> contextFactory,
+        ExchangeSinkExec originalPlan
+    ) {
+        FragmentExec fragmentExec = originalPlan.child() instanceof FragmentExec fe ? fe : null;
+        if (fragmentExec == null) {
+            return Optional.empty();
+        }
+
+        Project topLevelProject = fragmentExec.fragment() instanceof Project p ? p : null;
+        if (topLevelProject == null) {
+            return Optional.empty();
+        }
+
+        TopN topN = topLevelProject.child() instanceof TopN tn ? tn : null;
+        if (topN == null) {
+            return Optional.empty();
+        }
+
+        LocalPhysicalOptimizerContext context = contextFactory.apply(SEARCH_STATS_TOP_N_REPLACEMENT);
+        List<Attribute> physicalPlanOutput = toPhysical(topN, context).output();
+        Attribute doc = physicalPlanOutput.stream().filter(EsQueryExec::isDocAttribute).findFirst().orElse(null);
+        if (doc == null) {
+            return Optional.empty();
+        }
+
+        AttributeSet orderRefsSet = AttributeSet.of(topN.order().stream().flatMap(order -> order.references().stream()).toList());
+        List<Attribute> carryAttributes = new ArrayList<>();
+        for (Attribute attribute : physicalPlanOutput) {
+            if (orderRefsSet.contains(attribute) || EsQueryExec.isDocAttribute(attribute)) {
+                carryAttributes.add(attribute);
+            }
+        }
+        if (carryAttributes.stream().noneMatch(EsQueryExec::isDocAttribute)) {
+            return Optional.empty();
+        }
+
+        ReferenceAttribute handle = new ReferenceAttribute(Source.EMPTY, null, REMOTE_FETCH_HANDLE_NAME, DataType.KEYWORD);
+        return Optional.of(
+            new PlanningInfo(fragmentExec, topN, context, doc, handle, carryAttributes, replaceDocAttribute(carryAttributes, doc, handle))
+        );
+    }
+
+    private static Optional<PhysicalPlan> rewriteCoordinatorPlan(PhysicalPlan coordinatorPlan, PlanningInfo info) {
+        if (coordinatorPlan instanceof OutputExec outputExec) {
+            return rewriteCoordinatorPlan(outputExec.child(), info).map(outputExec::replaceChild);
+        }
+        if (coordinatorPlan instanceof EvalExec evalExec) {
+            Optional<PhysicalPlan> rewritten = rewriteCoordinatorPlan(evalExec.child(), info);
+            if (rewritten.isPresent()) {
+                PhysicalPlan child = rewritten.get();
+                if (child instanceof RemoteFetchExec remoteFetchExec && isPushdownEligible(evalExec, remoteFetchExec.attributesToFetch())) {
+                    return Optional.of(appendPushdown(remoteFetchExec, evalExec));
+                }
+                return Optional.of(evalExec.replaceChild(child));
+            }
+            Optional<RemoteFetchExec> injected = injectRemoteFetch(evalExec.source(), evalExec.child(), evalExec.references(), info);
+            if (injected.isEmpty()) {
+                return Optional.empty();
+            }
+            RemoteFetchExec remoteFetchExec = injected.get();
+            if (isPushdownEligible(evalExec, remoteFetchExec.attributesToFetch())) {
+                return Optional.of(appendPushdown(remoteFetchExec, evalExec));
+            }
+            return Optional.of(evalExec.replaceChild(remoteFetchExec));
+        }
+        if (coordinatorPlan instanceof FilterExec filterExec) {
+            Optional<PhysicalPlan> rewritten = rewriteCoordinatorPlan(filterExec.child(), info);
+            if (rewritten.isPresent()) {
+                PhysicalPlan child = rewritten.get();
+                if (child instanceof RemoteFetchExec remoteFetchExec
+                    && isPushdownEligible(filterExec, remoteFetchExec.attributesToFetch())) {
+                    return Optional.of(appendPushdown(remoteFetchExec, filterExec));
+                }
+                return Optional.of(filterExec.replaceChild(child));
+            }
+            Optional<RemoteFetchExec> injected = injectRemoteFetch(filterExec.source(), filterExec.child(), filterExec.references(), info);
+            if (injected.isEmpty()) {
+                return Optional.empty();
+            }
+            RemoteFetchExec remoteFetchExec = injected.get();
+            if (isPushdownEligible(filterExec, remoteFetchExec.attributesToFetch())) {
+                return Optional.of(appendPushdown(remoteFetchExec, filterExec));
+            }
+            return Optional.of(filterExec.replaceChild(remoteFetchExec));
+        }
+        if (coordinatorPlan instanceof LimitExec limitExec) {
+            return rewriteCoordinatorPlan(limitExec.child(), info).map(limitExec::replaceChild);
+        }
+        if (coordinatorPlan instanceof ProjectExec == false) {
+            return Optional.empty();
+        }
+        ProjectExec projectExec = (ProjectExec) coordinatorPlan;
+
+        Optional<PhysicalPlan> rewritten = rewriteCoordinatorPlan(projectExec.child(), info);
+        if (rewritten.isPresent()) {
+            PhysicalPlan child = rewritten.get();
+            if (child instanceof RemoteFetchExec remoteFetchExec && isPushdownEligible(projectExec, remoteFetchExec.attributesToFetch())) {
+                return Optional.of(appendPushdown(remoteFetchExec, projectExec));
+            }
+            return Optional.of(projectExec.replaceChild(child));
+        }
+
+        Optional<RemoteFetchExec> injected = injectRemoteFetch(projectExec.source(), projectExec.child(), projectExec.references(), info);
+        if (injected.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(projectExec.replaceChild(injected.get()));
+    }
+
+    private static boolean isPushdownEligible(PhysicalPlan pushdownNode, List<Attribute> fetchedAttributes) {
+        AttributeSet allowed = AttributeSet.of(fetchedAttributes);
+        for (Attribute reference : pushdownNode.references()) {
+            if (allowed.contains(reference) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static RemoteFetchExec appendPushdown(RemoteFetchExec remoteFetchExec, UnaryExec pushdownNode) {
+        PhysicalPlan source = remoteFetchExec.pushdownPlan();
+        Attribute positionAttribute;
+        if (source == null) {
+            positionAttribute = new ReferenceAttribute(Source.EMPTY, null, REMOTE_FETCH_POSITION_NAME, DataType.INTEGER);
+            List<Attribute> sourceOutput = new ArrayList<>(remoteFetchExec.attributesToFetch());
+            sourceOutput.add(positionAttribute);
+            source = new RemoteFetchSourceExec(Source.EMPTY, sourceOutput);
+        } else {
+            positionAttribute = source.output()
+                .stream()
+                .filter(attr -> REMOTE_FETCH_POSITION_NAME.equals(attr.name()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("pushdown source is missing [" + REMOTE_FETCH_POSITION_NAME + "]"));
+        }
+        UnaryExec adjustedPushdown = switch (pushdownNode) {
+            case ProjectExec projectExec -> {
+                List<NamedExpression> projections = new ArrayList<>(projectExec.projections().size() + 1);
+                projections.addAll(projectExec.projections());
+                if (projectExec.projections().stream().noneMatch(ne -> ne.id().equals(positionAttribute.id()))) {
+                    projections.add(positionAttribute);
+                }
+                yield new ProjectExec(projectExec.source(), source, projections);
+            }
+            default -> (UnaryExec) pushdownNode.replaceChild(source);
+        };
+        PhysicalPlan newPushdown = adjustedPushdown;
+        return new RemoteFetchExec(
+            remoteFetchExec.source(),
+            remoteFetchExec.child(),
+            remoteFetchExec.handleAttribute(),
+            remoteFetchExec.attributesToFetch(),
+            stripPositionAttribute(newPushdown.output(), positionAttribute.id()),
+            newPushdown
+        );
+    }
+
+    private static List<Attribute> stripPositionAttribute(List<Attribute> attributes, NameId positionAttributeId) {
+        return attributes.stream().filter(attr -> attr.id().equals(positionAttributeId) == false).toList();
+    }
+
+    private static boolean isRemoteFetchableAttribute(Attribute attribute) {
+        if (attribute instanceof FieldAttribute) {
+            return true;
+        }
+        return attribute instanceof MetadataAttribute
+            && MetadataAttribute.SCORE.equals(attribute.name()) == false
+            && EsQueryExec.isDocAttribute(attribute) == false;
+    }
+
+    private static Optional<RemoteFetchExec> injectRemoteFetch(
+        Source source,
+        PhysicalPlan child,
+        AttributeSet references,
+        PlanningInfo info
+    ) {
+        List<ExchangeSourceExec> sources = child.collect(ExchangeSourceExec.class);
+        if (sources.size() != 1) {
+            return Optional.empty();
+        }
+        PhysicalPlan updatedChild = child.transformDown(
+            ExchangeSourceExec.class,
+            exchangeSource -> new ExchangeSourceExec(exchangeSource.source(), info.externalOutput(), exchangeSource.isIntermediateAgg())
+        );
+        List<Attribute> missingAttributes = references.stream()
+            .filter(attribute -> updatedChild.outputSet().contains(attribute) == false)
+            .toList();
+        if (missingAttributes.isEmpty()) {
+            return Optional.empty();
+        }
+        if (missingAttributes.stream().allMatch(RemoteFetchPlanner::isRemoteFetchableAttribute) == false) {
+            return Optional.empty();
+        }
+        return Optional.of(new RemoteFetchExec(source, updatedChild, info.handleAttribute(), missingAttributes, missingAttributes, null));
+    }
+
+    private static List<Attribute> replaceDocAttribute(List<Attribute> attributes, Attribute docAttribute, Attribute handleAttribute) {
+        List<Attribute> replaced = new ArrayList<>(attributes.size());
+        for (Attribute attribute : attributes) {
+            replaced.add(attribute.id().equals(docAttribute.id()) ? handleAttribute : attribute);
+        }
+        return replaced;
+    }
+
+    private static PhysicalPlan toPhysical(LogicalPlan plan, LocalPhysicalOptimizerContext context) {
+        return new InsertFieldExtraction().apply(new ReplaceSourceAttributes().apply(LocalMapper.INSTANCE.map(plan)), context);
+    }
+
+    private record PlanningInfo(
+        FragmentExec fragmentExec,
+        TopN topN,
+        LocalPhysicalOptimizerContext context,
+        Attribute docAttribute,
+        ReferenceAttribute handleAttribute,
+        List<Attribute> carryAttributes,
+        List<Attribute> externalOutput
+    ) {}
+
+    private RemoteFetchPlanner() {}
+
+    // A hack to avoid the ReplaceFieldWithConstantOrNull optimization, since we don't have search stats during the reduce planning phase.
+    // This sidesteps the issue by just assuming all fields exist and have no other meaningful stats. The local data optimizer will use the
+    // real statistics.
+    private static final SearchStats SEARCH_STATS_TOP_N_REPLACEMENT = new SearchStats.UnsupportedSearchStats() {
+        @Override
+        public boolean exists(FieldAttribute.FieldName field) {
+            return true;
+        }
+
+        @Override
+        public boolean isIndexed(FieldAttribute.FieldName field) {
+            return false;
+        }
+
+        @Override
+        public Object min(FieldAttribute.FieldName field) {
+            return null;
+        }
+
+        @Override
+        public Object max(FieldAttribute.FieldName field) {
+            return null;
+        }
+    };
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchService.java
@@ -1,0 +1,1059 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ChannelActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.compute.data.BatchMetadata;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockStreamInput;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DocVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.IndexedByShardId;
+import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator.EvalOperatorFactory;
+import org.elasticsearch.compute.operator.FilterOperator.FilterOperatorFactory;
+import org.elasticsearch.compute.operator.IsBlockedResult;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.operator.ProjectOperator.ProjectOperatorFactory;
+import org.elasticsearch.compute.operator.exchange.BidirectionalBatchExchangeClient;
+import org.elasticsearch.compute.operator.exchange.BidirectionalBatchExchangeServer;
+import org.elasticsearch.compute.operator.exchange.ExchangeService;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.AbstractTransportRequest;
+import org.elasticsearch.transport.TransportChannel;
+import org.elasticsearch.transport.TransportRequestHandler;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.action.EsqlQueryAction;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchSourceExec;
+import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.planner.Layout;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.session.Configuration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Internal transport service that fetches field values for coordinator-selected rows from the owning data node.
+ * <p>
+ * This is the transport half of the remote late-materialization prototype. It intentionally works on a narrow v1
+ * contract: a batch of {@link RemoteFetchHandle}s plus a list of plain field specifications to load.
+ */
+public final class RemoteFetchService {
+    private static final String ACTION_PREFIX = EsqlQueryAction.NAME + "/remote_fetch";
+    static final String RELEASE_ACTION_NAME = ACTION_PREFIX + "/release";
+    static final String EXCHANGE_SETUP_ACTION_NAME = ACTION_PREFIX + "/exchange_setup";
+
+    private static final Logger logger = LogManager.getLogger(RemoteFetchService.class);
+    private static final AtomicLong exchangeIdGenerator = new AtomicLong();
+
+    private final ClusterService clusterService;
+    private final TransportService transportService;
+    private final ExchangeService exchangeService;
+    private final BigArrays bigArrays;
+    private final BlockFactory blockFactory;
+    private final PlannerSettings.Holder plannerSettings;
+    private final LocalCircuitBreaker.SizeSettings localBreakerSettings;
+    private final RetainedSearchContextsRegistry retainedSearchContexts = new RetainedSearchContextsRegistry();
+
+    RemoteFetchService(TransportActionServices transportActionServices, BigArrays bigArrays, BlockFactory blockFactory) {
+        this.clusterService = transportActionServices.clusterService();
+        this.transportService = transportActionServices.transportService();
+        this.exchangeService = transportActionServices.exchangeService();
+        this.bigArrays = bigArrays;
+        this.blockFactory = blockFactory;
+        this.plannerSettings = transportActionServices.plannerSettings();
+        this.localBreakerSettings = new LocalCircuitBreaker.SizeSettings(clusterService.getSettings());
+        transportService.registerRequestHandler(
+            RELEASE_ACTION_NAME,
+            transportService.getThreadPool().executor(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME),
+            ReleaseRequest::new,
+            new ReleaseTransportHandler()
+        );
+        transportService.registerRequestHandler(
+            EXCHANGE_SETUP_ACTION_NAME,
+            transportService.getThreadPool().executor(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME),
+            ExchangeSetupRequest::new,
+            new ExchangeSetupTransportHandler()
+        );
+    }
+
+    RetainedSearchContextsRegistry.Handle retainSearchContexts(String sessionId, AcquiredSearchContexts searchContexts) {
+        return retainedSearchContexts.register(sessionId, searchContexts);
+    }
+
+    void releaseAsync(DiscoveryNode targetNode, String sessionId, ActionListener<Void> listener) {
+        transportService.sendRequest(
+            targetNode,
+            RELEASE_ACTION_NAME,
+            new ReleaseRequest(sessionId),
+            TransportRequestOptions.EMPTY,
+            new ActionListenerResponseHandler<>(
+                listener.map(ignored -> null),
+                in -> ActionResponse.Empty.INSTANCE,
+                transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
+            )
+        );
+    }
+
+    public ThreadContext threadContext() {
+        return transportService.getThreadPool().getThreadContext();
+    }
+
+    public RemoteFetchOperator.Client newBatchExchangeClient(CancellableTask parentTask) {
+        return new BatchExchangeFetchClient(parentTask);
+    }
+
+    private Page buildHandlesPage(List<RemoteFetchHandle> handles, long batchId) {
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(handles.size())) {
+            for (RemoteFetchHandle handle : handles) {
+                builder.appendBytesRef(handle.toBytesRef());
+            }
+            return new Page(new BatchMetadata(batchId, 0, true), builder.build());
+        }
+    }
+
+    private static Page stripBatchMetadata(Page page) {
+        Block[] blocks = new Block[page.getBlockCount()];
+        for (int i = 0; i < blocks.length; i++) {
+            blocks[i] = page.getBlock(i);
+            blocks[i].incRef();
+        }
+        return new Page(page.getPositionCount(), blocks);
+    }
+
+    private static Configuration readConfiguration(StreamInput in) throws IOException {
+        return new Configuration(
+            // TODO make Configuration Releasable
+            new BlockStreamInput(
+                in,
+                BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker(CircuitBreaker.REQUEST)).build()
+            )
+        );
+    }
+
+    TrackedSessions trackedSessions() {
+        return new TrackedSessions(this);
+    }
+
+    private final class BatchExchangeFetchClient implements RemoteFetchOperator.Client {
+        private final CancellableTask parentTask;
+        private final Executor executor = transportService.getThreadPool().executor(ThreadPool.Names.SEARCH);
+        private final Map<TargetSession, TargetState> targets = new HashMap<>();
+        private volatile boolean closed;
+
+        private BatchExchangeFetchClient(CancellableTask parentTask) {
+            this.parentTask = parentTask;
+        }
+
+        @Override
+        public void fetchAsync(String nodeId, Request request, ActionListener<List<Page>> listener) {
+            if (closed) {
+                listener.onFailure(new IllegalStateException("remote fetch exchange client is closed"));
+                return;
+            }
+            TargetSession target = new TargetSession(nodeId, request.sessionId());
+            final TargetState state;
+            synchronized (this) {
+                state = targets.computeIfAbsent(
+                    target,
+                    t -> createTargetState(t, request.fields(), request.pushdownPlan(), request.configuration())
+                );
+            }
+            ActionListener<List<Page>> cleanupListener = ActionListener.wrap(listener::onResponse, e -> {
+                removeTargetState(target, state);
+                listener.onFailure(e);
+            });
+            executor.execute(() -> state.fetch(request, cleanupListener));
+        }
+
+        @Override
+        public void close() {
+            Map<TargetSession, TargetState> states;
+            synchronized (this) {
+                if (closed) {
+                    return;
+                }
+                closed = true;
+                states = new HashMap<>(targets);
+                targets.clear();
+            }
+            for (TargetState state : states.values()) {
+                state.close();
+            }
+        }
+
+        private TargetState createTargetState(
+            TargetSession target,
+            List<FetchField> fields,
+            PhysicalPlan pushdownPlan,
+            Configuration configuration
+        ) {
+            DiscoveryNode node = clusterService.state().nodes().get(target.nodeId());
+            if (node == null) {
+                throw new IllegalStateException("remote fetch target node [" + target.nodeId() + "] not found");
+            }
+            BidirectionalBatchExchangeClient.ServerSetupCallback setupCallback = (
+                serverNode,
+                clientToServerId,
+                serverToClientId,
+                setupListener) -> {
+                ExchangeSetupRequest setupRequest = new ExchangeSetupRequest(
+                    target.sessionId(),
+                    fields,
+                    pushdownPlan,
+                    configuration,
+                    clientToServerId,
+                    serverToClientId
+                );
+                transportService.sendChildRequest(
+                    serverNode,
+                    EXCHANGE_SETUP_ACTION_NAME,
+                    setupRequest,
+                    parentTask,
+                    TransportRequestOptions.EMPTY,
+                    new ActionListenerResponseHandler<>(
+                        setupListener.map(ignored -> null),
+                        in -> ActionResponse.Empty.INSTANCE,
+                        transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
+                    )
+                );
+            };
+            BidirectionalBatchExchangeClient client = new BidirectionalBatchExchangeClient(
+                target.sessionId() + "/remote-fetch/" + exchangeIdGenerator.incrementAndGet(),
+                exchangeService,
+                transportService.getThreadPool().executor(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME),
+                Math.max(1, fields.size() + 1),
+                transportService,
+                parentTask,
+                ActionListener.noop(),
+                clusterService.getSettings(),
+                setupCallback,
+                null,
+                1,
+                () -> node
+            );
+            return new TargetState(client, fields, pushdownPlan, configuration);
+        }
+
+        private void removeTargetState(TargetSession target, TargetState expectedState) {
+            boolean removed;
+            synchronized (this) {
+                removed = targets.remove(target, expectedState);
+            }
+            if (removed) {
+                expectedState.close();
+            }
+        }
+    }
+
+    private final class TargetState {
+        private final BidirectionalBatchExchangeClient client;
+        private final List<FetchField> fields;
+        private final PhysicalPlan pushdownPlan;
+        private final Configuration configuration;
+        private final AtomicLong batchIdGenerator = new AtomicLong();
+        private final Object lock = new Object();
+        private boolean closed;
+
+        private TargetState(
+            BidirectionalBatchExchangeClient client,
+            List<FetchField> fields,
+            PhysicalPlan pushdownPlan,
+            Configuration configuration
+        ) {
+            this.client = client;
+            this.fields = List.copyOf(fields);
+            this.pushdownPlan = pushdownPlan;
+            this.configuration = configuration;
+        }
+
+        void fetch(Request request, ActionListener<List<Page>> listener) {
+            synchronized (lock) {
+                try {
+                    if (closed) {
+                        throw new IllegalStateException("remote fetch target state is closed");
+                    }
+                    if (fields.equals(request.fields()) == false) {
+                        throw new IllegalStateException("remote fetch fields differ for reused target session channel");
+                    }
+                    if (Objects.equals(pushdownPlan, request.pushdownPlan()) == false) {
+                        throw new IllegalStateException("remote fetch pushdown plan differs for reused target session channel");
+                    }
+                    if (configuration.equals(request.configuration()) == false) {
+                        throw new IllegalStateException("remote fetch configuration differs for reused target session channel");
+                    }
+                    long batchId = batchIdGenerator.incrementAndGet();
+                    Page handlesPage = buildHandlesPage(request.handles(), batchId);
+                    client.sendPage(handlesPage);
+                    listener.onResponse(collectFetchedPagesForBatch(client, batchId));
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                }
+            }
+        }
+
+        void close() {
+            synchronized (lock) {
+                if (closed) {
+                    return;
+                }
+                closed = true;
+                try {
+                    client.finish();
+                    client.finishCollectingResponseHeaders();
+                    client.close();
+                } catch (Exception e) {
+                    logger.debug("failed to close remote fetch target state", e);
+                }
+            }
+        }
+    }
+
+    private record TargetSession(String nodeId, String sessionId) {}
+
+    private List<Page> collectFetchedPagesForBatch(BidirectionalBatchExchangeClient client, long batchId) throws Exception {
+        List<Page> pages = new ArrayList<>();
+        boolean success = false;
+        try {
+            boolean completed = false;
+            while (completed == false) {
+                Page page = client.pollPage();
+                if (page != null) {
+                    try {
+                        BatchMetadata metadata = page.batchMetadata();
+                        if (metadata == null || metadata.batchId() != batchId) {
+                            throw new IllegalStateException("received unexpected batch metadata while awaiting batch [" + batchId + "]");
+                        }
+                        if (page.getPositionCount() > 0) {
+                            pages.add(stripBatchMetadata(page));
+                        }
+                        if (metadata.isLastPageInBatch()) {
+                            client.markBatchCompleted(batchId);
+                            completed = true;
+                        }
+                    } finally {
+                        page.releaseBlocks();
+                    }
+                    continue;
+                }
+                Exception failure = client.getPrimaryFailure();
+                if (failure != null) {
+                    throw failure;
+                }
+                IsBlockedResult blocked = client.waitUntilPageReady();
+                if (blocked.listener().isDone() == false) {
+                    PlainActionFuture<Void> waitFuture = new PlainActionFuture<>();
+                    blocked.listener().addListener(waitFuture);
+                    FutureUtils.get(waitFuture);
+                }
+            }
+            success = true;
+            return pages;
+        } finally {
+            if (success == false) {
+                Releasables.closeExpectNoException(Releasables.wrap(Iterators.map(pages.iterator(), page -> page::releaseBlocks)));
+            }
+        }
+    }
+
+    int retainedSessions() {
+        return retainedSearchContexts.retainedSessions();
+    }
+
+    boolean isRetained(String sessionId) {
+        return retainedSearchContexts.isRetained(sessionId);
+    }
+
+    private void releaseSession(String sessionId) {
+        retainedSearchContexts.closeRegistration(sessionId);
+    }
+
+    private void releaseBestEffort(DiscoveryNode targetNode, String sessionId) {
+        releaseAsync(
+            targetNode,
+            sessionId,
+            ActionListener.wrap(
+                ignored -> {},
+                e -> logger.debug("failed to release retained remote fetch session [{}] on node [{}]", sessionId, targetNode.getId(), e)
+            )
+        );
+    }
+
+    private void startExchangeFetchServer(ExchangeSetupRequest request, CancellableTask task, ActionListener<Void> listener) {
+        final RetainedSearchContextsRegistry.Handle lease;
+        try {
+            lease = retainedSearchContexts.acquire(request.sessionId());
+        } catch (Exception e) {
+            listener.onFailure(e);
+            return;
+        }
+        final DiscoveryNode clientNode;
+        try {
+            clientNode = determineClientNode(task);
+        } catch (Exception e) {
+            lease.close();
+            listener.onFailure(e);
+            return;
+        }
+        final PlannerSettings settings = plannerSettings.get();
+        final IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts = lease.searchContexts()
+            .map(ComputeSearchContext::newDetachedShardContext);
+        final LocalCircuitBreaker localBreaker = new LocalCircuitBreaker(
+            blockFactory.breaker(),
+            localBreakerSettings.overReservedBytes(),
+            localBreakerSettings.maxOverReservedBytes()
+        );
+        final DriverContext driverContext = new DriverContext(
+            bigArrays,
+            blockFactory.newChildFactory(localBreaker),
+            localBreakerSettings,
+            "remote_fetch_exchange"
+        );
+        final BidirectionalBatchExchangeServer server = new BidirectionalBatchExchangeServer(
+            request.sessionId(),
+            request.clientToServerId(),
+            request.serverToClientId(),
+            exchangeService,
+            transportService.getThreadPool().executor(EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME),
+            Math.max(1, request.fields().size()),
+            transportService,
+            task,
+            clientNode,
+            clusterService.getSettings()
+        );
+        final Releasable releasable = Releasables.wrap(server, lease, localBreaker);
+        List<Operator> intermediate = List.of(
+            new RemoteFetchBatchOperator(request.fields(), shardContexts, settings, request.pushdownPlan(), this)
+        );
+        server.startWithOperators(
+            driverContext,
+            transportService.getThreadPool().getThreadContext(),
+            intermediate,
+            clusterService.getClusterName().value(),
+            releasable,
+            listener
+        );
+    }
+
+    private DiscoveryNode determineClientNode(CancellableTask task) {
+        if (task == null) {
+            throw new IllegalStateException("cannot determine remote fetch exchange client node: task is null");
+        }
+        if (task.getParentTaskId().isSet() == false) {
+            throw new IllegalStateException("cannot determine remote fetch exchange client node: parent task is not set");
+        }
+        String nodeId = task.getParentTaskId().getNodeId();
+        DiscoveryNode node = clusterService.state().nodes().get(nodeId);
+        if (node == null) {
+            throw new IllegalStateException("remote fetch exchange client node [" + nodeId + "] not found");
+        }
+        return node;
+    }
+
+    List<Page> executeFetchForExchange(
+        List<RemoteFetchHandle> handles,
+        List<FetchField> fields,
+        IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts,
+        PlannerSettings settings
+    ) {
+        List<ValuesSourceReaderOperator.FieldInfo> fieldInfos = buildFieldInfos(fields, shardContexts, settings);
+        IndexedByShardId<ValuesSourceReaderOperator.ShardContext> readerContexts = shardContexts.map(
+            c -> new ValuesSourceReaderOperator.ShardContext(
+                c.searcher().getIndexReader(),
+                c::newSourceLoader,
+                c.storedFieldsSequentialProportion()
+            )
+        );
+        return executeFetch(handles, fieldInfos, readerContexts, bigArrays, blockFactory, localBreakerSettings, settings);
+    }
+
+    List<Page> executePushdownForExchange(
+        List<Page> pages,
+        PhysicalPlan pushdownPlan,
+        IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts
+    ) {
+        if (pushdownPlan == null || pages.isEmpty()) {
+            return pages;
+        }
+        List<Page> current = appendPositionColumn(pages);
+        List<Operator.OperatorFactory> factories = new ArrayList<>();
+        compilePushdownFactories(pushdownPlan, factories, shardContexts);
+        boolean success = false;
+        try {
+            for (Operator.OperatorFactory factory : factories) {
+                List<Page> next = new ArrayList<>();
+                try (
+                    Operator operator = factory.get(
+                        new DriverContext(bigArrays, blockFactory, localBreakerSettings, "remote_fetch_pushdown")
+                    )
+                ) {
+                    for (Page page : current) {
+                        operator.addInput(page);
+                        Page output;
+                        while ((output = operator.getOutput()) != null) {
+                            output.allowPassingToDifferentDriver();
+                            next.add(output);
+                        }
+                    }
+                    operator.finish();
+                    Page output;
+                    while ((output = operator.getOutput()) != null) {
+                        output.allowPassingToDifferentDriver();
+                        next.add(output);
+                    }
+                }
+                current = next;
+            }
+            success = true;
+            return current;
+        } finally {
+            if (success == false) {
+                Releasables.closeExpectNoException(Releasables.wrap(Iterators.map(current.iterator(), page -> page::releaseBlocks)));
+            }
+        }
+    }
+
+    private List<Page> appendPositionColumn(List<Page> pages) {
+        List<Page> withPosition = new ArrayList<>(pages.size());
+        int position = 0;
+        for (Page page : pages) {
+            try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(page.getPositionCount())) {
+                for (int row = 0; row < page.getPositionCount(); row++) {
+                    builder.appendInt(position++);
+                }
+                Block positionBlock = builder.build();
+                Block[] blocks = new Block[page.getBlockCount() + 1];
+                for (int i = 0; i < page.getBlockCount(); i++) {
+                    blocks[i] = page.getBlock(i);
+                    blocks[i].incRef();
+                }
+                blocks[page.getBlockCount()] = positionBlock;
+                withPosition.add(new Page(page.getPositionCount(), blocks));
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+        return withPosition;
+    }
+
+    private Layout compilePushdownFactories(
+        PhysicalPlan plan,
+        List<Operator.OperatorFactory> factories,
+        IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts
+    ) {
+        if (plan instanceof RemoteFetchSourceExec sourceExec) {
+            Layout.Builder builder = new Layout.Builder();
+            builder.append(sourceExec.output());
+            return builder.build();
+        }
+        if (plan instanceof EvalExec evalExec) {
+            Layout childLayout = compilePushdownFactories(evalExec.child(), factories, shardContexts);
+            Layout.Builder builder = childLayout.builder();
+            for (Alias field : evalExec.fields()) {
+                factories.add(
+                    new EvalOperatorFactory(EvalMapper.toEvaluator(FoldContext.small(), field.child(), childLayout, shardContexts))
+                );
+                builder.append(field.toAttribute());
+            }
+            return builder.build();
+        }
+        if (plan instanceof FilterExec filterExec) {
+            Layout childLayout = compilePushdownFactories(filterExec.child(), factories, shardContexts);
+            factories.add(
+                new FilterOperatorFactory(EvalMapper.toEvaluator(FoldContext.small(), filterExec.condition(), childLayout, shardContexts))
+            );
+            return childLayout;
+        }
+        if (plan instanceof ProjectExec projectExec) {
+            Layout childLayout = compilePushdownFactories(projectExec.child(), factories, shardContexts);
+            List<Integer> projectionList = new ArrayList<>(projectExec.projections().size());
+            Layout.Builder builder = new Layout.Builder();
+            for (NamedExpression projection : projectExec.projections()) {
+                NameId inputId = projection instanceof Alias alias ? ((NamedExpression) alias.child()).id() : projection.id();
+                Layout.ChannelAndType input = childLayout.get(inputId);
+                if (input == null) {
+                    throw new IllegalStateException("can't find pushdown input for [" + projection + "]");
+                }
+                projectionList.add(input.channel());
+                builder.append(projection);
+            }
+            factories.add(new ProjectOperatorFactory(projectionList));
+            return builder.build();
+        }
+        throw new IllegalStateException("unsupported remote fetch pushdown plan [" + plan.getClass().getSimpleName() + "]");
+    }
+
+    static List<ValuesSourceReaderOperator.FieldInfo> buildFieldInfos(
+        List<FetchField> fields,
+        IndexedByShardId<? extends EsPhysicalOperationProviders.ShardContext> shardContexts,
+        PlannerSettings plannerSettings
+    ) {
+        List<ValuesSourceReaderOperator.FieldInfo> fieldInfos = new ArrayList<>(fields.size());
+        for (FetchField field : fields) {
+            fieldInfos.add(
+                new ValuesSourceReaderOperator.FieldInfo(
+                    field.fieldName(),
+                    PlannerUtils.toElementType(field.dataType()),
+                    false,
+                    (warningsMode, shardIdx) -> {
+                        BlockLoader loader = shardContexts.get(shardIdx)
+                            .blockLoader(
+                                field.fieldName(),
+                                field.dataType() == DataType.UNSUPPORTED,
+                                MappedFieldType.FieldExtractPreference.NONE,
+                                null,
+                                null,
+                                plannerSettings.blockLoaderSizeOrdinals(),
+                                plannerSettings.blockLoaderSizeScript()
+                            );
+                        return ValuesSourceReaderOperator.load(loader);
+                    }
+                )
+            );
+        }
+        return fieldInfos;
+    }
+
+    static List<Page> executeFetch(
+        List<RemoteFetchHandle> handles,
+        List<ValuesSourceReaderOperator.FieldInfo> fieldInfos,
+        IndexedByShardId<ValuesSourceReaderOperator.ShardContext> shardContexts,
+        BigArrays bigArrays,
+        BlockFactory blockFactory,
+        LocalCircuitBreaker.SizeSettings localBreakerSettings,
+        PlannerSettings plannerSettings
+    ) {
+        if (handles.isEmpty()) {
+            return List.of();
+        }
+        if (fieldInfos.isEmpty()) {
+            throw new IllegalArgumentException("remote fetch requires at least one field");
+        }
+
+        final LocalCircuitBreaker localBreaker = new LocalCircuitBreaker(
+            blockFactory.breaker(),
+            localBreakerSettings.overReservedBytes(),
+            localBreakerSettings.maxOverReservedBytes()
+        );
+        final DriverContext driverContext = new DriverContext(
+            bigArrays,
+            blockFactory.newChildFactory(localBreaker),
+            localBreakerSettings,
+            "remote_fetch"
+        );
+        final Operator operator = new ValuesSourceReaderOperator.Factory(
+            plannerSettings.valuesLoadingJumboSize(),
+            fieldInfos,
+            shardContexts,
+            fieldInfos.size() <= plannerSettings.reuseColumnLoadersThreshold(),
+            0,
+            plannerSettings.sourceReservationFactor(),
+            plannerSettings.docSequenceBytesRefFieldThreshold()
+        ).get(driverContext);
+        final int[] projection = new int[fieldInfos.size()];
+        for (int i = 0; i < projection.length; i++) {
+            projection[i] = i + 1;
+        }
+        Page inputPage = inputPage(driverContext.blockFactory(), handles);
+        boolean releaseInputPage = true;
+        boolean success = false;
+        List<Page> outputPages = new ArrayList<>();
+        try {
+            operator.addInput(inputPage);
+            releaseInputPage = false;
+            operator.finish();
+            while (operator.isFinished() == false) {
+                Page page = operator.getOutput();
+                if (page == null) {
+                    throw new IllegalStateException("remote fetch operator stalled without producing output");
+                }
+                Page projected = page.projectBlocks(projection);
+                page.releaseBlocks();
+                projected.allowPassingToDifferentDriver();
+                outputPages.add(projected);
+            }
+            success = true;
+            return outputPages;
+        } finally {
+            Releasables.closeExpectNoException(operator, localBreaker);
+            if (releaseInputPage) {
+                inputPage.releaseBlocks();
+            }
+            if (success == false) {
+                Releasables.closeExpectNoException(Releasables.wrap(Iterators.map(outputPages.iterator(), page -> page::releaseBlocks)));
+            }
+        }
+    }
+
+    static Page inputPage(BlockFactory blockFactory, List<RemoteFetchHandle> handles) {
+        try (DocVector.FixedBuilder builder = DocVector.newFixedBuilder(blockFactory, handles.size())) {
+            for (RemoteFetchHandle handle : handles) {
+                builder.append(handle.shard(), handle.segment(), handle.doc());
+            }
+            return new Page(builder.build(DocVector.config()).asBlock());
+        }
+    }
+
+    public static final class FetchField implements Writeable {
+        private final String fieldName;
+        private final DataType dataType;
+
+        public FetchField(String fieldName, DataType dataType) {
+            this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
+            this.dataType = Objects.requireNonNull(dataType, "dataType");
+        }
+
+        FetchField(StreamInput in) throws IOException {
+            this(in.readString(), DataType.fromTypeName(in.readString()));
+        }
+
+        public String fieldName() {
+            return fieldName;
+        }
+
+        public DataType dataType() {
+            return dataType;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(fieldName);
+            out.writeString(dataType.typeName());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj instanceof FetchField == false) {
+                return false;
+            }
+            FetchField other = (FetchField) obj;
+            return fieldName.equals(other.fieldName) && dataType == other.dataType;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fieldName, dataType);
+        }
+
+        @Override
+        public String toString() {
+            return fieldName + ":" + dataType.typeName();
+        }
+    }
+
+    public static final class Request extends AbstractTransportRequest {
+        private final String sessionId;
+        private final List<FetchField> fields;
+        private final List<RemoteFetchHandle> handles;
+        private final PhysicalPlan pushdownPlan;
+        private final Configuration configuration;
+
+        public Request(String sessionId, List<FetchField> fields, List<RemoteFetchHandle> handles, Configuration configuration) {
+            this(sessionId, fields, handles, null, configuration);
+        }
+
+        public Request(
+            String sessionId,
+            List<FetchField> fields,
+            List<RemoteFetchHandle> handles,
+            PhysicalPlan pushdownPlan,
+            Configuration configuration
+        ) {
+            this.sessionId = Objects.requireNonNull(sessionId, "sessionId");
+            this.fields = List.copyOf(fields);
+            this.handles = List.copyOf(handles);
+            this.pushdownPlan = pushdownPlan;
+            this.configuration = Objects.requireNonNull(configuration, "configuration");
+        }
+
+        Request(StreamInput in) throws IOException {
+            super(in);
+            this.sessionId = in.readString();
+            this.fields = in.readCollectionAsList(FetchField::new);
+            this.handles = in.readCollectionAsList(RemoteFetchHandle.READER);
+            this.configuration = readConfiguration(in);
+            PlanStreamInput pin = new PlanStreamInput(in, in.namedWriteableRegistry(), configuration);
+            this.pushdownPlan = pin.readOptionalNamedWriteable(PhysicalPlan.class);
+        }
+
+        String sessionId() {
+            return sessionId;
+        }
+
+        List<FetchField> fields() {
+            return fields;
+        }
+
+        List<RemoteFetchHandle> handles() {
+            return handles;
+        }
+
+        PhysicalPlan pushdownPlan() {
+            return pushdownPlan;
+        }
+
+        Configuration configuration() {
+            return configuration;
+        }
+
+        void validateForNode(String localNodeId) {
+            if (fields.isEmpty()) {
+                throw new IllegalArgumentException("remote fetch requires at least one field");
+            }
+            for (RemoteFetchHandle handle : handles) {
+                if (sessionId.equals(handle.sessionId()) == false) {
+                    throw new IllegalArgumentException(
+                        "remote fetch request session [" + sessionId + "] does not match handle session [" + handle.sessionId() + "]"
+                    );
+                }
+                if (localNodeId.equals(handle.nodeId()) == false) {
+                    throw new IllegalArgumentException(
+                        "remote fetch handle node [" + handle.nodeId() + "] does not match local node [" + localNodeId + "]"
+                    );
+                }
+            }
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(sessionId);
+            out.writeCollection(fields);
+            out.writeCollection(handles);
+            configuration.writeTo(out);
+            new PlanStreamOutput(out, configuration).writeOptionalNamedWriteable(pushdownPlan);
+        }
+
+        @Override
+        public String toString() {
+            return "RemoteFetchRequest[session=" + sessionId + ", fields=" + fields + ", handles=" + handles.size() + "]";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj instanceof Request == false) {
+                return false;
+            }
+            Request other = (Request) obj;
+            return sessionId.equals(other.sessionId)
+                && fields.equals(other.fields)
+                && handles.equals(other.handles)
+                && Objects.equals(pushdownPlan, other.pushdownPlan)
+                && configuration.equals(other.configuration);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(sessionId, fields, handles, pushdownPlan, configuration);
+        }
+    }
+
+    static final class ReleaseRequest extends AbstractTransportRequest {
+        private final String sessionId;
+
+        ReleaseRequest(String sessionId) {
+            this.sessionId = Objects.requireNonNull(sessionId, "sessionId");
+        }
+
+        ReleaseRequest(StreamInput in) throws IOException {
+            super(in);
+            this.sessionId = in.readString();
+        }
+
+        String sessionId() {
+            return sessionId;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(sessionId);
+        }
+    }
+
+    static final class ExchangeSetupRequest extends AbstractTransportRequest {
+        private final String sessionId;
+        private final List<FetchField> fields;
+        private final PhysicalPlan pushdownPlan;
+        private final Configuration configuration;
+        private final String clientToServerId;
+        private final String serverToClientId;
+
+        ExchangeSetupRequest(
+            String sessionId,
+            List<FetchField> fields,
+            PhysicalPlan pushdownPlan,
+            Configuration configuration,
+            String clientToServerId,
+            String serverToClientId
+        ) {
+            this.sessionId = Objects.requireNonNull(sessionId);
+            this.fields = List.copyOf(fields);
+            this.pushdownPlan = pushdownPlan;
+            this.configuration = Objects.requireNonNull(configuration);
+            this.clientToServerId = Objects.requireNonNull(clientToServerId);
+            this.serverToClientId = Objects.requireNonNull(serverToClientId);
+        }
+
+        ExchangeSetupRequest(StreamInput in) throws IOException {
+            super(in);
+            this.sessionId = in.readString();
+            this.fields = in.readCollectionAsList(FetchField::new);
+            this.configuration = readConfiguration(in);
+            PlanStreamInput pin = new PlanStreamInput(in, in.namedWriteableRegistry(), configuration);
+            this.pushdownPlan = pin.readOptionalNamedWriteable(PhysicalPlan.class);
+            this.clientToServerId = in.readString();
+            this.serverToClientId = in.readString();
+        }
+
+        String sessionId() {
+            return sessionId;
+        }
+
+        List<FetchField> fields() {
+            return fields;
+        }
+
+        PhysicalPlan pushdownPlan() {
+            return pushdownPlan;
+        }
+
+        Configuration configuration() {
+            return configuration;
+        }
+
+        String clientToServerId() {
+            return clientToServerId;
+        }
+
+        String serverToClientId() {
+            return serverToClientId;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(sessionId);
+            out.writeCollection(fields);
+            configuration.writeTo(out);
+            new PlanStreamOutput(out, configuration).writeOptionalNamedWriteable(pushdownPlan);
+            out.writeString(clientToServerId);
+            out.writeString(serverToClientId);
+        }
+    }
+
+    private class ReleaseTransportHandler implements TransportRequestHandler<ReleaseRequest> {
+        @Override
+        public void messageReceived(ReleaseRequest request, TransportChannel channel, Task task) throws Exception {
+            releaseSession(request.sessionId());
+            channel.sendResponse(ActionResponse.Empty.INSTANCE);
+        }
+    }
+
+    private class ExchangeSetupTransportHandler implements TransportRequestHandler<ExchangeSetupRequest> {
+        @Override
+        public void messageReceived(ExchangeSetupRequest request, TransportChannel channel, Task task) {
+            startExchangeFetchServer(
+                request,
+                (CancellableTask) task,
+                new ChannelActionListener<>(channel).map(ignored -> ActionResponse.Empty.INSTANCE)
+            );
+        }
+    }
+
+    static final class TrackedSessions implements Releasable {
+        private final RemoteFetchService remoteFetchService;
+        private final List<TrackedSession> sessions = new ArrayList<>();
+        private boolean closed;
+
+        private TrackedSessions(RemoteFetchService remoteFetchService) {
+            this.remoteFetchService = remoteFetchService;
+        }
+
+        synchronized void track(DiscoveryNode targetNode, String sessionId) {
+            if (closed) {
+                remoteFetchService.releaseBestEffort(targetNode, sessionId);
+                return;
+            }
+            sessions.add(new TrackedSession(targetNode, sessionId));
+        }
+
+        @Override
+        public void close() {
+            List<TrackedSession> tracked;
+            synchronized (this) {
+                if (closed) {
+                    return;
+                }
+                closed = true;
+                tracked = List.copyOf(sessions);
+                sessions.clear();
+            }
+            for (TrackedSession session : tracked) {
+                remoteFetchService.releaseBestEffort(session.targetNode(), session.sessionId());
+            }
+        }
+    }
+
+    private record TrackedSession(DiscoveryNode targetNode, String sessionId) {}
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -485,6 +485,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
             ByteSizeValue.ofMb(1),
             10_000,
             ByteSizeValue.ofMb(1),
+            false,
             between(1, 10000),
             randomDoubleBetween(0.1, 1.0, true),
             between(0, 1000),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleOperatorTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DocBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.test.ESTestCase;
+
+public class RemoteFetchHandleOperatorTests extends ESTestCase {
+    public void testEncodesDocColumnIntoRemoteFetchHandles() {
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TestBlockFactory.getNonBreakingInstance(), null);
+        Page input = null;
+        Page output = null;
+        try (
+            DocBlock.Builder docBuilder = DocBlock.newBlockBuilder(driverContext.blockFactory(), 2);
+            IntBlock.Builder sortBuilder = driverContext.blockFactory().newIntBlockBuilder(2);
+            RemoteFetchHandleOperator operator = new RemoteFetchHandleOperator(driverContext, "node-a", "session-a", 0)
+        ) {
+            docBuilder.appendShard(1).appendSegment(2).appendDoc(10);
+            docBuilder.appendShard(3).appendSegment(4).appendDoc(20);
+            sortBuilder.appendInt(100);
+            sortBuilder.appendInt(200);
+            input = new Page(docBuilder.build(), sortBuilder.build());
+
+            operator.addInput(input);
+            input = null;
+            output = operator.getOutput();
+
+            BytesRefBlock handles = output.getBlock(0);
+            assertEquals(2, handles.getPositionCount());
+            assertEquals(new RemoteFetchHandle("node-a", "session-a", 1, 2, 10), decode(handles, 0));
+            assertEquals(new RemoteFetchHandle("node-a", "session-a", 3, 4, 20), decode(handles, 1));
+
+            IntBlock sortValues = output.getBlock(1);
+            assertEquals(100, sortValues.getInt(0));
+            assertEquals(200, sortValues.getInt(1));
+        } finally {
+            if (input != null) {
+                input.releaseBlocks();
+            }
+            if (output != null) {
+                output.releaseBlocks();
+            }
+        }
+    }
+
+    private static RemoteFetchHandle decode(BytesRefBlock handles, int position) {
+        BytesRef scratch = new BytesRef();
+        return RemoteFetchHandle.fromBytesRef(handles.getBytesRef(handles.getFirstValueIndex(position), scratch));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchHandleTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class RemoteFetchHandleTests extends ESTestCase {
+    public void testBytesRefRoundTrip() {
+        RemoteFetchHandle handle = randomHandle();
+
+        BytesRef encoded = handle.toBytesRef();
+
+        assertEquals(handle, RemoteFetchHandle.fromBytesRef(encoded));
+    }
+
+    public void testWriteableRoundTrip() throws IOException {
+        RemoteFetchHandle handle = randomHandle();
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            handle.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                assertEquals(handle, RemoteFetchHandle.READER.read(in));
+            }
+        }
+    }
+
+    private RemoteFetchHandle randomHandle() {
+        return new RemoteFetchHandle(
+            randomAlphaOfLengthBetween(5, 12),
+            randomAlphaOfLengthBetween(5, 16),
+            randomIntBetween(0, 1024),
+            randomIntBetween(0, 4096),
+            randomIntBetween(0, 1 << 20)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchOperatorTests.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.capabilities.ConfigurationAware;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RemoteFetchOperatorTests extends ESTestCase {
+    public void testFetchesAcrossNodesAndReassemblesInInputOrder() {
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TestBlockFactory.getNonBreakingInstance(), null);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        List<RemoteFetchService.FetchField> fields = List.of(
+            new RemoteFetchService.FetchField("salary", DataType.INTEGER),
+            new RemoteFetchService.FetchField("name", DataType.KEYWORD)
+        );
+        List<Attribute> outputFields = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "salary", DataType.INTEGER),
+            new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD)
+        );
+        AtomicInteger requests = new AtomicInteger();
+        RemoteFetchOperator.Client client = (nodeId, request, listener) -> {
+            requests.incrementAndGet();
+            switch (nodeId) {
+                case "node-a" -> {
+                    assertEquals("session-a", request.sessionId());
+                    assertEquals(List.of(11, 33), request.handles().stream().map(RemoteFetchHandle::doc).toList());
+                    listener.onResponse(List.of(page(driverContext, 10, "a"), page(driverContext, 30, "c")));
+                }
+                case "node-b" -> {
+                    assertEquals("session-b", request.sessionId());
+                    assertEquals(List.of(22), request.handles().stream().map(RemoteFetchHandle::doc).toList());
+                    listener.onResponse(List.of(page(driverContext, 20, "b")));
+                }
+                default -> listener.onFailure(new IllegalStateException("unexpected node [" + nodeId + "]"));
+            }
+        };
+
+        Page input = null;
+        Page output = null;
+        try (
+            RemoteFetchOperator operator = new RemoteFetchOperator(
+                driverContext,
+                threadContext,
+                0,
+                fields,
+                outputFields,
+                null,
+                ConfigurationAware.CONFIGURATION_MARKER,
+                2,
+                client
+            )
+        ) {
+            input = new Page(handles(driverContext), carry(driverContext));
+            operator.addInput(input);
+            input = null;
+            output = operator.getOutput();
+
+            assertNotNull(output);
+            assertEquals(4, output.getBlockCount());
+            assertEquals(2, requests.get());
+
+            IntBlock carryValues = output.getBlock(1);
+            assertEquals(100, carryValues.getInt(0));
+            assertEquals(200, carryValues.getInt(1));
+            assertEquals(300, carryValues.getInt(2));
+
+            IntBlock fetchedInts = output.getBlock(2);
+            assertEquals(10, fetchedInts.getInt(0));
+            assertEquals(20, fetchedInts.getInt(1));
+            assertEquals(30, fetchedInts.getInt(2));
+
+            BytesRefBlock fetchedStrings = output.getBlock(3);
+            assertEquals("a", utf8(fetchedStrings, 0));
+            assertEquals("b", utf8(fetchedStrings, 1));
+            assertEquals("c", utf8(fetchedStrings, 2));
+        } finally {
+            if (input != null) {
+                input.releaseBlocks();
+            }
+            if (output != null) {
+                output.releaseBlocks();
+            }
+        }
+    }
+
+    public void testFilteredFetchDropsRowsAndRemapsPositions() {
+        DriverContext driverContext = new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, TestBlockFactory.getNonBreakingInstance(), null);
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        List<RemoteFetchService.FetchField> fields = List.of(
+            new RemoteFetchService.FetchField("salary", DataType.INTEGER),
+            new RemoteFetchService.FetchField("name", DataType.KEYWORD)
+        );
+        List<Attribute> outputFields = List.of(
+            new ReferenceAttribute(Source.EMPTY, null, "salary", DataType.INTEGER),
+            new ReferenceAttribute(Source.EMPTY, null, "name", DataType.KEYWORD)
+        );
+        RemoteFetchOperator.Client client = (nodeId, request, listener) -> {
+            switch (nodeId) {
+                case "node-a" -> {
+                    // sent handles [h0, h1], filter keeps only h1 (original offset 1)
+                    listener.onResponse(List.of(pageWithPosition(driverContext, 30, "c", 1)));
+                }
+                case "node-b" -> {
+                    // sent handle [h0], filter keeps it (original offset 0)
+                    listener.onResponse(List.of(pageWithPosition(driverContext, 20, "b", 0)));
+                }
+                default -> listener.onFailure(new IllegalStateException("unexpected node [" + nodeId + "]"));
+            }
+        };
+
+        Page input = null;
+        Page output = null;
+        try (
+            RemoteFetchOperator operator = new RemoteFetchOperator(
+                driverContext,
+                threadContext,
+                0,
+                fields,
+                outputFields,
+                null,
+                ConfigurationAware.CONFIGURATION_MARKER,
+                2,
+                client
+            )
+        ) {
+            input = new Page(handles(driverContext), carry(driverContext));
+            operator.addInput(input);
+            input = null;
+            output = operator.getOutput();
+
+            assertNotNull(output);
+            // row 0 (node-a, offset 0) was filtered out, so only 2 rows survive
+            assertEquals(2, output.getPositionCount());
+            assertEquals(4, output.getBlockCount());
+
+            // carry column: row 1 (node-b, offset 0) and row 2 (node-a, offset 1) survive
+            IntBlock carryValues = output.getBlock(1);
+            assertEquals(200, carryValues.getInt(0));
+            assertEquals(300, carryValues.getInt(1));
+
+            IntBlock fetchedInts = output.getBlock(2);
+            assertEquals(20, fetchedInts.getInt(0));
+            assertEquals(30, fetchedInts.getInt(1));
+
+            BytesRefBlock fetchedStrings = output.getBlock(3);
+            assertEquals("b", utf8(fetchedStrings, 0));
+            assertEquals("c", utf8(fetchedStrings, 1));
+        } finally {
+            if (input != null) {
+                input.releaseBlocks();
+            }
+            if (output != null) {
+                output.releaseBlocks();
+            }
+        }
+    }
+
+    private static Page page(DriverContext driverContext, int intValue, String stringValue) {
+        try (
+            IntBlock.Builder intBuilder = driverContext.blockFactory().newIntBlockBuilder(1);
+            BytesRefBlock.Builder stringBuilder = driverContext.blockFactory().newBytesRefBlockBuilder(1)
+        ) {
+            intBuilder.appendInt(intValue);
+            stringBuilder.appendBytesRef(new BytesRef(stringValue));
+            return new Page(intBuilder.build(), stringBuilder.build());
+        }
+    }
+
+    private static Page pageWithPosition(DriverContext driverContext, int intValue, String stringValue, int originalPosition) {
+        try (
+            IntBlock.Builder intBuilder = driverContext.blockFactory().newIntBlockBuilder(1);
+            BytesRefBlock.Builder stringBuilder = driverContext.blockFactory().newBytesRefBlockBuilder(1);
+            IntBlock.Builder posBuilder = driverContext.blockFactory().newIntBlockBuilder(1)
+        ) {
+            intBuilder.appendInt(intValue);
+            stringBuilder.appendBytesRef(new BytesRef(stringValue));
+            posBuilder.appendInt(originalPosition);
+            return new Page(intBuilder.build(), stringBuilder.build(), posBuilder.build());
+        }
+    }
+
+    private static BytesRefBlock handles(DriverContext driverContext) {
+        try (BytesRefBlock.Builder builder = driverContext.blockFactory().newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new RemoteFetchHandle("node-a", "session-a", 1, 0, 11).toBytesRef());
+            builder.appendBytesRef(new RemoteFetchHandle("node-b", "session-b", 2, 0, 22).toBytesRef());
+            builder.appendBytesRef(new RemoteFetchHandle("node-a", "session-a", 1, 0, 33).toBytesRef());
+            return builder.build();
+        }
+    }
+
+    private static IntBlock carry(DriverContext driverContext) {
+        try (IntBlock.Builder builder = driverContext.blockFactory().newIntBlockBuilder(3)) {
+            builder.appendInt(100);
+            builder.appendInt(200);
+            builder.appendInt(300);
+            return builder.build();
+        }
+    }
+
+    private static String utf8(BytesRefBlock block, int position) {
+        return block.getBytesRef(block.getFirstValueIndex(position), new BytesRef()).utf8ToString();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchPlannerTests.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
+import org.elasticsearch.xpack.esql.TestAnalyzer;
+import org.elasticsearch.xpack.esql.analysis.Analyzer;
+import org.elasticsearch.xpack.esql.analysis.PreAnalyzer;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.optimizer.GoldenTestCase;
+import org.elasticsearch.xpack.esql.optimizer.LocalPhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalPlanOptimizer;
+import org.elasticsearch.xpack.esql.plan.EsqlStatement;
+import org.elasticsearch.xpack.esql.plan.IndexPattern;
+import org.elasticsearch.xpack.esql.plan.QuerySettings;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.EmitRemoteFetchHandleExec;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeSinkExec;
+import org.elasticsearch.xpack.esql.plan.physical.ExchangeSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchExec;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchSourceExec;
+import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.planner.mapper.Mapper;
+import org.elasticsearch.xpack.esql.session.Configuration;
+import org.elasticsearch.xpack.esql.session.Versioned;
+import org.elasticsearch.xpack.esql.stats.SearchStats;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.CSV_DATASET;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_PARSER;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.analyzer;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class RemoteFetchPlannerTests extends ESTestCase {
+    public void testCoordinatorPlanIsRewrittenToRemoteFetch() {
+        PlannedQuery planned = planQuery("""
+            FROM employees
+            | KEEP hire_date, salary
+            | SORT hire_date
+            | LIMIT 5
+            """);
+        Tuple<PhysicalPlan, PhysicalPlan> split = PlannerUtils.breakPlanBetweenCoordinatorAndDataNode(
+            planned.physicalPlan(),
+            planned.configuration()
+        );
+
+        PhysicalPlan coordinatorPlan = RemoteFetchPlanner.planCoordinatorTopN(
+            contextFactory(planned.configuration()),
+            split.v1(),
+            (ExchangeSinkExec) split.v2()
+        ).orElseThrow();
+
+        ProjectExec projectExec = (ProjectExec) coordinatorPlan;
+        assertThat(projectExec.child(), instanceOf(RemoteFetchExec.class));
+
+        RemoteFetchExec remoteFetchExec = (RemoteFetchExec) projectExec.child();
+        assertThat(remoteFetchExec.attributesToFetch().stream().map(Attribute::name).toList(), contains("salary"));
+
+        ExchangeSourceExec exchangeSource = singleValue(remoteFetchExec.child().collect(ExchangeSourceExec.class));
+        assertTrue(
+            exchangeSource.output().stream().anyMatch(attribute -> RemoteFetchPlanner.REMOTE_FETCH_HANDLE_NAME.equals(attribute.name()))
+        );
+        assertFalse(exchangeSource.output().stream().anyMatch(EsQueryExec::isDocAttribute));
+    }
+
+    public void testReductionPlanEmitsRemoteFetchHandles() {
+        PlannedQuery planned = planQuery("""
+            FROM employees
+            | KEEP hire_date, salary
+            | SORT hire_date
+            | LIMIT 5
+            """);
+        Tuple<PhysicalPlan, PhysicalPlan> split = PlannerUtils.breakPlanBetweenCoordinatorAndDataNode(
+            planned.physicalPlan(),
+            planned.configuration()
+        );
+
+        ReductionPlan reductionPlan = RemoteFetchPlanner.planReduceDriverTopN(
+            contextFactory(planned.configuration()),
+            (ExchangeSinkExec) split.v2()
+        ).orElseThrow();
+
+        assertThat(reductionPlan.nodeReducePlan().child(), instanceOf(EmitRemoteFetchHandleExec.class));
+        EmitRemoteFetchHandleExec emitRemoteFetchHandleExec = (EmitRemoteFetchHandleExec) reductionPlan.nodeReducePlan().child();
+        assertTrue(EsQueryExec.isDocAttribute(emitRemoteFetchHandleExec.sourceAttribute()));
+        assertEquals(RemoteFetchPlanner.REMOTE_FETCH_HANDLE_NAME, emitRemoteFetchHandleExec.handleAttribute().name());
+        assertTrue(reductionPlan.dataNodePlan().output().stream().anyMatch(EsQueryExec::isDocAttribute));
+        assertFalse(reductionPlan.nodeReducePlan().output().stream().anyMatch(EsQueryExec::isDocAttribute));
+    }
+
+    public void testChainedPushdownsReuseRemoteFetchPositionIdentity() {
+        ReferenceAttribute handleAttribute = new ReferenceAttribute(
+            Source.EMPTY,
+            null,
+            RemoteFetchPlanner.REMOTE_FETCH_HANDLE_NAME,
+            DataType.KEYWORD
+        );
+        ReferenceAttribute fetchedAttribute = new ReferenceAttribute(Source.EMPTY, null, "salary", DataType.LONG);
+        ReferenceAttribute existingPositionAttribute = new ReferenceAttribute(
+            Source.EMPTY,
+            null,
+            RemoteFetchPlanner.REMOTE_FETCH_POSITION_NAME,
+            DataType.INTEGER
+        );
+        PhysicalPlan existingPushdown = new ProjectExec(
+            Source.EMPTY,
+            new RemoteFetchSourceExec(Source.EMPTY, List.of(fetchedAttribute, existingPositionAttribute)),
+            List.of(fetchedAttribute, existingPositionAttribute)
+        );
+        RemoteFetchExec remoteFetchExec = new RemoteFetchExec(
+            Source.EMPTY,
+            new ExchangeSourceExec(Source.EMPTY, List.of(handleAttribute), false),
+            handleAttribute,
+            List.of(fetchedAttribute),
+            List.of(fetchedAttribute),
+            existingPushdown
+        );
+        ProjectExec nextPushdown = new ProjectExec(Source.EMPTY, remoteFetchExec.child(), List.of(fetchedAttribute));
+        RemoteFetchExec appendedPushdownRemoteFetch = invokeAppendPushdown(remoteFetchExec, nextPushdown);
+        assertNotNull(appendedPushdownRemoteFetch.pushdownPlan());
+
+        Set<NameId> positionAttributeIds = new HashSet<>();
+        collectPositionAttributeIds(appendedPushdownRemoteFetch.pushdownPlan(), positionAttributeIds);
+        assertEquals(1, positionAttributeIds.size());
+    }
+
+    public void testPushdownPositionStrippingKeepsUserNamedField() {
+        ReferenceAttribute handleAttribute = new ReferenceAttribute(
+            Source.EMPTY,
+            null,
+            RemoteFetchPlanner.REMOTE_FETCH_HANDLE_NAME,
+            DataType.KEYWORD
+        );
+        ReferenceAttribute fetchedAttribute = new ReferenceAttribute(Source.EMPTY, null, "salary", DataType.LONG);
+        ReferenceAttribute userNamedPositionAttribute = new ReferenceAttribute(
+            Source.EMPTY,
+            null,
+            RemoteFetchPlanner.REMOTE_FETCH_POSITION_NAME,
+            DataType.LONG
+        );
+        RemoteFetchExec remoteFetchExec = new RemoteFetchExec(
+            Source.EMPTY,
+            new ExchangeSourceExec(Source.EMPTY, List.of(handleAttribute), false),
+            handleAttribute,
+            List.of(fetchedAttribute, userNamedPositionAttribute),
+            List.of(fetchedAttribute, userNamedPositionAttribute),
+            null
+        );
+        ProjectExec pushdown = new ProjectExec(
+            Source.EMPTY,
+            remoteFetchExec.child(),
+            List.of(fetchedAttribute, userNamedPositionAttribute)
+        );
+        RemoteFetchExec appendedPushdownRemoteFetch = invokeAppendPushdown(remoteFetchExec, pushdown);
+
+        assertTrue(
+            appendedPushdownRemoteFetch.fetchedOutputAttributes().stream().anyMatch(a -> a.id().equals(userNamedPositionAttribute.id()))
+        );
+    }
+
+    public void testLimitBoundaryStillPushesDownFilter() {
+        PlannedQuery planned = planQuery("""
+            FROM employees
+            | SORT hire_date DESC
+            | LIMIT 5
+            | WHERE salary > 1000
+            | KEEP hire_date, salary
+            """);
+        Tuple<PhysicalPlan, PhysicalPlan> split = PlannerUtils.breakPlanBetweenCoordinatorAndDataNode(
+            planned.physicalPlan(),
+            planned.configuration()
+        );
+
+        PhysicalPlan coordinatorPlan = RemoteFetchPlanner.planCoordinatorTopN(
+            contextFactory(planned.configuration()),
+            split.v1(),
+            (ExchangeSinkExec) split.v2()
+        ).orElseThrow();
+
+        RemoteFetchExec remoteFetchExec = singleValue(coordinatorPlan.collect(RemoteFetchExec.class));
+        assertNotNull(remoteFetchExec.pushdownPlan());
+        assertFalse(remoteFetchExec.pushdownPlan().collect(FilterExec.class).isEmpty());
+        assertTrue(remoteFetchExec.child().collect(FilterExec.class).isEmpty());
+    }
+
+    private PlannedQuery planQuery(String query) {
+        TransportVersion transportVersion = TransportVersion.current();
+        EsqlStatement statement = TEST_PARSER.createStatement(query);
+        LogicalPlan parsedPlan = statement.plan();
+        TestAnalyzer testAnalyzer = analyzer().addLanguagesLookup()
+            .addAnalysisTestsEnrichResolution()
+            .addAnalysisTestsInferenceResolution()
+            .minimumTransportVersion(transportVersion)
+            .unmappedResolution(statement.setting(QuerySettings.UNMAPPED_FIELDS));
+        GoldenTestCase.loadIndexResolution(testDatasets(parsedPlan))
+            .forEach((pattern, resolution) -> testAnalyzer.addIndex(pattern.indexPattern(), resolution));
+        Analyzer analyzer = testAnalyzer.buildAnalyzer();
+        Configuration configuration = analyzer.context().configuration();
+        LogicalPlan logicalPlan = new LogicalPlanOptimizer(
+            new LogicalOptimizerContext(configuration, configuration.newFoldContext(), transportVersion)
+        ).optimize(analyzer.analyze(parsedPlan));
+        PhysicalPlan physicalPlan = new PhysicalPlanOptimizer(new PhysicalOptimizerContext(configuration, transportVersion)).optimize(
+            new Mapper().map(new Versioned<>(logicalPlan, transportVersion))
+        );
+        return new PlannedQuery(configuration, physicalPlan);
+    }
+
+    private static Function<SearchStats, LocalPhysicalOptimizerContext> contextFactory(Configuration configuration) {
+        return stats -> new LocalPhysicalOptimizerContext(
+            PlannerSettings.DEFAULTS,
+            new EsqlFlags(false),
+            configuration,
+            configuration.newFoldContext(),
+            stats
+        );
+    }
+
+    private static Map<IndexPattern, CsvTestsDataLoader.MultiIndexTestDataset> testDatasets(LogicalPlan parsed) {
+        var preAnalysis = new PreAnalyzer().preAnalyze(parsed);
+        if (preAnalysis.indexes().isEmpty()) {
+            return Map.of(
+                new IndexPattern(Source.EMPTY, "employees"),
+                CsvTestsDataLoader.MultiIndexTestDataset.of(CSV_DATASET.get("employees"))
+            );
+        }
+
+        List<String> missing = new ArrayList<>();
+        Map<IndexPattern, CsvTestsDataLoader.MultiIndexTestDataset> all = new HashMap<>();
+        for (IndexPattern indexPattern : preAnalysis.indexes().keySet()) {
+            List<CsvTestsDataLoader.TestDataset> datasets = new ArrayList<>();
+            String indexName = indexPattern.indexPattern();
+            if (indexName.endsWith("*")) {
+                String indexPrefix = indexName.substring(0, indexName.length() - 1);
+                for (var entry : CSV_DATASET.entrySet()) {
+                    if (entry.getKey().startsWith(indexPrefix)) {
+                        datasets.add(entry.getValue());
+                    }
+                }
+            } else {
+                for (String index : indexName.split(",")) {
+                    var dataset = CSV_DATASET.get(index);
+                    if (dataset == null) {
+                        throw new IllegalArgumentException("unknown CSV dataset for table [" + index + "]");
+                    }
+                    datasets.add(dataset);
+                }
+            }
+            if (datasets.isEmpty() == false) {
+                all.put(indexPattern, new CsvTestsDataLoader.MultiIndexTestDataset(indexName, datasets));
+            } else {
+                missing.add(indexName);
+            }
+        }
+        if (all.isEmpty()) {
+            throw new IllegalArgumentException("Found no CSV datasets for table [" + preAnalysis.indexes() + "]");
+        }
+        if (missing.isEmpty() == false) {
+            throw new IllegalArgumentException("Did not find datasets for tables: " + missing);
+        }
+        return all;
+    }
+
+    private static <T> T singleValue(List<T> values) {
+        assertEquals(1, values.size());
+        return values.get(0);
+    }
+
+    private static void collectPositionAttributeIds(PhysicalPlan plan, Set<NameId> ids) {
+        for (Attribute attribute : plan.output()) {
+            if (RemoteFetchPlanner.REMOTE_FETCH_POSITION_NAME.equals(attribute.name())) {
+                ids.add(attribute.id());
+            }
+        }
+        for (PhysicalPlan child : plan.children()) {
+            collectPositionAttributeIds(child, ids);
+        }
+    }
+
+    private static RemoteFetchExec invokeAppendPushdown(RemoteFetchExec remoteFetchExec, UnaryExec pushdownNode) {
+        return RemoteFetchPlanner.appendPushdown(remoteFetchExec, pushdownNode);
+    }
+
+    private record PlannedQuery(Configuration configuration, PhysicalPlan physicalPlan) {}
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchServiceRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchServiceRequestTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.ConfigurationTestUtils.randomConfiguration;
+
+public class RemoteFetchServiceRequestTests extends AbstractWireSerializingTestCase<RemoteFetchService.Request> {
+    @Override
+    protected Writeable.Reader<RemoteFetchService.Request> instanceReader() {
+        return RemoteFetchService.Request::new;
+    }
+
+    @Override
+    protected RemoteFetchService.Request createTestInstance() {
+        return new RemoteFetchService.Request(
+            randomAlphaOfLengthBetween(5, 12),
+            randomList(1, 5, this::randomField),
+            randomList(0, 8, this::randomHandle),
+            randomConfiguration()
+        );
+    }
+
+    @Override
+    protected RemoteFetchService.Request mutateInstance(RemoteFetchService.Request instance) throws IOException {
+        return switch (between(0, 3)) {
+            case 0 -> new RemoteFetchService.Request(
+                randomAlphaOfLengthBetween(5, 12),
+                instance.fields(),
+                instance.handles(),
+                instance.configuration()
+            );
+            case 1 -> new RemoteFetchService.Request(
+                instance.sessionId(),
+                randomList(1, 5, this::randomField),
+                instance.handles(),
+                instance.configuration()
+            );
+            case 2 -> new RemoteFetchService.Request(
+                instance.sessionId(),
+                instance.fields(),
+                instance.handles().isEmpty()
+                    ? randomList(1, 8, this::randomHandle)
+                    : randomValueOtherThan(instance.handles(), () -> randomList(0, 8, this::randomHandle)),
+                instance.configuration()
+            );
+            case 3 -> new RemoteFetchService.Request(
+                instance.sessionId(),
+                instance.fields(),
+                instance.handles(),
+                randomValueOtherThan(instance.configuration(), org.elasticsearch.xpack.esql.ConfigurationTestUtils::randomConfiguration)
+            );
+            default -> throw new AssertionError("unexpected mutation branch");
+        };
+    }
+
+    private RemoteFetchService.FetchField randomField() {
+        DataType dataType = randomFrom(DataType.KEYWORD, DataType.LONG, DataType.INTEGER, DataType.DOUBLE, DataType.BOOLEAN, DataType.TEXT);
+        return new RemoteFetchService.FetchField(randomAlphaOfLengthBetween(3, 10), dataType);
+    }
+
+    private RemoteFetchHandle randomHandle() {
+        return new RemoteFetchHandle(
+            randomAlphaOfLengthBetween(5, 12),
+            randomAlphaOfLengthBetween(5, 12),
+            randomIntBetween(0, 32),
+            randomIntBetween(0, 16),
+            randomIntBetween(0, 4096)
+        );
+    }
+
+    public void testValidateRejectsEmptyFields() {
+        RemoteFetchService.Request request = new RemoteFetchService.Request(
+            "session-1",
+            List.of(),
+            List.of(new RemoteFetchHandle("node-1", "session-1", 0, 0, 0)),
+            randomConfiguration()
+        );
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> request.validateForNode("node-1"));
+        assertEquals("remote fetch requires at least one field", e.getMessage());
+    }
+
+    public void testValidateRejectsSessionMismatch() {
+        RemoteFetchService.Request request = new RemoteFetchService.Request(
+            "session-1",
+            List.of(new RemoteFetchService.FetchField("field", DataType.KEYWORD)),
+            List.of(new RemoteFetchHandle("node-1", "session-2", 0, 0, 0)),
+            randomConfiguration()
+        );
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> request.validateForNode("node-1"));
+        assertEquals("remote fetch request session [session-1] does not match handle session [session-2]", e.getMessage());
+    }
+
+    public void testValidateRejectsNodeMismatch() {
+        RemoteFetchService.Request request = new RemoteFetchService.Request(
+            "session-1",
+            List.of(new RemoteFetchService.FetchField("field", DataType.KEYWORD)),
+            List.of(new RemoteFetchHandle("node-2", "session-1", 0, 0, 0)),
+            randomConfiguration()
+        );
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> request.validateForNode("node-1"));
+        assertEquals("remote fetch handle node [node-2] does not match local node [node-1]", e.getMessage());
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchServiceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/RemoteFetchServiceTests.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DocBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.IndexedByShardIdFromSingleton;
+import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
+import org.elasticsearch.compute.test.NoOpReleasable;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.mapper.SourceLoader;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.search.internal.AliasFilter;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.esql.ConfigurationTestUtils;
+import org.elasticsearch.xpack.esql.SerializationTestUtils;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.plan.physical.FilterExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.RemoteFetchSourceExec;
+import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.planner.PlannerSettings;
+import org.elasticsearch.xpack.esql.session.Configuration;
+import org.junit.After;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class RemoteFetchServiceTests extends MapperServiceTestCase {
+    private Directory directory;
+    private IndexReader reader;
+    private BlockFactory blockFactory;
+
+    public void testInputPagePreservesHandleCoordinates() {
+        blockFactory = blockFactory();
+        List<RemoteFetchHandle> handles = List.of(
+            new RemoteFetchHandle("node-1", "session-1", 3, 7, 11),
+            new RemoteFetchHandle("node-1", "session-1", 5, 13, 17)
+        );
+
+        Page page = RemoteFetchService.inputPage(blockFactory, handles);
+        try {
+            DocBlock docBlock = page.getBlock(0);
+            assertThat(docBlock.asVector().shards().getInt(0), equalTo(3));
+            assertThat(docBlock.asVector().segments().getInt(0), equalTo(7));
+            assertThat(docBlock.asVector().docs().getInt(0), equalTo(11));
+            assertThat(docBlock.asVector().shards().getInt(1), equalTo(5));
+            assertThat(docBlock.asVector().segments().getInt(1), equalTo(13));
+            assertThat(docBlock.asVector().docs().getInt(1), equalTo(17));
+        } finally {
+            page.releaseBlocks();
+        }
+    }
+
+    public void testExecuteFetchLoadsRequestedFieldsInHandleOrder() throws Exception {
+        blockFactory = blockFactory();
+        MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("k").field("type", "keyword").endObject();
+            b.startObject("n").field("type", "long").endObject();
+        }));
+
+        directory = newDirectory();
+        try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig())) {
+            addDoc(writer, "k0", 10);
+            addDoc(writer, "k1", 20);
+            addDoc(writer, "k2", 30);
+        }
+        reader = DirectoryReader.open(directory);
+
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(mapperService, null);
+        EsPhysicalOperationProviders.DefaultShardContext fetchShardContext = new EsPhysicalOperationProviders.DefaultShardContext(
+            0,
+            new NoOpReleasable(),
+            searchExecutionContext,
+            AliasFilter.EMPTY
+        );
+        List<ValuesSourceReaderOperator.FieldInfo> fieldInfos = RemoteFetchService.buildFieldInfos(
+            List.of(new RemoteFetchService.FetchField("k", DataType.KEYWORD), new RemoteFetchService.FetchField("n", DataType.LONG)),
+            new IndexedByShardIdFromSingleton<>(fetchShardContext),
+            PlannerSettings.DEFAULTS
+        );
+
+        List<Page> pages = RemoteFetchService.executeFetch(
+            List.of(
+                new RemoteFetchHandle("node-1", "session-1", 0, 0, 2),
+                new RemoteFetchHandle("node-1", "session-1", 0, 0, 0),
+                new RemoteFetchHandle("node-1", "session-1", 0, 0, 1)
+            ),
+            fieldInfos,
+            new IndexedByShardIdFromSingleton<>(
+                new ValuesSourceReaderOperator.ShardContext(reader, sourcePaths -> SourceLoader.FROM_STORED_SOURCE, 0.2)
+            ),
+            BigArrays.NON_RECYCLING_INSTANCE,
+            blockFactory,
+            LocalCircuitBreaker.SizeSettings.DEFAULT_SETTINGS,
+            PlannerSettings.DEFAULTS
+        );
+
+        try {
+            assertThat(pages.size(), equalTo(1));
+            Page page = pages.getFirst();
+            BytesRef scratch = new BytesRef();
+            assertThat(page.getBlockCount(), equalTo(2));
+            assertThat(
+                page.<org.elasticsearch.compute.data.BytesRefBlock>getBlock(0).getBytesRef(0, scratch).utf8ToString(),
+                equalTo("k2")
+            );
+            assertThat(
+                page.<org.elasticsearch.compute.data.BytesRefBlock>getBlock(0).getBytesRef(1, scratch).utf8ToString(),
+                equalTo("k0")
+            );
+            assertThat(
+                page.<org.elasticsearch.compute.data.BytesRefBlock>getBlock(0).getBytesRef(2, scratch).utf8ToString(),
+                equalTo("k1")
+            );
+            assertThat(page.<org.elasticsearch.compute.data.LongBlock>getBlock(1).getLong(0), equalTo(30L));
+            assertThat(page.<org.elasticsearch.compute.data.LongBlock>getBlock(1).getLong(1), equalTo(10L));
+            assertThat(page.<org.elasticsearch.compute.data.LongBlock>getBlock(1).getLong(2), equalTo(20L));
+        } finally {
+            Releasables.closeExpectNoException(Releasables.wrap(Iterators.map(pages.iterator(), page -> page::releaseBlocks)));
+        }
+    }
+
+    public void testExecutePushdownForExchangeSupportsFilterExec() {
+        blockFactory = blockFactory();
+        RemoteFetchService remoteFetchService = newRemoteFetchService(blockFactory);
+        ReferenceAttribute fetchedAttribute = new ReferenceAttribute(Source.EMPTY, null, "n", DataType.LONG);
+        ReferenceAttribute positionAttribute = new ReferenceAttribute(Source.EMPTY, null, "_remote_fetch_position", DataType.INTEGER);
+        PhysicalPlan pushdownPlan = new FilterExec(
+            Source.EMPTY,
+            new RemoteFetchSourceExec(Source.EMPTY, List.of(fetchedAttribute, positionAttribute)),
+            new GreaterThan(Source.EMPTY, fetchedAttribute, new Literal(Source.EMPTY, 15L, DataType.LONG))
+        );
+        Page inputPage;
+        try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(3)) {
+            builder.appendLong(10L);
+            builder.appendLong(20L);
+            builder.appendLong(30L);
+            inputPage = new Page(builder.build());
+        }
+
+        List<Page> outputPages = remoteFetchService.executePushdownForExchange(
+            List.of(inputPage),
+            pushdownPlan,
+            new IndexedByShardIdFromSingleton<>(
+                Mockito.mock(EsPhysicalOperationProviders.ShardContext.class, Mockito.withSettings().stubOnly())
+            )
+        );
+
+        try {
+            assertThat(outputPages.size(), equalTo(1));
+            Page output = outputPages.getFirst();
+            assertThat(output.getPositionCount(), equalTo(2));
+            assertThat(output.getBlockCount(), equalTo(2));
+            assertThat(output.<LongBlock>getBlock(0).getLong(0), equalTo(20L));
+            assertThat(output.<LongBlock>getBlock(0).getLong(1), equalTo(30L));
+            assertThat(output.<IntBlock>getBlock(1).getInt(0), equalTo(1));
+            assertThat(output.<IntBlock>getBlock(1).getInt(1), equalTo(2));
+        } finally {
+            Releasables.closeExpectNoException(Releasables.wrap(Iterators.map(outputPages.iterator(), page -> page::releaseBlocks)));
+        }
+    }
+
+    public void testExchangeSetupRequestRoundTripsPushdownPlanWithFieldAttributes() throws IOException {
+        FieldAttribute fieldAttribute = new FieldAttribute(
+            Source.EMPTY,
+            "n",
+            new EsField("n", DataType.LONG, Map.of(), false, EsField.TimeSeriesFieldType.NONE)
+        );
+        Configuration configuration = ConfigurationTestUtils.randomConfiguration();
+        PhysicalPlan pushdownPlan = new RemoteFetchSourceExec(Source.EMPTY, List.of(fieldAttribute));
+        RemoteFetchService.ExchangeSetupRequest request = new RemoteFetchService.ExchangeSetupRequest(
+            "session-1",
+            List.of(new RemoteFetchService.FetchField("n", DataType.LONG)),
+            pushdownPlan,
+            configuration,
+            "clientToServer-1",
+            "serverToClient-1"
+        );
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            request.writeTo(out);
+            try (
+                StreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), SerializationTestUtils.writableRegistry())
+            ) {
+                RemoteFetchService.ExchangeSetupRequest copy = new RemoteFetchService.ExchangeSetupRequest(in);
+                assertThat(copy.sessionId(), equalTo("session-1"));
+                assertThat(copy.fields(), equalTo(List.of(new RemoteFetchService.FetchField("n", DataType.LONG))));
+                assertThat(copy.pushdownPlan() instanceof RemoteFetchSourceExec, equalTo(true));
+                assertThat(copy.configuration(), equalTo(configuration));
+                assertThat(copy.clientToServerId(), equalTo("clientToServer-1"));
+                assertThat(copy.serverToClientId(), equalTo("serverToClient-1"));
+            }
+        }
+    }
+
+    private static RemoteFetchService newRemoteFetchService(BlockFactory blockFactory) {
+        ClusterService clusterService = Mockito.mock(ClusterService.class, Mockito.withSettings().stubOnly());
+        Mockito.when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        ThreadPool threadPool = Mockito.mock(ThreadPool.class, Mockito.withSettings().stubOnly());
+        Mockito.when(threadPool.executor(Mockito.anyString())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        TransportService transportService = Mockito.mock(TransportService.class, Mockito.withSettings().stubOnly());
+        Mockito.when(transportService.getThreadPool()).thenReturn(threadPool);
+        PlannerSettings.Holder plannerSettings = Mockito.mock(PlannerSettings.Holder.class, Mockito.withSettings().stubOnly());
+        Mockito.when(plannerSettings.get()).thenReturn(PlannerSettings.DEFAULTS);
+        return new RemoteFetchService(
+            new TransportActionServices(
+                transportService,
+                null,
+                null,
+                clusterService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                plannerSettings,
+                null
+            ),
+            blockFactory.bigArrays(),
+            blockFactory
+        );
+    }
+
+    private static void addDoc(IndexWriter writer, String keyword, long number) throws IOException {
+        Document document = new Document();
+        document.add(new SortedDocValuesField("k", new BytesRef(keyword)));
+        document.add(new NumericDocValuesField("n", number));
+        writer.addDocument(document);
+    }
+
+    private BlockFactory blockFactory() {
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(4)).withCircuitBreaking();
+        return BlockFactory.builder(bigArrays).build();
+    }
+
+    @After
+    public void tearDownResources() throws Exception {
+        IOUtils.close(reader, directory);
+        if (blockFactory != null) {
+            assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+            assertThat(blockFactory.breaker().getTrippedCount(), equalTo(0L));
+            assertThat(blockFactory.breaker().getName(), equalTo(CircuitBreaker.REQUEST));
+        }
+        MockBigArrays.ensureAllArraysAreReleased();
+        super.tearDown();
+    }
+}


### PR DESCRIPTION
## Summary

Full coordinator story: planner, orchestration wiring, and TrackedSessions lifecycle.

- Add `RemoteFetchPlanner` for coordinator TopN planning and reduce-driver TopN planning
- Add `PlannerSettings.remoteFetchLateMaterialization()` setting
- Wire `TrackedSessions` lifecycle in `ComputeService.runQuery` with listener cleanup
- Thread `remoteFetchSessions` through `startComputeOnDataNodes` for per-node tracking
- Add `reductionPlan` 8-arg overload with `remoteFetchLateMaterialization` and `RemoteFetchPlanner` switch case
- Update `LocalExecutionPlanner` to accept `RemoteFetchService` and local node ID
- Extend `ReductionPlan` with `LocalPhysicalOptimization` field

Stack: 3/4
- PR 1: #148028 — Wire protocol + retention primitives
- PR 2: #148906 — Remote fetch service, operators, context ownership
- **PR 3 (this)**: Planner + coordinator orchestration
- PR 4: #148031 — Integration tests