### PR TITLE
Fix DiskBBQ per-slice merge when sliceField is a keyword

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsWriter.java
@@ -35,6 +35,7 @@ import org.apache.lucene.util.packed.DirectWriter;
 import org.apache.lucene.util.packed.PackedInts;
 import org.apache.lucene.util.packed.PackedLongValues;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.index.IndexSortConfig;
 import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
 import org.elasticsearch.index.codec.vectors.cluster.ClusteringFloatVectorValues;
 import org.elasticsearch.index.codec.vectors.cluster.ClusteringFloatVectorValuesSlice;
@@ -139,7 +140,7 @@ public class ESNextDiskBBQVectorsWriter extends IVFVectorsWriter {
             if (sliceField.equals(primary.getField()) == false) {
                 throw new IllegalStateException("sliceField must be primary index sort");
             }
-            if (primary.getType() != SortField.Type.STRING) {
+            if (IndexSortConfig.getSortFieldType(primary) != SortField.Type.STRING) {
                 throw new IllegalStateException("sliceField requires primary index sort");
             }
         }
@@ -914,7 +915,9 @@ public class ESNextDiskBBQVectorsWriter extends IVFVectorsWriter {
         } else {
             final FieldInfo slicedFieldInfo = mergeState.mergeFieldInfos.fieldInfo(sliceField);
             assert slicedFieldInfo != null;
-            assert slicedFieldInfo.getDocValuesType() == DocValuesType.SORTED : "sliceField must be SortedDocValues";
+            assert slicedFieldInfo.getDocValuesType() == DocValuesType.SORTED
+                || slicedFieldInfo.getDocValuesType() == DocValuesType.SORTED_SET
+                : "sliceField must be SortedDocValues or SortedSetDocValues";
             final SortedDocValues values = DocValueConsumerHelper.INSTANCE.getMergeSortedField(slicedFieldInfo, mergeState);
             final int numSlices = values.getValueCount();
             final KnnVectorValues.DocIndexIterator iterator = floatVectorValues.iterator();
@@ -987,6 +990,22 @@ public class ESNextDiskBBQVectorsWriter extends IVFVectorsWriter {
 
         public SortedDocValues getMergeSortedField(FieldInfo fieldInfo, final MergeState mergeState) throws IOException {
             // This is the magic to get a merged view from the segments.
+            boolean isSortedSet = false;
+            for (int i = 0; i < mergeState.fieldInfos.length; i++) {
+                if (mergeState.fieldInfos[i] != null) {
+                    FieldInfo fi = mergeState.fieldInfos[i].fieldInfo(fieldInfo.name);
+                    if (fi != null && fi.getDocValuesType() == DocValuesType.SORTED_SET) {
+                        isSortedSet = true;
+                        break;
+                    }
+                }
+            }
+            if (isSortedSet) {
+                final java.util.List<org.apache.lucene.index.SortedSetDocValues> toMerge = selectLeavesToMerge(fieldInfo, mergeState);
+                final OrdinalMap map = createOrdinalMapForSortedSetDV(toMerge, mergeState);
+                final org.apache.lucene.index.SortedSetDocValues merged = getMergedSortedSetDocValues(fieldInfo, mergeState, map, toMerge);
+                return org.apache.lucene.search.SortedSetSelector.wrap(merged, org.apache.lucene.search.SortedSetSelector.Type.MIN);
+            }
             final OrdinalMap map = createOrdinalMapForSortedDV(fieldInfo, mergeState);
             return getMergedSortedSetDocValues(fieldInfo, mergeState, map);
         }

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
@@ -19,6 +19,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.CodecReader;
@@ -42,6 +43,8 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedSetSelector;
+import org.apache.lucene.search.SortedSetSortField;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopDocsCollector;
@@ -719,6 +722,77 @@ public class ESNextDiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCas
                     }
                     assertEquals(expectedDocs, uniqueDocIds.size());
                 }
+            }
+        }
+    }
+
+    // Regression test for keyword-typed slice fields. Keyword fields produce SORTED_SET doc-values,
+    // which the merge helper used to mishandle: it always asked for SORTED via createOrdinalMapForSortedDV,
+    // got an empty ordinal map back, and the per-slice centroid file was written without any vectors.
+    // Post-merge knn then returned zero hits. The fix detects SORTED_SET via per-segment FieldInfo and
+    // routes through createOrdinalMapForSortedSetDV + SortedSetSelector.MIN.
+    public void testSlicesWithSortedSetSliceField() throws IOException {
+        String sliceField = "_slice";
+        ESNextDiskBBQVectorsFormat.QuantEncoding encoding = ESNextDiskBBQVectorsFormat.QuantEncoding.values()[random().nextInt(
+            ESNextDiskBBQVectorsFormat.QuantEncoding.values().length
+        )];
+        int vectorPerCluster = random().nextInt(MIN_VECTORS_PER_CLUSTER, 2 * MIN_VECTORS_PER_CLUSTER);
+        ESNextDiskBBQVectorsFormat localFormat = new ESNextDiskBBQVectorsFormat(
+            encoding,
+            vectorPerCluster,
+            random().nextInt(MIN_CENTROIDS_PER_PARENT_CLUSTER, MAX_CENTROIDS_PER_PARENT_CLUSTER),
+            DenseVectorFieldMapper.ElementType.FLOAT,
+            false,
+            null,
+            1,
+            false,
+            DEFAULT_PRECONDITIONING_BLOCK_DIMENSION,
+            0,
+            sliceField
+        );
+        int dimensions = random().nextInt(12, 64);
+        int slices = random().nextInt(2, 8);
+        int numDocs = random().nextInt(800, 2000);
+        int[] docsPerSlice = new int[slices];
+        IndexWriterConfig iwc = newIndexWriterConfig();
+        // SortedSet index sort to match keyword-field behaviour
+        iwc.setIndexSort(new Sort(new SortedSetSortField(sliceField, false, SortedSetSelector.Type.MIN)));
+        iwc.setCodec(TestUtil.alwaysKnnVectorsFormat(localFormat));
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, iwc)) {
+            for (int i = 0; i < numDocs; i++) {
+                int slice = random().nextInt(slices);
+                Document doc = new Document();
+                // SortedSetDocValuesField → DocValuesType.SORTED_SET (the keyword-field shape)
+                doc.add(SortedSetDocValuesField.indexedField(sliceField, new BytesRef("" + slice)));
+                doc.add(new StoredField(sliceField, new BytesRef("" + slice)));
+                doc.add(new KnnFloatVectorField("vector", randomVector(dimensions), VectorSimilarityFunction.EUCLIDEAN));
+                w.addDocument(doc);
+                docsPerSlice[slice]++;
+                // commit a few times so we end up with multiple segments to merge
+                if (i > 0 && i % (numDocs / 4) == 0) {
+                    w.commit();
+                }
+            }
+            w.commit();
+            w.forceMerge(1);
+
+            try (IndexReader reader = DirectoryReader.open(w)) {
+                assertEquals("force-merge should leave one segment", 1, reader.leaves().size());
+                LeafReader leafReader = reader.leaves().get(0).reader();
+                float[] queryVector = randomVector(dimensions);
+                // Without the fix, the per-slice centroid file is empty post-merge and knn returns 0 hits.
+                TopDocs topDocs = leafReader.searchNearestVectors(
+                    "vector",
+                    queryVector,
+                    Math.min(numDocs, 50),
+                    AcceptDocs.fromLiveDocs(leafReader.getLiveDocs(), leafReader.maxDoc()),
+                    Integer.MAX_VALUE
+                );
+                assertThat(
+                    "knn must return hits after merge with SORTED_SET sliceField",
+                    topDocs.scoreDocs.length,
+                    greaterThanOrEqualTo(1)
+                );
             }
         }
     }


### PR DESCRIPTION
When the slice field is a keyword (which it normally is for `_slice` from #148778), KNN returns 0 hits after a force-merge. The flush segment is fine, but the merged segment ends up with an empty centroid file so every per-slice posting list is empty.

The issue is in `ESNextDiskBBQVectorsWriter#calculateCentroids`. The merge path goes through `DocValueConsumerHelper.getMergeSortedField` which always calls `createOrdinalMapForSortedDV`. That helper does `producer.getSorted(fi)` per segment, and for a keyword field the producer only exposes `SORTED_SET`, so it returns null and falls back to `DocValues.emptySorted()`. `numSlices` becomes 0 and the per-slice clustering loop skips every doc. The assertion right above the call (`getDocValuesType() == SORTED`) also trips when assertions are on.

Fix detects `SORTED_SET` from any segment's `FieldInfo` and, when found, takes the SortedSet path: `selectLeavesToMerge` + `createOrdinalMapForSortedSetDV` + `getMergedSortedSetDocValues`, then `SortedSetSelector.wrap(MIN)` to expose it as `SortedDocValues`. Single-valued so `MIN` is fine. The plain `SORTED` path stays unchanged.

There was a second blocker hiding behind this one. The constructor's sort-type check uses `primary.getType()`, but `SortedSetSortField` (what keyword index sort produces) reports `Type.CUSTOM` from `getType()` even though `IndexSortConfig.getSortFieldType` already classifies it as `STRING`. The check rejected any keyword-driven index sort before merge could even run, so the merge bug above is not reachable until this one is fixed too. Switched the constructor to use `IndexSortConfig.getSortFieldType(primary)`.

Did not catch this earlier because the existing `testSlices*` cases use `SortedDocValuesField` directly, which produces `SORTED`. Added `testSlicesWithSortedSetSliceField` mirroring those tests but with `SortedSetDocValuesField.indexedField` and `SortedSetSortField` for the index sort. It writes ~1k docs across multiple commits, force-merges to one segment, and asserts a KNN query returns at least one hit. Confirmed it fails on `main` (`AssertionError: sliceField must be SortedDocValues` during merge) and passes here.

Relates to #147173.
