### PR TITLE
Convert Google Vertex AI integration to use new rerank code path

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiModel.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.googlevertexai;
 
+import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.ServiceSettings;
@@ -14,17 +15,26 @@ import org.elasticsearch.inference.TaskSettings;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.services.RateLimitGroupingModel;
 import org.elasticsearch.xpack.inference.services.googlevertexai.action.GoogleVertexAiActionVisitor;
+import org.elasticsearch.xpack.inference.services.googlevertexai.request.GoogleVertexAiRequestUtils;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 
 public abstract class GoogleVertexAiModel extends RateLimitGroupingModel {
 
     private final GoogleVertexAiRateLimitServiceSettings rateLimitServiceSettings;
 
     protected URI nonStreamingUri;
+
+    /**
+     * This field defines the behaviour used to apply authorization headers to a {@link HttpPost}. By default, this is
+     * {@link GoogleVertexAiRequestUtils#decorateWithBearerToken(HttpPost, GoogleVertexAiSecretSettings)}. Unit tests may provide different
+     * behaviour to allow requests to be created without needing to retrieve credentials.
+     */
+    private final BiConsumer<HttpPost, GoogleVertexAiModel> authHeaderDecorator;
 
     public GoogleVertexAiModel(
         ModelConfigurations configurations,
@@ -34,6 +44,23 @@ public abstract class GoogleVertexAiModel extends RateLimitGroupingModel {
         super(configurations, secrets);
 
         this.rateLimitServiceSettings = Objects.requireNonNull(rateLimitServiceSettings);
+        this.authHeaderDecorator = (httpPost, model) -> GoogleVertexAiRequestUtils.decorateWithBearerToken(
+            httpPost,
+            (GoogleVertexAiSecretSettings) model.getSecretSettings()
+        );
+    }
+
+    // Should only be used for testing. Allows bypassing retrieving the OAuth2 credentials when creating a request
+    public GoogleVertexAiModel(
+        ModelConfigurations configurations,
+        ModelSecrets secrets,
+        GoogleVertexAiRateLimitServiceSettings rateLimitServiceSettings,
+        BiConsumer<HttpPost, GoogleVertexAiModel> authHeaderDecorator
+    ) {
+        super(configurations, secrets);
+
+        this.rateLimitServiceSettings = Objects.requireNonNull(rateLimitServiceSettings);
+        this.authHeaderDecorator = authHeaderDecorator;
     }
 
     public GoogleVertexAiModel(GoogleVertexAiModel model, ServiceSettings serviceSettings) {
@@ -41,6 +68,7 @@ public abstract class GoogleVertexAiModel extends RateLimitGroupingModel {
 
         nonStreamingUri = model.nonStreamingUri();
         rateLimitServiceSettings = model.rateLimitServiceSettings();
+        authHeaderDecorator = model.authHeaderDecorator();
     }
 
     public GoogleVertexAiModel(GoogleVertexAiModel model, TaskSettings taskSettings) {
@@ -48,6 +76,7 @@ public abstract class GoogleVertexAiModel extends RateLimitGroupingModel {
 
         nonStreamingUri = model.nonStreamingUri();
         rateLimitServiceSettings = model.rateLimitServiceSettings();
+        authHeaderDecorator = model.authHeaderDecorator();
     }
 
     public abstract ExecutableAction accept(GoogleVertexAiActionVisitor creator, Map<String, Object> taskSettings);
@@ -58,6 +87,10 @@ public abstract class GoogleVertexAiModel extends RateLimitGroupingModel {
 
     public URI nonStreamingUri() {
         return nonStreamingUri;
+    }
+
+    public BiConsumer<HttpPost, GoogleVertexAiModel> authHeaderDecorator() {
+        return authHeaderDecorator;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiModel.java
@@ -41,12 +41,14 @@ public abstract class GoogleVertexAiModel extends RateLimitGroupingModel {
         ModelSecrets secrets,
         GoogleVertexAiRateLimitServiceSettings rateLimitServiceSettings
     ) {
-        super(configurations, secrets);
-
-        this.rateLimitServiceSettings = Objects.requireNonNull(rateLimitServiceSettings);
-        this.authHeaderDecorator = (httpPost, model) -> GoogleVertexAiRequestUtils.decorateWithBearerToken(
-            httpPost,
-            (GoogleVertexAiSecretSettings) model.getSecretSettings()
+        this(
+            configurations,
+            secrets,
+            rateLimitServiceSettings,
+            (httpPost, model) -> GoogleVertexAiRequestUtils.decorateWithBearerToken(
+                httpPost,
+                (GoogleVertexAiSecretSettings) model.getSecretSettings()
+            )
         );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiService.java
@@ -21,6 +21,7 @@ import org.elasticsearch.inference.InferenceServiceExtension;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.RerankRequest;
 import org.elasticsearch.inference.RerankingInferenceService;
 import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.TaskType;
@@ -43,6 +44,7 @@ import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.Goog
 import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsModelCreator;
 import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.googlevertexai.request.completion.GoogleVertexAiUnifiedChatCompletionRequest;
+import org.elasticsearch.xpack.inference.services.googlevertexai.rerank.GoogleVertexAiRerankModel;
 import org.elasticsearch.xpack.inference.services.googlevertexai.rerank.GoogleVertexAiRerankModelCreator;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
@@ -53,6 +55,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.inference.external.action.ActionUtils.constructFailedToSendRequestMessage;
+import static org.elasticsearch.xpack.inference.external.http.sender.QueryAndDocsInputs.fromRerankRequest;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiServiceFields.EMBEDDING_MAX_BATCH_SIZE;
@@ -194,6 +197,23 @@ public class GoogleVertexAiService extends SenderService<GoogleVertexAiModel> im
             unifiedChatInput -> new GoogleVertexAiUnifiedChatCompletionRequest(unifiedChatInput, model),
             UnifiedChatInput.class
         );
+    }
+
+    @Override
+    protected void doRerankInfer(Model model, RerankRequest request, TimeValue timeout, ActionListener<InferenceServiceResults> listener) {
+        if (!(model instanceof GoogleVertexAiRerankModel googleVertexAiRerankModel)) {
+            listener.onFailure(createInvalidModelException(model));
+            return;
+        }
+        var actionCreator = new GoogleVertexAiActionCreator(getSender(), getServiceComponents());
+
+        var action = googleVertexAiRerankModel.accept(actionCreator, request.taskSettings());
+        action.execute(fromRerankRequest(request), timeout, listener);
+    }
+
+    @Override
+    public boolean supportsNewRerankCodePath() {
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/completion/GoogleVertexAiChatCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/completion/GoogleVertexAiChatCompletionModel.java
@@ -84,7 +84,9 @@ public class GoogleVertexAiChatCompletionModel extends GoogleVertexAiModel {
 
     public GoogleVertexAiChatCompletionModel(ModelConfigurations modelConfigurations, ModelSecrets modelSecrets) {
         super(modelConfigurations, modelSecrets, (GoogleVertexAiRateLimitServiceSettings) modelConfigurations.getServiceSettings());
-        this.streamingURI = setUris(modelConfigurations);
+        var resolvedUris = resolveUris(modelConfigurations);
+        this.streamingURI = resolvedUris.streaming();
+        this.nonStreamingUri = resolvedUris.nonStreaming();
     }
 
     // Should only be used for testing
@@ -99,35 +101,40 @@ public class GoogleVertexAiChatCompletionModel extends GoogleVertexAiModel {
             (GoogleVertexAiRateLimitServiceSettings) modelConfigurations.getServiceSettings(),
             authHeaderDecorator
         );
-        this.streamingURI = setUris(modelConfigurations);
+        var resolvedUris = resolveUris(modelConfigurations);
+        this.streamingURI = resolvedUris.streaming();
+        this.nonStreamingUri = resolvedUris.nonStreaming();
     }
 
-    private URI setUris(ModelConfigurations modelConfigurations) {
-        final URI streamingURI;
+    private record ResolvedUris(URI streaming, URI nonStreaming) {}
+
+    private ResolvedUris resolveUris(ModelConfigurations modelConfigurations) {
+        URI streamingUri;
+        URI nonStreamingUri;
         try {
             var serviceSettings = (GoogleVertexAiChatCompletionServiceSettings) modelConfigurations.getServiceSettings();
             var uri = serviceSettings.uri();
-            var streamingUri = serviceSettings.streamingUri();
+            streamingUri = serviceSettings.streamingUri();
             // For Google Model Garden uri or streamingUri must be set. If not - location, projectId and modelId must be set
             if (uri != null || streamingUri != null) {
                 // If both uris are provided, each will be used as-is (non-streaming vs. streaming).
                 // If only one is provided, it will be reused for both non-streaming and streaming requests.
                 // Some providers require both (e.g. Anthropic, Mistral, Ai21).
                 // Some providers work fine with a single URL (e.g. Meta, Hugging Face).
-                this.nonStreamingUri = Objects.requireNonNullElse(uri, streamingUri);
-                streamingURI = Objects.requireNonNullElse(streamingUri, uri);
+                nonStreamingUri = Objects.requireNonNullElse(uri, streamingUri);
+                streamingUri = Objects.requireNonNullElse(streamingUri, uri);
             } else {
                 // If neither uri nor streamingUri is provided, build them from location, projectId, and modelId.
                 var location = serviceSettings.location();
                 var projectId = serviceSettings.projectId();
                 var model = serviceSettings.modelId();
-                streamingURI = buildUriStreaming(location, projectId, model);
-                this.nonStreamingUri = buildUriNonStreaming(location, projectId, model);
+                streamingUri = buildUriStreaming(location, projectId, model);
+                nonStreamingUri = buildUriNonStreaming(location, projectId, model);
             }
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
-        return streamingURI;
+        return new ResolvedUris(streamingUri, nonStreamingUri);
     }
 
     private GoogleVertexAiChatCompletionModel(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/completion/GoogleVertexAiChatCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/completion/GoogleVertexAiChatCompletionModel.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.googlevertexai.completion;
 
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -25,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -63,8 +65,45 @@ public class GoogleVertexAiChatCompletionModel extends GoogleVertexAiModel {
         this(new ModelConfigurations(inferenceEntityId, taskType, service, serviceSettings, taskSettings), new ModelSecrets(secrets));
     }
 
+    // Should only be used for testing
+    GoogleVertexAiChatCompletionModel(
+        String inferenceEntityId,
+        TaskType taskType,
+        String service,
+        GoogleVertexAiChatCompletionServiceSettings serviceSettings,
+        GoogleVertexAiChatCompletionTaskSettings taskSettings,
+        @Nullable GoogleVertexAiSecretSettings secrets,
+        BiConsumer<HttpPost, GoogleVertexAiModel> authHeaderDecorator
+    ) {
+        this(
+            new ModelConfigurations(inferenceEntityId, taskType, service, serviceSettings, taskSettings),
+            new ModelSecrets(secrets),
+            authHeaderDecorator
+        );
+    }
+
     public GoogleVertexAiChatCompletionModel(ModelConfigurations modelConfigurations, ModelSecrets modelSecrets) {
         super(modelConfigurations, modelSecrets, (GoogleVertexAiRateLimitServiceSettings) modelConfigurations.getServiceSettings());
+        this.streamingURI = setUris(modelConfigurations);
+    }
+
+    // Should only be used for testing
+    public GoogleVertexAiChatCompletionModel(
+        ModelConfigurations modelConfigurations,
+        ModelSecrets modelSecrets,
+        BiConsumer<HttpPost, GoogleVertexAiModel> authHeaderDecorator
+    ) {
+        super(
+            modelConfigurations,
+            modelSecrets,
+            (GoogleVertexAiRateLimitServiceSettings) modelConfigurations.getServiceSettings(),
+            authHeaderDecorator
+        );
+        this.streamingURI = setUris(modelConfigurations);
+    }
+
+    private URI setUris(ModelConfigurations modelConfigurations) {
+        final URI streamingURI;
         try {
             var serviceSettings = (GoogleVertexAiChatCompletionServiceSettings) modelConfigurations.getServiceSettings();
             var uri = serviceSettings.uri();
@@ -76,18 +115,19 @@ public class GoogleVertexAiChatCompletionModel extends GoogleVertexAiModel {
                 // Some providers require both (e.g. Anthropic, Mistral, Ai21).
                 // Some providers work fine with a single URL (e.g. Meta, Hugging Face).
                 this.nonStreamingUri = Objects.requireNonNullElse(uri, streamingUri);
-                this.streamingURI = Objects.requireNonNullElse(streamingUri, uri);
+                streamingURI = Objects.requireNonNullElse(streamingUri, uri);
             } else {
                 // If neither uri nor streamingUri is provided, build them from location, projectId, and modelId.
                 var location = serviceSettings.location();
                 var projectId = serviceSettings.projectId();
                 var model = serviceSettings.modelId();
-                this.streamingURI = buildUriStreaming(location, projectId, model);
+                streamingURI = buildUriStreaming(location, projectId, model);
                 this.nonStreamingUri = buildUriNonStreaming(location, projectId, model);
             }
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
+        return streamingURI;
     }
 
     private GoogleVertexAiChatCompletionModel(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsModel.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.googlevertexai.embeddings;
 
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ChunkingSettings;
@@ -25,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -93,19 +95,21 @@ public class GoogleVertexAiEmbeddingsModel extends GoogleVertexAiModel {
     }
 
     // Should only be used directly for testing
-    protected GoogleVertexAiEmbeddingsModel(
+    public GoogleVertexAiEmbeddingsModel(
         String inferenceEntityId,
         TaskType taskType,
         String service,
         String uri,
         GoogleVertexAiEmbeddingsServiceSettings serviceSettings,
         GoogleVertexAiEmbeddingsTaskSettings taskSettings,
-        @Nullable GoogleVertexAiSecretSettings secrets
+        @Nullable GoogleVertexAiSecretSettings secrets,
+        BiConsumer<HttpPost, GoogleVertexAiModel> authHeaderDecorator
     ) {
         super(
             new ModelConfigurations(inferenceEntityId, taskType, service, serviceSettings, taskSettings),
             new ModelSecrets(secrets),
-            serviceSettings
+            serviceSettings,
+            authHeaderDecorator
         );
         try {
             this.nonStreamingUri = new URI(uri);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequest.java
@@ -65,13 +65,9 @@ public class GoogleVertexAiEmbeddingsRequest implements OutboundDenseEmbeddingRe
         httpPost.setEntity(byteEntity);
         httpPost.setHeader(HttpHeaders.CONTENT_TYPE, XContentType.JSON.mediaType());
 
-        decorateWithAuth(httpPost);
+        model.authHeaderDecorator().accept(httpPost, model);
 
         listener.onResponse(new HttpRequest(httpPost, getInferenceEntityId()));
-    }
-
-    public void decorateWithAuth(HttpPost httpPost) {
-        GoogleVertexAiRequestUtils.decorateWithBearerToken(httpPost, model.getSecretSettings());
     }
 
     Truncator truncator() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiRerankRequest.java
@@ -69,13 +69,9 @@ public class GoogleVertexAiRerankRequest implements OutboundRerankRequest {
         httpPost.setEntity(byteEntity);
         httpPost.setHeader(HttpHeaders.CONTENT_TYPE, XContentType.JSON.mediaType());
 
-        decorateWithAuth(httpPost);
+        model.authHeaderDecorator().accept(httpPost, model);
 
         listener.onResponse(new HttpRequest(httpPost, getInferenceEntityId()));
-    }
-
-    public void decorateWithAuth(HttpPost httpPost) {
-        GoogleVertexAiRequestUtils.decorateWithBearerToken(httpPost, model.getSecretSettings());
     }
 
     public GoogleVertexAiRerankModel model() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequest.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.inference.external.request.HttpRequest;
 import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.request.OutboundUnifiedCompletionRequest;
 import org.elasticsearch.xpack.inference.services.googlevertexai.completion.GoogleVertexAiChatCompletionModel;
-import org.elasticsearch.xpack.inference.services.googlevertexai.request.GoogleVertexAiRequestUtils;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -52,7 +51,7 @@ public class GoogleVertexAiUnifiedChatCompletionRequest implements OutboundUnifi
 
         httpPost.setHeader(HttpHeaders.CONTENT_TYPE, XContentType.JSON.mediaType());
 
-        decorateWithAuth(httpPost);
+        model.authHeaderDecorator().accept(httpPost, model);
         listener.onResponse(new HttpRequest(httpPost, getInferenceEntityId()));
     }
 
@@ -63,10 +62,6 @@ public class GoogleVertexAiUnifiedChatCompletionRequest implements OutboundUnifi
      */
     private String extractModelId() {
         return unifiedChatInput.getRequest().model() != null ? unifiedChatInput.getRequest().model() : model.getServiceSettings().modelId();
-    }
-
-    public void decorateWithAuth(HttpPost httpPost) {
-        GoogleVertexAiRequestUtils.decorateWithBearerToken(httpPost, model.getSecretSettings());
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/rerank/GoogleVertexAiRerankModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/rerank/GoogleVertexAiRerankModel.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.googlevertexai.rerank;
 
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -24,6 +25,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -74,7 +76,9 @@ public class GoogleVertexAiRerankModel extends GoogleVertexAiModel {
         }
     }
 
-    // Should only be used directly for testing
+    // Should only be used directly for testing.
+    // This constructor allows tests to override the behaviour when setting the auth header, which by default requires a valid service
+    // account JSON
     protected GoogleVertexAiRerankModel(
         String inferenceEntityId,
         TaskType taskType,
@@ -82,12 +86,14 @@ public class GoogleVertexAiRerankModel extends GoogleVertexAiModel {
         String uri,
         GoogleVertexAiRerankServiceSettings serviceSettings,
         GoogleVertexAiRerankTaskSettings taskSettings,
-        @Nullable GoogleVertexAiSecretSettings secrets
+        @Nullable GoogleVertexAiSecretSettings secrets,
+        BiConsumer<HttpPost, GoogleVertexAiModel> authHeaderDecorator
     ) {
         super(
             new ModelConfigurations(inferenceEntityId, taskType, service, serviceSettings, taskSettings),
             new ModelSecrets(secrets),
-            serviceSettings
+            serviceSettings,
+            authHeaderDecorator
         );
         try {
             this.nonStreamingUri = new URI(uri);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiServiceTests.java
@@ -7,9 +7,11 @@
 
 package org.elasticsearch.xpack.inference.services.googlevertexai;
 
+import org.apache.http.HttpHeaders;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -18,19 +20,26 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkedInference;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.DataType;
 import org.elasticsearch.inference.InferenceService;
 import org.elasticsearch.inference.InferenceServiceConfiguration;
+import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.inference.InferenceString;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.RerankRequest;
 import org.elasticsearch.inference.RerankingInferenceService;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.UnparsedModel;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
 import org.elasticsearch.xpack.inference.services.InferenceServiceTestCase;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
@@ -48,6 +57,7 @@ import org.hamcrest.Matchers;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,16 +65,20 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.inference.InferenceStringTests.createRandomUsingDataTypes;
 import static org.elasticsearch.inference.TaskType.CHAT_COMPLETION;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.Utils.randomSimilarityMeasure;
+import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
+import static org.elasticsearch.xpack.inference.external.http.Utils.getUrl;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
 import static org.elasticsearch.xpack.inference.services.cohere.embeddings.CohereEmbeddingsTaskSettingsTests.getTaskSettingsMapEmpty;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -998,6 +1012,117 @@ public class GoogleVertexAiServiceTests extends InferenceServiceTestCase {
         }
     }
 
+    public void testRerankInfer() throws IOException {
+        var responseJson = """
+            {
+                 "records": [
+                     {
+                         "id": "2",
+                         "title": "title 2",
+                         "content": "content 2",
+                         "score": 0.97
+                     },
+                     {
+                         "id": "1",
+                         "title": "title 1",
+                         "content": "content 1",
+                         "score": 0.90
+                     }
+                ]
+            }
+            """;
+        try (var service = createInferenceService()) {
+            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
+
+            var modelId = randomAlphaOfLengthOrNull(8);
+            var authHeaderValue = "auth header value";
+            var model = GoogleVertexAiRerankModelTests.createModel(getUrl(webServer), modelId, null, authHeaderValue);
+
+            TestPlainActionFuture<InferenceServiceResults> listener = new TestPlainActionFuture<>();
+            var inputOne = "abc";
+            var inputTwo = "def";
+            var query = "some query";
+            var topN = randomNonNegativeIntOrNull();
+            var returnDocuments = randomOptionalBoolean();
+            var request = new RerankRequest(
+                List.of(new InferenceString(DataType.TEXT, inputOne), new InferenceString(DataType.TEXT, inputTwo)),
+                new InferenceString(DataType.TEXT, query),
+                topN,
+                returnDocuments,
+                new HashMap<>()
+            );
+            service.rerankInfer(model, request, null, listener);
+
+            var result = listener.actionGet(TEST_REQUEST_TIMEOUT);
+            assertThat(result, CoreMatchers.instanceOf(RankedDocsResults.class));
+
+            var rankedDocsResults = (RankedDocsResults) result;
+            var rankedDocs = rankedDocsResults.getRankedDocs();
+            assertThat(rankedDocs.size(), is(2));
+            assertThat(rankedDocs.get(0).relevanceScore(), is(0.97f));
+            assertThat(rankedDocs.get(0).index(), is(2));
+            assertThat(rankedDocs.get(1).relevanceScore(), is(0.90f));
+            assertThat(rankedDocs.get(1).index(), is(1));
+
+            assertThat(webServer.requests(), hasSize(1));
+            assertNull(webServer.requests().getFirst().getUri().getQuery());
+            assertThat(webServer.requests().getFirst().getHeader(HttpHeaders.CONTENT_TYPE), equalTo(XContentType.JSON.mediaType()));
+            assertThat(webServer.requests().getFirst().getHeader(HttpHeaders.AUTHORIZATION), is(authHeaderValue));
+
+            var requestMap = entityAsMap(webServer.requests().getFirst().getBody());
+            Map<String, Object> expectedRequestMap = new HashMap<>(
+                Map.of("query", query, "records", List.of(Map.of("id", "0", "content", inputOne), Map.of("id", "1", "content", inputTwo)))
+            );
+            if (modelId != null) {
+                expectedRequestMap.put("model", modelId);
+            }
+            if (topN != null) {
+                expectedRequestMap.put("topN", topN);
+            }
+            if (returnDocuments != null) {
+                expectedRequestMap.put("ignoreRecordDetailsInResponse", returnDocuments == false);
+            }
+            assertThat(requestMap, is(expectedRequestMap));
+        }
+    }
+
+    public void testRerankInfer_ThrowsError_WithNonTextQuery() throws IOException {
+        var textInputs = randomList(1, 5, () -> createRandomUsingDataTypes(EnumSet.of(DataType.TEXT)));
+        var nonTextQuery = createRandomUsingDataTypes(EnumSet.complementOf(EnumSet.of(DataType.TEXT)));
+        testRerankInfer_ThrowsError_WithNonTextInputOrQuery(textInputs, nonTextQuery);
+    }
+
+    public void testRerankInfer_ThrowsError_WithNonTextInputs() throws IOException {
+        var nonTextInputs = randomList(1, 5, () -> createRandomUsingDataTypes(EnumSet.complementOf(EnumSet.of(DataType.TEXT))));
+        var textQuery = createRandomUsingDataTypes(EnumSet.of(DataType.TEXT));
+        testRerankInfer_ThrowsError_WithNonTextInputOrQuery(nonTextInputs, textQuery);
+    }
+
+    public void testRerankInfer_ThrowsError_WithNonTextInputsAndQuery() throws IOException {
+        var nonTextInputs = randomList(1, 5, () -> createRandomUsingDataTypes(EnumSet.complementOf(EnumSet.of(DataType.TEXT))));
+        var nonTextQuery = createRandomUsingDataTypes(EnumSet.complementOf(EnumSet.of(DataType.TEXT)));
+        testRerankInfer_ThrowsError_WithNonTextInputOrQuery(nonTextInputs, nonTextQuery);
+    }
+
+    private void testRerankInfer_ThrowsError_WithNonTextInputOrQuery(List<InferenceString> inputs, InferenceString query)
+        throws IOException {
+
+        var model = mock(GoogleVertexAiRerankModel.class);
+
+        try (var service = createInferenceService()) {
+            TestPlainActionFuture<InferenceServiceResults> listener = new TestPlainActionFuture<>();
+
+            service.rerankInfer(model, new RerankRequest(inputs, query, null, null, new HashMap<>()), null, listener);
+
+            var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TEST_REQUEST_TIMEOUT));
+            assertThat(thrownException.status(), is(RestStatus.BAD_REQUEST));
+            assertThat(
+                thrownException.getMessage(),
+                is("The googlevertexai service does not support rerank with non-text inputs or queries")
+            );
+        }
+    }
+
     @SuppressWarnings("checkstyle:LineLength")
     public void testGetConfiguration() throws Exception {
         try (var service = createInferenceService()) {
@@ -1110,12 +1235,12 @@ public class GoogleVertexAiServiceTests extends InferenceServiceTestCase {
     protected void assertRerankerWindowSize(RerankingInferenceService rerankingInferenceService) {
         assertThat(
             rerankingInferenceService.rerankerWindowSize("semantic-ranker-default-003"),
-            CoreMatchers.is(RerankingInferenceService.CONSERVATIVE_DEFAULT_WINDOW_SIZE)
+            is(RerankingInferenceService.CONSERVATIVE_DEFAULT_WINDOW_SIZE)
         );
-        assertThat(rerankingInferenceService.rerankerWindowSize("semantic-ranker-default-004"), CoreMatchers.is(600));
+        assertThat(rerankingInferenceService.rerankerWindowSize("semantic-ranker-default-004"), is(600));
         assertThat(
             rerankingInferenceService.rerankerWindowSize("any other"),
-            CoreMatchers.is(RerankingInferenceService.CONSERVATIVE_DEFAULT_WINDOW_SIZE)
+            is(RerankingInferenceService.CONSERVATIVE_DEFAULT_WINDOW_SIZE)
         );
     }
 
@@ -1152,7 +1277,7 @@ public class GoogleVertexAiServiceTests extends InferenceServiceTestCase {
     private static ActionListener<Model> getModelListenerForException(Class<?> exceptionClass, String expectedMessage) {
         return ActionListener.<Model>wrap(model -> fail("Model parsing should have failed"), e -> {
             assertThat(e, Matchers.instanceOf(exceptionClass));
-            assertThat(e.getMessage(), CoreMatchers.is(expectedMessage));
+            assertThat(e.getMessage(), is(expectedMessage));
         });
     }
 
@@ -1210,7 +1335,7 @@ public class GoogleVertexAiServiceTests extends InferenceServiceTestCase {
             );
             assertThat(
                 thrownException.getMessage(),
-                CoreMatchers.is(
+                is(
                     Strings.format(
                         "The [%s] service does not support task type [%s]",
                         GoogleVertexAiService.NAME,
@@ -1256,7 +1381,7 @@ public class GoogleVertexAiServiceTests extends InferenceServiceTestCase {
     private void validateModelBuilding(Model model) throws IOException {
         try (var inferenceService = createInferenceService()) {
             var resultModel = inferenceService.buildModelFromConfigAndSecrets(model.getConfigurations(), model.getSecrets());
-            assertThat(resultModel, CoreMatchers.is(model));
+            assertThat(resultModel, is(model));
         }
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/action/GoogleVertexAiEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/action/GoogleVertexAiEmbeddingsActionTests.java
@@ -115,7 +115,7 @@ public class GoogleVertexAiEmbeddingsActionTests extends ESTestCase {
     }
 
     private ExecutableAction createAction(String url, String location, String projectId, String modelName, Sender sender) {
-        var model = createModel(location, projectId, modelName, url, "{}");
+        var model = createModel(location, projectId, modelName, url, "{}", randomAlphaOfLength(8));
         var requestManager = new GoogleVertexAiEmbeddingsRequestManager(model, TruncatorTests.createTruncator(), threadPool);
         var failedToSendRequestErrorMessage = constructFailedToSendRequestMessage("Google Vertex AI embeddings");
         return new SenderExecutableAction(sender, requestManager, failedToSendRequestErrorMessage);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/action/GoogleVertexAiRerankActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/action/GoogleVertexAiRerankActionTests.java
@@ -112,7 +112,7 @@ public class GoogleVertexAiRerankActionTests extends ESTestCase {
     }
 
     private ExecutableAction createAction(String url, String projectId, Sender sender) {
-        var model = GoogleVertexAiRerankModelTests.createModel(url, projectId, null);
+        var model = GoogleVertexAiRerankModelTests.createModel(url, projectId, null, randomAlphaOfLength(8));
         var failedToSendRequestErrorMessage = constructFailedToSendRequestMessage("Google Vertex AI rerank");
         var requestManager = GoogleVertexAiRerankRequestManager.of(model, threadPool);
         return new SenderExecutableAction(sender, requestManager, failedToSendRequestErrorMessage);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/completion/GoogleVertexAiChatCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/completion/GoogleVertexAiChatCompletionModelTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.googlevertexai.completion;
 
+import org.apache.http.HttpHeaders;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.UnifiedCompletionRequest;
@@ -270,6 +271,29 @@ public class GoogleVertexAiChatCompletionModelTests extends ESTestCase {
             new GoogleVertexAiChatCompletionServiceSettings(projectId, location, modelId, uri, uri, provider, rateLimitSettings),
             new GoogleVertexAiChatCompletionTaskSettings(thinkingConfig, maxTokens),
             new GoogleVertexAiSecretSettings(new SecureString(apiKey.toCharArray()))
+        );
+    }
+
+    public static GoogleVertexAiChatCompletionModel createCompletionModel(
+        String projectId,
+        String location,
+        String modelId,
+        String apiKey,
+        RateLimitSettings rateLimitSettings,
+        ThinkingConfig thinkingConfig,
+        GoogleModelGardenProvider provider,
+        URI uri,
+        Integer maxTokens,
+        String authHeaderValue
+    ) {
+        return new GoogleVertexAiChatCompletionModel(
+            "google-vertex-ai-chat-test-id",
+            TaskType.CHAT_COMPLETION,
+            "google_vertex_ai",
+            new GoogleVertexAiChatCompletionServiceSettings(projectId, location, modelId, uri, uri, provider, rateLimitSettings),
+            new GoogleVertexAiChatCompletionTaskSettings(thinkingConfig, maxTokens),
+            new GoogleVertexAiSecretSettings(new SecureString(apiKey.toCharArray())),
+            (httpPost, model) -> httpPost.setHeader(HttpHeaders.AUTHORIZATION, authHeaderValue)
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsModelTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.googlevertexai.embeddings;
 
+import org.apache.http.HttpHeaders;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.Nullable;
@@ -91,7 +92,8 @@ public class GoogleVertexAiEmbeddingsModelTests extends ESTestCase {
         String projectId,
         String modelId,
         String uri,
-        String serviceAccountJson
+        String serviceAccountJson,
+        String authHeaderValue
     ) {
         return new GoogleVertexAiEmbeddingsModel(
             "id",
@@ -100,7 +102,8 @@ public class GoogleVertexAiEmbeddingsModelTests extends ESTestCase {
             uri,
             new GoogleVertexAiEmbeddingsServiceSettings(location, projectId, modelId, false, null, null, null, null, null),
             new GoogleVertexAiEmbeddingsTaskSettings(Boolean.FALSE, null),
-            new GoogleVertexAiSecretSettings(new SecureString(serviceAccountJson.toCharArray()))
+            new GoogleVertexAiSecretSettings(new SecureString(serviceAccountJson.toCharArray())),
+            (httpPost, model) -> httpPost.setHeader(HttpHeaders.AUTHORIZATION, authHeaderValue)
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequestTests.java
@@ -12,17 +12,16 @@ import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.InputType;
+import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.InputTypeTests;
 import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.common.TruncatorTests;
-import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
 import org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiSecretSettings;
 import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsModel;
-import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsModelTests;
 import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsTaskSettings;
 
@@ -239,9 +238,28 @@ public class GoogleVertexAiEmbeddingsRequestTests extends ESTestCase {
         @Nullable InputType taskSettingsInputType,
         @Nullable InputType requestInputType
     ) {
-        var embeddingsModel = GoogleVertexAiEmbeddingsModelTests.createModel(modelId, autoTruncate, taskSettingsInputType);
+        var embeddingsModel = new GoogleVertexAiEmbeddingsModel(
+            "id",
+            TaskType.TEXT_EMBEDDING,
+            "service",
+            "https://fake.abc",
+            new GoogleVertexAiEmbeddingsServiceSettings(
+                "location",
+                "projectId",
+                modelId,
+                false,
+                null,
+                null,
+                null,
+                SimilarityMeasure.DOT_PRODUCT,
+                null
+            ),
+            new GoogleVertexAiEmbeddingsTaskSettings(autoTruncate, taskSettingsInputType),
+            new GoogleVertexAiSecretSettings(new SecureString("testString".toCharArray())),
+            (httpPost, model) -> httpPost.setHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_VALUE)
+        );
 
-        return new GoogleVertexAiEmbeddingsWithoutAuthRequest(
+        return new GoogleVertexAiEmbeddingsRequest(
             TruncatorTests.createTruncator(),
             new Truncator.TruncationResult(List.of(input), new boolean[] { false }),
             requestInputType,
@@ -260,6 +278,7 @@ public class GoogleVertexAiEmbeddingsRequestTests extends ESTestCase {
             "id",
             TaskType.TEXT_EMBEDDING,
             "service",
+            "https://fake.abc",
             new GoogleVertexAiEmbeddingsServiceSettings(
                 randomAlphaOfLength(8),
                 randomAlphaOfLength(8),
@@ -272,50 +291,16 @@ public class GoogleVertexAiEmbeddingsRequestTests extends ESTestCase {
                 null
             ),
             new GoogleVertexAiEmbeddingsTaskSettings(null, null),
-            null,
-            new GoogleVertexAiSecretSettings(new SecureString(randomAlphaOfLength(8).toCharArray()))
+            new GoogleVertexAiSecretSettings(new SecureString(randomAlphaOfLength(8).toCharArray())),
+            (httpPost, model) -> httpPost.setHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_VALUE)
         );
 
-        return new GoogleVertexAiEmbeddingsWithoutAuthRequest(
+        return new GoogleVertexAiEmbeddingsRequest(
             TruncatorTests.createTruncator(),
             new Truncator.TruncationResult(List.of(input), new boolean[] { false }),
             requestInputType,
             embeddingsModel
         );
-    }
-
-    /**
-     * We use this class to fake the auth implementation to avoid static mocking of {@link GoogleVertexAiRequestUtils}
-     */
-    private static class GoogleVertexAiEmbeddingsWithoutAuthRequest extends GoogleVertexAiEmbeddingsRequest {
-
-        private final InputType inputType;
-
-        GoogleVertexAiEmbeddingsWithoutAuthRequest(
-            Truncator truncator,
-            Truncator.TruncationResult input,
-            InputType inputType,
-            GoogleVertexAiEmbeddingsModel model
-        ) {
-            super(truncator, input, inputType, model);
-            this.inputType = inputType;
-        }
-
-        @Override
-        public void decorateWithAuth(HttpPost httpPost) {
-            httpPost.setHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_VALUE);
-        }
-
-        @Override
-        public OutboundRequest truncate() {
-            GoogleVertexAiEmbeddingsRequest embeddingsRequest = (GoogleVertexAiEmbeddingsRequest) super.truncate();
-            return new GoogleVertexAiEmbeddingsWithoutAuthRequest(
-                embeddingsRequest.truncator(),
-                embeddingsRequest.truncationResult(),
-                inputType,
-                embeddingsRequest.model()
-            );
-        }
     }
 
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiRerankRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiRerankRequestTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
-import org.elasticsearch.xpack.inference.services.googlevertexai.rerank.GoogleVertexAiRerankModel;
 import org.elasticsearch.xpack.inference.services.googlevertexai.rerank.GoogleVertexAiRerankModelTests;
 
 import java.io.IOException;
@@ -153,28 +152,8 @@ public class GoogleVertexAiRerankRequestTests extends ESTestCase {
         @Nullable Boolean returnDocuments,
         @Nullable Integer taskSettingsTopN
     ) {
-        var rerankModel = GoogleVertexAiRerankModelTests.createModel(modelId, taskSettingsTopN);
+        var rerankModel = GoogleVertexAiRerankModelTests.createModel("https://fake.abc", modelId, taskSettingsTopN, AUTH_HEADER_VALUE);
 
-        return new GoogleVertexAiRerankWithoutAuthRequest(query, List.of(input), rerankModel, topN, returnDocuments);
-    }
-
-    /**
-     * We use this class to fake the auth implementation to avoid static mocking of {@link GoogleVertexAiRequestUtils}
-     */
-    private static class GoogleVertexAiRerankWithoutAuthRequest extends GoogleVertexAiRerankRequest {
-        GoogleVertexAiRerankWithoutAuthRequest(
-            String query,
-            List<String> input,
-            GoogleVertexAiRerankModel model,
-            @Nullable Integer topN,
-            @Nullable Boolean returnDocuments
-        ) {
-            super(query, input, returnDocuments, topN, model);
-        }
-
-        @Override
-        public void decorateWithAuth(HttpPost httpPost) {
-            httpPost.setHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_VALUE);
-        }
+        return new GoogleVertexAiRerankRequest(query, List.of(input), returnDocuments, topN, rerankModel);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/completion/GoogleVertexAiUnifiedChatCompletionRequestTests.java
@@ -16,10 +16,8 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
 import org.elasticsearch.xpack.inference.services.googlevertexai.GoogleModelGardenProvider;
-import org.elasticsearch.xpack.inference.services.googlevertexai.completion.GoogleVertexAiChatCompletionModel;
 import org.elasticsearch.xpack.inference.services.googlevertexai.completion.GoogleVertexAiChatCompletionModelTests;
 import org.elasticsearch.xpack.inference.services.googlevertexai.completion.ThinkingConfig;
-import org.elasticsearch.xpack.inference.services.googlevertexai.request.GoogleVertexAiRequestUtils;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.io.IOException;
@@ -115,24 +113,11 @@ public class GoogleVertexAiUnifiedChatCompletionRequestTests extends ESTestCase 
             thinkingConfig,
             provider,
             null,
-            null
+            null,
+            AUTH_HEADER_VALUE
         );
         var unifiedChatInput = new UnifiedChatInput(messages, "user", true);
 
-        return new GoogleVertexAiUnifiedChatCompletionWithoutAuthRequest(unifiedChatInput, model);
-    }
-
-    /**
-     * We use this class to fake the auth implementation to avoid static mocking of {@link GoogleVertexAiRequestUtils}
-     */
-    private static class GoogleVertexAiUnifiedChatCompletionWithoutAuthRequest extends GoogleVertexAiUnifiedChatCompletionRequest {
-        GoogleVertexAiUnifiedChatCompletionWithoutAuthRequest(UnifiedChatInput unifiedChatInput, GoogleVertexAiChatCompletionModel model) {
-            super(unifiedChatInput, model);
-        }
-
-        @Override
-        public void decorateWithAuth(HttpPost httpPost) {
-            httpPost.setHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_VALUE);
-        }
+        return new GoogleVertexAiUnifiedChatCompletionRequest(unifiedChatInput, model);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/rerank/GoogleVertexAiRerankModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/rerank/GoogleVertexAiRerankModelTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.googlevertexai.rerank;
 
+import org.apache.http.HttpHeaders;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.TaskType;
@@ -39,17 +40,15 @@ public class GoogleVertexAiRerankModelTests extends ESTestCase {
     }
 
     public static GoogleVertexAiRerankModel createModel(@Nullable String modelId, @Nullable Integer topN) {
-        return new GoogleVertexAiRerankModel(
-            "id",
-            TaskType.RERANK,
-            "service",
-            new GoogleVertexAiRerankServiceSettings(randomAlphaOfLength(10), modelId, null),
-            new GoogleVertexAiRerankTaskSettings(topN),
-            new GoogleVertexAiSecretSettings(randomSecureStringOfLength(8))
-        );
+        return createModel("https://fake.abc", modelId, topN, randomAlphaOfLength(8));
     }
 
-    public static GoogleVertexAiRerankModel createModel(String url, @Nullable String modelId, @Nullable Integer topN) {
+    public static GoogleVertexAiRerankModel createModel(
+        String url,
+        @Nullable String modelId,
+        @Nullable Integer topN,
+        String authHeaderValue
+    ) {
         return new GoogleVertexAiRerankModel(
             "id",
             TaskType.RERANK,
@@ -57,7 +56,8 @@ public class GoogleVertexAiRerankModelTests extends ESTestCase {
             url,
             new GoogleVertexAiRerankServiceSettings(randomAlphaOfLength(10), modelId, null),
             new GoogleVertexAiRerankTaskSettings(topN),
-            new GoogleVertexAiSecretSettings(randomSecureStringOfLength(8))
+            new GoogleVertexAiSecretSettings(randomSecureStringOfLength(8)),
+            (httpPost, model) -> httpPost.setHeader(HttpHeaders.AUTHORIZATION, authHeaderValue)
         );
     }
 


### PR DESCRIPTION
This commit implements doRerankInfer() in GoogleVertexAiService and overrides supportsNewRerankCodePath() to return true, and adds unit tests for the new code path.

Other changes:
- Add authHeaderDecorator field to GoogleVertexAiModel to allow tests to override the default behaviour when adding an authorization header when creating a GoogleVertexAi*Request
- Refactor various test methods used to construct GoogleVertexAi models to account for being able to set authHeaderDecorator