### PR TITLE
[9.3] [Test] Eanble log4j2 annotation processor for test framework (#149132)

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -64,6 +64,14 @@ sourceSets {
   }
 }
 
+// log4j-core registers both the PluginProcessor and GraalVmProcessor on the processor path; we only want the former
+tasks.named("compileJava").configure {
+  options.compilerArgs.addAll(
+    "-processor",
+    "org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor",
+  )
+}
+
 // the main files are actually test files, so use the appropriate forbidden api sigs
 tasks.named('forbiddenApisMain').configure {
   replaceSignatureFiles 'jdk-signatures', 'es-all-signatures', 'es-test-signatures'

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"
 
+  annotationProcessor "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+  annotationProcessor "org.apache.logging.log4j:log4j-core:${versions.log4j}"
+
   testImplementation project(":modules:mapper-extras")
   testImplementation project(':x-pack:plugin:core')
   testImplementation project(':x-pack:plugin:mapper-unsigned-long')


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [Test] Eanble log4j2 annotation processor for test framework (#149132)