### PR TITLE
[9.4] Align workflows system data stream mappings with Kibana schema (#148886)

### DIFF
--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -48,9 +48,9 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
 
     private static final String KIBANA_WORKFLOWS_VERSION_VARIABLE = "kibana.workflows.version";
 
-    private static final int WORKFLOWS_EVENTS_MAPPINGS_VERSION = 2;
+    private static final int WORKFLOWS_EVENTS_MAPPINGS_VERSION = 3;
 
-    private static final int WORKFLOWS_EXECUTION_LOGS_MAPPINGS_VERSION = 1;
+    private static final int WORKFLOWS_EXECUTION_LOGS_MAPPINGS_VERSION = 2;
 
     /** Log data stream registered in {@link #getSystemDataStreamDescriptors()}. */
     public static final String WORKFLOWS_EVENTS_DATA_STREAM_NAME = ".workflows-events";

--- a/modules/kibana/src/main/resources/org/elasticsearch/kibana/workflows-events.json
+++ b/modules/kibana/src/main/resources/org/elasticsearch/kibana/workflows-events.json
@@ -22,15 +22,34 @@
         "version": "${kibana.workflows.version}",
         "managed_index_mappings_version": ${kibana.workflows.events.managed.index.version}
       },
-      "dynamic": true,
+      "dynamic": false,
       "properties": {
         "@timestamp": {
           "type": "date"
+        },
+        "eventId": {
+          "type": "keyword"
+        },
+        "triggerId": {
+          "type": "keyword"
+        },
+        "spaceId": {
+          "type": "keyword"
+        },
+        "subscriptions": {
+          "type": "keyword"
+        },
+        "sourceExecutionId": {
+          "type": "keyword"
+        },
+        "payload": {
+          "type": "object",
+          "properties": {}
         }
       }
     }
   },
   "composed_of": [],
   "priority": 200,
-  "version": 2
+  "version": 3
 }

--- a/modules/kibana/src/main/resources/org/elasticsearch/kibana/workflows-execution-data-stream-logs.json
+++ b/modules/kibana/src/main/resources/org/elasticsearch/kibana/workflows-execution-data-stream-logs.json
@@ -22,15 +22,39 @@
         "version": "${kibana.workflows.version}",
         "managed_index_mappings_version": ${kibana.workflows.execution.logs.managed.index.version}
       },
-      "dynamic": true,
+      "dynamic": false,
       "properties": {
         "@timestamp": {
           "type": "date"
+        },
+        "spaceId": {
+          "type": "keyword"
+        },
+        "level": {
+          "type": "keyword"
+        },
+        "workflow": {
+          "type": "object",
+          "dynamic": false,
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "execution_id": {
+              "type": "keyword"
+            },
+            "step_id": {
+              "type": "keyword"
+            },
+            "step_execution_id": {
+              "type": "keyword"
+            }
+          }
         }
       }
     }
   },
   "composed_of": [],
   "priority": 200,
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Align workflows system data stream mappings with Kibana schema (#148886)](https://github.com/elastic/elasticsearch/pull/148886)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)