### PR TITLE
Avoid storing in BlobTranslogFile totalOps for active shards when it is equal to zero

### DIFF
--- a/docs/changelog/148992.yaml
+++ b/docs/changelog/148992.yaml
@@ -1,0 +1,6 @@
+area: Engine
+issues: []
+pr: 148992
+summary: Avoid storing in `BlobTranslogFile` `totalOps` for active shards when it
+  is equal to zero
+type: enhancement

--- a/x-pack/plugin/stateless/build.gradle
+++ b/x-pack/plugin/stateless/build.gradle
@@ -24,8 +24,6 @@ dependencies {
   compileOnly project(xpackModule('core'))
   compileOnly project(xpackModule('blob-cache'))
 
-  implementation 'com.carrotsearch:hppc:0.8.1'
-
   testImplementation project(':test:framework')
   testImplementation testArtifact(project(xpackModule('searchable-snapshots')))
   testImplementation 'com.amazonaws:aws-java-sdk-core:1.12.684'

--- a/x-pack/plugin/stateless/src/main/java/module-info.java
+++ b/x-pack/plugin/stateless/src/main/java/module-info.java
@@ -23,7 +23,6 @@ module org.elasticsearch.xpack.stateless {
 
     requires org.apache.logging.log4j;
     requires org.apache.lucene.core;
-    requires hppc;
 
     exports org.elasticsearch.xpack.stateless
         to

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBuffer.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBuffer.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.stateless.engine.translog;
 
-import com.carrotsearch.hppc.ObjectLongHashMap;
-
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
@@ -29,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 public class NodeTranslogBuffer implements Releasable {
 
@@ -156,8 +155,13 @@ public class NodeTranslogBuffer implements Releasable {
                 () -> Releasables.close(headerStream, compoundTranslogStream)
             );
 
-            ObjectLongHashMap<ShardId> totalOps = new ObjectLongHashMap<>(metadata.size());
-            metadata.forEach((key, value) -> totalOps.put(key, value.operations().totalOps()));
+            // We do not need to store totalOps when they are equal to zero as it can simply be assumed when there is no entry
+            // for a specified ShardId. Storing them has a memory cost that is non-negligible in some scenarios.
+            // We also use toUnmodifiableMap as it has a lower memory usage than HashMap.
+            Map<ShardId, Long> totalOps = metadata.entrySet()
+                .stream()
+                .filter(e -> e.getValue().operations().totalOps() > 0)
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().operations().totalOps()));
 
             TranslogReplicator.CompoundTranslogMetadata compoundMetadata = new TranslogReplicator.CompoundTranslogMetadata(
                 Strings.format("%019d", generation),

--- a/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicator.java
+++ b/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/translog/TranslogReplicator.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.stateless.engine.translog;
 
-import com.carrotsearch.hppc.ObjectLongHashMap;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.AlreadyClosedException;
@@ -491,7 +489,7 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
     public record CompoundTranslogMetadata(
         String name,
         long generation,
-        ObjectLongHashMap<ShardId> totalOps,
+        Map<ShardId, Long> totalOps,
         Map<ShardId, ShardSyncState.SyncMarker> syncedLocations
     ) {}
 
@@ -608,15 +606,13 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
 
         private final long generation;
         private final String blobName;
-        // ObjectLongHashMap allows us to avoid using Long wrappers and HashMap$Node which can account for a significant amount of memory,
-        // when the number of shards and BlobTranslogFiles are high.
-        private final ObjectLongHashMap<ShardId> totalOps;
+        private final Map<ShardId, Long> totalOps;
         private final Set<ShardId> includedShards;
 
         private volatile boolean safeForDelete = true;
         private ArrayList<ShardId> unsafeForDeleteShards = null;
 
-        BlobTranslogFile(long generation, String blobName, ObjectLongHashMap<ShardId> totalOps, Set<ShardId> includedShards) {
+        BlobTranslogFile(long generation, String blobName, Map<ShardId, Long> totalOps, Set<ShardId> includedShards) {
             this.generation = generation;
             this.blobName = blobName;
             this.totalOps = totalOps;
@@ -632,7 +628,7 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
         }
 
         public long getTotalOps(ShardId shardId) {
-            return this.totalOps.get(shardId);
+            return this.totalOps.getOrDefault(shardId, 0L);
         }
 
         @Override
@@ -682,11 +678,11 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
 
     private class BlobTranslogFileImpl extends BlobTranslogFile {
 
-        private final TranslogReplicator.CompoundTranslogMetadata metadata;
+        private final Map<ShardId, ShardSyncState.SyncMarker> syncedLocations;
 
         private BlobTranslogFileImpl(CompoundTranslogMetadata metadata) {
             super(metadata.generation(), metadata.name(), metadata.totalOps(), metadata.syncedLocations().keySet());
-            this.metadata = metadata;
+            this.syncedLocations = metadata.syncedLocations();
         }
 
         @Override
@@ -808,7 +804,7 @@ public class TranslogReplicator extends AbstractLifecycleComponent {
                         task.completedUploads.forEach(upload -> {
                             try {
                                 activeTranslogFiles.add(upload);
-                                for (Map.Entry<ShardId, ShardSyncState.SyncMarker> entry : upload.metadata.syncedLocations().entrySet()) {
+                                for (Map.Entry<ShardId, ShardSyncState.SyncMarker> entry : upload.syncedLocations.entrySet()) {
                                     ShardSyncState shardSyncState = shardSyncStates.get(entry.getKey());
                                     if (shardSyncState == null) {
                                         logger.debug(

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBufferTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/NodeTranslogBufferTests.java
@@ -113,8 +113,9 @@ public class NodeTranslogBufferTests extends ESTestCase {
 
         TranslogReplicator.CompoundTranslog translog = translogBuffer.complete(0, Set.of(activeShard, activeButNoBufferedDataShard));
         assertTrue(translog.metadata().totalOps().containsKey(activeShardId));
-        assertTrue(translog.metadata().totalOps().containsKey(activeButNoBufferedShardId));
-        assertThat(translog.metadata().totalOps().size(), equalTo(2));
+        // The active but not buffered ShardId should not be in the totalOps
+        assertFalse(translog.metadata().totalOps().containsKey(activeButNoBufferedShardId));
+        assertThat(translog.metadata().totalOps().size(), equalTo(1));
         assertThat(translog.metadata().syncedLocations().keySet(), hasItems(activeShardId));
         assertThat(translog.metadata().syncedLocations().size(), equalTo(1));
     }

--- a/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/ShardSyncStateTests.java
+++ b/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/translog/ShardSyncStateTests.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.stateless.engine.translog;
 
-import com.carrotsearch.hppc.ObjectLongHashMap;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -21,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
@@ -41,7 +40,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            totalOps(shardId, 1),
+            Map.of(shardId, 1L),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -65,12 +64,6 @@ public class ShardSyncStateTests extends ESTestCase {
         assertFalse(activeTranslogFile.hasReferences());
     }
 
-    private static ObjectLongHashMap<ShardId> totalOps(ShardId shardId, long value) {
-        ObjectLongHashMap<ShardId> totalOps = new ObjectLongHashMap<>(1);
-        totalOps.put(shardId, value);
-        return totalOps;
-    }
-
     public void testActiveTranslogFileIsReferencedInNextSync() throws IOException {
         ShardId shardId = new ShardId(new Index("name", "uuid"), 0);
         long primaryTerm = randomLongBetween(0, 20);
@@ -78,7 +71,7 @@ public class ShardSyncStateTests extends ESTestCase {
 
         shardSyncState.markSyncStarting(
             primaryTerm,
-            new TranslogReplicator.BlobTranslogFile(1, "", totalOps(shardId, 1), Collections.singleton(shardId)) {
+            new TranslogReplicator.BlobTranslogFile(1, "", Map.of(shardId, 1L), Collections.singleton(shardId)) {
                 @Override
                 protected void closeInternal() {}
             }
@@ -86,7 +79,7 @@ public class ShardSyncStateTests extends ESTestCase {
 
         shardSyncState.markSyncStarting(
             primaryTerm,
-            new TranslogReplicator.BlobTranslogFile(2, "", totalOps(shardId, 2), Collections.singleton(shardId)) {
+            new TranslogReplicator.BlobTranslogFile(2, "", Map.of(shardId, 2L), Collections.singleton(shardId)) {
                 @Override
                 protected void closeInternal() {}
             }
@@ -97,7 +90,7 @@ public class ShardSyncStateTests extends ESTestCase {
         assertThat(directory.referencedTranslogFileOffsets(), equalTo(new int[] { 3, 2 }));
         shardSyncState.markSyncStarting(
             primaryTerm,
-            new TranslogReplicator.BlobTranslogFile(4, "", totalOps(shardId, 1), Collections.singleton(shardId)) {
+            new TranslogReplicator.BlobTranslogFile(4, "", Map.of(shardId, 1L), Collections.singleton(shardId)) {
                 @Override
                 protected void closeInternal() {}
             }
@@ -110,7 +103,7 @@ public class ShardSyncStateTests extends ESTestCase {
         assertThat(directory2.referencedTranslogFileOffsets(), equalTo(new int[] { 4, 3, 1 }));
         shardSyncState.markSyncStarting(
             primaryTerm,
-            new TranslogReplicator.BlobTranslogFile(5, "", totalOps(shardId, 1), Collections.singleton(shardId)) {
+            new TranslogReplicator.BlobTranslogFile(5, "", Map.of(shardId, 1L), Collections.singleton(shardId)) {
                 @Override
                 protected void closeInternal() {}
             }
@@ -133,7 +126,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            totalOps(shardId, 1),
+            Map.of(shardId, 1L),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -166,7 +159,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            totalOps(shardId, 1),
+            Map.of(shardId, 1L),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -194,7 +187,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            totalOps(shardId, 1),
+            Map.of(shardId, 1L),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -224,7 +217,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            totalOps(shardId, 4),
+            Map.of(shardId, 4L),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -257,7 +250,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            totalOps(shardId, 3),
+            Map.of(shardId, 3L),
             Collections.singleton(shardId)
         ) {
             @Override
@@ -301,7 +294,7 @@ public class ShardSyncStateTests extends ESTestCase {
         TranslogReplicator.BlobTranslogFile activeTranslogFile = new TranslogReplicator.BlobTranslogFile(
             generation,
             "",
-            totalOps(shardId, 3),
+            Map.of(shardId, 3L),
             Collections.singleton(shardId)
         ) {
             @Override


### PR DESCRIPTION
When we have a a high number of shards and a high number of pending files, the on heap usage of totalOps can be significant and trigger some OOMs. Not storing totalOps when it is equals to zero can significantly reduce this memory usage for some scenarios.
