### PR TITLE
[9.3] [Inference API] Fixing potential NPE if InferenceContext is null (#148921)

### DIFF
--- a/docs/changelog/148921.yaml
+++ b/docs/changelog/148921.yaml
@@ -1,0 +1,5 @@
+area: Inference
+issues: []
+pr: 148921
+summary: "[Inference API] Fixing potential NPE if `InferenceContext` is null"
+type: bug

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/BaseInferenceActionRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/BaseInferenceActionRequest.java
@@ -32,7 +32,8 @@ public abstract class BaseInferenceActionRequest extends LegacyActionRequest {
 
     public BaseInferenceActionRequest(InferenceContext context) {
         super();
-        this.context = context;
+        // The context should never be null, but this is just a safeguard in case we missed a place where null could be passed in.
+        this.context = Objects.requireNonNullElse(context, InferenceContext.EMPTY_INSTANCE);
     }
 
     public BaseInferenceActionRequest(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
@@ -119,6 +119,23 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
             );
         }
 
+        /**
+         * Constructor that allows an {@link InferenceContext} to be specified
+         *
+         * @param taskType the {@link TaskType} of the inference request. May be {@link TaskType#ANY}, which will result in the task type
+         *                 being determined after parsing the stored model
+         * @param inferenceEntityId the endpoint ID
+         * @param query for {@link TaskType#RERANK}, the query to use
+         * @param returnDocuments for {@link TaskType#RERANK}, whether the request should return the input values as part of the results
+         * @param topN for {@link TaskType#RERANK}, the number of results to return
+         * @param input the inputs to use for the inference request
+         * @param taskSettings the task settings to use for the inference request
+         * @param inputType the {@link InputType} of the request
+         * @param inferenceTimeout the timeout to use. If null, a placeholder timeout will be used until the appropriate timeout for the
+         *                         task type and input type can be determined by the inference service implementation
+         * @param stream whether the request should use streaming
+         * @param context the {@link InferenceContext} to use, if {@code null} then an empty context will be used
+         */
         public Request(
             TaskType taskType,
             String inferenceEntityId,
@@ -328,7 +345,7 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
             private Integer topN;
             private TimeValue timeout = DEFAULT_TIMEOUT;
             private boolean stream = false;
-            private InferenceContext context;
+            private InferenceContext context = InferenceContext.EMPTY_INSTANCE;
 
             private Builder() {}
 
@@ -391,8 +408,13 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
                 return this;
             }
 
+            /**
+             * Sets the {@link InferenceContext} for this request. If not set, an empty context will be used.
+             * If the context is set to {@code null}, an empty context will also be used.
+             * @param context the context to set
+             */
             public Builder setContext(InferenceContext context) {
-                this.context = context;
+                this.context = Objects.requireNonNullElse(context, InferenceContext.EMPTY_INSTANCE);
                 return this;
             }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
@@ -26,12 +26,16 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 
 public class InferenceActionRequestTests extends AbstractBWCWireSerializationTestCase<InferenceAction.Request> {
 
     private static final TransportVersion INFERENCE_CONTEXT = TransportVersion.fromName("inference_context");
     private static final TransportVersion RERANK_COMMON_OPTIONS_ADDED = TransportVersion.fromName("rerank_common_options_added");
+
+    private static final String TEST_INFERENCE_ENDPOINT = "test_endpoint";
+    private static final List<String> TEST_INPUT = List.of("test input");
 
     @Override
     protected Writeable.Reader<InferenceAction.Request> instanceReader() {
@@ -89,7 +93,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             null,
             null,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -106,7 +110,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "query",
             Boolean.TRUE,
             34,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -159,7 +163,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             null,
             Boolean.TRUE,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -180,7 +184,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             null,
             null,
             12,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -198,7 +202,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "query",
             null,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -216,7 +220,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             null,
             null,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -234,7 +238,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "",
             null,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -252,7 +256,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "query",
             null,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             InputType.SEARCH,
             null,
@@ -270,7 +274,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             null,
             null,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             InputType.SEARCH,
             null,
@@ -291,7 +295,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "",
             Boolean.FALSE,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -313,7 +317,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "",
             null,
             22,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -334,7 +338,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "query",
             null,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -355,7 +359,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "",
             null,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             InputType.SEARCH,
             null,
@@ -373,7 +377,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "",
             Boolean.TRUE,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -394,7 +398,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "",
             null,
             77,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -412,7 +416,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "",
             null,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             InputType.SEARCH,
             null,
@@ -433,7 +437,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "",
             Boolean.TRUE,
             null,
-            List.of("input"),
+            TEST_INPUT,
             null,
             null,
             null,
@@ -454,7 +458,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
             "",
             null,
             11,
-            List.of("input"),
+            TEST_INPUT,
             null,
             InputType.SEARCH,
             null,
@@ -463,6 +467,34 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
         ActionRequestValidationException queryError = queryRequest.validate();
         assertNotNull(queryError);
         assertThat(queryError.getMessage(), is("Validation Failed: 1: Field [top_n] cannot be specified for task type [chat_completion];"));
+    }
+
+    public void testBuilder_DefaultContextIsEmptyInstance() {
+        var request = InferenceAction.Request.builder(TEST_INFERENCE_ENDPOINT, TaskType.TEXT_EMBEDDING).setInput(TEST_INPUT).build();
+        assertThat(request.getContext(), sameInstance(InferenceContext.EMPTY_INSTANCE));
+    }
+
+    public void testBuilder_SetContextNull_UsesEmptyContext() {
+        var request = InferenceAction.Request.builder(TEST_INFERENCE_ENDPOINT, TaskType.TEXT_EMBEDDING).setContext(null).build();
+        assertThat(request.getContext(), sameInstance(InferenceContext.EMPTY_INSTANCE));
+    }
+
+    public void testConstructor_NullContext_UsesEmptyContext() {
+        var request = new InferenceAction.Request(
+            TaskType.TEXT_EMBEDDING,
+            TEST_INFERENCE_ENDPOINT,
+            null,
+            null,
+            null,
+            TEST_INPUT,
+            null,
+            null,
+            null,
+            false,
+            null
+        );
+
+        assertThat(request.getContext(), sameInstance(InferenceContext.EMPTY_INSTANCE));
     }
 
     public void testParseRequest_DefaultsInputTypeToIngest() throws IOException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Inference API] Fixing potential NPE if InferenceContext is null (#148921)](https://github.com/elastic/elasticsearch/pull/148921)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)