### PR TITLE
ESQL: Gate field_extract unit tests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractErrorTests.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.equalTo;
 public class FieldExtractErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
     @Override
     protected List<TestCaseSupplier> cases() {
-        assumeTrue("FLATTENED type is only supported in snapshot builds", DataType.FLATTENED.supportedVersion().supportedLocally());
         return paramsToSuppliers(FieldExtractTests.parameters());
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractErrorTests.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class FieldExtractErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
     @Override
     protected List<TestCaseSupplier> cases() {
+        assumeTrue("FLATTENED type is only supported in snapshot builds", DataType.FLATTENED.supportedVersion().supportedLocally());
         return paramsToSuppliers(FieldExtractTests.parameters());
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractTests.java
@@ -28,7 +28,6 @@ import java.util.function.Supplier;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link FieldExtract}.
@@ -48,47 +47,49 @@ public class FieldExtractTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
-        for (DataType pathType : List.of(DataType.KEYWORD, DataType.TEXT)) {
-            suppliers.add(new TestCaseSupplier("literal dotted key " + pathType.typeName(), types(DataType.FLATTENED, pathType), () -> {
+        if (DataType.FLATTENED.supportedVersion().supportedLocally()) {
+            for (DataType pathType : List.of(DataType.KEYWORD, DataType.TEXT)) {
+                suppliers.add(new TestCaseSupplier("literal dotted key " + pathType.typeName(), types(DataType.FLATTENED, pathType), () -> {
+                    assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
+                    return new TestCaseSupplier.TestCase(
+                        List.of(
+                            new TestCaseSupplier.TypedData(new BytesRef("{\"host.name\":\"node-a\"}"), DataType.FLATTENED, "field"),
+                            new TestCaseSupplier.TypedData(new BytesRef("host.name"), pathType, "path")
+                        ),
+                        "FieldExtractEvaluator[flattenedJson=Attribute[channel=0], path=Attribute[channel=1]]",
+                        DataType.KEYWORD,
+                        equalTo(new BytesRef("node-a"))
+                    );
+                }));
+            }
+
+            suppliers.add(new TestCaseSupplier("constant dotted path", types(DataType.FLATTENED, DataType.KEYWORD), () -> {
                 assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
                 return new TestCaseSupplier.TestCase(
                     List.of(
-                        new TestCaseSupplier.TypedData(new BytesRef("{\"host.name\":\"node-a\"}"), DataType.FLATTENED, "field"),
-                        new TestCaseSupplier.TypedData(new BytesRef("host.name"), pathType, "path")
+                        new TestCaseSupplier.TypedData(new BytesRef("{\"k.inner\":\"v\"}"), DataType.FLATTENED, "field"),
+                        new TestCaseSupplier.TypedData(new BytesRef("k.inner"), DataType.KEYWORD, "path").forceLiteral()
+                    ),
+                    "FieldExtractConstantEvaluator[flattenedJson=Attribute[channel=0], path=k.inner]",
+                    DataType.KEYWORD,
+                    equalTo(new BytesRef("v"))
+                );
+            }));
+
+            suppliers.add(new TestCaseSupplier("missing path", types(DataType.FLATTENED, DataType.KEYWORD), () -> {
+                assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
+                return new TestCaseSupplier.TestCase(
+                    List.of(
+                        new TestCaseSupplier.TypedData(new BytesRef("{\"a\":1}"), DataType.FLATTENED, "field"),
+                        new TestCaseSupplier.TypedData(new BytesRef("missing"), DataType.KEYWORD, "path")
                     ),
                     "FieldExtractEvaluator[flattenedJson=Attribute[channel=0], path=Attribute[channel=1]]",
                     DataType.KEYWORD,
-                    equalTo(new BytesRef("node-a"))
-                );
+                    nullValue()
+                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                    .withWarning("Line 1:1: java.lang.IllegalArgumentException: path [missing] does not exist");
             }));
         }
-
-        suppliers.add(new TestCaseSupplier("constant dotted path", types(DataType.FLATTENED, DataType.KEYWORD), () -> {
-            assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(new BytesRef("{\"k.inner\":\"v\"}"), DataType.FLATTENED, "field"),
-                    new TestCaseSupplier.TypedData(new BytesRef("k.inner"), DataType.KEYWORD, "path").forceLiteral()
-                ),
-                "FieldExtractConstantEvaluator[flattenedJson=Attribute[channel=0], path=k.inner]",
-                DataType.KEYWORD,
-                equalTo(new BytesRef("v"))
-            );
-        }));
-
-        suppliers.add(new TestCaseSupplier("missing path", types(DataType.FLATTENED, DataType.KEYWORD), () -> {
-            assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(new BytesRef("{\"a\":1}"), DataType.FLATTENED, "field"),
-                    new TestCaseSupplier.TypedData(new BytesRef("missing"), DataType.KEYWORD, "path")
-                ),
-                "FieldExtractEvaluator[flattenedJson=Attribute[channel=0], path=Attribute[channel=1]]",
-                DataType.KEYWORD,
-                nullValue()
-            ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
-                .withWarning("Line 1:1: java.lang.IllegalArgumentException: path [missing] does not exist");
-        }));
 
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/FieldExtractTests.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link FieldExtract}.
@@ -47,49 +48,47 @@ public class FieldExtractTests extends AbstractScalarFunctionTestCase {
     public static Iterable<Object[]> parameters() {
         List<TestCaseSupplier> suppliers = new ArrayList<>();
 
-        if (DataType.FLATTENED.supportedVersion().supportedLocally()) {
-            for (DataType pathType : List.of(DataType.KEYWORD, DataType.TEXT)) {
-                suppliers.add(new TestCaseSupplier("literal dotted key " + pathType.typeName(), types(DataType.FLATTENED, pathType), () -> {
-                    assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
-                    return new TestCaseSupplier.TestCase(
-                        List.of(
-                            new TestCaseSupplier.TypedData(new BytesRef("{\"host.name\":\"node-a\"}"), DataType.FLATTENED, "field"),
-                            new TestCaseSupplier.TypedData(new BytesRef("host.name"), pathType, "path")
-                        ),
-                        "FieldExtractEvaluator[flattenedJson=Attribute[channel=0], path=Attribute[channel=1]]",
-                        DataType.KEYWORD,
-                        equalTo(new BytesRef("node-a"))
-                    );
-                }));
-            }
-
-            suppliers.add(new TestCaseSupplier("constant dotted path", types(DataType.FLATTENED, DataType.KEYWORD), () -> {
+        for (DataType pathType : List.of(DataType.KEYWORD, DataType.TEXT)) {
+            suppliers.add(new TestCaseSupplier("literal dotted key " + pathType.typeName(), types(DataType.FLATTENED, pathType), () -> {
                 assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
                 return new TestCaseSupplier.TestCase(
                     List.of(
-                        new TestCaseSupplier.TypedData(new BytesRef("{\"k.inner\":\"v\"}"), DataType.FLATTENED, "field"),
-                        new TestCaseSupplier.TypedData(new BytesRef("k.inner"), DataType.KEYWORD, "path").forceLiteral()
-                    ),
-                    "FieldExtractConstantEvaluator[flattenedJson=Attribute[channel=0], path=k.inner]",
-                    DataType.KEYWORD,
-                    equalTo(new BytesRef("v"))
-                );
-            }));
-
-            suppliers.add(new TestCaseSupplier("missing path", types(DataType.FLATTENED, DataType.KEYWORD), () -> {
-                assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
-                return new TestCaseSupplier.TestCase(
-                    List.of(
-                        new TestCaseSupplier.TypedData(new BytesRef("{\"a\":1}"), DataType.FLATTENED, "field"),
-                        new TestCaseSupplier.TypedData(new BytesRef("missing"), DataType.KEYWORD, "path")
+                        new TestCaseSupplier.TypedData(new BytesRef("{\"host.name\":\"node-a\"}"), DataType.FLATTENED, "field"),
+                        new TestCaseSupplier.TypedData(new BytesRef("host.name"), pathType, "path")
                     ),
                     "FieldExtractEvaluator[flattenedJson=Attribute[channel=0], path=Attribute[channel=1]]",
                     DataType.KEYWORD,
-                    nullValue()
-                ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
-                    .withWarning("Line 1:1: java.lang.IllegalArgumentException: path [missing] does not exist");
+                    equalTo(new BytesRef("node-a"))
+                );
             }));
         }
+
+        suppliers.add(new TestCaseSupplier("constant dotted path", types(DataType.FLATTENED, DataType.KEYWORD), () -> {
+            assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(new BytesRef("{\"k.inner\":\"v\"}"), DataType.FLATTENED, "field"),
+                    new TestCaseSupplier.TypedData(new BytesRef("k.inner"), DataType.KEYWORD, "path").forceLiteral()
+                ),
+                "FieldExtractConstantEvaluator[flattenedJson=Attribute[channel=0], path=k.inner]",
+                DataType.KEYWORD,
+                equalTo(new BytesRef("v"))
+            );
+        }));
+
+        suppliers.add(new TestCaseSupplier("missing path", types(DataType.FLATTENED, DataType.KEYWORD), () -> {
+            assumeTrue("Requires FIELD_EXTRACT_FUNCTION capability", EsqlCapabilities.Cap.FIELD_EXTRACT_FUNCTION.isEnabled());
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(new BytesRef("{\"a\":1}"), DataType.FLATTENED, "field"),
+                    new TestCaseSupplier.TypedData(new BytesRef("missing"), DataType.KEYWORD, "path")
+                ),
+                "FieldExtractEvaluator[flattenedJson=Attribute[channel=0], path=Attribute[channel=1]]",
+                DataType.KEYWORD,
+                nullValue()
+            ).withWarning("Line 1:1: evaluation of [source] failed, treating result as null. Only first 20 failures recorded.")
+                .withWarning("Line 1:1: java.lang.IllegalArgumentException: path [missing] does not exist");
+        }));
 
         return parameterSuppliersFromTypedDataWithDefaultChecks(true, suppliers);
     }


### PR DESCRIPTION
Fails if run with "-Dbuild.snapshot=false": https://gradle-enterprise.elastic.co/s/ztoqtvlyn2aiq/console-log?page=3
