### PR TITLE
[9.4] [Test] Eanble log4j2 annotation processor for test framework (#149132)

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"
 
+  annotationProcessor "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+  annotationProcessor "org.apache.logging.log4j:log4j-core:${versions.log4j}"
+
   testImplementation project(":modules:mapper-extras")
   testImplementation project(':x-pack:plugin:core')
   testImplementation project(':x-pack:plugin:mapper-unsigned-long')


### PR DESCRIPTION
Backports the following commits to 9.4:
 - [Test] Eanble log4j2 annotation processor for test framework (#149132)