### PR TITLE
Introduce `InternalTestCluster#awaitNodesInclude`

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -2168,22 +2168,39 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     /**
-     * Returns a set of nodes that have at least one shard of the given index.
+     * Returns the names of the nodes that have at least one shard of the given index.
      */
-    public synchronized Set<String> nodesInclude(String index) {
-        if (clusterService().state().routingTable().hasIndex(index)) {
-            List<ShardRouting> allShards = clusterService().state().routingTable().allShards(index);
-            DiscoveryNodes discoveryNodes = clusterService().state().getNodes();
-            Set<String> nodeNames = new HashSet<>();
-            for (ShardRouting shardRouting : allShards) {
+    private static Set<String> nodesInclude(ClusterState clusterState, String index) {
+        if (clusterState.routingTable().hasIndex(index)) {
+            final var discoveryNodes = clusterState.getNodes();
+            final var nodeNames = new HashSet<String>();
+            for (final var shardRouting : clusterState.routingTable().allShards(index)) {
                 if (shardRouting.assignedToNode()) {
-                    DiscoveryNode discoveryNode = discoveryNodes.get(shardRouting.currentNodeId());
-                    nodeNames.add(discoveryNode.getName());
+                    nodeNames.add(discoveryNodes.get(shardRouting.currentNodeId()).getName());
                 }
             }
             return nodeNames;
         }
         return Collections.emptySet();
+    }
+
+    /**
+     * Returns the names of the nodes that have at least one shard of the given index.
+     */
+    public synchronized Set<String> nodesInclude(String index) {
+        return nodesInclude(clusterService().state(), index);
+    }
+
+    /**
+     * Blocks until the set of nodes that have at least one shard of the given index matches the given predicate.
+     */
+    public void awaitNodesInclude(String index, Predicate<Set<String>> nodeNamesPredicate) {
+        safeAwait(
+            ClusterServiceUtils.addTemporaryStateListener(
+                clusterService(),
+                clusterState -> nodeNamesPredicate.test(nodesInclude(clusterState, index))
+            )
+        );
     }
 
     /**

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/AbstractStatelessPluginIntegTestCase.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/AbstractStatelessPluginIntegTestCase.java
@@ -131,11 +131,9 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFa
 import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.STATELESS_HOLLOW_INDEX_SHARDS_ENABLED;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
@@ -1284,11 +1282,7 @@ public abstract class AbstractStatelessPluginIntegTestCase extends ESIntegTestCa
 
         logger.debug("--> relocating {} hollowable shards from {} to {}", numberOfShards, indexNodeA, indexNodeB);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> {
-            var nodes = internalCluster().nodesInclude(indexName);
-            assertThat(nodes, not(hasItem(indexNodeA)));
-            assertThat(nodes, hasItem(indexNodeB));
-        });
+        internalCluster().awaitNodesInclude(indexName, nodes -> nodes.contains(indexNodeA) == false && nodes.contains(indexNodeB));
         ensureGreen(indexName);
 
         var hollowShardsServiceB = internalCluster().getInstance(HollowShardsService.class, indexNodeB);


### PR DESCRIPTION
No need to spin in `assertBusy()` waiting for a cluster state with the
expected properties, we can listen for updates directly instead.