### PR TITLE
Restrict Log4j annotation processor to PluginProcessor

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -94,6 +94,14 @@ dependencies {
   internalClusterTestImplementation(project(':modules:data-streams'))
 }
 
+// log4j-core registers both the PluginProcessor and GraalVmProcessor on the processor path; we only want the former
+tasks.named("compileJava").configure {
+  options.compilerArgs.addAll(
+    "-processor",
+    "org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor",
+  )
+}
+
 spotless {
   java {
     targetExclude "src/main/java/org/elasticsearch/index/IndexVersion.java"


### PR DESCRIPTION
Restrict Log4j annotation processor to PluginProcessor.
This prevents the additional GraalVM annotation processor to run. This one is not needed and might fail the build due to additional compiler warnings.

This change is already included in the backports for 8.19 / 9.3.

Relates to #132166