### PR TITLE
ESQL: Fix InvalidMappedField equality metadata

### DIFF
--- a/docs/changelog/149151.yaml
+++ b/docs/changelog/149151.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 145907
+pr: 149151
+summary: Include conflict metadata in `InvalidMappedField` equality checks
+type: bug

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/type/InvalidMappedField.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  */
 public class InvalidMappedField extends EsField {
 
-    private final String errorMessage;
+    private final String customErrorMessage;
     private final Map<String, Set<String>> typesToIndices;
     private final boolean isPotentiallyUnmapped;
 
@@ -44,7 +44,7 @@ public class InvalidMappedField extends EsField {
     }
 
     public InvalidMappedField(String name, Map<String, Set<String>> typesToIndices) {
-        this(name, makeErrorMessage(typesToIndices, false), new TreeMap<>(), typesToIndices, false, TimeSeriesFieldType.UNKNOWN);
+        this(name, null, new TreeMap<>(), typesToIndices, false, TimeSeriesFieldType.UNKNOWN);
     }
 
     /**
@@ -53,26 +53,19 @@ public class InvalidMappedField extends EsField {
      * unmapped fields as {@link DataType#KEYWORD}.
      */
     public static InvalidMappedField potentiallyUnmapped(String name, Map<String, Set<String>> typesToIndices) {
-        return new InvalidMappedField(
-            name,
-            makeErrorMessage(typesToIndices, true),
-            new TreeMap<>(),
-            typesToIndices,
-            true,
-            TimeSeriesFieldType.UNKNOWN
-        );
+        return new InvalidMappedField(name, null, new TreeMap<>(), typesToIndices, true, TimeSeriesFieldType.UNKNOWN);
     }
 
     private InvalidMappedField(
         String name,
-        String errorMessage,
+        String customErrorMessage,
         Map<String, EsField> properties,
         Map<String, Set<String>> typesToIndices,
         boolean isPotentiallyUnmapped,
         TimeSeriesFieldType type
     ) {
         super(name, DataType.UNSUPPORTED, properties, false, type);
-        this.errorMessage = errorMessage;
+        this.customErrorMessage = customErrorMessage;
         this.typesToIndices = typesToIndices;
         this.isPotentiallyUnmapped = isPotentiallyUnmapped;
     }
@@ -95,7 +88,7 @@ public class InvalidMappedField extends EsField {
     @Override
     public void writeContent(StreamOutput out) throws IOException {
         ((PlanStreamOutput) out).writeCachedString(getName());
-        out.writeString(errorMessage);
+        out.writeString(errorMessage());
         out.writeMap(getProperties(), (o, x) -> x.writeTo(out));
         writeTimeSeriesFieldType(out);
     }
@@ -105,19 +98,19 @@ public class InvalidMappedField extends EsField {
     }
 
     public String errorMessage() {
-        return errorMessage;
+        return customErrorMessage != null ? customErrorMessage : makeErrorMessage(typesToIndices, isPotentiallyUnmapped);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), errorMessage);
+        return Objects.hash(super.hashCode(), typesToIndices, isPotentiallyUnmapped);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (super.equals(obj)) {
             InvalidMappedField other = (InvalidMappedField) obj;
-            return Objects.equals(errorMessage, other.errorMessage);
+            return Objects.equals(typesToIndices, other.typesToIndices) && isPotentiallyUnmapped == other.isPotentiallyUnmapped;
         }
 
         return false;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/InvalidMappedFieldTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/InvalidMappedFieldTests.java
@@ -11,6 +11,11 @@ import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.InvalidMappedField;
 
 import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
 
 public class InvalidMappedFieldTests extends AbstractEsFieldTypeTests<InvalidMappedField> {
     static InvalidMappedField randomInvalidMappedField(int maxPropertiesDepth) {
@@ -30,12 +35,31 @@ public class InvalidMappedFieldTests extends AbstractEsFieldTypeTests<InvalidMap
         String name = instance.getName();
         String errorMessage = instance.errorMessage();
         Map<String, EsField> properties = instance.getProperties();
-        switch (between(0, 2)) {
+        switch (between(0, 1)) {
             case 0 -> name = randomAlphaOfLength(name.length() + 1);
-            case 1 -> errorMessage = randomValueOtherThan(errorMessage, () -> randomAlphaOfLengthBetween(1, 100));
-            case 2 -> properties = randomValueOtherThan(properties, () -> randomProperties(4));
+            case 1 -> properties = randomValueOtherThan(properties, () -> randomProperties(4));
             default -> throw new IllegalArgumentException();
         }
         return new InvalidMappedField(name, errorMessage, properties);
+    }
+
+    public void testEqualsAndHashCodeIncludeConflictMetadata() {
+        InvalidMappedField first = new InvalidMappedField("field", Map.of(INTEGER.typeName(), Set.of("index-a")));
+        InvalidMappedField second = new InvalidMappedField("field", Map.of(LONG.typeName(), Set.of("index-b")));
+        InvalidMappedField potentiallyUnmapped = InvalidMappedField.potentiallyUnmapped(
+            "field",
+            Map.of(INTEGER.typeName(), Set.of("index-a"))
+        );
+
+        assertNotEquals(first, second);
+        assertNotEquals(first.hashCode(), second.hashCode());
+        assertNotEquals(first, potentiallyUnmapped);
+        assertNotEquals(first.hashCode(), potentiallyUnmapped.hashCode());
+    }
+
+    public void testErrorMessageIsDerivedFromConflictMetadata() {
+        InvalidMappedField field = InvalidMappedField.potentiallyUnmapped("field", Map.of(KEYWORD.typeName(), Set.of("index-a")));
+
+        assertEquals("mapped as [1] incompatible types: [keyword] due to loading from _source and in [index-a]", field.errorMessage());
     }
 }


### PR DESCRIPTION
Closes #145907

This updates InvalidMappedField so equality and hash code include the conflict metadata that distinguishes different mapped field conflicts. Error messages for type-conflict metadata are derived when needed instead of being eagerly stored.

Tests:
- ./gradlew :x-pack:plugin:esql:test --tests org.elasticsearch.xpack.esql.type.InvalidMappedFieldTests
- ./gradlew :x-pack:plugin:esql:spotlessJavaCheck