### PR TITLE
Keep health indicator green during resharding

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
@@ -169,10 +169,10 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
      * Checks if an inactive primary shard should cause the cluster health to go RED.
      *
      * An inactive primary shard in an index should cause the cluster health to be RED to make it visible that some of the existing data is
-     * unavailable. In case of index creation, snapshot restore or index shrinking, which are unexceptional events in the cluster lifecycle,
-     * cluster health should not turn RED for the time when primaries are still in the initializing state but go to YELLOW instead.
-     * However, in case of exceptional events, for example when the primary shard cannot be assigned to a node or initialization fails at
-     * some point, cluster health should still turn RED.
+     * unavailable. In case of index creation, snapshot restore, index shrinking or reshard split, which are unexceptional events in the
+     * cluster lifecycle, cluster health should not turn RED for the time when primaries are still in the initializing state but go to
+     * YELLOW instead. However, in case of exceptional events, for example when the primary shard cannot be assigned to a node or
+     * initialization fails at some point, cluster health should still turn RED.
      *
      * NB: this method should *not* be called on active shards nor on non-primary shards.
      */
@@ -187,7 +187,8 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
             && unassignedInfo.failedAllocations() == 0
             && (recoveryType == RecoverySource.Type.EMPTY_STORE
                 || recoveryType == RecoverySource.Type.LOCAL_SHARDS
-                || recoveryType == RecoverySource.Type.SNAPSHOT)) {
+                || recoveryType == RecoverySource.Type.SNAPSHOT
+                || recoveryType == RecoverySource.Type.RESHARD_SPLIT)) {
             return ClusterHealthStatus.YELLOW;
         } else {
             return ClusterHealthStatus.RED;

--- a/x-pack/plugin/stateless-health-shards-availability/src/test/java/org/elasticsearch/xpack/stateless/health/StatelessShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/x-pack/plugin/stateless-health-shards-availability/src/test/java/org/elasticsearch/xpack/stateless/health/StatelessShardsAvailabilityHealthIndicatorServiceTests.java
@@ -268,6 +268,64 @@ public class StatelessShardsAvailabilityHealthIndicatorServiceTests extends ESTe
         }
     }
 
+    public void testHealthWhileReshardSplitTargetShardsInactive() {
+        final var projectId = randomProjectIdOrDefault();
+        final var indexMetadata = IndexMetadata.builder(INDEX_NAME)
+            .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current()).build())
+            .numberOfShards(2)
+            .numberOfReplicas(1)
+            .build();
+        var nodeA = randomNodeId();
+        var nodeB = randomNodeId();
+        final var index = indexMetadata.getIndex();
+        final var sourceShardId = new ShardId(index.getName(), index.getUUID(), 0);
+        final var sourceShardPrimary = shardRouting(sourceShardId, true, nodeA, null, STARTED);
+        final var sourceShardReplica = shardRouting(sourceShardId, false, nodeB, null, STARTED);
+        final var targetShardId = new ShardId(index.getName(), index.getUUID(), 1);
+        final var unassignedAt = new TimeValue(System.currentTimeMillis() - TimeValue.timeValueMinutes(5).millis(), TimeUnit.MILLISECONDS);
+        var targetShardPrimary = newUnassigned(
+            targetShardId,
+            true,
+            new RecoverySource.ReshardSplitRecoverySource(sourceShardId),
+            unassignedInfo(UnassignedInfo.Reason.RESHARD_ADDED, unassignedAt),
+            ShardRouting.Role.DEFAULT
+        );
+        var targetShardReplica = newUnassigned(
+            targetShardId,
+            false,
+            RecoverySource.PeerRecoverySource.INSTANCE,
+            unassignedInfo(UnassignedInfo.Reason.RESHARD_ADDED, unassignedAt),
+            ShardRouting.Role.DEFAULT
+        );
+        if (randomBoolean()) {
+            targetShardPrimary = targetShardPrimary.initialize(nodeB, null, 0);
+        }
+        var routingTable = IndexRoutingTable.builder(index)
+            .addShard(sourceShardPrimary)
+            .addShard(sourceShardReplica)
+            .addShard(targetShardPrimary)
+            .addShard(targetShardReplica)
+            .build();
+
+        final var state = clusterState(projectId, routingTable);
+        final var service = createStatelessIndicator(
+            projectId,
+            Settings.builder()
+                .put(ShardsAvailabilityHealthIndicatorService.PRIMARY_INACTIVE_BUFFER_TIME.getKey(), "0s")
+                .put(ShardsAvailabilityHealthIndicatorService.REPLICA_INACTIVE_BUFFER_TIME.getKey(), "0s")
+                .build(),
+            state
+        );
+        final var result = service.calculate(true, 10, HealthInfo.EMPTY_HEALTH_INFO);
+        final var details = ((SimpleHealthIndicatorDetails) result.details()).details();
+
+        assertThat(result.status(), equalTo(HealthStatus.GREEN));
+        assertThat(details.get("indices_with_provisionally_unavailable_primaries"), equalTo(INDEX_NAME));
+        assertThat(details.get("indices_with_unavailable_primaries"), nullValue());
+        assertThat(details.get("indices_with_provisionally_unavailable_replicas"), equalTo(INDEX_NAME));
+        assertThat(details.get("indices_with_unavailable_replicas"), nullValue());
+    }
+
     private static UnassignedInfo randomUnassignedInfo(TimeValue withinBuffer, TimeValue beyondBuffer) {
         if (randomBoolean()) {
             return unassignedInfo(

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -52,11 +52,14 @@ import org.elasticsearch.action.termvectors.TermVectorsResponse;
 import org.elasticsearch.action.termvectors.TransportShardMultiTermsVectorAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.coordination.PublicationTransportHandler;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.health.ClusterStateHealth;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexReshardingMetadata;
@@ -82,6 +85,8 @@ import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.health.HealthStatus;
+import org.elasticsearch.health.node.HealthInfo;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -4553,6 +4558,45 @@ public class StatelessReshardIT extends AbstractStatelessPluginIntegTestCase {
 
             doneBlocked.countDown();
             waitForReshardCompletion(indexName);
+        }
+    }
+
+    public void testHealthNeverGoesRedDuringResharding() {
+        var indexNode = startMasterAndIndexNode();
+        startSearchNode();
+        ensureStableCluster(2);
+
+        final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        int numShards = randomIntBetween(1, 5);
+        createIndex(indexName, indexSettings(numShards, 1).build());
+        ensureGreen(indexName);
+
+        final ClusterService clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
+        final var projectId = clusterService.state().metadata().getProject().id();
+        final AtomicReference<AssertionError> failure = new AtomicReference<>();
+        ClusterStateListener listener = event -> {
+            var health = new ClusterStateHealth(event.state(), new String[] { indexName }, projectId);
+            if (health.getStatus() == ClusterHealthStatus.RED) {
+                failure.compareAndSet(null, new AssertionError("cluster turned red during reshard:\n" + event.state().routingTable()));
+            }
+        };
+        clusterService.addListener(listener);
+
+        try {
+            int numDocs = randomIntBetween(10, 100);
+            indexDocs(indexName, numDocs);
+            refresh(indexName);
+            assertHitCount(prepareSearchAll(indexName), numDocs);
+
+            client(indexNode).execute(TransportReshardAction.TYPE, new ReshardIndexRequest(indexName)).actionGet();
+            waitForReshardCompletion(indexName);
+            ensureGreen(indexName);
+            assertHitCount(prepareSearchAll(indexName), numDocs);
+        } finally {
+            clusterService.removeListener(listener);
+        }
+        if (failure.get() != null) {
+            throw failure.get();
         }
     }
 

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/reshard/StatelessReshardIT.java
@@ -85,8 +85,6 @@ import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
-import org.elasticsearch.health.HealthStatus;
-import org.elasticsearch.health.node.HealthInfo;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexNotFoundException;


### PR DESCRIPTION
The health stays green for the serverless health check, as the target shards are considered provisionally unavailable (see [ShardsAvailabilityHealthIndicatorService](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java#L498-L503))

The health turns yellow with the raw health API `_cluster/health` 

Relates ES-14674