### PR TITLE
Fix SoftDeletesRetentionIT.testRetentionLeasesIgnoredForSoftDeletesPolicy test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -476,9 +476,6 @@ tests:
 - class: org.elasticsearch.compute.data.BlockAccountingTests
   method: testBytesRefVector
   issue: https://github.com/elastic/elasticsearch/issues/148481
-- class: org.elasticsearch.xpack.stateless.engine.SoftDeletesRetentionIT
-  method: testRetentionLeasesIgnoredForSoftDeletesPolicy
-  issue: https://github.com/elastic/elasticsearch/issues/148557
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/148339

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/engine/SoftDeletesRetentionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/engine/SoftDeletesRetentionIT.java
@@ -108,8 +108,9 @@ public class SoftDeletesRetentionIT extends AbstractStatelessPluginIntegTestCase
             assertTrue(leases.stream().anyMatch(l -> l.id().equals(retentionLeaseId) && l.retainingSequenceNumber() == 0L));
         });
 
-        // Update random docs to create soft-deleted versions of the originals
-        var randomDocs = randomNonEmptySubsetOf(docsIds);
+        // Update random docs to create soft-deleted versions of the originals.
+        // We leave at least one doc behind, so the merge still has a target to hit.
+        var randomDocs = randomSubsetOf(randomIntBetween(1, docsIds.size() - 1), docsIds);
         var bulk = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         for (var randomDoc : randomDocs) {
             bulk.add(prepareIndex(indexName).setId(randomDoc).setSource("field", "updated-" + randomDoc));


### PR DESCRIPTION
Prevent updating all documents that would cause merge operation being skipped (only one segment remains in this case).

Closes #148557 