### PR TITLE
Support form encoded POST REST bodies

### DIFF
--- a/docs/changelog/148973.yaml
+++ b/docs/changelog/148973.yaml
@@ -1,0 +1,5 @@
+area: Infra/REST API
+issues: []
+pr: 148973
+summary: Support form encoded POST REST bodies
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/rest/FilterRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/FilterRestHandler.java
@@ -44,6 +44,11 @@ public abstract class FilterRestHandler implements RestHandler {
     }
 
     @Override
+    public boolean supportsReadOnlyFormEncodedPostBody() {
+        return delegate.supportsReadOnlyFormEncodedPostBody();
+    }
+
+    @Override
     public boolean mediaTypesValid(RestRequest request) {
         return delegate.mediaTypesValid(request);
     }

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -68,6 +68,7 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.indices.SystemIndices.EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY;
 import static org.elasticsearch.indices.SystemIndices.SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY;
@@ -86,7 +87,8 @@ public class RestController implements HttpServerTransport.Dispatcher {
      * list of browser safelisted media types - not allowed on Content-Type header
      * https://fetch.spec.whatwg.org/#cors-safelisted-request-header
      */
-    static final Set<String> SAFELISTED_MEDIA_TYPES = Set.of("application/x-www-form-urlencoded", "multipart/form-data", "text/plain");
+    static final String FORM_URLENCODED_MEDIA_TYPE = "application/x-www-form-urlencoded";
+    static final Set<String> SAFELISTED_MEDIA_TYPES = Set.of(FORM_URLENCODED_MEDIA_TYPE, "multipart/form-data", "text/plain");
 
     static final String ELASTIC_PRODUCT_HTTP_HEADER = "X-elastic-product";
     static final String ELASTIC_PRODUCT_HTTP_HEADER_VALUE = "Elasticsearch";
@@ -235,6 +237,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
      * @param handler The handler to actually execute
      */
     protected void registerHandler(RestRequest.Method method, String path, RestApiVersion version, RestHandler handler) {
+        validateReadOnlyFormEncodedPostBodySupport(handler, method, path, version);
         if (handler instanceof BaseRestHandler) {
             usageService.addRestHandler((BaseRestHandler) handler);
         }
@@ -300,6 +303,124 @@ public class RestController implements HttpServerTransport.Dispatcher {
      */
     public void registerHandler(final RestHandler handler) {
         handler.routes().forEach(route -> registerHandler(route, handler));
+    }
+
+    private static void validateReadOnlyFormEncodedPostBodySupport(
+        RestHandler handler,
+        RestRequest.Method method,
+        String path,
+        RestApiVersion version
+    ) {
+        if (handler.supportsReadOnlyFormEncodedPostBody() == false) {
+            return;
+        }
+
+        final List<Route> routes = declaredRoutes(handler);
+        validateOnlyGetAndPostRoutesAreDeclared(handler, routes);
+        validatePostRouteIsDeclared(handler, routes);
+        validatePostRoutesHaveMatchingGetRoutes(handler, routes);
+        validateAllRoutesAreDeclaredByHandlerRoutes(handler, routes, method, path, version);
+    }
+
+    /**
+     * Checks that every declared route uses a method compatible with the read-only form POST contract.
+     */
+    private static void validateOnlyGetAndPostRoutesAreDeclared(RestHandler handler, List<Route> routes) {
+        final String handlerName = handler.getConcreteRestHandler().getClass().getName();
+        for (Route route : routes) {
+            if (route.getMethod() != RestRequest.Method.GET && route.getMethod() != RestRequest.Method.POST) {
+                throw new IllegalArgumentException(
+                    "handler ["
+                        + handlerName
+                        + "] supports read-only form-encoded POST bodies but route ["
+                        + route.getMethod()
+                        + " "
+                        + route.getPath()
+                        + "] is not a GET or POST route"
+                );
+            }
+        }
+    }
+
+    /**
+     * Checks that the opted-in handler declares at least one {@code POST} route.
+     */
+    private static void validatePostRouteIsDeclared(RestHandler handler, List<Route> routes) {
+        final boolean foundPostRoute = routes.stream().anyMatch(route -> route.getMethod() == RestRequest.Method.POST);
+        if (foundPostRoute == false) {
+            throw new IllegalArgumentException(
+                "handler ["
+                    + handler.getConcreteRestHandler().getClass().getName()
+                    + "] supports read-only form-encoded POST bodies but does not define any POST routes"
+            );
+        }
+    }
+
+    /**
+     * Checks that every declared {@code POST} route has a matching {@code GET} route.
+     */
+    private static void validatePostRoutesHaveMatchingGetRoutes(RestHandler handler, List<Route> routes) {
+        final String handlerName = handler.getConcreteRestHandler().getClass().getName();
+        for (Route route : routes) {
+            if (route.getMethod() == RestRequest.Method.GET) {
+                continue;
+            }
+            final boolean hasMatchingGetRoute = routes.stream()
+                .anyMatch(
+                    candidate -> candidate.getMethod() == RestRequest.Method.GET
+                        && candidate.getPath().equals(route.getPath())
+                        && candidate.getRestApiVersion() == route.getRestApiVersion()
+                );
+            if (hasMatchingGetRoute == false) {
+                throw new IllegalArgumentException(
+                    "handler ["
+                        + handlerName
+                        + "] supports read-only form-encoded POST bodies but route ["
+                        + route.getMethod()
+                        + " "
+                        + route.getPath()
+                        + "] does not have a matching GET route"
+                );
+            }
+        }
+    }
+
+    /**
+     * Prevents callers of {@link #registerHandler(RestRequest.Method, String, RestApiVersion, RestHandler)} from registering a
+     * form-enabled route that the handler did not declare in {@link RestHandler#routes()}.
+     */
+    private static void validateAllRoutesAreDeclaredByHandlerRoutes(
+        RestHandler handler,
+        List<Route> routes,
+        RestRequest.Method method,
+        String path,
+        RestApiVersion version
+    ) {
+        final boolean registeredRouteIsDeclared = routes.stream().anyMatch(route -> routeMatches(route, method, path, version));
+        if (registeredRouteIsDeclared == false) {
+            throw new IllegalArgumentException(
+                "handler ["
+                    + handler.getConcreteRestHandler().getClass().getName()
+                    + "] supports read-only form-encoded POST bodies but registered route ["
+                    + method
+                    + " "
+                    + path
+                    + "] is not declared by the handler"
+            );
+        }
+    }
+
+    private static List<Route> declaredRoutes(RestHandler handler) {
+        return handler.routes()
+            .stream()
+            .flatMap(
+                route -> route.hasReplacement() ? Stream.of(route, Objects.requireNonNull(route.getReplacedRoute())) : Stream.of(route)
+            )
+            .toList();
+    }
+
+    private static boolean routeMatches(Route route, RestRequest.Method method, String path, RestApiVersion version) {
+        return route.getMethod() == method && route.getPath().equals(path) && route.getRestApiVersion() == version;
     }
 
     @Override
@@ -416,8 +537,12 @@ public class RestController implements HttpServerTransport.Dispatcher {
         MethodHandlers methodHandlers,
         ThreadContext threadContext
     ) throws Exception {
+        final boolean formEncodedBodyAllowed = request.method() == RestRequest.Method.POST
+            && handler.supportsReadOnlyFormEncodedPostBody()
+            && isFormEncodedBody(request);
         if (request.hasContent()) {
-            if (isContentTypeDisallowed(request) || handler.mediaTypesValid(request) == false) {
+            if ((isContentTypeDisallowed(request) && formEncodedBodyAllowed == false)
+                || (formEncodedBodyAllowed == false && handler.mediaTypesValid(request) == false)) {
                 sendContentTypeErrorMessage(request.getAllHeaderValues("Content-Type"), channel);
                 return;
             }
@@ -460,6 +585,10 @@ public class RestController implements HttpServerTransport.Dispatcher {
                 // request as a serverless mode request here, so downstream handlers can use the marker
                 request.markAsServerlessRequest();
                 logger.trace("Marked request for uri [{}] as serverless request", request.uri());
+            }
+
+            if (formEncodedBodyAllowed) {
+                request.consumeFormEncodedBodyParameters();
             }
 
             final var finalChannel = responseChannel;
@@ -511,6 +640,11 @@ public class RestController implements HttpServerTransport.Dispatcher {
     private static boolean isContentTypeDisallowed(RestRequest request) {
         return request.getParsedContentType() != null
             && SAFELISTED_MEDIA_TYPES.contains(request.getParsedContentType().mediaTypeWithoutParameters());
+    }
+
+    private static boolean isFormEncodedBody(RestRequest request) {
+        return request.getParsedContentType() != null
+            && FORM_URLENCODED_MEDIA_TYPE.equals(request.getParsedContentType().mediaTypeWithoutParameters());
     }
 
     private boolean handleNoHandlerFound(

--- a/server/src/main/java/org/elasticsearch/rest/RestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestHandler.java
@@ -44,6 +44,32 @@ public interface RestHandler {
     }
 
     /**
+     * Whether this handler accepts read-only {@code POST} requests with
+     * {@code application/x-www-form-urlencoded} bodies as an alternative to
+     * query-string parameters.
+     * <p>
+     * This opt-in is intended for endpoints such as Prometheus-compatible APIs
+     * that expose equivalent {@code GET} and {@code POST} routes. Handlers that
+     * opt in may only declare {@code GET} and {@code POST} routes, must still
+     * declare the corresponding {@code POST} routes explicitly, and each opted-in
+     * {@code POST} route must have a matching {@code GET} route for the same path.
+     * <p>
+     * Elasticsearch rejects browser-safelisted media types such as
+     * {@code application/x-www-form-urlencoded} by default as a CSRF safeguard.
+     * Opting in here creates a narrowly scoped exemption for {@code POST} requests
+     * to endpoints that need form-encoded compatibility with existing clients.
+     * <p>
+     * Because these requests bypass the default CSRF-oriented content-type
+     * rejection, every corresponding {@code POST} route must be equivalent to
+     * its {@code GET} route and must not mutate cluster or index state. Use this
+     * only for read-only APIs where {@code POST} is merely an alternate transport
+     * for request parameters.
+     */
+    default boolean supportsReadOnlyFormEncodedPostBody() {
+        return false;
+    }
+
+    /**
      * Returns the concrete RestHandler for this RestHandler. That is, if this is a delegating RestHandler it returns the delegate.
      * Otherwise it returns itself.
      * @return The underlying RestHandler

--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -414,6 +414,30 @@ public class RestRequest implements ToXContent.Params, Traceable {
     }
 
     /**
+     * Decodes an {@code application/x-www-form-urlencoded} request body and adds
+     * the resulting parameters to this request.
+     * <p>
+     * Form-body parameters must not use the same names as existing URI or path parameters.
+     * Repeated parameters are supported within the form body itself.
+     */
+    public void consumeFormEncodedBodyParameters() {
+        if (hasContent() == false) {
+            return;
+        }
+        final RequestParams formParams = RequestParams.fromQueryString(content().utf8ToString());
+        for (String key : formParams.keySet()) {
+            if (params.containsKey(key)) {
+                throw new IllegalArgumentException("form parameter [" + key + "] conflicts with an existing request parameter");
+            }
+        }
+        for (String key : formParams.keySet()) {
+            for (String value : formParams.getAll(key)) {
+                params.addValue(key, value);
+            }
+        }
+    }
+
+    /**
      * Returns all values for the given query parameter, preserving the order in which they appeared in the URL.
      * This is useful for parameters that may be repeated (e.g. {@code match[]=foo&match[]=bar}).
      * Unlike {@link #param(String)}, path parameters are not visible through this method.

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -76,6 +76,7 @@ import static org.elasticsearch.rest.RestController.ELASTIC_PRODUCT_HTTP_HEADER_
 import static org.elasticsearch.rest.RestController.HANDLER_NAME_KEY;
 import static org.elasticsearch.rest.RestController.REQUEST_METHOD_KEY;
 import static org.elasticsearch.rest.RestController.STATUS_CODE_KEY;
+import static org.elasticsearch.rest.RestRequest.Method.DELETE;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.OPTIONS;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -1098,6 +1099,167 @@ public class RestControllerTests extends ESTestCase {
         );
     }
 
+    public void testFormEncodedBodySupportRequiresMatchingGetRoute() {
+        final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
+        final RestHandler handler = new FormEncodedHandler(List.of(new Route(POST, "/form-only")));
+
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> restController.registerHandler(handler));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "handler [org.elasticsearch.rest.RestControllerTests$FormEncodedHandler] supports read-only form-encoded POST bodies "
+                    + "but route [POST /form-only] does not have a matching GET route"
+            )
+        );
+    }
+
+    public void testFormEncodedBodySupportRequiresMatchingGetRouteForReplacedRoutes() {
+        final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
+        final RestHandler handler = new FormEncodedHandler(
+            List.of(
+                new Route(GET, "/form"),
+                Route.builder(POST, "/form").replaces(POST, "/old-form", RestApiVersion.minimumSupported()).build()
+            )
+        );
+
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> restController.registerHandler(handler));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "handler [org.elasticsearch.rest.RestControllerTests$FormEncodedHandler] supports read-only form-encoded POST bodies "
+                    + "but route [POST /old-form] does not have a matching GET route"
+            )
+        );
+    }
+
+    public void testFormEncodedBodySupportRejectsNonGetPostRoutes() {
+        final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
+        final RestHandler handler = new FormEncodedHandler(
+            List.of(new Route(GET, "/form"), new Route(POST, "/form"), new Route(DELETE, "/form"))
+        );
+
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> restController.registerHandler(handler));
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "handler [org.elasticsearch.rest.RestControllerTests$FormEncodedHandler] supports read-only form-encoded POST bodies "
+                    + "but route [DELETE /form] is not a GET or POST route"
+            )
+        );
+    }
+
+    public void testDispatchAllowsFormEncodedBodyForOptedInHandler() {
+        final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
+        final RestHandler handler = new FormEncodedHandler(List.of(new Route(GET, "/form"), new Route(POST, "/form")), request -> {
+            assertThat(request.param("query"), equalTo("from_body"));
+            assertThat(request.repeatedParamAsList("match[]"), equalTo(List.of("from_body_one", "from_body_two")));
+        });
+        restController.registerHandler(handler);
+
+        final RestRequest request = formPostRequest(
+            "/form",
+            "query=from_body&match%5B%5D=from_body_one&match%5B%5D=from_body_two",
+            RestController.FORM_URLENCODED_MEDIA_TYPE
+        );
+
+        final AssertingChannel channel = new AssertingChannel(request, randomBoolean(), RestStatus.OK);
+        restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
+        assertTrue(channel.getSendResponseCalled());
+    }
+
+    public void testDispatchRejectsFormEncodedBodyForNonOptedInHandler() {
+        final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
+        restController.registerHandler(new Route(POST, "/form"), (request, channel, client) -> fail("handler should not be called"));
+
+        final RestRequest request = formPostRequest("/form", "query=from_body", RestController.FORM_URLENCODED_MEDIA_TYPE);
+        final AssertingChannel channel = new AssertingChannel(request, randomBoolean(), RestStatus.NOT_ACCEPTABLE);
+        restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
+        assertTrue(channel.getSendResponseCalled());
+    }
+
+    public void testDispatchRejectsOtherSafelistedBodyTypesForOptedInHandler() {
+        final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
+        restController.registerHandler(
+            new FormEncodedHandler(
+                List.of(new Route(GET, "/form"), new Route(POST, "/form")),
+                request -> fail("handler should not receive non-form safelisted content")
+            )
+        );
+
+        for (String mediaType : List.of("multipart/form-data", "text/plain")) {
+            final RestRequest request = formPostRequest("/form", "query=from_body", mediaType);
+            final AssertingChannel channel = new AssertingChannel(request, randomBoolean(), RestStatus.NOT_ACCEPTABLE);
+            restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
+            assertTrue(channel.getSendResponseCalled());
+        }
+    }
+
+    public void testDispatchRejectsDuplicateFormEncodedBodyParametersForOptedInHandler() {
+        final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
+        restController.registerHandler(
+            new FormEncodedHandler(
+                List.of(new Route(GET, "/form"), new Route(POST, "/form")),
+                request -> fail("duplicate form-encoded parameter should be rejected before the handler is called")
+            )
+        );
+
+        final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/form")
+            .withMethod(POST)
+            .withMultiParams(RequestParams.fromQueryString("query=from_uri"))
+            .withContent(new BytesArray("query=from_body"), null)
+            .withHeaders(Collections.singletonMap("Content-Type", Collections.singletonList(RestController.FORM_URLENCODED_MEDIA_TYPE)))
+            .build();
+
+        final AssertingChannel channel = new AssertingChannel(request, randomBoolean(), RestStatus.BAD_REQUEST);
+        restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
+        assertTrue(channel.getSendResponseCalled());
+    }
+
+    public void testDirectRegistrationRejectsReadOnlyFormEncodedBodySupportWithoutDeclaredPostRoute() {
+        final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
+        final RestHandler handler = new DirectlyRegisteredFormEncodedHandler();
+
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> restController.registerHandler(POST, "/form", RestApiVersion.current(), handler)
+        );
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "handler [org.elasticsearch.rest.RestControllerTests$DirectlyRegisteredFormEncodedHandler] supports read-only "
+                    + "form-encoded POST bodies but does not define any POST routes"
+            )
+        );
+    }
+
+    public void testDirectRegistrationRejectsUndeclaredReadOnlyFormEncodedRoute() {
+        final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
+        final RestHandler handler = new FormEncodedHandler(List.of(new Route(GET, "/declared"), new Route(POST, "/declared")));
+
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> restController.registerHandler(POST, "/undeclared", RestApiVersion.current(), handler)
+        );
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "handler [org.elasticsearch.rest.RestControllerTests$FormEncodedHandler] supports read-only form-encoded POST bodies "
+                    + "but registered route [POST /undeclared] is not declared by the handler"
+            )
+        );
+    }
+
+    public void testDispatchRejectsMalformedFormEncodedBodyForOptedInHandler() {
+        final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
+        restController.registerHandler(new FormEncodedHandler(List.of(new Route(GET, "/form"), new Route(POST, "/form"))));
+
+        final RestRequest request = formPostRequest("/form", "query=%", RestController.FORM_URLENCODED_MEDIA_TYPE);
+
+        final AssertingChannel channel = new AssertingChannel(request, randomBoolean(), RestStatus.BAD_REQUEST);
+        restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
+        assertTrue(channel.getSendResponseCalled());
+    }
+
     public void testRegisterWithReservedPath() {
         final RestController restController = new RestController(null, client, circuitBreakerService, usageService, telemetryProvider);
         for (String path : RestController.RESERVED_PATHS) {
@@ -1199,6 +1361,66 @@ public class RestControllerTests extends ESTestCase {
 
         // Multi-values must survive the per-iteration reset that PathTrie triggers
         assertThat(params.getAll("format"), equalTo(List.of("json", "yaml")));
+    }
+
+    private RestRequest formPostRequest(String path, String body, String contentType) {
+        return new FakeRestRequest.Builder(xContentRegistry()).withPath(path)
+            .withMethod(POST)
+            .withContent(new BytesArray(body), null)
+            .withHeaders(Collections.singletonMap("Content-Type", Collections.singletonList(contentType)))
+            .build();
+    }
+
+    private static final class FormEncodedHandler extends BaseRestHandler {
+        private final List<Route> routes;
+        private final Consumer<RestRequest> requestAssertions;
+
+        private FormEncodedHandler(List<Route> routes) {
+            this(routes, request -> {});
+        }
+
+        private FormEncodedHandler(List<Route> routes, Consumer<RestRequest> requestAssertions) {
+            this.routes = routes;
+            this.requestAssertions = requestAssertions;
+        }
+
+        @Override
+        public String getName() {
+            return "formEncodedHandler";
+        }
+
+        @Override
+        public List<Route> routes() {
+            return routes;
+        }
+
+        @Override
+        public boolean supportsReadOnlyFormEncodedPostBody() {
+            return true;
+        }
+
+        @Override
+        public boolean canTripCircuitBreaker() {
+            return false;
+        }
+
+        @Override
+        protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+            requestAssertions.accept(request);
+            return channel -> channel.sendResponse(new RestResponse(RestStatus.OK, RestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY));
+        }
+    }
+
+    private static final class DirectlyRegisteredFormEncodedHandler implements RestHandler {
+        @Override
+        public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) {
+            throw new AssertionError("directly registered form-encoded POST handler should be rejected during registration");
+        }
+
+        @Override
+        public boolean supportsReadOnlyFormEncodedPostBody() {
+            return true;
+        }
     }
 
     @ServerlessScope(Scope.PUBLIC)


### PR DESCRIPTION
This adds a narrowly scoped REST handler opt-in for accepting `application/x-www-form-urlencoded` POST bodies on read-only endpoints.

Elasticsearch rejects browser-safelisted content types by default as part of its CSRF protections. That is still the default behavior. The new opt-in is intended for compatibility endpoints where POST is only an alternate way to submit the same parameters that a GET route already accepts, such as APIs modeled after Prometheus conventions.

To keep that exception constrained, handlers that opt in must declare matching GET and POST routes for the same path and API version, and they may not declare unrelated methods. Form body parameters are decoded into the request parameter set before handler execution, while conflicts with existing URI or path parameters are rejected instead of silently overriding values.

The tests cover the allowed form-encoded POST path, repeated form parameters, malformed bodies, duplicate parameter rejection, non-opted handlers, and the registration-time guardrails that keep the opt-in limited to read-only GET/POST route pairs.