### PR TITLE
[TEST] Add feature flag guarding for the vectordb mode in more tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
@@ -130,6 +130,11 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
             "columnar index modes require transport version " + IndexMode.COLUMNAR_INDEX_MODES_ADDED,
             hasColumnarMode == false || version.supports(IndexMode.COLUMNAR_INDEX_MODES_ADDED)
         );
+        final boolean hasVectordbMode = indexResponses.stream().anyMatch(r -> r.getIndexMode() == IndexMode.VECTORDB_DOCUMENT);
+        assumeTrue(
+            "vectordb_document index mode requires transport version " + IndexMode.VECTORDB_DOCUMENT_INDEX_MODE,
+            hasVectordbMode == false || version.supports(IndexMode.VECTORDB_DOCUMENT_INDEX_MODE)
+        );
         final FieldCapabilitiesNodeResponse outNode = copyInstance(inNode, version);
         assertThat(outNode.getFailures().keySet(), equalTo(inNode.getFailures().keySet()));
         assertThat(outNode.getUnmatchedShardIds(), equalTo(inNode.getUnmatchedShardIds()));

--- a/server/src/test/java/org/elasticsearch/index/VectordbDocumentIndexModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/VectordbDocumentIndexModeTests.java
@@ -25,11 +25,13 @@ import static org.hamcrest.Matchers.not;
 public class VectordbDocumentIndexModeTests extends ESTestCase {
 
     public void testFromString() {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         assertThat(IndexMode.fromString("vectordb_document"), equalTo(IndexMode.VECTORDB_DOCUMENT));
         assertThat(IndexMode.fromString("VECTORDB_DOCUMENT"), equalTo(IndexMode.VECTORDB_DOCUMENT));
     }
 
     public void testProviderSetsDefaultSettings() {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         // _source mode defaults to STORED for vectordb_document index mode.
         assertThat(IndexMode.VECTORDB_DOCUMENT.defaultSourceMode().name(), equalTo("STORED"));
 
@@ -56,6 +58,7 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
     }
 
     public void testProviderRejectsExplicitFalseExcludeSourceVectors() {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         Settings userSettings = Settings.builder()
             .put(IndexSettings.MODE.getKey(), "vectordb_document")
             .put(IndexSettings.INDEX_MAPPING_EXCLUDE_SOURCE_VECTORS_SETTING.getKey(), false)
@@ -66,6 +69,7 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
     }
 
     public void testProviderAcceptsExplicitTrueExcludeSourceVectors() {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         Settings userSettings = Settings.builder()
             .put(IndexSettings.MODE.getKey(), "vectordb_document")
             .put(IndexSettings.INDEX_MAPPING_EXCLUDE_SOURCE_VECTORS_SETTING.getKey(), true)
@@ -76,6 +80,7 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
     }
 
     public void testProviderDoesNotOverrideExplicitSettings() {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         Settings userSettings = Settings.builder()
             .put(IndexSettings.MODE.getKey(), "vectordb_document")
             .putList(IndexModule.INDEX_STORE_PRE_LOAD_SETTING.getKey(), "vex")

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -1084,6 +1084,7 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
     }
 
     public void testDefaultElementTypeUnderVectordbDocumentIndexMode() throws Exception {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), "vectordb_document").build();
         MapperService mapperService = createMapperService(settings, fieldMapping(b -> b.field("type", "dense_vector").field("dims", 8)));
         DenseVectorFieldMapper mapper = (DenseVectorFieldMapper) mapperService.mappingLookup().getMapper("field");
@@ -1091,6 +1092,7 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
     }
 
     public void testExplicitElementTypeOverridesVectordbDocumentModeDefault() throws Exception {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), "vectordb_document").build();
         MapperService mapperService = createMapperService(
             settings,

--- a/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperLicensedStatefulDefaultsTests.java
+++ b/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperLicensedStatefulDefaultsTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.diskbbq;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
@@ -57,6 +58,7 @@ public class DiskBBQDenseVectorFieldMapperLicensedStatefulDefaultsTests extends 
     }
 
     public void testDefaultsToBBQHnswInVectordbDocumentIndexModeWhenLicensedOnStatefulNodeAndDimensionsAreHigh() throws IOException {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), "vectordb_document").build();
         MapperService mapperService = createMapperService(
             getVersion(),
@@ -84,6 +86,7 @@ public class DiskBBQDenseVectorFieldMapperLicensedStatefulDefaultsTests extends 
     }
 
     public void testDefaultsToInt8HnswInVectordbDocumentIndexModeWhenLicensedOnStatefulNodeAndDimensionsAreLow() throws IOException {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), "vectordb_document").build();
         MapperService mapperService = createMapperService(
             getVersion(),

--- a/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperTests.java
+++ b/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.Build;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.SliceIndexing;
 import org.elasticsearch.index.codec.CodecService;
@@ -89,6 +90,7 @@ public class DiskBBQDenseVectorFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testDefaultsToBBQDiskInVectordbDocumentIndexMode() throws IOException {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), "vectordb_document").build();
         MapperService mapperService = createMapperService(
             getVersion(),

--- a/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperUnlicensedDefaultsTests.java
+++ b/x-pack/plugin/diskbbq/src/test/java/org/elasticsearch/xpack/diskbbq/DiskBBQDenseVectorFieldMapperUnlicensedDefaultsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.diskbbq;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
@@ -45,6 +46,7 @@ public class DiskBBQDenseVectorFieldMapperUnlicensedDefaultsTests extends Mapper
     }
 
     public void testDoesNotDefaultToBBQDiskInVectordbDocumentIndexModeWhenUnlicensedAndDimensionsAreHigh() throws IOException {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), "vectordb_document").build();
         MapperService mapperService = createMapperService(
             getVersion(),
@@ -72,6 +74,7 @@ public class DiskBBQDenseVectorFieldMapperUnlicensedDefaultsTests extends Mapper
     }
 
     public void testDoesNotDefaultToBBQDiskInVectordbDocumentIndexModeWhenUnlicensedAndDimensionsAreLow() throws IOException {
+        assumeTrue("vectordb_document index mode requires snapshot build", IndexMode.VECTORDB_FEATURE_FLAG.isEnabled());
         Settings settings = Settings.builder().put(IndexSettings.MODE.getKey(), "vectordb_document").build();
         MapperService mapperService = createMapperService(
             getVersion(),


### PR DESCRIPTION
Got them from running `test-release` in another pr: https://buildkite.com/elastic/elasticsearch-pull-request/builds/145219#019e2132-bbcf-4970-9709-a040fdad6bfb