### PR TITLE
ESQL: Rename some evaluators

### DIFF
--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsBytesRefEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsBytesRefEvaluator.java
@@ -22,11 +22,11 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
- * {@link ExpressionEvaluator} implementation for {@link LessThanOrEqual}.
+ * {@link ExpressionEvaluator} implementation for {@link Equals}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class LessThanOrEqualKeywordsEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(LessThanOrEqualKeywordsEvaluator.class);
+public final class EqualsBytesRefEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(EqualsBytesRefEvaluator.class);
 
   private final Source source;
 
@@ -38,8 +38,8 @@ public final class LessThanOrEqualKeywordsEvaluator implements ExpressionEvaluat
 
   private Warnings warnings;
 
-  public LessThanOrEqualKeywordsEvaluator(Source source, ExpressionEvaluator lhs,
-      ExpressionEvaluator rhs, DriverContext driverContext) {
+  public EqualsBytesRefEvaluator(Source source, ExpressionEvaluator lhs, ExpressionEvaluator rhs,
+      DriverContext driverContext) {
     this.source = source;
     this.lhs = lhs;
     this.rhs = rhs;
@@ -100,7 +100,7 @@ public final class LessThanOrEqualKeywordsEvaluator implements ExpressionEvaluat
         }
         BytesRef lhs = lhsBlock.getBytesRef(lhsBlock.getFirstValueIndex(p), lhsScratch);
         BytesRef rhs = rhsBlock.getBytesRef(rhsBlock.getFirstValueIndex(p), rhsScratch);
-        result.appendBoolean(LessThanOrEqual.processKeywords(lhs, rhs));
+        result.appendBoolean(Equals.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -113,7 +113,7 @@ public final class LessThanOrEqualKeywordsEvaluator implements ExpressionEvaluat
       position: for (int p = 0; p < positionCount; p++) {
         BytesRef lhs = lhsVector.getBytesRef(p, lhsScratch);
         BytesRef rhs = rhsVector.getBytesRef(p, rhsScratch);
-        result.appendBoolean(p, LessThanOrEqual.processKeywords(lhs, rhs));
+        result.appendBoolean(p, Equals.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -121,7 +121,7 @@ public final class LessThanOrEqualKeywordsEvaluator implements ExpressionEvaluat
 
   @Override
   public String toString() {
-    return "LessThanOrEqualKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+    return "EqualsBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
   }
 
   @Override
@@ -151,13 +151,13 @@ public final class LessThanOrEqualKeywordsEvaluator implements ExpressionEvaluat
     }
 
     @Override
-    public LessThanOrEqualKeywordsEvaluator get(DriverContext context) {
-      return new LessThanOrEqualKeywordsEvaluator(source, lhs.get(context), rhs.get(context), context);
+    public EqualsBytesRefEvaluator get(DriverContext context) {
+      return new EqualsBytesRefEvaluator(source, lhs.get(context), rhs.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "LessThanOrEqualKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+      return "EqualsBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThanBytesRefEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThanBytesRefEvaluator.java
@@ -22,11 +22,11 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
- * {@link ExpressionEvaluator} implementation for {@link NotEquals}.
+ * {@link ExpressionEvaluator} implementation for {@link GreaterThan}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class NotEqualsKeywordsEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(NotEqualsKeywordsEvaluator.class);
+public final class GreaterThanBytesRefEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(GreaterThanBytesRefEvaluator.class);
 
   private final Source source;
 
@@ -38,8 +38,8 @@ public final class NotEqualsKeywordsEvaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public NotEqualsKeywordsEvaluator(Source source, ExpressionEvaluator lhs, ExpressionEvaluator rhs,
-      DriverContext driverContext) {
+  public GreaterThanBytesRefEvaluator(Source source, ExpressionEvaluator lhs,
+      ExpressionEvaluator rhs, DriverContext driverContext) {
     this.source = source;
     this.lhs = lhs;
     this.rhs = rhs;
@@ -100,7 +100,7 @@ public final class NotEqualsKeywordsEvaluator implements ExpressionEvaluator {
         }
         BytesRef lhs = lhsBlock.getBytesRef(lhsBlock.getFirstValueIndex(p), lhsScratch);
         BytesRef rhs = rhsBlock.getBytesRef(rhsBlock.getFirstValueIndex(p), rhsScratch);
-        result.appendBoolean(NotEquals.processKeywords(lhs, rhs));
+        result.appendBoolean(GreaterThan.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -113,7 +113,7 @@ public final class NotEqualsKeywordsEvaluator implements ExpressionEvaluator {
       position: for (int p = 0; p < positionCount; p++) {
         BytesRef lhs = lhsVector.getBytesRef(p, lhsScratch);
         BytesRef rhs = rhsVector.getBytesRef(p, rhsScratch);
-        result.appendBoolean(p, NotEquals.processKeywords(lhs, rhs));
+        result.appendBoolean(p, GreaterThan.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -121,7 +121,7 @@ public final class NotEqualsKeywordsEvaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "NotEqualsKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+    return "GreaterThanBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
   }
 
   @Override
@@ -151,13 +151,13 @@ public final class NotEqualsKeywordsEvaluator implements ExpressionEvaluator {
     }
 
     @Override
-    public NotEqualsKeywordsEvaluator get(DriverContext context) {
-      return new NotEqualsKeywordsEvaluator(source, lhs.get(context), rhs.get(context), context);
+    public GreaterThanBytesRefEvaluator get(DriverContext context) {
+      return new GreaterThanBytesRefEvaluator(source, lhs.get(context), rhs.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "NotEqualsKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+      return "GreaterThanBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThanOrEqualBytesRefEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThanOrEqualBytesRefEvaluator.java
@@ -22,11 +22,11 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
- * {@link ExpressionEvaluator} implementation for {@link LessThan}.
+ * {@link ExpressionEvaluator} implementation for {@link GreaterThanOrEqual}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class LessThanKeywordsEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(LessThanKeywordsEvaluator.class);
+public final class GreaterThanOrEqualBytesRefEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(GreaterThanOrEqualBytesRefEvaluator.class);
 
   private final Source source;
 
@@ -38,8 +38,8 @@ public final class LessThanKeywordsEvaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public LessThanKeywordsEvaluator(Source source, ExpressionEvaluator lhs, ExpressionEvaluator rhs,
-      DriverContext driverContext) {
+  public GreaterThanOrEqualBytesRefEvaluator(Source source, ExpressionEvaluator lhs,
+      ExpressionEvaluator rhs, DriverContext driverContext) {
     this.source = source;
     this.lhs = lhs;
     this.rhs = rhs;
@@ -100,7 +100,7 @@ public final class LessThanKeywordsEvaluator implements ExpressionEvaluator {
         }
         BytesRef lhs = lhsBlock.getBytesRef(lhsBlock.getFirstValueIndex(p), lhsScratch);
         BytesRef rhs = rhsBlock.getBytesRef(rhsBlock.getFirstValueIndex(p), rhsScratch);
-        result.appendBoolean(LessThan.processKeywords(lhs, rhs));
+        result.appendBoolean(GreaterThanOrEqual.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -113,7 +113,7 @@ public final class LessThanKeywordsEvaluator implements ExpressionEvaluator {
       position: for (int p = 0; p < positionCount; p++) {
         BytesRef lhs = lhsVector.getBytesRef(p, lhsScratch);
         BytesRef rhs = rhsVector.getBytesRef(p, rhsScratch);
-        result.appendBoolean(p, LessThan.processKeywords(lhs, rhs));
+        result.appendBoolean(p, GreaterThanOrEqual.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -121,7 +121,7 @@ public final class LessThanKeywordsEvaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "LessThanKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+    return "GreaterThanOrEqualBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
   }
 
   @Override
@@ -151,13 +151,13 @@ public final class LessThanKeywordsEvaluator implements ExpressionEvaluator {
     }
 
     @Override
-    public LessThanKeywordsEvaluator get(DriverContext context) {
-      return new LessThanKeywordsEvaluator(source, lhs.get(context), rhs.get(context), context);
+    public GreaterThanOrEqualBytesRefEvaluator get(DriverContext context) {
+      return new GreaterThanOrEqualBytesRefEvaluator(source, lhs.get(context), rhs.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "LessThanKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+      return "GreaterThanOrEqualBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThanBytesRefEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThanBytesRefEvaluator.java
@@ -22,11 +22,11 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
- * {@link ExpressionEvaluator} implementation for {@link GreaterThanOrEqual}.
+ * {@link ExpressionEvaluator} implementation for {@link LessThan}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class GreaterThanOrEqualKeywordsEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(GreaterThanOrEqualKeywordsEvaluator.class);
+public final class LessThanBytesRefEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(LessThanBytesRefEvaluator.class);
 
   private final Source source;
 
@@ -38,8 +38,8 @@ public final class GreaterThanOrEqualKeywordsEvaluator implements ExpressionEval
 
   private Warnings warnings;
 
-  public GreaterThanOrEqualKeywordsEvaluator(Source source, ExpressionEvaluator lhs,
-      ExpressionEvaluator rhs, DriverContext driverContext) {
+  public LessThanBytesRefEvaluator(Source source, ExpressionEvaluator lhs, ExpressionEvaluator rhs,
+      DriverContext driverContext) {
     this.source = source;
     this.lhs = lhs;
     this.rhs = rhs;
@@ -100,7 +100,7 @@ public final class GreaterThanOrEqualKeywordsEvaluator implements ExpressionEval
         }
         BytesRef lhs = lhsBlock.getBytesRef(lhsBlock.getFirstValueIndex(p), lhsScratch);
         BytesRef rhs = rhsBlock.getBytesRef(rhsBlock.getFirstValueIndex(p), rhsScratch);
-        result.appendBoolean(GreaterThanOrEqual.processKeywords(lhs, rhs));
+        result.appendBoolean(LessThan.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -113,7 +113,7 @@ public final class GreaterThanOrEqualKeywordsEvaluator implements ExpressionEval
       position: for (int p = 0; p < positionCount; p++) {
         BytesRef lhs = lhsVector.getBytesRef(p, lhsScratch);
         BytesRef rhs = rhsVector.getBytesRef(p, rhsScratch);
-        result.appendBoolean(p, GreaterThanOrEqual.processKeywords(lhs, rhs));
+        result.appendBoolean(p, LessThan.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -121,7 +121,7 @@ public final class GreaterThanOrEqualKeywordsEvaluator implements ExpressionEval
 
   @Override
   public String toString() {
-    return "GreaterThanOrEqualKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+    return "LessThanBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
   }
 
   @Override
@@ -151,13 +151,13 @@ public final class GreaterThanOrEqualKeywordsEvaluator implements ExpressionEval
     }
 
     @Override
-    public GreaterThanOrEqualKeywordsEvaluator get(DriverContext context) {
-      return new GreaterThanOrEqualKeywordsEvaluator(source, lhs.get(context), rhs.get(context), context);
+    public LessThanBytesRefEvaluator get(DriverContext context) {
+      return new LessThanBytesRefEvaluator(source, lhs.get(context), rhs.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "GreaterThanOrEqualKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+      return "LessThanBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThanOrEqualBytesRefEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThanOrEqualBytesRefEvaluator.java
@@ -22,11 +22,11 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
- * {@link ExpressionEvaluator} implementation for {@link GreaterThan}.
+ * {@link ExpressionEvaluator} implementation for {@link LessThanOrEqual}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class GreaterThanKeywordsEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(GreaterThanKeywordsEvaluator.class);
+public final class LessThanOrEqualBytesRefEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(LessThanOrEqualBytesRefEvaluator.class);
 
   private final Source source;
 
@@ -38,7 +38,7 @@ public final class GreaterThanKeywordsEvaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public GreaterThanKeywordsEvaluator(Source source, ExpressionEvaluator lhs,
+  public LessThanOrEqualBytesRefEvaluator(Source source, ExpressionEvaluator lhs,
       ExpressionEvaluator rhs, DriverContext driverContext) {
     this.source = source;
     this.lhs = lhs;
@@ -100,7 +100,7 @@ public final class GreaterThanKeywordsEvaluator implements ExpressionEvaluator {
         }
         BytesRef lhs = lhsBlock.getBytesRef(lhsBlock.getFirstValueIndex(p), lhsScratch);
         BytesRef rhs = rhsBlock.getBytesRef(rhsBlock.getFirstValueIndex(p), rhsScratch);
-        result.appendBoolean(GreaterThan.processKeywords(lhs, rhs));
+        result.appendBoolean(LessThanOrEqual.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -113,7 +113,7 @@ public final class GreaterThanKeywordsEvaluator implements ExpressionEvaluator {
       position: for (int p = 0; p < positionCount; p++) {
         BytesRef lhs = lhsVector.getBytesRef(p, lhsScratch);
         BytesRef rhs = rhsVector.getBytesRef(p, rhsScratch);
-        result.appendBoolean(p, GreaterThan.processKeywords(lhs, rhs));
+        result.appendBoolean(p, LessThanOrEqual.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -121,7 +121,7 @@ public final class GreaterThanKeywordsEvaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "GreaterThanKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+    return "LessThanOrEqualBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
   }
 
   @Override
@@ -151,13 +151,13 @@ public final class GreaterThanKeywordsEvaluator implements ExpressionEvaluator {
     }
 
     @Override
-    public GreaterThanKeywordsEvaluator get(DriverContext context) {
-      return new GreaterThanKeywordsEvaluator(source, lhs.get(context), rhs.get(context), context);
+    public LessThanOrEqualBytesRefEvaluator get(DriverContext context) {
+      return new LessThanOrEqualBytesRefEvaluator(source, lhs.get(context), rhs.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "GreaterThanKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+      return "LessThanOrEqualBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsBytesRefEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsBytesRefEvaluator.java
@@ -22,11 +22,11 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 /**
- * {@link ExpressionEvaluator} implementation for {@link Equals}.
+ * {@link ExpressionEvaluator} implementation for {@link NotEquals}.
  * This class is generated. Edit {@code EvaluatorImplementer} instead.
  */
-public final class EqualsKeywordsEvaluator implements ExpressionEvaluator {
-  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(EqualsKeywordsEvaluator.class);
+public final class NotEqualsBytesRefEvaluator implements ExpressionEvaluator {
+  private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(NotEqualsBytesRefEvaluator.class);
 
   private final Source source;
 
@@ -38,7 +38,7 @@ public final class EqualsKeywordsEvaluator implements ExpressionEvaluator {
 
   private Warnings warnings;
 
-  public EqualsKeywordsEvaluator(Source source, ExpressionEvaluator lhs, ExpressionEvaluator rhs,
+  public NotEqualsBytesRefEvaluator(Source source, ExpressionEvaluator lhs, ExpressionEvaluator rhs,
       DriverContext driverContext) {
     this.source = source;
     this.lhs = lhs;
@@ -100,7 +100,7 @@ public final class EqualsKeywordsEvaluator implements ExpressionEvaluator {
         }
         BytesRef lhs = lhsBlock.getBytesRef(lhsBlock.getFirstValueIndex(p), lhsScratch);
         BytesRef rhs = rhsBlock.getBytesRef(rhsBlock.getFirstValueIndex(p), rhsScratch);
-        result.appendBoolean(Equals.processKeywords(lhs, rhs));
+        result.appendBoolean(NotEquals.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -113,7 +113,7 @@ public final class EqualsKeywordsEvaluator implements ExpressionEvaluator {
       position: for (int p = 0; p < positionCount; p++) {
         BytesRef lhs = lhsVector.getBytesRef(p, lhsScratch);
         BytesRef rhs = rhsVector.getBytesRef(p, rhsScratch);
-        result.appendBoolean(p, Equals.processKeywords(lhs, rhs));
+        result.appendBoolean(p, NotEquals.processBytesRef(lhs, rhs));
       }
       return result.build();
     }
@@ -121,7 +121,7 @@ public final class EqualsKeywordsEvaluator implements ExpressionEvaluator {
 
   @Override
   public String toString() {
-    return "EqualsKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+    return "NotEqualsBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
   }
 
   @Override
@@ -151,13 +151,13 @@ public final class EqualsKeywordsEvaluator implements ExpressionEvaluator {
     }
 
     @Override
-    public EqualsKeywordsEvaluator get(DriverContext context) {
-      return new EqualsKeywordsEvaluator(source, lhs.get(context), rhs.get(context), context);
+    public NotEqualsBytesRefEvaluator get(DriverContext context) {
+      return new NotEqualsBytesRefEvaluator(source, lhs.get(context), rhs.get(context), context);
     }
 
     @Override
     public String toString() {
-      return "EqualsKeywordsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+      return "NotEqualsBytesRefEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
     }
   }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/Equals.java
@@ -52,12 +52,12 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
         Map.entry(DataType.GEOHASH, EqualsLongsEvaluator.Factory::new),
         Map.entry(DataType.GEOTILE, EqualsLongsEvaluator.Factory::new),
         Map.entry(DataType.GEOHEX, EqualsLongsEvaluator.Factory::new),
-        Map.entry(DataType.KEYWORD, EqualsKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.TEXT, EqualsKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.VERSION, EqualsKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.IP, EqualsKeywordsEvaluator.Factory::new),
+        Map.entry(DataType.KEYWORD, EqualsBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.TEXT, EqualsBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.VERSION, EqualsBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.IP, EqualsBytesRefEvaluator.Factory::new),
         Map.entry(DataType.DENSE_VECTOR, EqualsDenseVectorEvaluator.Factory::new),
-        Map.entry(DataType.FLATTENED, EqualsKeywordsEvaluator.Factory::new)
+        Map.entry(DataType.FLATTENED, EqualsBytesRefEvaluator.Factory::new)
     );
 
     @FunctionInfo(
@@ -232,8 +232,8 @@ public class Equals extends EsqlBinaryComparison implements Negatable<EsqlBinary
         return lhs == rhs;
     }
 
-    @Evaluator(extraName = "Keywords")
-    static boolean processKeywords(BytesRef lhs, BytesRef rhs) {
+    @Evaluator(extraName = "BytesRef")
+    static boolean processBytesRef(BytesRef lhs, BytesRef rhs) {
         return lhs.equals(rhs);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EsqlBinaryComparison.java
@@ -363,7 +363,7 @@ public abstract class EsqlBinaryComparison extends BinaryComparison
     public Translatable translatable(LucenePushdownPredicates pushdownPredicates) {
         if (right() instanceof Literal lit) {
             // Multi-valued literals are not supported going further. This also makes sure that we are handling multi-valued literals with
-            // a "warning" header, as well (see EqualsKeywordsEvaluator, for example, where lhs and rhs are both dealt with equally when
+            // a "warning" header, as well (see EqualsBytesRefEvaluator, for example, where lhs and rhs are both dealt with equally when
             // it comes to multi-value handling).
             if (lit.value() instanceof Collection<?>) {
                 return Translatable.NO;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThan.java
@@ -36,10 +36,10 @@ public class GreaterThan extends EsqlBinaryComparison implements Negatable<EsqlB
         Map.entry(DataType.UNSIGNED_LONG, GreaterThanLongsEvaluator.Factory::new),
         Map.entry(DataType.DATETIME, GreaterThanLongsEvaluator.Factory::new),
         Map.entry(DataType.DATE_NANOS, GreaterThanLongsEvaluator.Factory::new),
-        Map.entry(DataType.KEYWORD, GreaterThanKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.TEXT, GreaterThanKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.VERSION, GreaterThanKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.IP, GreaterThanKeywordsEvaluator.Factory::new)
+        Map.entry(DataType.KEYWORD, GreaterThanBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.TEXT, GreaterThanBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.VERSION, GreaterThanBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.IP, GreaterThanBytesRefEvaluator.Factory::new)
     );
 
     @FunctionInfo(
@@ -165,8 +165,8 @@ public class GreaterThan extends EsqlBinaryComparison implements Negatable<EsqlB
         return lhs > rhs;
     }
 
-    @Evaluator(extraName = "Keywords")
-    static boolean processKeywords(BytesRef lhs, BytesRef rhs) {
+    @Evaluator(extraName = "BytesRef")
+    static boolean processBytesRef(BytesRef lhs, BytesRef rhs) {
         return lhs.compareTo(rhs) > 0;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThanOrEqual.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThanOrEqual.java
@@ -36,10 +36,10 @@ public class GreaterThanOrEqual extends EsqlBinaryComparison implements Negatabl
         Map.entry(DataType.UNSIGNED_LONG, GreaterThanOrEqualLongsEvaluator.Factory::new),
         Map.entry(DataType.DATETIME, GreaterThanOrEqualLongsEvaluator.Factory::new),
         Map.entry(DataType.DATE_NANOS, GreaterThanOrEqualLongsEvaluator.Factory::new),
-        Map.entry(DataType.KEYWORD, GreaterThanOrEqualKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.TEXT, GreaterThanOrEqualKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.VERSION, GreaterThanOrEqualKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.IP, GreaterThanOrEqualKeywordsEvaluator.Factory::new)
+        Map.entry(DataType.KEYWORD, GreaterThanOrEqualBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.TEXT, GreaterThanOrEqualBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.VERSION, GreaterThanOrEqualBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.IP, GreaterThanOrEqualBytesRefEvaluator.Factory::new)
     );
 
     @FunctionInfo(
@@ -165,8 +165,8 @@ public class GreaterThanOrEqual extends EsqlBinaryComparison implements Negatabl
         return lhs >= rhs;
     }
 
-    @Evaluator(extraName = "Keywords")
-    static boolean processKeywords(BytesRef lhs, BytesRef rhs) {
+    @Evaluator(extraName = "BytesRef")
+    static boolean processBytesRef(BytesRef lhs, BytesRef rhs) {
         return lhs.compareTo(rhs) >= 0;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThan.java
@@ -36,10 +36,10 @@ public class LessThan extends EsqlBinaryComparison implements Negatable<EsqlBina
         Map.entry(DataType.UNSIGNED_LONG, LessThanLongsEvaluator.Factory::new),
         Map.entry(DataType.DATETIME, LessThanLongsEvaluator.Factory::new),
         Map.entry(DataType.DATE_NANOS, LessThanLongsEvaluator.Factory::new),
-        Map.entry(DataType.KEYWORD, LessThanKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.TEXT, LessThanKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.VERSION, LessThanKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.IP, LessThanKeywordsEvaluator.Factory::new)
+        Map.entry(DataType.KEYWORD, LessThanBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.TEXT, LessThanBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.VERSION, LessThanBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.IP, LessThanBytesRefEvaluator.Factory::new)
     );
 
     @FunctionInfo(
@@ -159,8 +159,8 @@ public class LessThan extends EsqlBinaryComparison implements Negatable<EsqlBina
         return lhs < rhs;
     }
 
-    @Evaluator(extraName = "Keywords")  // TODO rename to "Bytes"
-    static boolean processKeywords(BytesRef lhs, BytesRef rhs) {
+    @Evaluator(extraName = "BytesRef")
+    static boolean processBytesRef(BytesRef lhs, BytesRef rhs) {
         return lhs.compareTo(rhs) < 0;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThanOrEqual.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThanOrEqual.java
@@ -36,10 +36,10 @@ public class LessThanOrEqual extends EsqlBinaryComparison implements Negatable<E
         Map.entry(DataType.UNSIGNED_LONG, LessThanOrEqualLongsEvaluator.Factory::new),
         Map.entry(DataType.DATETIME, LessThanOrEqualLongsEvaluator.Factory::new),
         Map.entry(DataType.DATE_NANOS, LessThanOrEqualLongsEvaluator.Factory::new),
-        Map.entry(DataType.KEYWORD, LessThanOrEqualKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.TEXT, LessThanOrEqualKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.VERSION, LessThanOrEqualKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.IP, LessThanOrEqualKeywordsEvaluator.Factory::new)
+        Map.entry(DataType.KEYWORD, LessThanOrEqualBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.TEXT, LessThanOrEqualBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.VERSION, LessThanOrEqualBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.IP, LessThanOrEqualBytesRefEvaluator.Factory::new)
     );
 
     @FunctionInfo(
@@ -157,8 +157,8 @@ public class LessThanOrEqual extends EsqlBinaryComparison implements Negatable<E
         return lhs <= rhs;
     }
 
-    @Evaluator(extraName = "Keywords")
-    static boolean processKeywords(BytesRef lhs, BytesRef rhs) {
+    @Evaluator(extraName = "BytesRef")
+    static boolean processBytesRef(BytesRef lhs, BytesRef rhs) {
         return lhs.compareTo(rhs) <= 0;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEquals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEquals.java
@@ -44,12 +44,12 @@ public class NotEquals extends EsqlBinaryComparison implements Negatable<EsqlBin
         Map.entry(DataType.GEOHASH, NotEqualsLongsEvaluator.Factory::new),
         Map.entry(DataType.GEOTILE, NotEqualsLongsEvaluator.Factory::new),
         Map.entry(DataType.GEOHEX, NotEqualsLongsEvaluator.Factory::new),
-        Map.entry(DataType.KEYWORD, NotEqualsKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.TEXT, NotEqualsKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.VERSION, NotEqualsKeywordsEvaluator.Factory::new),
-        Map.entry(DataType.IP, NotEqualsKeywordsEvaluator.Factory::new),
+        Map.entry(DataType.KEYWORD, NotEqualsBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.TEXT, NotEqualsBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.VERSION, NotEqualsBytesRefEvaluator.Factory::new),
+        Map.entry(DataType.IP, NotEqualsBytesRefEvaluator.Factory::new),
         Map.entry(DataType.DENSE_VECTOR, NotEqualsDenseVectorEvaluator.Factory::new),
-        Map.entry(DataType.FLATTENED, NotEqualsKeywordsEvaluator.Factory::new)
+        Map.entry(DataType.FLATTENED, NotEqualsBytesRefEvaluator.Factory::new)
     );
 
     @FunctionInfo(
@@ -167,8 +167,8 @@ public class NotEquals extends EsqlBinaryComparison implements Negatable<EsqlBin
         return lhs != rhs;
     }
 
-    @Evaluator(extraName = "Keywords")
-    static boolean processKeywords(BytesRef lhs, BytesRef rhs) {
+    @Evaluator(extraName = "BytesRef")
+    static boolean processBytesRef(BytesRef lhs, BytesRef rhs) {
         return false == lhs.equals(rhs);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/EqualsTests.java
@@ -93,7 +93,7 @@ public class EqualsTests extends AbstractScalarFunctionTestCase {
         );
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "EqualsKeywordsEvaluator",
+                "EqualsBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 Object::equals,
@@ -106,7 +106,7 @@ public class EqualsTests extends AbstractScalarFunctionTestCase {
         );
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "EqualsKeywordsEvaluator",
+                "EqualsBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 Object::equals,
@@ -177,7 +177,7 @@ public class EqualsTests extends AbstractScalarFunctionTestCase {
         suppliers.addAll(
             TestCaseSupplier.stringCases(
                 Object::equals,
-                (lhsType, rhsType) -> "EqualsKeywordsEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                (lhsType, rhsType) -> "EqualsBytesRefEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
                 List.of(),
                 DataType.BOOLEAN
             )
@@ -258,7 +258,7 @@ public class EqualsTests extends AbstractScalarFunctionTestCase {
         if (DataType.FLATTENED.supportedVersion().supportedLocally()) {
             suppliers.addAll(
                 TestCaseSupplier.forBinaryNotCasting(
-                    "EqualsKeywordsEvaluator",
+                    "EqualsBytesRefEvaluator",
                     "lhs",
                     "rhs",
                     Object::equals,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThanOrEqualTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThanOrEqualTests.java
@@ -81,7 +81,7 @@ public class GreaterThanOrEqualTests extends AbstractScalarFunctionTestCase {
 
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "GreaterThanOrEqualKeywordsEvaluator",
+                "GreaterThanOrEqualBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) >= 0,
@@ -95,7 +95,7 @@ public class GreaterThanOrEqualTests extends AbstractScalarFunctionTestCase {
 
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "GreaterThanOrEqualKeywordsEvaluator",
+                "GreaterThanOrEqualBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) >= 0,
@@ -152,7 +152,7 @@ public class GreaterThanOrEqualTests extends AbstractScalarFunctionTestCase {
         suppliers.addAll(
             TestCaseSupplier.stringCases(
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) >= 0,
-                (lhsType, rhsType) -> "GreaterThanOrEqualKeywordsEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                (lhsType, rhsType) -> "GreaterThanOrEqualBytesRefEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
                 List.of(),
                 DataType.BOOLEAN
             )

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/GreaterThanTests.java
@@ -81,7 +81,7 @@ public class GreaterThanTests extends AbstractScalarFunctionTestCase {
 
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "GreaterThanKeywordsEvaluator",
+                "GreaterThanBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) > 0,
@@ -95,7 +95,7 @@ public class GreaterThanTests extends AbstractScalarFunctionTestCase {
 
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "GreaterThanKeywordsEvaluator",
+                "GreaterThanBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) > 0,
@@ -166,7 +166,7 @@ public class GreaterThanTests extends AbstractScalarFunctionTestCase {
         suppliers.addAll(
             TestCaseSupplier.stringCases(
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) > 0,
-                (lhsType, rhsType) -> "GreaterThanKeywordsEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                (lhsType, rhsType) -> "GreaterThanBytesRefEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
                 List.of(),
                 DataType.BOOLEAN
             )

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThanOrEqualTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThanOrEqualTests.java
@@ -81,7 +81,7 @@ public class LessThanOrEqualTests extends AbstractScalarFunctionTestCase {
 
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "LessThanOrEqualKeywordsEvaluator",
+                "LessThanOrEqualBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) <= 0,
@@ -95,7 +95,7 @@ public class LessThanOrEqualTests extends AbstractScalarFunctionTestCase {
 
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "LessThanOrEqualKeywordsEvaluator",
+                "LessThanOrEqualBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) <= 0,
@@ -152,7 +152,7 @@ public class LessThanOrEqualTests extends AbstractScalarFunctionTestCase {
         suppliers.addAll(
             TestCaseSupplier.stringCases(
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) <= 0,
-                (lhsType, rhsType) -> "LessThanOrEqualKeywordsEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                (lhsType, rhsType) -> "LessThanOrEqualBytesRefEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
                 List.of(),
                 DataType.BOOLEAN
             )

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/LessThanTests.java
@@ -81,7 +81,7 @@ public class LessThanTests extends AbstractScalarFunctionTestCase {
 
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "LessThanKeywordsEvaluator",
+                "LessThanBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) < 0,
@@ -95,7 +95,7 @@ public class LessThanTests extends AbstractScalarFunctionTestCase {
 
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "LessThanKeywordsEvaluator",
+                "LessThanBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) < 0,
@@ -166,7 +166,7 @@ public class LessThanTests extends AbstractScalarFunctionTestCase {
         suppliers.addAll(
             TestCaseSupplier.stringCases(
                 (l, r) -> ((BytesRef) l).compareTo((BytesRef) r) < 0,
-                (lhsType, rhsType) -> "LessThanKeywordsEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                (lhsType, rhsType) -> "LessThanBytesRefEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
                 List.of(),
                 DataType.BOOLEAN
             )

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/NotEqualsTests.java
@@ -92,7 +92,7 @@ public class NotEqualsTests extends AbstractScalarFunctionTestCase {
         );
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "NotEqualsKeywordsEvaluator",
+                "NotEqualsBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 (l, r) -> false == l.equals(r),
@@ -105,7 +105,7 @@ public class NotEqualsTests extends AbstractScalarFunctionTestCase {
         );
         suppliers.addAll(
             TestCaseSupplier.forBinaryNotCasting(
-                "NotEqualsKeywordsEvaluator",
+                "NotEqualsBytesRefEvaluator",
                 "lhs",
                 "rhs",
                 (l, r) -> false == l.equals(r),
@@ -177,7 +177,7 @@ public class NotEqualsTests extends AbstractScalarFunctionTestCase {
         suppliers.addAll(
             TestCaseSupplier.stringCases(
                 (l, r) -> false == l.equals(r),
-                (lhsType, rhsType) -> "NotEqualsKeywordsEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                (lhsType, rhsType) -> "NotEqualsBytesRefEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
                 List.of(),
                 DataType.BOOLEAN
             )
@@ -255,7 +255,7 @@ public class NotEqualsTests extends AbstractScalarFunctionTestCase {
         if (DataType.FLATTENED.supportedVersion().supportedLocally()) {
             suppliers.addAll(
                 TestCaseSupplier.forBinaryNotCasting(
-                    "NotEqualsKeywordsEvaluator",
+                    "NotEqualsBytesRefEvaluator",
                     "lhs",
                     "rhs",
                     (l, r) -> false == l.equals(r),


### PR DESCRIPTION
We called a bunch of evaluators the `Keyword` evaluators - but they work for any `BytesRef`. They work for `flattened` and `text` and `version` and `geo_shape` and, yes, `keyword`.
