### PR TITLE
Handle case of read-only repo and fail fast

### DIFF
--- a/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozen.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/main/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozen.java
@@ -55,6 +55,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -68,6 +69,7 @@ import org.elasticsearch.datastreams.lifecycle.DataStreamLifecycleService;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.snapshots.RestoreInfo;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotMissingException;
@@ -210,14 +212,23 @@ public class DLMConvertToFrozen implements DLMFrozenTransitionRunnable {
                 indexName
             );
         }
-        boolean repoIsRegistered = RepositoriesMetadata.get(getProjectState().metadata())
+        RepositoryMetadata registeredRepo = RepositoriesMetadata.get(getProjectState().metadata())
             .repositories()
             .stream()
-            .anyMatch(repositoryMetadata -> repositoryMetadata.name().equals(repositoryName));
-        if (repoIsRegistered == false) {
+            .filter(repositoryMetadata -> repositoryMetadata.name().equals(repositoryName))
+            .findFirst()
+            .orElse(null);
+        if (registeredRepo == null) {
             throw new DLMUnrecoverableException(
                 indexName,
                 "Repository [{}] required for convert-to-frozen steps is no longer registered in project [{}]",
+                repositoryName,
+                projectId
+            );
+        }
+        if (RepositoriesService.isReadOnly(registeredRepo.settings())) {
+            throw new DLMUnrecoverableException(
+                "Repository [{}] required for convert-to-frozen steps is configured as read-only in project [{}]",
                 repositoryName,
                 projectId
             );

--- a/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenMarkReadOnlyTests.java
+++ b/x-pack/plugin/dlm-frozen-transition/src/test/java/org/elasticsearch/xpack/dlm/frozen/DLMConvertToFrozenMarkReadOnlyTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.internal.XPackLicenseStatus;
+import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -419,6 +420,23 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
         assertThat(exception.getMessage(), containsString(repoName));
     }
 
+    public void testIsEligibleThrowsWhenRepositoryIsReadOnly() {
+        String repoName = "my-repo";
+        createProjectStateWithRepo(repoName, Settings.builder().put(BlobStoreRepository.READONLY_SETTING_KEY, true).build());
+
+        DLMConvertToFrozen converter = new DLMConvertToFrozen(
+            indexName,
+            projectId,
+            createMockClient(),
+            clusterService,
+            () -> licenseState,
+            Clock.systemUTC()
+        );
+
+        ElasticsearchException exception = expectThrows(DLMUnrecoverableException.class, converter::checkIfEligibleForConvertToFrozen);
+        assertThat(exception.getMessage(), containsString(repoName));
+    }
+
     public void testIsEligibleThrowsWhenLicenseDoesNotAllowSearchableSnapshots() {
         String repoName = "my-repo";
         createProjectStateWithRepo(repoName, true);
@@ -490,6 +508,10 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
      * and optionally registers a matching repository in the project's RepositoriesMetadata.
      */
     private void createProjectStateWithRepo(String repoName, boolean registerRepo) {
+        createProjectStateWithRepo(repoName, registerRepo ? Settings.EMPTY : null);
+    }
+
+    private void createProjectStateWithRepo(String repoName, Settings repoSettings) {
         ProjectMetadata.Builder projectMetadataBuilder = ProjectMetadata.builder(projectId)
             .put(
                 IndexMetadata.builder(indexName)
@@ -504,8 +526,8 @@ public class DLMConvertToFrozenMarkReadOnlyTests extends ESTestCase {
                 false
             );
 
-        if (registerRepo) {
-            RepositoryMetadata repo = new RepositoryMetadata(repoName, "fs", Settings.EMPTY);
+        if (repoSettings != null) {
+            RepositoryMetadata repo = new RepositoryMetadata(repoName, "fs", repoSettings);
             projectMetadataBuilder.putCustom(RepositoriesMetadata.TYPE, new RepositoriesMetadata(List.of(repo)));
         }
 


### PR DESCRIPTION
This PR causes transitions to unrecoverable fast fail of the cluster default repo is read only, much like how we fail of the default repo is missing or unset.