### PR TITLE
ESQL:DS: Parquet: fix bit allignment issue. Add IT

### DIFF
--- a/x-pack/plugin/esql-datasource-parquet/qa/build.gradle
+++ b/x-pack/plugin/esql-datasource-parquet/qa/build.gradle
@@ -53,12 +53,12 @@ dependencies {
 
 // Generate Parquet fixtures at build time from CSV.
 // Uses shared ParquetFixtureGenerator from esql:qa:server.
-def serverProject = project(xpackModule('esql:qa:server'))
-def parquetFixtureOutputDir = file("${buildDir}/parquet-fixtures/iceberg-fixtures")
-def parquetFixtureDir = file("${parquetFixtureOutputDir}/standalone")
-def testFixturesProject = project(xpackModule('esql:qa:testFixtures'))
-def testFixturesDataDir = testFixturesProject.file('src/main/resources/data')
-def csvToParquetFixtures = ['employees', 'web_logs', 'books']
+ext.serverProject = project(xpackModule('esql:qa:server'))
+ext.parquetFixtureOutputDir = file("${buildDir}/parquet-fixtures/iceberg-fixtures")
+def parquetFixtureDir = file("${ext.parquetFixtureOutputDir}/standalone")
+ext.testFixturesProject = project(xpackModule('esql:qa:testFixtures'))
+ext.testFixturesDataDir = ext.testFixturesProject.file('src/main/resources/data')
+ext.csvToParquetFixtures = ['employees', 'web_logs', 'books']
 
 tasks.register('syncIcebergFixtures', Sync) {
   dependsOn testFixturesProject.tasks.named('processResources')
@@ -69,7 +69,7 @@ tasks.register('syncIcebergFixtures', Sync) {
   into parquetFixtureDir
 }
 
-def generateParquetTasks = []
+ext.generateParquetTasks = []
 csvToParquetFixtures.each { baseName ->
   def taskName = "generateParquet_${baseName}"
   def csvInput = new File(testFixturesDataDir, "${baseName}.csv")
@@ -101,6 +101,10 @@ tasks.register('generateMultifileParquet_employees', JavaExec) {
   systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
 }
 generateParquetTasks.add(tasks.named('generateMultifileParquet_employees'))
+
+// Generate compressed Parquet fixtures for each supported internal codec.
+// Each codec gets its own directory: standalone-snappy/, standalone-gzip/, etc.
+apply from: serverProject.file('compressed-parquet-fixtures.gradle')
 
 tasks.register('generateParquetFixtures') {
   dependsOn generateParquetTasks

--- a/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetCompressedFormatSpecIT.java
+++ b/x-pack/plugin/esql-datasource-parquet/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/parquet/ParquetCompressedFormatSpecIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.parquet;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
+import org.elasticsearch.test.AzureReactorThreadFilter;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.xpack.esql.CsvSpecReader.CsvTestCase;
+import org.elasticsearch.xpack.esql.datasources.FormatNameResolver;
+import org.elasticsearch.xpack.esql.qa.rest.AbstractExternalSourceSpecTestCase;
+import org.junit.ClassRule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parameterized integration tests for Parquet files with internal compression.
+ * Each csv-spec test is run against every configured storage backend and every
+ * supported Parquet internal compression codec (SNAPPY, GZIP, ZSTD, LZ4_RAW).
+ * <p>
+ * The fixtures are generated at build time by {@code ParquetFixtureGenerator} with the
+ * corresponding codec and placed into codec-specific directories
+ * ({@code standalone-snappy/}, {@code standalone-gzip/}, etc.).
+ */
+@ThreadLeakFilters(filters = { TestClustersThreadFilter.class, AzureReactorThreadFilter.class })
+public class ParquetCompressedFormatSpecIT extends AbstractExternalSourceSpecTestCase {
+
+    private static final Map<String, String> CODEC_DIR_SUFFIXES = Map.of(
+        "snappy",
+        "standalone-snappy",
+        "gzip",
+        "standalone-gzip",
+        "zstd",
+        "standalone-zstd",
+        "lz4raw",
+        "standalone-lz4raw"
+    );
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.testCluster(() -> s3Fixture.getAddress());
+
+    private final String codecName;
+
+    public ParquetCompressedFormatSpecIT(
+        String fileName,
+        String groupName,
+        String testName,
+        Integer lineNumber,
+        CsvTestCase testCase,
+        String instructions,
+        String codecName,
+        StorageBackend storageBackend
+    ) {
+        super(fileName, groupName, testName, lineNumber, testCase, instructions, storageBackend, "parquet");
+        this.codecName = codecName;
+    }
+
+    @Override
+    protected String fixturesBase() {
+        String dir = CODEC_DIR_SUFFIXES.get(codecName);
+        assert dir != null : "Unknown codec: " + codecName;
+        return dir;
+    }
+
+    @Override
+    protected String readerName() {
+        return FormatNameResolver.READER_JAVA;
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @Override
+    protected boolean enableRoundingDoubleValuesOnAsserting() {
+        return true;
+    }
+
+    @ParametersFactory(argumentFormatting = "csv-spec:%2$s.%3$s [%7$s/%8$s]")
+    public static List<Object[]> readScriptSpec() throws Exception {
+        return readExternalSpecTestsWithCodecs(List.of("snappy", "gzip", "zstd", "lz4raw"), "/external-basic.csv-spec");
+    }
+
+    /**
+     * Cross-products csv-spec tests with codec names and storage backends.
+     * Returns parameter arrays with 8 arguments:
+     * (fileName, groupName, testName, lineNumber, testCase, instructions, codecName, storageBackend).
+     */
+    private static List<Object[]> readExternalSpecTestsWithCodecs(List<String> codecs, String... specPatterns) throws Exception {
+        List<Object[]> baseWithBackends = readExternalSpecTests(specPatterns);
+        List<Object[]> parameterized = new ArrayList<>();
+        for (Object[] baseTest : baseWithBackends) {
+            for (String codec : codecs) {
+                int len = baseTest.length;
+                Object[] expanded = new Object[len + 1];
+                System.arraycopy(baseTest, 0, expanded, 0, len - 1);
+                expanded[len - 1] = codec;
+                expanded[len] = baseTest[len - 1];
+                parameterized.add(expanded);
+            }
+        }
+        return parameterized;
+    }
+}

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoder.java
@@ -14,15 +14,28 @@ import java.nio.ByteOrder;
 
 /**
  * Bulk PLAIN decoder over a little-endian value {@link ByteBuffer} for page-level Parquet reads.
- * Fixed-width types (INT32, INT64, FLOAT, DOUBLE) are read contiguously; BOOLEAN uses 1 byte
- * per value; BINARY is length-prefixed; FIXED_LEN_BYTE_ARRAY uses a fixed stride.
+ * Fixed-width types (INT32, INT64, FLOAT, DOUBLE) are read contiguously; BOOLEAN is bit-packed
+ * (1 bit per value); BINARY is length-prefixed; FIXED_LEN_BYTE_ARRAY uses a fixed stride.
  */
 final class PlainValueDecoder {
 
     private ByteBuffer buffer;
 
+    /**
+     * Bit offset within the current byte for boolean reads/skips. Parquet PLAIN booleans are
+     * bit-packed (8 values per byte) and interleaved skip/read calls (e.g. during sparse reads)
+     * can consume a non-multiple-of-8 count, leaving a partial byte. This field tracks how many
+     * bits of the current byte have already been consumed (range 0..7). Reset on {@link #init}.
+     */
+    private int boolBitOffset;
+
+    /**
+     * Initializes (or re-initializes) the decoder with a new value buffer. Must be called before
+     * each Parquet data page to reset internal state (including the boolean bit offset).
+     */
     void init(ByteBuffer valueBytes) {
         this.buffer = valueBytes.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        this.boolBitOffset = 0;
     }
 
     void readInts(int[] values, int offset, int count) {
@@ -53,10 +66,12 @@ final class PlainValueDecoder {
     void readBooleans(boolean[] values, int offset, int count) {
         int basePos = buffer.position();
         for (int i = 0; i < count; i++) {
-            int pos = basePos + (i / 8);
-            values[offset + i] = ((buffer.get(pos) >>> (i % 8)) & 1) != 0;
+            int absoluteBit = boolBitOffset + i;
+            values[offset + i] = ((buffer.get(basePos + absoluteBit / 8) >>> (absoluteBit % 8)) & 1) != 0;
         }
-        buffer.position(basePos + (count + 7) / 8);
+        int totalBits = boolBitOffset + count;
+        buffer.position(basePos + totalBits / 8);
+        boolBitOffset = totalBits % 8;
     }
 
     /** Returned BytesRef instances share storage with the value buffer and must be copied before the buffer is reused. */
@@ -132,7 +147,9 @@ final class PlainValueDecoder {
     }
 
     void skipBooleans(int count) {
-        buffer.position(buffer.position() + (count + 7) / 8);
+        int totalBits = boolBitOffset + count;
+        buffer.position(buffer.position() + totalBits / 8);
+        boolBitOffset = totalBits % 8;
     }
 
     void skipBinaries(int count) {

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReaderTests.java
@@ -2251,10 +2251,7 @@ public class ParquetFormatReaderTests extends ESTestCase {
             .named("v_bool")
             .named("retention_test_pc");
 
-        // batchSize must be a multiple of 8 so PlainValueDecoder.readBooleans does not skip
-        // bits across batch boundaries - that is an unrelated decoder issue we do not want to
-        // entangle with this regression.
-        int batchSize = 32;
+        int batchSize = 37;
         int totalRows = batchSize * 20;
         // Lookahead must exceed the DecodeBuffers slot count (2 for long/double, 1 for
         // int/boolean) so the producer is guaranteed to reuse a buffer the consumer still

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoderTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/PlainValueDecoderTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasource.parquet;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Tests for {@link PlainValueDecoder}, focusing on boolean bit-packing correctness
+ * when read and skip calls are interleaved with non-byte-aligned counts.
+ */
+public class PlainValueDecoderTests extends ESTestCase {
+
+    /**
+     * Verifies that interleaved skip/read calls with non-multiple-of-8 counts
+     * produce the same results as a single contiguous read.
+     * This is the pattern triggered by {@code PageColumnReader.readBatchSparse}.
+     */
+    public void testBooleanSkipReadInterleaving() {
+        boolean[] expected = new boolean[20];
+        byte[] packed = new byte[3];
+        for (int i = 0; i < 20; i++) {
+            expected[i] = i % 3 == 0;
+            if (expected[i]) {
+                packed[i / 8] |= (byte) (1 << (i % 8));
+            }
+        }
+
+        PlainValueDecoder decoder = new PlainValueDecoder();
+
+        // skip 5 (non-aligned), read 3, skip 7, read 5
+        decoder.init(ByteBuffer.wrap(packed));
+        boolean[] result = new boolean[8];
+        decoder.skipBooleans(5);
+        decoder.readBooleans(result, 0, 3);
+        assertBoolArrayEquals("read after skip(5)", new boolean[] { expected[5], expected[6], expected[7] }, slice(result, 0, 3));
+
+        decoder.skipBooleans(7);
+        decoder.readBooleans(result, 0, 5);
+        assertBoolArrayEquals(
+            "read after skip(7)",
+            new boolean[] { expected[15], expected[16], expected[17], expected[18], expected[19] },
+            slice(result, 0, 5)
+        );
+    }
+
+    /**
+     * Tests skip/read where each call consumes exactly 1 boolean at a time,
+     * alternating skip(1) and read(1) to exercise every bit position within a byte.
+     */
+    public void testBooleanSingleBitSteps() {
+        byte[] packed = new byte[] { (byte) 0b10101010, (byte) 0b01010101 };
+        boolean[] expectedAll = new boolean[16];
+        for (int i = 0; i < 16; i++) {
+            expectedAll[i] = ((packed[i / 8] >>> (i % 8)) & 1) != 0;
+        }
+
+        PlainValueDecoder decoder = new PlainValueDecoder();
+        decoder.init(ByteBuffer.wrap(packed));
+
+        boolean[] result = new boolean[1];
+        for (int i = 0; i < 16; i++) {
+            if (i % 2 == 0) {
+                decoder.skipBooleans(1);
+            } else {
+                decoder.readBooleans(result, 0, 1);
+                assertEquals("bit " + i, expectedAll[i], result[0]);
+            }
+        }
+    }
+
+    /**
+     * Tests that reading all booleans in one call still works (no regression from
+     * the boolBitOffset tracking).
+     */
+    public void testBooleanContiguousRead() {
+        byte[] packed = new byte[] { (byte) 0xFF, (byte) 0x00, (byte) 0xAA };
+        boolean[] expectedAll = new boolean[20];
+        for (int i = 0; i < 20; i++) {
+            expectedAll[i] = ((packed[i / 8] >>> (i % 8)) & 1) != 0;
+        }
+
+        PlainValueDecoder decoder = new PlainValueDecoder();
+        decoder.init(ByteBuffer.wrap(packed));
+
+        boolean[] result = new boolean[20];
+        decoder.readBooleans(result, 0, 20);
+        assertBoolArrayEquals("contiguous read", expectedAll, result);
+    }
+
+    /**
+     * Tests that zero-count read/skip calls do not disturb the bit offset.
+     */
+    public void testBooleanZeroCount() {
+        byte[] packed = new byte[] { (byte) 0b10101010 };
+        PlainValueDecoder decoder = new PlainValueDecoder();
+        decoder.init(ByteBuffer.wrap(packed));
+
+        decoder.skipBooleans(0);
+        decoder.readBooleans(new boolean[0], 0, 0);
+        decoder.skipBooleans(3);
+        decoder.readBooleans(new boolean[0], 0, 0);
+
+        boolean[] result = new boolean[1];
+        decoder.readBooleans(result, 0, 1);
+        boolean expected = ((packed[0] >>> 3) & 1) != 0;
+        assertEquals("bit 3 after zero-count calls", expected, result[0]);
+    }
+
+    /**
+     * Tests skip that spans multiple bytes with a non-aligned start.
+     */
+    public void testBooleanSkipAcrossMultipleBytes() {
+        byte[] packed = new byte[] { (byte) 0b11111111, (byte) 0b11111111, (byte) 0b00000001 };
+        PlainValueDecoder decoder = new PlainValueDecoder();
+        decoder.init(ByteBuffer.wrap(packed));
+
+        decoder.skipBooleans(3);
+        decoder.skipBooleans(13);
+
+        boolean[] result = new boolean[1];
+        decoder.readBooleans(result, 0, 1);
+        assertTrue("bit 16 should be true", result[0]);
+    }
+
+    private static boolean[] slice(boolean[] arr, int offset, int length) {
+        boolean[] result = new boolean[length];
+        System.arraycopy(arr, offset, result, 0, length);
+        return result;
+    }
+
+    private static void assertBoolArrayEquals(String msg, boolean[] expected, boolean[] actual) {
+        assertEquals(msg + " length", expected.length, actual.length);
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(msg + " [" + i + "]", expected[i], actual[i]);
+        }
+    }
+}

--- a/x-pack/plugin/esql/qa/server/build.gradle
+++ b/x-pack/plugin/esql/qa/server/build.gradle
@@ -81,6 +81,9 @@ dependencies {
   parquetFixtureGenerator("org.apache.hadoop:hadoop-client-api:${versions.hadoop}") { exclude group: 'org.apache.logging.log4j' }
   parquetFixtureGenerator("org.apache.hadoop:hadoop-client-runtime:${versions.hadoop}") { exclude group: 'org.apache.logging.log4j' }
   parquetFixtureGenerator "org.slf4j:slf4j-api:${versions.slf4j}"
+  parquetFixtureGenerator "org.xerial.snappy:snappy-java:${versions.snappyJava}"
+  parquetFixtureGenerator "com.github.luben:zstd-jni:${versions.zstdJni}"
+  parquetFixtureGenerator "io.airlift:aircompressor:${versions.aircompressor}"
   parquetFixtureGenerator project(':libs:core')
   parquetFixtureGenerator project(xpackModule('esql-datasource-csv'))
 

--- a/x-pack/plugin/esql/qa/server/compressed-parquet-fixtures.gradle
+++ b/x-pack/plugin/esql/qa/server/compressed-parquet-fixtures.gradle
@@ -1,0 +1,49 @@
+/*
+ * Shared Gradle snippet for generating compressed Parquet fixtures.
+ * Applied by QA build.gradle files that need codec-specific fixture generation.
+ *
+ * Required ext properties (must be set before applying):
+ *   - parquetFixtureOutputDir: base output directory for fixtures
+ *   - csvToParquetFixtures: list of CSV base names to convert
+ *   - testFixturesDataDir: directory containing source CSV files
+ *   - serverProject: reference to the esql:qa:server project
+ *   - generateParquetTasks: list to which generated task providers are appended
+ *   - testFixturesProject: reference to the esql:qa:testFixtures project
+ */
+
+def compressedCodecs = [
+  [name: 'snappy',  codec: 'SNAPPY'],
+  [name: 'gzip',    codec: 'GZIP'],
+  [name: 'zstd',    codec: 'ZSTD'],
+  [name: 'lz4raw',  codec: 'LZ4_RAW'],
+]
+
+def serverProj = ext.serverProject
+def testFixturesProj = ext.testFixturesProject
+def fixtureOutputDir = ext.parquetFixtureOutputDir
+def fixturesDataDir = ext.testFixturesDataDir
+def csvFixtures = ext.csvToParquetFixtures
+def parquetTasks = ext.generateParquetTasks
+
+compressedCodecs.each { entry ->
+  def codecName = entry.name
+  def codecArg = entry.codec
+  def codecFixtureDir = file("${fixtureOutputDir}/standalone-${codecName}")
+
+  csvFixtures.each { baseName ->
+    def taskName = "generateParquet_${baseName}_${codecName}"
+    def csvInput = new File(fixturesDataDir, "${baseName}.csv")
+    def parquetFile = file("${codecFixtureDir}/${baseName}.parquet")
+    tasks.register(taskName, JavaExec) {
+      dependsOn serverProj.tasks.named('compileParquetFixtureGeneratorJava'), 'syncIcebergFixtures'
+      dependsOn testFixturesProj.tasks.named('processResources')
+      classpath = serverProj.configurations.parquetFixtureGenerator + serverProj.sourceSets.parquetFixtureGenerator.output
+      mainClass = 'org.elasticsearch.xpack.esql.datasources.ParquetFixtureGenerator'
+      args = [csvInput.path, parquetFile.path, codecArg]
+      inputs.file(csvInput)
+      outputs.file(parquetFile)
+      systemProperty 'slf4j.provider', 'org.slf4j.nop.NOPServiceProvider'
+    }
+    parquetTasks.add(tasks.named(taskName))
+  }
+}

--- a/x-pack/plugin/esql/qa/server/multi-node/build.gradle
+++ b/x-pack/plugin/esql/qa/server/multi-node/build.gradle
@@ -47,13 +47,13 @@ tasks.named('javaRestTestTestingConventions').configure {
 
 // Generate Parquet fixtures at build time from CSV.
 // Uses shared ParquetFixtureGenerator from esql:qa:server.
-def serverProject = project(xpackModule('esql:qa:server'))
-def parquetFixtureOutputDir = file("${buildDir}/parquet-fixtures/iceberg-fixtures")
-def parquetFixtureDir = file("${parquetFixtureOutputDir}/standalone")
-def testFixturesProject = project(xpackModule('esql:qa:testFixtures'))
-def testFixturesDataDir = testFixturesProject.file('src/main/resources/data')
+ext.serverProject = project(xpackModule('esql:qa:server'))
+ext.parquetFixtureOutputDir = file("${buildDir}/parquet-fixtures/iceberg-fixtures")
+def parquetFixtureDir = file("${ext.parquetFixtureOutputDir}/standalone")
+ext.testFixturesProject = project(xpackModule('esql:qa:testFixtures'))
+ext.testFixturesDataDir = ext.testFixturesProject.file('src/main/resources/data')
 // CSV base names for sync + Parquet generation; source: esql:qa:testFixtures/src/main/resources/data/{name}.csv
-def csvToParquetFixtures = ['employees', 'web_logs', 'books']
+ext.csvToParquetFixtures = ['employees', 'web_logs', 'books']
 
 tasks.register('syncIcebergFixtures', Sync) {
   dependsOn testFixturesProject.tasks.named('processResources')
@@ -64,7 +64,7 @@ tasks.register('syncIcebergFixtures', Sync) {
   into parquetFixtureDir
 }
 
-def generateParquetTasks = []
+ext.generateParquetTasks = []
 csvToParquetFixtures.each { baseName ->
   def taskName = "generateParquet_${baseName}"
   def csvInput = new File(testFixturesDataDir, "${baseName}.csv")
@@ -81,6 +81,10 @@ csvToParquetFixtures.each { baseName ->
   }
   generateParquetTasks.add(tasks.named(taskName))
 }
+
+// Generate compressed Parquet fixtures for each supported internal codec.
+// Each codec gets its own directory: standalone-snappy/, standalone-gzip/, etc.
+apply from: serverProject.file('compressed-parquet-fixtures.gradle')
 
 tasks.register('generateParquetFixtures') {
   dependsOn generateParquetTasks

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AbstractExternalSourceSpecTestCase.java
@@ -60,7 +60,7 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
     /** Pattern to match template placeholders like {{employees}} */
     private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{(\\w+)}}");
 
-    /** Base path for fixtures within the resource directory */
+    /** Default base path for fixtures within the resource directory */
     private static final String FIXTURES_BASE = "standalone";
 
     /**
@@ -323,6 +323,15 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
     }
 
     /**
+     * Override to change the base directory within the resource tree where single-file fixtures live.
+     * Defaults to {@code "standalone"}. Subclasses testing compressed Parquet fixtures can override
+     * this to point at codec-specific directories (e.g. {@code "standalone-snappy"}).
+     */
+    protected String fixturesBase() {
+        return FIXTURES_BASE;
+    }
+
+    /**
      * Override to specify a reader implementation for the EXTERNAL query.
      * When non-null, a {@code "reader": "<name>"} parameter is injected into the WITH clause.
      *
@@ -439,7 +448,7 @@ public abstract class AbstractExternalSourceSpecTestCase extends EsqlSpecTestCas
         } else {
             // Single-file template: employees -> standalone/employees.parquet
             String filename = templateName + "." + format;
-            relativePath = FIXTURES_BASE + "/" + filename;
+            relativePath = fixturesBase() + "/" + filename;
         }
 
         switch (storageBackend) {

--- a/x-pack/plugin/esql/qa/server/src/parquetFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/ParquetFixtureGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/parquetFixtureGenerator/java/org/elasticsearch/xpack/esql/datasources/ParquetFixtureGenerator.java
@@ -30,10 +30,14 @@ import java.util.List;
 /**
  * Build-time generator for Parquet fixture files. Converts CSV to Parquet.
  * <p>
- * Single-file mode: {@code <source-csv> <output.parquet>}
+ * Single-file mode: {@code <source-csv> <output.parquet> [codec]}
  * <br>
- * Split mode:       {@code <source-csv> <output-dir> <num-parts>} — writes
+ * Split mode:       {@code <source-csv> <output-dir> <num-parts> [codec]} — writes
  * {@code <basename>_00.parquet}, {@code <basename>_01.parquet}, … into the directory.
+ * <p>
+ * The optional {@code codec} argument selects the Parquet internal compression codec
+ * (e.g. {@code SNAPPY}, {@code GZIP}, {@code ZSTD}, {@code LZ4_RAW}).
+ * When omitted, {@code UNCOMPRESSED} is used.
  * <p>
  * Uses {@link CsvFixtureParser} for bracket-aware CSV parsing with correct multi-value handling.
  */
@@ -43,20 +47,22 @@ public final class ParquetFixtureGenerator {
 
     @SuppressForbidden(reason = "main method for Gradle JavaExec task needs System.out and Path.of")
     public static void main(String[] args) throws IOException {
-        if (args.length == 2) {
+        if (args.length == 2 || (args.length == 3 && isCodecName(args[2]))) {
             Path sourcePath = Path.of(args[0]);
             Path outputPath = Path.of(args[1]);
+            CompressionCodecName codec = args.length == 3 ? CompressionCodecName.valueOf(args[2]) : CompressionCodecName.UNCOMPRESSED;
             if (Files.exists(sourcePath) == false) {
                 throw new IOException("Source CSV not found: " + sourcePath);
             }
             Files.createDirectories(outputPath.getParent());
-            byte[] parquetBytes = generateFromCsv(sourcePath, 0, Integer.MAX_VALUE);
+            byte[] parquetBytes = generateFromCsv(sourcePath, 0, Integer.MAX_VALUE, codec);
             Files.write(outputPath, parquetBytes);
-            System.out.println("Generated Parquet fixture: " + outputPath);
-        } else if (args.length == 3) {
+            System.out.println("Generated Parquet fixture (" + codec + "): " + outputPath);
+        } else if (args.length == 3 || args.length == 4) {
             Path sourcePath = Path.of(args[0]);
             Path outputDir = Path.of(args[1]);
             int numParts = Integer.parseInt(args[2]);
+            CompressionCodecName codec = args.length == 4 ? CompressionCodecName.valueOf(args[3]) : CompressionCodecName.UNCOMPRESSED;
             if (Files.exists(sourcePath) == false) {
                 throw new IOException("Source CSV not found: " + sourcePath);
             }
@@ -70,22 +76,38 @@ public final class ParquetFixtureGenerator {
                 int to = Math.min(from + partSize, total);
                 String fileName = String.format(java.util.Locale.ROOT, "%s_%02d.parquet", baseName, part);
                 Path outputPath = outputDir.resolve(fileName);
-                byte[] parquetBytes = generateFromRows(result, from, to);
+                byte[] parquetBytes = generateFromRows(result, from, to, codec);
                 Files.write(outputPath, parquetBytes);
-                System.out.println("Generated Parquet fixture: " + outputPath);
+                System.out.println("Generated Parquet fixture (" + codec + "): " + outputPath);
             }
         } else {
-            System.err.println("Usage: ParquetFixtureGenerator <source-csv> <output.parquet>");
-            System.err.println("       ParquetFixtureGenerator <source-csv> <output-dir> <num-parts>");
+            System.err.println("Usage: ParquetFixtureGenerator <source-csv> <output.parquet> [codec]");
+            System.err.println("       ParquetFixtureGenerator <source-csv> <output-dir> <num-parts> [codec]");
+            System.err.println("Codecs: UNCOMPRESSED (default), SNAPPY, GZIP, ZSTD, LZ4_RAW");
             System.exit(1);
         }
     }
 
-    private static byte[] generateFromCsv(Path sourcePath, int from, int to) throws IOException {
-        return generateFromRows(CsvFixtureParser.parseCsvFile(sourcePath), from, to);
+    /**
+     * Returns true when the string is one of the supported Parquet compression codec names.
+     * Used to disambiguate the 3-arg form (single-file + codec) from the 3-arg split form
+     * (split mode with num-parts).
+     */
+    private static boolean isCodecName(String s) {
+        for (CompressionCodecName c : CompressionCodecName.values()) {
+            if (c.name().equals(s)) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    private static byte[] generateFromRows(CsvFixtureParser.CsvFixtureResult result, int from, int to) throws IOException {
+    private static byte[] generateFromCsv(Path sourcePath, int from, int to, CompressionCodecName codec) throws IOException {
+        return generateFromRows(CsvFixtureParser.parseCsvFile(sourcePath), from, to, codec);
+    }
+
+    private static byte[] generateFromRows(CsvFixtureParser.CsvFixtureResult result, int from, int to, CompressionCodecName codec)
+        throws IOException {
         List<CsvFixtureParser.ColumnSpec> columns = result.schema();
         List<Object[]> rows = result.rows().subList(from, Math.min(to, result.rows().size()));
 
@@ -104,12 +126,7 @@ public final class ParquetFixtureGenerator {
         OutputFile outputFile = createOutputFile(baos);
         SimpleGroupFactory factory = new SimpleGroupFactory(schema);
 
-        try (
-            ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile)
-                .withType(schema)
-                .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
-                .build()
-        ) {
+        try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputFile).withType(schema).withCompressionCodec(codec).build()) {
             for (Object[] row : rows) {
                 Group g = factory.newGroup();
                 for (int i = 0; i < columns.size(); i++) {


### PR DESCRIPTION
This adds integration tests for Parquet compressed with Snappy, gzip, zstd, lz4_raw.

It also fixes an issue with the decoder skipping a byte on record boundaries, on bit-packed booleans.
