### PR TITLE
[9.4] Fix: propagate ReloadableCustomAnalyzer reloads through AnalyzerWrapper subclasses (#147695)

### DIFF
--- a/docs/changelog/147695.yaml
+++ b/docs/changelog/147695.yaml
@@ -1,0 +1,6 @@
+pr: 147695
+summary: Fix synonym reloads not propagating through AnalyzerWrapper subclasses
+area: Search
+type: bug
+issues:
+  - 146914

--- a/modules/mapper-extras/build.gradle
+++ b/modules/mapper-extras/build.gradle
@@ -18,8 +18,17 @@ esplugin {
 
 restResources {
   restApi {
-    include '_common', 'cluster', 'field_caps', 'nodes', 'indices', 'index', 'search', 'get'
+    include '_common', 'bulk', 'cluster', 'field_caps', 'nodes', 'indices', 'index', 'search', 'get', 'synonyms'
   }
+}
+
+dependencies {
+  clusterModules project(':modules:analysis-common')
+  clusterModules project(':modules:reindex')
+}
+
+testClusters.configureEach {
+  module ':modules:analysis-common'
 }
 
 tasks.named("yamlRestCompatTestTransform").configure { task ->

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.index.mapper.extras;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.AnalyzerWrapper;
 import org.apache.lucene.analysis.CachingTokenFilter;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
@@ -39,6 +38,7 @@ import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.AnalyzerScope;
+import org.elasticsearch.index.analysis.ElasticsearchAnalyzerWrapper;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.DocumentParserContext;
@@ -771,15 +771,14 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
      * ngrams token filter, it also adds a {@link TrailingShingleTokenFilter} to add extra position increments at the end of the stream
      * to induce the shingle token filter to create tokens at the end of the stream smaller than the shingle size
      */
-    static class SearchAsYouTypeAnalyzer extends AnalyzerWrapper {
+    static class SearchAsYouTypeAnalyzer extends ElasticsearchAnalyzerWrapper {
 
         private final Analyzer delegate;
         private final int shingleSize;
         private final boolean indexPrefixes;
 
         private SearchAsYouTypeAnalyzer(Analyzer delegate, int shingleSize, boolean indexPrefixes) {
-
-            super(delegate.getReuseStrategy());
+            super(delegate);
             this.delegate = Objects.requireNonNull(delegate);
             this.shingleSize = shingleSize;
             this.indexPrefixes = indexPrefixes;

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapperTests.java
@@ -888,4 +888,5 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
     protected boolean supportsDocValuesSkippers() {
         return false;
     }
+
 }

--- a/modules/mapper-extras/src/yamlRestTest/java/org/elasticsearch/index/mapper/MapperExtrasClientYamlTestSuiteIT.java
+++ b/modules/mapper-extras/src/yamlRestTest/java/org/elasticsearch/index/mapper/MapperExtrasClientYamlTestSuiteIT.java
@@ -33,6 +33,8 @@ public class MapperExtrasClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("mapper-extras")
+        .module("analysis-common")
+        .module("reindex")
         .feature(FeatureFlag.EXTENDED_DOC_VALUES_PARAMS)
         .build();
 

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/40_reloadable_search_analyzer.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/search-as-you-type/40_reloadable_search_analyzer.yml
@@ -1,0 +1,157 @@
+setup:
+  - requires:
+      cluster_features: ["mapper.analyzer-wrapper.reloadable_search_analyzer"]
+      reason: "analyzer wrappers such as search_as_you_type must work with a reloadable analyzer"
+
+  - do:
+      synonyms.put_synonym:
+        id: set1
+        body:
+          synonyms_set:
+            - synonyms: "quick, fast"
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+            analysis:
+              filter:
+                sayt_synonym_filter:
+                  type: synonym_graph
+                  synonyms_set: set1
+                  updateable: true
+              analyzer:
+                sayt_search_analyzer:
+                  type: custom
+                  tokenizer: standard
+                  filter: [ lowercase, sayt_synonym_filter ]
+          mappings:
+            properties:
+              title:
+                type: search_as_you_type
+                search_analyzer: sayt_search_analyzer
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test
+              _id: "1"
+          - title: "quick brown fox"
+          - index:
+              _index: test
+              _id: "2"
+          - title: "the lazy dog"
+          - index:
+              _index: test
+              _id: "3"
+          - title: "swift red bird"
+
+---
+teardown:
+  - do:
+      synonyms.delete_synonym:
+        id: set1
+
+---
+"search_as_you_type with reloadable search_analyzer":
+  # RCA directly: sayt_search_analyzer is NamedAnalyzer(RCA), UPDATE_STRATEGY path.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          query:
+            match:
+              title:
+                query: "fast"
+                analyzer: sayt_search_analyzer
+
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  # Both paths on the same thread: title uses NamedAnalyzer(RCA) (UPDATE_STRATEGY),
+  # title._2gram and title._3gram use NamedAnalyzer(SearchAsYouTypeAnalyzer(RCA)) (WRAPPER_REUSE_STRATEGY).
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          query:
+            multi_match:
+              query: "quick brown"
+              type: bool_prefix
+              fields: [ "title", "title._2gram", "title._3gram" ]
+
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  # RCA directly with an explicit analyzer override: UPDATE_STRATEGY path.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          query:
+            match_bool_prefix:
+              title:
+                query: "fast br"
+                analyzer: sayt_search_analyzer
+
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+---
+"search_as_you_type with reloadable search_analyzer after synonym reload":
+  - do:
+      synonyms.put_synonym:
+        id: set1
+        body:
+          synonyms_set:
+            - synonyms: "quick, fast, swift"
+
+  # RCA directly: UPDATE_STRATEGY path — both doc 1 ("quick") and doc 3 ("swift") must match.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          query:
+            match:
+              title:
+                query: "fast"
+                analyzer: sayt_search_analyzer
+
+  - match: { hits.total: 2 }
+
+  # Both paths on the same thread: title (UPDATE_STRATEGY) and title._2gram/_3gram (WRAPPER_REUSE_STRATEGY).
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          query:
+            multi_match:
+              query: "quick red"
+              type: bool_prefix
+              fields: [ "title", "title._2gram", "title._3gram" ]
+
+  - match: { hits.total: 2 }
+
+  # RCA directly with explicit analyzer override: UPDATE_STRATEGY path.
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          query:
+            match_bool_prefix:
+              title:
+                query: "swift re"
+                analyzer: sayt_search_analyzer
+
+  - match: { hits.total: 2 }

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.index.mapper.annotatedtext;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.AnalyzerWrapper;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -25,6 +24,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.AnalyzerScope;
+import org.elasticsearch.index.analysis.ElasticsearchAnalyzerWrapper;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.CompositeSyntheticFieldLoader;
@@ -284,7 +284,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
      * keep state about the annotations being processed and pass them into token streams
      * being highlighted.
      */
-    public static final class AnnotatedHighlighterAnalyzer extends AnalyzerWrapper {
+    public static final class AnnotatedHighlighterAnalyzer extends ElasticsearchAnalyzerWrapper {
         private final Analyzer delegate;
         private AnnotatedText[] annotations;
         // If the field has arrays of values this counter is used to keep track of
@@ -292,7 +292,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
         int readerNum;
 
         public AnnotatedHighlighterAnalyzer(Analyzer delegate) {
-            super(delegate.getReuseStrategy());
+            super(delegate);
             this.delegate = delegate;
         }
 
@@ -320,12 +320,12 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
         }
     }
 
-    public static final class AnnotationAnalyzerWrapper extends AnalyzerWrapper {
+    public static final class AnnotationAnalyzerWrapper extends ElasticsearchAnalyzerWrapper {
 
         private final Analyzer delegate;
 
         public AnnotationAnalyzerWrapper(Analyzer delegate) {
-            super(delegate.getReuseStrategy());
+            super(delegate);
             this.delegate = delegate;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/AnalyzerComponents.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AnalyzerComponents.java
@@ -27,7 +27,7 @@ public final class AnalyzerComponents {
     private final TokenFilterFactory[] tokenFilters;
     private final AnalysisMode analysisMode;
 
-    AnalyzerComponents(TokenizerFactory tokenizerFactory, CharFilterFactory[] charFilters, TokenFilterFactory[] tokenFilters) {
+    public AnalyzerComponents(TokenizerFactory tokenizerFactory, CharFilterFactory[] charFilters, TokenFilterFactory[] tokenFilters) {
 
         this.tokenizerFactory = tokenizerFactory;
         this.charFilters = charFilters;

--- a/server/src/main/java/org/elasticsearch/index/analysis/ElasticsearchAnalyzerWrapper.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/ElasticsearchAnalyzerWrapper.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.AnalyzerWrapper;
+
+/**
+ * Base class for Elasticsearch {@link AnalyzerWrapper} subclasses. Selects a
+ * {@link ReuseStrategy} that detects when the wrapped delegate is a
+ * {@link ReloadableCustomAnalyzer} and propagates reloads (e.g. synonym
+ * updates) to the wrapper, instead of inheriting a strategy that either
+ * ignores reloads or assumes the wrapping analyzer is itself reloadable.
+ */
+public abstract class ElasticsearchAnalyzerWrapper extends AnalyzerWrapper {
+
+    /**
+     * Reuse strategy for wrappers around a {@link ReloadableCustomAnalyzer}.
+     * Tracks freshness independently by storing the {@link AnalyzerComponents} version
+     * together with the {@link TokenStreamComponents} in the wrapper's per-thread slot.
+     */
+    private static final ReuseStrategy WRAPPER_REUSE_STRATEGY = new ReuseStrategy() {
+        @Override
+        public TokenStreamComponents getReusableComponents(Analyzer analyzer, String fieldName) {
+            ElasticsearchAnalyzerWrapper wrapper = (ElasticsearchAnalyzerWrapper) analyzer;
+            ReloadableCustomAnalyzer rca = (ReloadableCustomAnalyzer) wrapper.getWrappedAnalyzer(fieldName);
+            AnalyzerComponents current = rca.getComponents();
+            WrapperEntry entry = (WrapperEntry) getStoredValue(analyzer);
+            if (entry == null || entry.components != current) {
+                return null;
+            }
+            return entry.tsc;
+        }
+
+        @Override
+        public void setReusableComponents(Analyzer analyzer, String fieldName, TokenStreamComponents tsc) {
+            ElasticsearchAnalyzerWrapper wrapper = (ElasticsearchAnalyzerWrapper) analyzer;
+            ReloadableCustomAnalyzer rca = (ReloadableCustomAnalyzer) wrapper.getWrappedAnalyzer(fieldName);
+            setStoredValue(analyzer, new WrapperEntry(rca.getComponents(), tsc));
+        }
+    };
+
+    /** Pairs an {@link AnalyzerComponents} snapshot with the corresponding {@link TokenStreamComponents}. */
+    private record WrapperEntry(AnalyzerComponents components, TokenStreamComponents tsc) {}
+
+    protected ElasticsearchAnalyzerWrapper(Analyzer delegate) {
+        super(reuseStrategyFor(delegate));
+    }
+
+    private static ReuseStrategy reuseStrategyFor(Analyzer delegate) {
+        if (delegate instanceof ReloadableCustomAnalyzer) {
+            return WRAPPER_REUSE_STRATEGY;
+        }
+        return delegate.getReuseStrategy();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/analysis/ReloadableCustomAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/ReloadableCustomAnalyzer.java
@@ -60,7 +60,7 @@ public final class ReloadableCustomAnalyzer extends Analyzer implements Analyzer
         }
     };
 
-    ReloadableCustomAnalyzer(AnalyzerComponents components, int positionIncrementGap, int offsetGap) {
+    public ReloadableCustomAnalyzer(AnalyzerComponents components, int positionIncrementGap, int offsetGap) {
         super(UPDATE_STRATEGY);
         if (components.analysisMode().equals(AnalysisMode.SEARCH_TIME) == false) {
             throw new IllegalArgumentException(
@@ -165,7 +165,8 @@ public final class ReloadableCustomAnalyzer extends Analyzer implements Analyzer
 
     @Override
     protected TokenStreamComponents createComponents(String fieldName) {
-        final AnalyzerComponents components = getStoredComponents();
+        AnalyzerComponents stored = getStoredComponents();
+        final AnalyzerComponents components = stored != null ? stored : getComponents();
         Tokenizer tokenizer = components.getTokenizerFactory().create();
         TokenStream tokenStream = tokenizer;
         for (TokenFilterFactory tokenFilter : components.getTokenFilters()) {
@@ -176,7 +177,11 @@ public final class ReloadableCustomAnalyzer extends Analyzer implements Analyzer
 
     @Override
     protected Reader initReader(String fieldName, Reader reader) {
-        final AnalyzerComponents components = getStoredComponents();
+        AnalyzerComponents stored = getStoredComponents();
+        // AnalyzerWrapper subclasses that wrap this RCA bypass UPDATE_STRATEGY, so storedComponents
+        // may be unset; fall back to the volatile. initReader and createComponents may then see
+        // different versions, but char filters are never updateable so the difference is harmless.
+        final AnalyzerComponents components = stored != null ? stored : getComponents();
         if (CollectionUtils.isEmpty(components.getCharFilters()) == false) {
             for (CharFilterFactory charFilter : components.getCharFilters()) {
                 reader = charFilter.create(reader);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -87,9 +87,11 @@ public class MapperFeatures implements FeatureSpecification {
     public static final NodeFeature ES940_DISK_BBQ = new NodeFeature("mapper.es940_disk_bbq");
     public static final NodeFeature IGNORED_VALUES_STORED_IN_BINARY_DV = new NodeFeature("mapper.doc_values.ignored_values_in_binary_dv");
     static final NodeFeature KEYWORD_NORMALIZER_SKIP_STORE_SETTING = new NodeFeature("mapper.keyword.normalizer_skip_store_setting");
-
     public static final NodeFeature KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED = new NodeFeature(
         "mapper.keyword.multi_fields_not_stored_when_ignored"
+    );
+    static final NodeFeature ANALYZER_WRAPPER_RELOADABLE_SEARCH_ANALYZER = new NodeFeature(
+        "mapper.analyzer-wrapper.reloadable_search_analyzer"
     );
 
     @Override
@@ -154,7 +156,8 @@ public class MapperFeatures implements FeatureSpecification {
             FLATTENED_PASSTHROUGH_FEATURE,
             IGNORED_VALUES_STORED_IN_BINARY_DV,
             KEYWORD_NORMALIZER_SKIP_STORE_SETTING,
-            KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED
+            KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED,
+            ANALYZER_WRAPPER_RELOADABLE_SEARCH_ANALYZER
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.AnalyzerWrapper;
 import org.apache.lucene.analysis.CachingTokenFilter;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
@@ -64,6 +63,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.AnalyzerScope;
+import org.elasticsearch.index.analysis.ElasticsearchAnalyzerWrapper;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.FieldData;
@@ -604,13 +604,13 @@ public final class TextFieldMapper extends FieldMapper {
 
     public static final TypeParser PARSER = createTypeParserWithLegacySupport(Builder::new);
 
-    private static class PhraseWrappedAnalyzer extends AnalyzerWrapper {
+    private static class PhraseWrappedAnalyzer extends ElasticsearchAnalyzerWrapper {
 
         private final Analyzer delegate;
         private final int posIncGap;
 
         PhraseWrappedAnalyzer(Analyzer delegate, int posIncGap) {
-            super(delegate.getReuseStrategy());
+            super(delegate);
             this.delegate = delegate;
             this.posIncGap = posIncGap;
         }
@@ -631,7 +631,7 @@ public final class TextFieldMapper extends FieldMapper {
         }
     }
 
-    private static class PrefixWrappedAnalyzer extends AnalyzerWrapper {
+    private static class PrefixWrappedAnalyzer extends ElasticsearchAnalyzerWrapper {
 
         private final int minChars;
         private final int maxChars;
@@ -639,7 +639,7 @@ public final class TextFieldMapper extends FieldMapper {
         private final Analyzer delegate;
 
         PrefixWrappedAnalyzer(Analyzer delegate, int posIncGap, int minChars, int maxChars) {
-            super(delegate.getReuseStrategy());
+            super(delegate);
             this.delegate = delegate;
             this.posIncGap = posIncGap;
             this.minChars = minChars;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/LimitTokenOffsetAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/LimitTokenOffsetAnalyzer.java
@@ -9,15 +9,15 @@
 package org.elasticsearch.search.fetch.subphase.highlight;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.AnalyzerWrapper;
 import org.apache.lucene.analysis.miscellaneous.LimitTokenOffsetFilter;
+import org.elasticsearch.index.analysis.ElasticsearchAnalyzerWrapper;
 
 /**
  * This analyzer limits the highlighting once it sees a token with a start offset &lt;= the configured limit,
  * which won't pass and will end the stream.
  * @see LimitTokenOffsetFilter
  */
-public final class LimitTokenOffsetAnalyzer extends AnalyzerWrapper {
+public final class LimitTokenOffsetAnalyzer extends ElasticsearchAnalyzerWrapper {
 
     private final Analyzer delegate;
     private final int maxOffset;
@@ -30,7 +30,7 @@ public final class LimitTokenOffsetAnalyzer extends AnalyzerWrapper {
      * @param maxOffset max number of tokens to produce
      */
     public LimitTokenOffsetAnalyzer(Analyzer delegate, int maxOffset) {
-        super(delegate.getReuseStrategy());
+        super(delegate);
         this.delegate = delegate;
         this.maxOffset = maxOffset;
     }

--- a/server/src/test/java/org/elasticsearch/index/analysis/ElasticsearchAnalyzerWrapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/ElasticsearchAnalyzerWrapperTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.analysis;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ElasticsearchAnalyzerWrapperTests extends ESTestCase {
+
+    /**
+     * Verifies that {@link ElasticsearchAnalyzerWrapper} selects a reload-aware reuse strategy when wrapping a
+     * {@link ReloadableCustomAnalyzer}. After the delegate is reloaded, the wrapper must invalidate its cached
+     * token stream and rebuild it from the new components — otherwise reloadable analyzer's
+     * updates are silently ignored.
+     */
+    public void testWrapperPropagatesReloadFromReloadableDelegate() throws Exception {
+        TokenizerFactory tokenizerFactory = TokenizerFactory.newFactory("standard", StandardTokenizer::new);
+        AtomicInteger createCallCount = new AtomicInteger(0);
+        AbstractTokenFilterFactory trackingFilter = new AbstractTokenFilterFactory("tracking") {
+            @Override
+            public AnalysisMode getAnalysisMode() {
+                return AnalysisMode.SEARCH_TIME;
+            }
+
+            @Override
+            public TokenStream create(TokenStream tokenStream) {
+                createCallCount.incrementAndGet();
+                return tokenStream;
+            }
+        };
+        AnalyzerComponents components = new AnalyzerComponents(
+            tokenizerFactory,
+            new CharFilterFactory[0],
+            new TokenFilterFactory[] { trackingFilter }
+        );
+
+        try (
+            ReloadableCustomAnalyzer delegate = new ReloadableCustomAnalyzer(components, 0, -1);
+            ElasticsearchAnalyzerWrapper wrapper = new ElasticsearchAnalyzerWrapper(delegate) {
+                @Override
+                protected Analyzer getWrappedAnalyzer(String fieldName) {
+                    return delegate;
+                }
+            }
+        ) {
+            consume(wrapper);
+            assertEquals("first use should create components", 1, createCallCount.get());
+
+            consume(wrapper);
+            assertEquals("second use without reload should reuse cached components", 1, createCallCount.get());
+
+            delegate.reload(
+                "test_analyzer",
+                Settings.builder().put("tokenizer", "standard").putList("filter", "tracking").build(),
+                Map.of("standard", tokenizerFactory),
+                Map.of(),
+                Map.of("tracking", trackingFilter)
+            );
+
+            consume(wrapper);
+            assertEquals("reload must force the wrapper to rebuild components", 2, createCallCount.get());
+        }
+    }
+
+    private static void consume(Analyzer analyzer) throws Exception {
+        try (TokenStream ts = analyzer.tokenStream("field", "hello world")) {
+            ts.reset();
+            while (ts.incrementToken()) {
+            }
+            ts.end();
+        }
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - [Fix: propagate ReloadableCustomAnalyzer reloads through AnalyzerWrapper subclasses (#147695)](https://github.com/elastic/elasticsearch/pull/147695)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)