### PR TITLE
Do not redirect 5xx errors to failure store during shard level bulk operations.

### DIFF
--- a/docs/changelog/149104.yaml
+++ b/docs/changelog/149104.yaml
@@ -1,0 +1,5 @@
+area: Data streams
+issues: []
+pr: 149104
+summary: Do not redirect 5xx errors to failure store during shard level bulk operations
+type: bug

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -43,7 +43,6 @@ import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.cluster.routing.SplitShardCountSummary;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -691,11 +691,11 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
             return false;
         }
         return switch (error) {
-            case VersionConflictEngineException err -> false;
-            case EsRejectedExecutionException err -> false;
-            case CircuitBreakingException err -> false;
-            case ClusterBlockException err -> false;
-            case ElasticsearchException err -> err.status().getStatus() != 429;
+            case VersionConflictEngineException err -> false; // A 4xx Exception we don't want to redirect
+            case EsRejectedExecutionException err -> false; // Rejection exception not tied with ElasticsearchException
+            case ClusterBlockException err -> false; // Status is dependent on the blocks, but we don't ever want to redirect it
+            // If exception is not a 5xx or a 429, nor one of the above, it should be redirected
+            case ElasticsearchException err -> err.status().getStatus() != 429 && (err.status().getStatus() / 100 != 5);
             default -> true;
         };
     }

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.NoMasterBlockService;
-import org.elasticsearch.cluster.desirednodes.VersionConflictException;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamFailureStoreSettings;
@@ -51,11 +50,13 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.mapper.MapperException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
@@ -66,6 +67,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpNodeClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.NodeNotConnectedException;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.junit.After;
 import org.junit.Before;
@@ -504,11 +506,19 @@ public class BulkOperationTests extends ESTestCase {
         bulkRequest.add(new IndexRequest(fsDataStreamName).id("3").source(Map.of("key", "val")).opType(DocWriteRequest.OpType.CREATE));
 
         final Exception expectedException = randomFrom(
-            new VersionConflictException("test"),
+            new VersionConflictEngineException(new ShardId("test-idx", "abcdefg", 0), "test", "conflicted"),
             new EsRejectedExecutionException("test"),
             new CircuitBreakingException("test", randomFrom(CircuitBreaker.Durability.values())),
             new ClusterBlockException(Set.of(MetadataIndexStateService.createIndexClosingBlock())),
-            new BulkOperation429Exception("test")
+            new BulkOperation429Exception("test"),
+            new NodeNotConnectedException(
+                DiscoveryNode.createLocal(
+                    Settings.EMPTY,
+                    new TransportAddress(TransportAddress.META_ADDRESS, randomIntBetween(1000, 2000)),
+                    "test-node"
+                ),
+                "test"
+            )
         );
 
         NodeClient client = getNodeClient(
@@ -525,7 +535,7 @@ public class BulkOperationTests extends ESTestCase {
                 l,
                 new FailureStoreDocumentConverter(),
                 DataStreamFailureStoreSettings.create(ClusterSettings.createBuiltInClusterSettings()),
-                false
+                true
             ).run()
         );
         assertThat(bulkItemResponses.hasFailures(), is(true));


### PR DESCRIPTION
Updates failure store shard bulk failure redirection filtering to skip any exceptions that result in 5xx errors. Additional fixes were applied to the test case. 