### PR TITLE
ESQL: tighten parsed-footer cache after review feedback

### DIFF
--- a/docs/changelog/149045.yaml
+++ b/docs/changelog/149045.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149045
+summary: Tighten parsed-footer cache after review feedback
+type: enhancement

--- a/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
+++ b/x-pack/plugin/esql-datasource-orc/src/main/java/org/elasticsearch/xpack/esql/datasource/orc/OrcFormatReader.java
@@ -32,9 +32,6 @@ import org.apache.orc.StripeStatistics;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.OrcTail;
 import org.apache.orc.impl.ReaderImpl;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
@@ -193,33 +190,32 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
                 // Open a reader once, extract the parsed tail, then close the reader. The
                 // OrcTail itself retains the serialized buffer + parsed protobuf footer and is
                 // safe to share across threads (treated as immutable by all callers).
+                //
+                // This deliberately parses the tail twice on a cache miss: once inside
+                // OrcFile.createReader (which calls the protected ReaderImpl.extractFileTail
+                // (FileSystem, Path, long) to fetch and parse from storage) and once via the
+                // public ReaderImpl.extractFileTail(ByteBuffer) to produce a shareable OrcTail.
+                // The single-parse alternative would require re-implementing ORC's tail-fetch
+                // protocol (variable-length postscript, optional metadata sections, version
+                // handling) outside the library — fragile across ORC versions. Since this only
+                // runs on the cold path (first producer per file per TTL window), the second
+                // parse is a small cost that pays off as every subsequent producer hits the
+                // cache and skips both the parse and the remote read entirely.
                 try (Reader r = OrcFile.createReader(path, orcReaderOptions(fs))) {
                     return ReaderImpl.extractFileTail(r.getSerializedFileFooter());
                 }
             });
         } catch (ExecutionException e) {
-            // The winning loader thread sees its exception propagate directly out of the cache;
-            // every other concurrently-waiting thread sees an ExecutionException whose cause is
-            // the original throwable. Re-shape the cause to match the prior in-line createReader
-            // behaviour so callers observe identical exception types regardless of who won the
-            // load race. In particular Error/OOM must propagate as-is and never be reshaped into
-            // a generic IOException. Mirrors {@code ParquetFormatReader#loadFooter} so the two
-            // format readers stay consistent.
-            Throwable cause = e.getCause();
-            ExceptionsHelper.maybeError(cause).ifPresent(error -> { throw error; });
-            if (cause instanceof IOException io) {
-                throw io;
-            }
-            if (cause instanceof CircuitBreakingException cbe) {
-                throw cbe;
-            }
-            if (cause instanceof ElasticsearchException ese) {
-                throw ese;
-            }
-            if (cause instanceof RuntimeException re) {
+            // rethrowStructural handles Error/IOException/CircuitBreakingException/
+            // ElasticsearchException; anything else (typically a plain RuntimeException from
+            // orc-core indicating a corrupt tail) is returned for format-specific wrapping.
+            // Unlike Parquet there is no orc-tagged exception factory; surface a structurally
+            // tagged IOException so log lines clearly attribute the failure to ORC tail parsing.
+            Throwable other = ParsedFooterCache.rethrowStructural(e);
+            if (other instanceof RuntimeException re) {
                 throw re;
             }
-            throw new IOException("Failed to parse ORC tail for [" + path + "]", cause != null ? cause : e);
+            throw new IOException("Failed to parse ORC tail for [" + path + "]", other);
         }
     }
 
@@ -421,8 +417,13 @@ public class OrcFormatReader implements RangeAwareFormatReader, NoConfigFormatRe
         // thread.
         // 2. PARSED_FOOTERS — JVM-wide cache keyed by (path, length); shared across producer
         // threads and across queries within the access TTL.
-        OrcTail tail = context.fileContext() instanceof OrcTail cached ? cached : loadTail(fs, path);
-        context.setFileContext(tail);
+        OrcTail tail;
+        if (context.fileContext() instanceof OrcTail cached) {
+            tail = cached;
+        } else {
+            tail = loadTail(fs, path);
+            context.setFileContext(tail);
+        }
         Reader reader = OrcFile.createReader(path, orcReaderOptions(fs).orcTail(tail));
         TypeDescription schema = reader.getSchema();
 

--- a/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
+++ b/x-pack/plugin/esql-datasource-parquet/src/main/java/org/elasticsearch/xpack/esql/datasource/parquet/ParquetFormatReader.java
@@ -32,7 +32,6 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -277,6 +276,15 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
      * Loads the parsed Parquet footer for {@code adapter} via the JVM-wide {@link #PARSED_FOOTERS}
      * cache, parsing on a cache miss. The loader explicitly uses unranged read options so the
      * cached value is the full file footer (all row groups) and can be reused across split readers.
+     *
+     * <p>This method is intentionally non-static: the loader lambda calls {@link #readOptionsBuilder()},
+     * which wires in this instance's {@link CircuitBreakerByteBufferAllocator}. Under cache miss,
+     * the parse is therefore charged to whichever reader instance won the load race. In practice
+     * all ESQL Parquet readers share a parent {@link org.elasticsearch.compute.data.BlockFactory}
+     * breaker, so the breaker that wins is equivalent to any other; the cached
+     * {@link ParquetMetadata} itself is independent of the allocator. If breakers ever become
+     * per-query, the parse-time allocation accounting would need to move off of this instance's
+     * builder.
      */
     private ParquetMetadata loadFooter(StorageObject object, ParquetStorageObjectAdapter adapter) throws IOException {
         try {
@@ -289,27 +297,13 @@ public class ParquetFormatReader implements RangeAwareFormatReader {
                 return ParquetFileReader.readFooter(adapter, readOptionsBuilder().build(), adapter.newStream());
             });
         } catch (ExecutionException e) {
-            // The winning loader thread sees its exception propagate directly out of the cache;
-            // every other concurrently-waiting thread sees an ExecutionException whose cause is
-            // the original throwable. Re-shape the cause to match the prior in-line readFooter
-            // behaviour so callers observe identical exception types regardless of who won the
-            // load race. In particular Error/OOM must propagate as-is and never be reshaped into
-            // an invalid-file IOException.
-            Throwable cause = e.getCause();
-            ExceptionsHelper.maybeError(cause).ifPresent(error -> { throw error; });
-            if (cause instanceof IOException io) {
-                throw io;
-            }
-            if (cause instanceof CircuitBreakingException cbe) {
-                throw cbe;
-            }
-            if (cause instanceof ElasticsearchException ese) {
-                throw ese;
-            }
-            if (cause instanceof RuntimeException re) {
-                throw newInvalidParquetFileException(object.path().toString(), re);
-            }
-            throw newInvalidParquetFileException(object.path().toString(), e);
+            // rethrowStructural handles Error/IOException/CircuitBreakingException/
+            // ElasticsearchException; any other cause (typically a plain RuntimeException from
+            // parquet-mr signalling a malformed file) is returned here so we can apply the
+            // parquet-specific wrapping that the prior in-line readFooter path used. The returned
+            // throwable is never an Error (already rethrown) so the Exception cast is safe.
+            // Callers see the same exception shapes regardless of who won the load race.
+            throw newInvalidParquetFileException(object.path().toString(), (Exception) ParsedFooterCache.rethrowStructural(e));
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ParsedFooterCache.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/datasources/cache/ParsedFooterCache.java
@@ -7,11 +7,15 @@
 
 package org.elasticsearch.xpack.esql.datasources.cache;
 
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.cache.CacheLoader;
 import org.elasticsearch.core.TimeValue;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -49,11 +53,16 @@ import java.util.concurrent.ExecutionException;
  *       fresh parse.</li>
  *   <li>Count-based LRU eviction — parsed metadata structures (e.g. Parquet {@code ParquetMetadata}
  *       or ORC {@code OrcTail}) do not expose a cheap byte size, so the cache caps the number of
- *       entries instead. Defaults are intentionally conservative: a parsed footer for a wide file
- *       (hundreds of columns, hundreds of row groups) can occupy several MiB of heap, so the
- *       entry count is kept well below {@link FooterByteCache}'s ratio of MiB budget to average
- *       entry size. Note that the byte and parsed caches evict independently — TTL alignment
- *       keeps them timing-consistent but does not synchronize eviction events.</li>
+ *       entries rather than total bytes. <b>Worst-case heap budget</b>: a single parsed footer
+ *       for an extreme file (e.g. 100 columns × 200 row groups → ~20k column-chunk entries) can
+ *       occupy ~10–20 MiB of heap. With {@link #DEFAULT_MAX_ENTRIES} = {@value #DEFAULT_MAX_ENTRIES}
+ *       the absolute worst case is in the hundreds of MiB if every cached entry is for such an
+ *       extreme file <i>and</i> all live concurrently inside the TTL window. Typical workloads
+ *       (≤10 columns, ≤50 row groups, ≈200 KiB per entry) sit at a few MiB total. Adding a real
+ *       weigher would require an estimator pass over the parsed structure on every {@code put} —
+ *       not implemented here, but tracked for follow-up if heap pressure shows up in production.
+ *       Note that the byte and parsed caches evict independently — TTL alignment keeps them
+ *       timing-consistent but does not synchronize eviction events.</li>
  * </ul>
  *
  * <p>Cached values must be treated as immutable by all callers — callers that need to derive a
@@ -64,8 +73,13 @@ import java.util.concurrent.ExecutionException;
  */
 public final class ParsedFooterCache<T> {
 
-    /** Default maximum number of cached parsed footers across the JVM. */
-    public static final int DEFAULT_MAX_ENTRIES = 64;
+    /**
+     * Default maximum number of cached parsed footers across the JVM. Sized small enough that the
+     * worst-case heap (see class Javadoc) stays bounded even when extremely wide files dominate
+     * the working set, while still being large enough to absorb the typical fan-out of one query
+     * over many distinct files.
+     */
+    public static final int DEFAULT_MAX_ENTRIES = 32;
 
     private final Cache<FooterByteCache.Key, T> cache;
 
@@ -117,5 +131,44 @@ public final class ParsedFooterCache<T> {
     /** Removes all entries. Intended for test isolation. */
     public void invalidateAll() {
         cache.invalidateAll();
+    }
+
+    /**
+     * Unwraps an {@link ExecutionException} thrown by {@link #getOrLoad} and reshapes the
+     * <i>structural</i> failure modes back to their original types so callers see the same shapes
+     * they would have seen had they parsed the footer synchronously: {@link Error} (including
+     * {@code OutOfMemoryError}, given highest priority so JVM-level failures are never silently
+     * swallowed), {@link IOException}, {@link CircuitBreakingException}, and
+     * {@link ElasticsearchException}.
+     *
+     * <p>Any other cause — typically a plain {@link RuntimeException} from a format library
+     * indicating a malformed file — is returned for format-specific wrapping. The two readers
+     * differ here: Parquet wraps every such cause in {@code newInvalidParquetFileException}, ORC
+     * rethrows it directly. Keeping that policy out of this helper avoids dragging
+     * format-specific factories into the shared cache.
+     *
+     * <p>Always invoke as {@code throw new ...(rethrowStructural(e))} or
+     * {@code throw rethrowStructural(e)} so the compiler treats the call as terminal — see the
+     * callers in the format readers.
+     *
+     * @return the original cause (or the {@code ExecutionException} itself if the cause is null),
+     *         for the caller to either rethrow or wrap
+     * @throws IOException             if the cause is an {@link IOException}
+     * @throws CircuitBreakingException if the cause is a {@link CircuitBreakingException}
+     * @throws ElasticsearchException  if the cause is an {@link ElasticsearchException}
+     */
+    public static Throwable rethrowStructural(ExecutionException e) throws IOException {
+        Throwable cause = e.getCause();
+        ExceptionsHelper.maybeError(cause).ifPresent(error -> { throw error; });
+        if (cause instanceof IOException io) {
+            throw io;
+        }
+        if (cause instanceof CircuitBreakingException cbe) {
+            throw cbe;
+        }
+        if (cause instanceof ElasticsearchException ese) {
+            throw ese;
+        }
+        return cause != null ? cause : e;
     }
 }


### PR DESCRIPTION
Follow-up to #149018 incorporating feedback. Three
behavioural/structural changes plus two doc improvements.

ParsedFooterCache
- Lower DEFAULT_MAX_ENTRIES from 64 to 32. Worst case is now bounded
  closer to a few hundred MiB instead of multiple GiB when extremely wide
  files dominate the working set; typical workloads still sit at a few
  MiB total.
- Replace 'intentionally conservative' wording with an explicit
  worst-case heap budget (column-chunk math, typical-vs-extreme split,
  weigher follow-up note) so the operational tradeoff is visible.
- Extract rethrowStructural(ExecutionException) as a shared helper that
  reshapes Error/IOException/CircuitBreakingException/ElasticsearchException
  back to their original types. Format-specific RuntimeException wrapping
  stays at the call site since the two readers differ there.

ParquetFormatReader
- Use ParsedFooterCache.rethrowStructural in loadFooter; the format-
  specific newInvalidParquetFileException now wraps only what rethrow
  could not rethrow structurally.
- Document why loadFooter is non-static (captured 'this' threads the
  per-instance CircuitBreakerByteBufferAllocator into the loader) and
  why that is harmless under the current shared-parent-breaker layout.

OrcFormatReader
- Use ParsedFooterCache.rethrowStructural in loadTail and rethrow
  RuntimeException directly; only non-structural causes get wrapped as
  IOException with a format-tagged message.
- Document why the cold path deliberately parses the tail twice (the
  single-parse alternative would require re-implementing ORC's tail
  fetch protocol outside the library, fragile across versions).
- Restrict setFileContext to the cache-miss branch in readRange,
  matching parquet style — no functional change but removes a redundant
  self-write on the hot per-producer path.

No SPI changes. No behavioural change to the cache hit path.

Developed using AI-assisted tooling

