### PR TITLE
ESQL: cache parsed Parquet and ORC footers across producers

### DIFF
--- a/docs/changelog/149018.yaml
+++ b/docs/changelog/149018.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149018
+summary: Cache parsed Parquet and ORC footers across producers
+type: enhancement

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -30,6 +30,11 @@ import org.apache.orc.StringColumnStatistics;
 import org.apache.orc.StripeInformation;
 import org.apache.orc.StripeStatistics;
 import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.OrcTail;
+import org.apache.orc.impl.ReaderImpl;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
@@ -42,6 +47,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.cache.ParsedFooterCache;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.FilterPushdownSupport;
@@ -67,6 +73,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.concurrent.ExecutionException;
 
 /**
  * {@link RangeAwareFormatReader} implementation for Apache ORC files.
@@ -90,6 +97,19 @@ import java.util.OptionalLong;
 public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatReader {
 
     private static final long MILLIS_PER_DAY = Duration.ofDays(1).toMillis();
+
+    /**
+     * JVM-wide cache of parsed ORC tails ({@link OrcTail}). Singleton — every
+     * {@link OrcFormatReader} instance reads from and writes to the same cache so that producer
+     * threads spawned from different reader instances (e.g. across concurrent queries) still
+     * coalesce footer parses.
+     */
+    private static final ParsedFooterCache<OrcTail> PARSED_FOOTERS = new ParsedFooterCache<>();
+
+    /** Clears the parsed-footer cache. Intended for test isolation only. */
+    static void clearParsedFooterCacheForTests() {
+        PARSED_FOOTERS.invalidateAll();
+    }
 
     private final BlockFactory blockFactory;
     private final SearchArgument pushedFilter;
@@ -120,8 +140,7 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
     public SourceMetadata metadata(StorageObject object) throws IOException {
         OrcStorageObjectAdapter fs = new OrcStorageObjectAdapter(object);
         Path path = new Path(object.path().toString());
-        OrcFile.ReaderOptions options = orcReaderOptions(fs);
-        try (Reader reader = OrcFile.createReader(path, options)) {
+        try (Reader reader = openReaderCached(fs, path)) {
             TypeDescription schema = reader.getSchema();
             List<Attribute> attributes = convertOrcSchemaToAttributes(schema);
             SourceStatistics statistics = extractStatistics(reader, schema);
@@ -146,6 +165,62 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
      */
     private static OrcFile.ReaderOptions orcReaderOptions(OrcStorageObjectAdapter fs) {
         return OrcFile.readerOptions(new Configuration(false)).filesystem(fs).useUTCTimestamp(true);
+    }
+
+    /**
+     * Opens an ORC {@link Reader} using the JVM-wide {@link #PARSED_FOOTERS} cache so that the
+     * tail (postscript + footer + types + stripe directory) is deserialized at most once per
+     * {@code (path, length)} key. On a cache miss the loader parses the tail by opening a reader
+     * once and extracting the {@link OrcTail} from its serialized footer buffer; the parsed result
+     * is then handed to subsequent {@code OrcFile.createReader} calls via
+     * {@link OrcFile.ReaderOptions#orcTail}. When ORC sees a pre-supplied tail it skips
+     * {@code ReaderImpl.extractFileTail(FileSystem, Path, long)} and the associated remote read.
+     */
+    private static Reader openReaderCached(OrcStorageObjectAdapter fs, Path path) throws IOException {
+        OrcTail tail = loadTail(fs, path);
+        return OrcFile.createReader(path, orcReaderOptions(fs).orcTail(tail));
+    }
+
+    /**
+     * Loads the parsed ORC tail for {@code fs} via the JVM-wide {@link #PARSED_FOOTERS} cache,
+     * parsing on a cache miss. The first call for a given key opens an ORC reader (which parses
+     * the tail) and immediately closes it after extracting the {@link OrcTail}; subsequent calls
+     * reuse the cached tail.
+     */
+    private static OrcTail loadTail(OrcStorageObjectAdapter fs, Path path) throws IOException {
+        try {
+            return PARSED_FOOTERS.getOrLoad(fs.cacheKey(), key -> {
+                // Open a reader once, extract the parsed tail, then close the reader. The
+                // OrcTail itself retains the serialized buffer + parsed protobuf footer and is
+                // safe to share across threads (treated as immutable by all callers).
+                try (Reader r = OrcFile.createReader(path, orcReaderOptions(fs))) {
+                    return ReaderImpl.extractFileTail(r.getSerializedFileFooter());
+                }
+            });
+        } catch (ExecutionException e) {
+            // The winning loader thread sees its exception propagate directly out of the cache;
+            // every other concurrently-waiting thread sees an ExecutionException whose cause is
+            // the original throwable. Re-shape the cause to match the prior in-line createReader
+            // behaviour so callers observe identical exception types regardless of who won the
+            // load race. In particular Error/OOM must propagate as-is and never be reshaped into
+            // a generic IOException. Mirrors {@code ParquetFormatReader#loadFooter} so the two
+            // format readers stay consistent.
+            Throwable cause = e.getCause();
+            ExceptionsHelper.maybeError(cause).ifPresent(error -> { throw error; });
+            if (cause instanceof IOException io) {
+                throw io;
+            }
+            if (cause instanceof CircuitBreakingException cbe) {
+                throw cbe;
+            }
+            if (cause instanceof ElasticsearchException ese) {
+                throw ese;
+            }
+            if (cause instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new IOException("Failed to parse ORC tail for [" + path + "]", cause != null ? cause : e);
+        }
     }
 
     private static SourceStatistics extractStatistics(Reader reader, TypeDescription schema) {
@@ -245,7 +320,7 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
 
         OrcStorageObjectAdapter fs = new OrcStorageObjectAdapter(object);
         Path path = new Path(object.path().toString());
-        Reader reader = OrcFile.createReader(path, orcReaderOptions(fs));
+        Reader reader = openReaderCached(fs, path);
         TypeDescription schema = reader.getSchema();
         List<Attribute> attributes = convertOrcSchemaToAttributes(schema);
 
@@ -263,7 +338,7 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
     public List<SplitRange> discoverSplitRanges(StorageObject object) throws IOException {
         OrcStorageObjectAdapter fs = new OrcStorageObjectAdapter(object);
         Path path = new Path(object.path().toString());
-        try (Reader reader = OrcFile.createReader(path, orcReaderOptions(fs))) {
+        try (Reader reader = openReaderCached(fs, path)) {
             List<StripeInformation> stripes = reader.getStripes();
             if (stripes.isEmpty()) {
                 return List.of();
@@ -340,7 +415,15 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         }
         OrcStorageObjectAdapter fs = new OrcStorageObjectAdapter(object);
         Path path = new Path(object.path().toString());
-        Reader reader = OrcFile.createReader(path, orcReaderOptions(fs));
+        // Tail resolution order, mirroring the parquet reader:
+        // 1. context.fileContext() — per-producer fast path, single-writer/single-reader, no map
+        // lookup; carries the parsed tail across successive splits of the same file on one
+        // thread.
+        // 2. PARSED_FOOTERS — JVM-wide cache keyed by (path, length); shared across producer
+        // threads and across queries within the access TTL.
+        OrcTail tail = context.fileContext() instanceof OrcTail cached ? cached : loadTail(fs, path);
+        context.setFileContext(tail);
+        Reader reader = OrcFile.createReader(path, orcReaderOptions(fs).orcTail(tail));
         TypeDescription schema = reader.getSchema();
 
         final List<Attribute> attributes = resolvedAttributes != null && resolvedAttributes.isEmpty() == false

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcStorageObjectAdapter.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.esql.datasources.spi.StorageObject;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.concurrent.ExecutionException;
 
@@ -39,6 +40,7 @@ public class OrcStorageObjectAdapter extends FileSystem {
 
     private final StorageObject storageObject;
     private final Path path;
+    private final FooterByteCache.Key cacheKey;
 
     /**
      * Creates an adapter for the given StorageObject.
@@ -52,7 +54,21 @@ public class OrcStorageObjectAdapter extends FileSystem {
         }
         this.storageObject = storageObject;
         this.path = new Path(storageObject.path().toString());
+        try {
+            this.cacheKey = FooterByteCache.Key.keyFor(storageObject, storageObject.length());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read storage object length for [" + storageObject.path() + "]", e);
+        }
         setConf(new Configuration(false));
+    }
+
+    /**
+     * Returns the cache key identifying this file by {@code (path, length)}. Shared with
+     * {@link FooterByteCache} and the parsed-footer cache held by {@link OrcFormatReader} so that
+     * callers reusing this adapter can hit those caches without recomputing the key.
+     */
+    FooterByteCache.Key cacheKey() {
+        return cacheKey;
     }
 
     @Override
@@ -72,6 +88,7 @@ public class OrcStorageObjectAdapter extends FileSystem {
 
     static void clearCacheForTests() {
         FooterByteCache.getInstance().invalidateAll();
+        OrcFormatReader.clearParsedFooterCacheForTests();
     }
 
     @Override

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -32,6 +32,7 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -47,6 +48,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.datasources.FormatNameResolver;
 import org.elasticsearch.xpack.esql.datasources.SourceStatisticsSerializer;
+import org.elasticsearch.xpack.esql.datasources.cache.ParsedFooterCache;
 import org.elasticsearch.xpack.esql.datasources.spi.AggregatePushdownSupport;
 import org.elasticsearch.xpack.esql.datasources.spi.ColumnBlockConversions;
 import org.elasticsearch.xpack.esql.datasources.spi.Configured;
@@ -78,6 +80,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 /**
  * FormatReader implementation for Parquet files.
@@ -97,6 +100,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
     private static final Logger logger = LogManager.getLogger(ParquetFormatReader.class);
 
+    /**
+     * JVM-wide cache of parsed Parquet footers. Singleton — every {@link ParquetFormatReader}
+     * instance reads from and writes to the same cache so that producer threads spawned from
+     * different reader instances (e.g. across concurrent queries) still coalesce footer parses.
+     */
+    private static final ParsedFooterCache<ParquetMetadata> PARSED_FOOTERS = new ParsedFooterCache<>();
+
     private final BlockFactory blockFactory;
     private final FilterCompat.Filter pushedFilter;
     private final ParquetPushedExpressions pushedExpressions;
@@ -114,6 +124,11 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
     /** Keys recognised by {@link #withConfigTrackingConsumedKeys(Map)}. */
     static final Set<String> RECOGNIZED_KEYS = Set.of(CONFIG_OPTIMIZED_READER, CONFIG_LATE_MATERIALIZATION);
+
+    /** Clears the parsed-footer cache. Intended for test isolation only. */
+    static void clearParsedFooterCacheForTests() {
+        PARSED_FOOTERS.invalidateAll();
+    }
 
     public ParquetFormatReader(BlockFactory blockFactory) {
         this(blockFactory, FilterCompat.NOOP, null, false, true, true);
@@ -216,24 +231,6 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
      * Opens a Parquet reader, mapping parquet-mr failures (checked and unchecked) to an
      * {@link IOException} that includes the storage object URI for operators and REST clients.
      */
-    private static ParquetFileReader openParquetFile(StorageObject object, InputFile inputFile, ParquetReadOptions options)
-        throws IOException {
-        String uri = object.path().toString();
-        try {
-            return ParquetFileReader.open(inputFile, options);
-        } catch (IOException e) {
-            throw newInvalidParquetFileException(uri, e);
-        } catch (RuntimeException e) {
-            if (e instanceof CircuitBreakingException) {
-                throw e;
-            }
-            if (e instanceof ElasticsearchException) {
-                throw e;
-            }
-            throw newInvalidParquetFileException(uri, e);
-        }
-    }
-
     private static ParquetFileReader openParquetFile(
         StorageObject object,
         InputFile inputFile,
@@ -253,6 +250,66 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 throw e;
             }
             throw newInvalidParquetFileException(uri, e);
+        }
+    }
+
+    /**
+     * Opens a Parquet reader using the JVM-wide {@link #PARSED_FOOTERS} cache so that the Thrift
+     * footer deserialization runs at most once per {@code (path, length)} key. On a cache miss the
+     * loader parses the full footer (no range filter) so the cached {@link ParquetMetadata} remains
+     * usable for any subsequent split of the same file; the per-call read options are then applied
+     * when opening the reader against the cached metadata.
+     * <p>
+     * Range-restricted reads should call this with the loader-time options unrestricted but the
+     * open-time options range-restricted; see {@code readRange} for an example.
+     *
+     * @param object the storage object — used only for error reporting
+     * @param adapter the storage adapter that owns the byte-level cache key
+     * @param options open-time read options (may include {@code withRange} / {@code withRecordFilter})
+     */
+    private ParquetFileReader openParquetFileCached(StorageObject object, ParquetStorageObjectAdapter adapter, ParquetReadOptions options)
+        throws IOException {
+        ParquetMetadata footer = loadFooter(object, adapter);
+        return openParquetFile(object, adapter, options, footer);
+    }
+
+    /**
+     * Loads the parsed Parquet footer for {@code adapter} via the JVM-wide {@link #PARSED_FOOTERS}
+     * cache, parsing on a cache miss. The loader explicitly uses unranged read options so the
+     * cached value is the full file footer (all row groups) and can be reused across split readers.
+     */
+    private ParquetMetadata loadFooter(StorageObject object, ParquetStorageObjectAdapter adapter) throws IOException {
+        try {
+            return PARSED_FOOTERS.getOrLoad(adapter.cacheKey(), key -> {
+                // Always parse the full footer (no range filter) so the cached entry is reusable
+                // by any split. ParquetFileReader.open with a range only retains blocks whose
+                // midpoint falls in the range, which would make getFooter() unusable for other
+                // splits. The underlying FooterByteCache ensures the tail bytes are fetched from
+                // storage only once on the first parse.
+                return ParquetFileReader.readFooter(adapter, readOptionsBuilder().build(), adapter.newStream());
+            });
+        } catch (ExecutionException e) {
+            // The winning loader thread sees its exception propagate directly out of the cache;
+            // every other concurrently-waiting thread sees an ExecutionException whose cause is
+            // the original throwable. Re-shape the cause to match the prior in-line readFooter
+            // behaviour so callers observe identical exception types regardless of who won the
+            // load race. In particular Error/OOM must propagate as-is and never be reshaped into
+            // an invalid-file IOException.
+            Throwable cause = e.getCause();
+            ExceptionsHelper.maybeError(cause).ifPresent(error -> { throw error; });
+            if (cause instanceof IOException io) {
+                throw io;
+            }
+            if (cause instanceof CircuitBreakingException cbe) {
+                throw cbe;
+            }
+            if (cause instanceof ElasticsearchException ese) {
+                throw ese;
+            }
+            if (cause instanceof RuntimeException re) {
+                throw newInvalidParquetFileException(object.path().toString(), re);
+            }
+            throw newInvalidParquetFileException(object.path().toString(), e);
         }
     }
 
@@ -282,10 +339,10 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
     @Override
     public SourceMetadata metadata(StorageObject object) throws IOException {
-        InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
+        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object);
         ParquetReadOptions options = readOptionsBuilder().build();
 
-        try (ParquetFileReader reader = openParquetFile(object, parquetInputFile, options)) {
+        try (ParquetFileReader reader = openParquetFileCached(object, parquetInputFile, options)) {
             FileMetaData fileMetaData = reader.getFileMetaData();
             MessageType parquetSchema = fileMetaData.getSchema();
             List<Attribute> schema = convertParquetSchemaToAttributes(parquetSchema);
@@ -440,8 +497,8 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         int batchSize = context.batchSize();
         int rowLimit = context.rowLimit();
 
-        InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
-        ParquetFileReader reader = openParquetFile(object, parquetInputFile, readOptionsBuilder().build());
+        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object);
+        ParquetFileReader reader = openParquetFileCached(object, parquetInputFile, readOptionsBuilder().build());
         try {
             FileMetaData fileMetaData = reader.getFileMetaData();
             MessageType parquetSchema = fileMetaData.getSchema();
@@ -455,7 +512,7 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
             // parquet-mr never sees the filter and the reader does not need to be re-opened.
             if (useOptimized == false && FilterCompat.isFilteringRequired(recordFilter)) {
                 reader.close();
-                reader = openParquetFile(object, parquetInputFile, readOptionsBuilder().withRecordFilter(recordFilter).build());
+                reader = openParquetFileCached(object, parquetInputFile, readOptionsBuilder().withRecordFilter(recordFilter).build());
                 fileMetaData = reader.getFileMetaData();
                 parquetSchema = fileMetaData.getSchema();
             }
@@ -518,9 +575,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
 
     @Override
     public List<SplitRange> discoverSplitRanges(StorageObject object) throws IOException {
-        InputFile parquetInputFile = new ParquetStorageObjectAdapter(object);
+        ParquetStorageObjectAdapter parquetInputFile = new ParquetStorageObjectAdapter(object);
         ParquetReadOptions options = readOptionsBuilder().build();
-        try (ParquetFileReader reader = openParquetFile(object, parquetInputFile, options)) {
+        try (ParquetFileReader reader = openParquetFileCached(object, parquetInputFile, options)) {
             List<BlockMetaData> rowGroups = reader.getRowGroups();
             if (rowGroups.isEmpty()) {
                 return List.of();
@@ -649,27 +706,25 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
         int batchSize = context.batchSize();
         List<Attribute> resolvedAttributes = context.resolvedAttributes();
 
-        InputFile parquetInputFile = ParquetStorageObjectAdapter.forRange(object, rangeEnd - rangeStart);
+        ParquetStorageObjectAdapter parquetInputFile = ParquetStorageObjectAdapter.forRange(object, rangeEnd - rangeStart);
         ParquetReadOptions rangeOptions = readOptionsBuilder().withRange(rangeStart, rangeEnd).build();
-        ParquetFileReader reader;
-        if (context.fileContext() instanceof ParquetMetadata cachedFooter) {
-            ParquetMetadata rangeMetadata = filterBlocksByRange(cachedFooter, rangeStart, rangeEnd);
-            reader = openParquetFile(object, parquetInputFile, rangeOptions, rangeMetadata);
-        } else {
-            // Parse the full footer (all row groups) and cache it for subsequent splits.
-            // ParquetFileReader.open with a range only retains blocks whose midpoint falls
-            // in the range, making getFooter() unusable for other splits. readFooter with
-            // options that have no range returns the complete metadata. The underlying
-            // FooterByteCache ensures the footer bytes are fetched from storage only once.
-            ParquetMetadata fullFooter = ParquetFileReader.readFooter(
-                parquetInputFile,
-                readOptionsBuilder().build(),
-                parquetInputFile.newStream()
-            );
-            context.setFileContext(fullFooter);
-            ParquetMetadata rangeMetadata = filterBlocksByRange(fullFooter, rangeStart, rangeEnd);
-            reader = openParquetFile(object, parquetInputFile, rangeOptions, rangeMetadata);
-        }
+        // Footer resolution order:
+        // 1. context.fileContext() — per-producer fast path, single-writer/single-reader, no map
+        // lookup; carries the footer across successive splits of the same file on one thread.
+        // 2. ParsedParquetFooterCache — JVM-wide LRU keyed by (path, length); shared across
+        // producer threads and across queries within the access TTL. The loader explicitly
+        // uses unranged read options so the cached value is the full file footer (all row
+        // groups) and is reusable by any split. The underlying FooterByteCache ensures the
+        // tail bytes are fetched from storage only once on the first parse.
+        // ParquetFileReader.open with a range only retains blocks whose midpoint falls in the
+        // range, making getFooter() unusable for other splits — so we must always derive the
+        // range-filtered metadata from the unranged full footer via filterBlocksByRange.
+        ParquetMetadata fullFooter = context.fileContext() instanceof ParquetMetadata cachedFooter
+            ? cachedFooter
+            : loadFooter(object, parquetInputFile);
+        context.setFileContext(fullFooter);
+        ParquetMetadata rangeMetadata = filterBlocksByRange(fullFooter, rangeStart, rangeEnd);
+        ParquetFileReader reader = openParquetFile(object, parquetInputFile, rangeOptions, rangeMetadata);
         try {
             FileMetaData fileMetaData = reader.getFileMetaData();
             MessageType parquetSchema = fileMetaData.getSchema();
@@ -686,11 +741,9 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 ParquetReadOptions filteredOptions = readOptionsBuilder().withRange(rangeStart, rangeEnd)
                     .withRecordFilter(recordFilter)
                     .build();
-                if (context.fileContext() instanceof ParquetMetadata cf) {
-                    reader = openParquetFile(object, parquetInputFile, filteredOptions, filterBlocksByRange(cf, rangeStart, rangeEnd));
-                } else {
-                    reader = openParquetFile(object, parquetInputFile, filteredOptions);
-                }
+                // fullFooter was resolved (and stashed into context) above, so we always reuse it
+                // rather than risk a re-parse through the no-footer overload.
+                reader = openParquetFile(object, parquetInputFile, filteredOptions, filterBlocksByRange(fullFooter, rangeStart, rangeEnd));
                 fileMetaData = reader.getFileMetaData();
                 parquetSchema = fileMetaData.getSchema();
             }

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetStorageObjectAdapter.java
@@ -100,6 +100,16 @@ public class ParquetStorageObjectAdapter implements org.apache.parquet.io.InputF
 
     static void clearFooterCacheForTests() {
         FooterByteCache.getInstance().invalidateAll();
+        ParquetFormatReader.clearParsedFooterCacheForTests();
+    }
+
+    /**
+     * Returns the cache key identifying this file by {@code (path, length)}. Shared with
+     * {@link FooterByteCache} and the parsed-footer cache held by {@link ParquetFormatReader} so
+     * that callers reusing this adapter can hit those caches without recomputing the key.
+     */
+    FooterByteCache.Key cacheKey() {
+        return cacheKey;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ParsedFooterCache.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ParsedFooterCache.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.common.cache.CacheLoader;
+import org.elasticsearch.core.TimeValue;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * JVM-wide cache for parsed file metadata (e.g. Parquet {@code ParquetMetadata}, ORC
+ * {@code OrcTail}). Sits at the same architectural layer as {@link FooterByteCache} but stores
+ * the result of the format-specific footer parse rather than its raw bytes, so the (typically
+ * Thrift/protobuf) deserialization runs at most once per {@code (path, fileLength)} key across:
+ * <ul>
+ *   <li>concurrent splits of the same file taken by N producer threads;</li>
+ *   <li>back-to-back queries against the same file within the access TTL.</li>
+ * </ul>
+ *
+ * <h2>Why parsed metadata and not just raw bytes</h2>
+ * {@link FooterByteCache} eliminates redundant tail-byte reads from object storage, but the parse
+ * still runs every time a reader is opened: N producers fanning out over a wide file each pay the
+ * full deserialization cost, even though the cached bytes are identical. Caching the parsed
+ * result collapses that into a single deserialization. {@link FooterByteCache} stays in place
+ * because it also serves opportunistic partial-tail reads (page indexes, dictionary tails) that
+ * are not full-footer parses, and because format readers fall back to byte reads on a cold cache.
+ *
+ * <h2>Sharing keys with {@link FooterByteCache}</h2>
+ * The cache is keyed by {@link FooterByteCache.Key} ({@code (path, fileLength)}) so that the same
+ * key construction logic used to hit the byte cache also hits this cache; both caches stay aligned
+ * without an extra key type. Per-format singletons (one for Parquet, one for ORC, etc.) keep the
+ * value type concrete and the cache's ownership unambiguous.
+ *
+ * <h2>Lifecycle</h2>
+ * <ul>
+ *   <li>Created as a singleton per format reader; no SPI plumbing is required to share entries
+ *       across producers since every code path that needs a parsed footer already constructs a
+ *       {@link FooterByteCache.Key} via the storage-object adapter.</li>
+ *   <li>Access-based TTL — sourced from {@link FooterByteCache#EXPIRE_AFTER_ACCESS_SECONDS} so
+ *       the two caches age out together; covers a single query's fan-out (where concurrent splits
+ *       keep the entry alive) while ensuring that file modifications between queries trigger a
+ *       fresh parse.</li>
+ *   <li>Count-based LRU eviction — parsed metadata structures (e.g. Parquet {@code ParquetMetadata}
+ *       or ORC {@code OrcTail}) do not expose a cheap byte size, so the cache caps the number of
+ *       entries instead. Defaults are intentionally conservative: a parsed footer for a wide file
+ *       (hundreds of columns, hundreds of row groups) can occupy several MiB of heap, so the
+ *       entry count is kept well below {@link FooterByteCache}'s ratio of MiB budget to average
+ *       entry size. Note that the byte and parsed caches evict independently — TTL alignment
+ *       keeps them timing-consistent but does not synchronize eviction events.</li>
+ * </ul>
+ *
+ * <p>Cached values must be treated as immutable by all callers — callers that need to derive a
+ * filtered view (e.g. only the row groups for a specific byte range) should build a new value
+ * from the cached one rather than mutating the cached structure.</p>
+ *
+ * @param <T> the parsed metadata type held by this cache (e.g. {@code ParquetMetadata}).
+ */
+public final class ParsedFooterCache<T> {
+
+    /** Default maximum number of cached parsed footers across the JVM. */
+    public static final int DEFAULT_MAX_ENTRIES = 64;
+
+    private final Cache<FooterByteCache.Key, T> cache;
+
+    /** Creates a cache with the default maximum entry count. */
+    public ParsedFooterCache() {
+        this(DEFAULT_MAX_ENTRIES);
+    }
+
+    /**
+     * Creates a cache with the given maximum entry count. Exposed for tests; production callers
+     * should rely on {@link #DEFAULT_MAX_ENTRIES}.
+     *
+     * @throws IllegalArgumentException if {@code maxEntries <= 0}
+     */
+    public ParsedFooterCache(int maxEntries) {
+        if (maxEntries <= 0) {
+            throw new IllegalArgumentException("maxEntries must be positive, got [" + maxEntries + "]");
+        }
+        // Single-source the TTL from FooterByteCache so the byte and parsed caches always age out
+        // together — if the bytes are stale, the parse derived from them is stale too.
+        this.cache = CacheBuilder.<FooterByteCache.Key, T>builder()
+            .setMaximumWeight(maxEntries)
+            .setExpireAfterAccess(TimeValue.timeValueSeconds(FooterByteCache.EXPIRE_AFTER_ACCESS_SECONDS))
+            .build();
+    }
+
+    /**
+     * Returns the cached parsed footer for the given key, or loads it via {@code loader}. The
+     * loader is invoked at most once per key under concurrent access — additional callers for the
+     * same key block until the first load completes and then receive its result. This is the
+     * thundering-herd protection that lets a single producer parse the footer while N siblings
+     * skip the parse entirely.
+     *
+     * @throws ExecutionException if the loader throws an exception or returns null
+     */
+    public T getOrLoad(FooterByteCache.Key key, CacheLoader<FooterByteCache.Key, T> loader) throws ExecutionException {
+        return cache.computeIfAbsent(key, loader);
+    }
+
+    /**
+     * Returns the cached parsed footer or {@code null} if not present. Does not start a load, but
+     * may block briefly if another thread is currently loading the same key (consistent with
+     * {@link FooterByteCache#get}).
+     */
+    public T get(FooterByteCache.Key key) {
+        return cache.get(key);
+    }
+
+    /** Removes all entries. Intended for test isolation. */
+    public void invalidateAll() {
+        cache.invalidateAll();
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ParsedFooterCacheTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/cache/ParsedFooterCacheTests.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.cache;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Tests the generic parsed-footer cache without depending on any specific format. The cache treats
+ * values as opaque, so a {@link String} stand-in for the format-specific metadata type
+ * ({@code ParquetMetadata}, {@code OrcTail}, ...) is sufficient to exercise every invariant.
+ */
+public class ParsedFooterCacheTests extends ESTestCase {
+
+    private ParsedFooterCache<String> cache;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        cache = new ParsedFooterCache<>(8);
+    }
+
+    public void testGetReturnsNullOnMiss() {
+        assertNull(cache.get(key("file.parquet", 1000)));
+    }
+
+    public void testGetOrLoadPopulatesCache() throws ExecutionException {
+        FooterByteCache.Key k = key("file.parquet", 1000);
+        String expected = "footer-1";
+        String result = cache.getOrLoad(k, ignore -> expected);
+        assertSame(expected, result);
+        assertSame(expected, cache.get(k));
+    }
+
+    public void testGetOrLoadInvokesLoaderOnce() throws ExecutionException {
+        FooterByteCache.Key k = key("file.parquet", 1000);
+        String first = "first";
+        AtomicInteger loadCount = new AtomicInteger();
+        cache.getOrLoad(k, ignore -> {
+            loadCount.incrementAndGet();
+            return first;
+        });
+        String second = cache.getOrLoad(k, ignore -> {
+            loadCount.incrementAndGet();
+            return "second";
+        });
+        assertEquals("loader invoked only on cache miss", 1, loadCount.get());
+        assertSame(first, second);
+    }
+
+    public void testSamePathDifferentLengthAreDifferentKeys() throws ExecutionException {
+        FooterByteCache.Key k1 = key("file.parquet", 1000);
+        FooterByteCache.Key k2 = key("file.parquet", 2000);
+        String v1 = "v1";
+        String v2 = "v2";
+        cache.getOrLoad(k1, ignore -> v1);
+        cache.getOrLoad(k2, ignore -> v2);
+        assertSame(v1, cache.get(k1));
+        assertSame(v2, cache.get(k2));
+    }
+
+    public void testCapacityEvictionPreservesNewestEntries() throws ExecutionException {
+        // Verifies the cap-by-entry-count invariant: once the capacity is exceeded, the most
+        // recent loads remain available. The exact eviction order is delegated to ES Cache and
+        // is intentionally not asserted here beyond "the newest survives".
+        ParsedFooterCache<String> tiny = new ParsedFooterCache<>(2);
+        FooterByteCache.Key k1 = key("a.parquet", 1);
+        FooterByteCache.Key k2 = key("b.parquet", 2);
+        FooterByteCache.Key k3 = key("c.parquet", 3);
+        tiny.getOrLoad(k1, ignore -> "1");
+        tiny.getOrLoad(k2, ignore -> "2");
+        tiny.getOrLoad(k3, ignore -> "3");
+        assertNull("oldest entry evicted once budget is exceeded", tiny.get(k1));
+        assertNotNull(tiny.get(k3));
+    }
+
+    public void testInvalidateAll() throws ExecutionException {
+        FooterByteCache.Key k = key("file.parquet", 1000);
+        cache.getOrLoad(k, ignore -> "v");
+        assertNotNull(cache.get(k));
+        cache.invalidateAll();
+        assertNull(cache.get(k));
+    }
+
+    /**
+     * Verifies thundering-herd protection: concurrent {@code getOrLoad} calls for the same key
+     * invoke the loader exactly once. This is the core invariant — without it the parse would
+     * still run N times under the producer fan-out pattern that motivated this cache.
+     */
+    public void testThunderingHerdCoalescesConcurrentLoads() throws Exception {
+        FooterByteCache.Key k = key("shared.parquet", 5000);
+        String expected = "winner";
+        AtomicInteger loadCount = new AtomicInteger();
+        CountDownLatch start = new CountDownLatch(1);
+        int threadCount = randomIntBetween(4, 16);
+        AtomicReference<AssertionError> failure = new AtomicReference<>();
+        List<Thread> threads = new ArrayList<>(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            Thread t = new Thread(() -> {
+                try {
+                    start.await(10, TimeUnit.SECONDS);
+                    String result = cache.getOrLoad(k, ignore -> {
+                        loadCount.incrementAndGet();
+                        return expected;
+                    });
+                    assertSame(expected, result);
+                } catch (AssertionError e) {
+                    failure.compareAndSet(null, e);
+                } catch (Exception e) {
+                    failure.compareAndSet(null, new AssertionError("Unexpected exception", e));
+                }
+            }, "herd-" + i);
+            t.start();
+            threads.add(t);
+        }
+        start.countDown();
+        for (Thread t : threads) {
+            t.join(TimeUnit.SECONDS.toMillis(10));
+            assertFalse("Thread " + t.getName() + " did not finish in time", t.isAlive());
+        }
+        AssertionError err = failure.get();
+        if (err != null) {
+            throw err;
+        }
+        assertEquals("loader invoked exactly once across all concurrent callers", 1, loadCount.get());
+    }
+
+    public void testGetOrLoadPropagatesLoaderException() {
+        FooterByteCache.Key k = key("bad.parquet", 1000);
+        ExecutionException ex = expectThrows(ExecutionException.class, () -> cache.getOrLoad(k, ignore -> {
+            throw new RuntimeException("simulated parse failure");
+        }));
+        assertNotNull(ex.getCause());
+        assertEquals("simulated parse failure", ex.getCause().getMessage());
+    }
+
+    public void testGetOrLoadFailsWhenLoaderReturnsNull() {
+        // The cache documents that {@code getOrLoad} surfaces an ExecutionException if the loader
+        // returns null; verify that the underlying ES Cache contract still holds for callers.
+        FooterByteCache.Key k = key("null.parquet", 1000);
+        expectThrows(ExecutionException.class, () -> cache.getOrLoad(k, ignore -> null));
+        assertNull("a failed load must not leave a phantom entry behind", cache.get(k));
+    }
+
+    public void testConstructorRejectsNonPositiveMaxEntries() {
+        expectThrows(IllegalArgumentException.class, () -> new ParsedFooterCache<String>(0));
+        expectThrows(IllegalArgumentException.class, () -> new ParsedFooterCache<String>(-1));
+    }
+
+    private static FooterByteCache.Key key(String path, long length) {
+        return new FooterByteCache.Key(path, length);
+    }
+}


### PR DESCRIPTION
The footer/tail deserialization (Thrift for Parquet, protobuf for ORC)
dominates CPU on remote-storage queries with many row groups and columns.
FooterByteCache prevents redundant tail-byte fetches, but every reader
open still re-runs the parse: N producer threads fanning out over a wide
file each pay the full cost, even though the cached bytes are identical.

Add a JVM-wide cache of parsed footers shared by both formats:
- A generic ParsedFooterCache<T> in datasources.cache, keyed the same
  (path, length) as FooterByteCache and built on the same common Cache
  infrastructure. TTL is single-sourced from FooterByteCache so the two
  caches age out together. computeIfAbsent gives thundering-herd
  protection: one producer parses, siblings block briefly and reuse the
  result.
- ParquetFormatReader holds a ParsedFooterCache<ParquetMetadata>
  singleton and routes every footer-parse site (read, readRange,
  metadata, discoverSplitRanges) through it.
- OrcFormatReader holds a ParsedFooterCache<OrcTail> singleton and uses
  ORC's ReaderOptions.orcTail() hook so the second-and-onward reader
  skips ReaderImpl.extractFileTail and the associated remote read.
- The RangeReadContext.fileContext fast path is preserved in both
  readers for consecutive splits within a single producer.

No SPI changes — the cache lives at the same architectural layer as
FooterByteCache so it benefits every node and every query
opportunistically, and the same abstraction now backs both formats.

Developed using AI-assisted tooling

