### PR TITLE
[9.4] Restrict Log4j annotation processor to PluginProcessor, relates to #132166 (#148949)

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -94,6 +94,14 @@ dependencies {
   internalClusterTestImplementation(project(':modules:data-streams'))
 }
 
+// log4j-core registers both the PluginProcessor and GraalVmProcessor on the processor path; we only want the former
+tasks.named("compileJava").configure {
+  options.compilerArgs.addAll(
+    "-processor",
+    "org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor",
+  )
+}
+
 spotless {
   java {
     targetExclude "src/main/java/org/elasticsearch/index/IndexVersion.java"


### PR DESCRIPTION
Backports the following commits to 9.4:
 - Restrict Log4j annotation processor to PluginProcessor, relates to #132166 (#148949)