### PR TITLE
S3HttpFixture: track and expose storage class on blobs

### DIFF
--- a/docs/changelog/149069.yaml
+++ b/docs/changelog/149069.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 149069
+summary: "S3HttpFixture: track and expose storage class on blobs"
+type: enhancement

--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.MockSecureSettings;
@@ -63,6 +64,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -218,6 +220,11 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
                 null /* no auth header validation - sometimes it's omitted in these tests (TODO why?) */,
                 MockAzureBlobStore.LeaseExpiryPredicate.NEVER_EXPIRE
             );
+        }
+
+        @Override
+        public Set<String> blobsKeyset() {
+            return blobs().keySet();
         }
     }
 

--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.MockSecureSettings;

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -64,6 +64,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
@@ -383,6 +384,11 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
 
         GoogleCloudStorageBlobStoreHttpHandler(final String bucket) {
             super(bucket);
+        }
+
+        @Override
+        public Set<String> blobsKeyset() {
+            return blobs().keySet();
         }
     }
 

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -8,7 +8,6 @@
  */
 package org.elasticsearch.repositories.s3;
 
-import fixture.s3.BlobEntry;
 import fixture.s3.S3ConsistencyModel;
 import fixture.s3.S3HttpHandler;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -8,6 +8,7 @@
  */
 package org.elasticsearch.repositories.s3;
 
+import fixture.s3.BlobEntry;
 import fixture.s3.S3ConsistencyModel;
 import fixture.s3.S3HttpHandler;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
@@ -744,6 +745,11 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
                 )
             );
             super.handle(exchange);
+        }
+
+        @Override
+        public Set<String> blobsKeyset() {
+            return blobs().keySet();
         }
     }
 

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTimeoutTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTimeoutTests.java
@@ -8,7 +8,6 @@
  */
 package org.elasticsearch.repositories.s3;
 
-import fixture.s3.BlobEntry;
 import fixture.s3.S3ConsistencyModel;
 import fixture.s3.S3HttpHandler;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTimeoutTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTimeoutTests.java
@@ -8,6 +8,7 @@
  */
 package org.elasticsearch.repositories.s3;
 
+import fixture.s3.BlobEntry;
 import fixture.s3.S3ConsistencyModel;
 import fixture.s3.S3HttpHandler;
 import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
@@ -42,6 +43,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -217,6 +219,11 @@ public class S3BlobStoreRepositoryTimeoutTests extends ESMockAPIBasedRepositoryI
 
         void setStallLatchRef(CountDownLatch latch) {
             stallLatchRef.set(latch);
+        }
+
+        @Override
+        public Set<String> blobsKeyset() {
+            return blobs().keySet();
         }
     }
 }

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/BlobEntry.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/BlobEntry.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package fixture.s3;
+
+import org.elasticsearch.common.bytes.BytesReference;
+
+public record BlobEntry(BytesReference contents, String storageClass) {
+
+    public static final String DEFAULT_STORAGE_CLASS = "STANDARD";
+
+    public BlobEntry(BytesReference contents) {
+        this(contents, DEFAULT_STORAGE_CLASS);
+    }
+}

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/BlobEntry.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/BlobEntry.java
@@ -10,11 +10,4 @@ package fixture.s3;
 
 import org.elasticsearch.common.bytes.BytesReference;
 
-public record BlobEntry(BytesReference contents, String storageClass) {
-
-    public static final String DEFAULT_STORAGE_CLASS = "STANDARD";
-
-    public BlobEntry(BytesReference contents) {
-        this(contents, DEFAULT_STORAGE_CLASS);
-    }
-}
+public record BlobEntry(BytesReference contents, String storageClass) {}

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/BlobEntry.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/BlobEntry.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
 package fixture.s3;
 
 import org.elasticsearch.common.bytes.BytesReference;

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/BlobEntry.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/BlobEntry.java
@@ -1,12 +1,3 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
- */
-
 package fixture.s3;
 
 import org.elasticsearch.common.bytes.BytesReference;

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/MultipartUpload.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/MultipartUpload.java
@@ -26,10 +26,6 @@ public class MultipartUpload {
     private final Map<String, BytesReference> parts = new ConcurrentHashMap<>();
     private final String initiatedDateTime = java.time.Instant.now().toString();
 
-    public MultipartUpload(String uploadId, String path) {
-        this(uploadId, path, BlobEntry.DEFAULT_STORAGE_CLASS);
-    }
-
     public MultipartUpload(String uploadId, String path, String storageClass) {
         this.uploadId = uploadId;
         this.path = path;

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/MultipartUpload.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/MultipartUpload.java
@@ -22,12 +22,18 @@ public class MultipartUpload {
 
     private final String uploadId;
     private final String path;
+    private final String storageClass;
     private final Map<String, BytesReference> parts = new ConcurrentHashMap<>();
     private final String initiatedDateTime = java.time.Instant.now().toString();
 
     public MultipartUpload(String uploadId, String path) {
+        this(uploadId, path, BlobEntry.DEFAULT_STORAGE_CLASS);
+    }
+
+    public MultipartUpload(String uploadId, String path, String storageClass) {
         this.uploadId = uploadId;
         this.path = path;
+        this.storageClass = storageClass;
     }
 
     public String getUploadId() {
@@ -36,6 +42,10 @@ public class MultipartUpload {
 
     public String getPath() {
         return path;
+    }
+
+    public String getStorageClass() {
+        return storageClass;
     }
 
     public String getInitiatedDateTime() {

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -138,7 +138,7 @@ public class S3HttpHandler implements HttpHandler {
                     // HEAD response must include Content-Length header for S3 clients (AWS SDK) that read file size
                     exchange.getResponseHeaders().add("Content-Length", String.valueOf(blobEntry.contents().length()));
                     exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
-                    if (!BlobEntry.DEFAULT_STORAGE_CLASS.equals(blobEntry.storageClass())) {
+                    if (!"STANDARD".equals(blobEntry.storageClass())) {
                         exchange.getResponseHeaders().add("x-amz-storage-class", blobEntry.storageClass());
                     }
                     exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
@@ -408,7 +408,7 @@ public class S3HttpHandler implements HttpHandler {
                 }
 
                 exchange.getResponseHeaders().add("ETag", etagFromContents);
-                if (BlobEntry.DEFAULT_STORAGE_CLASS.equals(blobEntry.storageClass()) == false) {
+                if (!"STANDARD".equals(blobEntry.storageClass())) {
                     exchange.getResponseHeaders().add("x-amz-storage-class", blobEntry.storageClass());
                 }
                 final String rangeHeader = exchange.getRequestHeaders().getFirst("Range");
@@ -677,7 +677,7 @@ public class S3HttpHandler implements HttpHandler {
 
     private static String getRequestStorageClass(final HttpExchange exchange) {
         final var storageClassHeader = exchange.getRequestHeaders().getFirst("x-amz-storage-class");
-        return storageClassHeader != null ? storageClassHeader : BlobEntry.DEFAULT_STORAGE_CLASS;
+        return storageClassHeader != null ? storageClassHeader : "STANDARD";
     }
 
     @Nullable // if no X-amz-copy-source header present

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -70,7 +70,7 @@ import static org.w3c.dom.Node.ELEMENT_NODE;
 public class S3HttpHandler implements HttpHandler {
 
     private static final Logger logger = LogManager.getLogger(S3HttpHandler.class);
-    public static final String STORAGE_CLASS_HEADER = "x-amz-storage-class";
+    public static final String STORAGE_CLASS_HEADER = "X-amz-storage-class";
 
     private final String bucket;
     private final String basePath;

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -138,7 +138,7 @@ public class S3HttpHandler implements HttpHandler {
                     // HEAD response must include Content-Length header for S3 clients (AWS SDK) that read file size
                     exchange.getResponseHeaders().add("Content-Length", String.valueOf(blobEntry.contents().length()));
                     exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
-                    if (BlobEntry.DEFAULT_STORAGE_CLASS.equals(blobEntry.storageClass()) == false) {
+                    if (!BlobEntry.DEFAULT_STORAGE_CLASS.equals(blobEntry.storageClass())) {
                         exchange.getResponseHeaders().add("x-amz-storage-class", blobEntry.storageClass());
                     }
                     exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
@@ -749,10 +749,6 @@ public class S3HttpHandler implements HttpHandler {
         }
 
         throw new AssertionError("multiple If-Match headers found: " + ifMatch);
-    }
-
-    MultipartUpload putUpload(String path) {
-        return putUpload(path, BlobEntry.DEFAULT_STORAGE_CLASS);
     }
 
     MultipartUpload putUpload(String path, String storageClass) {

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -77,7 +77,7 @@ public class S3HttpHandler implements HttpHandler {
     private final S3ConsistencyModel consistencyModel;
     private final Supplier<String> uuidGenerator;
 
-    private final ConcurrentMap<String, BytesReference> blobs = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, BlobEntry> blobs = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, MultipartUpload> uploads = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, AtomicInteger> completingUploads = new ConcurrentHashMap<>();
     private final List<RequestEntry> requestLog = new CopyOnWriteArrayList<>();
@@ -111,6 +111,7 @@ public class S3HttpHandler implements HttpHandler {
      */
     public static final String DEFAULT_LIST_OBJECT_LAST_MODIFIED = "1970-01-01T00:00:00.000Z";
 
+
     public List<RequestEntry> requestLog() {
         return Collections.unmodifiableList(requestLog);
     }
@@ -131,13 +132,16 @@ public class S3HttpHandler implements HttpHandler {
 
         try (exchange) {
             if (request.isHeadObjectRequest()) {
-                final BytesReference blob = blobs.get(request.path());
-                if (blob == null) {
+                final BlobEntry blobEntry = blobs.get(request.path());
+                if (blobEntry == null) {
                     exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
                 } else {
                     // HEAD response must include Content-Length header for S3 clients (AWS SDK) that read file size
-                    exchange.getResponseHeaders().add("Content-Length", String.valueOf(blob.length()));
+                    exchange.getResponseHeaders().add("Content-Length", String.valueOf(blobEntry.contents().length()));
                     exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+                    if (BlobEntry.DEFAULT_STORAGE_CLASS.equals(blobEntry.storageClass()) == false) {
+                        exchange.getResponseHeaders().add("x-amz-storage-class", blobEntry.storageClass());
+                    }
                     exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
                 }
             } else if (request.isListMultipartUploadsRequest()) {
@@ -174,7 +178,7 @@ public class S3HttpHandler implements HttpHandler {
                 exchange.getResponseBody().write(response);
 
             } else if (request.isInitiateMultipartUploadRequest()) {
-                final var upload = putUpload(request.path().substring(bucket.length() + 2));
+                final var upload = putUpload(request.path().substring(bucket.length() + 2), getRequestStorageClass(exchange));
                 final var uploadResult = new StringBuilder();
                 uploadResult.append("<?xml version='1.0' encoding='UTF-8'?>");
                 uploadResult.append("<InitiateMultipartUploadResult>");
@@ -196,8 +200,8 @@ public class S3HttpHandler implements HttpHandler {
                     // CopyPart is UploadPart with an x-amz-copy-source header
                     final var copySource = copySourceName(exchange);
                     if (copySource != null) {
-                        var sourceBlob = blobs.get(copySource);
-                        if (sourceBlob == null) {
+                        var sourceBlobEntry = blobs.get(copySource);
+                        if (sourceBlobEntry == null) {
                             exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
                         } else {
                             var range = parsePartRange(exchange);
@@ -206,7 +210,7 @@ public class S3HttpHandler implements HttpHandler {
                             }
                             int start = Math.toIntExact(range.start());
                             int len = Math.toIntExact(range.end() - range.start() + 1);
-                            var part = sourceBlob.slice(start, len);
+                            var part = sourceBlobEntry.contents().slice(start, len);
                             var etag = getEtagFromContents(part);
                             upload.addPart(etag, part);
                             byte[] response = ("""
@@ -250,7 +254,7 @@ public class S3HttpHandler implements HttpHandler {
                             }
                         } else {
                             final var blobContents = upload.complete(extractPartEtags(Streams.readFully(exchange.getRequestBody())));
-                            responseCode = updateBlobContents(exchange, request.path(), blobContents);
+                            responseCode = updateBlobContents(exchange, request.path(), new BlobEntry(blobContents, upload.getStorageClass()));
                             if (responseCode == RestStatus.OK) {
                                 responseBody = ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                                     + "<CompleteMultipartUploadResult>\n"
@@ -299,11 +303,11 @@ public class S3HttpHandler implements HttpHandler {
                         throw new AssertionError("If-Match: * header is not supported here");
                     }
 
-                    var sourceBlob = blobs.get(copySource);
-                    if (sourceBlob == null) {
+                    var sourceBlobEntry = blobs.get(copySource);
+                    if (sourceBlobEntry == null) {
                         exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
                     } else {
-                        blobs.put(request.path(), sourceBlob);
+                        blobs.put(request.path(), new BlobEntry(sourceBlobEntry.contents(), getRequestStorageClass(exchange)));
 
                         byte[] response = ("""
                             <?xml version="1.0" encoding="UTF-8"?>
@@ -314,7 +318,11 @@ public class S3HttpHandler implements HttpHandler {
                     }
                 } else {
                     final Tuple<String, BytesReference> blob = parseRequestBody(exchange);
-                    final var updateResponseCode = updateBlobContents(exchange, request.path(), blob.v2());
+                    final var updateResponseCode = updateBlobContents(
+                        exchange,
+                        request.path(),
+                        new BlobEntry(blob.v2(), getRequestStorageClass(exchange))
+                    );
 
                     if (updateResponseCode == RestStatus.OK) {
                         exchange.getResponseHeaders().add("ETag", blob.v1());
@@ -338,7 +346,7 @@ public class S3HttpHandler implements HttpHandler {
                 // Would be good to test pagination here (the only real difference between ListObjects and ListObjectsV2) but for now
                 // we return all the results at once.
                 list.append("<IsTruncated>false</IsTruncated>");
-                for (Map.Entry<String, BytesReference> blob : blobs.entrySet()) {
+                for (Map.Entry<String, BlobEntry> blob : blobs.entrySet()) {
                     if (prefix != null && blob.getKey().startsWith("/" + bucket + "/" + prefix) == false) {
                         continue;
                     }
@@ -354,7 +362,8 @@ public class S3HttpHandler implements HttpHandler {
                     list.append("<Contents>");
                     list.append("<Key>").append(blobPath).append("</Key>");
                     list.append("<LastModified>").append(DEFAULT_LIST_OBJECT_LAST_MODIFIED).append("</LastModified>");
-                    list.append("<Size>").append(blob.getValue().length()).append("</Size>");
+                    list.append("<Size>").append(blob.getValue().contents().length()).append("</Size>");
+                    list.append("<StorageClass>").append(blob.getValue().storageClass()).append("</StorageClass>");
                     list.append("</Contents>");
                 }
                 commonPrefixes.forEach(
@@ -368,12 +377,13 @@ public class S3HttpHandler implements HttpHandler {
                 exchange.getResponseBody().write(response);
 
             } else if (request.isGetObjectRequest()) {
-                final BytesReference blob = blobs.get(request.path());
-                if (blob == null) {
+                final BlobEntry blobEntry = blobs.get(request.path());
+                if (blobEntry == null) {
                     exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
                     return;
                 }
 
+                final BytesReference blob = blobEntry.contents();
                 final String etagFromContents = getEtagFromContents(blob);
                 final String ifMatchHeader = exchange.getRequestHeaders().getFirst("If-Match");
                 if (ifMatchHeader != null && ifMatchHeader.equals("*") == false) {
@@ -395,6 +405,9 @@ public class S3HttpHandler implements HttpHandler {
                 }
 
                 exchange.getResponseHeaders().add("ETag", etagFromContents);
+                if (BlobEntry.DEFAULT_STORAGE_CLASS.equals(blobEntry.storageClass()) == false) {
+                    exchange.getResponseHeaders().add("x-amz-storage-class", blobEntry.storageClass());
+                }
                 final String rangeHeader = exchange.getRequestHeaders().getFirst("Range");
                 if (rangeHeader == null) {
                     exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
@@ -434,8 +447,8 @@ public class S3HttpHandler implements HttpHandler {
 
             } else if (request.isDeleteObjectRequest()) {
                 int deletions = 0;
-                for (Iterator<Map.Entry<String, BytesReference>> iterator = blobs.entrySet().iterator(); iterator.hasNext();) {
-                    Map.Entry<String, BytesReference> blob = iterator.next();
+                for (Iterator<Map.Entry<String, BlobEntry>> iterator = blobs.entrySet().iterator(); iterator.hasNext();) {
+                    Map.Entry<String, BlobEntry> blob = iterator.next();
                     if (blob.getKey().startsWith(request.path())) {
                         iterator.remove();
                         deletions++;
@@ -449,8 +462,8 @@ public class S3HttpHandler implements HttpHandler {
                 final StringBuilder deletes = new StringBuilder();
                 deletes.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
                 deletes.append("<DeleteResult>");
-                for (Iterator<Map.Entry<String, BytesReference>> iterator = blobs.entrySet().iterator(); iterator.hasNext();) {
-                    Map.Entry<String, BytesReference> blob = iterator.next();
+                for (Iterator<Map.Entry<String, BlobEntry>> iterator = blobs.entrySet().iterator(); iterator.hasNext();) {
+                    Map.Entry<String, BlobEntry> blob = iterator.next();
                     String key = blob.getKey().replace("/" + bucket + "/", "");
                     if (requestBody.contains("<Key>" + key + "</Key>")) {
                         deletes.append("<Deleted><Key>").append(key).append("</Key></Deleted>");
@@ -484,10 +497,10 @@ public class S3HttpHandler implements HttpHandler {
      *
      * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html#conditional-error-response">AWS docs</a>
      */
-    private RestStatus updateBlobContents(HttpExchange exchange, String path, BytesReference newContents) {
+    private RestStatus updateBlobContents(HttpExchange exchange, String path, BlobEntry newEntry) {
         if (consistencyModel.hasConditionalWrites()) {
             if (isProtectOverwrite(exchange)) {
-                return blobs.putIfAbsent(path, newContents) == null
+                return blobs.putIfAbsent(path, newEntry) == null
                     ? RestStatus.OK
                     : ESTestCase.randomFrom(RestStatus.PRECONDITION_FAILED, RestStatus.CONFLICT);
             }
@@ -495,24 +508,24 @@ public class S3HttpHandler implements HttpHandler {
             final var requireExistingETag = getRequiredExistingETag(exchange);
             if (requireExistingETag != null) {
                 final var responseCode = new AtomicReference<>(RestStatus.OK);
-                blobs.compute(path, (ignoredPath, existingContents) -> {
-                    if (existingContents != null && requireExistingETag.equals(getEtagFromContents(existingContents))) {
-                        return newContents;
+                blobs.compute(path, (ignoredPath, existingEntry) -> {
+                    if (existingEntry != null && requireExistingETag.equals(getEtagFromContents(existingEntry.contents()))) {
+                        return newEntry;
                     }
 
                     responseCode.set(
                         ESTestCase.randomFrom(
-                            existingContents == null ? RestStatus.NOT_FOUND : RestStatus.PRECONDITION_FAILED,
+                            existingEntry == null ? RestStatus.NOT_FOUND : RestStatus.PRECONDITION_FAILED,
                             RestStatus.CONFLICT
                         )
                     );
-                    return existingContents;
+                    return existingEntry;
                 });
                 return responseCode.get();
             }
         }
 
-        blobs.put(path, newContents);
+        blobs.put(path, newEntry);
         return RestStatus.OK;
     }
 
@@ -525,7 +538,7 @@ public class S3HttpHandler implements HttpHandler {
         return '"' + SHA_256_ETAG_PREFIX + MessageDigests.toHexString(MessageDigests.digest(blobContents, MessageDigests.sha256())) + '"';
     }
 
-    public Map<String, BytesReference> blobs() {
+    public Map<String, BlobEntry> blobs() {
         return blobs;
     }
 
@@ -659,6 +672,11 @@ public class S3HttpHandler implements HttpHandler {
         }
     }
 
+    private static String getRequestStorageClass(final HttpExchange exchange) {
+        final var storageClassHeader = exchange.getRequestHeaders().getFirst("x-amz-storage-class");
+        return storageClassHeader != null ? storageClassHeader : BlobEntry.DEFAULT_STORAGE_CLASS;
+    }
+
     @Nullable // if no X-amz-copy-source header present
     private static String copySourceName(final HttpExchange exchange) {
         final var copySources = exchange.getRequestHeaders().get("X-amz-copy-source");
@@ -731,7 +749,11 @@ public class S3HttpHandler implements HttpHandler {
     }
 
     MultipartUpload putUpload(String path) {
-        final var upload = new MultipartUpload(uuidGenerator.get(), path);
+        return putUpload(path, BlobEntry.DEFAULT_STORAGE_CLASS);
+    }
+
+    MultipartUpload putUpload(String path, String storageClass) {
+        final var upload = new MultipartUpload(uuidGenerator.get(), path, storageClass);
         synchronized (uploads) {
             assertNull("upload " + upload.getUploadId() + " should not exist", uploads.put(upload.getUploadId(), upload));
             return upload;

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -111,7 +111,6 @@ public class S3HttpHandler implements HttpHandler {
      */
     public static final String DEFAULT_LIST_OBJECT_LAST_MODIFIED = "1970-01-01T00:00:00.000Z";
 
-
     public List<RequestEntry> requestLog() {
         return Collections.unmodifiableList(requestLog);
     }
@@ -254,7 +253,11 @@ public class S3HttpHandler implements HttpHandler {
                             }
                         } else {
                             final var blobContents = upload.complete(extractPartEtags(Streams.readFully(exchange.getRequestBody())));
-                            responseCode = updateBlobContents(exchange, request.path(), new BlobEntry(blobContents, upload.getStorageClass()));
+                            responseCode = updateBlobContents(
+                                exchange,
+                                request.path(),
+                                new BlobEntry(blobContents, upload.getStorageClass())
+                            );
                             if (responseCode == RestStatus.OK) {
                                 responseBody = ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                                     + "<CompleteMultipartUploadResult>\n"

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -70,6 +70,7 @@ import static org.w3c.dom.Node.ELEMENT_NODE;
 public class S3HttpHandler implements HttpHandler {
 
     private static final Logger logger = LogManager.getLogger(S3HttpHandler.class);
+    public static final String STORAGE_CLASS_HEADER = "x-amz-storage-class";
 
     private final String bucket;
     private final String basePath;
@@ -139,7 +140,7 @@ public class S3HttpHandler implements HttpHandler {
                     exchange.getResponseHeaders().add("Content-Length", String.valueOf(blobEntry.contents().length()));
                     exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
                     if (!"STANDARD".equals(blobEntry.storageClass())) {
-                        exchange.getResponseHeaders().add("x-amz-storage-class", blobEntry.storageClass());
+                        exchange.getResponseHeaders().add(STORAGE_CLASS_HEADER, blobEntry.storageClass());
                     }
                     exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
                 }
@@ -409,7 +410,7 @@ public class S3HttpHandler implements HttpHandler {
 
                 exchange.getResponseHeaders().add("ETag", etagFromContents);
                 if (!"STANDARD".equals(blobEntry.storageClass())) {
-                    exchange.getResponseHeaders().add("x-amz-storage-class", blobEntry.storageClass());
+                    exchange.getResponseHeaders().add(STORAGE_CLASS_HEADER, blobEntry.storageClass());
                 }
                 final String rangeHeader = exchange.getRequestHeaders().getFirst("Range");
                 if (rangeHeader == null) {
@@ -676,7 +677,7 @@ public class S3HttpHandler implements HttpHandler {
     }
 
     private static String getRequestStorageClass(final HttpExchange exchange) {
-        final var storageClassHeader = exchange.getRequestHeaders().getFirst("x-amz-storage-class");
+        final var storageClassHeader = exchange.getRequestHeaders().getFirst(STORAGE_CLASS_HEADER);
         return storageClassHeader != null ? storageClassHeader : "STANDARD";
     }
 

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -243,10 +243,7 @@ public class S3HttpHandlerTests extends ESTestCase {
         // PUT without storage class header defaults to STANDARD
         assertEquals(RestStatus.OK, handleRequest(handler, "PUT", standardPath, body).status());
         // PUT with an explicit storage class
-        assertEquals(
-            RestStatus.OK,
-            handleRequest(handler, "PUT", tieredPath, body, storageClassHeader(storageClass)).status()
-        );
+        assertEquals(RestStatus.OK, handleRequest(handler, "PUT", tieredPath, body, storageClassHeader(storageClass)).status());
 
         // GET: STANDARD objects do not carry the x-amz-storage-class header
         assertNull(handleRequest(handler, "GET", standardPath).headers().getFirst("X-amz-storage-class"));
@@ -263,11 +260,15 @@ public class S3HttpHandlerTests extends ESTestCase {
             </ListBucketResult>""", storageClass));
 
         // Multipart upload with explicit storage class
-        final var createUploadResponse = handleRequest(handler, "POST", "/bucket/path/mp-blob?uploads", BytesArray.EMPTY,
-            storageClassHeader(storageClass));
+        final var createUploadResponse = handleRequest(
+            handler,
+            "POST",
+            "/bucket/path/mp-blob?uploads",
+            BytesArray.EMPTY,
+            storageClassHeader(storageClass)
+        );
         final var uploadId = getUploadId(createUploadResponse.body());
-        final var partResponse = handleRequest(handler, "PUT",
-            "/bucket/path/mp-blob?uploadId=" + uploadId + "&partNumber=1", body);
+        final var partResponse = handleRequest(handler, "PUT", "/bucket/path/mp-blob?uploadId=" + uploadId + "&partNumber=1", body);
         final var partEtag = Objects.requireNonNull(partResponse.etag());
         handleRequest(handler, "POST", "/bucket/path/mp-blob?uploadId=" + uploadId, new BytesArray(Strings.format("""
             <?xml version="1.0" encoding="UTF-8"?>

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -275,7 +275,10 @@ public class S3HttpHandlerTests extends ESTestCase {
             <CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                <Part><ETag>%s</ETag><PartNumber>1</PartNumber></Part>
             </CompleteMultipartUpload>""", partEtag).getBytes(StandardCharsets.UTF_8)));
-        assertEquals(storageClass, handleRequest(handler, "GET", "/bucket/path/mp-blob").headers().getFirst(S3HttpHandler.STORAGE_CLASS_HEADER));
+        assertEquals(
+            storageClass,
+            handleRequest(handler, "GET", "/bucket/path/mp-blob").headers().getFirst(S3HttpHandler.STORAGE_CLASS_HEADER)
+        );
     }
 
     public void testSingleMultipartUpload() {

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -94,12 +94,14 @@ public class S3HttpHandlerTests extends ESTestCase {
 
         assertListObjectsResponse(handler, "", null, """
             <?xml version="1.0" encoding="UTF-8"?><ListBucketResult><Prefix></Prefix><IsTruncated>false</IsTruncated>\
-            <Contents><Key>path/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>50</Size></Contents>\
+            <Contents><Key>path/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>50</Size>\
+            <StorageClass>STANDARD</StorageClass></Contents>\
             </ListBucketResult>""");
 
         assertListObjectsResponse(handler, "path/", null, """
             <?xml version="1.0" encoding="UTF-8"?><ListBucketResult><Prefix>path/</Prefix><IsTruncated>false</IsTruncated>\
-            <Contents><Key>path/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>50</Size></Contents>\
+            <Contents><Key>path/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>50</Size>\
+            <StorageClass>STANDARD</StorageClass></Contents>\
             </ListBucketResult>""");
 
         assertListObjectsResponse(handler, "path/other", null, """
@@ -111,7 +113,8 @@ public class S3HttpHandlerTests extends ESTestCase {
         assertListObjectsResponse(handler, "path/", "/", """
             <?xml version="1.0" encoding="UTF-8"?><ListBucketResult>\
             <Prefix>path/</Prefix><Delimiter>/</Delimiter><IsTruncated>false</IsTruncated>\
-            <Contents><Key>path/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>50</Size></Contents>\
+            <Contents><Key>path/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>50</Size>\
+            <StorageClass>STANDARD</StorageClass></Contents>\
             <CommonPrefixes><Prefix>path/subpath1/</Prefix></CommonPrefixes>\
             <CommonPrefixes><Prefix>path/subpath2/</Prefix></CommonPrefixes>\
             </ListBucketResult>""");
@@ -121,8 +124,10 @@ public class S3HttpHandlerTests extends ESTestCase {
 
         assertListObjectsResponse(handler, "", null, """
             <?xml version="1.0" encoding="UTF-8"?><ListBucketResult><Prefix></Prefix><IsTruncated>false</IsTruncated>\
-            <Contents><Key>path/subpath1/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>50</Size></Contents>\
-            <Contents><Key>path/subpath2/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>50</Size></Contents>\
+            <Contents><Key>path/subpath1/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>50</Size>\
+            <StorageClass>STANDARD</StorageClass></Contents>\
+            <Contents><Key>path/subpath2/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>50</Size>\
+            <StorageClass>STANDARD</StorageClass></Contents>\
             </ListBucketResult>""");
 
         assertEquals(RestStatus.OK, handleRequest(handler, "DELETE", "/bucket/path/subpath1/blob").status());
@@ -228,6 +233,50 @@ public class S3HttpHandlerTests extends ESTestCase {
         );
     }
 
+    public void testStorageClass() {
+        final var handler = new S3HttpHandler("bucket", "path", S3ConsistencyModel.randomConsistencyModel());
+        final var standardPath = "/bucket/path/standard-blob";
+        final var tieredPath = "/bucket/path/tiered-blob";
+        final var storageClass = randomFrom("INTELLIGENT_TIERING", "STANDARD_IA", "GLACIER", "DEEP_ARCHIVE");
+        final var body = new BytesArray(randomAlphaOfLength(20).getBytes(StandardCharsets.UTF_8));
+
+        // PUT without storage class header defaults to STANDARD
+        assertEquals(RestStatus.OK, handleRequest(handler, "PUT", standardPath, body).status());
+        // PUT with an explicit storage class
+        assertEquals(
+            RestStatus.OK,
+            handleRequest(handler, "PUT", tieredPath, body, storageClassHeader(storageClass)).status()
+        );
+
+        // GET: STANDARD objects do not carry the x-amz-storage-class header
+        assertNull(handleRequest(handler, "GET", standardPath).headers().getFirst("X-amz-storage-class"));
+        // GET: non-STANDARD objects carry the header
+        assertEquals(storageClass, handleRequest(handler, "GET", tieredPath).headers().getFirst("X-amz-storage-class"));
+
+        // LIST: both objects appear with their correct StorageClass elements
+        assertListObjectsResponse(handler, "path/", null, Strings.format("""
+            <?xml version="1.0" encoding="UTF-8"?><ListBucketResult><Prefix>path/</Prefix><IsTruncated>false</IsTruncated>\
+            <Contents><Key>path/standard-blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>20</Size>\
+            <StorageClass>STANDARD</StorageClass></Contents>\
+            <Contents><Key>path/tiered-blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>20</Size>\
+            <StorageClass>%s</StorageClass></Contents>\
+            </ListBucketResult>""", storageClass));
+
+        // Multipart upload with explicit storage class
+        final var createUploadResponse = handleRequest(handler, "POST", "/bucket/path/mp-blob?uploads", BytesArray.EMPTY,
+            storageClassHeader(storageClass));
+        final var uploadId = getUploadId(createUploadResponse.body());
+        final var partResponse = handleRequest(handler, "PUT",
+            "/bucket/path/mp-blob?uploadId=" + uploadId + "&partNumber=1", body);
+        final var partEtag = Objects.requireNonNull(partResponse.etag());
+        handleRequest(handler, "POST", "/bucket/path/mp-blob?uploadId=" + uploadId, new BytesArray(Strings.format("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+               <Part><ETag>%s</ETag><PartNumber>1</PartNumber></Part>
+            </CompleteMultipartUpload>""", partEtag).getBytes(StandardCharsets.UTF_8)));
+        assertEquals(storageClass, handleRequest(handler, "GET", "/bucket/path/mp-blob").headers().getFirst("X-amz-storage-class"));
+    }
+
     public void testSingleMultipartUpload() {
         final var handler = new S3HttpHandler("bucket", "path", S3ConsistencyModel.randomConsistencyModel());
 
@@ -285,7 +334,8 @@ public class S3HttpHandlerTests extends ESTestCase {
 
         assertListObjectsResponse(handler, "", null, """
             <?xml version="1.0" encoding="UTF-8"?><ListBucketResult><Prefix></Prefix><IsTruncated>false</IsTruncated>\
-            <Contents><Key>path/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>100</Size></Contents>\
+            <Contents><Key>path/blob</Key><LastModified>1970-01-01T00:00:00.000Z</LastModified><Size>100</Size>\
+            <StorageClass>STANDARD</StorageClass></Contents>\
             </ListBucketResult>""");
 
         final var expectedContents = new BytesArray((part1 + part2).getBytes(StandardCharsets.UTF_8));
@@ -625,7 +675,7 @@ public class S3HttpHandlerTests extends ESTestCase {
         var responseHeaders = new Headers();
         httpExchange.getResponseHeaders().forEach((header, values) -> {
             // com.sun.net.httpserver.Headers.Headers() normalize keys
-            if ("Etag".equals(header) || "Content-range".equals(header)) {
+            if ("Etag".equals(header) || "Content-range".equals(header) || "X-amz-storage-class".equals(header)) {
                 responseHeaders.put(header, List.copyOf(values));
             }
         });
@@ -663,6 +713,12 @@ public class S3HttpHandlerTests extends ESTestCase {
     private static Headers contentRangeHeader(long start, long end, long length) {
         var headers = new Headers();
         headers.put("Content-Range", List.of(Strings.format("bytes %d-%d/%d", start, end, length)));
+        return headers;
+    }
+
+    private static Headers storageClassHeader(String storageClass) {
+        var headers = new Headers();
+        headers.put("x-amz-storage-class", List.of(storageClass));
         return headers;
     }
 

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -246,9 +246,9 @@ public class S3HttpHandlerTests extends ESTestCase {
         assertEquals(RestStatus.OK, handleRequest(handler, "PUT", tieredPath, body, storageClassHeader(storageClass)).status());
 
         // GET: STANDARD objects do not carry the x-amz-storage-class header
-        assertNull(handleRequest(handler, "GET", standardPath).headers().getFirst("X-amz-storage-class"));
+        assertNull(handleRequest(handler, "GET", standardPath).headers().getFirst(S3HttpHandler.STORAGE_CLASS_HEADER));
         // GET: non-STANDARD objects carry the header
-        assertEquals(storageClass, handleRequest(handler, "GET", tieredPath).headers().getFirst("X-amz-storage-class"));
+        assertEquals(storageClass, handleRequest(handler, "GET", tieredPath).headers().getFirst(S3HttpHandler.STORAGE_CLASS_HEADER));
 
         // LIST: both objects appear with their correct StorageClass elements
         assertListObjectsResponse(handler, "path/", null, Strings.format("""
@@ -275,7 +275,7 @@ public class S3HttpHandlerTests extends ESTestCase {
             <CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                <Part><ETag>%s</ETag><PartNumber>1</PartNumber></Part>
             </CompleteMultipartUpload>""", partEtag).getBytes(StandardCharsets.UTF_8)));
-        assertEquals(storageClass, handleRequest(handler, "GET", "/bucket/path/mp-blob").headers().getFirst("X-amz-storage-class"));
+        assertEquals(storageClass, handleRequest(handler, "GET", "/bucket/path/mp-blob").headers().getFirst(S3HttpHandler.STORAGE_CLASS_HEADER));
     }
 
     public void testSingleMultipartUpload() {
@@ -676,7 +676,7 @@ public class S3HttpHandlerTests extends ESTestCase {
         var responseHeaders = new Headers();
         httpExchange.getResponseHeaders().forEach((header, values) -> {
             // com.sun.net.httpserver.Headers.Headers() normalize keys
-            if ("Etag".equals(header) || "Content-range".equals(header) || "X-amz-storage-class".equals(header)) {
+            if ("Etag".equals(header) || "Content-range".equals(header) || S3HttpHandler.STORAGE_CLASS_HEADER.equals(header)) {
                 responseHeaders.put(header, List.copyOf(values));
             }
         });
@@ -719,7 +719,7 @@ public class S3HttpHandlerTests extends ESTestCase {
 
     private static Headers storageClassHeader(String storageClass) {
         var headers = new Headers();
-        headers.put("x-amz-storage-class", List.of(storageClass));
+        headers.put(S3HttpHandler.STORAGE_CLASS_HEADER, List.of(storageClass));
         return headers;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -18,7 +18,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -74,7 +75,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
      */
     @SuppressForbidden(reason = "Uses a HttpServer to emulate a cloud-based storage service")
     protected interface BlobStoreHttpHandler extends HttpHandler {
-        Map<String, BytesReference> blobs();
+        Set<String> blobsKeyset();
     }
 
     private static final byte[] BUFFER = new byte[1024];
@@ -139,14 +140,14 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
                     h = ((DelegatingHttpHandler) h).getDelegate();
                 }
                 if (h instanceof BlobStoreHttpHandler) {
-                    assertEmptyRepo(((BlobStoreHttpHandler) h).blobs());
+                    assertEmptyRepo(((BlobStoreHttpHandler) h).blobsKeyset());
                 }
             }
         }
     }
 
-    protected static void assertEmptyRepo(Map<String, BytesReference> blobsMap) {
-        List<String> blobs = blobsMap.keySet().stream().filter(blob -> blob.contains("index") == false).collect(Collectors.toList());
+    protected static void assertEmptyRepo(Set<String> blobsKeyset) {
+        List<String> blobs = blobsKeyset.stream().filter(blob -> blob.contains("index") == false).toList();
         assertThat("Only index blobs should remain in repository but found " + blobs, blobs, hasSize(0));
     }
 

--- a/x-pack/plugin/esql-datasource-iceberg/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/iceberg/InteractiveFixtureManual.java
+++ b/x-pack/plugin/esql-datasource-iceberg/qa/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/iceberg/InteractiveFixtureManual.java
@@ -214,13 +214,13 @@ public class InteractiveFixtureManual extends ESRestTestCase {
         if (SHOW_BLOBS) {
             messages.print("fixtures_show_all");
             blobs.keySet().stream().sorted().forEach(key -> {
-                long size = blobs.get(key).length();
+                long size = blobs.get(key).contents().length();
                 out.printf(Locale.ROOT, "  %-80s %10s%n", key, MessageTemplates.formatBytes(size));
             });
         } else {
             messages.print("fixtures_show_key");
             blobs.keySet().stream().filter(key -> key.contains("employees") || key.contains("standalone")).sorted().forEach(key -> {
-                long size = blobs.get(key).length();
+                long size = blobs.get(key).contents().length();
                 out.printf(Locale.ROOT, "  %-80s %10s%n", key, MessageTemplates.formatBytes(size));
             });
             messages.print("fixtures_footer");

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3GlobDiscoveryTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3GlobDiscoveryTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.datasource.s3;
 
+import fixture.s3.BlobEntry;
 import fixture.s3.S3ConsistencyModel;
 import fixture.s3.S3HttpFixture;
 import fixture.s3.S3HttpHandler;
@@ -143,7 +144,7 @@ public class S3GlobDiscoveryTests extends ESTestCase {
     }
 
     private static void addBlob(String key, byte[] content) {
-        s3Fixture.handler().blobs().put("/" + BUCKET + "/" + key, new BytesArray(content));
+        s3Fixture.handler().blobs().put("/" + BUCKET + "/" + key, new BlobEntry(new BytesArray(content)));
     }
 
     private static List<StorageEntry> collectAll(StorageIterator iterator) throws IOException {

--- a/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3GlobDiscoveryTests.java
+++ b/x-pack/plugin/esql-datasource-s3/src/test/java/org/elasticsearch/xpack/esql/datasource/s3/S3GlobDiscoveryTests.java
@@ -144,7 +144,7 @@ public class S3GlobDiscoveryTests extends ESTestCase {
     }
 
     private static void addBlob(String key, byte[] content) {
-        s3Fixture.handler().blobs().put("/" + BUCKET + "/" + key, new BlobEntry(new BytesArray(content)));
+        s3Fixture.handler().blobs().put("/" + BUCKET + "/" + key, new BlobEntry(new BytesArray(content), "STANDARD"));
     }
 
     private static List<StorageEntry> collectAll(StorageIterator iterator) throws IOException {

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/FaultInjectingS3HttpHandlerIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/FaultInjectingS3HttpHandlerIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.qa.multi_node;
 
+import fixture.s3.BlobEntry;
 import fixture.s3.S3ConsistencyModel;
 import fixture.s3.S3HttpHandler;
 
@@ -33,7 +34,7 @@ public class FaultInjectingS3HttpHandlerIT extends ESTestCase {
 
     public void testNoFaultReturnsNormalResponse() throws Exception {
         S3HttpHandler s3Handler = new S3HttpHandler("bucket", S3ConsistencyModel.STRONG_MPUS);
-        s3Handler.blobs().put("/bucket/data.parquet", new BytesArray("test-content".getBytes(StandardCharsets.UTF_8)));
+        s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("test-content".getBytes(StandardCharsets.UTF_8))));
         FaultInjectingS3HttpHandler handler = new FaultInjectingS3HttpHandler(s3Handler);
 
         try (TestHttpServer server = new TestHttpServer(handler)) {
@@ -53,7 +54,7 @@ public class FaultInjectingS3HttpHandlerIT extends ESTestCase {
             assertEquals(0, handler.remainingFaults());
 
             // Next request should succeed (fault exhausted)
-            s3Handler.blobs().put("/bucket/data.parquet", new BytesArray("ok".getBytes(StandardCharsets.UTF_8)));
+            s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("ok".getBytes(StandardCharsets.UTF_8))));
             HttpURLConnection conn2 = openConnection(server, "/bucket/data.parquet");
             assertEquals(200, conn2.getResponseCode());
         }
@@ -72,7 +73,7 @@ public class FaultInjectingS3HttpHandlerIT extends ESTestCase {
 
     public void testFaultCountdownDecrementsCorrectly() throws Exception {
         S3HttpHandler s3Handler = new S3HttpHandler("bucket", S3ConsistencyModel.STRONG_MPUS);
-        s3Handler.blobs().put("/bucket/data.parquet", new BytesArray("ok".getBytes(StandardCharsets.UTF_8)));
+        s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("ok".getBytes(StandardCharsets.UTF_8))));
         FaultInjectingS3HttpHandler handler = new FaultInjectingS3HttpHandler(s3Handler);
         handler.setFault(FaultType.HTTP_503, 3);
 
@@ -89,7 +90,7 @@ public class FaultInjectingS3HttpHandlerIT extends ESTestCase {
 
     public void testPathFilterOnlyAffectsMatchingPaths() throws Exception {
         S3HttpHandler s3Handler = new S3HttpHandler("bucket", S3ConsistencyModel.STRONG_MPUS);
-        s3Handler.blobs().put("/bucket/metadata.json", new BytesArray("meta".getBytes(StandardCharsets.UTF_8)));
+        s3Handler.blobs().put("/bucket/metadata.json", new BlobEntry(new BytesArray("meta".getBytes(StandardCharsets.UTF_8))));
         FaultInjectingS3HttpHandler handler = new FaultInjectingS3HttpHandler(s3Handler);
         handler.setFault(FaultType.HTTP_503, 10, path -> path.endsWith(".parquet"));
 
@@ -102,7 +103,7 @@ public class FaultInjectingS3HttpHandlerIT extends ESTestCase {
 
     public void testClearFaultStopsInjection() throws Exception {
         S3HttpHandler s3Handler = new S3HttpHandler("bucket", S3ConsistencyModel.STRONG_MPUS);
-        s3Handler.blobs().put("/bucket/data.parquet", new BytesArray("ok".getBytes(StandardCharsets.UTF_8)));
+        s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("ok".getBytes(StandardCharsets.UTF_8))));
         FaultInjectingS3HttpHandler handler = new FaultInjectingS3HttpHandler(s3Handler);
         handler.setFault(FaultType.HTTP_503, 100);
 

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/FaultInjectingS3HttpHandlerIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/FaultInjectingS3HttpHandlerIT.java
@@ -34,7 +34,8 @@ public class FaultInjectingS3HttpHandlerIT extends ESTestCase {
 
     public void testNoFaultReturnsNormalResponse() throws Exception {
         S3HttpHandler s3Handler = new S3HttpHandler("bucket", S3ConsistencyModel.STRONG_MPUS);
-        s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("test-content".getBytes(StandardCharsets.UTF_8))));
+        s3Handler.blobs()
+            .put("/bucket/data.parquet", new BlobEntry(new BytesArray("test-content".getBytes(StandardCharsets.UTF_8)), "STANDARD"));
         FaultInjectingS3HttpHandler handler = new FaultInjectingS3HttpHandler(s3Handler);
 
         try (TestHttpServer server = new TestHttpServer(handler)) {
@@ -54,7 +55,7 @@ public class FaultInjectingS3HttpHandlerIT extends ESTestCase {
             assertEquals(0, handler.remainingFaults());
 
             // Next request should succeed (fault exhausted)
-            s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("ok".getBytes(StandardCharsets.UTF_8))));
+            s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("ok".getBytes(StandardCharsets.UTF_8)), "STANDARD"));
             HttpURLConnection conn2 = openConnection(server, "/bucket/data.parquet");
             assertEquals(200, conn2.getResponseCode());
         }
@@ -73,7 +74,7 @@ public class FaultInjectingS3HttpHandlerIT extends ESTestCase {
 
     public void testFaultCountdownDecrementsCorrectly() throws Exception {
         S3HttpHandler s3Handler = new S3HttpHandler("bucket", S3ConsistencyModel.STRONG_MPUS);
-        s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("ok".getBytes(StandardCharsets.UTF_8))));
+        s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("ok".getBytes(StandardCharsets.UTF_8)), "STANDARD"));
         FaultInjectingS3HttpHandler handler = new FaultInjectingS3HttpHandler(s3Handler);
         handler.setFault(FaultType.HTTP_503, 3);
 
@@ -90,7 +91,7 @@ public class FaultInjectingS3HttpHandlerIT extends ESTestCase {
 
     public void testPathFilterOnlyAffectsMatchingPaths() throws Exception {
         S3HttpHandler s3Handler = new S3HttpHandler("bucket", S3ConsistencyModel.STRONG_MPUS);
-        s3Handler.blobs().put("/bucket/metadata.json", new BlobEntry(new BytesArray("meta".getBytes(StandardCharsets.UTF_8))));
+        s3Handler.blobs().put("/bucket/metadata.json", new BlobEntry(new BytesArray("meta".getBytes(StandardCharsets.UTF_8)), "STANDARD"));
         FaultInjectingS3HttpHandler handler = new FaultInjectingS3HttpHandler(s3Handler);
         handler.setFault(FaultType.HTTP_503, 10, path -> path.endsWith(".parquet"));
 
@@ -103,7 +104,7 @@ public class FaultInjectingS3HttpHandlerIT extends ESTestCase {
 
     public void testClearFaultStopsInjection() throws Exception {
         S3HttpHandler s3Handler = new S3HttpHandler("bucket", S3ConsistencyModel.STRONG_MPUS);
-        s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("ok".getBytes(StandardCharsets.UTF_8))));
+        s3Handler.blobs().put("/bucket/data.parquet", new BlobEntry(new BytesArray("ok".getBytes(StandardCharsets.UTF_8)), "STANDARD"));
         FaultInjectingS3HttpHandler handler = new FaultInjectingS3HttpHandler(s3Handler);
         handler.setFault(FaultType.HTTP_503, 100);
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/S3FixtureUtils.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/S3FixtureUtils.java
@@ -86,7 +86,7 @@ public final class S3FixtureUtils {
      */
     public static void addBlobToFixture(S3HttpHandler handler, String key, byte[] content) {
         String fullPath = "/" + BUCKET + "/" + key;
-        handler.blobs().put(fullPath, new BlobEntry(new BytesArray(content)));
+        handler.blobs().put(fullPath, new BlobEntry(new BytesArray(content), "STANDARD"));
         logRequest("PUT_OBJECT", fullPath, content.length);
     }
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/S3FixtureUtils.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/datasources/S3FixtureUtils.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.esql.datasources;
 
+import fixture.s3.BlobEntry;
 import fixture.s3.S3ConsistencyModel;
 import fixture.s3.S3HttpFixture;
 import fixture.s3.S3HttpHandler;
@@ -85,7 +86,7 @@ public final class S3FixtureUtils {
      */
     public static void addBlobToFixture(S3HttpHandler handler, String key, byte[] content) {
         String fullPath = "/" + BUCKET + "/" + key;
-        handler.blobs().put(fullPath, new BytesArray(content));
+        handler.blobs().put(fullPath, new BlobEntry(new BytesArray(content)));
         logRequest("PUT_OBJECT", fullPath, content.length);
     }
 


### PR DESCRIPTION
  Extends the S3 test fixture to record and serve the S3 storage class of
  each blob, enabling tests to verify that the correct storage class is
  passed to S3 on write operations.


Closes elastic/elasticsearch-team#2773