### PR TITLE
[ESQL] SIMD contains for *literal* LIKE patterns

### DIFF
--- a/docs/changelog/149026.yaml
+++ b/docs/changelog/149026.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149026
+summary: SIMD contains for *literal* LIKE patterns
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -30,6 +30,7 @@ import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.lucene.queries.BinaryDocValuesContainsTermQuery;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
@@ -108,18 +109,29 @@ final class ParquetPushedExpressions {
     private final IdentityHashMap<WildcardLike, CompiledWildcard> automatonCache = new IdentityHashMap<>();
 
     /**
-     * Compiled form of a {@link WildcardLike}: the runnable matcher and a flag indicating that the
-     * source automaton accepts every input. The flag is computed against the case-aware automaton
-     * (the same one passed to {@link ByteRunAutomaton}), so the {@link #matchesAll} fast path in
+     * Compiled form of a {@link WildcardLike}: the runnable matcher, a flag indicating that the
+     * source automaton accepts every input, and an optional substring literal extracted from the
+     * pattern when it has the case-sensitive {@code *literal*} shape (see
+     * {@link #extractContainsLiteral}). The {@link #matchesAll} flag is computed against the
+     * case-aware automaton (the same one passed to {@link ByteRunAutomaton}), so the fast path in
      * {@link #evaluateWildcardLike} is consistent with the runtime case-sensitivity setting — it
      * does not silently fall through to the per-row loop just because the pattern's internal
      * case-insensitive cache disagrees with the requested flag.
      *
      * <p>{@code matcher} is {@code null} when the pattern failed to determinize; the caller treats
      * that as "fall back to FilterExec" (return {@code null} from evaluateWildcardLike).
+     *
+     * <p>{@code containsLiteral} is non-null only for case-sensitive {@code *literal*} patterns
+     * with no embedded wildcards or escapes (see {@link #extractContainsLiteral}). When present,
+     * {@link #evaluateWildcardLike} dispatches to {@link BinaryDocValuesContainsTermQuery#contains}
+     * (a thin wrapper over the SIMD-accelerated {@code ESVectorUtil#contains}) instead of the
+     * per-byte automaton — a 3-10x speedup for dictionary entries longer than the SIMD activation
+     * threshold (~24 bytes), which covers most URL/path data. Byte-substring against UTF-8 is
+     * codepoint-correct because UTF-8 is self-synchronizing on valid inputs (KEYWORD contract);
+     * this matches the long-standing assumption in {@link BinaryDocValuesContainsTermQuery}.
      */
-    private record CompiledWildcard(ByteRunAutomaton matcher, boolean matchesAll) {
-        static final CompiledWildcard FAILED = new CompiledWildcard(null, false);
+    private record CompiledWildcard(ByteRunAutomaton matcher, boolean matchesAll, @Nullable BytesRef containsLiteral) {
+        static final CompiledWildcard FAILED = new CompiledWildcard(null, false, null);
     }
 
     ParquetPushedExpressions(List<Expression> expressions) {
@@ -1235,15 +1247,16 @@ final class ParquetPushedExpressions {
             return maskNonNullRows(block, rowCount);
         }
         ByteRunAutomaton runner = compiled.matcher;
+        // For case-sensitive *literal* patterns, dispatch the per-byte loop to the SIMD-accelerated
+        // contains helper (ESVectorUtil#contains, exposed via BinaryDocValuesContainsTermQuery).
+        // Profiling on URL columns (ClickBench q20: URL LIKE "*google*") showed evaluateWildcardLike
+        // at ~25% CPU dominated by ByteRunAutomaton state transitions; the first+last byte SIMD
+        // filter wins by 3-10x once dictionary entries clear ~24 bytes.
+        Predicate<BytesRef> matcher = matcherFor(compiled, runner);
         if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
             WordMask mask = new WordMask();
             mask.reset(rowCount);
-            boolean[] dictMatches = memoizedDictionaryMatches(
-                dictCache,
-                wl,
-                obb.getDictionaryVector(),
-                entry -> runner.run(entry.bytes, entry.offset, entry.length)
-            );
+            boolean[] dictMatches = memoizedDictionaryMatches(dictCache, wl, obb.getDictionaryVector(), matcher);
             applyDictionaryMatches(obb, dictMatches, mask, rowCount);
             return mask;
         }
@@ -1257,7 +1270,7 @@ final class ParquetPushedExpressions {
                 }
                 if (block.isNull(i) == false) {
                     BytesRef val = bb.getBytesRef(i, scratch);
-                    if (runner.run(val.bytes, val.offset, val.length)) {
+                    if (matcher.test(val)) {
                         mask.set(i);
                     }
                 }
@@ -1265,6 +1278,14 @@ final class ParquetPushedExpressions {
             return mask;
         }
         return null;
+    }
+
+    private static Predicate<BytesRef> matcherFor(CompiledWildcard compiled, ByteRunAutomaton runner) {
+        BytesRef literal = compiled.containsLiteral();
+        if (literal != null) {
+            return entry -> BinaryDocValuesContainsTermQuery.contains(entry.bytes, entry.offset, entry.length, literal);
+        }
+        return entry -> runner.run(entry.bytes, entry.offset, entry.length);
     }
 
     /**
@@ -1391,7 +1412,8 @@ final class ParquetPushedExpressions {
                 // (For invalid UTF-8 — outside the KEYWORD contract — the byte-level automaton would
                 // simply reject the malformed prefix, matching the per-row scalar path's behavior.)
                 boolean matchesAll = Operations.isTotal(automaton);
-                compiled = new CompiledWildcard(new ByteRunAutomaton(automaton), matchesAll);
+                BytesRef containsLiteral = wl.caseInsensitive() ? null : extractContainsLiteral(wl.pattern().pattern());
+                compiled = new CompiledWildcard(new ByteRunAutomaton(automaton), matchesAll, containsLiteral);
             } catch (IllegalArgumentException | TooComplexToDeterminizeException e) {
                 logger.debug(
                     "Cannot push WildcardLike pattern [{}] to Parquet late materialization, falling back to FilterExec",
@@ -1403,6 +1425,41 @@ final class ParquetPushedExpressions {
             automatonCache.put(wl, compiled);
             return compiled;
         }
+    }
+
+    /**
+     * Returns the substring literal of a case-sensitive {@code *literal*} wildcard pattern, or
+     * {@code null} if the pattern does not have that exact shape. The literal is what
+     * {@link BinaryDocValuesContainsTermQuery#contains} should search for inside each row's value
+     * bytes.
+     *
+     * <p>Recognized iff <em>all</em> of the following hold:
+     * <ul>
+     *   <li>length &ge; 3 (at least one literal char between the two wildcards),</li>
+     *   <li>starts and ends with {@code '*'},</li>
+     *   <li>the middle contains no {@code '*'} (no leftover wildcards),</li>
+     *   <li>the middle contains no {@code '?'} (single-char wildcard not supported by contains),</li>
+     *   <li>the middle contains no {@code '\\'} (escape sequences kept on the automaton path).</li>
+     * </ul>
+     *
+     * <p>Caller already checks {@link WildcardLike#caseInsensitive()} — this helper is intentionally
+     * blind to it so the rule is local and easy to reason about. Returning the literal as a
+     * {@link BytesRef} commits to UTF-8 bytes, which is what KEYWORD values are encoded as and
+     * what {@link BinaryDocValuesContainsTermQuery#contains} compares; UTF-8's self-synchronizing
+     * property guarantees byte-substring matches are codepoint-substring matches for valid inputs.
+     */
+    @Nullable
+    static BytesRef extractContainsLiteral(String pattern) {
+        if (pattern.length() < 3 || pattern.charAt(0) != '*' || pattern.charAt(pattern.length() - 1) != '*') {
+            return null;
+        }
+        for (int i = 1, end = pattern.length() - 1; i < end; i++) {
+            char c = pattern.charAt(i);
+            if (c == '*' || c == '?' || c == '\\') {
+                return null;
+            }
+        }
+        return new BytesRef(pattern.substring(1, pattern.length() - 1));
     }
 
     // Package-private hook so tests can directly assert that automaton compilation is memoized

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
@@ -1256,6 +1256,181 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
         assertEquals(java.util.Set.of("url"), pushed.predicateColumnNames());
     }
 
+    public void testExtractContainsLiteralRecognizesPureContainsShape() {
+        // Pins the exact set of patterns that take the SIMD-accelerated contains() path. Anything
+        // not on this list falls back to the per-byte ByteRunAutomaton; that is correct, but a silent
+        // regression here would dial back the dictionary fast-path on URL/path columns and is the
+        // single most expensive perf bug this change can introduce.
+        assertEquals(new BytesRef("google"), ParquetPushedExpressions.extractContainsLiteral("*google*"));
+        // Single-character literal — minimum recognized length is 3 ("*x*").
+        assertEquals(new BytesRef("a"), ParquetPushedExpressions.extractContainsLiteral("*a*"));
+        // UTF-8 multi-byte: helper must commit to bytes, not codepoints, because the runtime matcher
+        // operates on bytes.
+        assertEquals(new BytesRef("café"), ParquetPushedExpressions.extractContainsLiteral("*café*"));
+    }
+
+    public void testExtractContainsLiteralRejectsNonContainsShapes() {
+        // "**" -> middle is empty AND length<3 -> not recognized; the matchesAll automaton fast-path
+        // already handles "*", and "**" is equivalent at the automaton level.
+        assertNull(ParquetPushedExpressions.extractContainsLiteral("**"));
+        // No leading wildcard -> StartsWith territory, not contains.
+        assertNull(ParquetPushedExpressions.extractContainsLiteral("google*"));
+        // No trailing wildcard -> EndsWith territory, not contains.
+        assertNull(ParquetPushedExpressions.extractContainsLiteral("*google"));
+        // Embedded '*' -> two-segment pattern; the simple substring check would be wrong.
+        assertNull(ParquetPushedExpressions.extractContainsLiteral("*foo*bar*"));
+        // Embedded '?' -> single-char wildcard; the simple substring check would be wrong.
+        assertNull(ParquetPushedExpressions.extractContainsLiteral("*foo?bar*"));
+        // Embedded escape '\\' -> the literal would need un-escaping; keep on the automaton path.
+        assertNull(ParquetPushedExpressions.extractContainsLiteral("*fo\\*o*"));
+    }
+
+    public void testWildcardLikeContainsLiteralOrdinalDictionaryAgreesWithAutomaton() {
+        // Cross-checks the SIMD contains path against the per-row scalar path on a dictionary
+        // mixing entries above and below the ~24-byte SIMD activation threshold. Long URLs
+        // exercise the Panama path inside ESVectorUtil#contains; the short "google" entry exercises
+        // the scalar fallback inside the same helper. Any divergence between the two evaluator
+        // paths (ordinal short-circuit vs per-row) surfaces as a failure.
+        String[] dict = {
+            "https://www.google.com/search?q=elasticsearch",
+            "https://github.com/elastic/elasticsearch/issues",
+            "https://www.bing.com/search?q=opensearch",
+            "https://duckduckgo.com/?q=lucene+vector",
+            "https://www.google.com/maps/place/London",
+            "https://stackoverflow.com/questions/tagged/lucene",
+            "google" };
+        int rowCount = 200;
+        int[] randomOrdinals = new int[rowCount];
+        for (int i = 0; i < rowCount; i++) {
+            randomOrdinals[i] = randomIntBetween(0, dict.length - 1);
+        }
+        Block ordinalsBlock = ordinalBlock(dict, randomOrdinals, null);
+        Block plainBlock = plainBytesRefBlock(dict, randomOrdinals);
+        try (ordinalsBlock; plainBlock) {
+            // *google* takes the SIMD path; *go?gle* (single-char wildcard) falls back to the
+            // automaton. They must agree on every row.
+            for (String pattern : new String[] { "*google*", "*google.com*", "*xyz*", "*go?gle*" }) {
+                Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern(pattern));
+
+                WordMask ordinalMask = new ParquetPushedExpressions(List.of(like)).evaluateFilter(
+                    Map.of("s", ordinalsBlock),
+                    rowCount,
+                    new WordMask()
+                );
+                WordMask plainMask = new ParquetPushedExpressions(List.of(like)).evaluateFilter(
+                    Map.of("s", plainBlock),
+                    rowCount,
+                    new WordMask()
+                );
+                if (ordinalMask == null) {
+                    assertNull("pattern [" + pattern + "]: ordinal returned null (all survive); plain must also", plainMask);
+                } else {
+                    assertNotNull("pattern [" + pattern + "]: ordinal produced a mask; plain must too", plainMask);
+                    assertArrayEquals(
+                        "pattern [" + pattern + "]: ordinal and plain masks diverge",
+                        plainMask.survivingPositions(),
+                        ordinalMask.survivingPositions()
+                    );
+                }
+            }
+        }
+    }
+
+    public void testWildcardLikeContainsLiteralScalarPath() {
+        // Direct functional test of the SIMD contains path through a plain BytesRefBlock — values
+        // are deliberately mixed: long enough to clear the SIMD activation threshold, short enough
+        // to exercise the scalar fallback inside ESVectorUtil#contains, and one null for SQL TVL.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(5)) {
+            builder.appendBytesRef(new BytesRef("https://www.google.com/maps")); // long, contains "google"
+            builder.appendBytesRef(new BytesRef("google")); // short, contains "google"
+            builder.appendBytesRef(new BytesRef("https://www.bing.com/")); // long, no "google"
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("Google")); // wrong case, must NOT match case-sensitive *google*
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*google*"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 5, new WordMask(), new int[] { 0, 1 });
+        }
+    }
+
+    public void testWildcardLikeContainsLiteralCaseInsensitiveStillCorrect() {
+        // Case-insensitive *literal* is intentionally NOT on the SIMD path (lowercasing the haystack
+        // would defeat the SIMD win). It must still produce the case-insensitive answer via the
+        // automaton fallback.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(3)) {
+            builder.appendBytesRef(new BytesRef("https://www.google.com/"));
+            builder.appendBytesRef(new BytesRef("https://www.GOOGLE.com/maps"));
+            builder.appendBytesRef(new BytesRef("https://www.bing.com/"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*google*"), true);
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 3, new WordMask(), new int[] { 0, 1 });
+        }
+    }
+
+    public void testWildcardLikeContainsLiteralNotOnOrdinalDictionaryAgreesWithAutomaton() {
+        // NOT (col LIKE *literal*) on an OrdinalBytesRefBlock now goes through the SIMD matcher
+        // for the inner LIKE before the TVL null-fixup and the negate. The existing NOT tests
+        // (testWildcardLikeNotInvertsAndExcludesNulls etc.) only cover plain BytesRefBlocks, so
+        // they would not catch a bug where the dictionary scatter or the ordinal-mode null fixup
+        // disagreed with the per-row scalar path under the new matcher. Cross-check the two paths
+        // on a small fixed layout that includes a null row to exercise SQL three-valued logic.
+        String[] dict = { "https://www.google.com/maps", "https://www.bing.com/", "google" };
+        // 7 rows: ordinal 0 (match), 1 (no-match), 2 (match), null, 0 (match), 1 (no-match), 2 (match)
+        int[] ordinals = { 0, 1, 2, 0, 0, 1, 2 };
+        boolean[] nulls = { false, false, false, true, false, false, false };
+        Block ordinalsBlock = ordinalBlock(dict, ordinals, nulls);
+        // Plain block must reflect the same null mask, not just the ordinals.
+        Block plainBlock;
+        try (var builder = blockFactory.newBytesRefBlockBuilder(ordinals.length)) {
+            for (int i = 0; i < ordinals.length; i++) {
+                if (nulls[i]) {
+                    builder.appendNull();
+                } else {
+                    builder.appendBytesRef(new BytesRef(dict[ordinals[i]]));
+                }
+            }
+            plainBlock = builder.build();
+        }
+        try (ordinalsBlock; plainBlock) {
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*google*"));
+            Expression not = new Not(Source.EMPTY, like);
+
+            WordMask ordinalMask = new ParquetPushedExpressions(List.of(not)).evaluateFilter(
+                Map.of("s", ordinalsBlock),
+                ordinals.length,
+                new WordMask()
+            );
+            WordMask plainMask = new ParquetPushedExpressions(List.of(not)).evaluateFilter(
+                Map.of("s", plainBlock),
+                ordinals.length,
+                new WordMask()
+            );
+            // Survivors: NOT *google* on dict {0=match, 1=no-match, 2=match} excluding the null row.
+            // -> ordinals 1 only (positions 1 and 5).
+            int[] expected = new int[] { 1, 5 };
+            assertNotNull(ordinalMask);
+            assertNotNull(plainMask);
+            assertArrayEquals("plain NOT survivors", expected, plainMask.survivingPositions());
+            assertArrayEquals("ordinal NOT survivors must agree with plain", expected, ordinalMask.survivingPositions());
+        }
+    }
+
+    public void testWildcardLikeContainsLiteralEscapeStillCorrect() {
+        // *foo\*bar* (literal "foo*bar") must NOT take the SIMD path — extractContainsLiteral
+        // returns null when the middle contains '\\'. The automaton fallback still produces the
+        // right answer; this test pins that behavior so a future "smarter" un-escape doesn't
+        // regress correctness.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(2)) {
+            builder.appendBytesRef(new BytesRef("xfoo*barx"));
+            builder.appendBytesRef(new BytesRef("xfooXbarx"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*foo\\*bar*"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 2, new WordMask(), new int[] { 0 });
+        }
+    }
+
     public void testOrdinalStartsWithMatchesDictionaryPrefix() {
         // STARTS_WITH(x, "ap") -> matching entries are "apple" (0) and "application" (1).
         int[] pattern = { 0, 1, 2, 0, 2 };


### PR DESCRIPTION
Replace `ByteRunAutomaton.run()` with the SIMD-accelerated `contains` helper (`ESVectorUtil.contains`, exposed via `BinaryDocValuesContainsTermQuery`) for case-sensitive `WildcardLike` patterns of the form `*literal*` in the Parquet late-materialization filter evaluator.

Profiling on URL columns (`LIKE "*google*"`) showed `evaluateWildcardLike` at ~25% CPU, dominated by per-byte automaton state transitions. The first+last byte SIMD filter wins by 3-10x once dictionary entries clear ~24 bytes, which covers most URL/path data.

Both the dictionary short-circuit and the per-row scalar paths share a single `Predicate<BytesRef>` matcher so the SIMD swap applies wherever the shape matches. Case-insensitive patterns and any pattern with embedded `*`, `?`, or escape sequences keep the existing automaton path.

Developed with AI-assisted tooling