### PR TITLE
ESQL: Mark histogram and tsid as unsortable

### DIFF
--- a/docs/changelog/149085.yaml
+++ b/docs/changelog/149085.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149085
+summary: Mark histogram and tsid as unsortable
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -909,6 +909,11 @@ public class EsqlCapabilities {
         SORTING_ON_SOURCE_AND_COUNTERS_FORBIDDEN,
 
         /**
+         * Fix sorting not allowed on histogram and _tsid.
+         */
+        SORTING_ON_HISTOGRAM_AND_TSID_FORBIDDEN,
+
+        /**
          * Fix {@code SORT} when the {@code _source} field is not a sort key but
          * <strong>is</strong> being returned.
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -832,8 +832,13 @@ public enum DataType implements Writeable {
     }
 
     public static boolean isSortable(DataType t) {
-        return false == (t == SOURCE || isCounter(t) || isSpatialOrGrid(t) || t == AGGREGATE_METRIC_DOUBLE || t == FLATTENED
-            || t == HISTOGRAM || t == TSID_DATA_TYPE);
+        return false == (t == SOURCE
+            || isCounter(t)
+            || isSpatialOrGrid(t)
+            || t == AGGREGATE_METRIC_DOUBLE
+            || t == FLATTENED
+            || t == HISTOGRAM
+            || t == TSID_DATA_TYPE);
     }
 
     public String nameUpper() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -832,7 +832,8 @@ public enum DataType implements Writeable {
     }
 
     public static boolean isSortable(DataType t) {
-        return false == (t == SOURCE || isCounter(t) || isSpatialOrGrid(t) || t == AGGREGATE_METRIC_DOUBLE || t == FLATTENED);
+        return false == (t == SOURCE || isCounter(t) || isSpatialOrGrid(t) || t == AGGREGATE_METRIC_DOUBLE || t == FLATTENED
+            || t == HISTOGRAM || t == TSID_DATA_TYPE);
     }
 
     public String nameUpper() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/130_spatial.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/130_spatial.yml
@@ -341,3 +341,48 @@ cartesian_shape unsortable with limit from row:
       esql.query:
         body:
           query: 'ROW wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"] | MV_EXPAND wkt | EVAL shape = TO_CARTESIANSHAPE(wkt) | limit 5 | sort shape'
+
+---
+geohash unsortable:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [ spatial_grid_types ]
+      reason: "geohash type requires spatial_grid_types capability"
+  - do:
+      catch: /cannot sort on geohash/
+      esql.query:
+        body:
+          query: 'ROW v = ["9q8yy9", "u4pruydqqvj"] | MV_EXPAND v | EVAL cell = TO_GEOHASH(v) | limit 5 | sort cell'
+
+---
+geotile unsortable:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [ spatial_grid_types ]
+      reason: "geotile type requires spatial_grid_types capability"
+  - do:
+      catch: /cannot sort on geotile/
+      esql.query:
+        body:
+          query: 'ROW v = ["4/2/5", "5/4/11"] | MV_EXPAND v | EVAL cell = TO_GEOTILE(v) | limit 5 | sort cell'
+
+---
+geohex unsortable:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [ spatial_grid_types ]
+      reason: "geohex type requires spatial_grid_types capability"
+  - do:
+      catch: /cannot sort on geohex/
+      esql.query:
+        body:
+          query: 'ROW v = ["811fbffffffffff", "811f3ffffffffff"] | MV_EXPAND v | EVAL cell = TO_GEOHEX(v) | limit 5 | sort cell'

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -208,7 +208,7 @@ setup:
 
   - do:
       indices.create:
-        index: test_histogram
+        index: idx_histogram
         body:
           mappings:
             properties:
@@ -1227,4 +1227,4 @@ sort by histogram:
       catch: /cannot sort on histogram/
       esql.query:
         body:
-          query: 'from test_histogram | sort h | limit 3'
+          query: 'from idx_histogram | sort h | limit 3'

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -1,6 +1,6 @@
 setup:
   - requires:
-      test_runner_features: [allowed_warnings_regex, allowed_warnings]
+      test_runner_features: [allowed_warnings_regex, allowed_warnings, capabilities]
   - do:
       indices.create:
           index: test
@@ -183,6 +183,37 @@ setup:
         body:
           - '{"index": {}}'
           - '{"@timestamp": "2021-04-28T23:50:04.467Z", "agg_metric": {"sum": 1, "value_count": 10}, "k8s": {"pod": {"uid":"947e4ced-1786-4e53-9e0c-5c447e959507"}}}'
+
+  - do:
+      indices.create:
+        index: test_counter_double
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [dim]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              dim:
+                type: keyword
+                time_series_dimension: true
+              value:
+                type: double
+                time_series_metric: counter
+
+  - do:
+      indices.create:
+        index: test_histogram
+        body:
+          mappings:
+            properties:
+              h:
+                type: histogram
 
 ---
 load everything:
@@ -1131,3 +1162,69 @@ Stats on aggregate_metric_double with no count, but has sum:
   - match: {values.0.2: 0}
   - match: {values.0.3: null}
   - match: {values.0.4: null}
+
+---
+'sort by _tsid':
+  - requires:
+      test_runner_features: [ contains ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [ sorting_on_histogram_and_tsid_forbidden ]
+      reason: "sorting on _tsid raises a verification error since this fix"
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          query: 'FROM test METADATA _tsid | SORT _tsid | LIMIT 3'
+  - match: { status: 400 }
+  - match: { error.type: verification_exception }
+  - contains: { error.reason: 'cannot sort on _tsid' }
+
+---
+sort by counter_integer:
+  - requires:
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [sorting_on_source_and_counters_forbidden]
+      reason: "Sorting on counters shouldn't have been possible"
+  - do:
+      catch: /cannot sort on counter_integer/
+      esql.query:
+        body:
+          query: 'from test | sort k8s.pod.network.rx | limit 1'
+
+---
+sort by counter_double:
+  - requires:
+      test_runner_features: [capabilities]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [sorting_on_source_and_counters_forbidden]
+      reason: "Sorting on counters shouldn't have been possible"
+  - do:
+      catch: /cannot sort on counter_double/
+      esql.query:
+        body:
+          query: 'from test_counter_double | sort value | limit 1'
+
+---
+sort by histogram:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: []
+          capabilities: [ sorting_on_histogram_and_tsid_forbidden ]
+      reason: "sorting on histogram raises a verification error since this fix"
+  - do:
+      catch: /cannot sort on histogram/
+      esql.query:
+        body:
+          query: 'from test_histogram | sort h | limit 3'


### PR DESCRIPTION
This causes ESQL to send a nice error message if you ask to sort by a `_tsid` or `histogram` field instead of just failing with 500 error. Adds more tests for other unsortable fields, just to make sure they return nice errors as well.
