### PR TITLE
Fix `testFieldCapsForHollowShards`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -539,9 +539,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.StatelessCommitServiceIT
   method: testRetainCommitForReadersAfterShardMovedAway
   issue: https://github.com/elastic/elasticsearch/issues/149083
-- class: org.elasticsearch.xpack.stateless.StatelessFieldCapabilitiesIT
-  method: testFieldCapsForHollowShards
-  issue: https://github.com/elastic/elasticsearch/issues/149113
 - class: org.elasticsearch.xpack.esql.qa.csv.CsvFormatSpecIT
   method: test {csv-spec:csv-headerless.multiFileHeaderlessReadSchemaPreventsTypeDrift [LOCAL]}
   issue: https://github.com/elastic/elasticsearch/issues/149126

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessFieldCapabilitiesIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessFieldCapabilitiesIT.java
@@ -11,11 +11,15 @@ import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesBuilder;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider.Rebalance;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 
 import java.util.Map;
 
+import static org.elasticsearch.cluster.InternalClusterInfoService.CLUSTER_ROUTING_ALLOCATION_ESTIMATED_HEAP_THRESHOLD_DECIDER_ENABLED;
+import static org.elasticsearch.cluster.routing.allocation.IndexBalanceConstraintSettings.INDEX_BALANCE_DECIDER_ENABLED_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.SETTING_HOLLOW_INGESTION_TTL;
 import static org.elasticsearch.xpack.stateless.commits.HollowShardsService.STATELESS_HOLLOW_INDEX_SHARDS_ENABLED;
@@ -56,6 +60,17 @@ public class StatelessFieldCapabilitiesIT extends AbstractStatelessPluginIntegTe
         assertFieldCaps(indexName);
     }
 
+    @Override
+    protected Settings.Builder nodeSettings() {
+        return super.nodeSettings()
+            // disable rebalancing to avoid spurious shard movements that might cause premature hollowing
+            .put(CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), Rebalance.NONE)
+            // disable index balance decider to avoid spurious shard movements that might cause premature hollowing
+            .put(INDEX_BALANCE_DECIDER_ENABLED_SETTING.getKey(), false)
+            // disable estimated heap decider to avoid spurious shard movements that might cause premature hollowing
+            .put(CLUSTER_ROUTING_ALLOCATION_ESTIMATED_HEAP_THRESHOLD_DECIDER_ENABLED.getKey(), false);
+    }
+
     public void testFieldCapsForHollowShards() throws Exception {
         startMasterOnlyNode();
         var indexNodeSettings = Settings.builder()
@@ -66,7 +81,7 @@ public class StatelessFieldCapabilitiesIT extends AbstractStatelessPluginIntegTe
         startSearchNode();
         ensureStableCluster(3);
 
-        var indexName = randomIdentifier();
+        var indexName = randomIndexName();
         int numberOfShards = randomIntBetween(1, 5);
         assertAcked(prepareCreate(indexName).setMapping(mapping).setSettings(indexSettings(numberOfShards, 1)));
         ensureGreen(indexName);


### PR DESCRIPTION
Today one of these shards may rebalance onto the new node, becoming
hollow, before it is explicitly hollowed via `hollowShards()`. This
commit disables rebalancing in this test suite to avoid the uncontrolled
shard movements that would cause this.

Closes #149113