### PR TITLE
Convert IBM Watsonx integration to use new rerank code path

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxModel.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.ibmwatsonx;
 
+import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.ServiceSettings;
@@ -14,41 +15,75 @@ import org.elasticsearch.inference.TaskSettings;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.services.RateLimitGroupingModel;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.action.IbmWatsonxActionVisitor;
+import org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxRequestUtils;
+import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 
 public abstract class IbmWatsonxModel extends RateLimitGroupingModel {
 
     private final IbmWatsonxRateLimitServiceSettings rateLimitServiceSettings;
+    /**
+     * This field defines the behaviour used to apply authorization headers to a {@link HttpPost}. By default, this is
+     * {@link IbmWatsonxRequestUtils#decorateWithBearerToken(HttpPost, DefaultSecretSettings, String)}. Unit tests may provide different
+     * behaviour to allow requests to be created without needing to retrieve credentials.
+     */
+    private final BiConsumer<HttpPost, IbmWatsonxModel> authHeaderDecorator;
 
     public IbmWatsonxModel(
         ModelConfigurations configurations,
         ModelSecrets secrets,
         IbmWatsonxRateLimitServiceSettings rateLimitServiceSettings
     ) {
+        this(
+            configurations,
+            secrets,
+            rateLimitServiceSettings,
+            (httpPost, model) -> IbmWatsonxRequestUtils.decorateWithBearerToken(
+                httpPost,
+                (DefaultSecretSettings) model.getSecretSettings(),
+                model.getInferenceEntityId()
+            )
+        );
+    }
+
+    public IbmWatsonxModel(
+        ModelConfigurations configurations,
+        ModelSecrets secrets,
+        IbmWatsonxRateLimitServiceSettings rateLimitServiceSettings,
+        BiConsumer<HttpPost, IbmWatsonxModel> authHeaderDecorator
+    ) {
         super(configurations, secrets);
 
         this.rateLimitServiceSettings = Objects.requireNonNull(rateLimitServiceSettings);
+        this.authHeaderDecorator = authHeaderDecorator;
     }
 
     public IbmWatsonxModel(IbmWatsonxModel model, ServiceSettings serviceSettings) {
         super(model, serviceSettings);
 
         rateLimitServiceSettings = model.rateLimitServiceSettings();
+        authHeaderDecorator = model.authHeaderDecorator();
     }
 
     public IbmWatsonxModel(IbmWatsonxModel model, TaskSettings taskSettings) {
         super(model, taskSettings);
 
         rateLimitServiceSettings = model.rateLimitServiceSettings();
+        authHeaderDecorator = model.authHeaderDecorator();
     }
 
     public abstract ExecutableAction accept(IbmWatsonxActionVisitor creator, Map<String, Object> taskSettings);
 
     public IbmWatsonxRateLimitServiceSettings rateLimitServiceSettings() {
         return rateLimitServiceSettings;
+    }
+
+    public BiConsumer<HttpPost, IbmWatsonxModel> authHeaderDecorator() {
+        return authHeaderDecorator;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxService.java
@@ -20,6 +20,7 @@ import org.elasticsearch.inference.InferenceServiceExtension;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.RerankRequest;
 import org.elasticsearch.inference.RerankingInferenceService;
 import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
@@ -45,6 +46,7 @@ import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatso
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModelCreator;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxChatCompletionRequest;
+import org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank.IbmWatsonxRerankModel;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank.IbmWatsonxRerankModelCreator;
 import org.elasticsearch.xpack.inference.services.openai.response.OpenAiChatCompletionResponseEntity;
 
@@ -54,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.inference.external.http.sender.QueryAndDocsInputs.fromRerankRequest;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MAX_INPUT_TOKENS;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.URL;
@@ -205,6 +208,23 @@ public class IbmWatsonxService extends SenderService<IbmWatsonxModel> implements
         var action = new SenderExecutableAction(getSender(), manager, errorMessage);
 
         action.execute(inputs, timeout, listener);
+    }
+
+    @Override
+    protected void doRerankInfer(Model model, RerankRequest request, TimeValue timeout, ActionListener<InferenceServiceResults> listener) {
+        if (!(model instanceof IbmWatsonxRerankModel ibmWatsonxRerankModel)) {
+            listener.onFailure(createInvalidModelException(model));
+            return;
+        }
+        var actionCreator = new IbmWatsonxActionCreator(getSender(), getServiceComponents());
+
+        var action = ibmWatsonxRerankModel.accept(actionCreator, request.taskSettings());
+        action.execute(fromRerankRequest(request), timeout, listener);
+    }
+
+    @Override
+    public boolean supportsNewRerankCodePath() {
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/completion/IbmWatsonxChatCompletionModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/completion/IbmWatsonxChatCompletionModel.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.ibmwatsonx.completion;
 
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -22,6 +23,7 @@ import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import static org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxUtils.COMPLETIONS;
 import static org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxUtils.ML;
@@ -98,8 +100,40 @@ public class IbmWatsonxChatCompletionModel extends IbmWatsonxModel {
         this(new ModelConfigurations(inferenceEntityId, taskType, service, serviceSettings), new ModelSecrets(secretSettings));
     }
 
+    // Should only be used directly for testing.
+    // This constructor allows tests to override the behaviour when setting the auth header, which by default requires making a call to
+    // IBM's token provider API
+    public IbmWatsonxChatCompletionModel(
+        String inferenceEntityId,
+        TaskType taskType,
+        String service,
+        IbmWatsonxChatCompletionServiceSettings serviceSettings,
+        @Nullable DefaultSecretSettings secretSettings,
+        BiConsumer<HttpPost, IbmWatsonxModel> authHeaderDecorator
+    ) {
+        this(
+            new ModelConfigurations(inferenceEntityId, taskType, service, serviceSettings),
+            new ModelSecrets(secretSettings),
+            authHeaderDecorator
+        );
+    }
+
     public IbmWatsonxChatCompletionModel(ModelConfigurations modelConfigurations, ModelSecrets modelSecrets) {
         super(modelConfigurations, modelSecrets, (IbmWatsonxChatCompletionServiceSettings) modelConfigurations.getServiceSettings());
+    }
+
+    // Should only be used for testing
+    public IbmWatsonxChatCompletionModel(
+        ModelConfigurations modelConfigurations,
+        ModelSecrets modelSecrets,
+        BiConsumer<HttpPost, IbmWatsonxModel> authHeaderDecorator
+    ) {
+        super(
+            modelConfigurations,
+            modelSecrets,
+            (IbmWatsonxChatCompletionServiceSettings) modelConfigurations.getServiceSettings(),
+            authHeaderDecorator
+        );
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/embeddings/IbmWatsonxEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/embeddings/IbmWatsonxEmbeddingsModel.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings;
 
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ChunkingSettings;
@@ -25,6 +26,7 @@ import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import static org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxUtils.EMBEDDINGS;
 import static org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxUtils.ML;
@@ -85,23 +87,27 @@ public class IbmWatsonxEmbeddingsModel extends IbmWatsonxModel {
         }
     }
 
-    // Should only be used directly for testing
+    // Should only be used directly for testing.
+    // This constructor allows tests to override the behaviour when setting the auth header, which by default requires making a call to
+    // IBM's token provider API. It also allows a custom URL to be set for unit testing.
     IbmWatsonxEmbeddingsModel(
         String inferenceEntityId,
         TaskType taskType,
         String service,
-        String uri,
+        @Nullable String url,
         IbmWatsonxEmbeddingsServiceSettings serviceSettings,
         TaskSettings taskSettings,
-        @Nullable DefaultSecretSettings secrets
+        @Nullable DefaultSecretSettings secrets,
+        BiConsumer<HttpPost, IbmWatsonxModel> authHeaderDecorator
     ) {
         super(
             new ModelConfigurations(inferenceEntityId, taskType, service, serviceSettings, taskSettings),
             new ModelSecrets(secrets),
-            serviceSettings
+            serviceSettings,
+            authHeaderDecorator
         );
         try {
-            this.uri = new URI(uri);
+            this.uri = url == null ? buildUri(serviceSettings.url().toString(), serviceSettings.apiVersion()) : new URI(url);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxChatCompletionRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxChatCompletionRequest.java
@@ -44,7 +44,7 @@ public class IbmWatsonxChatCompletionRequest implements OutboundUnifiedCompletio
 
         httpPost.setHeader(HttpHeaders.CONTENT_TYPE, XContentType.JSON.mediaType());
 
-        decorateWithAuth(httpPost);
+        model.authHeaderDecorator().accept(httpPost, model);
 
         listener.onResponse(new HttpRequest(httpPost, getInferenceEntityId()));
     }
@@ -52,10 +52,6 @@ public class IbmWatsonxChatCompletionRequest implements OutboundUnifiedCompletio
     @Override
     public URI getURI() {
         return model.uri();
-    }
-
-    public void decorateWithAuth(HttpPost httpPost) {
-        IbmWatsonxRequestUtils.decorateWithBearerToken(httpPost, model.getSecretSettings(), model.getInferenceEntityId());
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxEmbeddingsRequest.java
@@ -53,13 +53,9 @@ public class IbmWatsonxEmbeddingsRequest implements OutboundDenseEmbeddingReques
         httpPost.setEntity(byteEntity);
         httpPost.setHeader(HttpHeaders.CONTENT_TYPE, XContentType.JSON.mediaType());
 
-        decorateWithAuth(httpPost);
+        model.authHeaderDecorator().accept(httpPost, model);
 
         listener.onResponse(new HttpRequest(httpPost, getInferenceEntityId()));
-    }
-
-    public void decorateWithAuth(HttpPost httpPost) {
-        IbmWatsonxRequestUtils.decorateWithBearerToken(httpPost, model.getSecretSettings(), model.getInferenceEntityId());
     }
 
     public Truncator truncator() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxRequestUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxRequestUtils.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.xpack.inference.external.http.retry.BaseResponse
 
 public final class IbmWatsonxRequestUtils {
 
-    static void decorateWithBearerToken(HttpPost httpPost, DefaultSecretSettings secretSettings, String inferenceId) {
+    public static void decorateWithBearerToken(HttpPost httpPost, DefaultSecretSettings secretSettings, String inferenceId) {
         String bearerTokenGenUrl = "https://iam.cloud.ibm.com/identity/token";
         String bearerToken = "";
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxRerankRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxRerankRequest.java
@@ -68,13 +68,9 @@ public class IbmWatsonxRerankRequest implements OutboundRerankRequest {
         httpPost.setEntity(byteEntity);
         httpPost.setHeader(HttpHeaders.CONTENT_TYPE, XContentType.JSON.mediaType());
 
-        decorateWithAuth(httpPost);
+        model.authHeaderDecorator().accept(httpPost, model);
 
         listener.onResponse(new HttpRequest(httpPost, getInferenceEntityId()));
-    }
-
-    public void decorateWithAuth(HttpPost httpPost) {
-        IbmWatsonxRequestUtils.decorateWithBearerToken(httpPost, model.getSecretSettings(), model.getInferenceEntityId());
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/rerank/IbmWatsonxRerankModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/rerank/IbmWatsonxRerankModel.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank;
 
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -22,6 +23,7 @@ import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import static org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxUtils.ML;
 import static org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxUtils.RERANKS;
@@ -29,6 +31,9 @@ import static org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmW
 import static org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxUtils.V1;
 
 public class IbmWatsonxRerankModel extends IbmWatsonxModel {
+
+    private final URI uri;
+
     public static IbmWatsonxRerankModel of(IbmWatsonxRerankModel model, Map<String, Object> taskSettings) {
         var requestTaskSettings = IbmWatsonxRerankTaskSettings.fromMap(taskSettings);
         return new IbmWatsonxRerankModel(model, IbmWatsonxRerankTaskSettings.of(model.getTaskSettings(), requestTaskSettings));
@@ -66,10 +71,43 @@ public class IbmWatsonxRerankModel extends IbmWatsonxModel {
 
     public IbmWatsonxRerankModel(ModelConfigurations modelConfigurations, ModelSecrets modelSecrets) {
         super(modelConfigurations, modelSecrets, (IbmWatsonxRateLimitServiceSettings) modelConfigurations.getServiceSettings());
+        try {
+            var serviceSettings = (IbmWatsonxRerankServiceSettings) modelConfigurations.getServiceSettings();
+            this.uri = buildUri(serviceSettings.uri().toString(), serviceSettings.apiVersion());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // Should only be used directly for testing.
+    // This constructor allows tests to override the behaviour when setting the auth header, which by default requires making a call to
+    // IBM's token provider API. It also allows a custom URL to be set for unit testing.
+    public IbmWatsonxRerankModel(
+        String inferenceEntityId,
+        TaskType taskType,
+        String service,
+        String url,
+        IbmWatsonxRerankServiceSettings serviceSettings,
+        IbmWatsonxRerankTaskSettings taskSettings,
+        @Nullable DefaultSecretSettings secretSettings,
+        BiConsumer<HttpPost, IbmWatsonxModel> authHeaderDecorator
+    ) {
+        super(
+            new ModelConfigurations(inferenceEntityId, taskType, service, serviceSettings, taskSettings),
+            new ModelSecrets(secretSettings),
+            serviceSettings,
+            authHeaderDecorator
+        );
+        try {
+            this.uri = url == null ? buildUri(serviceSettings.uri().toString(), serviceSettings.apiVersion()) : new URI(url);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private IbmWatsonxRerankModel(IbmWatsonxRerankModel model, IbmWatsonxRerankTaskSettings taskSettings) {
         super(model, taskSettings);
+        this.uri = model.uri();
     }
 
     @Override
@@ -88,13 +126,6 @@ public class IbmWatsonxRerankModel extends IbmWatsonxModel {
     }
 
     public URI uri() {
-        URI uri;
-        try {
-            uri = buildUri(this.getServiceSettings().uri().toString(), this.getServiceSettings().apiVersion());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-
         return uri;
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
@@ -8,52 +8,51 @@
 package org.elasticsearch.xpack.inference.services.ibmwatsonx;
 
 import org.apache.http.HttpHeaders;
-import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.ChunkInferenceInput;
 import org.elasticsearch.inference.ChunkedInference;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.inference.DataType;
 import org.elasticsearch.inference.EmptyTaskSettings;
 import org.elasticsearch.inference.InferenceService;
 import org.elasticsearch.inference.InferenceServiceConfiguration;
 import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.inference.InferenceString;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.RerankRequest;
 import org.elasticsearch.inference.RerankingInferenceService;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.UnparsedModel;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.http.MockResponse;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
-import org.elasticsearch.xpack.inference.common.Truncator;
+import org.elasticsearch.xpack.core.inference.results.RankedDocsResultsTests;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
-import org.elasticsearch.xpack.inference.external.http.sender.Sender;
-import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.services.InferenceServiceTestCase;
-import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
-import org.elasticsearch.xpack.inference.services.ibmwatsonx.action.IbmWatsonxActionCreator;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.completion.IbmWatsonxChatCompletionModelTests;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModelTests;
-import org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxEmbeddingsRequest;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank.IbmWatsonxRerankModel;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank.IbmWatsonxRerankModelTests;
 import org.hamcrest.MatcherAssert;
@@ -63,16 +62,21 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.inference.InferenceStringTests.createRandomUsingDataTypes;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettings;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
 import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.RankedDocsResults.RankedDoc.INDEX;
+import static org.elasticsearch.xpack.core.inference.results.RankedDocsResults.RankedDoc.RELEVANCE_SCORE;
+import static org.elasticsearch.xpack.core.inference.results.RankedDocsResultsTests.buildExpectationRerank;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
@@ -87,6 +91,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -634,7 +639,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
 
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
-        try (var service = new IbmWatsonxServiceWithoutAuth(senderFactory, createWithEmptySettings(threadPool))) {
+        try (var service = new IbmWatsonxService(senderFactory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
             String responseJson = """
                 {
                      "results": [
@@ -676,6 +681,153 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
         }
     }
 
+    public void testRerankInfer_SendsRerankRequest() throws IOException {
+        try (var service = createInferenceService()) {
+            String responseJson = """
+                {
+                    "results": [
+                        {
+                            "index": 2,
+                            "score": 0.98005307
+                        },
+                        {
+                            "index": 3,
+                            "score": 0.27904198
+                        }
+                    ]
+                }
+                """;
+            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
+
+            var modelId = randomAlphaOfLength(8);
+            var projectId = randomAlphaOfLength(8);
+            var topN = randomBoolean() ? null : randomIntBetween(1, 128);
+            var returnDocuments = randomOptionalBoolean();
+            var truncateInputTokens = randomBoolean() ? null : randomIntBetween(1, 128);
+            var model = IbmWatsonxRerankModelTests.createModel(
+                modelId,
+                projectId,
+                URI.create(URL_VALUE),
+                API_VERSION_VALUE,
+                API_KEY_VALUE,
+                getUrl(webServer),
+                randomAlphaOfLength(8),
+                topN,
+                returnDocuments,
+                truncateInputTokens
+            );
+
+            var inputOne = randomAlphanumericOfLength(8);
+            var inputTwo = randomAlphanumericOfLength(8);
+            var query = randomAlphanumericOfLength(8);
+            var request = new RerankRequest(
+                List.of(new InferenceString(DataType.TEXT, inputOne), new InferenceString(DataType.TEXT, inputTwo)),
+                new InferenceString(DataType.TEXT, query),
+                null,
+                null,
+                null
+            );
+
+            var listener = new TestPlainActionFuture<InferenceServiceResults>();
+            service.rerankInfer(model, request, null, listener);
+            var result = listener.actionGet(TIMEOUT);
+
+            var expectedResults = List.of(
+                new RankedDocsResultsTests.RerankExpectation(Map.of(INDEX, 2, RELEVANCE_SCORE, 0.98005307f)),
+                new RankedDocsResultsTests.RerankExpectation(Map.of(INDEX, 3, RELEVANCE_SCORE, 0.27904198f))
+            );
+            assertThat(result.asMap(), is(buildExpectationRerank(expectedResults)));
+
+            assertThat(webServer.requests(), hasSize(1));
+            assertNull(webServer.requests().getFirst().getUri().getQuery());
+            assertThat(webServer.requests().getFirst().getHeader(HttpHeaders.CONTENT_TYPE), equalTo(XContentType.JSON.mediaType()));
+
+            var requestMap = entityAsMap(webServer.requests().getFirst().getBody());
+            var expectedRequestMap = buildExpectedRequestMap(
+                modelId,
+                query,
+                inputOne,
+                inputTwo,
+                projectId,
+                topN,
+                returnDocuments,
+                truncateInputTokens
+            );
+            assertThat(requestMap, is(expectedRequestMap));
+        }
+    }
+
+    private static Map<String, Object> buildExpectedRequestMap(
+        String modelId,
+        String query,
+        String inputOne,
+        String inputTwo,
+        String projectId,
+        @Nullable Integer topN,
+        @Nullable Boolean returnDocuments,
+        @Nullable Integer truncateInputTokens
+    ) {
+        Map<String, Object> expectedRequestMap = new HashMap<>(
+            Map.of(
+                "model_id",
+                modelId,
+                "query",
+                query,
+                "inputs",
+                List.of(Map.of("text", inputOne), Map.of("text", inputTwo)),
+                "project_id",
+                projectId
+            )
+        );
+        var returnOptionsMap = new HashMap<>();
+        if (topN != null) {
+            returnOptionsMap.put("top_n", topN);
+        }
+        if (returnDocuments != null) {
+            returnOptionsMap.put("inputs", returnDocuments);
+        }
+        var parametersMap = new HashMap<String, Object>(Map.of("return_options", returnOptionsMap));
+        if (truncateInputTokens != null) {
+            parametersMap.put("truncate_input_tokens", truncateInputTokens);
+        }
+        expectedRequestMap.put("parameters", parametersMap);
+        return expectedRequestMap;
+    }
+
+    public void testRerankInfer_ThrowsError_WithNonTextQuery() throws IOException {
+        var textInputs = randomList(1, 5, () -> createRandomUsingDataTypes(EnumSet.of(DataType.TEXT)));
+        var nonTextQuery = createRandomUsingDataTypes(EnumSet.complementOf(EnumSet.of(DataType.TEXT)));
+        testRerankInfer_ThrowsError_WithNonTextInputOrQuery(textInputs, nonTextQuery);
+    }
+
+    public void testRerankInfer_ThrowsError_WithNonTextInputs() throws IOException {
+        var nonTextInputs = randomList(1, 5, () -> createRandomUsingDataTypes(EnumSet.complementOf(EnumSet.of(DataType.TEXT))));
+        var textQuery = createRandomUsingDataTypes(EnumSet.of(DataType.TEXT));
+        testRerankInfer_ThrowsError_WithNonTextInputOrQuery(nonTextInputs, textQuery);
+    }
+
+    public void testRerankInfer_ThrowsError_WithNonTextInputsAndQuery() throws IOException {
+        var nonTextInputs = randomList(1, 5, () -> createRandomUsingDataTypes(EnumSet.complementOf(EnumSet.of(DataType.TEXT))));
+        var nonTextQuery = createRandomUsingDataTypes(EnumSet.complementOf(EnumSet.of(DataType.TEXT)));
+        testRerankInfer_ThrowsError_WithNonTextInputOrQuery(nonTextInputs, nonTextQuery);
+    }
+
+    private void testRerankInfer_ThrowsError_WithNonTextInputOrQuery(List<InferenceString> inputs, InferenceString query)
+        throws IOException {
+
+        var model = mock(IbmWatsonxRerankModel.class);
+
+        try (var service = createInferenceService()) {
+            TestPlainActionFuture<InferenceServiceResults> listener = new TestPlainActionFuture<>();
+
+            service.rerankInfer(model, new RerankRequest(inputs, query, null, null, new HashMap<>()), null, listener);
+
+            var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
+            assertThat(thrownException.status(), is(RestStatus.BAD_REQUEST));
+            assertThat(thrownException.getMessage(), is("The watsonxai service does not support rerank with non-text inputs or queries"));
+        }
+    }
+
     public void testChunkedInfer_ChunkingSettingsNotSet() throws IOException {
         testChunkedInfer_Batches(null);
     }
@@ -694,7 +846,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
             API_KEY_VALUE,
             getUrl(webServer)
         );
-        try (var service = new IbmWatsonxServiceWithoutAuth(senderFactory, createWithEmptySettings(threadPool))) {
+        try (var service = new IbmWatsonxService(senderFactory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
             PlainActionFuture<List<ChunkedInference>> listener = new PlainActionFuture<>();
             service.chunkedInfer(model, null, List.of(), new HashMap<>(), InputType.INTERNAL_INGEST, null, listener);
 
@@ -709,7 +861,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
 
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
-        try (var service = new IbmWatsonxServiceWithoutAuth(senderFactory, createWithEmptySettings(threadPool))) {
+        try (var service = new IbmWatsonxService(senderFactory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
             String responseJson = """
                 {
                      "results": [
@@ -789,7 +941,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
     public void testInfer_ResourceNotFound() throws IOException {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
-        try (var service = new IbmWatsonxServiceWithoutAuth(senderFactory, createWithEmptySettings(threadPool))) {
+        try (var service = new IbmWatsonxService(senderFactory, createWithEmptySettings(threadPool), mockClusterServiceEmpty())) {
 
             String responseJson = """
                 {
@@ -950,71 +1102,6 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
         assertThat(rerankingInferenceService.rerankerWindowSize("any model"), is(RERANK_WINDOW_SIZE));
     }
 
-    private static class IbmWatsonxServiceWithoutAuth extends IbmWatsonxService {
-        IbmWatsonxServiceWithoutAuth(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
-            super(factory, serviceComponents, mockClusterServiceEmpty());
-        }
-
-        @Override
-        protected IbmWatsonxActionCreator getActionCreator(Sender sender, ServiceComponents serviceComponents) {
-            return new IbmWatsonxActionCreatorWithoutAuth(getSender(), getServiceComponents());
-        }
-    }
-
-    private static class IbmWatsonxActionCreatorWithoutAuth extends IbmWatsonxActionCreator {
-        IbmWatsonxActionCreatorWithoutAuth(Sender sender, ServiceComponents serviceComponents) {
-            super(sender, serviceComponents);
-        }
-
-        @Override
-        protected IbmWatsonxEmbeddingsRequestManager getEmbeddingsRequestManager(
-            IbmWatsonxEmbeddingsModel model,
-            Truncator truncator,
-            ThreadPool threadPool
-        ) {
-            return new IbmWatsonxEmbeddingsRequestManagerWithoutAuth(model, truncator, threadPool);
-        }
-    }
-
-    private static class IbmWatsonxEmbeddingsRequestManagerWithoutAuth extends IbmWatsonxEmbeddingsRequestManager {
-        IbmWatsonxEmbeddingsRequestManagerWithoutAuth(IbmWatsonxEmbeddingsModel model, Truncator truncator, ThreadPool threadPool) {
-            super(model, truncator, threadPool);
-        }
-
-        @Override
-        protected IbmWatsonxEmbeddingsRequest getEmbeddingRequest(
-            Truncator truncator,
-            Truncator.TruncationResult truncatedInput,
-            IbmWatsonxEmbeddingsModel model
-        ) {
-            return new IbmWatsonxEmbeddingsWithoutAuthRequest(truncator, truncatedInput, model);
-        }
-
-    }
-
-    private static class IbmWatsonxEmbeddingsWithoutAuthRequest extends IbmWatsonxEmbeddingsRequest {
-        private static final String AUTH_HEADER_VALUE = "foo";
-
-        IbmWatsonxEmbeddingsWithoutAuthRequest(Truncator truncator, Truncator.TruncationResult input, IbmWatsonxEmbeddingsModel model) {
-            super(truncator, input, model);
-        }
-
-        @Override
-        public void decorateWithAuth(HttpPost httpPost) {
-            httpPost.setHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_VALUE);
-        }
-
-        @Override
-        public OutboundRequest truncate() {
-            IbmWatsonxEmbeddingsRequest embeddingsRequest = (IbmWatsonxEmbeddingsRequest) super.truncate();
-            return new IbmWatsonxEmbeddingsWithoutAuthRequest(
-                embeddingsRequest.truncator(),
-                embeddingsRequest.truncationResult(),
-                embeddingsRequest.model()
-            );
-        }
-    }
-
     public void testBuildModelFromConfigAndSecrets_TextEmbedding() throws IOException, URISyntaxException {
         var model = createTestModel(TaskType.TEXT_EMBEDDING);
         validateModelBuilding(model);
@@ -1084,7 +1171,9 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                 PROJECT_ID_VALUE,
                 URI.create(URL_VALUE),
                 API_VERSION_VALUE,
-                API_KEY_VALUE
+                API_KEY_VALUE,
+                URL_VALUE,
+                randomAlphaOfLength(8)
             );
             default -> throw new IllegalArgumentException("Unsupported task type: " + taskType);
         };

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/action/IbmWatsonxEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/action/IbmWatsonxEmbeddingsActionTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.ibmwatsonx.action;
 
 import org.apache.http.HttpHeaders;
-import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -21,7 +20,6 @@ import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.InputTypeTests;
-import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.common.TruncatorTests;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.SenderExecutableAction;
@@ -29,11 +27,9 @@ import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.EmbeddingsInput;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
-import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxEmbeddingsRequestManager;
-import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModel;
-import org.elasticsearch.xpack.inference.services.ibmwatsonx.request.IbmWatsonxEmbeddingsRequest;
+import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModelTests;
 import org.junit.After;
 import org.junit.Before;
 
@@ -50,7 +46,6 @@ import static org.elasticsearch.xpack.inference.external.action.ActionUtils.cons
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
 import static org.elasticsearch.xpack.inference.external.http.Utils.getUrl;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
-import static org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModelTests.createModel;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -61,6 +56,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 public class IbmWatsonxEmbeddingsActionTests extends ESTestCase {
+    private static final String AUTH_HEADER_VALUE = "auth_header_value";
     private static final TimeValue TIMEOUT = new TimeValue(30, TimeUnit.SECONDS);
     private final MockWebServer webServer = new MockWebServer();
     private ThreadPool threadPool;
@@ -117,6 +113,7 @@ public class IbmWatsonxEmbeddingsActionTests extends ESTestCase {
             assertThat(result.asMap(), is(buildExpectationFloat(List.of(new float[] { 0.0123F, -0.0123F }))));
             assertThat(webServer.requests(), hasSize(1));
             assertThat(webServer.requests().get(0).getHeader(HttpHeaders.CONTENT_TYPE), equalTo(XContentType.JSON.mediaType()));
+            assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo(AUTH_HEADER_VALUE));
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             assertThat(requestMap, aMapWithSize(3));
@@ -197,48 +194,20 @@ public class IbmWatsonxEmbeddingsActionTests extends ESTestCase {
         String apiVersion,
         Sender sender
     ) {
-        var model = createModel(modelName, projectId, uri, apiVersion, apiKey, url);
-        var requestManager = new IbmWatsonxEmbeddingsRequestManagerWithoutAuth(model, TruncatorTests.createTruncator(), threadPool);
+        var model = IbmWatsonxEmbeddingsModelTests.createModel(
+            modelName,
+            projectId,
+            uri,
+            apiVersion,
+            apiKey,
+            null,
+            null,
+            null,
+            url,
+            AUTH_HEADER_VALUE
+        );
+        var requestManager = new IbmWatsonxEmbeddingsRequestManager(model, TruncatorTests.createTruncator(), threadPool);
         var failedToSendRequestErrorMessage = constructFailedToSendRequestMessage("IBM watsonx embeddings");
         return new SenderExecutableAction(sender, requestManager, failedToSendRequestErrorMessage);
-    }
-
-    private static class IbmWatsonxEmbeddingsRequestManagerWithoutAuth extends IbmWatsonxEmbeddingsRequestManager {
-        IbmWatsonxEmbeddingsRequestManagerWithoutAuth(IbmWatsonxEmbeddingsModel model, Truncator truncator, ThreadPool threadPool) {
-            super(model, truncator, threadPool);
-        }
-
-        @Override
-        protected IbmWatsonxEmbeddingsRequest getEmbeddingRequest(
-            Truncator truncator,
-            Truncator.TruncationResult truncatedInput,
-            IbmWatsonxEmbeddingsModel model
-        ) {
-            return new IbmWatsonxEmbeddingsWithoutAuthRequest(truncator, truncatedInput, model);
-        }
-
-    }
-
-    private static class IbmWatsonxEmbeddingsWithoutAuthRequest extends IbmWatsonxEmbeddingsRequest {
-        private static final String AUTH_HEADER_VALUE = "foo";
-
-        IbmWatsonxEmbeddingsWithoutAuthRequest(Truncator truncator, Truncator.TruncationResult input, IbmWatsonxEmbeddingsModel model) {
-            super(truncator, input, model);
-        }
-
-        @Override
-        public void decorateWithAuth(HttpPost httpPost) {
-            httpPost.setHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_VALUE);
-        }
-
-        @Override
-        public OutboundRequest truncate() {
-            IbmWatsonxEmbeddingsRequest embeddingsRequest = (IbmWatsonxEmbeddingsRequest) super.truncate();
-            return new IbmWatsonxEmbeddingsWithoutAuthRequest(
-                embeddingsRequest.truncator(),
-                embeddingsRequest.truncationResult(),
-                embeddingsRequest.model()
-            );
-        }
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/completion/IbmWatsonxChatCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/completion/IbmWatsonxChatCompletionModelTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.ibmwatsonx.completion;
 
+import org.apache.http.HttpHeaders;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.UnifiedCompletionRequest;
@@ -31,7 +32,7 @@ public class IbmWatsonxChatCompletionModelTests extends ESTestCase {
         String projectId,
         String apiKey
     ) {
-        return createModel1(uri, apiVersion, modelId, projectId, apiKey, TaskType.COMPLETION);
+        return createModel(uri, apiVersion, modelId, projectId, apiKey, TaskType.COMPLETION, "foo");
     }
 
     public static IbmWatsonxChatCompletionModel createChatCompletionModel(
@@ -41,23 +42,25 @@ public class IbmWatsonxChatCompletionModelTests extends ESTestCase {
         String projectId,
         String apiKey
     ) {
-        return createModel1(uri, apiVersion, modelId, projectId, apiKey, TaskType.CHAT_COMPLETION);
+        return createModel(uri, apiVersion, modelId, projectId, apiKey, TaskType.CHAT_COMPLETION, "foo");
     }
 
-    private static IbmWatsonxChatCompletionModel createModel1(
+    public static IbmWatsonxChatCompletionModel createModel(
         URI uri,
         String apiVersion,
         String modelId,
         String projectId,
         String apiKey,
-        TaskType taskType
+        TaskType taskType,
+        String authHeaderValue
     ) {
         return new IbmWatsonxChatCompletionModel(
             "id",
             taskType,
             "service",
             new IbmWatsonxChatCompletionServiceSettings(uri, apiVersion, modelId, projectId, null),
-            new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
+            new DefaultSecretSettings(new SecureString(apiKey.toCharArray())),
+            (httpPost, model) -> httpPost.setHeader(HttpHeaders.AUTHORIZATION, authHeaderValue)
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/embeddings/IbmWatsonxEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/embeddings/IbmWatsonxEmbeddingsModelTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings;
 
+import org.apache.http.HttpHeaders;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.EmptyTaskSettings;
@@ -26,20 +27,12 @@ public class IbmWatsonxEmbeddingsModelTests extends ESTestCase {
         String apiKey,
         String url
     ) {
-        return new IbmWatsonxEmbeddingsModel(
-            "id",
-            TaskType.TEXT_EMBEDDING,
-            "service",
-            url,
-            new IbmWatsonxEmbeddingsServiceSettings(model, projectId, uri, apiVersion, null, null, SimilarityMeasure.DOT_PRODUCT, null),
-            EmptyTaskSettings.INSTANCE,
-            new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
-        );
+        return createModel(model, projectId, uri, apiVersion, apiKey, null, null, SimilarityMeasure.DOT_PRODUCT, url, "foo");
     }
 
     public static IbmWatsonxEmbeddingsModel createModel(
         String url,
-        String model,
+        String modelId,
         String projectId,
         URI uri,
         String apiVersion,
@@ -52,38 +45,34 @@ public class IbmWatsonxEmbeddingsModelTests extends ESTestCase {
             TaskType.TEXT_EMBEDDING,
             "service",
             url,
-            new IbmWatsonxEmbeddingsServiceSettings(model, projectId, uri, apiVersion, null, dimensions, similarityMeasure, null),
+            new IbmWatsonxEmbeddingsServiceSettings(modelId, projectId, uri, apiVersion, null, dimensions, similarityMeasure, null),
             EmptyTaskSettings.INSTANCE,
-            new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
+            new DefaultSecretSettings(new SecureString(apiKey.toCharArray())),
+            (httpPost, model) -> httpPost.setHeader(HttpHeaders.AUTHORIZATION, "foo")
         );
     }
 
     public static IbmWatsonxEmbeddingsModel createModel(
-        String model,
+        String modelId,
         String projectId,
         URI uri,
         String apiVersion,
         String apiKey,
         @Nullable Integer tokenLimit,
-        @Nullable Integer dimensions
+        @Nullable Integer dimensions,
+        @Nullable SimilarityMeasure similarityMeasure,
+        @Nullable String url,
+        String authHeaderValue
     ) {
         return new IbmWatsonxEmbeddingsModel(
             "id",
             TaskType.TEXT_EMBEDDING,
             "service",
-            new IbmWatsonxEmbeddingsServiceSettings(
-                model,
-                projectId,
-                uri,
-                apiVersion,
-                tokenLimit,
-                dimensions,
-                SimilarityMeasure.DOT_PRODUCT,
-                null
-            ),
+            url,
+            new IbmWatsonxEmbeddingsServiceSettings(modelId, projectId, uri, apiVersion, tokenLimit, dimensions, similarityMeasure, null),
             EmptyTaskSettings.INSTANCE,
-            null,
-            new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
+            new DefaultSecretSettings(new SecureString(apiKey.toCharArray())),
+            (httpPost, model) -> httpPost.setHeader(HttpHeaders.AUTHORIZATION, authHeaderValue)
         );
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxChatCompletionRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxChatCompletionRequestTests.java
@@ -7,13 +7,11 @@
 
 package org.elasticsearch.xpack.inference.services.ibmwatsonx.request;
 
-import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.sender.UnifiedChatInput;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
-import org.elasticsearch.xpack.inference.services.ibmwatsonx.completion.IbmWatsonxChatCompletionModel;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.completion.IbmWatsonxChatCompletionModelTests;
 
 import java.io.IOException;
@@ -80,18 +78,7 @@ public class IbmWatsonxChatCompletionRequestTests extends ESTestCase {
             randomAlphaOfLength(5),
             apiKey
         );
-        return new IbmWatsonxChatCompletionWithoutAuthRequest(new UnifiedChatInput(List.of(input), "user", stream), chatCompletionModel);
-    }
-
-    private static class IbmWatsonxChatCompletionWithoutAuthRequest extends IbmWatsonxChatCompletionRequest {
-        IbmWatsonxChatCompletionWithoutAuthRequest(UnifiedChatInput input, IbmWatsonxChatCompletionModel model) {
-            super(input, model);
-        }
-
-        @Override
-        public void decorateWithAuth(HttpPost httpPost) {
-            httpPost.setHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_VALUE);
-        }
+        return new IbmWatsonxChatCompletionRequest(new UnifiedChatInput(List.of(input), "user", stream), chatCompletionModel);
     }
 
     private void assertCreateRequestWithStreaming(boolean isStreaming) throws URISyntaxException, IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxEmbeddingsRequestTests.java
@@ -15,9 +15,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.common.TruncatorTests;
-import org.elasticsearch.xpack.inference.external.request.OutboundRequest;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
-import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.embeddings.IbmWatsonxEmbeddingsModelTests;
 
 import java.io.IOException;
@@ -86,6 +84,7 @@ public class IbmWatsonxEmbeddingsRequestTests extends ESTestCase {
 
         assertThat(httpPost.getURI().toString(), endsWith(Strings.format("%s=%s", "version", apiVersion)));
         assertThat(httpPost.getLastHeader(HttpHeaders.CONTENT_TYPE).getValue(), is(XContentType.JSON.mediaType()));
+        assertThat(httpPost.getLastHeader(HttpHeaders.AUTHORIZATION).getValue(), is(AUTH_HEADER_VALUE));
 
         var requestMap = entityAsMap(httpPost.getEntity().getContent());
         assertThat(requestMap, aMapWithSize(3));
@@ -127,33 +126,23 @@ public class IbmWatsonxEmbeddingsRequestTests extends ESTestCase {
         @Nullable Integer maxTokens,
         @Nullable Integer dimensions
     ) {
-        var embeddingsModel = IbmWatsonxEmbeddingsModelTests.createModel(model, projectId, uri, apiVersion, apiKey, maxTokens, dimensions);
+        var embeddingsModel = IbmWatsonxEmbeddingsModelTests.createModel(
+            model,
+            projectId,
+            uri,
+            apiVersion,
+            apiKey,
+            maxTokens,
+            dimensions,
+            null,
+            null,
+            AUTH_HEADER_VALUE
+        );
 
-        return new IbmWatsonxEmbeddingsWithoutAuthRequest(
+        return new IbmWatsonxEmbeddingsRequest(
             TruncatorTests.createTruncator(),
             new Truncator.TruncationResult(List.of(input), new boolean[] { false }),
             embeddingsModel
         );
-    }
-
-    private static class IbmWatsonxEmbeddingsWithoutAuthRequest extends IbmWatsonxEmbeddingsRequest {
-        IbmWatsonxEmbeddingsWithoutAuthRequest(Truncator truncator, Truncator.TruncationResult input, IbmWatsonxEmbeddingsModel model) {
-            super(truncator, input, model);
-        }
-
-        @Override
-        public void decorateWithAuth(HttpPost httpPost) {
-            httpPost.setHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_VALUE);
-        }
-
-        @Override
-        public OutboundRequest truncate() {
-            IbmWatsonxEmbeddingsRequest embeddingsRequest = (IbmWatsonxEmbeddingsRequest) super.truncate();
-            return new IbmWatsonxEmbeddingsWithoutAuthRequest(
-                embeddingsRequest.truncator(),
-                embeddingsRequest.truncationResult(),
-                embeddingsRequest.model()
-            );
-        }
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxRerankRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/request/IbmWatsonxRerankRequestTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
-import org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank.IbmWatsonxRerankModel;
 import org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank.IbmWatsonxRerankModelTests;
 
 import java.io.IOException;
@@ -42,7 +41,10 @@ public class IbmWatsonxRerankRequestTests extends ESTestCase {
         var query = "database";
         List<String> input = List.of("greenland", "google", "john", "mysql", "potter", "grammar");
 
-        var request = createRequest(model, projectId, uri, apiVersion, apiKey, query, input);
+        var topN = randomIntBetween(1, 128);
+        var returnDocuments = randomBoolean();
+        var truncateInputTokens = randomIntBetween(1, 128);
+        var request = createRequest(model, projectId, uri, apiVersion, apiKey, query, input, topN, returnDocuments, truncateInputTokens);
         var httpRequest = RequestTests.getHttpRequestSync(request);
 
         assertThat(httpRequest.httpRequestBase(), instanceOf(HttpPost.class));
@@ -50,6 +52,7 @@ public class IbmWatsonxRerankRequestTests extends ESTestCase {
 
         assertThat(httpPost.getURI().toString(), endsWith(Strings.format("%s=%s", "version", apiVersion)));
         assertThat(httpPost.getLastHeader(HttpHeaders.CONTENT_TYPE).getValue(), is(XContentType.JSON.mediaType()));
+        assertThat(httpPost.getLastHeader(HttpHeaders.AUTHORIZATION).getValue(), is(AUTH_HEADER_VALUE));
 
         var requestMap = entityAsMap(httpPost.getEntity().getContent());
         assertThat(requestMap, aMapWithSize(5));
@@ -74,7 +77,7 @@ public class IbmWatsonxRerankRequestTests extends ESTestCase {
                     "query",
                     "database",
                     "parameters",
-                    Map.of("return_options", Map.of("top_n", 2, "inputs", true), "truncate_input_tokens", 100)
+                    Map.of("return_options", Map.of("top_n", topN, "inputs", returnDocuments), "truncate_input_tokens", truncateInputTokens)
                 )
             )
         );
@@ -87,21 +90,24 @@ public class IbmWatsonxRerankRequestTests extends ESTestCase {
         String apiVersion,
         String apiKey,
         String query,
-        List<String> input
+        List<String> input,
+        int topN,
+        boolean returnDocuments,
+        int truncateInputTokens
     ) {
-        var embeddingsModel = IbmWatsonxRerankModelTests.createModel(model, projectId, uri, apiVersion, apiKey);
+        var rerankModel = IbmWatsonxRerankModelTests.createModel(
+            model,
+            projectId,
+            uri,
+            apiVersion,
+            apiKey,
+            null,
+            AUTH_HEADER_VALUE,
+            topN,
+            returnDocuments,
+            truncateInputTokens
+        );
 
-        return new IbmWatsonxRerankWithoutAuthRequest(query, input, embeddingsModel);
-    }
-
-    private static class IbmWatsonxRerankWithoutAuthRequest extends IbmWatsonxRerankRequest {
-        IbmWatsonxRerankWithoutAuthRequest(String query, List<String> input, IbmWatsonxRerankModel model) {
-            super(query, input, model);
-        }
-
-        @Override
-        public void decorateWithAuth(HttpPost httpPost) {
-            httpPost.setHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_VALUE);
-        }
+        return new IbmWatsonxRerankRequest(query, input, rerankModel);
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/rerank/IbmWatsonxRerankModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/rerank/IbmWatsonxRerankModelTests.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank;
 
+import org.apache.http.HttpHeaders;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
@@ -15,14 +17,39 @@ import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings
 import java.net.URI;
 
 public class IbmWatsonxRerankModelTests extends ESTestCase {
-    public static IbmWatsonxRerankModel createModel(String model, String projectId, URI uri, String apiVersion, String apiKey) {
+    public static IbmWatsonxRerankModel createModel(
+        String modelId,
+        String projectId,
+        URI uri,
+        String apiVersion,
+        String apiKey,
+        String url,
+        String authHeaderValue
+    ) {
+        return createModel(modelId, projectId, uri, apiVersion, apiKey, url, authHeaderValue, null, null, null);
+    }
+
+    public static IbmWatsonxRerankModel createModel(
+        String modelId,
+        String projectId,
+        URI uri,
+        String apiVersion,
+        String apiKey,
+        String url,
+        String authHeaderValue,
+        @Nullable Integer topN,
+        @Nullable Boolean returnDocuments,
+        @Nullable Integer truncateInputTokens
+    ) {
         return new IbmWatsonxRerankModel(
             "id",
             TaskType.RERANK,
             "service",
-            new IbmWatsonxRerankServiceSettings(uri, apiVersion, model, projectId, null),
-            new IbmWatsonxRerankTaskSettings(2, true, 100),
-            new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
+            url,
+            new IbmWatsonxRerankServiceSettings(uri, apiVersion, modelId, projectId, null),
+            new IbmWatsonxRerankTaskSettings(topN, returnDocuments, truncateInputTokens),
+            new DefaultSecretSettings(new SecureString(apiKey.toCharArray())),
+            (httpPost, model) -> httpPost.setHeader(HttpHeaders.AUTHORIZATION, authHeaderValue)
         );
     }
 }


### PR DESCRIPTION
This commit implements doRerankInfer() in IbmWatsonxService and overrides supportsNewRerankCodePath() to return true, and adds unit tests for the new code path.

Other changes:
- Add authHeaderDecorator field to IbmWatsonxModel to allow tests to override the default behaviour when adding an authorization header when creating an IbmWatsonx*Request
- Add ability to set custom URL on IbmWatsonxRerankModel to allow unit testing
- Rework various test classes to handle custom URL and autherHeaderDecorator values