### PR TITLE
Mute UpgradeClusterClientYamlTestSuiteIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -543,11 +543,7 @@ tests:
   method: testFieldValueRangeForBatchedCompoundCommit
   issue: https://github.com/elastic/elasticsearch/issues/148961
 - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-  method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
-  issue: https://github.com/elastic/elasticsearch/issues/147516
-- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-  method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Get old regression job stats}
-  issue: https://github.com/elastic/elasticsearch/issues/147517
+  issue: https://github.com/elastic/elasticsearch/issues/149010
 - class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecForceStoredLoadingIT
   method: test {csv-spec:flattened.casePicksPerRow}
   issue: https://github.com/elastic/elasticsearch/issues/149027


### PR DESCRIPTION
See: https://github.com/elastic/elasticsearch/issues/149010.
This suite is currently failing in 2% of builds.
