### PR TITLE
[Test] Don't include global state in snapshot test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -545,9 +545,6 @@ tests:
 - class: org.elasticsearch.reindex.management.ReindexRethrottleRelocationIT
   method: testRethrottleByOriginalTaskIdAfterRelocation
   issue: https://github.com/elastic/elasticsearch/issues/148893
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {yaml=snapshot/10_basic/Create a source only snapshot and then restore it}
-  issue: https://github.com/elastic/elasticsearch/issues/148917
 - class: org.elasticsearch.xpack.ccr.index.engine.FollowingEngineTests
   method: testProcessOnceOnPrimary
   issue: https://github.com/elastic/elasticsearch/issues/148943

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -42,7 +42,10 @@ setup:
         snapshot: test_snapshot
         wait_for_completion: true
         body: |
-          { "indices": "test_index" }
+          {
+            "indices": "test_index",
+            "include_global_state": false
+          }
 
   - match: { snapshot.snapshot: test_snapshot }
   - match: { snapshot.state : SUCCESS }


### PR DESCRIPTION
### Summary

The YAML test `snapshot/10_basic → “Create a source only snapshot and then restore it”` assumed the snapshot contained only test_index (`snapshot.shards.successful: 1`). Snapshot creation defaults to `include_global_state: true`, which causes the snapshot logic to merge all feature-state indices that exist on the cluster (e.g. ML internal indices such as `.ml-annotations-000001`) into the snapshot alongside the requested user index.

### Why it failed
`XPackRestIT` runs with ML enabled. Once those internal indices exist, they were included in the snapshot even though the test body only listed `test_index`. That produced extra successful shards (e.g. 3 instead of 1) and, on restore, a `snapshot_restore_exception` because an index like `.ml-annotations-000001` was both in the snapshot and already open in the cluster. Later assertions (recovery type, search, hits) were cascade failures after restore failed.

### Why this fix
- Other test fixes in the file did the same thing by setting `include_global_state=false`, related: https://github.com/elastic/elasticsearch/pull/123458
- Doing this matches the intent of the test (only the user index)

Closes https://github.com/elastic/elasticsearch/issues/148917