### PR TITLE
[9.4] Fix bc-upgrade tests agent config

### DIFF
--- a/.buildkite/scripts/run-bc-upgrade-tests.sh
+++ b/.buildkite/scripts/run-bc-upgrade-tests.sh
@@ -70,6 +70,7 @@ steps:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: n4-standard-16
+          diskType: hyperdisk-balanced
           buildDirectory: /dev/shm/bk
         matrix:
           setup:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.4`:
 - Fix bc-upgrade tests agent config (d095fbe4)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)