### PR TITLE
ESQL: Skip flattened tests in release mode

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -133,7 +133,10 @@ import static org.elasticsearch.xpack.esql.expression.predicate.operator.compari
  *         natural ordering, make sure to test sorting and the other binary
  *         comparisons. Make sure these functions all have CSV tests that run
  *         against indexed data. When you add support to the function, add
- *         a new {@link FunctionDefinition.Builder#capabilities(String...) capability}.</li>
+ *         a new {@link FunctionDefinition.Builder#capabilities(String...) capability}.
+ *         As you add support for more functions, run the tests in normal
+ *         mode <strong>and</strong> release mode. See {@code Testing.asciidoc}
+ *         for instructions on how to run the release build.</li>
  *     <li>
  *         Add conversion functions as appropriate.  Almost all types should
  *         support {@link ToString}, and should have a "ToType" function that

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -1466,6 +1466,7 @@ public class VerifierTests extends ESTestCase {
     }
 
     public void testFieldExtractFirstArgumentMustBeFlattened() {
+        assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
         var index = analyzer().addIndex("flattened_otel_logs", "mapping-flattened_otel_logs.json").stripErrorPrefix(true);
         index.error(
             "FROM flattened_otel_logs | EVAL x = field_extract(@timestamp, \"a\")",

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
@@ -111,6 +111,7 @@ public class CountTests extends AbstractAggregationTestCase {
                 }
                 return new TestCaseSupplier.TestCase(
                     List.of(field),
+                    // Dense vector uses a different count implementation
                     dataType == DataType.DENSE_VECTOR ? "DenseVectorCount" : "Count",
                     DataType.LONG,
                     equalTo(0L)

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
@@ -13,6 +13,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
 import org.elasticsearch.compute.data.TDigestHolder;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -104,18 +105,17 @@ public class CountTests extends AbstractAggregationTestCase {
                     .withAppliesTo(histogramPreviewAppliesTo)
                     .withAppliesTo(histogramGaAppliesTo)
                 : TestCaseSupplier.TypedData.multiRow(List.of(), dataType, "field");
-            suppliers.add(
-                new TestCaseSupplier(
-                    "No rows (" + dataType + ")",
-                    List.of(dataType),
-                    () -> new TestCaseSupplier.TestCase(
-                        List.of(field),
-                        dataType == DataType.DENSE_VECTOR ? "DenseVectorCount" : "Count",
-                        DataType.LONG,
-                        equalTo(0L)
-                    )
-                )
-            );
+            suppliers.add(new TestCaseSupplier("No rows (" + dataType + ")", List.of(dataType), () -> {
+                if (dataType == DataType.FLATTENED) {
+                    assumeTrue("Requires FLATTENED_DATATYPE capability", EsqlCapabilities.Cap.FLATTENED_DATATYPE.isEnabled());
+                }
+                return new TestCaseSupplier.TestCase(
+                    List.of(field),
+                    dataType == DataType.DENSE_VECTOR ? "DenseVectorCount" : "Count",
+                    DataType.LONG,
+                    equalTo(0L)
+                );
+            }));
         }
 
         // "No rows" expects 0 here instead of null

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.compute.test.TestBlockFactory;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
@@ -182,6 +183,7 @@ public class CoalesceTests extends AbstractScalarFunctionTestCase {
             );
         }));
         noNullsSuppliers.add(new TestCaseSupplier(List.of(DataType.FLATTENED, DataType.FLATTENED), () -> {
+            assumeTrue("Requires FLATTENED_DATATYPE capability", EsqlCapabilities.Cap.FLATTENED_DATATYPE.isEnabled());
             BytesRef first = randomBoolean() ? null : FlattenedCases.RANDOM.get();
             BytesRef second = FlattenedCases.RANDOM.get();
             return new TestCaseSupplier.TestCase(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractTests.java
@@ -13,6 +13,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -48,55 +49,46 @@ public class FieldExtractTests extends AbstractScalarFunctionTestCase {
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
         for (DataType pathType : List.of(DataType.KEYWORD, DataType.TEXT)) {
-            suppliers.add(
-                new TestCaseSupplier(
-                    "literal dotted key " + pathType.typeName(),
-                    types(DataType.FLATTENED, pathType),
-                    () -> new TestCaseSupplier.TestCase(
-                        List.of(
-                            new TestCaseSupplier.TypedData(new BytesRef("{\"host.name\":\"node-a\"}"), DataType.FLATTENED, "field"),
-                            new TestCaseSupplier.TypedData(new BytesRef("host.name"), pathType, "path")
-                        ),
-                        "FieldExtractEvaluator[flattenedJson=Attribute[channel=0], path=Attribute[channel=1]]",
-                        DataType.KEYWORD,
-                        equalTo(new BytesRef("node-a"))
-                    )
-                )
-            );
-        }
-
-        suppliers.add(
-            new TestCaseSupplier(
-                "constant dotted path",
-                types(DataType.FLATTENED, DataType.KEYWORD),
-                () -> new TestCaseSupplier.TestCase(
+            suppliers.add(new TestCaseSupplier("literal dotted key " + pathType.typeName(), types(DataType.FLATTENED, pathType), () -> {
+                assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
+                return new TestCaseSupplier.TestCase(
                     List.of(
-                        new TestCaseSupplier.TypedData(new BytesRef("{\"k.inner\":\"v\"}"), DataType.FLATTENED, "field"),
-                        new TestCaseSupplier.TypedData(new BytesRef("k.inner"), DataType.KEYWORD, "path").forceLiteral()
-                    ),
-                    "FieldExtractConstantEvaluator[flattenedJson=Attribute[channel=0], path=k.inner]",
-                    DataType.KEYWORD,
-                    equalTo(new BytesRef("v"))
-                )
-            )
-        );
-
-        suppliers.add(
-            new TestCaseSupplier(
-                "missing path",
-                types(DataType.FLATTENED, DataType.KEYWORD),
-                () -> new TestCaseSupplier.TestCase(
-                    List.of(
-                        new TestCaseSupplier.TypedData(new BytesRef("{\"a\":1}"), DataType.FLATTENED, "field"),
-                        new TestCaseSupplier.TypedData(new BytesRef("missing"), DataType.KEYWORD, "path")
+                        new TestCaseSupplier.TypedData(new BytesRef("{\"host.name\":\"node-a\"}"), DataType.FLATTENED, "field"),
+                        new TestCaseSupplier.TypedData(new BytesRef("host.name"), pathType, "path")
                     ),
                     "FieldExtractEvaluator[flattenedJson=Attribute[channel=0], path=Attribute[channel=1]]",
                     DataType.KEYWORD,
-                    nullValue()
-                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
-                    .withWarning("Line 1:1: java.lang.IllegalArgumentException: path [missing] does not exist")
-            )
-        );
+                    equalTo(new BytesRef("node-a"))
+                );
+            }));
+        }
+
+        suppliers.add(new TestCaseSupplier("constant dotted path", types(DataType.FLATTENED, DataType.KEYWORD), () -> {
+            assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(new BytesRef("{\"k.inner\":\"v\"}"), DataType.FLATTENED, "field"),
+                    new TestCaseSupplier.TypedData(new BytesRef("k.inner"), DataType.KEYWORD, "path").forceLiteral()
+                ),
+                "FieldExtractConstantEvaluator[flattenedJson=Attribute[channel=0], path=k.inner]",
+                DataType.KEYWORD,
+                equalTo(new BytesRef("v"))
+            );
+        }));
+
+        suppliers.add(new TestCaseSupplier("missing path", types(DataType.FLATTENED, DataType.KEYWORD), () -> {
+            assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(new BytesRef("{\"a\":1}"), DataType.FLATTENED, "field"),
+                    new TestCaseSupplier.TypedData(new BytesRef("missing"), DataType.KEYWORD, "path")
+                ),
+                "FieldExtractEvaluator[flattenedJson=Attribute[channel=0], path=Attribute[channel=1]]",
+                DataType.KEYWORD,
+                nullValue()
+            ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                .withWarning("Line 1:1: java.lang.IllegalArgumentException: path [missing] does not exist");
+        }));
 
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
     }


### PR DESCRIPTION
Skip `flattened` tests in release mode. They aren't released and won't pass.

Close #148960
