### PR TITLE
ESQL:DS: testing: expand test coverage

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -76,6 +76,7 @@ dependencies {
   testImplementation project(path: xpackModule('esql-datasource-snappy'))
   testImplementation project(path: xpackModule('esql-datasource-brotli'))
   testImplementation "com.github.luben:zstd-jni:${versions.zstdJni}"
+  testImplementation "org.xerial.snappy:snappy-java:${versions.snappyJava}"
   testImplementation "org.apache.commons:commons-compress:${versions.esql_commons_compress}"
   testImplementation project(path: ':modules:reindex')
   testImplementation project(path: ':modules:parent-join')

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/CompressionDelegatingFormatReaderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/CompressionDelegatingFormatReaderTests.java
@@ -7,13 +7,22 @@
 
 package org.elasticsearch.xpack.esql.datasources;
 
-import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.BlockFactory;
+import net.jpountz.lz4.LZ4FrameOutputStream;
+
+import com.github.luben.zstd.ZstdOutputStream;
+
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.CloseableIterator;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.datasource.brotli.BrotliDecompressionCodec;
+import org.elasticsearch.xpack.esql.datasource.bzip2.Bzip2DecompressionCodec;
+import org.elasticsearch.xpack.esql.datasource.gzip.GzipDecompressionCodec;
+import org.elasticsearch.xpack.esql.datasource.lz4.Lz4DecompressionCodec;
+import org.elasticsearch.xpack.esql.datasource.snappy.SnappyDecompressionCodec;
+import org.elasticsearch.xpack.esql.datasource.zstd.ZstdDecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.DecompressionCodec;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReadContext;
 import org.elasticsearch.xpack.esql.datasources.spi.FormatReader;
@@ -22,12 +31,15 @@ import org.elasticsearch.xpack.esql.datasources.spi.SimpleSourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.SourceMetadata;
 import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 import org.elasticsearch.xpack.esql.datasources.spi.StoragePath;
+import org.xerial.snappy.SnappyFramedOutputStream;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -38,20 +50,46 @@ import java.util.zip.GZIPOutputStream;
  */
 public class CompressionDelegatingFormatReaderTests extends ESTestCase {
 
-    private BlockFactory blockFactory;
+    private static final byte[] CSV_CONTENT = "a:keyword,b:integer\nfoo,1\nbar,2".getBytes(StandardCharsets.UTF_8);
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        blockFactory = BlockFactory.builder(BigArrays.NON_RECYCLING_INSTANCE).breaker(new NoopCircuitBreaker("test")).build();
+    // printf 'a:keyword,b:integer\nfoo,1\nbar,2' | brotli -1 | base64
+    private static final String CSV_CONTENT_BROTLI_BASE64 = "Dw+AYTprZXl3b3JkLGI6aW50ZWdlcgpmb28sMQpiYXIsMgM=";
+
+    public void testDelegatesMetadataAndReadGzip() throws IOException {
+        assertDelegatesMetadataAndRead(gzip(CSV_CONTENT), "file:///data.csv.gz", new GzipDecompressionCodec());
     }
 
-    public void testDelegatesMetadataAndRead() throws IOException {
-        byte[] csvContent = "a:keyword,b:integer\nfoo,1\nbar,2".getBytes(StandardCharsets.UTF_8);
-        byte[] compressed = gzip(csvContent);
+    public void testDelegatesMetadataAndReadZstd() throws IOException {
+        assertDelegatesMetadataAndRead(zstd(CSV_CONTENT), "file:///data.csv.zst", new ZstdDecompressionCodec());
+    }
 
-        StorageObject rawObject = new BytesStorageObject(compressed, StoragePath.of("file:///data.csv.gz"));
-        DecompressionCodec codec = new org.elasticsearch.xpack.esql.datasource.gzip.GzipDecompressionCodec();
+    public void testDelegatesMetadataAndReadBzip2() throws IOException {
+        assertDelegatesMetadataAndRead(
+            bzip2(CSV_CONTENT),
+            "file:///data.csv.bz2",
+            new Bzip2DecompressionCodec(EsExecutors.DIRECT_EXECUTOR_SERVICE)
+        );
+    }
+
+    public void testDelegatesMetadataAndReadLz4() throws IOException {
+        assertDelegatesMetadataAndRead(lz4(CSV_CONTENT), "file:///data.csv.lz4", new Lz4DecompressionCodec());
+    }
+
+    public void testDelegatesMetadataAndReadSnappy() throws IOException {
+        assertDelegatesMetadataAndRead(snappy(CSV_CONTENT), "file:///data.csv.snappy", new SnappyDecompressionCodec());
+    }
+
+    public void testDelegatesMetadataAndReadBrotli() throws IOException {
+        byte[] brotliCompressed = Base64.getDecoder().decode(CSV_CONTENT_BROTLI_BASE64);
+        BrotliDecompressionCodec codec = new BrotliDecompressionCodec();
+        try (InputStream decompressed = codec.decompress(new ByteArrayInputStream(brotliCompressed))) {
+            assertArrayEquals("pre-compressed brotli blob is stale", CSV_CONTENT, decompressed.readAllBytes());
+        }
+        assertDelegatesMetadataAndRead(brotliCompressed, "file:///data.csv.br", codec);
+    }
+
+    private void assertDelegatesMetadataAndRead(byte[] compressed, String path, DecompressionCodec codec) throws IOException {
+        StorageObject rawObject = new BytesStorageObject(compressed, StoragePath.of(path));
 
         FormatReader innerReader = new CapturingFormatReader();
         FormatReader delegating = new CompressionDelegatingFormatReader(innerReader, codec);
@@ -133,9 +171,41 @@ public class CompressionDelegatingFormatReaderTests extends ESTestCase {
     }
 
     private static byte[] gzip(byte[] input) throws IOException {
-        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (GZIPOutputStream gzipOut = new GZIPOutputStream(baos)) {
             gzipOut.write(input);
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] zstd(byte[] input) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZstdOutputStream zstdOut = new ZstdOutputStream(baos)) {
+            zstdOut.write(input);
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] bzip2(byte[] input) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (BZip2CompressorOutputStream bz2Out = new BZip2CompressorOutputStream(baos)) {
+            bz2Out.write(input);
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] lz4(byte[] input) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (LZ4FrameOutputStream lz4Out = new LZ4FrameOutputStream(baos)) {
+            lz4Out.write(input);
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] snappy(byte[] input) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (SnappyFramedOutputStream snappyOut = new SnappyFramedOutputStream(baos)) {
+            snappyOut.write(input);
         }
         return baos.toByteArray();
     }
@@ -187,7 +257,7 @@ public class CompressionDelegatingFormatReaderTests extends ESTestCase {
             try (InputStream stream = object.newStream()) {
                 stream.readAllBytes();
             }
-            return new SimpleSourceMetadata(List.of(), "csv", "file:///data.csv.gz");
+            return new SimpleSourceMetadata(List.of(), "csv", object.path().toString());
         }
 
         @Override


### PR DESCRIPTION
This expands the coverage of CompressionDelegatingFormatReaderTests to all supported compressions (previously was just gzip).

