### PR TITLE
[9.4] Add logging tracking to _xpack/usage (#148087)

### DIFF
--- a/docs/changelog/148087.yaml
+++ b/docs/changelog/148087.yaml
@@ -1,0 +1,5 @@
+area: Search
+issues: []
+pr: 148087
+summary: Add logging tracking to _xpack/usage
+type: enhancement

--- a/x-pack/plugin/core/src/main/java/module-info.java
+++ b/x-pack/plugin/core/src/main/java/module-info.java
@@ -244,6 +244,7 @@ module org.elasticsearch.xcore {
     exports org.elasticsearch.xpack.core.watcher;
     exports org.elasticsearch.xpack.core.common.chunks;
     exports org.elasticsearch.xpack.core.inference.chunking;
+    exports org.elasticsearch.xpack.core.logging;
 
     provides org.elasticsearch.action.admin.cluster.node.info.ComponentVersionNumber
         with

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
@@ -100,6 +100,7 @@ public final class XPackField {
     /** Name for Universal Profiling. */
     public static final String UNIVERSAL_PROFILING = "universal_profiling";
     public static final String LOGSDB = "logsdb";
+    public static final String LOGGING = "logging";
 
     private XPackField() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -95,6 +95,7 @@ import org.elasticsearch.xpack.core.async.TransportDeleteAsyncResultAction;
 import org.elasticsearch.xpack.core.datatiers.DataTiersInfoTransportAction;
 import org.elasticsearch.xpack.core.datatiers.DataTiersUsageTransportAction;
 import org.elasticsearch.xpack.core.datatiers.NodesDataTiersUsageTransportAction;
+import org.elasticsearch.xpack.core.logging.LoggingUsageTransportAction;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.rest.action.RestXPackInfoAction;
 import org.elasticsearch.xpack.core.rest.action.RestXPackUsageAction;
@@ -352,6 +353,7 @@ public class XPackPlugin extends XPackClientPlugin
         actions.add(new ActionHandler(XPackUsageFeatureAction.REMOTE_CLUSTERS, RemoteClusterUsageTransportAction.class));
         actions.add(new ActionHandler(NodesDataTiersUsageTransportAction.TYPE, NodesDataTiersUsageTransportAction.class));
         actions.add(new ActionHandler(XPackUsageFeatureAction.TIME_SERIES_DATA_STREAMS, TimeSeriesUsageTransportAction.class));
+        actions.add(new ActionHandler(XPackUsageFeatureAction.LOGGING, LoggingUsageTransportAction.class));
         return actions;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
@@ -65,6 +65,7 @@ public final class XPackUsageFeatureAction {
     public static final ActionType<XPackUsageFeatureResponse> UNIVERSAL_PROFILING = xpackUsageFeatureAction(XPackField.UNIVERSAL_PROFILING);
     public static final ActionType<XPackUsageFeatureResponse> LOGSDB = xpackUsageFeatureAction(XPackField.LOGSDB);
     public static final ActionType<XPackUsageFeatureResponse> GPU_VECTOR_INDEXING = xpackUsageFeatureAction(XPackField.GPU_VECTOR_INDEXING);
+    public static final ActionType<XPackUsageFeatureResponse> LOGGING = xpackUsageFeatureAction(XPackField.LOGGING);
 
     static final List<ActionType<XPackUsageFeatureResponse>> ALL = List.of(
         AGGREGATE_METRIC,
@@ -97,7 +98,8 @@ public final class XPackUsageFeatureAction {
         UNIVERSAL_PROFILING,
         LOGSDB,
         TIME_SERIES_DATA_STREAMS,
-        GPU_VECTOR_INDEXING
+        GPU_VECTOR_INDEXING,
+        LOGGING
     );
 
     public static ActionType<XPackUsageFeatureResponse> xpackUsageFeatureAction(String suffix) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/logging/LoggingFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/logging/LoggingFeatureSetUsage.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.logging;
+
+import org.apache.logging.log4j.util.Strings;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.XPackFeatureUsage;
+import org.elasticsearch.xpack.core.XPackField;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+public class LoggingFeatureSetUsage extends XPackFeatureUsage {
+
+    record LoggingConfig(boolean enabled, boolean userInfo) implements Writeable, ToXContentFragment {
+
+        LoggingConfig(StreamInput in) throws IOException {
+            this(in.readBoolean(), in.readBoolean());
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(enabled);
+            out.writeBoolean(userInfo);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.field("enabled", enabled);
+            builder.field("user", userInfo);
+            return builder;
+        }
+    }
+
+    record EsqlLoggingConfig(LoggingConfig base, Map<String, String> thresholds) implements Writeable, ToXContentObject {
+
+        EsqlLoggingConfig(StreamInput input) throws IOException {
+            this(new LoggingConfig(input), input.readMap(StreamInput::readString, StreamInput::readString));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            base.writeTo(out);
+            out.writeMap(thresholds, StreamOutput::writeString, StreamOutput::writeString);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            base.toXContent(builder, params);
+            if (thresholds.isEmpty() == false) {
+                builder.field("thresholds", thresholds);
+            }
+            builder.endObject();
+            return builder;
+        }
+    }
+
+    record QueryLoggingConfig(LoggingConfig base, boolean system, String threshold) implements Writeable, ToXContentObject {
+
+        QueryLoggingConfig(StreamInput input) throws IOException {
+            this(new LoggingConfig(input), input.readBoolean(), input.readOptionalString());
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            base.writeTo(out);
+            out.writeBoolean(system);
+            out.writeOptionalString(threshold);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            base.toXContent(builder, params);
+            builder.field("system", system);
+            if (Strings.isNotEmpty(threshold)) {
+                builder.field("threshold", threshold);
+            }
+            builder.endObject();
+            return builder;
+        }
+    }
+
+    private final EsqlLoggingConfig esqlConfig;
+    private final QueryLoggingConfig queryConfig;
+
+    LoggingFeatureSetUsage(QueryLoggingConfig queryConfig, EsqlLoggingConfig esqlConfig) {
+        super(XPackField.LOGGING, true, true);
+        this.esqlConfig = esqlConfig;
+        this.queryConfig = queryConfig;
+    }
+
+    QueryLoggingConfig queryConfig() {
+        return queryConfig;
+    }
+
+    EsqlLoggingConfig esqlConfig() {
+        return esqlConfig;
+    }
+
+    public LoggingFeatureSetUsage(StreamInput input) throws IOException {
+        super(input);
+        esqlConfig = new EsqlLoggingConfig(input);
+        queryConfig = new QueryLoggingConfig(input);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        esqlConfig.writeTo(out);
+        queryConfig.writeTo(out);
+    }
+
+    @Override
+    protected void innerXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field("querylog", queryConfig);
+        builder.field("esql", esqlConfig);
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersion.zero();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LoggingFeatureSetUsage that = (LoggingFeatureSetUsage) o;
+        return Objects.equals(esqlConfig, that.esqlConfig) && Objects.equals(queryConfig, that.queryConfig);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(esqlConfig, queryConfig);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/logging/LoggingUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/logging/LoggingUsageTransportAction.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.logging;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.protocol.xpack.XPackUsageRequest;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureTransportAction;
+import org.elasticsearch.xpack.core.logging.LoggingFeatureSetUsage.EsqlLoggingConfig;
+import org.elasticsearch.xpack.core.logging.LoggingFeatureSetUsage.LoggingConfig;
+import org.elasticsearch.xpack.core.logging.LoggingFeatureSetUsage.QueryLoggingConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LoggingUsageTransportAction extends XPackUsageFeatureTransportAction {
+    // Accessible for testing
+    static final String[] LOG_LEVELS = { "trace", "debug", "info", "warn" };
+
+    @Inject
+    public LoggingUsageTransportAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters
+    ) {
+        super(XPackUsageFeatureAction.LOGGING.name(), transportService, clusterService, threadPool, actionFilters);
+    }
+
+    @Override
+    protected void localClusterStateOperation(
+        Task task,
+        XPackUsageRequest request,
+        ClusterState state,
+        ActionListener<XPackUsageFeatureResponse> listener
+    ) throws Exception {
+        var settings = clusterService.getClusterSettings();
+        var usage = new LoggingFeatureSetUsage(getQueryLoggingConfig(settings), getEsqlLoggingConfig(settings));
+        listener.onResponse(new XPackUsageFeatureResponse(usage));
+    }
+
+    @SuppressWarnings("unchecked")
+    private boolean getBooleanSetting(ClusterSettings clusterSettings, String setting) {
+        var settingValue = (Setting<Boolean>) clusterSettings.get(setting);
+        return settingValue != null && clusterSettings.get(settingValue);
+    }
+
+    @SuppressWarnings("unchecked")
+    private EsqlLoggingConfig getEsqlLoggingConfig(ClusterSettings clusterSettings) {
+        Map<String, String> thresholds = new HashMap<>();
+        for (String logLevel : LOG_LEVELS) {
+            Setting<TimeValue> value = (Setting<TimeValue>) clusterSettings.get("esql.querylog.threshold." + logLevel);
+            if (value != null && clusterSettings.get(value).nanos() >= 0) {
+                thresholds.put(logLevel, clusterSettings.get(value).getStringRep());
+            }
+        }
+        boolean includeUserEnabled = getBooleanSetting(clusterSettings, "esql.querylog.include.user");
+        return thresholds.isEmpty()
+            ? new EsqlLoggingConfig(new LoggingConfig(false, includeUserEnabled), Map.of())
+            : new EsqlLoggingConfig(new LoggingConfig(true, includeUserEnabled), thresholds);
+    }
+
+    @SuppressWarnings("unchecked")
+    private QueryLoggingConfig getQueryLoggingConfig(ClusterSettings clusterSettings) {
+        Setting<TimeValue> value = (Setting<TimeValue>) clusterSettings.get("elasticsearch.querylog.threshold");
+        String threshold = null;
+        if (value != null && clusterSettings.get(value).nanos() > 0) {
+            threshold = clusterSettings.get(value).getStringRep();
+        }
+        return new QueryLoggingConfig(
+            new LoggingConfig(
+                getBooleanSetting(clusterSettings, "elasticsearch.querylog.enabled"),
+                getBooleanSetting(clusterSettings, "elasticsearch.querylog.include.user")
+            ),
+            getBooleanSetting(clusterSettings, "elasticsearch.querylog.include.system_indices"),
+            threshold
+        );
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rest/action/RestXPackUsageAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rest/action/RestXPackUsageAction.java
@@ -64,6 +64,6 @@ public class RestXPackUsageAction extends BaseRestHandler {
 
     @Override
     public Set<String> supportedCapabilities() {
-        return Sets.union(super.supportedCapabilities(), Set.of("global_retention_telemetry"));
+        return Sets.union(super.supportedCapabilities(), Set.of("global_retention_telemetry", "logging_usage"));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/logging/LoggingFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/logging/LoggingFeatureSetUsageTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.logging;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.logging.LoggingFeatureSetUsage.EsqlLoggingConfig;
+import org.elasticsearch.xpack.core.logging.LoggingFeatureSetUsage.LoggingConfig;
+import org.elasticsearch.xpack.core.logging.LoggingFeatureSetUsage.QueryLoggingConfig;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LoggingFeatureSetUsageTests extends AbstractWireSerializingTestCase<LoggingFeatureSetUsage> {
+
+    @Override
+    protected Writeable.Reader<LoggingFeatureSetUsage> instanceReader() {
+        return LoggingFeatureSetUsage::new;
+    }
+
+    @Override
+    protected LoggingFeatureSetUsage createTestInstance() {
+        return new LoggingFeatureSetUsage(randomQueryLoggingConfig(), randomEsqlLoggingConfig());
+    }
+
+    @Override
+    protected LoggingFeatureSetUsage mutateInstance(LoggingFeatureSetUsage instance) throws IOException {
+        var queryConfig = instance.queryConfig();
+        var esqlConfig = instance.esqlConfig();
+        return switch (between(0, 6)) {
+            case 0 -> {
+                var base = queryConfig.base();
+                var newBase = new LoggingConfig(!base.enabled(), base.userInfo());
+                yield new LoggingFeatureSetUsage(
+                    new QueryLoggingConfig(newBase, queryConfig.system(), queryConfig.threshold()),
+                    esqlConfig
+                );
+            }
+            case 1 -> {
+                var base = queryConfig.base();
+                var newBase = new LoggingConfig(base.enabled(), !base.userInfo());
+                yield new LoggingFeatureSetUsage(
+                    new QueryLoggingConfig(newBase, queryConfig.system(), queryConfig.threshold()),
+                    esqlConfig
+                );
+            }
+            case 2 -> new LoggingFeatureSetUsage(
+                new QueryLoggingConfig(queryConfig.base(), !queryConfig.system(), queryConfig.threshold()),
+                esqlConfig
+            );
+            case 3 -> {
+                String threshold = queryConfig.threshold();
+                String newThreshold = threshold == null ? randomAlphaOfLength(5)
+                    : randomBoolean() ? null
+                    : randomValueOtherThan(threshold, () -> randomAlphaOfLength(8));
+                yield new LoggingFeatureSetUsage(
+                    new QueryLoggingConfig(queryConfig.base(), queryConfig.system(), newThreshold),
+                    esqlConfig
+                );
+            }
+            case 4 -> {
+                var base = esqlConfig.base();
+                var newBase = new LoggingConfig(!base.enabled(), base.userInfo());
+                yield new LoggingFeatureSetUsage(queryConfig, new EsqlLoggingConfig(newBase, esqlConfig.thresholds()));
+            }
+            case 5 -> {
+                var base = esqlConfig.base();
+                var newBase = new LoggingConfig(base.enabled(), !base.userInfo());
+                yield new LoggingFeatureSetUsage(queryConfig, new EsqlLoggingConfig(newBase, esqlConfig.thresholds()));
+            }
+            case 6 -> {
+                Map<String, String> thresholds = new HashMap<>(esqlConfig.thresholds());
+                if (thresholds.isEmpty() || randomBoolean()) {
+                    thresholds.put(randomAlphaOfLength(4), randomAlphaOfLength(4));
+                } else {
+                    String key = randomFrom(thresholds.keySet());
+                    thresholds.put(key, randomValueOtherThan(thresholds.get(key), () -> randomAlphaOfLength(8)));
+                }
+                yield new LoggingFeatureSetUsage(queryConfig, new EsqlLoggingConfig(esqlConfig.base(), thresholds));
+            }
+            default -> throw new AssertionError("unexpected branch");
+        };
+    }
+
+    private LoggingConfig randomLoggingConfig() {
+        return new LoggingConfig(randomBoolean(), randomBoolean());
+    }
+
+    private QueryLoggingConfig randomQueryLoggingConfig() {
+        return new QueryLoggingConfig(randomLoggingConfig(), randomBoolean(), randomBoolean() ? null : randomAlphaOfLength(10));
+    }
+
+    private EsqlLoggingConfig randomEsqlLoggingConfig() {
+        Map<String, String> thresholds = randomMap(0, 5, () -> Tuple.tuple(randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        return new EsqlLoggingConfig(randomLoggingConfig(), thresholds);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/logging/LoggingUsageTransportActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/logging/LoggingUsageTransportActionTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.logging;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.logging.activity.QueryLogger;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LoggingUsageTransportActionTests extends ESTestCase {
+
+    /**
+     * Mirrors {@code EsqlPlugin}'s ES|QL querylog settings to avoid dependency on the ES|QL module.
+     */
+    private static final Setting<Boolean> ESQL_QUERYLOG_INCLUDE_USER = Setting.boolSetting(
+        "esql.querylog.include.user",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    private static final Set<Setting<?>> ALL_SETTINGS = new HashSet<>(
+        Set.of(
+            QueryLogger.QUERY_LOGGER_ENABLED,
+            QueryLogger.QUERY_LOGGER_THRESHOLD,
+            QueryLogger.QUERY_LOGGER_INCLUDE_USER,
+            QueryLogger.QUERY_LOGGER_LOG_SYSTEM,
+            ESQL_QUERYLOG_INCLUDE_USER
+        )
+    );
+
+    private static final Map<String, Setting<TimeValue>> ESQL_SETTINGS = new HashMap<>();
+
+    static {
+        for (String level : LoggingUsageTransportAction.LOG_LEVELS) {
+            Setting<TimeValue> setting = Setting.timeSetting(
+                "esql.querylog.threshold." + level,
+                TimeValue.timeValueMillis(-1),
+                TimeValue.timeValueMillis(-1),
+                TimeValue.timeValueMillis(Integer.MAX_VALUE),
+                Setting.Property.NodeScope,
+                Setting.Property.Dynamic
+            );
+            ESQL_SETTINGS.put(level, setting);
+            ALL_SETTINGS.add(setting);
+        }
+    }
+
+    private final TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+
+    public void testElasticsearchQueryLogBooleanSettings() throws Exception {
+        boolean enabled = randomBoolean(), system = randomBoolean(), user = randomBoolean();
+
+        Settings on = Settings.builder()
+            .put(QueryLogger.QUERY_LOGGER_ENABLED.getKey(), enabled)
+            .put(QueryLogger.QUERY_LOGGER_INCLUDE_USER.getKey(), user)
+            .put(QueryLogger.QUERY_LOGGER_LOG_SYSTEM.getKey(), system)
+            .build();
+        LoggingFeatureSetUsage usageOn = usage(on);
+        assertThat(usageOn.queryConfig().base().enabled(), equalTo(enabled));
+        assertThat(usageOn.queryConfig().base().userInfo(), equalTo(user));
+        assertThat(usageOn.queryConfig().system(), equalTo(system));
+    }
+
+    public void testElasticsearchQueryLogThresholdSetting() throws Exception {
+        TimeValue threshold = TimeValue.timeValueMillis(randomIntBetween(1, 100));
+        Settings settings = Settings.builder().put(QueryLogger.QUERY_LOGGER_THRESHOLD.getKey(), threshold.getStringRep()).build();
+
+        LoggingFeatureSetUsage usage = usage(settings);
+        assertThat(usage.queryConfig().threshold(), equalTo(threshold.getStringRep()));
+    }
+
+    public void testElasticsearchQueryLogThresholdAbsentWhenNotPositive() throws Exception {
+        Settings minusOne = Settings.builder().put(QueryLogger.QUERY_LOGGER_THRESHOLD.getKey(), TimeValue.MINUS_ONE.getStringRep()).build();
+        assertThat(usage(minusOne).queryConfig().threshold(), nullValue());
+
+        Settings zero = Settings.builder().put(QueryLogger.QUERY_LOGGER_THRESHOLD.getKey(), TimeValue.ZERO.getStringRep()).build();
+        assertThat(usage(zero).queryConfig().threshold(), nullValue());
+    }
+
+    public void testEsqlQueryLogThresholdSettings() throws Exception {
+        String level = randomFrom(ESQL_SETTINGS.keySet());
+        Setting<TimeValue> setting = ESQL_SETTINGS.get(level);
+        // 0 is important since for ESQL threshold=0 enables the query log
+        long ms = randomBoolean() ? randomIntBetween(1, 100) : 0;
+        Settings settings = Settings.builder().put(setting.getKey(), ms + "ms").build();
+
+        LoggingFeatureSetUsage usage = usage(settings);
+        assertThat(usage.esqlConfig().base().enabled(), equalTo(true));
+        assertThat(usage.esqlConfig().thresholds().get(level), equalTo(ms + "ms"));
+    }
+
+    public void testEsqlQueryLogDisabledWhenNoThresholdAtOrAboveZero() throws Exception {
+        String level = randomFrom(ESQL_SETTINGS.keySet());
+        Setting<TimeValue> setting = ESQL_SETTINGS.get(level);
+        Settings settings = Settings.builder().put(setting.getKey(), TimeValue.MINUS_ONE.getStringRep()).build();
+        LoggingFeatureSetUsage usage = usage(settings);
+        assertThat(usage.esqlConfig().base().enabled(), equalTo(false));
+        assertThat(usage.esqlConfig().thresholds().isEmpty(), equalTo(true));
+    }
+
+    public void testEsqlQueryLogIncludeUserSetting() throws Exception {
+        Settings off = Settings.builder().put(ESQL_QUERYLOG_INCLUDE_USER.getKey(), false).build();
+        assertThat(usage(off).esqlConfig().base().userInfo(), equalTo(false));
+
+        Settings on = Settings.builder().put(ESQL_QUERYLOG_INCLUDE_USER.getKey(), true).build();
+        assertThat(usage(on).esqlConfig().base().userInfo(), equalTo(true));
+    }
+
+    private LoggingFeatureSetUsage usage(Settings settings) throws Exception {
+        ClusterSettings clusterSettings = new ClusterSettings(settings, ALL_SETTINGS);
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        LoggingUsageTransportAction action = new LoggingUsageTransportAction(
+            transportService,
+            clusterService,
+            transportService.getThreadPool(),
+            mock(ActionFilters.class)
+        );
+
+        PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
+        action.localClusterStateOperation(null, null, null, future);
+        return (LoggingFeatureSetUsage) future.get().getUsage();
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -489,6 +489,7 @@ public class Constants {
         "cluster:monitor/xpack/usage/health_api",
         "cluster:monitor/xpack/usage/ilm",
         "cluster:monitor/xpack/usage/inference",
+        "cluster:monitor/xpack/usage/logging",
         "cluster:monitor/xpack/usage/logsdb",
         "cluster:monitor/xpack/usage/logstash",
         "cluster:monitor/xpack/usage/ml",

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/logging/10_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/logging/10_usage.yml
@@ -1,0 +1,61 @@
+---
+"Logging section is present in xpack usage with default settings":
+  - requires:
+      reason: "Logging usage tracking requires 'logging_usage' capability"
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: GET
+          path: /_xpack/usage
+          capabilities: [ 'logging_usage' ]
+
+  - do:
+      xpack.usage: {}
+  - match: { logging.querylog.enabled: false }
+  - match: { logging.querylog.user: true }
+  - match: { logging.querylog.system: false }
+  - is_false: logging.querylog.threshold
+  - match: { logging.esql.enabled: false }
+  - match: { logging.esql.user: false }
+  - is_false: logging.esql.thresholds
+
+---
+"Logging usage reflects persisted querylog and ES|QL querylog settings":
+  - requires:
+      reason: "Logging usage tracking requires 'logging_usage' capability"
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: GET
+          path: /_xpack/usage
+          capabilities: [ 'logging_usage' ]
+
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            elasticsearch.querylog.enabled: true
+            elasticsearch.querylog.threshold: 50ms
+            elasticsearch.querylog.include.user: false
+            elasticsearch.querylog.include.system_indices: true
+            esql.querylog.threshold.info: 0ms
+            esql.querylog.include.user: true
+
+  - do:
+      xpack.usage: {}
+  - match: { logging.querylog.enabled: true }
+  - match: { logging.querylog.threshold: 50ms }
+  - match: { logging.querylog.user: false }
+  - match: { logging.querylog.system: true }
+  - match: { logging.esql.enabled: true }
+  - match: { logging.esql.user: true }
+  - match: { logging.esql.thresholds.info: 0ms }
+
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            elasticsearch.querylog.enabled: null
+            elasticsearch.querylog.threshold: null
+            elasticsearch.querylog.include.user: null
+            elasticsearch.querylog.include.system_indices: null
+            esql.querylog.threshold.info: null
+            esql.querylog.include.user: null


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Add logging tracking to _xpack/usage (#148087)](https://github.com/elastic/elasticsearch/pull/148087)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)