### PR TITLE
[9.4] Stabilize fetch chunk tests: breaker busy-wait, avoid acquireResponseStream poll leak (#148026)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -322,3 +322,4 @@ tests:
 #    issue: "https://github.com/elastic/elasticsearch/..."
 #  - class: "org.elasticsearch.xpack.esql.**"
 #    method: "test {union_types.MultiIndexIpStringStatsInline *}"
+#    issue: "https://github.com/elastic/elasticsearch/..."

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -285,18 +285,6 @@ tests:
 - class: org.elasticsearch.search.KnnSearchIT
   method: testKnnSearchWithScroll
   issue: https://github.com/elastic/elasticsearch/issues/148590
-- class: org.elasticsearch.search.fetch.chunk.TransportFetchPhaseCoordinationActionTests
-  method: testActionType
-  issue: https://github.com/elastic/elasticsearch/issues/148911
-- class: org.elasticsearch.search.fetch.chunk.TransportFetchPhaseCoordinationActionTests
-  method: testDoExecuteReleasesRegistrationOnLastChunkDeserializationFailure
-  issue: https://github.com/elastic/elasticsearch/issues/148912
-- class: org.elasticsearch.search.fetch.chunk.TransportFetchPhaseCoordinationActionTests
-  method: testDoExecuteReleasesRegistrationWhenDataNodeFailsAfterChunkStreaming
-  issue: https://github.com/elastic/elasticsearch/issues/148913
-- class: org.elasticsearch.search.rescore.QueryRescoreModeTests
-  method: testQueryRescoreMode
-  issue: https://github.com/elastic/elasticsearch/issues/148923
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -322,4 +322,3 @@ tests:
 #    issue: "https://github.com/elastic/elasticsearch/..."
 #  - class: "org.elasticsearch.xpack.esql.**"
 #    method: "test {union_types.MultiIndexIpStringStatsInline *}"
-#    issue: "https://github.com/elastic/elasticsearch/..."

--- a/server/src/test/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseCoordinationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseCoordinationActionTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.VersionInformation;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
@@ -75,6 +76,7 @@ public class TransportFetchPhaseCoordinationActionTests extends ESTestCase {
     private ActiveFetchPhaseTasks activeFetchPhaseTasks;
     private NamedWriteableRegistry namedWriteableRegistry;
     private TransportFetchPhaseCoordinationAction action;
+    private CircuitBreakerService breakerService;
 
     @Before
     public void setUp() throws Exception {
@@ -92,7 +94,7 @@ public class TransportFetchPhaseCoordinationActionTests extends ESTestCase {
         activeFetchPhaseTasks = new ActiveFetchPhaseTasks();
         namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
 
-        CircuitBreakerService breakerService = newLimitedBreakerService(ByteSizeValue.ofMb(64));
+        breakerService = newLimitedBreakerService(ByteSizeValue.ofMb(64));
         action = new TransportFetchPhaseCoordinationAction(
             transportService,
             new ActionFilters(Set.of()),
@@ -381,9 +383,20 @@ public class TransportFetchPhaseCoordinationActionTests extends ESTestCase {
         action.doExecute(createTask(taskId), request, future);
         expectThrows(Exception.class, () -> future.actionGet(10, TimeUnit.SECONDS));
 
-        assertBusy(() -> {
-            expectThrows(ResourceNotFoundException.class, () -> activeFetchPhaseTasks.acquireResponseStream(taskId, TEST_SHARD_ID));
-        });
+        // doExecute adds bytes to the REQUEST breaker before SearchHit.readFrom() throws on the
+        // invalid payload. closeInternal (triggered when the stream's refCount reaches zero after
+        // cleanup) releases those bytes, so zero bytes is the reliable signal that the stream is
+        // fully cleaned up. Polling acquireResponseStream instead would tryIncRef on every failed
+        // attempt and leak refs, preventing closeInternal from ever firing.
+        assertBusy(
+            () -> assertThat(
+                "breaker bytes must be zero once stream closeInternal has completed",
+                breakerService.getBreaker(CircuitBreaker.REQUEST).getUsed(),
+                equalTo(0L)
+            )
+        );
+        // Confirm the task was also deregistered (single call, no retry loop, no ref leak).
+        expectThrows(ResourceNotFoundException.class, () -> activeFetchPhaseTasks.acquireResponseStream(taskId, TEST_SHARD_ID));
     }
 
     public void testDoExecutePreservesContextIdInFinalResult() throws Exception {
@@ -470,9 +483,21 @@ public class TransportFetchPhaseCoordinationActionTests extends ESTestCase {
         Exception failure = expectThrows(Exception.class, () -> future.actionGet(10, TimeUnit.SECONDS));
         assertThat(failure.getMessage(), equalTo("simulated data node failure during chunk streaming"));
 
+        // Wait until closeInternal fires so tearDown's transportService.close() cannot race with
+        // processChunk.finally still holding the stream ref. The circuit breaker is released in
+        // closeInternal, so zero bytes means the stream has been fully cleaned up (cleanup ran
+        // AND processChunk.finally ran AND closeInternal was triggered). Using the breaker check
+        // instead of polling acquireResponseStream, which would tryIncRef on every failed poll and
+        // leak refs, preventing closeInternal from ever being triggered.
         assertBusy(
-            () -> expectThrows(ResourceNotFoundException.class, () -> activeFetchPhaseTasks.acquireResponseStream(taskId, TEST_SHARD_ID))
+            () -> assertThat(
+                "breaker bytes must be zero once stream closeInternal has completed",
+                breakerService.getBreaker(CircuitBreaker.REQUEST).getUsed(),
+                equalTo(0L)
+            )
         );
+        // Confirm the task was also deregistered (single call, no retry loop, no ref leak).
+        expectThrows(ResourceNotFoundException.class, () -> activeFetchPhaseTasks.acquireResponseStream(taskId, TEST_SHARD_ID));
     }
 
     private ShardFetchSearchRequest createShardFetchSearchRequest() {

--- a/server/src/test/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseResponseChunkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/chunk/TransportFetchPhaseResponseChunkActionTests.java
@@ -256,7 +256,10 @@ public class TransportFetchPhaseResponseChunkActionTests extends ESTestCase {
             originalHit.decRef();
         }
 
-        assertThat("breaker bytes should be released when stream is closed", breaker.getUsed(), equalTo(0L));
+        // processChunk.finally (responseStream.decRef) may still be pending on a transport thread
+        // when the test's own stream.decRef runs. assertBusy waits until closeInternal fires
+        // (observable via breaker bytes = 0) before returning, preventing tearDown from racing it.
+        assertBusy(() -> assertThat("breaker bytes should be released when stream is closed", breaker.getUsed(), equalTo(0L)));
     }
 
     private SearchHit createHit(int id) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Stabilize fetch chunk tests: breaker busy-wait, avoid acquireResponseStream poll leak (#148026)](https://github.com/elastic/elasticsearch/pull/148026)

<!--- Backport version: 10.2.0 -->

Closes #148912
Closes #148913
Closes #148923