### PR TITLE
[ESQL] Speed up REPLACE on constant regex

### DIFF
--- a/docs/changelog/149033.yaml
+++ b/docs/changelog/149033.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149033
+summary: Speed up REPLACE on constant regex
+type: enhancement

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceConstantEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceConstantEvaluator.java
@@ -33,6 +33,8 @@ public final class ReplaceConstantEvaluator implements ExpressionEvaluator {
 
   private final Pattern regex;
 
+  private final byte[] literalPrefix;
+
   private final ExpressionEvaluator newStr;
 
   private final DriverContext driverContext;
@@ -40,10 +42,11 @@ public final class ReplaceConstantEvaluator implements ExpressionEvaluator {
   private Warnings warnings;
 
   public ReplaceConstantEvaluator(Source source, ExpressionEvaluator str, Pattern regex,
-      ExpressionEvaluator newStr, DriverContext driverContext) {
+      byte[] literalPrefix, ExpressionEvaluator newStr, DriverContext driverContext) {
     this.source = source;
     this.str = str;
     this.regex = regex;
+    this.literalPrefix = literalPrefix;
     this.newStr = newStr;
     this.driverContext = driverContext;
   }
@@ -103,7 +106,7 @@ public final class ReplaceConstantEvaluator implements ExpressionEvaluator {
         BytesRef str = strBlock.getBytesRef(strBlock.getFirstValueIndex(p), strScratch);
         BytesRef newStr = newStrBlock.getBytesRef(newStrBlock.getFirstValueIndex(p), newStrScratch);
         try {
-          result.appendBytesRef(Replace.process(str, this.regex, newStr));
+          result.appendBytesRef(Replace.process(str, this.regex, this.literalPrefix, newStr));
         } catch (IllegalArgumentException e) {
           warnings().registerException(e);
           result.appendNull();
@@ -122,7 +125,7 @@ public final class ReplaceConstantEvaluator implements ExpressionEvaluator {
         BytesRef str = strVector.getBytesRef(p, strScratch);
         BytesRef newStr = newStrVector.getBytesRef(p, newStrScratch);
         try {
-          result.appendBytesRef(Replace.process(str, this.regex, newStr));
+          result.appendBytesRef(Replace.process(str, this.regex, this.literalPrefix, newStr));
         } catch (IllegalArgumentException e) {
           warnings().registerException(e);
           result.appendNull();
@@ -156,19 +159,22 @@ public final class ReplaceConstantEvaluator implements ExpressionEvaluator {
 
     private final Pattern regex;
 
+    private final byte[] literalPrefix;
+
     private final ExpressionEvaluator.Factory newStr;
 
     public Factory(Source source, ExpressionEvaluator.Factory str, Pattern regex,
-        ExpressionEvaluator.Factory newStr) {
+        byte[] literalPrefix, ExpressionEvaluator.Factory newStr) {
       this.source = source;
       this.str = str;
       this.regex = regex;
+      this.literalPrefix = literalPrefix;
       this.newStr = newStr;
     }
 
     @Override
     public ReplaceConstantEvaluator get(DriverContext context) {
-      return new ReplaceConstantEvaluator(source, str.get(context), regex, newStr.get(context), context);
+      return new ReplaceConstantEvaluator(source, str.get(context), regex, literalPrefix, newStr.get(context), context);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Replace.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Replace.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunctio
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -130,10 +131,19 @@ public class Replace extends EsqlScalarFunction {
         return str.foldable() && regex.foldable() && newStr.foldable();
     }
 
+    /**
+     * Empty literal-prefix sentinel: when the regex has no extractable anchored literal prefix,
+     * the constant evaluator is built with this array and the byte-level fast-path check is skipped.
+     */
+    static final byte[] NO_LITERAL_PREFIX = new byte[0];
+
     @Evaluator(extraName = "Constant", warnExceptions = IllegalArgumentException.class)
-    static BytesRef process(BytesRef str, @Fixed Pattern regex, BytesRef newStr) {
+    static BytesRef process(BytesRef str, @Fixed Pattern regex, @Fixed(includeInToString = false) byte[] literalPrefix, BytesRef newStr) {
         if (str == null || regex == null || newStr == null) {
             return null;
+        }
+        if (literalPrefix.length > 0 && startsWith(str, literalPrefix) == false) {
+            return str;
         }
         return safeReplace(str, regex, newStr);
     }
@@ -147,6 +157,224 @@ public class Replace extends EsqlScalarFunction {
             return str;
         }
         return safeReplace(str, Pattern.compile(regex.utf8ToString()), newStr);
+    }
+
+    /**
+     * Byte-level prefix check on a {@link BytesRef}. Cheaper than {@link BytesRef#utf8ToString()}
+     * + {@link String#startsWith(String)} because it avoids the UTF-8 to UTF-16 conversion and
+     * the {@link String} allocation. Safe for UTF-8 because the prefix bytes are themselves a
+     * complete UTF-8 sequence (produced by {@link String#getBytes(java.nio.charset.Charset)}).
+     */
+    static boolean startsWith(BytesRef ref, byte[] prefix) {
+        if (ref.length < prefix.length) {
+            return false;
+        }
+        return Arrays.equals(ref.bytes, ref.offset, ref.offset + prefix.length, prefix, 0, prefix.length);
+    }
+
+    /**
+     * Extract a literal UTF-8 byte prefix from a constant regex pattern, when safe to do so.
+     * <p>
+     * Returns {@link #NO_LITERAL_PREFIX} unless the pattern is anchored at input start and begins
+     * with at least one literal character whose match position can be statically determined.
+     * Conservative by design: any construct that could shift the effective anchor (multiline mode,
+     * top-level alternation, look-arounds, etc.) results in no prefix. When a prefix is returned,
+     * any input that does not start with these bytes is guaranteed not to match the pattern, so the
+     * caller can short-circuit the row without invoking the regex engine.
+     * <p>
+     * Handled constructs:
+     * <ul>
+     *   <li>Anchors {@code ^} and {@code \A} at the start of the pattern.</li>
+     *   <li>Plain literal characters (ASCII and non-ASCII).</li>
+     *   <li>Escaped meta characters (e.g. {@code \.}, {@code \?}).</li>
+     *   <li>{@code \Q...\E} literal sections.</li>
+     * </ul>
+     * Walk semantics for quantifiers attached to a preceding literal:
+     * <ul>
+     *   <li>{@code ?}, {@code *}, {@code {n,m}}: drop the preceding literal (it could be absent) and stop.</li>
+     *   <li>{@code +}: keep the preceding literal but stop the walk (anything after it sits at an unknown offset).</li>
+     * </ul>
+     * Bails on top-level alternation, groups, character classes, anchors elsewhere, inline flags, and any other meta construct.
+     */
+    static byte[] extractLiteralPrefix(Pattern pattern) {
+        // Patterns compiled with these flags can match `^` after newlines, treat the input
+        // case-insensitively / loosely, or change which characters are literal in the pattern source,
+        // any of which would invalidate a byte-level prefix check on the raw input.
+        // - MULTILINE / inline (?m): `^` matches after newlines, not just input start.
+        // - CASE_INSENSITIVE / UNICODE_CASE / inline (?i): the prefix bytes need not equal the input bytes.
+        // - COMMENTS / inline (?x): whitespace and `#…` in the pattern are ignored, so our literal walk would
+        // include characters that the engine treats as comments / whitespace.
+        // - CANON_EQ: two distinct UTF-8 byte sequences can be considered equivalent by the matcher.
+        // - LITERAL: pattern source is treated as a literal string, not a regex (so leading `^` is not an anchor).
+        int flags = pattern.flags();
+        int disqualifying = Pattern.MULTILINE | Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE | Pattern.COMMENTS | Pattern.CANON_EQ
+            | Pattern.LITERAL;
+        if ((flags & disqualifying) != 0) {
+            return NO_LITERAL_PREFIX;
+        }
+        String regex = pattern.pattern();
+        int n = regex.length();
+        if (n == 0) {
+            return NO_LITERAL_PREFIX;
+        }
+
+        int i = 0;
+        if (regex.charAt(i) == '^') {
+            i++;
+        } else if (regex.startsWith("\\A", i)) {
+            i += 2;
+        } else {
+            return NO_LITERAL_PREFIX;
+        }
+
+        // Top-level alternation invalidates anchoring: `^a|b` is `(^a)|(b)`, so an input starting with `b`
+        // would still match. Java regex hex / unicode / control / octal escapes always produce literal
+        // characters (they cannot encode a meta `|`), so a simple literal-`|` scan outside `\Q...\E` is enough.
+        if (containsTopLevelAlternation(regex, i)) {
+            return NO_LITERAL_PREFIX;
+        }
+
+        StringBuilder prefix = new StringBuilder();
+        // Track the last position in `prefix` where a single literal code point was appended,
+        // so a following `?`, `*` or `{...}` quantifier can drop it.
+        int lastLiteralStart = -1;
+
+        while (i < n) {
+            char c = regex.charAt(i);
+
+            // \Q...\E quoted literal section.
+            if (c == '\\' && i + 1 < n && regex.charAt(i + 1) == 'Q') {
+                int end = regex.indexOf("\\E", i + 2);
+                int quoteEnd = (end < 0) ? n : end;
+                // The whole \Q...\E is one literal chunk; treat the last code point inside it
+                // as the "last literal" so a following quantifier (after \E) can drop just that char.
+                if (quoteEnd > i + 2) {
+                    int chunkStart = prefix.length();
+                    prefix.append(regex, i + 2, quoteEnd);
+                    // Set lastLiteralStart to the last code point of the chunk.
+                    lastLiteralStart = prefix.offsetByCodePoints(prefix.length(), -1);
+                    if (lastLiteralStart < chunkStart) {
+                        lastLiteralStart = chunkStart;
+                    }
+                }
+                if (end < 0) {
+                    // Unterminated \Q…; rest of the pattern is literal, we are done.
+                    break;
+                }
+                i = end + 2;
+                continue;
+            }
+
+            if (c == '\\') {
+                if (i + 1 >= n) {
+                    // Trailing backslash — malformed; stop conservatively.
+                    break;
+                }
+                char next = regex.charAt(i + 1);
+                if (isEscapedLiteral(next)) {
+                    lastLiteralStart = prefix.length();
+                    prefix.append(next);
+                    i += 2;
+                    continue;
+                }
+                // Backreferences (\1), character classes (\w, \d, \s, \b, \B, \A, \z, \Z), etc. — bail.
+                break;
+            }
+
+            // Quantifiers attaching to the last literal.
+            if (c == '?' || c == '*') {
+                if (lastLiteralStart < 0) {
+                    break;
+                }
+                prefix.setLength(lastLiteralStart);
+                break;
+            }
+            if (c == '{') {
+                // `{n,m}` — `{0,…}` makes the prior char optional; we conservatively drop it.
+                if (lastLiteralStart < 0) {
+                    break;
+                }
+                prefix.setLength(lastLiteralStart);
+                break;
+            }
+            if (c == '+') {
+                // One-or-more keeps the preceding literal at position `lastLiteralStart`, but anything
+                // after the quantifier sits at an unknown offset, so we stop the walk here without dropping.
+                break;
+            }
+
+            // Any other meta character terminates the literal prefix.
+            // This includes: `.` `(` `[` `|` `$` `)` `]` and the unused-here `^`.
+            if (isRegexMeta(c)) {
+                break;
+            }
+
+            // Plain literal code point (possibly a UTF-16 surrogate pair).
+            lastLiteralStart = prefix.length();
+            if (Character.isHighSurrogate(c) && i + 1 < n && Character.isLowSurrogate(regex.charAt(i + 1))) {
+                prefix.append(c);
+                prefix.append(regex.charAt(i + 1));
+                i += 2;
+            } else {
+                prefix.append(c);
+                i++;
+            }
+        }
+
+        if (prefix.isEmpty()) {
+            return NO_LITERAL_PREFIX;
+        }
+        return prefix.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static boolean isEscapedLiteral(char c) {
+        // Characters that, when preceded by `\`, denote themselves as a literal in Java regex syntax.
+        // We deliberately exclude letters/digits because those introduce special meaning
+        // (\d, \w, \s, \b, \A, \z, \Z, \n, \t, \r, \1, etc.).
+        return switch (c) {
+            case '.', '\\', '/', '(', ')', '[', ']', '{', '}', '*', '+', '?', '|', '^', '$', '-', '"', '\'', '#', ' ', ':', '=', '!', ',',
+                '@', '&', '~', '`', '<', '>', '%' -> true;
+            default -> false;
+        };
+    }
+
+    private static boolean isRegexMeta(char c) {
+        return switch (c) {
+            case '.', '(', ')', '[', ']', '{', '}', '|', '$', '^', '?', '*', '+', '\\' -> true;
+            default -> false;
+        };
+    }
+
+    /**
+     * Returns {@code true} if a literal {@code |} appears outside a {@code \Q...\E} block in the pattern
+     * starting at {@code from}. This is a deliberately coarse check: any {@code |} (including those nested
+     * in a group) disqualifies the pattern, which keeps the analysis simple at the cost of giving up on
+     * patterns like {@code ^a(b|c)} where a prefix could still be extracted.
+     * <p>
+     * Hex / unicode / control / octal escapes in Java regex always produce a literal character (never an
+     * unescaped meta), so they cannot smuggle in a hidden top-level alternation.
+     */
+    private static boolean containsTopLevelAlternation(String regex, int from) {
+        int n = regex.length();
+        for (int i = from; i < n; i++) {
+            char c = regex.charAt(i);
+            if (c == '\\') {
+                if (i + 1 >= n) {
+                    break;
+                }
+                if (regex.charAt(i + 1) == 'Q') {
+                    int end = regex.indexOf("\\E", i + 2);
+                    i = (end < 0) ? n - 1 : end + 1;
+                } else {
+                    i++;
+                }
+                continue;
+            }
+            if (c == '|') {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -214,7 +442,16 @@ public class Replace extends EsqlScalarFunction {
                 // but for the moment we let the exception through
                 throw pse;
             }
-            return new ReplaceConstantEvaluator.Factory(source(), strEval, regexPattern, newStrEval);
+            byte[] literalPrefix = extractLiteralPrefix(regexPattern);
+            if (newStr.foldable() && newStr.dataType() == DataType.KEYWORD) {
+                // Both regex and newStr are constants: use the dictionary-aware evaluator that applies
+                // REPLACE once per dictionary entry on OrdinalBytesRefBlock inputs.
+                BytesRef constantNewStr = BytesRefs.toBytesRef(newStr.fold(toEvaluator.foldCtx()));
+                if (constantNewStr != null) {
+                    return new ReplaceConstantOrdinalEvaluator.Factory(source(), strEval, regexPattern, literalPrefix, constantNewStr);
+                }
+            }
+            return new ReplaceConstantEvaluator.Factory(source(), strEval, regexPattern, literalPrefix, newStrEval);
         }
 
         var regexEval = toEvaluator.apply(regex);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceConstantOrdinalEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceConstantOrdinalEvaluator.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.util.regex.Pattern;
+
+/**
+ * Hand-written {@link ExpressionEvaluator} for {@code REPLACE(str, regex, newStr)} when both
+ * {@code regex} and {@code newStr} are foldable.
+ * <p>
+ * When the input column is dictionary-encoded ({@link OrdinalBytesRefBlock}) and single-valued and dense,
+ * REPLACE is applied once per dictionary entry and the result is emitted as a fresh
+ * {@link OrdinalBytesRefBlock} that re-uses the original ordinals. For a column with N positions backed
+ * by a dictionary of size D, this reduces regex work from N calls down to D — typically a 10–50x
+ * reduction on Lucene keyword columns where doc-value ordinals naturally deduplicate.
+ * <p>
+ * The fast-path is correctness-equivalent to the per-row path because:
+ * <ul>
+ *   <li>REPLACE is a pure function of its inputs, so {@code f(input)} is the same regardless of how many
+ *       rows reference the same dictionary entry.</li>
+ *   <li>Dictionary entries are never null (the {@link BytesRefVector} contract), so the row-level
+ *       null-out logic from the per-row path doesn't apply here — nulls are already represented in
+ *       the ordinals {@link IntBlock} and carried over unchanged.</li>
+ *   <li>If {@link Replace#process} throws {@link IllegalArgumentException} (result-too-large) for any
+ *       dictionary entry, we abandon the dictionary path for this page and fall back to per-row
+ *       evaluation. The fallback emits warnings exactly as the existing per-row path does.</li>
+ * </ul>
+ * <p>
+ * The dictionary path is gated by {@link OrdinalBytesRefBlock#isDense()} and a no-multi-value check;
+ * when those don't hold, evaluation goes through the same per-row loop as
+ * {@code ReplaceConstantEvaluator}.
+ * <p>
+ * The successful dictionary path returns an {@link OrdinalBytesRefBlock}; the per-row fallback returns
+ * a materialized {@code BytesRefBlock} produced by a builder. Logical equality (values, nulls) is
+ * identical between the two — see {@code BytesRefBlock.equals(BytesRefBlock, BytesRefBlock)} — but the
+ * underlying block type may differ. Callers that pattern-match on block identity must not rely on
+ * either shape.
+ */
+final class ReplaceConstantOrdinalEvaluator implements ExpressionEvaluator {
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ReplaceConstantOrdinalEvaluator.class);
+
+    private final Source source;
+    private final ExpressionEvaluator str;
+    private final Pattern regex;
+    private final byte[] literalPrefix;
+    private final BytesRef newStr;
+    private final DriverContext driverContext;
+    private Warnings warnings;
+
+    ReplaceConstantOrdinalEvaluator(
+        Source source,
+        ExpressionEvaluator str,
+        Pattern regex,
+        byte[] literalPrefix,
+        BytesRef newStr,
+        DriverContext driverContext
+    ) {
+        this.source = source;
+        this.str = str;
+        this.regex = regex;
+        this.literalPrefix = literalPrefix;
+        this.newStr = newStr;
+        this.driverContext = driverContext;
+    }
+
+    @Override
+    public Block eval(Page page) {
+        try (BytesRefBlock strBlock = (BytesRefBlock) str.eval(page)) {
+            OrdinalBytesRefBlock ordinals = strBlock.asOrdinals();
+            if (ordinals != null && ordinals.isDense() && ordinals.mayHaveMultivaluedFields() == false) {
+                Block dictResult = evalDictionary(ordinals);
+                if (dictResult != null) {
+                    return dictResult;
+                }
+                // Dictionary path bailed (an entry triggered an exception). Fall through to per-row.
+            }
+            return evalPerRow(page.getPositionCount(), strBlock);
+        }
+    }
+
+    /**
+     * Apply REPLACE once per dictionary entry and build an {@link OrdinalBytesRefBlock} that re-uses the
+     * input ordinals. Returns {@code null} if any dictionary entry throws {@link IllegalArgumentException}
+     * — the caller should fall back to per-row evaluation so warnings get attributed at the row level
+     * exactly as the legacy path would.
+     */
+    private Block evalDictionary(OrdinalBytesRefBlock ordinalsBlock) {
+        BytesRefVector dictionary = ordinalsBlock.getDictionaryVector();
+        int dictSize = dictionary.getPositionCount();
+        BytesRefVector newDictionary = null;
+        try (BytesRefVector.Builder builder = driverContext.blockFactory().newBytesRefVectorBuilder(dictSize)) {
+            BytesRef scratch = new BytesRef();
+            for (int i = 0; i < dictSize; i++) {
+                BytesRef entry = dictionary.getBytesRef(i, scratch);
+                BytesRef replaced;
+                try {
+                    replaced = Replace.process(entry, regex, literalPrefix, newStr);
+                } catch (IllegalArgumentException e) {
+                    // Bail to the per-row path so warnings are emitted from the row that triggered the failure
+                    // (matching the legacy evaluator's behavior).
+                    return null;
+                }
+                builder.appendBytesRef(replaced);
+            }
+            newDictionary = builder.build();
+        }
+        OrdinalBytesRefBlock result = null;
+        try {
+            IntBlock inputOrdinals = ordinalsBlock.getOrdinalsBlock();
+            inputOrdinals.incRef();
+            result = new OrdinalBytesRefBlock(inputOrdinals, newDictionary);
+            newDictionary = null;
+            return result;
+        } finally {
+            if (result == null) {
+                Releasables.closeExpectNoException(newDictionary);
+            }
+        }
+    }
+
+    /**
+     * Per-row fallback. Mirrors the loop emitted by the {@code @Evaluator}-generated
+     * {@code ReplaceConstantEvaluator} so behavior — nulls, multi-value warnings, and per-row exception
+     * handling — matches the legacy path exactly.
+     */
+    private Block evalPerRow(int positionCount, BytesRefBlock strBlock) {
+        try (BytesRefBlock.Builder result = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
+            BytesRef strScratch = new BytesRef();
+            position: for (int p = 0; p < positionCount; p++) {
+                switch (strBlock.getValueCount(p)) {
+                    case 0:
+                        result.appendNull();
+                        continue position;
+                    case 1:
+                        break;
+                    default:
+                        warnings().registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+                        result.appendNull();
+                        continue position;
+                }
+                BytesRef strVal = strBlock.getBytesRef(strBlock.getFirstValueIndex(p), strScratch);
+                try {
+                    result.appendBytesRef(Replace.process(strVal, regex, literalPrefix, newStr));
+                } catch (IllegalArgumentException e) {
+                    warnings().registerException(e);
+                    result.appendNull();
+                }
+            }
+            return result.build();
+        }
+    }
+
+    @Override
+    public long baseRamBytesUsed() {
+        return BASE_RAM_BYTES_USED + str.baseRamBytesUsed();
+    }
+
+    @Override
+    public String toString() {
+        return "ReplaceConstantOrdinalEvaluator[" + "str=" + str + ", regex=" + regex + ", newStr=" + newStr + "]";
+    }
+
+    @Override
+    public void close() {
+        Releasables.closeExpectNoException(str);
+    }
+
+    private Warnings warnings() {
+        if (warnings == null) {
+            this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
+        }
+        return warnings;
+    }
+
+    static final class Factory implements ExpressionEvaluator.Factory {
+        private final Source source;
+        private final ExpressionEvaluator.Factory str;
+        private final Pattern regex;
+        private final byte[] literalPrefix;
+        private final BytesRef newStr;
+
+        Factory(Source source, ExpressionEvaluator.Factory str, Pattern regex, byte[] literalPrefix, BytesRef newStr) {
+            this.source = source;
+            this.str = str;
+            this.regex = regex;
+            this.literalPrefix = literalPrefix;
+            this.newStr = newStr;
+        }
+
+        @Override
+        public ReplaceConstantOrdinalEvaluator get(DriverContext context) {
+            return new ReplaceConstantOrdinalEvaluator(source, str.get(context), regex, literalPrefix, newStr, context);
+        }
+
+        @Override
+        public String toString() {
+            return "ReplaceConstantOrdinalEvaluator[" + "str=" + str + ", regex=" + regex + ", newStr=" + newStr + "]";
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceOrdinalTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceOrdinalTests.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.expression.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
+import org.junit.After;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * Unit tests for the dictionary-memoization fast path in {@link ReplaceConstantOrdinalEvaluator}.
+ * <p>
+ * The {@link ReplaceTests}/{@link ReplaceStaticTests} suites already cover correctness on plain
+ * {@link BytesRefBlock} inputs; this class focuses on the ordinal path:
+ * <ul>
+ *   <li>An {@link OrdinalBytesRefBlock} input that is dense and single-valued takes the fast path
+ *       and produces an {@link OrdinalBytesRefBlock} with a transformed dictionary.</li>
+ *   <li>Output values match the per-row reference (the input fed through plain {@code String.replaceAll}).</li>
+ *   <li>Nulls in the ordinal block are preserved at the same positions.</li>
+ *   <li>A non-dense ordinal block falls back to per-row evaluation but still produces the right values.</li>
+ *   <li>If a dictionary entry would overflow {@code MAX_BYTES_REF_RESULT_SIZE}, the evaluator falls
+ *       back to per-row evaluation and emits the same warning shape as the legacy path.</li>
+ * </ul>
+ */
+public class ReplaceOrdinalTests extends ESTestCase {
+
+    private final List<CircuitBreaker> breakers = Collections.synchronizedList(new ArrayList<>());
+
+    public void testDictionaryFastPathProducesOrdinalBlock() {
+        String[] dictionary = { "http://a.example.com/x", "https://b.example.com/y", "ftp://c.example.org/z" };
+        int[] ordinals = { 0, 1, 0, 2, 1, 0, 1, 2, 0, 0, 1, 2, 2, 0, 1 }; // 15 rows
+        try (Block result = runReplace(dictionary, ordinals, "^https?://(?:www\\.)?([^/]+)/.*$", "$1")) {
+            assertThat("dense ordinal input must produce an OrdinalBytesRefBlock", result, instanceOf(OrdinalBytesRefBlock.class));
+            assertResultValues(result, dictionary, ordinals, "^https?://(?:www\\.)?([^/]+)/.*$", "$1");
+        }
+    }
+
+    public void testDictionaryFastPathPreservesNullPositions() {
+        String[] dictionary = { "http://a/", "http://b/", "http://c/" };
+        // Use null in the ordinals at positions 2 and 5. Ordinals are dense (15 rows, 3 dict entries → ratio 5).
+        Integer[] ordinals = { 0, 1, null, 2, 0, null, 1, 2, 0, 1, 2, 0, 1, 2, 0 };
+        try (Block result = runReplaceWithNulls(dictionary, ordinals, "^https?://([^/]+)/.*$", "$1")) {
+            assertThat(result, instanceOf(OrdinalBytesRefBlock.class));
+            for (int p = 0; p < ordinals.length; p++) {
+                if (ordinals[p] == null) {
+                    assertTrue("position " + p + " should be null", result.isNull(p));
+                } else {
+                    assertFalse("position " + p + " should not be null", result.isNull(p));
+                }
+            }
+        }
+    }
+
+    public void testSparseOrdinalFallsBackToPerRow() {
+        // isDense() requires totalPositions >= 10 AND totalPositions >= 2 * dictSize. A 3-row block with a
+        // 3-entry dictionary fails both, so the evaluator must fall back to the per-row path.
+        String[] dictionary = { "http://a/", "https://b/", "ftp://c/" };
+        int[] ordinals = { 0, 1, 2 };
+        try (Block result = runReplace(dictionary, ordinals, "^https?://([^/]+)/.*$", "$1")) {
+            // The per-row path produces a regular BytesRefBlock, not an OrdinalBytesRefBlock.
+            assertThat(result, instanceOf(BytesRefBlock.class));
+            assertResultValues(result, dictionary, ordinals, "^https?://([^/]+)/.*$", "$1");
+        }
+    }
+
+    public void testDictionaryEntryOverflowFallsBackToPerRow() {
+        // Build a dictionary where one entry, when replaced, exceeds MAX_BYTES_REF_RESULT_SIZE. The
+        // dictionary path should bail and the per-row path should produce null + a warning for the affected
+        // rows (and correct values for the rest).
+        int oversizeLen = (int) (ScalarFunction.MAX_BYTES_REF_RESULT_SIZE / 10);
+        String oversize = "a".repeat(oversizeLen);
+        // Regex `.` with replacement equal to the entry itself; one match expands 1 byte to oversizeLen bytes.
+        String regex = ".";
+        String newStr = oversize;
+
+        String[] dictionary = { "abc", oversize }; // entry 0 small, entry 1 oversize
+        // 12 rows alternating: 0,1,0,1,0,1,0,1,0,1,0,1 — dense + 2*dictSize=4 ≤ 12. Triggers fast-path attempt
+        // which must bail when entry 1 overflows.
+        int[] ordinals = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 };
+        try (Block result = runReplace(dictionary, ordinals, regex, newStr)) {
+            // Fallback path → plain BytesRefBlock with nulls at the oversize-entry positions.
+            for (int p = 0; p < ordinals.length; p++) {
+                if (ordinals[p] == 1) {
+                    assertTrue("position " + p + " (oversize entry) must be null", result.isNull(p));
+                } else {
+                    assertFalse("position " + p + " (small entry) must not be null", result.isNull(p));
+                }
+            }
+            assertWarnings(
+                "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
+                "Line -1:-1: java.lang.IllegalArgumentException: "
+                    + "Creating strings with more than ["
+                    + ScalarFunction.MAX_BYTES_REF_RESULT_SIZE
+                    + "] bytes is not supported"
+            );
+        }
+    }
+
+    private Block runReplace(String[] dictionary, int[] ordinals, String regex, String newStr) {
+        Integer[] boxed = new Integer[ordinals.length];
+        for (int i = 0; i < ordinals.length; i++) {
+            boxed[i] = ordinals[i];
+        }
+        return runReplaceWithNulls(dictionary, boxed, regex, newStr);
+    }
+
+    private Block runReplaceWithNulls(String[] dictionary, Integer[] ordinals, String regex, String newStr) {
+        DriverContext ctx = driverContext();
+        OrdinalBytesRefBlock strBlock = buildOrdinalBlock(ctx.blockFactory(), dictionary, ordinals);
+        ExpressionEvaluator.Factory factory = AbstractScalarFunctionTestCase.evaluator(
+            new Replace(
+                Source.EMPTY,
+                field("text", DataType.KEYWORD),
+                new Literal(Source.EMPTY, new BytesRef(regex), DataType.KEYWORD),
+                new Literal(Source.EMPTY, new BytesRef(newStr), DataType.KEYWORD)
+            )
+        );
+        try (ExpressionEvaluator eval = factory.get(ctx)) {
+            Page page = new Page(strBlock);
+            try {
+                return eval.eval(page);
+            } finally {
+                page.releaseBlocks();
+            }
+        }
+    }
+
+    private static OrdinalBytesRefBlock buildOrdinalBlock(BlockFactory blockFactory, String[] dictionary, Integer[] ordinals) {
+        BytesRefVector dictVector = null;
+        IntBlock ordinalsBlock = null;
+        try (BytesRefVector.Builder dictBuilder = blockFactory.newBytesRefVectorBuilder(dictionary.length)) {
+            for (String entry : dictionary) {
+                dictBuilder.appendBytesRef(new BytesRef(entry));
+            }
+            dictVector = dictBuilder.build();
+            try (IntBlock.Builder b = blockFactory.newIntBlockBuilder(ordinals.length)) {
+                for (Integer ord : ordinals) {
+                    if (ord == null) {
+                        b.appendNull();
+                    } else {
+                        b.appendInt(ord);
+                    }
+                }
+                ordinalsBlock = b.build();
+            }
+            OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(ordinalsBlock, dictVector);
+            dictVector = null;
+            ordinalsBlock = null;
+            return result;
+        } finally {
+            if (dictVector != null) {
+                dictVector.close();
+            }
+            if (ordinalsBlock != null) {
+                ordinalsBlock.close();
+            }
+        }
+    }
+
+    private static void assertResultValues(Block result, String[] dictionary, int[] ordinals, String regex, String newStr) {
+        BytesRefBlock bb = (BytesRefBlock) result;
+        BytesRef scratch = new BytesRef();
+        for (int p = 0; p < ordinals.length; p++) {
+            String expected = dictionary[ordinals[p]].replaceAll(regex, newStr);
+            BytesRef actual = bb.getBytesRef(p, scratch);
+            assertThat("row " + p + " (ordinal " + ordinals[p] + ")", actual.utf8ToString(), equalTo(expected));
+        }
+    }
+
+    private static FieldAttribute field(String name, DataType type) {
+        return new FieldAttribute(Source.synthetic(name), name, new EsField(name, type, Map.of(), true, EsField.TimeSeriesFieldType.NONE));
+    }
+
+    private DriverContext driverContext() {
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofMb(256)).withCircuitBreaking();
+        breakers.add(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST));
+        return new DriverContext(bigArrays, BlockFactory.builder(bigArrays).build(), null);
+    }
+
+    @After
+    public void allMemoryReleased() {
+        for (CircuitBreaker breaker : breakers) {
+            assertThat(breaker.getUsed(), equalTo(0L));
+        }
+    }
+
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceStaticTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.test.TestBlockFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -28,10 +29,12 @@ import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
 import org.junit.After;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -91,6 +94,179 @@ public class ReplaceStaticTests extends ESTestCase {
                 + "Creating strings with more than ["
                 + ScalarFunction.MAX_BYTES_REF_RESULT_SIZE
                 + "] bytes is not supported"
+        );
+    }
+
+    public void testLiteralPrefixSimpleAnchor() {
+        assertPrefix("^http", "http");
+        assertPrefix("^abc", "abc");
+        assertPrefix("\\Aabc", "abc");
+    }
+
+    public void testLiteralPrefixOptionalChar() {
+        // `s?` makes the preceding `s` optional, so the prefix is only `http`.
+        assertPrefix("^https?://", "http");
+        // `*` is the same kind of quantifier.
+        assertPrefix("^foob*ar", "foo");
+        // `{0,3}` makes the preceding char optional.
+        assertPrefix("^foob{0,3}", "foo");
+        // `{2,3}` does NOT make it optional, but we are conservative and drop it anyway.
+        assertPrefix("^foob{2,3}", "foo");
+    }
+
+    public void testLiteralPrefixOneOrMore() {
+        // `+` is one-or-more, so the preceding `b` is required at that position, but any literal
+        // after the quantifier lives at an unknown offset, so we stop the walk there.
+        assertPrefix("^foob+", "foob");
+        assertPrefix("^foob+ar", "foob");
+    }
+
+    public void testLiteralPrefixEscapedSpecials() {
+        assertPrefix("^www\\.example\\.com", "www.example.com");
+        assertPrefix("^\\[special", "[special");
+    }
+
+    public void testLiteralPrefixQuotedSection() {
+        assertPrefix("^\\Q.*[(?)\\Etail", ".*[(?)tail");
+        // Unterminated \Q runs to end of pattern.
+        assertPrefix("^abc\\Q.*[(?)", "abc.*[(?)");
+        // Quantifier after \E drops only the last literal of the quoted chunk.
+        assertPrefix("^\\Qabc\\Ed?", "abc");
+    }
+
+    public void testLiteralPrefixNonAscii() {
+        // Non-ASCII literal — should encode as UTF-8 bytes.
+        byte[] expected = "café".getBytes(StandardCharsets.UTF_8);
+        assertArrayEquals(expected, Replace.extractLiteralPrefix(Pattern.compile("^café")));
+    }
+
+    public void testLiteralPrefixUnicodeSurrogate() {
+        // Supplementary code point (tiger emoji) as a surrogate pair in the regex source.
+        String tiger = "\ud83d\udc05";
+        byte[] expected = ("a" + tiger).getBytes(StandardCharsets.UTF_8);
+        assertArrayEquals(expected, Replace.extractLiteralPrefix(Pattern.compile("^a" + tiger)));
+    }
+
+    public void testLiteralPrefixNoAnchor() {
+        // Pattern must start with ^ or \A.
+        assertNoPrefix("http");
+        assertNoPrefix("abc^");
+        assertNoPrefix("");
+    }
+
+    public void testLiteralPrefixBailsOnAlternation() {
+        // Top-level alternation invalidates anchoring.
+        assertNoPrefix("^a|b");
+        // Alternation inside a group also bails — conservative simplification.
+        assertNoPrefix("^a(b|c)");
+    }
+
+    public void testLiteralPrefixBailsOnLeadingMeta() {
+        assertNoPrefix("^[a-z]+");
+        assertNoPrefix("^(group)");
+        assertNoPrefix("^.foo");
+        assertNoPrefix("^\\d+");
+    }
+
+    public void testLiteralPrefixBailsOnLeadingQuantifier() {
+        // No literal to attach to: `?` at start of body means we have no prefix.
+        assertNoPrefix("^?abc");
+        assertNoPrefix("^*abc");
+    }
+
+    public void testLiteralPrefixBailsOnMultiline() {
+        // With (?m), `^` matches after newlines and a byte-level prefix check would be wrong.
+        assertArrayEquals(Replace.NO_LITERAL_PREFIX, Replace.extractLiteralPrefix(Pattern.compile("^abc", Pattern.MULTILINE)));
+        // Same via inline flag.
+        assertNoPrefix("(?m)^abc");
+    }
+
+    public void testLiteralPrefixBailsOnCaseInsensitive() {
+        assertArrayEquals(Replace.NO_LITERAL_PREFIX, Replace.extractLiteralPrefix(Pattern.compile("^abc", Pattern.CASE_INSENSITIVE)));
+        assertNoPrefix("(?i)^abc");
+    }
+
+    public void testLiteralPrefixBailsOnComments() {
+        // (?x) / Pattern.COMMENTS makes whitespace and `#…` in the pattern source non-literal.
+        assertArrayEquals(Replace.NO_LITERAL_PREFIX, Replace.extractLiteralPrefix(Pattern.compile("^abc", Pattern.COMMENTS)));
+        assertNoPrefix("(?x)^abc");
+    }
+
+    public void testLiteralPrefixBailsOnCanonEq() {
+        assertArrayEquals(Replace.NO_LITERAL_PREFIX, Replace.extractLiteralPrefix(Pattern.compile("^abc", Pattern.CANON_EQ)));
+    }
+
+    public void testLiteralPrefixHexEscapesAreLiteral() {
+        // Java regex hex / unicode / control escapes always produce a literal character — they cannot encode a
+        // meta `|`. So `^a\x7cb` matches the literal string `a|b`, not `^a|b`, and we can safely emit `a` as the
+        // prefix (the walker stops at the unrecognized escape).
+        assertPrefix("^a\\x7cb", "a");
+    }
+
+    public void testEndToEndHexEscapeIsLiteral() {
+        // Sanity: `^a\x7cb` should match the literal "a|b" through the constant evaluator (with the prefix
+        // fast path active). Strings that don't start with `a` are safely rejected.
+        assertThat(processConstantRegex("a|b cat", "^a\\x7cb", "X"), equalTo("X cat"));
+        assertThat(processConstantRegex("baz", "^a\\x7cb", "X"), equalTo("baz"));
+    }
+
+    public void testLiteralPrefixStopsAtMeta() {
+        // For the q28 motivating example.
+        assertPrefix("^https?://(?:www\\.)?([^/]+)/.*$", "http");
+        // Exact-match pattern stops at `$`.
+        assertPrefix("^exact_match$", "exact_match");
+    }
+
+    /**
+     * End-to-end check that the prefix-rejection fast path does not change observable behavior:
+     * inputs that match must still be replaced, and inputs that don't (because they fail the prefix
+     * check) must come back unchanged.
+     */
+    public void testEndToEndAnchoredReplaceRespectsPrefixFastPath() {
+        // Regex with extractable prefix "http" — common motivating shape.
+        String regex = "^https?://(?:www\\.)?([^/]+)/.*$";
+        String newStr = "$1";
+
+        // Matches.
+        assertThat(processConstantRegex("http://example.com/a", regex, newStr), equalTo("example.com"));
+        assertThat(processConstantRegex("https://www.example.com/x/y", regex, newStr), equalTo("example.com"));
+
+        // Does NOT start with the extracted prefix — must be returned unchanged.
+        assertThat(processConstantRegex("ftp://example.com/a", regex, newStr), equalTo("ftp://example.com/a"));
+        assertThat(processConstantRegex("", regex, newStr), equalTo(""));
+        assertThat(processConstantRegex("htt", regex, newStr), equalTo("htt"));
+
+        // Starts with prefix but doesn't fully match — must be returned unchanged (regex falls through).
+        assertThat(processConstantRegex("httpbin", regex, newStr), equalTo("httpbin"));
+    }
+
+    private String processConstantRegex(String text, String regex, String newStr) {
+        try (
+            var eval = AbstractScalarFunctionTestCase.evaluator(
+                new Replace(
+                    Source.EMPTY,
+                    field("text", DataType.KEYWORD),
+                    new Literal(Source.EMPTY, new BytesRef(regex), DataType.KEYWORD),
+                    field("newStr", DataType.KEYWORD)
+                )
+            ).get(driverContext());
+            Block block = eval.eval(row(List.of(new BytesRef(text), new BytesRef(newStr))));
+        ) {
+            return block.isNull(0) ? null : ((BytesRef) BlockUtils.toJavaObject(block, 0)).utf8ToString();
+        }
+    }
+
+    private static void assertPrefix(String regex, String expected) {
+        byte[] actual = Replace.extractLiteralPrefix(Pattern.compile(regex));
+        byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
+        assertArrayEquals("for regex " + regex, expectedBytes, actual);
+    }
+
+    private static void assertNoPrefix(String regex) {
+        assertArrayEquals(
+            "expected NO_LITERAL_PREFIX for regex " + regex,
+            Replace.NO_LITERAL_PREFIX,
+            Replace.extractLiteralPrefix(Pattern.compile(regex))
         );
     }
 


### PR DESCRIPTION
## Summary

Two complementary, correctness-preserving fast paths for `REPLACE(field, regex, newStr)` when the regex is a constant:

1. **Anchored-prefix reject** — when the compiled pattern starts with `^` or `\A` followed by literal characters, those bytes are extracted once at plan time. Per row, a byte-level prefix check on the UTF-8 input rejects non-matching rows before paying for UTF-8 → UTF-16 conversion and Matcher allocation. The extractor is deliberately conservative: it bails on alternation, character classes, look-arounds, `(?m)` / `(?i)` / `(?x)` / `CANON_EQ`, and quantifiers that make the preceding literal optional.
2. **Dictionary memoization on dictionary-encoded inputs** — when both the regex and the replacement are constants and the input column is dictionary-encoded (typical for keyword fields backed by Lucene doc values), `REPLACE` is applied once per dictionary entry instead of once per row. The result re-uses the input's ordinal column with a transformed dictionary. For a column with N rows backed by D dictionary entries, this drops regex work from N calls to D — typically a 10–50x reduction.

The dictionary path is gated on `OrdinalBytesRefBlock#isDense()` and a single-valued check, and falls back to the existing per-row evaluator if any dictionary entry hits the result-size limit — so observable warning semantics are unchanged.

## Test plan

- Existing `ReplaceTests` and `ReplaceStaticTests` still pass.
- New `ReplaceStaticTests` cases cover the prefix extractor across a wide range of regex constructs (anchors, escapes, quantifiers, `\Q...\E`, flag combinations).
- New `ReplaceOrdinalTests` exercises the dictionary path on dense + null + sparse + overflow scenarios.
- `:x-pack:plugin:esql:precommit` passes.

Developed with AI-assisted tooling