### PR TITLE
Disable merge IO throttling for vectordb_document

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -952,6 +952,13 @@ public enum IndexMode {
                 if (IndexSettings.INTRA_MERGE_PARALLELISM_ENABLED_SETTING.exists(indexTemplateAndCreateRequestSettings) == false) {
                     additionalSettings.put(intraMergeKey, true);
                 }
+
+                // Disable merge IO auto-throttling.
+                // Only applied when the user has not set it explicitly.
+                String autoThrottleKey = MergeSchedulerConfig.AUTO_THROTTLE_SETTING.getKey();
+                if (MergeSchedulerConfig.AUTO_THROTTLE_SETTING.exists(indexTemplateAndCreateRequestSettings) == false) {
+                    additionalSettings.put(autoThrottleKey, false);
+                }
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/VectordbDocumentIndexModeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/VectordbDocumentIndexModeTests.java
@@ -55,6 +55,9 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
 
         // Intra-merge parallelism is enabled by default.
         assertEquals("true", resolved.get(IndexSettings.INTRA_MERGE_PARALLELISM_ENABLED_SETTING.getKey()));
+
+        // Merge IO auto-throttling is disabled by default.
+        assertEquals("false", resolved.get(MergeSchedulerConfig.AUTO_THROTTLE_SETTING.getKey()));
     }
 
     public void testProviderRejectsExplicitFalseExcludeSourceVectors() {
@@ -85,6 +88,7 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
             .put(IndexSettings.MODE.getKey(), "vectordb_document")
             .putList(IndexModule.INDEX_STORE_PRE_LOAD_SETTING.getKey(), "vex")
             .put(IndexSettings.INTRA_MERGE_PARALLELISM_ENABLED_SETTING.getKey(), false)
+            .put(MergeSchedulerConfig.AUTO_THROTTLE_SETTING.getKey(), true)
             .build();
         Settings.Builder additional = Settings.builder();
         runProvider(userSettings, additional);
@@ -97,6 +101,10 @@ public class VectordbDocumentIndexModeTests extends ESTestCase {
         assertNull(
             "should not override user-provided intra-merge parallelism setting",
             resolved.get(IndexSettings.INTRA_MERGE_PARALLELISM_ENABLED_SETTING.getKey())
+        );
+        assertNull(
+            "should not override user-provided merge auto-throttle setting",
+            resolved.get(MergeSchedulerConfig.AUTO_THROTTLE_SETTING.getKey())
         );
     }
 


### PR DESCRIPTION
Default index.merge.scheduler.auto_throttle=false for vectordb_document index mode.

The auto-throttle starts every merge at 20 MB/s and ramps up by 20% only when more merges pile up. As described in elastic/elasticsearch#139287, this ramp can be too slow: merges accumulate faster than they unthrottle and indexing throttling kicks in before merges reach a useful IO rate.

For vector indices this is especially painful — vector files are large, and HNSW/IVF merges are CPU bound rather than IO bound. Recent Lucene improvements (e.g.
apache/lucene#15732) further reduce the IO needed per merge by speeding up the merge itself.

Disabling IO throttling does not disable the indexing throttle safety net: if active merge tasks exceed the per-index limit, incoming indexing is still throttled.

Users can re-enable auto-throttle explicitly per index. 
