### PR TITLE
[ESQL] Parquet: dictionary filter fast paths and per-row-group memo

### DIFF
--- a/docs/changelog/148918.yaml
+++ b/docs/changelog/148918.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 148918
+summary: "Parquet: dictionary filter fast paths and per-row-group memo"
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/OptimizedParquetColumnIterator.java
@@ -29,6 +29,7 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
@@ -38,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -161,6 +163,24 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
      */
     private final FilterPredicate triviallyPassesPredicate;
     private final WordMask survivorMask;
+    /**
+     * Memoizes the dictionary-match bitmap computed by {@link ParquetPushedExpressions} for
+     * every pushed leaf predicate, so the predicate is evaluated against the dictionary
+     * once per row group rather than once per batch. The underlying {@code BytesRefArray}
+     * is fixed for the lifetime of a row group (see {@code PageColumnReader#ensureCachedDictArray}),
+     * which is what makes the entries valid across batches.
+     *
+     * <p>Lifecycle by stamp, not by callback: {@link #dictionaryBitmapsForCurrentRowGroup}
+     * compares the cached row-group ordinal with the current one and wipes the map on a
+     * mismatch. This makes the cache self-invalidating — a missed wipe in {@code advanceRowGroup}
+     * (e.g. on the two-phase "all rows filtered, try next row group" retry path) cannot
+     * leak entries into a different row group's evaluation.
+     *
+     * <p>{@code null} when late materialization is off; in that case no dictionary fast path
+     * runs and the map would be pure overhead.
+     */
+    private final Map<Expression, boolean[]> dictionaryBitmaps;
+    private int dictionaryBitmapsRowGroup = -1;
     private long rowsEliminatedByLateMaterialization;
     /**
      * When {@code true}, row-group statistics prove every row in the current row group satisfies
@@ -231,6 +251,7 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         this.isPredicateColumn = classifyPredicateColumns(attributes, columnInfos, pushedExpressions);
         this.lateMaterialization = pushedExpressions != null;
         this.survivorMask = lateMaterialization ? new WordMask() : null;
+        this.dictionaryBitmaps = lateMaterialization ? new IdentityHashMap<>() : null;
         // Caller supplies null when late materialization is off; defensively also drop it here so
         // the trivially-passes check is gated by a single condition below.
         this.triviallyPassesPredicate = lateMaterialization ? triviallyPassesPredicate : null;
@@ -559,6 +580,24 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
     }
 
     /**
+     * Returns the per-row-group dictionary bitmap memo for the current {@link #rowGroupOrdinal},
+     * resetting it on a row-group transition. The memo is owned by the iterator and shared
+     * with {@link ParquetPushedExpressions#evaluateFilter}; the caller writes new bitmaps to
+     * it as predicates are evaluated and reads them on subsequent batches within the same
+     * row group. Returns {@code null} when late materialization is off.
+     */
+    private Map<Expression, boolean[]> dictionaryBitmapsForCurrentRowGroup() {
+        if (dictionaryBitmaps == null) {
+            return null;
+        }
+        if (dictionaryBitmapsRowGroup != rowGroupOrdinal) {
+            dictionaryBitmaps.clear();
+            dictionaryBitmapsRowGroup = rowGroupOrdinal;
+        }
+        return dictionaryBitmaps;
+    }
+
+    /**
      * Advances to the next surviving row group: applies the row-group statistics filter to skip
      * dropped row groups, then builds a {@link PrefetchedPageReadStore} from the prefetched
      * (or sync-fetched) bytes for the surviving row group. Triggers prefetch for the row group
@@ -574,6 +613,9 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
         // Loop is for the two-phase "all rows filtered out" case, where the current row group
         // contributes zero rows and we must immediately attempt the next surviving ordinal.
         // Single-phase always returns within the first iteration via the standard return below.
+        // No cache wipe needed here: dictionaryBitmapsForCurrentRowGroup() self-invalidates on
+        // a row-group ordinal mismatch, so any retry through this loop with a different
+        // rowGroupOrdinal will see a fresh map at the next evaluateFilter call.
         while (true) {
             int nextOrdinal = nextSurvivingRowGroupOrdinal(rowGroupOrdinal + 1);
             if (nextOrdinal >= reader.getRowGroups().size()) {
@@ -908,7 +950,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
                 }
                 predicateBlockMap.put(attributes.get(col).name(), predicateBlocks[col]);
             }
-            WordMask mask = pushedExpressions.evaluateFilter(predicateBlockMap, rowsToRead, survivorMask);
+            WordMask mask = pushedExpressions.evaluateFilter(
+                predicateBlockMap,
+                rowsToRead,
+                survivorMask,
+                dictionaryBitmapsForCurrentRowGroup()
+            );
             int survivorCount;
             int[] positions;
             if (mask == null) {
@@ -1597,7 +1644,12 @@ final class OptimizedParquetColumnIterator implements CloseableIterator<Page> {
             }
 
             // Phase 2: evaluate filter
-            WordMask mask = pushedExpressions.evaluateFilter(predicateBlockMap, rowsToRead, survivorMask);
+            WordMask mask = pushedExpressions.evaluateFilter(
+                predicateBlockMap,
+                rowsToRead,
+                survivorMask,
+                dictionaryBitmapsForCurrentRowGroup()
+            );
 
             int survivorCount = rowsToRead;
             int[] positions = null;

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -611,18 +611,12 @@ final class ParquetPushedExpressions {
     }
 
     /**
-     * Evaluates all held filter expressions against the given predicate blocks and returns
-     * a survivor mask indicating which rows pass all predicates. Returns {@code null} if
-     * all rows survive (no filtering needed), signaling that compaction can be skipped.
-     *
-     * @param predicateBlocks map of column name to decoded Block for predicate columns
-     * @param rowCount        the number of rows in the current batch
-     * @param reusable        a reusable WordMask instance to avoid allocation
-     * @return the survivor mask with bits set for passing rows, or null if all rows survive
-     */
-    /**
      * Evaluates a single expression against blocks decoded from specific columns. Used by
-     * multi-stage Phase 1 where each stage evaluates one expression at a time.
+     * multi-stage Phase 1 where each stage evaluates one expression at a time. The
+     * dictionary memoization cache is not threaded here because callers in this path do
+     * not own a row-group lifecycle that lines up with the cache's invalidation contract;
+     * the six-argument overload exists for completeness but is currently always invoked
+     * with a {@code null} cache.
      *
      * @param expr             the expression to evaluate
      * @param blocks           decoded blocks indexed by column position (may have nulls for non-stage columns)
@@ -638,33 +632,99 @@ final class ParquetPushedExpressions {
         int rowCount,
         @Nullable WordMask intermediateMask
     ) {
+        return evaluateSingleExpression(expr, blocks, attributes, rowCount, intermediateMask, null);
+    }
+
+    WordMask evaluateSingleExpression(
+        Expression expr,
+        Block[] blocks,
+        List<Attribute> attributes,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
         Map<String, Block> blockMap = new HashMap<>();
         for (int i = 0; i < blocks.length; i++) {
             if (blocks[i] != null && i < attributes.size()) {
                 blockMap.put(attributes.get(i).name(), blocks[i]);
             }
         }
-        return evaluateExpression(expr, blockMap, rowCount, intermediateMask);
+        return evaluateExpression(expr, blockMap, rowCount, intermediateMask, dictCache);
     }
 
     WordMask evaluateFilter(Map<String, Block> predicateBlocks, int rowCount, WordMask reusable) {
+        return evaluateFilter(predicateBlocks, rowCount, reusable, null);
+    }
+
+    /**
+     * Same as {@link #evaluateFilter(Map, int, WordMask)} but reuses dictionary-match bitmaps
+     * across batches via {@code dictCache}, a map keyed by leaf {@link Expression} identity
+     * holding one {@code boolean[]} per pushed predicate. The caller (typically
+     * {@link OptimizedParquetColumnIterator#dictionaryBitmapsForCurrentRowGroup}) is
+     * responsible for handing in a map scoped to the current row group — within a row group
+     * the dictionary content is fixed so memoized results remain valid for every batch.
+     *
+     * <p>A {@code null} cache is permitted and preserves the original per-batch behavior;
+     * this matters for callers that do not know the row-group lifecycle (e.g. unit tests
+     * and the multi-stage single-expression path).
+     */
+    WordMask evaluateFilter(
+        Map<String, Block> predicateBlocks,
+        int rowCount,
+        WordMask reusable,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
         reusable.setAll(rowCount);
+        int evaluated = 0;
         for (Expression expr : expressions) {
-            WordMask exprResult = evaluateExpression(expr, predicateBlocks, rowCount, reusable);
+            WordMask exprResult = evaluateExpression(expr, predicateBlocks, rowCount, reusable, dictCache);
+            evaluated++;
             if (exprResult != null) {
                 reusable.and(exprResult);
+                // Early exit when no rows survive the conjunction so far. Subsequent expressions
+                // would only AND further (the result can never grow); their evaluation cost —
+                // notably the per-batch dictionary scan that does not consult the intermediate
+                // mask — is therefore pure waste. WordMask#isEmpty is a 128-word scan for an
+                // 8192-row batch, trivially cheap next to a dictionary scan of thousands of
+                // entries plus an ordinal-to-boolean per-row mapping. Plan-time ordering by
+                // FilterEvaluationOrderEstimator places selective predicates first, which is
+                // what makes this short-circuit effective in practice (the discriminating
+                // predicate runs first, then we skip the rest when its batch has no survivors).
+                if (reusable.isEmpty()) {
+                    lastExpressionsEvaluated = evaluated;
+                    return reusable;
+                }
             }
         }
+        lastExpressionsEvaluated = evaluated;
         if (reusable.isAll()) {
             return null;
         }
         return reusable;
     }
 
+    // Test-only observability: number of expressions actually evaluated by the most recent
+    // evaluateFilter call. Used to assert the empty-mask early-exit fires when the first
+    // predicate eliminates every row in a batch; production code does not read this field.
+    private int lastExpressionsEvaluated;
+
+    int lastExpressionsEvaluatedForTesting() {
+        return lastExpressionsEvaluated;
+    }
+
     // Note: not static — uses the per-instance automaton cache in evaluateWildcardLike.
     // The intermediateMask is the cumulative AND of all previously evaluated conjuncts;
-    // expensive evaluators (LIKE, StartsWith) use it to skip already-eliminated rows.
-    private WordMask evaluateExpression(Expression expr, Map<String, Block> blocks, int rowCount, @Nullable WordMask intermediateMask) {
+    // expensive evaluators (LIKE, StartsWith) use it to skip already-eliminated rows. The
+    // dictCache (optional) memoizes per-batch dictionary-match bitmaps for the lifetime of
+    // one row group; the caller owns the lifecycle (see
+    // OptimizedParquetColumnIterator#dictionaryBitmapsForCurrentRowGroup).
+    private WordMask evaluateExpression(
+        Expression expr,
+        Map<String, Block> blocks,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
         if (expr instanceof EsqlBinaryComparison bc && bc.left() instanceof NamedExpression ne && bc.right().foldable()) {
             Block block = blocks.get(ne.name());
             if (block == null) {
@@ -674,14 +734,14 @@ final class ParquetPushedExpressions {
             if (literal == null) {
                 return null;
             }
-            return evaluateComparison(bc, block, literal, rowCount);
+            return evaluateComparison(bc, block, literal, rowCount, dictCache);
         }
         if (expr instanceof In inExpr && inExpr.value() instanceof NamedExpression ne) {
             Block block = blocks.get(ne.name());
             if (block == null) {
                 return null;
             }
-            return evaluateIn(inExpr, block, rowCount);
+            return evaluateIn(inExpr, block, rowCount, dictCache);
         }
         if (expr instanceof IsNull isNull && isNull.field() instanceof NamedExpression ne) {
             Block block = blocks.get(ne.name());
@@ -689,6 +749,15 @@ final class ParquetPushedExpressions {
                 return null;
             }
             WordMask mask = new WordMask();
+            // Fast path: the block has no nulls at all -> the survivor set is empty.
+            // mayHaveNulls() is O(1) on every Block implementation; skipping the per-row
+            // scan avoids rowCount calls to isNull() on the (very common) no-null case.
+            // The zeroed mask is the correct result and contributes to the empty-mask
+            // early exit in evaluateFilter for batches where this conjunct fires first.
+            if (block.mayHaveNulls() == false) {
+                mask.reset(rowCount);
+                return mask;
+            }
             mask.reset(rowCount);
             for (int i = 0; i < rowCount; i++) {
                 if (block.isNull(i)) {
@@ -703,6 +772,14 @@ final class ParquetPushedExpressions {
                 return null;
             }
             WordMask mask = new WordMask();
+            // Fast path: the block has no nulls -> every row survives. setAll uses word-level
+            // operations to mark all positions in one pass instead of rowCount isNull() calls.
+            // Mirrors the same gate used by IsNull above and by maskNonNullRows on the
+            // dictionary fast path.
+            if (block.mayHaveNulls() == false) {
+                mask.setAll(rowCount);
+                return mask;
+            }
             mask.reset(rowCount);
             for (int i = 0; i < rowCount; i++) {
                 if (block.isNull(i) == false) {
@@ -719,8 +796,8 @@ final class ParquetPushedExpressions {
             return evaluateRange(range, block, rowCount);
         }
         if (expr instanceof And and) {
-            WordMask left = evaluateExpression(and.left(), blocks, rowCount, intermediateMask);
-            WordMask right = evaluateExpression(and.right(), blocks, rowCount, intermediateMask);
+            WordMask left = evaluateExpression(and.left(), blocks, rowCount, intermediateMask, dictCache);
+            WordMask right = evaluateExpression(and.right(), blocks, rowCount, intermediateMask, dictCache);
             if (left != null && right != null) {
                 left.and(right);
                 return left;
@@ -728,8 +805,8 @@ final class ParquetPushedExpressions {
             return left != null ? left : right;
         }
         if (expr instanceof Or or) {
-            WordMask left = evaluateExpression(or.left(), blocks, rowCount, intermediateMask);
-            WordMask right = evaluateExpression(or.right(), blocks, rowCount, intermediateMask);
+            WordMask left = evaluateExpression(or.left(), blocks, rowCount, intermediateMask, dictCache);
+            WordMask right = evaluateExpression(or.right(), blocks, rowCount, intermediateMask, dictCache);
             if (left != null && right != null) {
                 left.or(right);
                 return left;
@@ -755,9 +832,9 @@ final class ParquetPushedExpressions {
                 if (block == null) {
                     return null;
                 }
-                return evaluateNotWildcardLike(wl, block, rowCount, intermediateMask);
+                return evaluateNotWildcardLike(wl, block, rowCount, intermediateMask, dictCache);
             }
-            WordMask inner = evaluateExpression(not.field(), blocks, rowCount, intermediateMask);
+            WordMask inner = evaluateExpression(not.field(), blocks, rowCount, intermediateMask, dictCache);
             if (inner != null) {
                 inner.negate();
                 return inner;
@@ -769,19 +846,25 @@ final class ParquetPushedExpressions {
             if (block == null) {
                 return null;
             }
-            return evaluateStartsWith(sw, block, rowCount, intermediateMask);
+            return evaluateStartsWith(sw, block, rowCount, intermediateMask, dictCache);
         }
         if (expr instanceof WildcardLike wl && wl.field() instanceof NamedExpression ne) {
             Block block = blocks.get(ne.name());
             if (block == null) {
                 return null;
             }
-            return evaluateWildcardLike(wl, block, rowCount, intermediateMask);
+            return evaluateWildcardLike(wl, block, rowCount, intermediateMask, dictCache);
         }
         return null;
     }
 
-    private static WordMask evaluateComparison(EsqlBinaryComparison bc, Block block, Object literal, int rowCount) {
+    private static WordMask evaluateComparison(
+        EsqlBinaryComparison bc,
+        Block block,
+        Object literal,
+        int rowCount,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
         WordMask mask = new WordMask();
         mask.reset(rowCount);
         if (block instanceof IntBlock ib) {
@@ -812,9 +895,17 @@ final class ParquetPushedExpressions {
         } else if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
             // Dictionary short-circuit: evaluate the comparison once per dictionary entry,
             // then map each row's ordinal to a precomputed boolean. Avoids one string compareTo
-            // per row in favor of one int lookup per row.
+            // per row in favor of one int lookup per row. The dictionary content is fixed
+            // within a row group, so the bitmap is memoized across batches when dictCache is
+            // provided — typically reducing dictSize * batchCount predicate calls to dictSize
+            // per row group.
             BytesRef val = toByteRef(literal);
-            boolean[] dictMatches = matchingDictionaryEntries(obb.getDictionaryVector(), entry -> compareResult(entry.compareTo(val), bc));
+            boolean[] dictMatches = memoizedDictionaryMatches(
+                dictCache,
+                bc,
+                obb.getDictionaryVector(),
+                entry -> compareResult(entry.compareTo(val), bc)
+            );
             applyDictionaryMatches(obb, dictMatches, mask, rowCount);
         } else if (block instanceof BytesRefBlock bb) {
             BytesRef val = toByteRef(literal);
@@ -871,7 +962,7 @@ final class ParquetPushedExpressions {
         return new BytesRef(literal.toString());
     }
 
-    private static WordMask evaluateIn(In inExpr, Block block, int rowCount) {
+    private static WordMask evaluateIn(In inExpr, Block block, int rowCount, @Nullable Map<Expression, boolean[]> dictCache) {
         List<Object> values = new ArrayList<>();
         for (Expression item : inExpr.list()) {
             Object val = literalValueOf(item);
@@ -919,7 +1010,7 @@ final class ParquetPushedExpressions {
             for (Object v : values) {
                 refSet.add(toByteRef(v));
             }
-            boolean[] dictMatches = matchingDictionaryEntries(obb.getDictionaryVector(), refSet::contains);
+            boolean[] dictMatches = memoizedDictionaryMatches(dictCache, inExpr, obb.getDictionaryVector(), refSet::contains);
             applyDictionaryMatches(obb, dictMatches, mask, rowCount);
         } else if (block instanceof BytesRefBlock bb) {
             Set<BytesRef> refSet = new HashSet<>();
@@ -1019,7 +1110,13 @@ final class ParquetPushedExpressions {
         return true;
     }
 
-    private static WordMask evaluateStartsWith(StartsWith sw, Block block, int rowCount, @Nullable WordMask intermediateMask) {
+    private static WordMask evaluateStartsWith(
+        StartsWith sw,
+        Block block,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
         Object prefixValue = literalValueOf(sw.prefix());
         if (prefixValue == null) {
             return null;
@@ -1028,7 +1125,9 @@ final class ParquetPushedExpressions {
         if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
             WordMask mask = new WordMask();
             mask.reset(rowCount);
-            boolean[] dictMatches = matchingDictionaryEntries(
+            boolean[] dictMatches = memoizedDictionaryMatches(
+                dictCache,
+                sw,
                 obb.getDictionaryVector(),
                 entry -> entry.length >= prefix.length && startsWith(entry, prefix)
             );
@@ -1104,7 +1203,13 @@ final class ParquetPushedExpressions {
      * one of the two supported block types, so the block-type {@code null} sentinel is unreachable
      * on the YES path in practice.
      */
-    private WordMask evaluateWildcardLike(WildcardLike wl, Block block, int rowCount, @Nullable WordMask intermediateMask) {
+    private WordMask evaluateWildcardLike(
+        WildcardLike wl,
+        Block block,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
         CompiledWildcard compiled = automatonFor(wl);
         if (compiled.matcher == null) {
             return null;
@@ -1116,7 +1221,9 @@ final class ParquetPushedExpressions {
         if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
             WordMask mask = new WordMask();
             mask.reset(rowCount);
-            boolean[] dictMatches = matchingDictionaryEntries(
+            boolean[] dictMatches = memoizedDictionaryMatches(
+                dictCache,
+                wl,
                 obb.getDictionaryVector(),
                 entry -> runner.run(entry.bytes, entry.offset, entry.length)
             );
@@ -1170,8 +1277,14 @@ final class ParquetPushedExpressions {
      * far beyond {@code "*google*"}). If a future change broadens the YES-eligible set, this
      * contract must be revisited.
      */
-    private WordMask evaluateNotWildcardLike(WildcardLike wl, Block block, int rowCount, @Nullable WordMask intermediateMask) {
-        WordMask likeMask = evaluateWildcardLike(wl, block, rowCount, intermediateMask);
+    private WordMask evaluateNotWildcardLike(
+        WildcardLike wl,
+        Block block,
+        int rowCount,
+        @Nullable WordMask intermediateMask,
+        @Nullable Map<Expression, boolean[]> dictCache
+    ) {
+        WordMask likeMask = evaluateWildcardLike(wl, block, rowCount, intermediateMask, dictCache);
         if (likeMask == null) {
             return null;
         }
@@ -1284,14 +1397,9 @@ final class ParquetPushedExpressions {
 
     /**
      * Evaluates {@code matcher} against every entry of {@code dictionary} and returns a
-     * boolean array indexed by ordinal — {@code true} at position {@code k} means the
-     * entry at ordinal {@code k} satisfies the predicate.
-     *
-     * <p>This is the core of the dictionary short-circuit: instead of running a per-row
-     * predicate on every materialized value, we run it once per unique entry. For dictionary
-     * encodings that are well chosen by the writer, the dictionary holds far fewer entries
-     * than the row count, so we collapse O(rowCount) string compares into O(dictSize) plus
-     * a per-row int lookup.
+     * boolean array indexed by ordinal — {@code true} at position {@code k} means the entry
+     * at ordinal {@code k} satisfies the predicate. This is the core of the dictionary
+     * short-circuit: we run the predicate once per unique entry rather than once per row.
      */
     private static boolean[] matchingDictionaryEntries(BytesRefVector dictionary, Predicate<BytesRef> matcher) {
         int size = dictionary.getPositionCount();
@@ -1304,8 +1412,60 @@ final class ParquetPushedExpressions {
     }
 
     /**
+     * Returns the dictionary-match bitmap for {@code key}, computing it on first use and
+     * reusing the cached array on every subsequent batch within the row group whose lifecycle
+     * the caller's map represents. A {@code null} cache falls through to a fresh per-call
+     * computation; the cache is null for unit tests and for the multi-stage single-expression
+     * path that does not have a row-group lifecycle.
+     */
+    private static boolean[] memoizedDictionaryMatches(
+        @Nullable Map<Expression, boolean[]> cache,
+        Expression key,
+        BytesRefVector dictionary,
+        Predicate<BytesRef> matcher
+    ) {
+        if (cache == null) {
+            return matchingDictionaryEntries(dictionary, matcher);
+        }
+        boolean[] cached = cache.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        boolean[] fresh = matchingDictionaryEntries(dictionary, matcher);
+        cache.put(key, fresh);
+        return fresh;
+    }
+
+    /**
      * Sets bits in {@code mask} for rows whose dictionary ordinal is flagged in
      * {@code dictMatches}, skipping null rows.
+     *
+     * <p>Before walking the per-row ordinal indirection, this method scans the (typically
+     * small) {@code dictMatches} array once to detect two bulk-action shapes that arise
+     * routinely on real-world data:
+     * <ul>
+     *   <li><b>No dictionary entry matches</b> — every non-null row's ordinal points at a
+     *       {@code false}, so every row is filtered out. The pre-zeroed mask is already
+     *       correct; we return immediately and skip the {@code rowCount} ordinal lookups.
+     *       This is the dictionary-level analogue of the empty-mask early exit in
+     *       {@link #evaluateFilter}: the outer loop sees the resulting empty mask and
+     *       short-circuits the remaining expressions for this batch.</li>
+     *   <li><b>Every dictionary entry matches</b> — every non-null row passes. We delegate
+     *       to {@link #maskNonNullRows}, which uses {@link WordMask#setAll} when the block
+     *       has no nulls and a single-pass null scan otherwise. This is the same primitive
+     *       the {@code matchesAll} fast path in {@link #evaluateWildcardLike} already uses,
+     *       so this branch unifies the {@code LIKE "*"} shortcut with predicates that
+     *       happen to accept every entry in the current row group's dictionary (e.g.
+     *       {@code col != ""} on a column whose dictionary holds no empty strings, or
+     *       {@code col IN (...)} on a small column whose dictionary is a subset of the set).
+     *       The win is concrete: a 10K-entry dictionary is scanned in microseconds, while
+     *       an 8K-row ordinal-to-boolean mapping costs tens of microseconds per batch.</li>
+     * </ul>
+     * Plan-time row-group statistics rule out many of these cases, but not all (e.g. they
+     * cannot prove "no empty strings" when {@code numNulls > 0}, and they cannot reason
+     * about {@code LIKE} patterns at all). The dictionary-level check closes those gaps
+     * without compromising correctness — we are looking at the actual per-row-group
+     * dictionary, not at file-level metadata.
      *
      * <p>This relies on the ordinals block being <strong>single-valued</strong>: position
      * {@code i} maps directly to value index {@code i}. The Parquet reader's dictionary
@@ -1318,10 +1478,67 @@ final class ParquetPushedExpressions {
         assert rowCount == block.getPositionCount() : "rowCount " + rowCount + " != block positions " + block.getPositionCount();
         assert ordinals.asVector() != null || ordinals.mayHaveMultivaluedFields() == false
             : "OrdinalBytesRefBlock with multivalued ordinals is not supported by the dictionary short-circuit";
+        DictionaryMatchShape shape = classifyDictionaryMatches(dictMatches);
+        if (shape == DictionaryMatchShape.NONE) {
+            return; // mask is already zero-initialized via reset(rowCount); no row can pass
+        }
+        if (shape == DictionaryMatchShape.ALL) {
+            // Every non-null row's ordinal points at a true. Mirrors maskNonNullRows: setAll
+            // when the block has no nulls, otherwise a single-pass null scan. Inline here
+            // (rather than calling maskNonNullRows) to write into the caller's already
+            // zero-initialized mask without allocating a second WordMask in a hot loop.
+            // Keep this in sync with maskNonNullRows if the strategy ever changes.
+            if (block.mayHaveNulls() == false) {
+                mask.setAll(rowCount);
+            } else {
+                for (int i = 0; i < rowCount; i++) {
+                    if (block.isNull(i) == false) {
+                        mask.set(i);
+                    }
+                }
+            }
+            return;
+        }
         for (int i = 0; i < rowCount; i++) {
             if (block.isNull(i) == false && dictMatches[ordinals.getInt(i)]) {
                 mask.set(i);
             }
         }
+    }
+
+    /**
+     * Classifies a {@code dictMatches} bitmap as {@code NONE} (no entry matches), {@code ALL}
+     * (every entry matches), or {@code MIXED}. Empty arrays are treated as {@code NONE} so
+     * the caller's "no row can pass" branch fires — there are no ordinals to look up.
+     *
+     * <p>Single-pass with early exit as soon as both polarities are observed: the worst-case
+     * cost is bounded by the dictionary size, but for the {@code MIXED} case we typically
+     * exit after a handful of comparisons. Compared to the {@code O(rowCount)} per-row loop
+     * the caller would otherwise run, this is a low-cost gate even when it returns
+     * {@code MIXED} and the per-row loop still executes.
+     */
+    enum DictionaryMatchShape {
+        NONE,
+        ALL,
+        MIXED
+    }
+
+    static DictionaryMatchShape classifyDictionaryMatches(boolean[] dictMatches) {
+        boolean sawTrue = false;
+        boolean sawFalse = false;
+        for (boolean m : dictMatches) {
+            if (m) {
+                sawTrue = true;
+            } else {
+                sawFalse = true;
+            }
+            if (sawTrue && sawFalse) {
+                return DictionaryMatchShape.MIXED;
+            }
+        }
+        if (sawTrue) {
+            return DictionaryMatchShape.ALL;
+        }
+        return DictionaryMatchShape.NONE;
     }
 }

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Not
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -423,6 +424,326 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
         Expression inner = new Equals(Source.EMPTY, attr("x", DataType.LONG), lit(30L, DataType.LONG), null);
         Expression not = new Not(Source.EMPTY, inner);
         assertSurvivors(new ParquetPushedExpressions(List.of(not)), blocks, 5, reusable, new int[] { 0, 1, 3, 4 });
+    }
+
+    // ---- Test 6c: dictionary-match shape classifier and fast-path semantics ----
+
+    public void testDictionaryMatchShapeClassifier() {
+        // Pins the gating logic that drives the bulk fast path in applyDictionaryMatches.
+        // The behavioural tests below exercise the integrated path; this one isolates the
+        // tiny scanner so a regression in either branch (NONE/ALL/MIXED) localizes here.
+        assertEquals(
+            "empty dictionary maps to NONE (no row can pass)",
+            ParquetPushedExpressions.DictionaryMatchShape.NONE,
+            ParquetPushedExpressions.classifyDictionaryMatches(new boolean[0])
+        );
+        assertEquals(
+            "all-false maps to NONE",
+            ParquetPushedExpressions.DictionaryMatchShape.NONE,
+            ParquetPushedExpressions.classifyDictionaryMatches(new boolean[] { false, false, false })
+        );
+        assertEquals(
+            "all-true maps to ALL",
+            ParquetPushedExpressions.DictionaryMatchShape.ALL,
+            ParquetPushedExpressions.classifyDictionaryMatches(new boolean[] { true, true, true })
+        );
+        assertEquals(
+            "mixed maps to MIXED (early exit after both polarities seen)",
+            ParquetPushedExpressions.DictionaryMatchShape.MIXED,
+            ParquetPushedExpressions.classifyDictionaryMatches(new boolean[] { true, false, true })
+        );
+        assertEquals(
+            "mixed maps to MIXED regardless of position of the second polarity",
+            ParquetPushedExpressions.DictionaryMatchShape.MIXED,
+            ParquetPushedExpressions.classifyDictionaryMatches(new boolean[] { false, false, false, true })
+        );
+    }
+
+    public void testDictionaryFastPathNoMatchProducesEmptyMask() {
+        // Equals against a literal absent from the dictionary => dict bitmap is all-false =>
+        // applyDictionaryMatches takes the NONE branch and returns the zero-initialized mask
+        // without touching the per-row ordinals loop. The mask must be empty (zero survivors),
+        // which is the same outcome the per-row loop would produce — so this test is a sound
+        // regression guard if the NONE fast path is ever broken.
+        String[] dict = { "alpha", "beta", "gamma", "delta" };
+        int[] pattern = { 0, 2, 1, 0, 3, 2, 0 };
+        int[] ordinals = repeatPattern(pattern, 21);
+        Block block = ordinalBlock(dict, ordinals, null);
+        try (block) {
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+            // "never_in_dict" appears nowhere in the dictionary -> dict bitmap is all-false.
+            Expression expr = new Equals(
+                Source.EMPTY,
+                attr("s", DataType.KEYWORD),
+                lit(new BytesRef("never_in_dict"), DataType.KEYWORD),
+                null
+            );
+            ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+            WordMask result = pushed.evaluateFilter(blocks, ordinals.length, reusable);
+            assertNotNull(result);
+            assertTrue("expected zero survivors for absent literal", result.isEmpty());
+        }
+    }
+
+    public void testDictionaryFastPathAllMatchReturnsAllSurvivors() {
+        // NotEquals against a literal absent from the dictionary => dict bitmap is all-true =>
+        // applyDictionaryMatches takes the ALL branch. Every non-null row survives. With the
+        // ordinal block built without nulls, evaluateFilter returns null (the all-survive
+        // sentinel) — the strongest signal that the bulk shortcut worked end-to-end.
+        String[] dict = { "alpha", "beta", "gamma", "delta" };
+        int[] pattern = { 0, 2, 1, 0, 3, 2, 0 };
+        int[] ordinals = repeatPattern(pattern, 21);
+        Block block = ordinalBlock(dict, ordinals, null);
+        try (block) {
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+            Expression expr = new NotEquals(
+                Source.EMPTY,
+                attr("s", DataType.KEYWORD),
+                lit(new BytesRef("never_in_dict"), DataType.KEYWORD),
+                null
+            );
+            assertSurvivors(new ParquetPushedExpressions(List.of(expr)), blocks, ordinals.length, reusable, allPositions(ordinals.length));
+        }
+    }
+
+    public void testDictionaryFastPathAllMatchWithNullsExcludesNullRows() {
+        // Dictionary all-true, but the ordinal block has nulls => the ALL branch must still
+        // exclude null rows (SQL three-valued logic). Pins the non-null sweep inside the
+        // ALL branch against the inverse mistake of bulk-setting every position regardless
+        // of the null bitset.
+        String[] dict = { "X", "Y" };
+        int[] pattern = { 0, 0, 1, 0 };
+        boolean[] nullPattern = { false, true, false, false };
+        int[] ordinals = repeatPattern(pattern, 25);
+        boolean[] nulls = repeatBoolPattern(nullPattern, 25);
+        Block block = ordinalBlock(dict, ordinals, nulls);
+        try (block) {
+            Map<String, Block> blocks = Map.of("s", block);
+            WordMask reusable = new WordMask();
+            // "Z" is absent from the dictionary -> NotEquals dict bitmap is all-true.
+            Expression expr = new NotEquals(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("Z"), DataType.KEYWORD), null);
+            int[] expected = positionsWhere(ordinals, nulls, ord -> true);
+            assertSurvivors(new ParquetPushedExpressions(List.of(expr)), blocks, ordinals.length, reusable, expected);
+        }
+    }
+
+    public void testDictionaryFastPathEmptyStringNotEquals() {
+        // The motivating ClickBench case for the ALL branch: WHERE col != "" on a column whose
+        // dictionary contains no empty strings. Without the fast path this still requires an
+        // O(rowCount) ordinal-to-boolean mapping despite every row trivially passing the
+        // dictionary check; with the fast path it collapses to the null sweep (or setAll for
+        // no-nulls). Cross-validates against the per-row path for invariant correctness.
+        String[] dict = { "https://elastic.co", "https://kibana.dev", "https://lucene.apache.org" };
+        int[] pattern = { 0, 1, 2, 0, 1 };
+        int[] ordinals = repeatPattern(pattern, 25);
+        Block ordinalsBlock = ordinalBlock(dict, ordinals, null);
+        Block plainBlock = plainBytesRefBlock(dict, ordinals);
+        try (ordinalsBlock; plainBlock) {
+            Expression expr = new NotEquals(Source.EMPTY, attr("url", DataType.KEYWORD), lit(new BytesRef(""), DataType.KEYWORD), null);
+            WordMask ordinalMask = new ParquetPushedExpressions(List.of(expr)).evaluateFilter(
+                Map.of("url", ordinalsBlock),
+                ordinals.length,
+                new WordMask()
+            );
+            WordMask plainMask = new ParquetPushedExpressions(List.of(expr)).evaluateFilter(
+                Map.of("url", plainBlock),
+                ordinals.length,
+                new WordMask()
+            );
+            // Both paths must produce the same survivor set; nulls in the dictionary fast
+            // path get there via maskNonNullRows / the no-null setAll shortcut.
+            if (ordinalMask == null) {
+                assertNull("dictionary path returned null (all survive); per-row must agree", plainMask);
+            } else {
+                assertNotNull(plainMask);
+                assertArrayEquals(plainMask.survivingPositions(), ordinalMask.survivingPositions());
+            }
+        }
+    }
+
+    public void testIsNotNullFastPathOnBlockWithoutNulls() {
+        // Block with no nulls at all => IsNotNull should return a full mask without scanning
+        // every position. The mayHaveNulls() gate is what makes this an O(1) decision plus a
+        // word-level setAll; without the gate the loop runs rowCount times for the same
+        // outcome. Test asserts the survivor set is the full range — semantically what the
+        // per-row loop would compute, but the new path is the path under test.
+        long[] values = { 1L, 2L, 3L, 4L, 5L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+        WordMask reusable = new WordMask();
+
+        Expression expr = new IsNotNull(Source.EMPTY, attr("x", DataType.LONG));
+        assertSurvivors(new ParquetPushedExpressions(List.of(expr)), blocks, 5, reusable, allPositions(5));
+    }
+
+    public void testIsNullFastPathOnBlockWithoutNulls() {
+        // Mirror of the IsNotNull case: no nulls => IsNull's survivor set is empty. The fast
+        // path returns the zero-initialized mask without iterating; the integration assert is
+        // that the result is an empty (non-null) WordMask.
+        long[] values = { 1L, 2L, 3L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+
+        Expression expr = new IsNull(Source.EMPTY, attr("x", DataType.LONG));
+        WordMask result = new ParquetPushedExpressions(List.of(expr)).evaluateFilter(blocks, 3, new WordMask());
+        assertNotNull(result);
+        assertTrue("IsNull on a no-null block must yield an empty mask", result.isEmpty());
+    }
+
+    private static int[] allPositions(int rowCount) {
+        int[] out = new int[rowCount];
+        for (int i = 0; i < rowCount; i++) {
+            out[i] = i;
+        }
+        return out;
+    }
+
+    // ---- Test 6a: dictionary match memoization reuse across batches within a row group ----
+
+    public void testDictionaryBitmapPopulatedOnFirstUseAndReusedAcrossBatches() {
+        // The cache is the iterator's per-row-group memo passed straight into evaluateFilter
+        // as a plain map. The first call populates exactly one entry (one pushed predicate);
+        // subsequent calls within the same "row group" hit the entry. Observing the map's
+        // size after each batch is the cheapest way to assert that the memoization plumbing
+        // actually puts (and never re-puts) the bitmap.
+        String[] dict = { "apple", "application", "banana", "pineapple" };
+        int[] pattern = { 0, 1, 2, 3, 0, 2 };
+        int[] ordinals = repeatPattern(pattern, 24);
+        Block block = ordinalBlock(dict, ordinals, null);
+        try (block) {
+            Map<String, Block> blocks = Map.of("s", block);
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*app*"));
+            ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(like));
+            Map<Expression, boolean[]> cache = new IdentityHashMap<>();
+
+            int[] expected = positionsWithOrdinalIn(ordinals, 0, 1, 3);
+            for (int batch = 0; batch < 5; batch++) {
+                WordMask mask = pushed.evaluateFilter(blocks, ordinals.length, new WordMask(), cache);
+                assertNotNull("batch " + batch + " returned null", mask);
+                assertArrayEquals("batch " + batch + " survivors changed", expected, mask.survivingPositions());
+                assertEquals("cache should hold exactly one entry after batch " + batch, 1, cache.size());
+            }
+        }
+    }
+
+    public void testDictionaryBitmapClearBetweenRowGroupsProducesCorrectResults() {
+        // Regression guard for the row-group lifecycle: two consecutive row groups whose
+        // dictionaries differ in content but happen to be referenced by the same Expression
+        // identity must not share a memoized bitmap. The iterator's responsibility is to
+        // pass a different (or cleared) map at the row-group boundary; here we simulate that
+        // by clearing the map between calls. Without the clear, the second row group would
+        // reuse the first row group's bitmap and return incorrect survivors. With the clear,
+        // it recomputes from the second dictionary and produces an empty survivor set.
+        String[] firstDict = { "apple", "banana", "cherry", "date" };
+        String[] secondDict = { "elderberry", "fig", "grape", "honeydew" };
+        int[] ordinals = { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3 };
+
+        Map<Expression, boolean[]> cache = new IdentityHashMap<>();
+        Expression expr = new Equals(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("apple"), DataType.KEYWORD), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(expr));
+
+        Block firstBlock = ordinalBlock(firstDict, ordinals, null);
+        try (firstBlock) {
+            WordMask firstMask = pushed.evaluateFilter(Map.of("s", firstBlock), ordinals.length, new WordMask(), cache);
+            assertNotNull(firstMask);
+            // "apple" is ordinal 0 in the first dictionary -> positions 0, 4, 8 survive.
+            assertArrayEquals(new int[] { 0, 4, 8 }, firstMask.survivingPositions());
+            assertEquals("cache populated for first row group", 1, cache.size());
+        }
+
+        // Row-group boundary: the iterator's accessor wipes the map when rowGroupOrdinal
+        // changes. Simulate that here. Without this clear the next evaluateFilter would
+        // return wrong survivors because the bitmap was computed against the first dictionary.
+        cache.clear();
+
+        Block secondBlock = ordinalBlock(secondDict, ordinals, null);
+        try (secondBlock) {
+            WordMask secondMask = pushed.evaluateFilter(Map.of("s", secondBlock), ordinals.length, new WordMask(), cache);
+            assertNotNull(secondMask);
+            // "apple" is absent from the second dictionary -> no rows survive.
+            assertTrue("expected zero survivors for absent literal in second row group", secondMask.isEmpty());
+        }
+    }
+
+    public void testDictionaryBitmapCachedAndUncachedAgreeAcrossBatches() {
+        // Behavioural cross-check: with and without the cache, every batch must produce the
+        // same survivor set. The cache is a pure performance optimization — any divergence
+        // means a correctness regression. This is the test most likely to fail if the cache
+        // plumbing accidentally serves the wrong bitmap (e.g. identity collision, missed
+        // clear, or a wrong key in memoizedDictionaryMatches).
+        String[] dict = { "the", "quick", "brown", "fox", "jumps" };
+        int rowCount = 200;
+        int[] randomOrdinals = new int[rowCount];
+        for (int i = 0; i < rowCount; i++) {
+            randomOrdinals[i] = randomIntBetween(0, dict.length - 1);
+        }
+        Block block = ordinalBlock(dict, randomOrdinals, null);
+        try (block) {
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*o*"));
+            ParquetPushedExpressions cached = new ParquetPushedExpressions(List.of(like));
+            ParquetPushedExpressions uncached = new ParquetPushedExpressions(List.of(like));
+            Map<Expression, boolean[]> cache = new IdentityHashMap<>();
+
+            for (int batch = 0; batch < 3; batch++) {
+                WordMask cachedMask = cached.evaluateFilter(Map.of("s", block), rowCount, new WordMask(), cache);
+                WordMask uncachedMask = uncached.evaluateFilter(Map.of("s", block), rowCount, new WordMask());
+                if (cachedMask == null) {
+                    assertNull("batch " + batch + ": cached null implies uncached null", uncachedMask);
+                } else {
+                    assertNotNull("batch " + batch + ": cached non-null, uncached must agree", uncachedMask);
+                    assertArrayEquals(
+                        "batch " + batch + " survivors diverged between cached and uncached paths",
+                        uncachedMask.survivingPositions(),
+                        cachedMask.survivingPositions()
+                    );
+                }
+            }
+        }
+    }
+
+    // ---- Test 6b: empty-mask early exit in evaluateFilter ----
+
+    public void testEvaluateFilterEarlyExitsWhenMaskBecomesEmpty() {
+        // Two top-level expressions; the first eliminates every row (no Long equals 999).
+        // After the first AND, the survivor mask is empty: any subsequent expression's evaluation
+        // is pure waste (notably the per-batch dictionary scan that does not consult the
+        // intermediate mask). The early exit short-circuits evaluation of the remainder.
+        //
+        // Asserted via the lastExpressionsEvaluatedForTesting() hook: only the first expression
+        // is evaluated, even though the filter holds two. The mask returned is empty (zero
+        // survivors), matching the non-early-exit semantics so behavior is preserved.
+        long[] values = { 10L, 20L, 30L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+
+        Expression first = new Equals(Source.EMPTY, attr("x", DataType.LONG), lit(999L, DataType.LONG), null);
+        Expression second = new Equals(Source.EMPTY, attr("x", DataType.LONG), lit(20L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(first, second));
+
+        WordMask result = pushed.evaluateFilter(blocks, 3, new WordMask());
+        assertNotNull("expected an empty mask, not null", result);
+        assertTrue("expected empty mask after first predicate eliminates all rows", result.isEmpty());
+        assertEquals("only first expression should have been evaluated", 1, pushed.lastExpressionsEvaluatedForTesting());
+    }
+
+    public void testEvaluateFilterEvaluatesAllExpressionsWhenSurvivorsRemain() {
+        // Companion test to the early-exit case: when each predicate leaves at least one
+        // survivor, the loop must evaluate every expression. Pins the contract that 6b only
+        // skips work when the cumulative mask is fully empty — never when it is just sparse.
+        long[] values = { 10L, 20L, 30L, 40L };
+        Block block = blockFactory.newLongArrayVector(values, values.length).asBlock();
+        Map<String, Block> blocks = Map.of("x", block);
+
+        Expression first = new GreaterThan(Source.EMPTY, attr("x", DataType.LONG), lit(10L, DataType.LONG), null);
+        Expression second = new LessThan(Source.EMPTY, attr("x", DataType.LONG), lit(40L, DataType.LONG), null);
+        ParquetPushedExpressions pushed = new ParquetPushedExpressions(List.of(first, second));
+
+        WordMask result = pushed.evaluateFilter(blocks, 4, new WordMask());
+        assertNotNull(result);
+        assertArrayEquals(new int[] { 1, 2 }, result.survivingPositions());
+        assertEquals("both expressions should have been evaluated", 2, pushed.lastExpressionsEvaluatedForTesting());
     }
 
     // ---- Test 7: StartsWith ----


### PR DESCRIPTION
Three independent, additive performance improvements to pushed-down filter
evaluation in the Parquet datasource. Together they target ClickBench-style
workloads where most queries push selective string/keyword predicates over
dictionary-encoded columns.

6b - Empty-mask early exit in evaluateFilter
After each conjunct narrows the survivor mask, return immediately when it
becomes empty rather than continuing through the remaining expressions.
ParquetPushedExpressions already uses an intermediateMask to skip rows
within a single predicate, but the outer expression loop still ran every
expression. Skipping is correct because conjunction is monotone under AND
and saves the dictionary scan for follow-on expressions (which does not
consult intermediateMask) when the first predicate is already exclusive.

6c - Bulk dictionary fast paths plus IsNull/IsNotNull shortcuts
applyDictionaryMatches classifies the boolean[] dictionary-match bitmap as
NONE / ALL / MIXED in a single pass. NONE leaves the survivor mask zero-
initialized and returns. ALL bulk-sets non-null rows (setAll for blocks
without nulls, otherwise a single null sweep), skipping the per-row ordinal
indirection entirely. MIXED falls back to the existing per-row loop. The
same observation applies to IsNull / IsNotNull: when block.mayHaveNulls()
is false, the result is fully determined without scanning any row, so we
return an empty mask (IsNull) or set every position (IsNotNull) directly.

6a - Memoize per-predicate dictionary bitmaps within a row group
OptimizedParquetColumnIterator owns a Map<Expression, boolean[]> stamped
with the current rowGroupOrdinal. dictionaryBitmapsForCurrentRowGroup()
wipes the map on a stamp mismatch and hands it to evaluateFilter; within
one row group the underlying BytesRefArray is fixed (see PageColumnReader)
so the memoized bitmap stays valid for every batch. The cache self-
invalidates by ordinal — there are no clear() calls to miss, so the two-
phase 'all rows filtered, try next row group' retry path is correct by
construction rather than by a separate clear hook.

Includes unit tests that verify each fast path semantically, fail with the
optimization disabled, and pin the row-group boundary behaviour (clearing
the memo between two distinct dictionaries yields the correct survivors
on the second row group).

Developed with AI-assisted tooling

