### PR TITLE
[9.4] Fix ArrayIndexOutOfBoundsException in centroid grouping evaluateFinal (#148815)

### DIFF
--- a/docs/changelog/148815.yaml
+++ b/docs/changelog/148815.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+  - 141318
+pr: 148815
+summary: Fix ArrayIndexOutOfBoundsException in centroid grouping evaluateFinal
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidPointAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidPointAggregator.java
@@ -123,7 +123,7 @@ abstract class CentroidPointAggregator {
         try (BytesRefBlock.Builder builder = ctx.blockFactory().newBytesRefBlockBuilder(selected.getPositionCount())) {
             for (int i = 0; i < selected.getPositionCount(); i++) {
                 int si = selected.getInt(i);
-                if (state.hasValue(si) && si < state.xValues.size()) {
+                if (si < state.xValues.size() && state.hasValue(si)) {
                     BytesRef result = state.encodeCentroidResult(si);
                     builder.appendBytesRef(result);
                 } else {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidShapeAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidShapeAggregator.java
@@ -147,7 +147,7 @@ abstract class CentroidShapeAggregator {
         try (BytesRefBlock.Builder builder = ctx.blockFactory().newBytesRefBlockBuilder(selected.getPositionCount())) {
             for (int i = 0; i < selected.getPositionCount(); i++) {
                 int si = selected.getInt(i);
-                if (state.hasValue(si) && si < state.xValues.size()) {
+                if (si < state.xValues.size() && state.hasValue(si)) {
                     BytesRef result = state.encodeCentroidResult(si);
                     builder.appendBytesRef(result);
                 } else {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/spatial/CentroidGroupingAggregatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/spatial/CentroidGroupingAggregatorTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.spatial;
+
+import org.elasticsearch.compute.aggregation.GroupingAggregatorEvaluationContext;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.test.ComputeTestCase;
+import org.elasticsearch.lucene.spatial.CoordinateEncoder;
+import org.elasticsearch.lucene.spatial.DimensionalShapeType;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Reproduces <a href="https://github.com/elastic/elasticsearch/issues/141318">issue #141318</a>:
+ * {@code evaluateFinal} throws {@link ArrayIndexOutOfBoundsException} when the {@code selected}
+ * vector contains a group id that exceeds the state's allocated capacity. The fix reorders the
+ * condition so the bounds check runs before {@code hasValue()}.
+ */
+public class CentroidGroupingAggregatorTests extends ComputeTestCase {
+
+    public void testPointCentroidEvaluateFinalWithOutOfBoundsSelectedGroup() {
+        var blockFactory = blockFactory();
+        var driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+        try (
+            var state = CentroidPointAggregator.initGrouping(blockFactory.bigArrays(), CoordinateEncoder.GEO);
+            IntVector selected = blockFactory.newIntArrayVector(new int[] { 0, 1 }, 2);
+            var evaluationContext = new GroupingAggregatorEvaluationContext(driverContext)
+        ) {
+            CentroidPointAggregator.combineIntermediate(state, 0, 10.0, 0.0, 20.0, 0.0, 1L);
+            try (Block result = CentroidPointAggregator.evaluateFinal(state, selected, evaluationContext)) {
+                assertThat(result.getPositionCount(), equalTo(2));
+                assertThat("in-bounds group should have a centroid result", BlockUtils.toJavaObject(result, 0), notNullValue());
+                assertThat(
+                    "out-of-bounds group should produce null, not ArrayIndexOutOfBoundsException",
+                    BlockUtils.toJavaObject(result, 1),
+                    nullValue()
+                );
+            }
+        }
+    }
+
+    public void testShapeCentroidEvaluateFinalWithOutOfBoundsSelectedGroup() {
+        var blockFactory = blockFactory();
+        var driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+        try (
+            var state = CentroidShapeAggregator.initGrouping(blockFactory.bigArrays(), CoordinateEncoder.GEO);
+            IntVector selected = blockFactory.newIntArrayVector(new int[] { 0, 1 }, 2);
+            var evaluationContext = new GroupingAggregatorEvaluationContext(driverContext)
+        ) {
+            CentroidShapeAggregator.combineIntermediate(state, 0, 10.0, 0.0, 20.0, 0.0, 1.0, DimensionalShapeType.POINT.ordinal());
+            try (Block result = CentroidShapeAggregator.evaluateFinal(state, selected, evaluationContext)) {
+                assertThat(result.getPositionCount(), equalTo(2));
+                assertThat("in-bounds group should have a centroid result", BlockUtils.toJavaObject(result, 0), notNullValue());
+                assertThat(
+                    "out-of-bounds group should produce null, not ArrayIndexOutOfBoundsException",
+                    BlockUtils.toJavaObject(result, 1),
+                    nullValue()
+                );
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialCentroidAggregationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/spatial/SpatialCentroidAggregationIT.java
@@ -7,12 +7,21 @@
 
 package org.elasticsearch.xpack.esql.spatial;
 
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.esql.action.EsqlPluginWithEnterpriseOrTrialLicense;
 import org.elasticsearch.xpack.spatial.SpatialPlugin;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 public class SpatialCentroidAggregationIT extends SpatialCentroidAggregationTestCase {
     @Override
@@ -23,5 +32,52 @@ public class SpatialCentroidAggregationIT extends SpatialCentroidAggregationTest
     @Override
     public void testStCentroidAggregationWithShapes() {
         assertStCentroidFromIndex("index_geo_shape", 1e-7);
+    }
+
+    public void testStCentroidAggregationByGroupManyGroupsRegression() {
+        String index = "test_geo_bug";
+        assertAcked(prepareCreate(index).setMapping("""
+            {
+              "properties": {
+                "group_id": { "type": "integer" },
+                "location": { "type": "geo_point" }
+              }
+            }
+            """));
+        var bulk = client().prepareBulk();
+        for (int i = 1; i <= 136; i++) {
+            IndexRequest req = new IndexRequest(index).id(Integer.toString(i)).source("group_id", i);
+            if (i <= 129) {
+                req.source("group_id", i, "location", "39.9,116.3");
+            }
+            bulk.add(req);
+        }
+        bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
+        ensureYellow(index);
+
+        String query = String.format(Locale.ROOT, """
+            FROM %s
+            | STATS centroid = ST_CENTROID_AGG(location) BY group_id
+            | SORT group_id ASC
+            | EVAL x = ST_X(centroid), y = ST_Y(centroid)
+            """, index);
+        try (var resp = run(query)) {
+            assertColumnNames(resp.columns(), List.of("centroid", "group_id", "x", "y"));
+            assertColumnTypes(resp.columns(), List.of("geo_point", "integer", "double", "double"));
+            List<List<Object>> values = getValuesList(resp.values());
+            assertThat(values.size(), equalTo(136));
+            for (int i = 0; i < values.size(); i++) {
+                int expectedGroup = i + 1;
+                List<Object> row = values.get(i);
+                assertThat((Integer) row.get(1), equalTo(expectedGroup));
+                if (expectedGroup <= 129) {
+                    assertThat((Double) row.get(2), closeTo(116.3, 1e-7));
+                    assertThat((Double) row.get(3), closeTo(39.9, 1e-7));
+                } else {
+                    assertThat(row.get(2), nullValue());
+                    assertThat(row.get(3), nullValue());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Fix ArrayIndexOutOfBoundsException in centroid grouping evaluateFinal (#148815)