### PR TITLE
ES|QL Test alternative fix for OrdinalBytesRefBlock.filter() by immediately trim unused dictionary items

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -15,6 +15,7 @@ import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * A {@link BytesRefBlock} consists of a pair: an {@link IntBlock} for ordinals and a {@link BytesRefVector} for the dictionary.
@@ -108,33 +109,90 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
 
     @Override
     public BytesRefBlock filter(boolean mayContainDuplicates, int... positions) {
-        // Do not build a filtered block using the same dictionary, because dictionary entries that are not referenced
-        // may reappear when hashing the dictionary in BlockHash.
-        // TODO: merge this BytesRefArrayBlock#filter
         final OrdinalBytesRefVector vector = asVector();
         if (vector != null) {
             return vector.filter(mayContainDuplicates, positions).asBlock();
         }
-        BytesRef scratch = new BytesRef();
-        try (BytesRefBlock.Builder builder = blockFactory().newBytesRefBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendBytesRef(getBytesRef(getFirstValueIndex(pos), scratch));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendBytesRef(getBytesRef(first + c, scratch));
-                    }
-                    builder.endPositionEntry();
+        // Preserve the ordinal encoding through filter so downstream consumers (BytesRefBlockHash, etc.)
+        // keep the dictionary fast path. Dictionary entries that are no longer referenced are dropped,
+        // because every consumer of OrdinalBytesRefBlock hashes the entire dictionary unconditionally.
+        final int dictSize = bytes.getPositionCount();
+        final int[] remap = new int[dictSize];
+        Arrays.fill(remap, -1);
+        // keptOrds[i] is the original dictionary index that compacted to position i.
+        final int[] keptOrds = new int[dictSize];
+        int kept = 0;
+        // totalValues sums the (non-null) value count across the filtered positions so we can
+        // measure dictionary density on the same scale isDense() uses elsewhere (which counts
+        // total values, not positions, to handle multivalues correctly).
+        int totalValues = 0;
+        for (int p : positions) {
+            if (ordinals.isNull(p)) {
+                continue;
+            }
+            int valueCount = ordinals.getValueCount(p);
+            int first = ordinals.getFirstValueIndex(p);
+            totalValues += valueCount;
+            for (int c = 0; c < valueCount; c++) {
+                int ord = ordinals.getInt(first + c);
+                if (remap[ord] == -1) {
+                    remap[ord] = kept;
+                    keptOrds[kept] = ord;
+                    kept++;
                 }
             }
-            return builder.mvOrdering(mvOrdering()).build();
+        }
+        if (isDense(totalValues, kept) == false) {
+            // Compacted dictionary would not be dense enough to pay for the per-row indirection
+            // downstream. Materialize a plain BytesRefBlock instead.
+            return materializeFiltered(positions);
+        }
+        if (kept == dictSize) {
+            // Fast path: every dictionary entry is still referenced. Share the dictionary
+            // and only filter the ordinals; no remap needed.
+            IntBlock filteredOrds = ordinals.filter(mayContainDuplicates, positions);
+            OrdinalBytesRefBlock result = null;
+            try {
+                result = new OrdinalBytesRefBlock(filteredOrds, bytes);
+                bytes.incRef();
+                return result;
+            } finally {
+                if (result == null) {
+                    filteredOrds.close();
+                }
+            }
+        }
+        BytesRefVector newDict = null;
+        IntBlock newOrds = null;
+        OrdinalBytesRefBlock result = null;
+        try {
+            newDict = compactDictionary(bytes, keptOrds, kept, blockFactory());
+            try (IntBlock.Builder ordsBuilder = blockFactory().newIntBlockBuilder(positions.length)) {
+                for (int p : positions) {
+                    if (ordinals.isNull(p)) {
+                        ordsBuilder.appendNull();
+                        continue;
+                    }
+                    int valueCount = ordinals.getValueCount(p);
+                    int first = ordinals.getFirstValueIndex(p);
+                    if (valueCount == 1) {
+                        ordsBuilder.appendInt(remap[ordinals.getInt(first)]);
+                    } else {
+                        ordsBuilder.beginPositionEntry();
+                        for (int c = 0; c < valueCount; c++) {
+                            ordsBuilder.appendInt(remap[ordinals.getInt(first + c)]);
+                        }
+                        ordsBuilder.endPositionEntry();
+                    }
+                }
+                newOrds = ordsBuilder.mvOrdering(mvOrdering()).build();
+            }
+            result = new OrdinalBytesRefBlock(newOrds, newDict);
+            return result;
+        } finally {
+            if (result == null) {
+                Releasables.close(newDict, newOrds);
+            }
         }
     }
 
@@ -162,6 +220,44 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
             }
         }
         return result;
+    }
+
+    private BytesRefBlock materializeFiltered(int[] positions) {
+        BytesRef scratch = new BytesRef();
+        try (BytesRefBlock.Builder builder = blockFactory().newBytesRefBlockBuilder(positions.length)) {
+            for (int pos : positions) {
+                if (isNull(pos)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(pos);
+                int first = getFirstValueIndex(pos);
+                if (valueCount == 1) {
+                    builder.appendBytesRef(getBytesRef(first, scratch));
+                } else {
+                    builder.beginPositionEntry();
+                    for (int c = 0; c < valueCount; c++) {
+                        builder.appendBytesRef(getBytesRef(first + c, scratch));
+                    }
+                    builder.endPositionEntry();
+                }
+            }
+            return builder.mvOrdering(mvOrdering()).build();
+        }
+    }
+
+    /**
+     * Builds a new dictionary {@link BytesRefVector} containing only the entries listed in {@code keptOrds[0..kept)},
+     * preserving their order. Shared between {@link OrdinalBytesRefBlock#filter} and {@link OrdinalBytesRefVector#filter}.
+     */
+    static BytesRefVector compactDictionary(BytesRefVector source, int[] keptOrds, int kept, BlockFactory blockFactory) {
+        BytesRef scratch = new BytesRef();
+        try (BytesRefVector.Builder builder = blockFactory.newBytesRefVectorBuilder(kept)) {
+            for (int k = 0; k < kept; k++) {
+                builder.appendBytesRef(source.getBytesRef(keptOrds[k], scratch));
+            }
+            return builder.build();
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -16,6 +16,7 @@ import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * A {@link BytesRefVector} consists of a pair: an {@link IntVector} for ordinals and a {@link BytesRefVector} for the dictionary.
@@ -105,9 +106,66 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
 
     @Override
     public BytesRefVector filter(boolean mayContainDuplicates, int... positions) {
-        // Do not build a filtered block using the same dictionary, because dictionary entries that are not referenced
-        // may reappear when hashing the dictionary in BlockHash.
-        final BytesRef scratch = new BytesRef();
+        // Preserve the ordinal encoding through filter so downstream consumers (BytesRefBlockHash, etc.)
+        // keep the dictionary fast path. Dictionary entries that are no longer referenced are dropped,
+        // because every consumer of OrdinalBytesRefVector hashes the entire dictionary unconditionally.
+        final int dictSize = bytes.getPositionCount();
+        final int[] remap = new int[dictSize];
+        Arrays.fill(remap, -1);
+        // keptOrds[i] is the original dictionary index that compacted to position i.
+        final int[] keptOrds = new int[dictSize];
+        int kept = 0;
+        for (int p : positions) {
+            int ord = ordinals.getInt(p);
+            if (remap[ord] == -1) {
+                remap[ord] = kept;
+                keptOrds[kept] = ord;
+                kept++;
+            }
+        }
+        if (OrdinalBytesRefBlock.isDense(positions.length, kept) == false) {
+            // Compacted dictionary would not be dense enough to pay for the per-row indirection
+            // downstream (and would not serialize via SERIALIZE_BLOCK_ORDINAL either). Materialize
+            // a plain BytesRefVector instead so consumers take their fastest non-ordinal path.
+            return materializeFiltered(positions);
+        }
+        if (kept == dictSize) {
+            // Fast path: every dictionary entry is still referenced. Share the dictionary
+            // and only filter the ordinals; no remap needed.
+            IntVector filteredOrds = ordinals.filter(mayContainDuplicates, positions);
+            OrdinalBytesRefVector result = null;
+            try {
+                result = new OrdinalBytesRefVector(filteredOrds, bytes);
+                bytes.incRef();
+                return result;
+            } finally {
+                if (result == null) {
+                    filteredOrds.close();
+                }
+            }
+        }
+        BytesRefVector newDict = null;
+        IntVector newOrds = null;
+        OrdinalBytesRefVector result = null;
+        try {
+            newDict = OrdinalBytesRefBlock.compactDictionary(bytes, keptOrds, kept, blockFactory());
+            try (IntVector.Builder ordsBuilder = blockFactory().newIntVectorFixedBuilder(positions.length)) {
+                for (int p : positions) {
+                    ordsBuilder.appendInt(remap[ordinals.getInt(p)]);
+                }
+                newOrds = ordsBuilder.build();
+            }
+            result = new OrdinalBytesRefVector(newOrds, newDict);
+            return result;
+        } finally {
+            if (result == null) {
+                Releasables.close(newDict, newOrds);
+            }
+        }
+    }
+
+    private BytesRefVector materializeFiltered(int[] positions) {
+        BytesRef scratch = new BytesRef();
         try (BytesRefVector.Builder builder = blockFactory().newBytesRefVectorBuilder(positions.length)) {
             for (int p : positions) {
                 builder.appendBytesRef(getBytesRef(p, scratch));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -46,6 +46,7 @@ import java.util.stream.LongStream;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
 
 public class BlockHashTests extends BlockHashTestCase {
@@ -506,6 +507,59 @@ public class BlockHashTests extends BlockHashTestCase {
                 }
                 assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 3)));
             }, new OrdinalBytesRefBlock(ords.build(), bytes.build()));
+        }
+    }
+
+    /**
+     * Regression test for the OrdinalBytesRefBlock.filter ordinal-preserving fast path.
+     * Filters away every row referencing two of the four dictionary entries and asserts the
+     * downstream BlockHash sees only the surviving values - no phantom groups for the
+     * dropped dictionary entries (which would leak through if filter() returned the original
+     * dictionary unchanged). The position count is large enough that the compacted result
+     * passes OrdinalBytesRefBlock.isDense, so filter() takes the ordinal-preserving path.
+     */
+    public void testOrdinalsAfterFilterDropsUnreferencedEntries() {
+        // 24 input rows cycling through 4 dict entries; we keep the 12 rows that reference
+        // alpha+bravo. Compacted result: 12 positions, 2 dict entries -> dense, ordinal-preserved.
+        int sourceRows = 24;
+        try (
+            IntVector.Builder ords = blockFactory.newIntVectorFixedBuilder(sourceRows);
+            BytesRefVector.Builder bytes = blockFactory.newBytesRefVectorBuilder(4)
+        ) {
+            for (int i = 0; i < sourceRows; i++) {
+                ords.appendInt(i % 4);
+            }
+            bytes.appendBytesRef(new BytesRef("alpha"));
+            bytes.appendBytesRef(new BytesRef("bravo"));
+            bytes.appendBytesRef(new BytesRef("charlie"));
+            bytes.appendBytesRef(new BytesRef("delta"));
+
+            // Positions whose ord is 0 (alpha) or 1 (bravo): every (4*k) and (4*k+1) for k=0..5.
+            int[] kept = new int[12];
+            for (int k = 0; k < 6; k++) {
+                kept[2 * k] = 4 * k;
+                kept[2 * k + 1] = 4 * k + 1;
+            }
+
+            BytesRefBlock filtered;
+            try (var ordinalBlock = new OrdinalBytesRefVector(ords.build(), bytes.build()).asBlock()) {
+                filtered = ordinalBlock.filter(false, kept);
+            }
+            assertThat(filtered, instanceOf(OrdinalBytesRefBlock.class));
+            assertThat(((OrdinalBytesRefBlock) filtered).getDictionaryVector().getPositionCount(), equalTo(2));
+            // hash() takes ownership of the block and releases it.
+            hash(ordsAndKeys -> {
+                if (forcePackedHash) {
+                    assertThat(ordsAndKeys.description(), startsWith("PackedValuesBlockHash{groups=[0:BYTES_REF], entries=2, size="));
+                    assertOrds(ordsAndKeys.ords(), 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+                    assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(0, 2)));
+                } else {
+                    assertThat(ordsAndKeys.description(), startsWith("BytesRefBlockHash{channel=0, entries=2, size="));
+                    assertOrds(ordsAndKeys.ords(), 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2);
+                    assertThat(ordsAndKeys.nonEmpty(), equalTo(intRange(1, 3)));
+                }
+                assertKeys(ordsAndKeys.keys(), "alpha", "bravo");
+            }, filtered);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -1702,6 +1702,9 @@ public class BasicBlockTests extends ESTestCase {
     public void testFilterOrdinalBytesRefBlock() {
         int dictSize = between(1, 10);
         int positionCount = between(1, 100);
+        // Track the value at each position so we can verify it survives the filter.
+        // null means the position is null; otherwise it is the original dictionary index list for that position.
+        List<int[]> positionOrds = new ArrayList<>(positionCount);
         try (
             var dictBuilder = blockFactory.newBytesRefVectorBuilder(dictSize);
             var ordinalBuilder = blockFactory.newIntBlockBuilder(positionCount)
@@ -1712,14 +1715,24 @@ public class BasicBlockTests extends ESTestCase {
             for (int i = 0; i < positionCount; i++) {
                 int valueCount = randomIntBetween(0, 2);
                 switch (valueCount) {
-                    case 0 -> ordinalBuilder.appendNull();
-                    case 1 -> ordinalBuilder.appendInt(randomIntBetween(0, dictSize - 1));
+                    case 0 -> {
+                        ordinalBuilder.appendNull();
+                        positionOrds.add(null);
+                    }
+                    case 1 -> {
+                        int ord = randomIntBetween(0, dictSize - 1);
+                        ordinalBuilder.appendInt(ord);
+                        positionOrds.add(new int[] { ord });
+                    }
                     default -> {
                         ordinalBuilder.beginPositionEntry();
+                        int[] ords = new int[valueCount];
                         for (int v = 0; v < valueCount; v++) {
-                            ordinalBuilder.appendInt(randomIntBetween(0, dictSize - 1));
+                            ords[v] = randomIntBetween(0, dictSize - 1);
+                            ordinalBuilder.appendInt(ords[v]);
                         }
                         ordinalBuilder.endPositionEntry();
+                        positionOrds.add(ords);
                     }
                 }
             }
@@ -1728,14 +1741,69 @@ public class BasicBlockTests extends ESTestCase {
                 for (int i = 0; i < masks.length; i++) {
                     masks[i] = randomIntBetween(0, positionCount - 1);
                 }
-                try (var filtered = block.filter(true, masks)) {
-                    assertThat(filtered, not(instanceOf(OrdinalBytesRefBlock.class)));
-                }
+                assertFilterOrdinalBytesRefBlock(block, masks, positionOrds);
+                // Filtering with the full range of positions exercises the kept-everything fast path
+                // when the original block already references every dictionary entry.
+                int[] allPositions = IntStream.range(0, positionCount).toArray();
+                assertFilterOrdinalBytesRefBlock(block, allPositions, positionOrds);
                 assertSliceFullRange(block);
                 assertSliceOrdinalBytesRefBlock(block, 0, 0);
                 if (positionCount > 1) {
                     assertSliceOrdinalBytesRefBlock(block, 0, 1);
                     assertSliceOrdinalBytesRefBlock(block, 1, positionCount);
+                }
+            }
+        }
+    }
+
+    private void assertFilterOrdinalBytesRefBlock(OrdinalBytesRefBlock block, int[] masks, List<int[]> positionOrds) {
+        int dictSize = block.getDictionaryVector().getPositionCount();
+        // Track both the referenced dict entries and the total value count after filtering, so we
+        // can predict whether OrdinalBytesRefBlock.filter takes the ordinal path or materializes
+        // (which it does when the compacted result would not pass isDense).
+        BitSet referenced = new BitSet(dictSize);
+        int totalValues = 0;
+        for (int pos : masks) {
+            int[] ords = positionOrds.get(pos);
+            if (ords == null) {
+                continue;
+            }
+            totalValues += ords.length;
+            for (int ord : ords) {
+                referenced.set(ord);
+            }
+        }
+        int expectedDictSize = referenced.cardinality();
+        boolean expectOrdinal = OrdinalBytesRefBlock.isDense(totalValues, expectedDictSize);
+        try (var filtered = block.filter(true, masks)) {
+            assertThat(filtered.getPositionCount(), equalTo(masks.length));
+            if (expectOrdinal) {
+                assertThat(filtered, instanceOf(OrdinalBytesRefBlock.class));
+                OrdinalBytesRefBlock filteredOrdinal = (OrdinalBytesRefBlock) filtered;
+                assertThat(filteredOrdinal.getDictionaryVector().getPositionCount(), equalTo(expectedDictSize));
+                if (expectedDictSize == dictSize) {
+                    // Share-dictionary fast path: dict instance is reused.
+                    assertThat(filteredOrdinal.getDictionaryVector(), sameInstance(block.getDictionaryVector()));
+                }
+            } else {
+                assertThat(filtered, not(instanceOf(OrdinalBytesRefBlock.class)));
+            }
+            BytesRef scratch = new BytesRef();
+            BytesRef expectedScratch = new BytesRef();
+            for (int p = 0; p < masks.length; p++) {
+                int sourcePos = masks[p];
+                int[] expectedOrds = positionOrds.get(sourcePos);
+                if (expectedOrds == null) {
+                    assertThat(filtered.isNull(p), is(true));
+                } else {
+                    assertThat(filtered.isNull(p), is(false));
+                    assertThat(filtered.getValueCount(p), equalTo(expectedOrds.length));
+                    int first = filtered.getFirstValueIndex(p);
+                    for (int v = 0; v < expectedOrds.length; v++) {
+                        BytesRef expected = block.getDictionaryVector().getBytesRef(expectedOrds[v], expectedScratch);
+                        BytesRef actual = filtered.getBytesRef(first + v, scratch);
+                        assertThat(actual, equalTo(expected));
+                    }
                 }
             }
         }
@@ -1751,6 +1819,7 @@ public class BasicBlockTests extends ESTestCase {
     public void testFilterOrdinalBytesRefVector() {
         int dictSize = between(1, 10);
         int positionCount = between(1, 100);
+        int[] sourceOrds = new int[positionCount];
         try (
             var dictBuilder = blockFactory.newBytesRefVectorBuilder(dictSize);
             var ordinalBuilder = blockFactory.newIntVectorBuilder(positionCount)
@@ -1759,16 +1828,18 @@ public class BasicBlockTests extends ESTestCase {
                 dictBuilder.appendBytesRef(new BytesRef("value" + i));
             }
             for (int i = 0; i < positionCount; i++) {
-                ordinalBuilder.appendInt(randomIntBetween(0, dictSize - 1));
+                sourceOrds[i] = randomIntBetween(0, dictSize - 1);
+                ordinalBuilder.appendInt(sourceOrds[i]);
             }
             try (var vector = new OrdinalBytesRefVector(ordinalBuilder.build(), dictBuilder.build())) {
                 int[] masks = new int[between(1, 100)];
                 for (int i = 0; i < masks.length; i++) {
                     masks[i] = randomIntBetween(0, positionCount - 1);
                 }
-                try (var filtered = vector.filter(true, masks)) {
-                    assertThat(filtered, not(instanceOf(OrdinalBytesRefVector.class)));
-                }
+                assertFilterOrdinalBytesRefVector(vector, masks, sourceOrds);
+                // Filtering with the full position range exercises the kept-everything fast path.
+                int[] allPositions = IntStream.range(0, positionCount).toArray();
+                assertFilterOrdinalBytesRefVector(vector, allPositions, sourceOrds);
                 assertSliceFullRange(vector);
                 assertSliceOrdinalBytesRefVector(vector, 0, 0);
                 if (positionCount > 1) {
@@ -1779,10 +1850,112 @@ public class BasicBlockTests extends ESTestCase {
         }
     }
 
+    private void assertFilterOrdinalBytesRefVector(OrdinalBytesRefVector vector, int[] masks, int[] sourceOrds) {
+        int dictSize = vector.getDictionaryVector().getPositionCount();
+        BitSet referenced = new BitSet(dictSize);
+        for (int pos : masks) {
+            referenced.set(sourceOrds[pos]);
+        }
+        int expectedDictSize = referenced.cardinality();
+        boolean expectOrdinal = OrdinalBytesRefBlock.isDense(masks.length, expectedDictSize);
+        try (var filtered = vector.filter(true, masks)) {
+            assertThat(filtered.getPositionCount(), equalTo(masks.length));
+            if (expectOrdinal) {
+                assertThat(filtered, instanceOf(OrdinalBytesRefVector.class));
+                OrdinalBytesRefVector filteredOrdinal = (OrdinalBytesRefVector) filtered;
+                assertThat(filteredOrdinal.getDictionaryVector().getPositionCount(), equalTo(expectedDictSize));
+                if (expectedDictSize == dictSize) {
+                    // Share-dictionary fast path: dict instance is reused.
+                    assertThat(filteredOrdinal.getDictionaryVector(), sameInstance(vector.getDictionaryVector()));
+                }
+            } else {
+                assertThat(filtered, not(instanceOf(OrdinalBytesRefVector.class)));
+            }
+            BytesRef scratch = new BytesRef();
+            BytesRef expectedScratch = new BytesRef();
+            for (int p = 0; p < masks.length; p++) {
+                BytesRef expected = vector.getDictionaryVector().getBytesRef(sourceOrds[masks[p]], expectedScratch);
+                BytesRef actual = filtered.getBytesRef(p, scratch);
+                assertThat(actual, equalTo(expected));
+            }
+        }
+    }
+
     private void assertSliceOrdinalBytesRefVector(OrdinalBytesRefVector vector, int beginInclusive, int endExclusive) {
         try (var sliced = vector.slice(beginInclusive, endExclusive)) {
             assertThat(sliced, instanceOf(OrdinalBytesRefVector.class));
             assertThat(sliced.getPositionCount(), equalTo(endExclusive - beginInclusive));
+        }
+    }
+
+    public void testFilterOrdinalBytesRefVectorMaterializesWhenNotDense() {
+        // Construct a dense source (12 rows, 3 dict entries) so the source itself is ordinal-encoded.
+        // Then filter to a position set whose compacted dictionary fails isDense (dict 3, positions 4 ->
+        // dict > positions/2). Result should be a plain BytesRefVector, not OrdinalBytesRefVector.
+        try (var dictBuilder = blockFactory.newBytesRefVectorBuilder(3); var ordinalBuilder = blockFactory.newIntVectorBuilder(12)) {
+            dictBuilder.appendBytesRef(new BytesRef("a"));
+            dictBuilder.appendBytesRef(new BytesRef("b"));
+            dictBuilder.appendBytesRef(new BytesRef("c"));
+            for (int i = 0; i < 12; i++) {
+                ordinalBuilder.appendInt(i % 3);
+            }
+            try (var vector = new OrdinalBytesRefVector(ordinalBuilder.build(), dictBuilder.build())) {
+                // Pick one position per dict entry plus a duplicate -> 4 positions, 3 distinct dict entries.
+                int[] sparseMasks = new int[] { 0, 1, 2, 0 };
+                try (var filtered = vector.filter(true, sparseMasks)) {
+                    assertThat(filtered, not(instanceOf(OrdinalBytesRefVector.class)));
+                    assertThat(filtered.getPositionCount(), equalTo(4));
+                    BytesRef scratch = new BytesRef();
+                    assertThat(filtered.getBytesRef(0, scratch), equalTo(new BytesRef("a")));
+                    assertThat(filtered.getBytesRef(1, scratch), equalTo(new BytesRef("b")));
+                    assertThat(filtered.getBytesRef(2, scratch), equalTo(new BytesRef("c")));
+                    assertThat(filtered.getBytesRef(3, scratch), equalTo(new BytesRef("a")));
+                }
+                // Sanity: a denser filter (10 positions touching all 3 entries) keeps the ordinal encoding.
+                int[] denseMasks = new int[] { 0, 1, 2, 0, 1, 2, 0, 1, 2, 0 };
+                try (var filtered = vector.filter(true, denseMasks)) {
+                    assertThat(filtered, instanceOf(OrdinalBytesRefVector.class));
+                    assertThat(((OrdinalBytesRefVector) filtered).getDictionaryVector().getPositionCount(), equalTo(3));
+                }
+            }
+        }
+    }
+
+    public void testFilterOrdinalBytesRefBlockMaterializesWhenNotDense() {
+        // Same shape as the vector test but with nulls + multivalues to exercise the block materialize path.
+        try (var dictBuilder = blockFactory.newBytesRefVectorBuilder(4); var ordinalBuilder = blockFactory.newIntBlockBuilder(8)) {
+            dictBuilder.appendBytesRef(new BytesRef("w"));
+            dictBuilder.appendBytesRef(new BytesRef("x"));
+            dictBuilder.appendBytesRef(new BytesRef("y"));
+            dictBuilder.appendBytesRef(new BytesRef("z"));
+            ordinalBuilder.appendInt(0);
+            ordinalBuilder.appendInt(1);
+            ordinalBuilder.appendNull();
+            ordinalBuilder.beginPositionEntry();
+            ordinalBuilder.appendInt(2);
+            ordinalBuilder.appendInt(3);
+            ordinalBuilder.endPositionEntry();
+            ordinalBuilder.appendInt(0);
+            ordinalBuilder.appendInt(1);
+            ordinalBuilder.appendInt(2);
+            ordinalBuilder.appendInt(3);
+            try (var block = new OrdinalBytesRefBlock(ordinalBuilder.build(), dictBuilder.build())) {
+                // Filter to 4 positions with 4 distinct values -> not dense -> materialized.
+                // Position 3 is the multivalue [y, z]; positions 0/1/2 give w/x/null.
+                int[] masks = new int[] { 0, 1, 2, 3 };
+                try (var filtered = block.filter(true, masks)) {
+                    assertThat(filtered, not(instanceOf(OrdinalBytesRefBlock.class)));
+                    assertThat(filtered.getPositionCount(), equalTo(4));
+                    BytesRef scratch = new BytesRef();
+                    assertThat(filtered.getBytesRef(0, scratch), equalTo(new BytesRef("w")));
+                    assertThat(filtered.getBytesRef(1, scratch), equalTo(new BytesRef("x")));
+                    assertThat(filtered.isNull(2), is(true));
+                    assertThat(filtered.getValueCount(3), equalTo(2));
+                    int first = filtered.getFirstValueIndex(3);
+                    assertThat(filtered.getBytesRef(first, scratch), equalTo(new BytesRef("y")));
+                    assertThat(filtered.getBytesRef(first + 1, scratch), equalTo(new BytesRef("z")));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes elastic/esql-planning#691

# ES|QL: Preserve `OrdinalBytesRefBlock`/`Vector` encoding through `filter()`

Previously `OrdinalBytesRefBlock#filter` and `OrdinalBytesRefVector#filter` materialized a
plain `BytesRefBlock`/`Vector`. They had to: every consumer (notably `BytesRefBlockHash`)
hashes the **entire** dictionary unconditionally, so leaving unreferenced entries behind
would silently corrupt grouping results.

This PR keeps the ordinal encoding past `filter()` by compacting the dictionary in place:

- Walk the requested positions once, building `remap[oldOrd] -> newOrd` and `keptOrds[newOrd] -> oldOrd`.
- Fast path when every dictionary entry is still referenced: share the original dictionary
  (with an `incRef`) and only filter the ordinals, no remap pass needed.
- Otherwise build a compacted dictionary via the shared `compactDictionary` helper and
  rewrite the ordinals through `remap`.
- If the compacted result would no longer satisfy `isDense(totalValues, kept)`, fall back to
  `materializeFiltered(...)` so downstream code takes its fastest non-ordinal path (and we
  do not produce ordinal blocks that would not serialize via `SERIALIZE_BLOCK_ORDINAL`).

Density is measured on total (non-null) values, matching the existing `isDense()` callers
and correctly accounting for multivalued positions. Resource handling uses the standard
try/finally with a sentinel `result` so partially-built dictionaries/ordinals are released
on exception. New tests in `BasicBlockTests` and `BlockHashTests` cover the share, remap,
and density-fallback paths for both block and vector variants.

