### PR TITLE
ESQL: Bulk-grow TopN UTF-8 string encoding

### DIFF
--- a/docs/changelog/149022.yaml
+++ b/docs/changelog/149022.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149022
+summary: Bulk-grow TopN UTF-8 string encoding
+type: enhancement

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/Utf8AscTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/Utf8AscTopNEncoder.java
@@ -39,16 +39,24 @@ final class Utf8AscTopNEncoder extends SortableAscTopNEncoder {
         /*
          * add one to every non-continuation byte so that there are no "0" bytes
          * in the encoded copy. The only "0" bytes are separators.
+         *
+         * Pre-grow the destination once and write directly into the underlying array to
+         * avoid the per-byte grow + bounds-check overhead of append(byte). This is the
+         * pattern documented on BreakingBytesRefBuilder#bytes().
          */
         int end = value.offset + value.length;
+        bytesRefBuilder.grow(bytesRefBuilder.length() + value.length + 1);
+        byte[] dest = bytesRefBuilder.bytes();
+        int pos = bytesRefBuilder.length();
         for (int i = value.offset; i < end; i++) {
             byte b = value.bytes[i];
             if ((b & CONTINUATION_BYTE) == 0) {
                 b++;
             }
-            bytesRefBuilder.append(b);
+            dest[pos++] = b;
         }
-        bytesRefBuilder.append(TERMINATOR);
+        dest[pos++] = TERMINATOR;
+        bytesRefBuilder.setLength(pos);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/Utf8DescTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/Utf8DescTopNEncoder.java
@@ -35,16 +35,24 @@ final class Utf8DescTopNEncoder extends SortableDescTopNEncoder {
         /*
          * add one to every non-continuation byte so that there are no "0" bytes
          * in the encoded copy. The only "0" bytes are separators.
+         *
+         * Pre-grow the destination once and write directly into the underlying array to
+         * avoid the per-byte grow + bounds-check overhead of append(byte). This is the
+         * pattern documented on BreakingBytesRefBuilder#bytes().
          */
         int end = value.offset + value.length;
+        bytesRefBuilder.grow(bytesRefBuilder.length() + value.length + 1);
+        byte[] dest = bytesRefBuilder.bytes();
+        int pos = bytesRefBuilder.length();
         for (int i = value.offset; i < end; i++) {
             byte b = value.bytes[i];
             if ((b & CONTINUATION_BYTE) == 0) {
                 b++;
             }
-            bytesRefBuilder.append((byte) ~b);
+            dest[pos++] = (byte) ~b;
         }
-        bytesRefBuilder.append((byte) ~TERMINATOR);
+        dest[pos++] = (byte) ~TERMINATOR;
+        bytesRefBuilder.setLength(pos);
     }
 
     @Override


### PR DESCRIPTION
The TopN UTF-8 string encoders called BreakingBytesRefBuilder#append
once per input byte, which paid the grow + bounds-check overhead on
every byte. Switch to the documented bulk pattern: a single grow for
the whole encoded payload plus the terminator, direct writes into the
underlying byte[], and one setLength at the end. This matches the
existing pattern used by the fixed-width encoders such as encodeLong.

Encoding semantics (per-byte +1 on non-continuation bytes, NUL
terminator, ~b inversion for the descending variant) are unchanged,
so the on-wire format and decoder paths stay identical.

Developed with AI-assisted tooling