### PR TITLE
Unmute ArrayObjectsLimitIT tests - make DocumentParsingException a MapperException

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -464,15 +464,6 @@ tests:
 - class: org.elasticsearch.xpack.stateless.commits.StatelessBatchedBehavioursIT
   method: testGenerationalFileBlobReferenceIsRetainedCorrectly
   issue: https://github.com/elastic/elasticsearch/issues/148723
-- class: org.elasticsearch.index.mapper.ArrayObjectsLimitIT
-  method: testDynamicSettingUpdateAffectsSubsequentDocuments
-  issue: https://github.com/elastic/elasticsearch/issues/148745
-- class: org.elasticsearch.index.mapper.ArrayObjectsLimitIT
-  method: testBulkPartialFailureOnArrayObjectsLimit
-  issue: https://github.com/elastic/elasticsearch/issues/148746
-- class: org.elasticsearch.index.mapper.ArrayObjectsLimitIT
-  method: testNestedArrayExceeded
-  issue: https://github.com/elastic/elasticsearch/issues/148747
 - class: org.elasticsearch.index.reindex.ReindexRelocationOnShutdownIT
   method: testReindexFailsWhenPitRelocationFails
   issue: https://github.com/elastic/elasticsearch/issues/148748

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParsingException.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParsingException.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.XContentLocation;
@@ -21,7 +20,7 @@ import java.io.IOException;
  *
  * Contains information about the location in the document where the error was encountered
  */
-public class DocumentParsingException extends ElasticsearchException {
+public class DocumentParsingException extends MapperException {
 
     public DocumentParsingException(XContentLocation location, String message) {
         super(message(location, message));


### PR DESCRIPTION
`ArrayObjectsLimitIT` failed on CI with 

```
java.lang.AssertionError: All incoming requests on node [node_s0] should have finished. Expected 0 bytes for requests in-flight but got 321 bytes; pending tasks [[]]
```

During peer recovery, `RecoveryTarget#indexTranslogOperations` only tolerates `MapperException` as a translog-replay failure; anything else throws an `AssertionError` that escapes `ActionListener.completeWith` (which catches only `Exception`). The internal handler then never sends a response and its inbound-transport breaker reservation leak

The new dynamic `array_objects.limit` setting can reject previously-accepted documents on replay, throwing `DocumentParsingException`,  which extended `ElasticsearchException`, so it hit the assertion path.

Closes #148745
Closes #148746
Closes #148747