### PR TITLE
[Native] head+spread prefetch in amd64 bulk kernels

### DIFF
--- a/docs/changelog/148945.yaml
+++ b/docs/changelog/148945.yaml
@@ -1,0 +1,5 @@
+area: Vector Search
+issues: []
+pr: 148945
+summary: "[Native] head+spread prefetch in amd64 bulk kernels"
+type: enhancement

--- a/libs/native/libraries/build.gradle
+++ b/libs/native/libraries/build.gradle
@@ -19,7 +19,7 @@ configurations {
 }
 
 var zstdVersion = "1.5.7"
-var vecVersion = "1.0.122"
+var vecVersion = "1.0.123"
 var pqrsVersion = "0.2.0"
 
 repositories {

--- a/libs/simdvec/native/publish_vec_binaries.sh
+++ b/libs/simdvec/native/publish_vec_binaries.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.122"
+VERSION="1.0.123"
 
 LOCAL=false
 FORCE_UPLOAD=false

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bbq_packed_1.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bbq_packed_1.cpp
@@ -149,11 +149,9 @@ static inline void dotd2q4_packed_bulk_impl(
 
             const int end = std::min(i + chunk, blk);
 
-            // Inner step is 32 bytes (half a cache line), so gate the spread
-            // on cache-line boundaries to avoid re-prefetching the same line.
             for (; i < end; i += stride) {
-                if (has_next && (i & (CACHE_LINE_SIZE - 1)) == 0) {
-                    spread_prefetch<batches, 1>(next_doc_ptrs, i, lines_to_fetch);
+                if (has_next) {
+                    spread_prefetch_step<batches, 1, stride>(next_doc_ptrs, i, lines_to_fetch);
                 }
                 __m256i query_s0 = _mm256_loadu_si256((const __m256i*)(query + i));
                 __m256i query_s1 = _mm256_loadu_si256((const __m256i*)(query + i + packed_len));

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bbq_packed_1.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bbq_packed_1.cpp
@@ -125,8 +125,8 @@ static inline void dotd2q4_packed_bulk_impl(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_doc_ptrs[I] = mapper(docs, c + batches + I, offsets, pitch);
-                prefetch(next_doc_ptrs[I], lines_to_fetch);
             });
+            head_prefetch<batches, 1>(next_doc_ptrs);
         }
 
         __m256i acc32[batches];
@@ -149,7 +149,12 @@ static inline void dotd2q4_packed_bulk_impl(
 
             const int end = std::min(i + chunk, blk);
 
+            // Inner step is 32 bytes (half a cache line), so gate the spread
+            // on cache-line boundaries to avoid re-prefetching the same line.
             for (; i < end; i += stride) {
+                if (has_next && (i & (CACHE_LINE_SIZE - 1)) == 0) {
+                    spread_prefetch<batches, 1>(next_doc_ptrs, i, lines_to_fetch);
+                }
                 __m256i query_s0 = _mm256_loadu_si256((const __m256i*)(query + i));
                 __m256i query_s1 = _mm256_loadu_si256((const __m256i*)(query + i + packed_len));
                 __m256i query_s2 = _mm256_loadu_si256((const __m256i*)(query + i + 2 * packed_len));

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bbq_packed_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bbq_packed_2.cpp
@@ -114,6 +114,8 @@ static inline void dotd2q4_packed_bulk_impl_avx512(
 ) {
     const __m512i mask_two_bits = _mm512_set1_epi8(0x03);
     constexpr int stride = sizeof(__m512i);
+    static_assert(stride == CACHE_LINE_SIZE,
+        "spread_prefetch_step<lines_per_iter=1> below assumes one full cache line per iter");
     const int blk = packed_len & ~(stride - 1);
     const int lines_to_fetch = packed_len / CACHE_LINE_SIZE + 1;
 
@@ -146,12 +148,10 @@ static inline void dotd2q4_packed_bulk_impl_avx512(
             acc_s3[I] = _mm512_setzero_si512();
         });
 
-        // Inner step is 64 bytes (one cache line), so the spread fires every
-        // iter with lines_per_iter=1.
         int i = 0;
         for (; i < blk; i += stride) {
             if (has_next) {
-                spread_prefetch<batches, 1>(next_doc_ptrs, i, lines_to_fetch);
+                spread_prefetch_step<batches, 1, stride>(next_doc_ptrs, i, lines_to_fetch);
             }
             __m512i query_s0 = _mm512_loadu_si512((const __m512i*)(query + i));
             __m512i query_s1 = _mm512_loadu_si512((const __m512i*)(query + i + packed_len));

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bbq_packed_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bbq_packed_2.cpp
@@ -131,8 +131,8 @@ static inline void dotd2q4_packed_bulk_impl_avx512(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_doc_ptrs[I] = mapper(docs, c + batches + I, offsets, pitch);
-                prefetch(next_doc_ptrs[I], lines_to_fetch);
             });
+            head_prefetch<batches, 1>(next_doc_ptrs);
         }
 
         __m512i acc_s0[batches];
@@ -146,8 +146,13 @@ static inline void dotd2q4_packed_bulk_impl_avx512(
             acc_s3[I] = _mm512_setzero_si512();
         });
 
+        // Inner step is 64 bytes (one cache line), so the spread fires every
+        // iter with lines_per_iter=1.
         int i = 0;
         for (; i < blk; i += stride) {
+            if (has_next) {
+                spread_prefetch<batches, 1>(next_doc_ptrs, i, lines_to_fetch);
+            }
             __m512i query_s0 = _mm512_loadu_si512((const __m512i*)(query + i));
             __m512i query_s1 = _mm512_loadu_si512((const __m512i*)(query + i + packed_len));
             __m512i query_s2 = _mm512_loadu_si512((const __m512i*)(query + i + 2 * packed_len));

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bf16_1.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bf16_1.cpp
@@ -131,12 +131,11 @@ static inline void bf16_bulk_inner(
             sums[I] = _mm256_setzero_ps();
         });
 
-        // Inner step is 8 bf16 = 16 bytes (quarter cache line), so gate the spread
-        // on cache-line boundaries: fires every 4th iter (i = 0, 32, 64, ...).
         int i = 0;
         for (; i < (dims & ~(stride - 1)); i += stride) {
-            if (has_next && ((i * sizeof(bf16_t)) & (CACHE_LINE_SIZE - 1)) == 0) {
-                spread_prefetch<batches, 1>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
+            if (has_next) {
+                spread_prefetch_step<batches, 1, stride * sizeof(bf16_t)>(
+                    next_vecs, i * sizeof(bf16_t), lines_to_fetch);
             }
             __m256 bi = load_q(b, i);
             apply_indexed<batches>([&](auto I) {

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bf16_1.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bf16_1.cpp
@@ -109,26 +109,38 @@ static inline void bf16_bulk_inner(
     const int32_t count,
     f32_t* results
 ) {
+    constexpr int stride = sizeof(__m128) / sizeof(bf16_t);  // 8 bf16 = 16 bytes
+    const int lines_to_fetch = dims * sizeof(bf16_t) / CACHE_LINE_SIZE + 1;
     int c = 0;
 
+    const bf16_t* current_vecs[batches];
+    init_pointers<batches, TData, bf16_t, mapper>(current_vecs, a, pitch, offsets, 0, count);
+
     for (; c + batches - 1 < count; c += batches) {
-        // Pointers to the current batch of input vectors, resolved via mapper.
-        // as[0] points to the vector for index 0, [1] for index 1, etc
-        const bf16_t* as[batches];
+        const bf16_t* next_vecs[batches];
+        const bool has_next = c + 2 * batches - 1 < count;
+        if (has_next) {
+            apply_indexed<batches>([&](auto I) {
+                next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
+            });
+            head_prefetch<batches, 1>(next_vecs);
+        }
+
         __m256 sums[batches] = {};
         apply_indexed<batches>([&](auto I) {
-            as[I] = mapper(a, c + I, offsets, pitch);
             sums[I] = _mm256_setzero_ps();
         });
 
+        // Inner step is 8 bf16 = 16 bytes (quarter cache line), so gate the spread
+        // on cache-line boundaries: fires every 4th iter (i = 0, 32, 64, ...).
         int i = 0;
-        // do <batches> vectors at a time, iterating through the dimensions in parallel
-        // Each __m128 holds 8 bfloats
-        constexpr int stride = sizeof(__m128) / sizeof(bf16_t);
         for (; i < (dims & ~(stride - 1)); i += stride) {
+            if (has_next && ((i * sizeof(bf16_t)) & (CACHE_LINE_SIZE - 1)) == 0) {
+                spread_prefetch<batches, 1>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
+            }
             __m256 bi = load_q(b, i);
             apply_indexed<batches>([&](auto I) {
-                sums[I] = vector_op(load_bf16(as[I], i), bi, sums[I]);
+                sums[I] = vector_op(load_bf16(current_vecs[I], i), bi, sums[I]);
             });
         }
 
@@ -140,12 +152,16 @@ static inline void bf16_bulk_inner(
         // dimensions tail
         for (; i < dims; i++) {
             apply_indexed<batches>([&](auto I) {
-                res[I] += scalar_op(as[I][i], b[i]);
+                res[I] += scalar_op(current_vecs[I][i], b[i]);
             });
         }
 
         // this should be turned into direct value copies by the compiler
         std::copy_n(res, batches, results + c);
+
+        if (has_next) {
+            std::copy_n(next_vecs, batches, current_vecs);
+        }
     }
 
     // Tail-handling: remaining vectors

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bf16_3.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bf16_3.cpp
@@ -285,15 +285,7 @@ static inline void bf16Qf32_bulk_avx512(
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
             });
-            // Head + spread (shared-b path) only when batches > 1; at batches=1 the
-            // LFB-saturation problem the spread fixes does not exist and the extra
-            // in-loop prefetch instructions add μop pressure that hurts the L1/L2-
-            // resident sequential path (HW prefetcher already handles it).
-            if constexpr (batches > 1) {
-                head_prefetch<batches, 1>(next_vecs);
-            } else {
-                prefetch(next_vecs[0], lines_to_fetch);
-            }
+            head_prefetch_or_burst<batches, 1>(next_vecs, lines_to_fetch);
         }
 
         __m512 sums[batches];
@@ -301,14 +293,11 @@ static inline void bf16Qf32_bulk_avx512(
             sums[I] = _mm512_setzero_ps();
         });
 
-        // Inner step is 16 bf16 = 32 bytes (half a cache line), so gate the
-        // spread on cache-line boundaries to avoid re-prefetching the same line.
         int i = 0;
         for (; i + elements <= dims; i += elements) {
-            if constexpr (batches > 1) {
-                if (has_next && ((i * sizeof(bf16_t)) & (CACHE_LINE_SIZE - 1)) == 0) {
-                    spread_prefetch<batches, 1>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
-                }
+            if (has_next) {
+                spread_prefetch_step<batches, 1, elements * sizeof(bf16_t)>(
+                    next_vecs, i * sizeof(bf16_t), lines_to_fetch);
             }
             __m512 qi = load_f32(b, i);
             apply_indexed<batches>([&](auto I) {
@@ -398,12 +387,7 @@ static inline void dotDbf16Qbf16_bulk_avx512(
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
             });
-            // See bf16Qf32_bulk_avx512 for why head+spread is gated on batches>1.
-            if constexpr (batches > 1) {
-                head_prefetch<batches, unroll_dim>(next_vecs);
-            } else {
-                prefetch(next_vecs[0], lines_to_fetch);
-            }
+            head_prefetch_or_burst<batches, unroll_dim>(next_vecs, lines_to_fetch);
         }
 
         // Row-major layout: sums[I * unroll_dim + U] keeps the unroll_dim accumulators
@@ -419,10 +403,9 @@ static inline void dotDbf16Qbf16_bulk_avx512(
         // dimStride = unroll_dim cache lines, matching lines_per_iter=unroll_dim.
         int i = 0;
         for (; i + dimStride <= dims; i += dimStride) {
-            if constexpr (batches > 1) {
-                if (has_next) {
-                    spread_prefetch<batches, unroll_dim>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
-                }
+            if (has_next) {
+                spread_prefetch_step<batches, unroll_dim, dimStride * sizeof(bf16_t)>(
+                    next_vecs, i * sizeof(bf16_t), lines_to_fetch);
             }
             apply_indexed<unroll_dim>([&](auto U) {
                 __m512bh qi = (__m512bh)_mm512_loadu_epi16(b + i + U * elements);
@@ -444,10 +427,9 @@ static inline void dotDbf16Qbf16_bulk_avx512(
 
             // Dim-unroll-1 tail: full 32-element blocks not consumed by the main loop.
             for (; i + elements <= dims; i += elements) {
-                if constexpr (batches > 1) {
-                    if (has_next) {
-                        spread_prefetch<batches, 1>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
-                    }
+                if (has_next) {
+                    spread_prefetch_step<batches, 1, elements * sizeof(bf16_t)>(
+                        next_vecs, i * sizeof(bf16_t), lines_to_fetch);
                 }
                 __m512bh qi = (__m512bh)_mm512_loadu_epi16(b + i);
                 apply_indexed<batches>([&](auto I) {
@@ -532,12 +514,7 @@ static inline void sqrDbf16Qbf16_bulk_avx512(
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
             });
-            // See bf16Qf32_bulk_avx512 for why head+spread is gated on batches>1.
-            if constexpr (batches > 1) {
-                head_prefetch<batches, unroll_dim>(next_vecs);
-            } else {
-                prefetch(next_vecs[0], lines_to_fetch);
-            }
+            head_prefetch_or_burst<batches, unroll_dim>(next_vecs, lines_to_fetch);
         }
 
         // Row-major layout for sum_aa / sum_ab: sum_xx[I * unroll_dim + U] keeps
@@ -559,10 +536,9 @@ static inline void sqrDbf16Qbf16_bulk_avx512(
         // dimStride = unroll_dim cache lines, matching lines_per_iter=unroll_dim.
         int i = 0;
         for (; i + dimStride <= dims; i += dimStride) {
-            if constexpr (batches > 1) {
-                if (has_next) {
-                    spread_prefetch<batches, unroll_dim>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
-                }
+            if (has_next) {
+                spread_prefetch_step<batches, unroll_dim, dimStride * sizeof(bf16_t)>(
+                    next_vecs, i * sizeof(bf16_t), lines_to_fetch);
             }
             apply_indexed<unroll_dim>([&](auto U) {
                 __m512bh qi = (__m512bh)_mm512_loadu_epi16(b + i + U * elements);
@@ -588,10 +564,9 @@ static inline void sqrDbf16Qbf16_bulk_avx512(
 
             // Dim-unroll-1 tail: full 32-element blocks not consumed by the main loop.
             for (; i + elements <= dims; i += elements) {
-                if constexpr (batches > 1) {
-                    if (has_next) {
-                        spread_prefetch<batches, 1>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
-                    }
+                if (has_next) {
+                    spread_prefetch_step<batches, 1, elements * sizeof(bf16_t)>(
+                        next_vecs, i * sizeof(bf16_t), lines_to_fetch);
                 }
                 __m512bh qi = (__m512bh)_mm512_loadu_epi16(b + i);
                 sum_bb[0] = _mm512_dpbf16_ps(sum_bb[0], qi, qi);

--- a/libs/simdvec/native/src/vec/c/amd64/vec_bf16_3.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_bf16_3.cpp
@@ -284,8 +284,16 @@ static inline void bf16Qf32_bulk_avx512(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
-                prefetch(next_vecs[I], lines_to_fetch);
             });
+            // Head + spread (shared-b path) only when batches > 1; at batches=1 the
+            // LFB-saturation problem the spread fixes does not exist and the extra
+            // in-loop prefetch instructions add μop pressure that hurts the L1/L2-
+            // resident sequential path (HW prefetcher already handles it).
+            if constexpr (batches > 1) {
+                head_prefetch<batches, 1>(next_vecs);
+            } else {
+                prefetch(next_vecs[0], lines_to_fetch);
+            }
         }
 
         __m512 sums[batches];
@@ -293,8 +301,15 @@ static inline void bf16Qf32_bulk_avx512(
             sums[I] = _mm512_setzero_ps();
         });
 
+        // Inner step is 16 bf16 = 32 bytes (half a cache line), so gate the
+        // spread on cache-line boundaries to avoid re-prefetching the same line.
         int i = 0;
         for (; i + elements <= dims; i += elements) {
+            if constexpr (batches > 1) {
+                if (has_next && ((i * sizeof(bf16_t)) & (CACHE_LINE_SIZE - 1)) == 0) {
+                    spread_prefetch<batches, 1>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
+                }
+            }
             __m512 qi = load_f32(b, i);
             apply_indexed<batches>([&](auto I) {
                 sums[I] = vector_op(load_bf16(current_vecs[I], i), qi, sums[I]);
@@ -382,8 +397,13 @@ static inline void dotDbf16Qbf16_bulk_avx512(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
-                prefetch(next_vecs[I], lines_to_fetch);
             });
+            // See bf16Qf32_bulk_avx512 for why head+spread is gated on batches>1.
+            if constexpr (batches > 1) {
+                head_prefetch<batches, unroll_dim>(next_vecs);
+            } else {
+                prefetch(next_vecs[0], lines_to_fetch);
+            }
         }
 
         // Row-major layout: sums[I * unroll_dim + U] keeps the unroll_dim accumulators
@@ -396,8 +416,14 @@ static inline void dotDbf16Qbf16_bulk_avx512(
         // Main loop: each iteration advances the dim cursor by unroll_dim * elements
         // bf16 lanes, issuing unroll_dim * batches independent vdpbf16ps's into
         // distinct accumulators to fill the multi-cycle vdpbf16ps latency window.
+        // dimStride = unroll_dim cache lines, matching lines_per_iter=unroll_dim.
         int i = 0;
         for (; i + dimStride <= dims; i += dimStride) {
+            if constexpr (batches > 1) {
+                if (has_next) {
+                    spread_prefetch<batches, unroll_dim>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
+                }
+            }
             apply_indexed<unroll_dim>([&](auto U) {
                 __m512bh qi = (__m512bh)_mm512_loadu_epi16(b + i + U * elements);
                 apply_indexed<batches>([&](auto I) {
@@ -418,6 +444,11 @@ static inline void dotDbf16Qbf16_bulk_avx512(
 
             // Dim-unroll-1 tail: full 32-element blocks not consumed by the main loop.
             for (; i + elements <= dims; i += elements) {
+                if constexpr (batches > 1) {
+                    if (has_next) {
+                        spread_prefetch<batches, 1>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
+                    }
+                }
                 __m512bh qi = (__m512bh)_mm512_loadu_epi16(b + i);
                 apply_indexed<batches>([&](auto I) {
                     sums[I] = _mm512_dpbf16_ps(sums[I],
@@ -500,8 +531,13 @@ static inline void sqrDbf16Qbf16_bulk_avx512(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
-                prefetch(next_vecs[I], lines_to_fetch);
             });
+            // See bf16Qf32_bulk_avx512 for why head+spread is gated on batches>1.
+            if constexpr (batches > 1) {
+                head_prefetch<batches, unroll_dim>(next_vecs);
+            } else {
+                prefetch(next_vecs[0], lines_to_fetch);
+            }
         }
 
         // Row-major layout for sum_aa / sum_ab: sum_xx[I * unroll_dim + U] keeps
@@ -520,8 +556,14 @@ static inline void sqrDbf16Qbf16_bulk_avx512(
 
         // Main loop: each iteration advances the dim cursor by unroll_dim * elements
         // bf16 lanes, issuing unroll_dim * (1 + 2 * batches) independent vdpbf16ps's.
+        // dimStride = unroll_dim cache lines, matching lines_per_iter=unroll_dim.
         int i = 0;
         for (; i + dimStride <= dims; i += dimStride) {
+            if constexpr (batches > 1) {
+                if (has_next) {
+                    spread_prefetch<batches, unroll_dim>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
+                }
+            }
             apply_indexed<unroll_dim>([&](auto U) {
                 __m512bh qi = (__m512bh)_mm512_loadu_epi16(b + i + U * elements);
                 sum_bb[U] = _mm512_dpbf16_ps(sum_bb[U], qi, qi);
@@ -546,6 +588,11 @@ static inline void sqrDbf16Qbf16_bulk_avx512(
 
             // Dim-unroll-1 tail: full 32-element blocks not consumed by the main loop.
             for (; i + elements <= dims; i += elements) {
+                if constexpr (batches > 1) {
+                    if (has_next) {
+                        spread_prefetch<batches, 1>(next_vecs, i * sizeof(bf16_t), lines_to_fetch);
+                    }
+                }
                 __m512bh qi = (__m512bh)_mm512_loadu_epi16(b + i);
                 sum_bb[0] = _mm512_dpbf16_ps(sum_bb[0], qi, qi);
                 apply_indexed<batches>([&](auto I) {

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i4_1.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i4_1.cpp
@@ -103,8 +103,8 @@ static inline void doti4_bulk_impl(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_doc_ptrs[I] = mapper(docs, c + batches + I, offsets, pitch);
-                prefetch(next_doc_ptrs[I], lines_to_fetch);
             });
+            head_prefetch<batches, 1>(next_doc_ptrs);
         }
 
         __m256i acc32[batches];
@@ -123,7 +123,12 @@ static inline void doti4_bulk_impl(
 
             const int end = std::min(i + chunk, blk);
 
+            // Inner step is 32 bytes (half a cache line), so gate the spread
+            // on cache-line boundaries to avoid re-prefetching the same line.
             for (; i < end; i += stride) {
+                if (has_next && (i & (CACHE_LINE_SIZE - 1)) == 0) {
+                    spread_prefetch<batches, 1>(next_doc_ptrs, i, lines_to_fetch);
+                }
                 __m256i query_high = _mm256_loadu_si256((const __m256i*)(query + i));
                 __m256i query_low = _mm256_loadu_si256((const __m256i*)(query + i + packed_len));
 

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i4_1.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i4_1.cpp
@@ -123,11 +123,9 @@ static inline void doti4_bulk_impl(
 
             const int end = std::min(i + chunk, blk);
 
-            // Inner step is 32 bytes (half a cache line), so gate the spread
-            // on cache-line boundaries to avoid re-prefetching the same line.
             for (; i < end; i += stride) {
-                if (has_next && (i & (CACHE_LINE_SIZE - 1)) == 0) {
-                    spread_prefetch<batches, 1>(next_doc_ptrs, i, lines_to_fetch);
+                if (has_next) {
+                    spread_prefetch_step<batches, 1, stride>(next_doc_ptrs, i, lines_to_fetch);
                 }
                 __m256i query_high = _mm256_loadu_si256((const __m256i*)(query + i));
                 __m256i query_low = _mm256_loadu_si256((const __m256i*)(query + i + packed_len));

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i4_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i4_2.cpp
@@ -105,8 +105,8 @@ static inline void doti4_bulk_impl_avx512(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_doc_ptrs[I] = mapper(docs, c + batches + I, offsets, pitch);
-                prefetch(next_doc_ptrs[I], lines_to_fetch);
             });
+            head_prefetch<batches, 1>(next_doc_ptrs);
         }
 
         __m512i acc_high[batches];
@@ -116,8 +116,13 @@ static inline void doti4_bulk_impl_avx512(
             acc_low[I] = _mm512_setzero_si512();
         });
 
+        // Inner step is 64 bytes (one cache line), so the spread fires every
+        // iter with lines_per_iter=1.
         int i = 0;
         for (; i < blk; i += stride) {
+            if (has_next) {
+                spread_prefetch<batches, 1>(next_doc_ptrs, i, lines_to_fetch);
+            }
             __m512i query_high = _mm512_loadu_si512((const __m512i*)(query + i));
             __m512i query_low = _mm512_loadu_si512((const __m512i*)(query + i + packed_len));
 

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i4_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i4_2.cpp
@@ -88,6 +88,8 @@ static inline void doti4_bulk_impl_avx512(
 ) {
     const __m512i mask_half_byte = _mm512_set1_epi8(0x0F);
     constexpr int stride = sizeof(__m512i);
+    static_assert(stride == CACHE_LINE_SIZE,
+        "spread_prefetch_step<lines_per_iter=1> below assumes one full cache line per iter");
     const int blk = packed_len & ~(stride - 1);
     const int lines_to_fetch = packed_len / CACHE_LINE_SIZE + 1;
 
@@ -116,12 +118,10 @@ static inline void doti4_bulk_impl_avx512(
             acc_low[I] = _mm512_setzero_si512();
         });
 
-        // Inner step is 64 bytes (one cache line), so the spread fires every
-        // iter with lines_per_iter=1.
         int i = 0;
         for (; i < blk; i += stride) {
             if (has_next) {
-                spread_prefetch<batches, 1>(next_doc_ptrs, i, lines_to_fetch);
+                spread_prefetch_step<batches, 1, stride>(next_doc_ptrs, i, lines_to_fetch);
             }
             __m512i query_high = _mm512_loadu_si512((const __m512i*)(query + i));
             __m512i query_low = _mm512_loadu_si512((const __m512i*)(query + i + packed_len));

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
@@ -467,8 +467,8 @@ static inline void sqri8_bulk(
 
         int i = 0;
         for (; i + chunk <= blk; i += chunk) {
-            if (has_next && (i & (CACHE_LINE_SIZE - 1)) == 0) {
-                spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
+            if (has_next) {
+                spread_prefetch_step<batches, 1, chunk>(next_vecs, i, lines_to_fetch);
             }
             __m512i b16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(b + i)));
             apply_indexed<batches>([&](auto I) {
@@ -628,12 +628,10 @@ static inline void cosi8_inner_bulk(
             a_norms[I] = _mm512_setzero_si512();
         });
 
-        // Inner step is 32 bytes (half a cache line), so gate the spread on
-        // cache-line boundaries to avoid re-prefetching the same line.
         int i = 0;
         for (; i < blk; i += sizeof(__m256i)) {
-            if (has_next && (i & (CACHE_LINE_SIZE - 1)) == 0) {
-                spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
+            if (has_next) {
+                spread_prefetch_step<batches, 1, sizeof(__m256i)>(next_vecs, i, lines_to_fetch);
             }
             const __m512i vb16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(b + i)));
 

--- a/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
+++ b/libs/simdvec/native/src/vec/c/amd64/vec_i8_2.cpp
@@ -617,8 +617,8 @@ static inline void cosi8_inner_bulk(
         if (has_next) {
             apply_indexed<batches>([&](auto I) {
                 next_vecs[I] = mapper(a, c + batches + I, offsets, pitch);
-                prefetch(next_vecs[I], lines_to_fetch);
             });
+            head_prefetch<batches, 1>(next_vecs);
         }
 
         __m512i sums[batches];
@@ -628,8 +628,13 @@ static inline void cosi8_inner_bulk(
             a_norms[I] = _mm512_setzero_si512();
         });
 
+        // Inner step is 32 bytes (half a cache line), so gate the spread on
+        // cache-line boundaries to avoid re-prefetching the same line.
         int i = 0;
         for (; i < blk; i += sizeof(__m256i)) {
+            if (has_next && (i & (CACHE_LINE_SIZE - 1)) == 0) {
+                spread_prefetch<batches, 1>(next_vecs, i, lines_to_fetch);
+            }
             const __m512i vb16 = _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)(b + i)));
 
             apply_indexed<batches>([&](auto I) {

--- a/libs/simdvec/native/src/vec/headers/amd64/amd64_vec_common.h
+++ b/libs/simdvec/native/src/vec/headers/amd64/amd64_vec_common.h
@@ -34,10 +34,9 @@ static inline void head_prefetch(const T* const (&next_vecs)[batches]) {
 // fill-buffer occupancy bounded (callers issue `batches * lines_per_iter`
 // prefetches per iter instead of `batches * lines_to_fetch` at the boundary).
 //
-// For callers whose outer step is < CACHE_LINE_SIZE the call site must gate
-// on `(i & (CACHE_LINE_SIZE - 1)) == 0` so the spread fires only on the iter
-// that crosses a cache-line boundary (otherwise we'd re-prefetch the same
-// line on consecutive iters).
+// Low-level primitive: callers whose outer step is < CACHE_LINE_SIZE must gate
+// externally so the spread fires only on the iter that crosses a cache-line
+// boundary. Prefer `spread_prefetch_step` below, which absorbs the gating.
 template <int batches, int lines_per_iter, typename T>
 static inline void spread_prefetch(
     const T* const (&next_vecs)[batches], int i, int lines_to_fetch
@@ -52,6 +51,44 @@ static inline void spread_prefetch(
             });
         }
     });
+}
+
+// Head prefetch with single-batch burst fallback. At `batches == 1` the
+// LFB-saturation pathology that `spread_prefetch` is meant to dodge does not
+// exist, and the extra in-loop prefetch instructions would add μop pressure
+// that hurts the L1/L2-resident sequential path. So at `batches == 1` we burst
+// the whole vector at the head and skip the in-loop spread; the HW prefetcher
+// handles the sequential stream from there. At `batches > 1` we issue only
+// `lines_per_iter` lines per stream at the head and let `spread_prefetch_step`
+// trickle the rest in lockstep with the inner loop.
+template <int batches, int lines_per_iter, typename T>
+static inline void head_prefetch_or_burst(
+    const T* const (&next_vecs)[batches], int lines_to_fetch
+) {
+    if constexpr (batches > 1) {
+        head_prefetch<batches, lines_per_iter>(next_vecs);
+    } else {
+        prefetch(next_vecs[0], lines_to_fetch);
+    }
+}
+
+// Spread prefetch step: compile-time selects the gating from `stride_bytes`,
+// the per-iter byte stride of the calling loop.
+//   - batches == 1:                    no-op (the head burst already covered the run).
+//   - stride_bytes >= CACHE_LINE_SIZE: fires every iter.
+//   - stride_bytes <  CACHE_LINE_SIZE: fires only when `byte_offset` crosses a
+//     cache-line boundary, avoiding re-prefetching the same line.
+// `byte_offset` is always in bytes regardless of the caller's element type.
+template <int batches, int lines_per_iter, int stride_bytes, typename T>
+static inline void spread_prefetch_step(
+    const T* const (&next_vecs)[batches], int byte_offset, int lines_to_fetch
+) {
+    if constexpr (batches > 1) {
+        if constexpr (stride_bytes < CACHE_LINE_SIZE) {
+            if ((byte_offset & (CACHE_LINE_SIZE - 1)) != 0) return;
+        }
+        spread_prefetch<batches, lines_per_iter>(next_vecs, byte_offset, lines_to_fetch);
+    }
 }
 
 /* Utility functions to perform reduce operations (horizontal ops) over a vector


### PR DESCRIPTION
## Summary

Extends the head + spread prefetch schedule introduced in #147999 (and previously applied to `doti8_bulk` / `sqri8_bulk` in `vec_i8_2.cpp`) to the remaining amd64 bulk kernels that follow the shared-b shape but still use either burst prefetch or no prefetch at all:

| File | Template | Tier | Notes |
|------|----------|------|-------|
| `vec_i8_2.cpp` | `cosi8_inner_bulk` | AVX-512 | Direct sibling of the already-converted `doti8`/`sqri8`. |
| `vec_bf16_3.cpp` | `bf16Qf32_bulk_avx512` | AVX-512-BF16 | Gated on `batches > 1` (sequential path uses `batches=1`). |
| `vec_bf16_3.cpp` | `dotDbf16Qbf16_bulk_avx512` | AVX-512-BF16 | Gated on `batches > 1`. |
| `vec_bf16_3.cpp` | `sqrDbf16Qbf16_bulk_avx512` | AVX-512-BF16 | Gated on `batches > 1`. |
| `vec_i4_2.cpp` | `doti4_bulk_impl_avx512` | AVX-512 | |
| `vec_i4_1.cpp` | `doti4_bulk_impl` | AVX2 | Half-cache-line stride, gated spread. |
| `vec_bbq_packed_2.cpp` | `dotd2q4_packed_bulk_impl_avx512` | AVX-512 | |
| `vec_bbq_packed_1.cpp` | `dotd2q4_packed_bulk_impl` | AVX2 | Half-cache-line stride, gated spread. |
| `vec_bf16_1.cpp` | `bf16_bulk_inner` | AVX2 | Quarter-cache-line stride (16 bytes / iter); spread fires every 4th iter. |

`vec_f32_2.cpp` was investigated and **deliberately left unchanged** — see "Why f32 was skipped" below.

## Why this pattern, not burst

Burst prefetch at batch boundaries saturates Intel server cores' line-fill buffer (16 entries), causing most prefetches to drop silently. The head + spread schedule, introduced in #147999:

- Issues only `unroll_dim` prefetches per next-batch vector at boundaries
- Issues `lines_per_iter` more prefetches per inner-loop iteration
- Reduces LFB occupancy peak from `batches × lines_to_fetch` (~28–100) to `batches × lines_per_iter` (4–8)

Total prefetch count is unchanged; the issues are spread across the inner loop instead of bursting at the boundary.

## Why `batches > 1` gating on bf16 sequential

Three `vec_bf16_3.cpp` templates are called with `batches=1, unroll_dim>1` for sequential and `batches=4, unroll_dim=1` for offsets/sparse (the `batches=1` sequential layout is forced by the L1D set-aliasing pathology documented in #147672). With `batches=1` there is no shared-b amortization across documents and the LFB never saturates; the spread prefetches in the inner loop are pure µop overhead on the L1-resident sequential path. The `if constexpr (batches > 1)` gate keeps the original burst prefetch for the `batches=1` callers and applies head+spread only to the offsets/sparse callers where it pays off.

Without the gate, bf16 sequential regressed -10 to -25% at small `numVectors`. With the gate, sequential is neutral and offsets/sparse keep the full win.

## Why f32 was skipped

f32 is FMA-bound — one `vfmadd231ps` per 64-byte vector load. The kernel can absorb DRAM latency through the HW prefetcher alone; SW prefetch adds µop pressure into an already loop-bound issue stream. Measured impact of applying head+spread to `call_f32_bulk_512`:

| Pattern | Mean | Worst cell |
|--------|------|----|
| Sequential | -0.51% | -18.19% (dims=1024, nv=128) |
| Offsets | +1.79% | -17.39% (dims=1024, nv=128) |
| Sparse | +1.24% | -19.45% (dims=1024, nv=128) |

The marginal mean uplift isn't worth the ~-19% regression on dims=1024 cells (where four f32 vectors at dims=1024 ≈ 64 cache lines map onto exactly 64 L1D sets — the same aliasing pathology #147672 documents at dims=2048 bf16).

`vec_bbq_2.cpp` / `vec_bbq_1.cpp` and `vec_i7_1.cpp` / `vec_i8_1.cpp` were also surveyed but use monolithic per-pair scoring (`dotdNq4_inner_bulk`, `call_i8_bulk`) with no inner SIMD loop available to spread prefetch into; restructuring those is a separate refactor.

## Performance

Hardware: Intel Xeon Platinum 8573C (Emerald Rapids, AVX-512-VNNI / AVX-512-BF16). `clang++-21 -O3 -march=icelake-client` (tier 2) / `-march=cooperlake` (tier 3). Pinned to one CPU, 200 ms × 3 passes per cell, best of 3. Grid: dims ∈ {384, 768, 1024} × numVectors ∈ {128, 1500, 130000} × bulkSize ∈ {32, 1024} = 18 cells per kernel × pattern.

| Kernel | Pattern | n | Mean Δ | Range |
|--------|---------|---:|---:|---|
| `cosi8` (AVX-512) | sequential | 18 | **+12.46%** | +1.50% .. +24.84% |
| `cosi8` (AVX-512) | offsets_random | 18 | **+16.80%** | +6.42% .. +36.30% |
| `cosi8` (AVX-512) | sparse_random | 18 | **+14.73%** | +6.23% .. +35.52% |
| `dotDbf16Qf32` (AVX-512-BF16) | sequential | 18 | -0.10% | -3.40% .. +1.87% |
| `dotDbf16Qf32` (AVX-512-BF16) | offsets_random | 18 | **+24.38%** | +12.75% .. +34.40% |
| `dotDbf16Qf32` (AVX-512-BF16) | sparse_random | 18 | **+22.67%** | +10.88% .. +34.58% |
| `sqrDbf16Qf32` (AVX-512-BF16) | sequential | 18 | -0.52% | -3.56% .. +1.20% |
| `sqrDbf16Qf32` (AVX-512-BF16) | offsets_random | 18 | **+28.56%** | +8.23% .. +52.66% |
| `sqrDbf16Qf32` (AVX-512-BF16) | sparse_random | 18 | **+26.82%** | +7.45% .. +50.62% |
| `dotDbf16Qbf16` (AVX-512-BF16) | sequential | 18 | -0.97% | -12.67% .. +4.22% |
| `dotDbf16Qbf16` (AVX-512-BF16) | offsets_random | 18 | **+24.33%** | +10.81% .. +43.34% |
| `dotDbf16Qbf16` (AVX-512-BF16) | sparse_random | 18 | **+23.59%** | +12.63% .. +43.17% |
| `sqrDbf16Qbf16` (AVX-512-BF16) | sequential | 18 | +0.23% | -1.86% .. +1.23% |
| `sqrDbf16Qbf16` (AVX-512-BF16) | offsets_random | 18 | **+31.51%** | +5.25% .. +62.67% |
| `sqrDbf16Qbf16` (AVX-512-BF16) | sparse_random | 18 | **+30.02%** | +5.33% .. +63.13% |
| `doti4` (AVX-512) | sequential | 18 | **+5.01%** | -4.19% .. +11.54% |
| `doti4` (AVX-512) | offsets_random | 18 | **+18.02%** | -0.33% .. +29.24% |
| `doti4` (AVX-512) | sparse_random | 18 | **+16.74%** | +0.15% .. +27.36% |
| `dotd2q4_packed` (AVX-512) | sequential | 18 | **+6.41%** | +0.87% .. +26.74% |
| `dotd2q4_packed` (AVX-512) | offsets_random | 18 | **+20.62%** | +4.65% .. +58.82% |
| `dotd2q4_packed` (AVX-512) | sparse_random | 18 | **+19.31%** | +4.36% .. +55.94% |

Same shape as #147999: large wins on offsets/sparse (the LFB-saturating cases), neutral on sequential.

## Correctness

Validated locally with a back-to-back diff harness: for every export touched (cosine, bf16-AVX-512, f32, i4, bbq_packed), the modified library produces **byte-identical** outputs to the baseline across dims ∈ {16, 17, 32, 33, 63, 64, 65, 96, 128, 256, 257, 384, 512, 768, 1024, 1535, 1536, 4096} × counts ∈ {1, 4, 5, 8, 17, 32, 100, 1000} for sequential / offsets / sparse layouts. **567,162 sub-checks; 0 mismatches.** Prefetch is semantically a no-op for the kernel output, so this is the expected — and now verified — behaviour.

The pre-existing i7u/i8 dot/sqr correctness harness (against an i64-exact reference) also still passes (197,540/197,540).
