### PR TITLE
[ESQL] Generic byte matchers for pushdown predicates

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/datasources/pushdown/StartsWithBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/datasources/pushdown/StartsWithBenchmark.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.esql.datasources.pushdown;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.benchmark.Utils;
+import org.elasticsearch.xpack.esql.datasources.pushdown.ByteMatchers;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compares the pre-existing scalar {@code startsWith} byte loop in {@code ParquetPushedExpressions}
+ * against {@link ByteMatchers#startsWith}, which routes through the JDK-intrinsified
+ * {@link java.util.Arrays#equals(byte[], int, int, byte[], int, int)}.
+ *
+ * <p>The sweep covers prefix lengths typical of URL/path columns (4-32 bytes) where the JDK
+ * partial-inlining path applies. The intrinsic should win or tie at every length; if it loses
+ * for very short prefixes (the open-coded loop has zero JNI/stub overhead) this benchmark
+ * documents the threshold so a future hybrid dispatcher could route accordingly.
+ *
+ * <p>A self-test runs at setup time to confirm the two implementations agree on every value.
+ */
+@Warmup(iterations = 4, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Fork(value = 1, jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
+public class StartsWithBenchmark {
+
+    static {
+        Utils.configureBenchmarkLogging();
+    }
+
+    /** Prefix length in bytes. Sweep brackets the JDK partial-inline window (~32 bytes). */
+    @Param({ "4", "8", "16", "32" })
+    public int prefixLength;
+
+    /** Average value length in bytes. Picked to be larger than the prefix in every case. */
+    @Param({ "32", "80" })
+    public int valueLength;
+
+    private static final int NUM_VALUES = 1024;
+
+    private BytesRef[] values;
+    private BytesRef prefix;
+    private int index;
+
+    @Setup
+    public void setup() {
+        Random random = new Random(1L);
+        // The prefix is the same across all values so the predicate has a 50% hit rate (we flip
+        // a coin per value for whether to start with the prefix).
+        byte[] prefixBytes = randomAsciiBytes(random, prefixLength);
+        prefix = new BytesRef(prefixBytes);
+        values = new BytesRef[NUM_VALUES];
+        for (int i = 0; i < NUM_VALUES; i++) {
+            int targetLen = Math.max(prefixLength, valueLength + random.nextInt(8) - 4);
+            byte[] bytes = new byte[targetLen];
+            if (random.nextBoolean()) {
+                System.arraycopy(prefixBytes, 0, bytes, 0, prefixLength);
+                fillRandomAsciiBytes(random, bytes, prefixLength);
+            } else {
+                fillRandomAsciiBytes(random, bytes, 0);
+                // Ensure the first byte differs so we don't accidentally start with the prefix.
+                bytes[0] = (byte) (((bytes[0] - 'a' + 1) % 26) + 'a');
+            }
+            values[i] = new BytesRef(bytes);
+        }
+        // Self-test: scalar and intrinsic must agree on every value.
+        for (int i = 0; i < NUM_VALUES; i++) {
+            BytesRef v = values[i];
+            boolean scalarAns = scalarStartsWith(v, prefix);
+            boolean intrinsicAns = ByteMatchers.startsWith(v, prefix);
+            if (scalarAns != intrinsicAns) {
+                throw new AssertionError("Disagreement at value " + i);
+            }
+        }
+    }
+
+    @Benchmark
+    public boolean scalar() {
+        int idx = index++ % NUM_VALUES;
+        return scalarStartsWith(values[idx], prefix);
+    }
+
+    @Benchmark
+    public boolean intrinsic() {
+        int idx = index++ % NUM_VALUES;
+        return ByteMatchers.startsWith(values[idx], prefix);
+    }
+
+    /** Verbatim copy of the pre-existing open-coded scalar loop in ParquetPushedExpressions. */
+    private static boolean scalarStartsWith(BytesRef value, BytesRef prefix) {
+        if (value.length < prefix.length) {
+            return false;
+        }
+        for (int j = 0; j < prefix.length; j++) {
+            if (value.bytes[value.offset + j] != prefix.bytes[prefix.offset + j]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static byte[] randomAsciiBytes(Random random, int length) {
+        byte[] out = new byte[length];
+        fillRandomAsciiBytes(random, out, 0);
+        return out;
+    }
+
+    private static void fillRandomAsciiBytes(Random random, byte[] target, int from) {
+        for (int i = from; i < target.length; i++) {
+            target[i] = (byte) ('a' + random.nextInt(26));
+        }
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/datasources/pushdown/WildcardLikeMatcherBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/datasources/pushdown/WildcardLikeMatcherBenchmark.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.benchmark.esql.datasources.pushdown;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.benchmark.Utils;
+import org.elasticsearch.xpack.esql.datasources.pushdown.ByteMatchers;
+import org.elasticsearch.xpack.esql.datasources.pushdown.WildcardLikeShape;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compares the {@link ByteMatchers#affixContains} dispatch against the {@link ByteRunAutomaton}
+ * baseline that previously powered every {@code WildcardLike} pattern in the Parquet pushdown
+ * evaluator. The benchmark mimics the dictionary scan: a single compiled matcher is applied to a
+ * pre-built array of UTF-8 byte values (a stand-in for the ordinal dictionary), once per row.
+ *
+ * <p>{@code shape} controls the LIKE pattern's structure (prefix-only, suffix-only, contains,
+ * affix-contains, ...). {@code valueByteSize} sweeps typical URL/path sizes around the SIMD
+ * activation threshold inside {@code ESVectorUtil#contains}; the corpus is generated with values
+ * within ±10% of the requested size so the parameter label is faithful.
+ *
+ * <p>The "automaton" benchmark is the before-state and "affixContains" is the after-state. The
+ * ratio between them is the win — expect 3-10x for the contains-bearing shapes once values clear
+ * ~24 bytes; smaller — but still positive — for the affix-only shapes thanks to the JDK's
+ * vectorized {@code Arrays#equals}. The {@code COMPLEX_AUTOMATON_FALLBACK} shape is deliberately
+ * outside the affix-contains family — it pins the fact that the dispatcher correctly degenerates
+ * to the automaton path with no measurable overhead (expected ratio ~1).
+ *
+ * <p>The corpus is mixed: half of the values terminate with {@code .com} (so suffix-shaped
+ * patterns hit), and half contain the literal {@code "google"} (so contains-shaped patterns hit).
+ * The two predicates are independent, so the four hit/miss combinations all show up.
+ *
+ * <p>A self-test runs at setup time to confirm the automaton and the affix-contains dispatch
+ * agree on every value for every shape; without it, a silent regression that flipped one branch
+ * of the matcher would still measure "fast" and pass review. AGENTS.md mandates this discipline.
+ */
+@Warmup(iterations = 4, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Fork(value = 1, jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
+public class WildcardLikeMatcherBenchmark {
+
+    static {
+        Utils.configureBenchmarkLogging();
+    }
+
+    /**
+     * Wildcard pattern shape under test. The labels match the {@link WildcardLikeShape} taxonomy
+     * one-for-one; "complex" exercises the automaton fallback (the {@code ?} wildcard prevents
+     * the affix-contains dispatch).
+     */
+    @Param({ "PREFIX_ONLY", "SUFFIX_ONLY", "CONTAINS_ONLY", "PREFIX_SUFFIX", "PREFIX_CONTAINS_SUFFIX", "COMPLEX_AUTOMATON_FALLBACK" })
+    public String shape;
+
+    /** Approximate value length in bytes; sweep crosses the SIMD activation threshold (~24). */
+    @Param({ "16", "40", "120" })
+    public int valueByteSize;
+
+    private static final int NUM_VALUES = 1024;
+
+    private byte[][] values;
+    private BytesRef[] valueRefs;
+    private ByteRunAutomaton automaton;
+    private WildcardLikeShape compiledShape;
+    private int index;
+
+    @Setup
+    public void setup() {
+        Random random = new Random(1L);
+        values = new byte[NUM_VALUES][];
+        valueRefs = new BytesRef[NUM_VALUES];
+        // Build a corpus that looks like URL data: every value starts with "https://", optionally
+        // contains "google", and optionally ends with ".com". The two flags are independent so the
+        // four combinations all appear with ~25% frequency.
+        for (int i = 0; i < NUM_VALUES; i++) {
+            boolean includeGoogle = (i & 1) == 0;
+            boolean endsWithCom = (i & 2) == 0;
+            String value = synthesizeUrl(random, valueByteSize, includeGoogle, endsWithCom);
+            values[i] = value.getBytes(StandardCharsets.UTF_8);
+            valueRefs[i] = new BytesRef(values[i]);
+        }
+        String pattern = patternForShape(shape);
+        // Compile once — same as ParquetPushedExpressions#automatonFor caches per query.
+        Automaton autom = WildcardQuery.toAutomaton(new Term("f", pattern), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+        automaton = new ByteRunAutomaton(autom);
+        compiledShape = WildcardLikeShape.of(pattern);
+        // Self-test: every value must produce identical answers across both implementations.
+        // Skip when the shape is intentionally null (the automaton-fallback row).
+        if (compiledShape != null) {
+            for (int i = 0; i < NUM_VALUES; i++) {
+                boolean fromAutomaton = automaton.run(values[i], 0, values[i].length);
+                boolean fromShape = ByteMatchers.affixContains(
+                    valueRefs[i],
+                    compiledShape.prefix(),
+                    compiledShape.literal(),
+                    compiledShape.suffix()
+                );
+                if (fromShape != fromAutomaton) {
+                    throw new AssertionError(
+                        "Disagreement on value [" + new String(values[i], StandardCharsets.UTF_8) + "] for shape [" + shape + "]"
+                    );
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public boolean automaton() {
+        int idx = index++ % NUM_VALUES;
+        byte[] value = values[idx];
+        return automaton.run(value, 0, value.length);
+    }
+
+    @Benchmark
+    public boolean affixContains() {
+        int idx = index++ % NUM_VALUES;
+        if (compiledShape == null) {
+            // COMPLEX_AUTOMATON_FALLBACK row: the dispatcher in ParquetPushedExpressions delegates
+            // to the automaton when the shape parser rejects the pattern. Mirror that here so this
+            // benchmark column shows the fallback-parity throughput (expected: matches the
+            // automaton row almost exactly, no measurable overhead from the dispatch check).
+            byte[] bytes = values[idx];
+            return automaton.run(bytes, 0, bytes.length);
+        }
+        BytesRef value = valueRefs[idx];
+        return ByteMatchers.affixContains(value, compiledShape.prefix(), compiledShape.literal(), compiledShape.suffix());
+    }
+
+    /**
+     * Generates a pseudo-URL within roughly ±10% of {@code targetBytes} bytes long, optionally
+     * containing the literal {@code google} and optionally terminating in {@code .com}. The body
+     * between the affixes is random ASCII so the SIMD substring scan has typical Bloom-filter
+     * hit rates.
+     */
+    private static String synthesizeUrl(Random random, int targetBytes, boolean includeGoogle, boolean endsWithCom) {
+        StringBuilder sb = new StringBuilder(targetBytes + 16);
+        sb.append("https://www.");
+        if (includeGoogle) {
+            sb.append("google");
+        } else {
+            sb.append("bing");
+        }
+        sb.append('/');
+        // ±10% jitter so the param label is faithful (rather than the previous ±50% spread).
+        int jitter = Math.max(1, targetBytes / 10);
+        int actualLen = targetBytes - jitter + random.nextInt(2 * jitter + 1);
+        int suffixReserve = endsWithCom ? 4 : 0;
+        while (sb.length() + suffixReserve < actualLen) {
+            sb.append((char) ('a' + random.nextInt(26)));
+        }
+        if (endsWithCom) {
+            sb.append(".com");
+        }
+        return sb.toString();
+    }
+
+    private static String patternForShape(String shape) {
+        return switch (shape) {
+            case "PREFIX_ONLY" -> "https://*";
+            case "SUFFIX_ONLY" -> "*.com";
+            case "CONTAINS_ONLY" -> "*google*";
+            case "PREFIX_SUFFIX" -> "https://*.com";
+            case "PREFIX_CONTAINS_SUFFIX" -> "https://*google*.com";
+            case "COMPLEX_AUTOMATON_FALLBACK" -> "*go?gle*"; // '?' forces the automaton path
+            default -> throw new IllegalArgumentException("Unknown shape: " + shape);
+        };
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/datasources/pushdown/WildcardLikeMatcherBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/esql/datasources/pushdown/WildcardLikeMatcherBenchmark.java
@@ -77,7 +77,17 @@ public class WildcardLikeMatcherBenchmark {
      * one-for-one; "complex" exercises the automaton fallback (the {@code ?} wildcard prevents
      * the affix-contains dispatch).
      */
-    @Param({ "PREFIX_ONLY", "SUFFIX_ONLY", "CONTAINS_ONLY", "PREFIX_SUFFIX", "PREFIX_CONTAINS_SUFFIX", "COMPLEX_AUTOMATON_FALLBACK" })
+    @Param(
+        {
+            "PREFIX_ONLY",
+            "SUFFIX_ONLY",
+            "CONTAINS_ONLY",
+            "PREFIX_SUFFIX",
+            "PREFIX_CONTAINS",
+            "CONTAINS_SUFFIX",
+            "PREFIX_CONTAINS_SUFFIX",
+            "COMPLEX_AUTOMATON_FALLBACK" }
+    )
     public String shape;
 
     /** Approximate value length in bytes; sweep crosses the SIMD activation threshold (~24). */
@@ -188,6 +198,8 @@ public class WildcardLikeMatcherBenchmark {
             case "SUFFIX_ONLY" -> "*.com";
             case "CONTAINS_ONLY" -> "*google*";
             case "PREFIX_SUFFIX" -> "https://*.com";
+            case "PREFIX_CONTAINS" -> "https://*google*";
+            case "CONTAINS_SUFFIX" -> "*google*.com";
             case "PREFIX_CONTAINS_SUFFIX" -> "https://*google*.com";
             case "COMPLEX_AUTOMATON_FALLBACK" -> "*go?gle*"; // '?' forces the automaton path
             default -> throw new IllegalArgumentException("Unknown shape: " + shape);

--- a/docs/changelog/149030.yaml
+++ b/docs/changelog/149030.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149030
+summary: Generic byte matchers for pushdown predicates
+type: enhancement

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -1258,14 +1258,8 @@ final class ParquetPushedExpressions {
         if (compiled.matchesAll) {
             return maskNonNullRows(block, rowCount);
         }
-        ByteRunAutomaton runner = compiled.matcher;
-        // For case-sensitive patterns of the affix-contains family (prefix*literal*suffix and all
-        // degenerate forms), dispatch the per-byte loop through ByteMatchers#affixContains rather
-        // than the automaton: short JDK-intrinsified affix equality + the SIMD-backed contains
-        // helper. Profiling on URL columns (LIKE "*google*") showed evaluateWildcardLike at ~25%
-        // CPU dominated by ByteRunAutomaton state transitions; the affix-contains dispatch
-        // shortens the hot loop substantially once values clear the SIMD activation threshold.
-        Predicate<BytesRef> matcher = matcherFor(compiled, runner);
+        // Use the affix-contains dispatch when the pattern matches that shape; see CompiledWildcard.
+        Predicate<BytesRef> matcher = matcherFor(compiled);
         if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
             WordMask mask = new WordMask();
             mask.reset(rowCount);
@@ -1293,7 +1287,7 @@ final class ParquetPushedExpressions {
         return null;
     }
 
-    private static Predicate<BytesRef> matcherFor(CompiledWildcard compiled, ByteRunAutomaton runner) {
+    private static Predicate<BytesRef> matcherFor(CompiledWildcard compiled) {
         WildcardLikeShape shape = compiled.shape();
         if (shape != null) {
             BytesRef prefix = shape.prefix();
@@ -1301,6 +1295,7 @@ final class ParquetPushedExpressions {
             BytesRef suffix = shape.suffix();
             return entry -> ByteMatchers.affixContains(entry, prefix, literal, suffix);
         }
+        ByteRunAutomaton runner = compiled.matcher;
         return entry -> runner.run(entry.bytes, entry.offset, entry.length);
     }
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressions.java
@@ -30,12 +30,13 @@ import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
-import org.elasticsearch.lucene.queries.BinaryDocValuesContainsTermQuery;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.datasources.pushdown.ByteMatchers;
 import org.elasticsearch.xpack.esql.datasources.pushdown.StringPrefixUtils;
+import org.elasticsearch.xpack.esql.datasources.pushdown.WildcardLikeShape;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.Range;
@@ -110,27 +111,27 @@ final class ParquetPushedExpressions {
 
     /**
      * Compiled form of a {@link WildcardLike}: the runnable matcher, a flag indicating that the
-     * source automaton accepts every input, and an optional substring literal extracted from the
-     * pattern when it has the case-sensitive {@code *literal*} shape (see
-     * {@link #extractContainsLiteral}). The {@link #matchesAll} flag is computed against the
-     * case-aware automaton (the same one passed to {@link ByteRunAutomaton}), so the fast path in
-     * {@link #evaluateWildcardLike} is consistent with the runtime case-sensitivity setting — it
-     * does not silently fall through to the per-row loop just because the pattern's internal
-     * case-insensitive cache disagrees with the requested flag.
+     * source automaton accepts every input, and an optional shape decomposition extracted from
+     * case-sensitive patterns of the affix-contains family (see {@link WildcardLikeShape}). The
+     * {@link #matchesAll} flag is computed against the case-aware automaton (the same one passed
+     * to {@link ByteRunAutomaton}), so the fast path in {@link #evaluateWildcardLike} is
+     * consistent with the runtime case-sensitivity setting — it does not silently fall through
+     * to the per-row loop just because the pattern's internal case-insensitive cache disagrees
+     * with the requested flag.
      *
      * <p>{@code matcher} is {@code null} when the pattern failed to determinize; the caller treats
      * that as "fall back to FilterExec" (return {@code null} from evaluateWildcardLike).
      *
-     * <p>{@code containsLiteral} is non-null only for case-sensitive {@code *literal*} patterns
-     * with no embedded wildcards or escapes (see {@link #extractContainsLiteral}). When present,
-     * {@link #evaluateWildcardLike} dispatches to {@link BinaryDocValuesContainsTermQuery#contains}
-     * (a thin wrapper over the SIMD-accelerated {@code ESVectorUtil#contains}) instead of the
-     * per-byte automaton — a 3-10x speedup for dictionary entries longer than the SIMD activation
-     * threshold (~24 bytes), which covers most URL/path data. Byte-substring against UTF-8 is
-     * codepoint-correct because UTF-8 is self-synchronizing on valid inputs (KEYWORD contract);
-     * this matches the long-standing assumption in {@link BinaryDocValuesContainsTermQuery}.
+     * <p>{@code shape} is non-null only for case-sensitive patterns of the form
+     * {@code prefix*literal*suffix} (and all degenerate forms — {@code prefix*}, {@code *suffix},
+     * {@code *literal*}, {@code prefix*suffix}, {@code prefix*literal*}, {@code *literal*suffix}).
+     * When present, {@link #evaluateWildcardLike} dispatches to
+     * {@link ByteMatchers#affixContains} instead of the per-byte automaton: short JDK-intrinsified
+     * affix equality checks reject the bulk of non-matching values cheaply, and the SIMD-backed
+     * substring scan handles the literal middle. Byte-substring against UTF-8 is codepoint-correct
+     * because UTF-8 is self-synchronizing on valid inputs (the KEYWORD contract).
      */
-    private record CompiledWildcard(ByteRunAutomaton matcher, boolean matchesAll, @Nullable BytesRef containsLiteral) {
+    private record CompiledWildcard(ByteRunAutomaton matcher, boolean matchesAll, @Nullable WildcardLikeShape shape) {
         static final CompiledWildcard FAILED = new CompiledWildcard(null, false, null);
     }
 
@@ -929,18 +930,15 @@ final class ParquetPushedExpressions {
             // provided — typically reducing dictSize * batchCount predicate calls to dictSize
             // per row group.
             BytesRef val = toByteRef(literal);
-            boolean[] dictMatches = memoizedDictionaryMatches(
-                dictCache,
-                bc,
-                obb.getDictionaryVector(),
-                entry -> compareResult(entry.compareTo(val), bc)
-            );
+            Predicate<BytesRef> matcher = bytesRefComparisonMatcher(bc, val);
+            boolean[] dictMatches = memoizedDictionaryMatches(dictCache, bc, obb.getDictionaryVector(), matcher);
             applyDictionaryMatches(obb, dictMatches, mask, rowCount);
         } else if (block instanceof BytesRefBlock bb) {
             BytesRef val = toByteRef(literal);
+            Predicate<BytesRef> matcher = bytesRefComparisonMatcher(bc, val);
             BytesRef scratch = new BytesRef();
             for (int i = 0; i < rowCount; i++) {
-                if (block.isNull(i) == false && compareResult(bb.getBytesRef(i, scratch).compareTo(val), bc)) {
+                if (block.isNull(i) == false && matcher.test(bb.getBytesRef(i, scratch))) {
                     mask.set(i);
                 }
             }
@@ -955,6 +953,25 @@ final class ParquetPushedExpressions {
             return null;
         }
         return mask;
+    }
+
+    /**
+     * Returns the per-entry predicate for comparing a {@link BytesRef} block value to {@code val}.
+     * For {@link Equals}/{@link NotEquals} this is {@link ByteMatchers#equals}, which routes
+     * through the JDK's vectorized {@code Arrays#equals} intrinsic — the length pre-check rejects
+     * the bulk of non-matching values without touching the byte content. For lexicographic
+     * comparisons (LT, LE, GT, GE) the predicate falls back to {@link BytesRef#compareTo}, which
+     * is the only correct semantic on UTF-8 byte order; the JDK still vectorizes the underlying
+     * mismatch-finding step.
+     */
+    private static Predicate<BytesRef> bytesRefComparisonMatcher(EsqlBinaryComparison bc, BytesRef val) {
+        if (bc instanceof Equals) {
+            return entry -> ByteMatchers.equals(entry, val);
+        }
+        if (bc instanceof NotEquals) {
+            return entry -> ByteMatchers.equals(entry, val) == false;
+        }
+        return entry -> compareResult(entry.compareTo(val), bc);
     }
 
     private static boolean compareResult(int cmp, EsqlBinaryComparison bc) {
@@ -1151,6 +1168,10 @@ final class ParquetPushedExpressions {
             return null;
         }
         BytesRef prefix = toByteRef(prefixValue);
+        // ByteMatchers#startsWith routes through Arrays#equals, which HotSpot intrinsifies on
+        // x86 (AVX2/AVX-512) and ARM (NEON) with partial-inlining for sizes <= 64 bytes — typical
+        // URL/path prefixes ("https://", "https://www.") fit comfortably in that fast path. The
+        // helper performs the length pre-check internally.
         if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
             WordMask mask = new WordMask();
             mask.reset(rowCount);
@@ -1158,7 +1179,7 @@ final class ParquetPushedExpressions {
                 dictCache,
                 sw,
                 obb.getDictionaryVector(),
-                entry -> entry.length >= prefix.length && startsWith(entry, prefix)
+                entry -> ByteMatchers.startsWith(entry, prefix)
             );
             applyDictionaryMatches(obb, dictMatches, mask, rowCount);
             return mask;
@@ -1173,7 +1194,7 @@ final class ParquetPushedExpressions {
                 }
                 if (block.isNull(i) == false) {
                     BytesRef val = bb.getBytesRef(i, scratch);
-                    if (val.length >= prefix.length && startsWith(val, prefix)) {
+                    if (ByteMatchers.startsWith(val, prefix)) {
                         mask.set(i);
                     }
                 }
@@ -1181,15 +1202,6 @@ final class ParquetPushedExpressions {
             return mask;
         }
         return null;
-    }
-
-    private static boolean startsWith(BytesRef value, BytesRef prefix) {
-        for (int j = 0; j < prefix.length; j++) {
-            if (value.bytes[value.offset + j] != prefix.bytes[prefix.offset + j]) {
-                return false;
-            }
-        }
-        return true;
     }
 
     /**
@@ -1247,11 +1259,12 @@ final class ParquetPushedExpressions {
             return maskNonNullRows(block, rowCount);
         }
         ByteRunAutomaton runner = compiled.matcher;
-        // For case-sensitive *literal* patterns, dispatch the per-byte loop to the SIMD-accelerated
-        // contains helper (ESVectorUtil#contains, exposed via BinaryDocValuesContainsTermQuery).
-        // Profiling on URL columns (ClickBench q20: URL LIKE "*google*") showed evaluateWildcardLike
-        // at ~25% CPU dominated by ByteRunAutomaton state transitions; the first+last byte SIMD
-        // filter wins by 3-10x once dictionary entries clear ~24 bytes.
+        // For case-sensitive patterns of the affix-contains family (prefix*literal*suffix and all
+        // degenerate forms), dispatch the per-byte loop through ByteMatchers#affixContains rather
+        // than the automaton: short JDK-intrinsified affix equality + the SIMD-backed contains
+        // helper. Profiling on URL columns (LIKE "*google*") showed evaluateWildcardLike at ~25%
+        // CPU dominated by ByteRunAutomaton state transitions; the affix-contains dispatch
+        // shortens the hot loop substantially once values clear the SIMD activation threshold.
         Predicate<BytesRef> matcher = matcherFor(compiled, runner);
         if (block instanceof OrdinalBytesRefBlock obb && shouldShortCircuitOnDictionary(obb)) {
             WordMask mask = new WordMask();
@@ -1281,9 +1294,12 @@ final class ParquetPushedExpressions {
     }
 
     private static Predicate<BytesRef> matcherFor(CompiledWildcard compiled, ByteRunAutomaton runner) {
-        BytesRef literal = compiled.containsLiteral();
-        if (literal != null) {
-            return entry -> BinaryDocValuesContainsTermQuery.contains(entry.bytes, entry.offset, entry.length, literal);
+        WildcardLikeShape shape = compiled.shape();
+        if (shape != null) {
+            BytesRef prefix = shape.prefix();
+            BytesRef literal = shape.literal();
+            BytesRef suffix = shape.suffix();
+            return entry -> ByteMatchers.affixContains(entry, prefix, literal, suffix);
         }
         return entry -> runner.run(entry.bytes, entry.offset, entry.length);
     }
@@ -1412,8 +1428,11 @@ final class ParquetPushedExpressions {
                 // (For invalid UTF-8 — outside the KEYWORD contract — the byte-level automaton would
                 // simply reject the malformed prefix, matching the per-row scalar path's behavior.)
                 boolean matchesAll = Operations.isTotal(automaton);
-                BytesRef containsLiteral = wl.caseInsensitive() ? null : extractContainsLiteral(wl.pattern().pattern());
-                compiled = new CompiledWildcard(new ByteRunAutomaton(automaton), matchesAll, containsLiteral);
+                // Affix-contains shape detection is opt-in for case-sensitive patterns. Skip the
+                // matchesAll case (already handled by an upstream shortcut) so the shape only
+                // exists on the SIMD-eligible path; this keeps the dispatcher contract trivial.
+                WildcardLikeShape shape = (wl.caseInsensitive() || matchesAll) ? null : WildcardLikeShape.of(wl.pattern().pattern());
+                compiled = new CompiledWildcard(new ByteRunAutomaton(automaton), matchesAll, shape);
             } catch (IllegalArgumentException | TooComplexToDeterminizeException e) {
                 logger.debug(
                     "Cannot push WildcardLike pattern [{}] to Parquet late materialization, falling back to FilterExec",
@@ -1425,41 +1444,6 @@ final class ParquetPushedExpressions {
             automatonCache.put(wl, compiled);
             return compiled;
         }
-    }
-
-    /**
-     * Returns the substring literal of a case-sensitive {@code *literal*} wildcard pattern, or
-     * {@code null} if the pattern does not have that exact shape. The literal is what
-     * {@link BinaryDocValuesContainsTermQuery#contains} should search for inside each row's value
-     * bytes.
-     *
-     * <p>Recognized iff <em>all</em> of the following hold:
-     * <ul>
-     *   <li>length &ge; 3 (at least one literal char between the two wildcards),</li>
-     *   <li>starts and ends with {@code '*'},</li>
-     *   <li>the middle contains no {@code '*'} (no leftover wildcards),</li>
-     *   <li>the middle contains no {@code '?'} (single-char wildcard not supported by contains),</li>
-     *   <li>the middle contains no {@code '\\'} (escape sequences kept on the automaton path).</li>
-     * </ul>
-     *
-     * <p>Caller already checks {@link WildcardLike#caseInsensitive()} — this helper is intentionally
-     * blind to it so the rule is local and easy to reason about. Returning the literal as a
-     * {@link BytesRef} commits to UTF-8 bytes, which is what KEYWORD values are encoded as and
-     * what {@link BinaryDocValuesContainsTermQuery#contains} compares; UTF-8's self-synchronizing
-     * property guarantees byte-substring matches are codepoint-substring matches for valid inputs.
-     */
-    @Nullable
-    static BytesRef extractContainsLiteral(String pattern) {
-        if (pattern.length() < 3 || pattern.charAt(0) != '*' || pattern.charAt(pattern.length() - 1) != '*') {
-            return null;
-        }
-        for (int i = 1, end = pattern.length() - 1; i < end; i++) {
-            char c = pattern.charAt(i);
-            if (c == '*' || c == '?' || c == '\\') {
-                return null;
-            }
-        }
-        return new BytesRef(pattern.substring(1, pattern.length() - 1));
     }
 
     // Package-private hook so tests can directly assert that automaton compilation is memoized

--- a/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/test/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetPushedExpressionsEvaluatorTests.java
@@ -1256,34 +1256,9 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
         assertEquals(java.util.Set.of("url"), pushed.predicateColumnNames());
     }
 
-    public void testExtractContainsLiteralRecognizesPureContainsShape() {
-        // Pins the exact set of patterns that take the SIMD-accelerated contains() path. Anything
-        // not on this list falls back to the per-byte ByteRunAutomaton; that is correct, but a silent
-        // regression here would dial back the dictionary fast-path on URL/path columns and is the
-        // single most expensive perf bug this change can introduce.
-        assertEquals(new BytesRef("google"), ParquetPushedExpressions.extractContainsLiteral("*google*"));
-        // Single-character literal — minimum recognized length is 3 ("*x*").
-        assertEquals(new BytesRef("a"), ParquetPushedExpressions.extractContainsLiteral("*a*"));
-        // UTF-8 multi-byte: helper must commit to bytes, not codepoints, because the runtime matcher
-        // operates on bytes.
-        assertEquals(new BytesRef("café"), ParquetPushedExpressions.extractContainsLiteral("*café*"));
-    }
-
-    public void testExtractContainsLiteralRejectsNonContainsShapes() {
-        // "**" -> middle is empty AND length<3 -> not recognized; the matchesAll automaton fast-path
-        // already handles "*", and "**" is equivalent at the automaton level.
-        assertNull(ParquetPushedExpressions.extractContainsLiteral("**"));
-        // No leading wildcard -> StartsWith territory, not contains.
-        assertNull(ParquetPushedExpressions.extractContainsLiteral("google*"));
-        // No trailing wildcard -> EndsWith territory, not contains.
-        assertNull(ParquetPushedExpressions.extractContainsLiteral("*google"));
-        // Embedded '*' -> two-segment pattern; the simple substring check would be wrong.
-        assertNull(ParquetPushedExpressions.extractContainsLiteral("*foo*bar*"));
-        // Embedded '?' -> single-char wildcard; the simple substring check would be wrong.
-        assertNull(ParquetPushedExpressions.extractContainsLiteral("*foo?bar*"));
-        // Embedded escape '\\' -> the literal would need un-escaping; keep on the automaton path.
-        assertNull(ParquetPushedExpressions.extractContainsLiteral("*fo\\*o*"));
-    }
+    // Shape-detection unit tests live in WildcardLikeShapeTests now that the parser is a shared
+    // utility. The evaluator tests below cross-check that ParquetPushedExpressions actually
+    // dispatches through the shared shape on representative LIKE patterns.
 
     public void testWildcardLikeContainsLiteralOrdinalDictionaryAgreesWithAutomaton() {
         // Cross-checks the SIMD contains path against the per-row scalar path on a dictionary
@@ -1307,9 +1282,22 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
         Block ordinalsBlock = ordinalBlock(dict, randomOrdinals, null);
         Block plainBlock = plainBytesRefBlock(dict, randomOrdinals);
         try (ordinalsBlock; plainBlock) {
-            // *google* takes the SIMD path; *go?gle* (single-char wildcard) falls back to the
-            // automaton. They must agree on every row.
-            for (String pattern : new String[] { "*google*", "*google.com*", "*xyz*", "*go?gle*" }) {
+            // Each entry exercises a distinct WildcardLikeShape branch through the affix-contains
+            // dispatch (or its automaton fallback). The shape is a pre-existing cache key so the
+            // dispatch is exercised end-to-end for every pattern; ordinal vs plain must agree on
+            // every row, every pattern.
+            for (String pattern : new String[] {
+                "*google*",         // *literal*
+                "*google.com*",     // *literal*
+                "*xyz*",            // *literal* with no match anywhere
+                "https*",           // prefix*
+                "*lucene",          // *suffix
+                "https*lucene",     // prefix*suffix (both ends fixed, no middle literal)
+                "https*google*",    // prefix*literal*
+                "*google*com",      // *literal*suffix
+                "https*google*com", // prefix*literal*suffix (full affix-contains)
+                "*go?gle*"          // automaton fallback (single-char wildcard)
+            }) {
                 Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern(pattern));
 
                 WordMask ordinalMask = new ParquetPushedExpressions(List.of(like)).evaluateFilter(
@@ -1350,6 +1338,127 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
             Map<String, Block> blocks = Map.of("s", block);
             Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*google*"));
             assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 5, new WordMask(), new int[] { 0, 1 });
+        }
+    }
+
+    public void testStringEqualsRoutesThroughByteMatchers() {
+        // Sanity-pin: Equals on KEYWORD now dispatches via ByteMatchers#equals (Arrays#equals
+        // intrinsic + length pre-check) rather than BytesRef#compareTo. The functional answer must
+        // not change. Mixed-length values exercise the length pre-check fast path.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendBytesRef(new BytesRef("application")); // longer — length pre-check rejects
+            builder.appendBytesRef(new BytesRef("appl")); // shorter — length pre-check rejects
+            builder.appendBytesRef(new BytesRef("apple")); // equal again
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            Expression eq = new Equals(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("apple"), DataType.KEYWORD), null);
+            assertSurvivors(new ParquetPushedExpressions(List.of(eq)), blocks, 4, new WordMask(), new int[] { 0, 3 });
+        }
+    }
+
+    public void testStringLessThanOnPlainBytesRefBlockUsesCompareTo() {
+        // The Equals/NotEquals refactor introduced a Predicate-based dispatch in the BytesRefBlock
+        // path; ordered comparisons (LT, LE, GT, GE) must keep the lex-order semantics of
+        // BytesRef#compareTo. Pin the wire-up on a plain (non-dictionary) block — the existing
+        // testOrdinalLessThanComparesDictionaryEntries only covers the dictionary path.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(5)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendBytesRef(new BytesRef("banana"));
+            builder.appendBytesRef(new BytesRef("cherry"));
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("aardvark")); // sorts before "apple"
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            // s < "banana" -> matches "apple" (0) and "aardvark" (4); null (3) excluded by SQL TVL.
+            Expression lt = new LessThan(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("banana"), DataType.KEYWORD), null);
+            assertSurvivors(new ParquetPushedExpressions(List.of(lt)), blocks, 5, new WordMask(), new int[] { 0, 4 });
+        }
+    }
+
+    public void testStringNotEqualsRoutesThroughByteMatchers() {
+        // Cross-pin: NotEquals must agree with the inverse of Equals on the same data, including
+        // the SQL-TVL null exclusion (nulls are not survivors of either Equals or NotEquals).
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("apple"));
+            builder.appendBytesRef(new BytesRef("banana"));
+            builder.appendNull();
+            builder.appendBytesRef(new BytesRef("cherry"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            Expression ne = new NotEquals(Source.EMPTY, attr("s", DataType.KEYWORD), lit(new BytesRef("apple"), DataType.KEYWORD), null);
+            // Index 2 is null — must NOT survive (SQL TVL).
+            assertSurvivors(new ParquetPushedExpressions(List.of(ne)), blocks, 4, new WordMask(), new int[] { 1, 3 });
+        }
+    }
+
+    public void testWildcardLikeAffixContainsFullShape() {
+        // Pins the prefix*literal*suffix dispatch end-to-end with a known survivor set. The
+        // pattern carries all three components; rows are designed so each fails in a distinct way:
+        // index 0 matches all three, index 1 fails the prefix, index 2 fails the suffix, index 3
+        // fails the middle literal. Without affixContains routing the literal to the middle slice,
+        // the substring scan would spuriously accept index 4 (literal lives in the prefix region).
+        try (var builder = blockFactory.newBytesRefBlockBuilder(5)) {
+            builder.appendBytesRef(new BytesRef("https://www.google.com")); // 0: matches everything
+            builder.appendBytesRef(new BytesRef("ftp://www.google.com")); // 1: prefix mismatch
+            builder.appendBytesRef(new BytesRef("https://www.google.org")); // 2: suffix mismatch
+            builder.appendBytesRef(new BytesRef("https://www.bing.com")); // 3: middle mismatch
+            builder.appendBytesRef(new BytesRef("googleSurprise.com")); // 4: middle 'google' lives in prefix region — must NOT match
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("https*google*com"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 5, new WordMask(), new int[] { 0 });
+        }
+    }
+
+    public void testWildcardLikePrefixOnlyShapeUsesByteMatchers() {
+        // Functional pin for the prefix*-shape dispatch through the WildcardLikeShape decomposition.
+        // Equivalent semantics to a plain StartsWith but reaches the affix-contains path through
+        // WildcardLike, exercising the shared ByteMatchers#startsWith primitive on both prefixes
+        // shorter and longer than the JDK partial-inline window.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("https://www.google.com"));
+            builder.appendBytesRef(new BytesRef("https://github.com/"));
+            builder.appendBytesRef(new BytesRef("ftp://example.com"));
+            builder.appendBytesRef(new BytesRef("https"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("https://*"));
+            // Index 3 ("https") is shorter than the prefix and must be rejected by the length pre-check.
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 4, new WordMask(), new int[] { 0, 1 });
+        }
+    }
+
+    public void testWildcardLikeSuffixOnlyShapeUsesByteMatchers() {
+        // Functional pin for the *suffix-shape dispatch — there was no EndsWith evaluator before
+        // this change, so this is the first time the suffix-only LIKE shape gets a typed fast path.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(4)) {
+            builder.appendBytesRef(new BytesRef("photo.jpg"));
+            builder.appendBytesRef(new BytesRef("ARCHIVE.JPG")); // case mismatch — must NOT match
+            builder.appendBytesRef(new BytesRef("doc.pdf"));
+            builder.appendBytesRef(new BytesRef(".jpg"));
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("*.jpg"));
+            // Index 3 (".jpg") is exactly the suffix — endsWith on a value of equal length is true.
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 4, new WordMask(), new int[] { 0, 3 });
+        }
+    }
+
+    public void testWildcardLikePrefixSuffixShapeUsesByteMatchers() {
+        // prefix*suffix has both ends fixed and no middle literal. Dispatch must rely on
+        // startsWith + endsWith, with the combined-length guard preventing prefix and suffix
+        // from overlapping inside a too-short value.
+        try (var builder = blockFactory.newBytesRefBlockBuilder(5)) {
+            builder.appendBytesRef(new BytesRef("https://www.example.com")); // 0: full match
+            builder.appendBytesRef(new BytesRef("https://example.org")); // 1: wrong suffix
+            builder.appendBytesRef(new BytesRef("ftp://example.com")); // 2: wrong prefix
+            builder.appendBytesRef(new BytesRef("https://com")); // 3: prefix+suffix exactly fill the value (length 11) — match
+            builder.appendBytesRef(new BytesRef("https:/")); // 4: shorter than prefix — combined-length guard rejects
+            Block block = builder.build();
+            Map<String, Block> blocks = Map.of("s", block);
+            Expression like = new WildcardLike(Source.EMPTY, attr("s", DataType.KEYWORD), new WildcardPattern("https://*com"));
+            assertSurvivors(new ParquetPushedExpressions(List.of(like)), blocks, 5, new WordMask(), new int[] { 0, 3 });
         }
     }
 
@@ -1417,7 +1526,7 @@ public class ParquetPushedExpressionsEvaluatorTests extends ESTestCase {
     }
 
     public void testWildcardLikeContainsLiteralEscapeStillCorrect() {
-        // *foo\*bar* (literal "foo*bar") must NOT take the SIMD path — extractContainsLiteral
+        // *foo\*bar* (literal "foo*bar") must NOT take the SIMD path — WildcardLikeShape.of
         // returns null when the middle contains '\\'. The automaton fallback still produces the
         // right answer; this test pins that behavior so a future "smarter" un-escape doesn't
         // regress correctness.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/ByteMatchers.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/ByteMatchers.java
@@ -106,7 +106,16 @@ public final class ByteMatchers {
     /**
      * Returns {@code true} iff {@code value} contains {@code literal} as a contiguous subsequence.
      * An empty literal matches every value (including an empty one). Routes through the SIMD
-     * substring search exposed by {@link BinaryDocValuesContainsTermQuery}.
+     * substring search exposed by {@link BinaryDocValuesContainsTermQuery#contains(byte[], int,
+     * int, BytesRef)}.
+     *
+     * <p>The Lucene query class is used purely as a static-method shim around
+     * {@code ESVectorUtil#contains}: {@code simdvec}'s module exports the SIMD utility only to
+     * {@code org.elasticsearch.server}, so plugins (unnamed modules) cannot import it directly.
+     * Calling it through this server-side neighbor keeps the SIMD intent without forcing every
+     * consumer plugin to add a {@code simdvec} dependency it cannot legally use at runtime. If
+     * the shim ever moves to a more semantically-named {@code :server} home, only this method
+     * needs to change.
      */
     public static boolean containsLiteral(BytesRef value, BytesRef literal) {
         if (literal.length == 0) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/ByteMatchers.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/ByteMatchers.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.pushdown;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.lucene.queries.BinaryDocValuesContainsTermQuery;
+
+import java.util.Arrays;
+
+/**
+ * Byte-level matching primitives shared by datasource pushdown evaluators.
+ *
+ * <p>All operations are <b>byte-level</b> — they treat their inputs as opaque {@code byte[]} and
+ * make no assumption about character encoding or case. Callers that work with valid UTF-8 KEYWORD
+ * values (the Elasticsearch contract) get codepoint-correct semantics for free thanks to UTF-8's
+ * self-synchronizing property: a valid UTF-8 substring matches at byte boundaries iff it matches
+ * at codepoint boundaries. For inputs that are not valid UTF-8, the helpers degrade to plain byte
+ * comparison — caller's responsibility if that diverges from the desired semantics.
+ *
+ * <p>Each primitive routes the heavy lifting through the fastest implementation available on the
+ * platform:
+ * <ul>
+ *   <li>{@link #equals(BytesRef, BytesRef)}, {@link #startsWith(BytesRef, BytesRef)},
+ *       {@link #endsWith(BytesRef, BytesRef)} delegate to {@link Arrays#equals(byte[], int, int,
+ *       byte[], int, int)}, which HotSpot intrinsifies to AVX2/AVX-512 on x86 and NEON on ARM
+ *       (with partial-inlining for sizes &le; 64 bytes — no stub call).</li>
+ *   <li>{@link #containsLiteral(BytesRef, BytesRef)} delegates to
+ *       {@link BinaryDocValuesContainsTermQuery#contains(byte[], int, int, BytesRef)}, a thin
+ *       wrapper over {@code ESVectorUtil#contains} which uses Panama Vector API first+last byte
+ *       filtering for values &ge; 24 bytes.</li>
+ * </ul>
+ *
+ * <p>The methods are deliberately small and inlinable so the JIT can fuse them into per-row
+ * predicate loops without virtual-call overhead. Datasource evaluators (today: Parquet
+ * late-materialization; future: any in-Java filter on byte-shaped columns) should call these
+ * helpers rather than open-coding the byte loops.
+ */
+public final class ByteMatchers {
+
+    private ByteMatchers() {}
+
+    /**
+     * Returns {@code true} iff the two byte sequences have identical length and content.
+     * Equivalent to {@link BytesRef#bytesEquals(BytesRef)} but routed through
+     * {@link Arrays#equals(byte[], int, int, byte[], int, int)} so it picks up the JDK's
+     * vectorized intrinsic on hot paths.
+     */
+    public static boolean equals(BytesRef value, BytesRef target) {
+        if (value.length != target.length) {
+            return false;
+        }
+        return Arrays.equals(
+            value.bytes,
+            value.offset,
+            value.offset + value.length,
+            target.bytes,
+            target.offset,
+            target.offset + target.length
+        );
+    }
+
+    /**
+     * Returns {@code true} iff {@code value} begins with {@code prefix}. An empty prefix matches
+     * every value (including an empty one). Returns {@code false} when {@code prefix} is longer
+     * than {@code value}.
+     */
+    public static boolean startsWith(BytesRef value, BytesRef prefix) {
+        if (prefix.length == 0) {
+            return true;
+        }
+        if (prefix.length > value.length) {
+            return false;
+        }
+        return Arrays.equals(
+            value.bytes,
+            value.offset,
+            value.offset + prefix.length,
+            prefix.bytes,
+            prefix.offset,
+            prefix.offset + prefix.length
+        );
+    }
+
+    /**
+     * Returns {@code true} iff {@code value} ends with {@code suffix}. An empty suffix matches
+     * every value (including an empty one). Returns {@code false} when {@code suffix} is longer
+     * than {@code value}.
+     */
+    public static boolean endsWith(BytesRef value, BytesRef suffix) {
+        if (suffix.length == 0) {
+            return true;
+        }
+        if (suffix.length > value.length) {
+            return false;
+        }
+        int tailStart = value.offset + value.length - suffix.length;
+        return Arrays.equals(value.bytes, tailStart, tailStart + suffix.length, suffix.bytes, suffix.offset, suffix.offset + suffix.length);
+    }
+
+    /**
+     * Returns {@code true} iff {@code value} contains {@code literal} as a contiguous subsequence.
+     * An empty literal matches every value (including an empty one). Routes through the SIMD
+     * substring search exposed by {@link BinaryDocValuesContainsTermQuery}.
+     */
+    public static boolean containsLiteral(BytesRef value, BytesRef literal) {
+        if (literal.length == 0) {
+            return true;
+        }
+        if (literal.length > value.length) {
+            return false;
+        }
+        return BinaryDocValuesContainsTermQuery.contains(value.bytes, value.offset, value.length, literal);
+    }
+
+    /**
+     * Composite predicate: returns {@code true} iff {@code value} starts with {@code prefix},
+     * ends with {@code suffix}, and contains {@code literal} as a contiguous subsequence anywhere
+     * <i>between</i> the matched prefix and suffix. Any of the three components may be
+     * {@code null} or empty, in which case the corresponding check is skipped.
+     *
+     * <p>This implements the SQL {@code LIKE 'prefix%literal%suffix'} family in a single pass:
+     * <ul>
+     *   <li>{@code prefix*} → {@code (prefix, null, null)}</li>
+     *   <li>{@code *suffix} → {@code (null, null, suffix)}</li>
+     *   <li>{@code *literal*} → {@code (null, literal, null)}</li>
+     *   <li>{@code prefix*suffix} → {@code (prefix, null, suffix)}</li>
+     *   <li>{@code prefix*literal*} → {@code (prefix, literal, null)}</li>
+     *   <li>{@code *literal*suffix} → {@code (null, literal, suffix)}</li>
+     *   <li>{@code prefix*literal*suffix} → {@code (prefix, literal, suffix)}</li>
+     * </ul>
+     *
+     * <p>The order of checks is prefix → suffix → literal: the affix checks are short JDK-
+     * intrinsified equality comparisons (typically &le; 32 bytes) and reject the bulk of
+     * non-matching values cheaply, leaving the more expensive SIMD substring scan for survivors.
+     * For correctness, the literal scan is restricted to the bytes <i>strictly between</i> the
+     * prefix and suffix regions: this prevents the literal from straddling and double-counting
+     * either affix region (e.g. {@code value="aXa"}, {@code prefix="a"}, {@code literal="aXa"},
+     * {@code suffix="a"} must match iff {@code aXa} appears in the empty middle slice — which it
+     * does not — not iff it appears anywhere in the full value).
+     *
+     * <p>A single combined-length guard rejects any value that cannot host all three components
+     * end-to-end without overlap: when {@code prefix.length + literal.length + suffix.length >
+     * value.length} the predicate returns {@code false} immediately. This subsumes both the
+     * "affixes don't fit" case (literal length zero) and the "literal can't fit between the
+     * affixes" case, and it matches the non-overlapping-concatenation semantics that
+     * {@code ByteRunAutomaton} uses on the same patterns — the parity callers depend on.
+     *
+     * <p>When all three components are absent (every parameter {@code null} or empty) this
+     * returns {@code true} unconditionally — the vacuum predicate. Callers typically partition
+     * that case upstream as a {@code matchesAll} fast path; reaching this method with all-null
+     * arguments is harmless but wasteful.
+     */
+    public static boolean affixContains(BytesRef value, @Nullable BytesRef prefix, @Nullable BytesRef literal, @Nullable BytesRef suffix) {
+        int prefixLen = prefix == null ? 0 : prefix.length;
+        int suffixLen = suffix == null ? 0 : suffix.length;
+        int literalLen = literal == null ? 0 : literal.length;
+        if (prefixLen + suffixLen + literalLen > value.length) {
+            return false;
+        }
+        if (prefixLen > 0 && startsWith(value, prefix) == false) {
+            return false;
+        }
+        if (suffixLen > 0 && endsWith(value, suffix) == false) {
+            return false;
+        }
+        if (literalLen == 0) {
+            return true;
+        }
+        // The literal must fit in the middle slice (between prefix and suffix). Building a
+        // sub-BytesRef would allocate; instead, call the underlying byte-array contains directly
+        // with the slice bounds.
+        int sliceOffset = value.offset + prefixLen;
+        int sliceLength = value.length - prefixLen - suffixLen;
+        return BinaryDocValuesContainsTermQuery.contains(value.bytes, sliceOffset, sliceLength, literal);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/ByteMatchers.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/ByteMatchers.java
@@ -169,7 +169,11 @@ public final class ByteMatchers {
         int prefixLen = prefix == null ? 0 : prefix.length;
         int suffixLen = suffix == null ? 0 : suffix.length;
         int literalLen = literal == null ? 0 : literal.length;
-        if (prefixLen + suffixLen + literalLen > value.length) {
+        // Widen to long so the sum cannot wrap negative on pathological inputs and slip past the
+        // guard. In the LIKE-pattern path the lengths come from short UTF-8 segments and overflow
+        // is impossible — but ByteMatchers advertises itself as a generic primitive, so this
+        // single-instruction defense is the right price for the contract.
+        if ((long) prefixLen + suffixLen + literalLen > value.length) {
             return false;
         }
         if (prefixLen > 0 && startsWith(value, prefix) == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/WildcardLikeShape.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/pushdown/WildcardLikeShape.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.pushdown;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.core.Nullable;
+
+/**
+ * Shape decomposition for {@code WildcardLike} patterns of the affix-contains family:
+ * an optional literal prefix, an optional literal substring in the middle, and an optional
+ * literal suffix. The pattern is represented as
+ * <pre>{@code prefix * literal * suffix}</pre>
+ * where any of the three literal segments may be empty (rendered as {@code null} on the result).
+ *
+ * <p>Recognized shapes — adjacent {@code *}s are collapsed during parsing, so {@code **foo**bar*}
+ * is treated as {@code *foo*bar*} (and rejected; see below):
+ * <ul>
+ *   <li>{@code prefix*} — one wildcard, only a prefix</li>
+ *   <li>{@code *suffix} — one wildcard, only a suffix</li>
+ *   <li>{@code prefix*suffix} — one wildcard, both affixes</li>
+ *   <li>{@code *literal*} — two wildcards, only a middle literal</li>
+ *   <li>{@code prefix*literal*} — two wildcards, prefix + middle</li>
+ *   <li>{@code *literal*suffix} — two wildcards, middle + suffix</li>
+ *   <li>{@code prefix*literal*suffix} — two wildcards, all three segments</li>
+ * </ul>
+ *
+ * <p>Patterns that fall outside the family stay on the automaton path and produce {@code null}
+ * from {@link #of(String)}:
+ * <ul>
+ *   <li>any {@code ?} — single-codepoint wildcard, awkward on UTF-8 byte boundaries</li>
+ *   <li>any {@code \\} backslash anywhere in the pattern — escape handling would need to be
+ *       consistent with Lucene's wildcard un-escaping per segment; rejecting outright keeps the
+ *       parser bit-identical with {@code ByteRunAutomaton} and avoids divergence risk</li>
+ *   <li>three or more unescaped, non-adjacent {@code *} — would require multi-segment ordered
+ *       contains, more complex than the affix-contains shape can express</li>
+ *   <li>an empty pattern — degenerate; {@code WildcardPattern} guards against it upstream</li>
+ *   <li>a pattern with no {@code *} — equivalent to {@code Equals}, which the logical optimizer
+ *       already decomposes; not the responsibility of this parser</li>
+ * </ul>
+ *
+ * <p>Bytes are committed to UTF-8 by way of {@link BytesRef#BytesRef(CharSequence)}, matching
+ * what KEYWORD values are encoded as on the read path.
+ *
+ * @param prefix  the literal prefix, or {@code null} if the pattern starts with {@code *}
+ * @param literal the literal middle substring, or {@code null} if the pattern has fewer than two
+ *                {@code *} runs or the middle segment is empty
+ * @param suffix  the literal suffix, or {@code null} if the pattern ends with {@code *}
+ */
+public record WildcardLikeShape(@Nullable BytesRef prefix, @Nullable BytesRef literal, @Nullable BytesRef suffix) {
+
+    /**
+     * Returns the shape of the given case-sensitive {@code WildcardLike} pattern, or {@code null}
+     * if the pattern is outside the affix-contains family (see the class-level docs).
+     *
+     * <p>Caller is responsible for the case-sensitivity check — this parser is intentionally
+     * blind to it so the rule is local.
+     */
+    @Nullable
+    public static WildcardLikeShape of(String pattern) {
+        int len = pattern.length();
+        if (len == 0) {
+            return null;
+        }
+        // Walk once. Each unescaped non-collapsed '*' closes the current literal segment and
+        // opens the next one. We track at most three segments (prefix, middle, suffix); a fourth
+        // segment means a third star, which is outside the affix-contains shape — bail out.
+        // Adjacent '*'s collapse so '**foo**bar*' is parsed as '*foo*bar*'. '?' or '\\' anywhere
+        // forces the automaton path.
+        int segCount = 0;
+        int[] segStart = new int[3];
+        int[] segEnd = new int[3];
+        int currentStart = 0;
+        boolean lastWasStar = false;
+        for (int i = 0; i < len; i++) {
+            char c = pattern.charAt(i);
+            if (c == '?' || c == '\\') {
+                return null;
+            }
+            if (c == '*') {
+                if (lastWasStar) {
+                    currentStart = i + 1;
+                    continue;
+                }
+                if (segCount == 3) {
+                    return null;
+                }
+                segStart[segCount] = currentStart;
+                segEnd[segCount] = i;
+                segCount++;
+                currentStart = i + 1;
+                lastWasStar = true;
+            } else {
+                lastWasStar = false;
+            }
+        }
+        if (segCount == 0) {
+            // No '*' at all — equivalent to Equals, already decomposed by the logical optimizer.
+            return null;
+        }
+        // The trailing segment (after the final star, possibly empty) is also a valid segment.
+        if (segCount == 3) {
+            return null;
+        }
+        segStart[segCount] = currentStart;
+        segEnd[segCount] = len;
+        segCount++;
+        // segCount is now 2 (one '*') or 3 (two '*'s).
+        BytesRef prefix = sliceOrNull(pattern, segStart[0], segEnd[0]);
+        if (segCount == 2) {
+            // 'prefix*suffix', 'prefix*', '*suffix', or '*' (collapsed forms included).
+            BytesRef suffix = sliceOrNull(pattern, segStart[1], segEnd[1]);
+            return new WildcardLikeShape(prefix, null, suffix);
+        }
+        BytesRef middle = sliceOrNull(pattern, segStart[1], segEnd[1]);
+        BytesRef suffix = sliceOrNull(pattern, segStart[2], segEnd[2]);
+        return new WildcardLikeShape(prefix, middle, suffix);
+    }
+
+    @Nullable
+    private static BytesRef sliceOrNull(String pattern, int start, int end) {
+        if (end <= start) {
+            return null;
+        }
+        return new BytesRef(pattern.substring(start, end));
+    }
+
+    /**
+     * Returns {@code true} when this shape selects every value (every component is absent).
+     * Equivalent to a {@code LIKE *} pattern; callers typically have an upstream {@code matchesAll}
+     * fast path that handles this without dispatching to {@link ByteMatchers#affixContains}.
+     */
+    public boolean matchesAll() {
+        return prefix == null && literal == null && suffix == null;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/pushdown/ByteMatchersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/pushdown/ByteMatchersTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.pushdown;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.charset.StandardCharsets;
+
+public class ByteMatchersTests extends ESTestCase {
+
+    public void testEqualsHappyPath() {
+        assertTrue(ByteMatchers.equals(new BytesRef("hello"), new BytesRef("hello")));
+        assertFalse(ByteMatchers.equals(new BytesRef("hello"), new BytesRef("world")));
+        // Equal length, single byte differs.
+        assertFalse(ByteMatchers.equals(new BytesRef("hellO"), new BytesRef("hello")));
+    }
+
+    public void testEqualsLengthMismatchShortCircuits() {
+        // Different lengths must return false without descending to Arrays.equals — the
+        // pre-check guards the contract that Arrays.equals is only called on equal-length slices.
+        assertFalse(ByteMatchers.equals(new BytesRef("hello"), new BytesRef("hello!")));
+        assertFalse(ByteMatchers.equals(new BytesRef("hello!"), new BytesRef("hello")));
+    }
+
+    public void testEqualsEmpty() {
+        assertTrue(ByteMatchers.equals(new BytesRef(""), new BytesRef("")));
+        assertFalse(ByteMatchers.equals(new BytesRef(""), new BytesRef("x")));
+    }
+
+    public void testEqualsRespectsBytesRefOffset() {
+        // BytesRef can hold a slice of a larger backing array — equals must honor offset/length.
+        byte[] backing = "XXXhelloYYY".getBytes(StandardCharsets.UTF_8);
+        BytesRef sliced = new BytesRef(backing, 3, 5);
+        assertTrue(ByteMatchers.equals(sliced, new BytesRef("hello")));
+        assertFalse(ByteMatchers.equals(sliced, new BytesRef("XXXhello")));
+    }
+
+    public void testStartsWithHappyPath() {
+        assertTrue(ByteMatchers.startsWith(new BytesRef("https://www.google.com/"), new BytesRef("https://")));
+        assertFalse(ByteMatchers.startsWith(new BytesRef("https://www.google.com/"), new BytesRef("http://")));
+    }
+
+    public void testStartsWithEmptyPrefixMatchesAlways() {
+        // SQL convention and the wildcard-shape parser both treat an absent prefix as a no-op.
+        assertTrue(ByteMatchers.startsWith(new BytesRef("anything"), new BytesRef("")));
+        assertTrue(ByteMatchers.startsWith(new BytesRef(""), new BytesRef("")));
+    }
+
+    public void testStartsWithLongerPrefixReturnsFalse() {
+        assertFalse(ByteMatchers.startsWith(new BytesRef("abc"), new BytesRef("abcd")));
+    }
+
+    public void testStartsWithExactMatch() {
+        assertTrue(ByteMatchers.startsWith(new BytesRef("abc"), new BytesRef("abc")));
+    }
+
+    public void testStartsWithRespectsBytesRefOffset() {
+        byte[] backing = "XXXhelloYYY".getBytes(StandardCharsets.UTF_8);
+        BytesRef sliced = new BytesRef(backing, 3, 5);
+        assertTrue(ByteMatchers.startsWith(sliced, new BytesRef("hel")));
+        assertFalse(ByteMatchers.startsWith(sliced, new BytesRef("XXX")));
+    }
+
+    public void testEndsWithHappyPath() {
+        assertTrue(ByteMatchers.endsWith(new BytesRef("photo.jpg"), new BytesRef(".jpg")));
+        assertFalse(ByteMatchers.endsWith(new BytesRef("photo.jpg"), new BytesRef(".png")));
+    }
+
+    public void testEndsWithEmptySuffixMatchesAlways() {
+        assertTrue(ByteMatchers.endsWith(new BytesRef("anything"), new BytesRef("")));
+        assertTrue(ByteMatchers.endsWith(new BytesRef(""), new BytesRef("")));
+    }
+
+    public void testEndsWithLongerSuffixReturnsFalse() {
+        assertFalse(ByteMatchers.endsWith(new BytesRef("abc"), new BytesRef("zabc")));
+    }
+
+    public void testEndsWithExactMatch() {
+        assertTrue(ByteMatchers.endsWith(new BytesRef("abc"), new BytesRef("abc")));
+    }
+
+    public void testEndsWithRespectsBytesRefOffset() {
+        byte[] backing = "XXXhelloYYY".getBytes(StandardCharsets.UTF_8);
+        BytesRef sliced = new BytesRef(backing, 3, 5);
+        assertTrue(ByteMatchers.endsWith(sliced, new BytesRef("llo")));
+        assertFalse(ByteMatchers.endsWith(sliced, new BytesRef("YYY")));
+    }
+
+    public void testContainsLiteralHappyPath() {
+        // Long enough to clear the SIMD activation threshold (>= 24 bytes inside ESVectorUtil).
+        BytesRef url = new BytesRef("https://www.google.com/maps/place/London");
+        assertTrue(ByteMatchers.containsLiteral(url, new BytesRef("google")));
+        assertTrue(ByteMatchers.containsLiteral(url, new BytesRef("maps")));
+        assertFalse(ByteMatchers.containsLiteral(url, new BytesRef("bing")));
+    }
+
+    public void testContainsLiteralEmptyMatchesAlways() {
+        assertTrue(ByteMatchers.containsLiteral(new BytesRef("anything"), new BytesRef("")));
+        assertTrue(ByteMatchers.containsLiteral(new BytesRef(""), new BytesRef("")));
+    }
+
+    public void testContainsLiteralLongerThanValueReturnsFalse() {
+        assertFalse(ByteMatchers.containsLiteral(new BytesRef("abc"), new BytesRef("abcd")));
+    }
+
+    public void testContainsLiteralRespectsLiteralBytesRefOffset() {
+        // BinaryDocValuesContainsTermQuery#contains forwards the term's offset; if we ever stop
+        // doing so the SIMD scan would search the wrong bytes. Pin the contract from this side.
+        byte[] backing = "ZZZgoogleYYY".getBytes(StandardCharsets.UTF_8);
+        BytesRef literal = new BytesRef(backing, 3, 6);
+        assertTrue(ByteMatchers.containsLiteral(new BytesRef("https://www.google.com"), literal));
+        // The 'ZZZ' bytes outside the literal's window must not satisfy the search.
+        BytesRef zzzOnly = new BytesRef(backing, 0, 3);
+        assertFalse(ByteMatchers.containsLiteral(new BytesRef("https://www.google.com"), zzzOnly));
+    }
+
+    public void testAffixContainsExactFitNoLiteral() {
+        // prefix.length + suffix.length == value.length, no literal — the affixes meet at the
+        // middle with zero bytes between them. Must match.
+        assertTrue(ByteMatchers.affixContains(new BytesRef("abcd"), new BytesRef("ab"), null, new BytesRef("cd")));
+        // One byte short — combined-length guard rejects.
+        assertFalse(ByteMatchers.affixContains(new BytesRef("abc"), new BytesRef("ab"), null, new BytesRef("cd")));
+    }
+
+    public void testAffixContainsExactFitWithLiteral() {
+        // prefix + literal + suffix == value.length — literal occupies the entire middle slice.
+        assertTrue(ByteMatchers.affixContains(new BytesRef("abxxcd"), new BytesRef("ab"), new BytesRef("xx"), new BytesRef("cd")));
+        // One byte more than the literal needs — middle slice has room left over, literal still found.
+        assertTrue(ByteMatchers.affixContains(new BytesRef("abxxXcd"), new BytesRef("ab"), new BytesRef("xx"), new BytesRef("cd")));
+        // Literal does not appear in the middle slice (the only "xx" is straddling prefix/middle).
+        assertFalse(ByteMatchers.affixContains(new BytesRef("axxxcd"), new BytesRef("ax"), new BytesRef("xy"), new BytesRef("cd")));
+    }
+
+    public void testAffixContainsAllNullBehavesLikeMatchesAll() {
+        // Every component absent → match anything non-empty (including empty values).
+        assertTrue(ByteMatchers.affixContains(new BytesRef(""), null, null, null));
+        assertTrue(ByteMatchers.affixContains(new BytesRef("anything"), null, null, null));
+    }
+
+    public void testAffixContainsPrefixOnly() {
+        // Equivalent to startsWith.
+        assertTrue(ByteMatchers.affixContains(new BytesRef("https://www.google.com/"), new BytesRef("https://"), null, null));
+        assertFalse(ByteMatchers.affixContains(new BytesRef("https://www.google.com/"), new BytesRef("http://"), null, null));
+    }
+
+    public void testAffixContainsSuffixOnly() {
+        assertTrue(ByteMatchers.affixContains(new BytesRef("photo.jpg"), null, null, new BytesRef(".jpg")));
+        assertFalse(ByteMatchers.affixContains(new BytesRef("photo.jpg"), null, null, new BytesRef(".png")));
+    }
+
+    public void testAffixContainsLiteralOnly() {
+        BytesRef url = new BytesRef("https://www.google.com/maps");
+        assertTrue(ByteMatchers.affixContains(url, null, new BytesRef("google"), null));
+        assertFalse(ByteMatchers.affixContains(url, null, new BytesRef("bing"), null));
+    }
+
+    public void testAffixContainsPrefixAndSuffix() {
+        // 'http*com' shape — both affixes present, no literal in the middle.
+        BytesRef url = new BytesRef("https://www.google.com");
+        assertTrue(ByteMatchers.affixContains(url, new BytesRef("http"), null, new BytesRef("com")));
+        assertFalse(ByteMatchers.affixContains(url, new BytesRef("ftp"), null, new BytesRef("com")));
+        assertFalse(ByteMatchers.affixContains(url, new BytesRef("http"), null, new BytesRef("net")));
+    }
+
+    public void testAffixContainsAllThreeComponents() {
+        // 'http*google*com' shape — all three present.
+        BytesRef url = new BytesRef("https://www.google.com");
+        assertTrue(ByteMatchers.affixContains(url, new BytesRef("http"), new BytesRef("google"), new BytesRef("com")));
+        // Same value with a literal that is not present in the middle slice.
+        assertFalse(ByteMatchers.affixContains(url, new BytesRef("http"), new BytesRef("yahoo"), new BytesRef("com")));
+        // Affixes don't fit.
+        assertFalse(ByteMatchers.affixContains(new BytesRef("ab"), new BytesRef("a"), new BytesRef("x"), new BytesRef("b")));
+    }
+
+    public void testAffixContainsLiteralMustLiveStrictlyBetweenAffixes() {
+        // Pins the contract that the literal scan is restricted to value[prefix.length .. value.length - suffix.length].
+        // Without that restriction, the literal "aXa" would match the *full* value "aXa" trivially —
+        // but the affix-contains shape "a*aXa*a" semantically requires "aXa" to appear between the
+        // a-prefix and a-suffix, i.e. inside an empty middle slice. That cannot match.
+        BytesRef value = new BytesRef("aXa");
+        assertFalse(ByteMatchers.affixContains(value, new BytesRef("a"), new BytesRef("aXa"), new BytesRef("a")));
+        // But "a*X*a" does match — middle slice is "X" and "X" appears in it.
+        assertTrue(ByteMatchers.affixContains(value, new BytesRef("a"), new BytesRef("X"), new BytesRef("a")));
+    }
+
+    public void testAffixContainsRespectsBytesRefOffset() {
+        // Backing array carries garbage on either side of the value; offsets must isolate the
+        // affix and middle-slice scans to the value's window.
+        byte[] backing = "ZZZhttps://www.google.com/mapsZZZ".getBytes(StandardCharsets.UTF_8);
+        BytesRef value = new BytesRef(backing, 3, 27);
+        assertTrue(ByteMatchers.affixContains(value, new BytesRef("https://"), new BytesRef("google"), new BytesRef("/maps")));
+        // The 'ZZZ' bytes outside the window must not satisfy the affixes.
+        assertFalse(ByteMatchers.affixContains(value, new BytesRef("ZZZ"), null, null));
+        assertFalse(ByteMatchers.affixContains(value, null, null, new BytesRef("ZZZ")));
+    }
+
+    public void testAffixContainsCombinedLengthGuard() {
+        // prefix + literal + suffix together exceed value length → false without further work.
+        // Without the guard, this would either OOB or do unnecessary scans.
+        BytesRef shortValue = new BytesRef("abc");
+        assertFalse(ByteMatchers.affixContains(shortValue, new BytesRef("ab"), new BytesRef("xyz"), new BytesRef("c")));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/pushdown/WildcardLikeShapeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/datasources/pushdown/WildcardLikeShapeTests.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.datasources.pushdown;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.charset.StandardCharsets;
+
+public class WildcardLikeShapeTests extends ESTestCase {
+
+    public void testPrefixOnly() {
+        WildcardLikeShape s = WildcardLikeShape.of("foo*");
+        assertNotNull(s);
+        assertEquals(new BytesRef("foo"), s.prefix());
+        assertNull(s.literal());
+        assertNull(s.suffix());
+        assertFalse(s.matchesAll());
+    }
+
+    public void testSuffixOnly() {
+        WildcardLikeShape s = WildcardLikeShape.of("*foo");
+        assertNotNull(s);
+        assertNull(s.prefix());
+        assertNull(s.literal());
+        assertEquals(new BytesRef("foo"), s.suffix());
+    }
+
+    public void testPrefixAndSuffix() {
+        WildcardLikeShape s = WildcardLikeShape.of("http*com");
+        assertNotNull(s);
+        assertEquals(new BytesRef("http"), s.prefix());
+        assertNull(s.literal());
+        assertEquals(new BytesRef("com"), s.suffix());
+    }
+
+    public void testContainsLiteralOnly() {
+        WildcardLikeShape s = WildcardLikeShape.of("*google*");
+        assertNotNull(s);
+        assertNull(s.prefix());
+        assertEquals(new BytesRef("google"), s.literal());
+        assertNull(s.suffix());
+    }
+
+    public void testPrefixAndLiteral() {
+        WildcardLikeShape s = WildcardLikeShape.of("http*google*");
+        assertNotNull(s);
+        assertEquals(new BytesRef("http"), s.prefix());
+        assertEquals(new BytesRef("google"), s.literal());
+        assertNull(s.suffix());
+    }
+
+    public void testLiteralAndSuffix() {
+        WildcardLikeShape s = WildcardLikeShape.of("*google*com");
+        assertNotNull(s);
+        assertNull(s.prefix());
+        assertEquals(new BytesRef("google"), s.literal());
+        assertEquals(new BytesRef("com"), s.suffix());
+    }
+
+    public void testFullAffixContains() {
+        WildcardLikeShape s = WildcardLikeShape.of("http*google*com");
+        assertNotNull(s);
+        assertEquals(new BytesRef("http"), s.prefix());
+        assertEquals(new BytesRef("google"), s.literal());
+        assertEquals(new BytesRef("com"), s.suffix());
+    }
+
+    public void testStarAloneIsMatchesAll() {
+        WildcardLikeShape s = WildcardLikeShape.of("*");
+        assertNotNull(s);
+        assertTrue(s.matchesAll());
+        assertNull(s.prefix());
+        assertNull(s.literal());
+        assertNull(s.suffix());
+    }
+
+    public void testAdjacentStarsCollapseInPrefix() {
+        // "**" semantically matches anything — same as "*".
+        WildcardLikeShape s = WildcardLikeShape.of("**");
+        assertNotNull(s);
+        assertTrue(s.matchesAll());
+    }
+
+    public void testAdjacentStarsCollapseInLiteral() {
+        // "*foo**bar*" semantically equals "*foo*bar*", which has 3 unescaped non-adjacent stars
+        // (4 segments) and is outside the affix-contains family.
+        assertNull(WildcardLikeShape.of("*foo**bar*"));
+    }
+
+    public void testAdjacentStarsCollapseAtTail() {
+        // "foo***" collapses to "foo*" — pure prefix.
+        WildcardLikeShape s = WildcardLikeShape.of("foo***");
+        assertNotNull(s);
+        assertEquals(new BytesRef("foo"), s.prefix());
+        assertNull(s.literal());
+        assertNull(s.suffix());
+    }
+
+    public void testTooManyStarsRejected() {
+        // 'prefix*literal1*literal2*literal3*suffix' shape would need ordered substring matching;
+        // not in the affix-contains family.
+        assertNull(WildcardLikeShape.of("a*b*c*d"));
+    }
+
+    public void testQuestionMarkRejected() {
+        // '?' matches a single Unicode codepoint, awkward on UTF-8 byte boundaries.
+        assertNull(WildcardLikeShape.of("foo?bar"));
+        assertNull(WildcardLikeShape.of("*foo?bar*"));
+        assertNull(WildcardLikeShape.of("foo*bar?"));
+    }
+
+    public void testEscapeRejected() {
+        // Any backslash escape forces the automaton path so this parser stays simple and
+        // verifiably correct.
+        assertNull(WildcardLikeShape.of("foo\\*bar"));
+        assertNull(WildcardLikeShape.of("foo\\?bar"));
+        assertNull(WildcardLikeShape.of("foo\\\\bar"));
+        assertNull(WildcardLikeShape.of("*foo\\*bar*"));
+    }
+
+    public void testNoWildcardRejected() {
+        // Equivalent to Equals — already decomposed by the logical optimizer; out of scope here.
+        assertNull(WildcardLikeShape.of("exact"));
+    }
+
+    public void testEmptyPatternRejected() {
+        assertNull(WildcardLikeShape.of(""));
+    }
+
+    public void testUtf8MultiByteLiterals() {
+        // The shape parser commits to UTF-8 bytes — what KEYWORD inputs are encoded as on disk.
+        WildcardLikeShape s = WildcardLikeShape.of("*café*");
+        assertNotNull(s);
+        assertEquals(new BytesRef("café"), s.literal());
+        // 'café' is 5 UTF-8 bytes (c=1, a=1, f=1, é=2).
+        assertEquals(5, s.literal().length);
+    }
+
+    public void testSingleCharSegments() {
+        WildcardLikeShape s = WildcardLikeShape.of("a*b*c");
+        assertNotNull(s);
+        assertEquals(new BytesRef("a"), s.prefix());
+        assertEquals(new BytesRef("b"), s.literal());
+        assertEquals(new BytesRef("c"), s.suffix());
+    }
+
+    /**
+     * Property pin: for every accepted shape, {@link ByteMatchers#affixContains} must agree with
+     * the {@link ByteRunAutomaton} compiled from the same Lucene wildcard pattern on every value
+     * in a randomized corpus. Because the affix-contains dispatcher is the sole consumer of this
+     * parser inside the Parquet evaluator, divergence here would silently change query results.
+     *
+     * <p>The corpus mixes values that satisfy zero, one, two, and three of the components, plus
+     * values shorter than the combined affix length (to exercise the combined-length guard). The
+     * patterns sweep every shape branch in {@link WildcardLikeShape#of}.
+     */
+    public void testAffixContainsAgreesWithByteRunAutomaton() {
+        String[] patterns = {
+            "https*",
+            "*.com",
+            "*google*",
+            "https*com",
+            "https*google*",
+            "*google*com",
+            "https*google*com",
+            "a*",
+            "*a",
+            "*a*",
+            "a*b",
+            "a*b*",
+            "*a*b",
+            "a*b*c" };
+        String[] values = {
+            "",
+            "a",
+            "ab",
+            "abc",
+            "https://www.google.com",
+            "https://www.google.org",
+            "ftp://www.google.com",
+            "https://com",
+            "https://www.bing.com",
+            "google",
+            "googleSurprise.com",
+            ".com",
+            "https://www.café.com" };
+        for (String pattern : patterns) {
+            WildcardLikeShape shape = WildcardLikeShape.of(pattern);
+            assertNotNull("pattern [" + pattern + "] should be in the affix-contains family", shape);
+            ByteRunAutomaton runner = new ByteRunAutomaton(
+                WildcardQuery.toAutomaton(new Term("f", pattern), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT)
+            );
+            for (String v : values) {
+                byte[] bytes = v.getBytes(StandardCharsets.UTF_8);
+                BytesRef ref = new BytesRef(bytes);
+                boolean fromAutomaton = runner.run(bytes, 0, bytes.length);
+                boolean fromShape = ByteMatchers.affixContains(ref, shape.prefix(), shape.literal(), shape.suffix());
+                assertEquals("pattern [" + pattern + "] value [" + v + "]: shape and automaton diverge", fromAutomaton, fromShape);
+            }
+        }
+    }
+}


### PR DESCRIPTION
> Stacked on top of #149026 (SIMD `*literal*` LIKE). Reviewing this diff alone is correct; the merge order matters: #149026 first, then this. Once #149026 lands, this PR will rebase onto `main` automatically.

Extracts reusable byte-level matching primitives into a shared `datasources.pushdown` package and wires Parquet's late-materialization evaluator through them.

## What changes

**New shared utilities** (`x-pack/plugin/esql/.../datasources/pushdown/`)
- `ByteMatchers` — `equals`/`startsWith`/`endsWith`/`containsLiteral`/`affixContains`. Affix checks route through `Arrays.equals` (JDK SIMD intrinsic, partial-inlined for slices ≤ 64 B); substring scan reuses the `ESVectorUtil#contains` shim from `:server`.
- `WildcardLikeShape` — parses LIKE patterns into `(prefix, literal, suffix)`. Covers 7 shapes: `prefix*`, `*suffix`, `*literal*`, `prefix*suffix`, `prefix*literal*`, `*literal*suffix`, `prefix*literal*suffix`. Adjacent `*` collapse; `?`, `\`, and 3+ non-adjacent `*` fall back to the automaton path so parity with `ByteRunAutomaton` is preserved.

**ParquetPushedExpressions wiring**
- `evaluateStartsWith` → `ByteMatchers.startsWith`.
- `Equals`/`NotEquals` on KEYWORD → `ByteMatchers.equals`. `LT`/`LE`/`GT`/`GE` keep `BytesRef#compareTo` (lex order required).
- `evaluateWildcardLike` → dispatches every accepted shape to `ByteMatchers.affixContains`. The previous `extractContainsLiteral` static helper is retired in favor of `WildcardLikeShape.of`.

## Why generic

The new utilities live in `org.elasticsearch.xpack.esql.datasources.pushdown` (sibling to the pre-existing `StringPrefixUtils` shared by Parquet, parquet-rs, and ORC). Today only Parquet performs in-Java late-materialization byte-level evaluation, but the primitives are deliberately storage-agnostic so future evaluators can pick them up without copy-pasting the byte loops.

## Performance (smoke runs, JMH)

`WildcardLikeMatcherBenchmark`, automaton vs `affixContains` on a 120-byte URL corpus:

| Shape | automaton (ops/μs) | affixContains (ops/μs) | Speedup |
|---|---:|---:|---:|
| `PREFIX_ONLY` | 3.0 | 154 | **51×** |
| `SUFFIX_ONLY` | 3.7 | 181 | **49×** |
| `CONTAINS_ONLY` | 3.0 | 56 | **19×** |
| `PREFIX_SUFFIX` | 3.4 | 101 | **30×** |
| `PREFIX_CONTAINS_SUFFIX` | 3.0 | 53 | **18×** |
| `COMPLEX_AUTOMATON_FALLBACK` | 3.3 | 3.2 | **~1×** (correct fallback) |

`StartsWithBenchmark`, scalar loop vs `Arrays.equals` intrinsic at 80-byte values: intrinsic wins **1.4×–4×** for prefixes ≥ 16 B; ties at 8 B; ~2× slower at 4 B (partial-inline overhead is unavoidable at that size).

Both benchmarks self-test in `@Setup` against the reference implementation per `benchmarks/AGENTS.md`.

## Testing

- `ByteMatchersTests` — 23 unit tests including `BytesRef.offset` handling, exact-fit and combined-length-guard edges, the literal-must-live-strictly-between-affixes contract.
- `WildcardLikeShapeTests` — 18 parser tests + a randomized property test that asserts `affixContains` agrees with `ByteRunAutomaton` on every accepted shape × every value in a mixed corpus.
- `ParquetPushedExpressionsEvaluatorTests` — extended the cross-check test to iterate all 10 representative LIKE shapes for ordinal-vs-scalar agreement; added 7 new functional tests pinning Equals, NotEquals, plain-block LessThan, prefix/suffix/full-affix dispatches.

Developed with AI-assisted tooling