### PR TITLE
unmute testSoftDeletesAreAlmostAlwaysDisregardedForTimestampRange

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -498,9 +498,6 @@ tests:
   method: testProcessOnceOnPrimary
   issue: https://github.com/elastic/elasticsearch/issues/148943
 - class: org.elasticsearch.xpack.stateless.commits.IndexCommitTimestampFieldRangeTests
-  method: testSoftDeletesAreAlmostAlwaysDisregardedForTimestampRange
-  issue: https://github.com/elastic/elasticsearch/issues/148966
-- class: org.elasticsearch.xpack.stateless.commits.IndexCommitTimestampFieldRangeTests
   method: testFieldValueRangeForBatchedCompoundCommit
   issue: https://github.com/elastic/elasticsearch/issues/148961
 - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT


### PR DESCRIPTION
based on comments: https://github.com/elastic/elasticsearch/issues/148972 unmuting testSoftDeletesAreAlmostAlwaysDisregardedForTimestampRange

Fixes: https://github.com/elastic/elasticsearch/issues/148972