### PR TITLE
Update the threshold in ESVectorUtilTests.testLogSumExpNQT

### DIFF
--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
@@ -1081,7 +1081,7 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         }
 
         float referenceResult = defaultedProvider.getVectorUtilSupport().logSumExpNQT(x);
-        assertEquals(referenceResult, defOrPanamaProvider.getVectorUtilSupport().logSumExpNQT(x), 1e-2 * referenceResult);
+        assertEquals(referenceResult, defOrPanamaProvider.getVectorUtilSupport().logSumExpNQT(x), 1.1e-2 * referenceResult);
     }
 
     public void testLinearCombination() {


### PR DESCRIPTION
The threshold in this test was 0.01 and we run into an instance with a difference of 0.01008809. Updating the threshold to 1.1e-2 to be on the safe side.

The Panama and the default backends use slightly different versions of the LogSumExp trick, which explains why we cannot aim for machine precision in this test.