### PR TITLE
Use one class to capture both single and multi value numeric doc values

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -10,8 +10,6 @@
 package org.elasticsearch.index.mapper.extras;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.DoubleValues;
-import org.apache.lucene.search.LongValues;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.settings.Setting;
@@ -19,7 +17,6 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersions;
-import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
@@ -845,38 +842,12 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         @Override
         public SortedNumericDoubleValues getDoubleValues() {
             final SortedNumericLongValues values = scaledFieldData.getLongValues();
-            final LongValues singleValues = SortedNumericLongValues.unwrapSingleton(values);
-            if (singleValues != null) {
-                return FieldData.singleton(new DoubleValues() {
-                    @Override
-                    public boolean advanceExact(int doc) throws IOException {
-                        return singleValues.advanceExact(doc);
-                    }
-
-                    @Override
-                    public double doubleValue() throws IOException {
-                        return singleValues.longValue() * scalingFactorInverse;
-                    }
-                });
-            } else {
-                return new SortedNumericDoubleValues() {
-
-                    @Override
-                    public boolean advanceExact(int target) throws IOException {
-                        return values.advanceExact(target);
-                    }
-
-                    @Override
-                    public double nextValue() throws IOException {
-                        return values.nextValue() * scalingFactorInverse;
-                    }
-
-                    @Override
-                    public int docValueCount() {
-                        return values.docValueCount();
-                    }
-                };
-            }
+            return new SortedNumericDoubleValues.SortedNumericLongWrapper(values) {
+                @Override
+                public double nextValue() throws IOException {
+                    return values.nextValue() * scalingFactorInverse;
+                }
+            };
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
@@ -161,24 +161,24 @@ public enum FieldData {
      * Wrap the provided {@link SortedNumericDocValues} instance to cast all values to doubles.
      */
     public static SortedNumericDoubleValues castToDouble(final SortedNumericLongValues values) {
-        final LongValues singleton = SortedNumericLongValues.unwrapSingleton(values);
-        if (singleton != null) {
-            return singleton(new DoubleCastedValues(singleton));
-        } else {
-            return new SortedDoubleCastedValues(values);
-        }
+        return new SortedNumericDoubleValues.SortedNumericLongWrapper(values) {
+            @Override
+            public double nextValue() throws IOException {
+                return values.nextValue();
+            }
+        };
     }
 
     /**
      * Wrap the provided {@link SortedNumericDoubleValues} instance to cast all values to longs.
      */
     public static SortedNumericLongValues castToLong(final SortedNumericDoubleValues values) {
-        final DoubleValues singleton = SortedNumericDoubleValues.unwrapSingleton(values);
-        if (singleton != null) {
-            return SortedNumericLongValues.singleton(new LongCastedValues(singleton));
-        } else {
-            return new SortedLongCastedValues(values);
-        }
+        return new SortedNumericLongValues.SortedNumericDoubleWrapper(values) {
+            @Override
+            public long nextValue() throws IOException {
+                return (long) values.nextValue();
+            }
+        };
     }
 
     /**
@@ -473,95 +473,6 @@ public enum FieldData {
 
         /** return the {@link CharSequence} for the current document. */
         CharSequence get() throws IOException;
-
-    }
-
-    private static class DoubleCastedValues extends DoubleValues {
-
-        private final LongValues values;
-
-        DoubleCastedValues(LongValues values) {
-            this.values = values;
-        }
-
-        @Override
-        public double doubleValue() throws IOException {
-            return values.longValue();
-        }
-
-        @Override
-        public boolean advanceExact(int doc) throws IOException {
-            return values.advanceExact(doc);
-        }
-
-    }
-
-    private static class SortedDoubleCastedValues extends SortedNumericDoubleValues {
-
-        private final SortedNumericLongValues values;
-
-        SortedDoubleCastedValues(SortedNumericLongValues in) {
-            this.values = in;
-        }
-
-        @Override
-        public boolean advanceExact(int target) throws IOException {
-            return values.advanceExact(target);
-        }
-
-        @Override
-        public double nextValue() throws IOException {
-            return values.nextValue();
-        }
-
-        @Override
-        public int docValueCount() {
-            return values.docValueCount();
-        }
-
-    }
-
-    private static class LongCastedValues extends LongValues {
-
-        private final DoubleValues values;
-
-        LongCastedValues(DoubleValues values) {
-            this.values = values;
-        }
-
-        @Override
-        public boolean advanceExact(int target) throws IOException {
-            return values.advanceExact(target);
-        }
-
-        @Override
-        public long longValue() throws IOException {
-            return (long) values.doubleValue();
-        }
-    }
-
-    private static class SortedLongCastedValues extends SortedNumericLongValues {
-
-        private final SortedNumericDoubleValues values;
-
-        SortedLongCastedValues(SortedNumericDoubleValues in) {
-            this.values = in;
-        }
-
-        @Override
-        public boolean advanceExact(int target) throws IOException {
-            return values.advanceExact(target);
-        }
-
-        @Override
-        public int docValueCount() {
-            return values.docValueCount();
-        }
-
-        @Override
-        public long nextValue() throws IOException {
-            return (long) values.nextValue();
-        }
 
     }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
@@ -285,7 +285,7 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
      * Convert the values in <code>dvs</code> using the provided <code>converter</code>.
      */
     protected static SortedNumericLongValues convertNumeric(SortedNumericLongValues values, LongUnaryOperator converter) {
-        return new SortedNumericLongValues() {
+        return new SortedNumericLongValues(values.isSingleton()) {
 
             @Override
             public boolean advanceExact(int target) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsSortedNumericDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsSortedNumericDocValues.java
@@ -20,37 +20,20 @@ import java.io.IOException;
  * and converts the doubles to sortable long bits using
  * {@link NumericUtils#doubleToSortableLong(double)}.
  */
-final class SortableLongBitsSortedNumericDocValues extends SortedNumericLongValues implements ScorerAware {
-
-    private final SortedNumericDoubleValues values;
+final class SortableLongBitsSortedNumericDocValues extends SortedNumericLongValues.SortedNumericDoubleWrapper implements ScorerAware {
 
     SortableLongBitsSortedNumericDocValues(SortedNumericDoubleValues values) {
-        this.values = values;
-    }
-
-    @Override
-    public boolean advanceExact(int target) throws IOException {
-        return values.advanceExact(target);
+        super(values);
     }
 
     @Override
     public long nextValue() throws IOException {
-        return NumericUtils.doubleToSortableLong(values.nextValue());
-    }
-
-    @Override
-    public int docValueCount() {
-        return values.docValueCount();
-    }
-
-    /** Return the wrapped values. */
-    public SortedNumericDoubleValues getDoubleValues() {
-        return values;
+        return NumericUtils.doubleToSortableLong(getDoubleValues().nextValue());
     }
 
     @Override
     public void setScorer(Scorable scorer) {
-        if (values instanceof ScorerAware aware) {
+        if (getDoubleValues() instanceof ScorerAware aware) {
             aware.setScorer(scorer);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsToSortedNumericDoubleValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortableLongBitsToSortedNumericDoubleValues.java
@@ -18,32 +18,15 @@ import java.io.IOException;
  * and converts the doubles to sortable long bits using
  * {@link NumericUtils#sortableLongToDouble(long)}.
  */
-final class SortableLongBitsToSortedNumericDoubleValues extends SortedNumericDoubleValues {
-
-    private final SortedNumericLongValues values;
+final class SortableLongBitsToSortedNumericDoubleValues extends SortedNumericDoubleValues.SortedNumericLongWrapper {
 
     SortableLongBitsToSortedNumericDoubleValues(SortedNumericLongValues values) {
-        this.values = values;
-    }
-
-    @Override
-    public boolean advanceExact(int target) throws IOException {
-        return values.advanceExact(target);
+        super(values);
     }
 
     @Override
     public double nextValue() throws IOException {
-        return NumericUtils.sortableLongToDouble(values.nextValue());
-    }
-
-    @Override
-    public int docValueCount() {
-        return values.docValueCount();
-    }
-
-    /** Return the wrapped values. */
-    public SortedNumericLongValues getLongValues() {
-        return values;
+        return NumericUtils.sortableLongToDouble(getLongValues().nextValue());
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericDoubleValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericDoubleValues.java
@@ -22,9 +22,18 @@ import java.io.IOException;
  */
 public abstract class SortedNumericDoubleValues {
 
+    private final boolean isSingleton;
+    private DoubleValues doubleValues;
+
     /** Sole constructor. (For invocation by subclass
      * constructors, typically implicit.) */
-    protected SortedNumericDoubleValues() {}
+    protected SortedNumericDoubleValues() {
+        this(false);
+    }
+
+    protected SortedNumericDoubleValues(boolean isSingleton) {
+        this.isSingleton = isSingleton;
+    }
 
     /** Advance the iterator to exactly {@code target} and return whether
      *  {@code target} has a value.
@@ -47,46 +56,56 @@ public abstract class SortedNumericDoubleValues {
      */
     public abstract int docValueCount();
 
+    public boolean isSingleton() {
+        return isSingleton;
+    }
+
+    public DoubleValues asDoubleValues() {
+        if (isSingleton && doubleValues == null) {
+            var singleton = this;
+            doubleValues = new DoubleValues() {
+                @Override
+                public double doubleValue() throws IOException {
+                    return singleton.nextValue();
+                }
+
+                @Override
+                public boolean advanceExact(int doc) throws IOException {
+                    return singleton.advanceExact(doc);
+                }
+            };
+        }
+        return doubleValues;
+    }
+
     /**
      * Converts a {@link SortedNumericDoubleValues} values to a singly valued {@link DoubleValues}
      * if possible
      */
     public static DoubleValues unwrapSingleton(SortedNumericDoubleValues values) {
-        if (values instanceof SortedNumericDoubleValues.SingletonSortedNumericDoubleValues sv) {
-            return sv.values;
-        }
-        return null;
+        return values != null ? values.asDoubleValues() : null;
     }
 
     /**
      * Converts a {@link DoubleValues} to a {@link SortedNumericDoubleValues}
      */
     public static SortedNumericDoubleValues singleton(DoubleValues values) {
-        return new SortedNumericDoubleValues.SingletonSortedNumericDoubleValues(values);
-    }
+        return new SortedNumericDoubleValues(true) {
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                return values.advanceExact(target);
+            }
 
-    private static class SingletonSortedNumericDoubleValues extends SortedNumericDoubleValues {
+            @Override
+            public double nextValue() throws IOException {
+                return values.doubleValue();
+            }
 
-        private final DoubleValues values;
-
-        private SingletonSortedNumericDoubleValues(DoubleValues values) {
-            this.values = values;
-        }
-
-        @Override
-        public boolean advanceExact(int target) throws IOException {
-            return values.advanceExact(target);
-        }
-
-        @Override
-        public double nextValue() throws IOException {
-            return values.doubleValue();
-        }
-
-        @Override
-        public int docValueCount() {
-            return 1;
-        }
+            @Override
+            public int docValueCount() {
+                return 1;
+            }
+        };
     }
 
     /**
@@ -98,20 +117,7 @@ public abstract class SortedNumericDoubleValues {
      */
     public static SortedNumericDoubleValues wrap(SortedNumericDocValues values) {
         NumericDocValues singleton = DocValues.unwrapSingleton(values);
-        if (singleton != null) {
-            return new SortedNumericDoubleValues.SingletonSortedNumericDoubleValues(new DoubleValues() {
-                @Override
-                public double doubleValue() throws IOException {
-                    return NumericUtils.sortableLongToDouble(singleton.longValue());
-                }
-
-                @Override
-                public boolean advanceExact(int doc) throws IOException {
-                    return singleton.advanceExact(doc);
-                }
-            });
-        }
-        return new SortedNumericDoubleValues() {
+        return new SortedNumericDoubleValues(singleton != null) {
             @Override
             public boolean advanceExact(int target) throws IOException {
                 return values.advanceExact(target);
@@ -124,8 +130,27 @@ public abstract class SortedNumericDoubleValues {
 
             @Override
             public int docValueCount() {
-                return values.docValueCount();
+                return singleton != null ? 1 : values.docValueCount();
             }
         };
+    }
+
+    public static abstract class SortedNumericLongWrapper extends SortedNumericDoubleValues {
+        private final SortedNumericLongValues longValues;
+
+        protected SortedNumericLongWrapper(SortedNumericLongValues longValues) {
+            super(longValues.isSingleton());
+            this.longValues = longValues;
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+            return longValues.advanceExact(target);
+        }
+
+        @Override
+        public int docValueCount() {
+            return longValues.docValueCount();
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericDoubleValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericDoubleValues.java
@@ -105,6 +105,11 @@ public abstract class SortedNumericDoubleValues {
             public int docValueCount() {
                 return 1;
             }
+
+            @Override
+            public DoubleValues asDoubleValues() {
+                return values;
+            }
         };
     }
 
@@ -135,7 +140,7 @@ public abstract class SortedNumericDoubleValues {
         };
     }
 
-    public static abstract class SortedNumericLongWrapper extends SortedNumericDoubleValues {
+    public abstract static class SortedNumericLongWrapper extends SortedNumericDoubleValues {
         private final SortedNumericLongValues longValues;
 
         protected SortedNumericLongWrapper(SortedNumericLongValues longValues) {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericDoubleValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericDoubleValues.java
@@ -60,6 +60,10 @@ public abstract class SortedNumericDoubleValues {
         return isSingleton;
     }
 
+    /**
+     * Converts a {@link SortedNumericDoubleValues} values to a singly valued {@link DoubleValues}
+     * if possible
+     */
     public DoubleValues asDoubleValues() {
         if (isSingleton && doubleValues == null) {
             var singleton = this;

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericDoubleValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericDoubleValues.java
@@ -152,5 +152,10 @@ public abstract class SortedNumericDoubleValues {
         public int docValueCount() {
             return longValues.docValueCount();
         }
+
+        /** Return the wrapped values. */
+        public SortedNumericLongValues getLongValues() {
+            return longValues;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericLongValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericLongValues.java
@@ -171,5 +171,10 @@ public abstract class SortedNumericLongValues {
         public int docValueCount() {
             return doubleValues.docValueCount();
         }
+
+        /** Return the wrapped values. */
+        public SortedNumericDoubleValues getDoubleValues() {
+            return doubleValues;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericLongValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericLongValues.java
@@ -17,7 +17,7 @@ import org.apache.lucene.search.LongValues;
 import java.io.IOException;
 
 /**
- * A multivalued version of {@link LongValues}
+ * Clone of {@link SortedNumericDocValues} for long values.
  */
 public abstract class SortedNumericLongValues {
 
@@ -79,6 +79,10 @@ public abstract class SortedNumericLongValues {
         return isSingleton;
     }
 
+    /**
+     * Converts a {@link SortedNumericLongValues} values to a singly valued {@link LongValues}
+     * if possible
+     */
     public LongValues asLongValues() {
         if (isSingleton && longValues == null) {
             var singleton = this;

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericLongValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericLongValues.java
@@ -124,6 +124,11 @@ public abstract class SortedNumericLongValues {
             public int docValueCount() {
                 return 1;
             }
+
+            @Override
+            public LongValues asLongValues() {
+                return values;
+            }
         };
     }
 
@@ -154,7 +159,7 @@ public abstract class SortedNumericLongValues {
         };
     }
 
-    public static abstract class SortedNumericDoubleWrapper extends SortedNumericLongValues {
+    public abstract static class SortedNumericDoubleWrapper extends SortedNumericLongValues {
         private final SortedNumericDoubleValues doubleValues;
 
         protected SortedNumericDoubleWrapper(SortedNumericDoubleValues doubleValues) {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericLongValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortedNumericLongValues.java
@@ -21,6 +21,19 @@ import java.io.IOException;
  */
 public abstract class SortedNumericLongValues {
 
+    private final boolean isSingleton;
+    private LongValues longValues;
+
+    /** Sole constructor. (For invocation by subclass
+     * constructors, typically implicit.) */
+    protected SortedNumericLongValues() {
+        this(false);
+    }
+
+    protected SortedNumericLongValues(boolean isSingleton) {
+        this.isSingleton = isSingleton;
+    }
+
     /**
      * A {@link SortedNumericLongValues} instance that does not have a value for any document
      */
@@ -62,46 +75,56 @@ public abstract class SortedNumericLongValues {
      */
     public abstract int docValueCount();
 
+    public boolean isSingleton() {
+        return isSingleton;
+    }
+
+    public LongValues asLongValues() {
+        if (isSingleton && longValues == null) {
+            var singleton = this;
+            longValues = new LongValues() {
+                @Override
+                public long longValue() throws IOException {
+                    return singleton.nextValue();
+                }
+
+                @Override
+                public boolean advanceExact(int doc) throws IOException {
+                    return singleton.advanceExact(doc);
+                }
+            };
+        }
+        return longValues;
+    }
+
     /**
      * Converts a {@link SortedNumericLongValues} values to a singly valued {@link LongValues}
      * if possible
      */
     public static LongValues unwrapSingleton(SortedNumericLongValues values) {
-        if (values instanceof SingletonSortedNumericLongValues sv) {
-            return sv.values;
-        }
-        return null;
+        return values != null ? values.asLongValues() : null;
     }
 
     /**
      * Converts a {@link LongValues} to a {@link SortedNumericLongValues}
      */
     public static SortedNumericLongValues singleton(LongValues values) {
-        return new SingletonSortedNumericLongValues(values);
-    }
+        return new SortedNumericLongValues(true) {
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                return values.advanceExact(target);
+            }
 
-    private static class SingletonSortedNumericLongValues extends SortedNumericLongValues {
+            @Override
+            public long nextValue() throws IOException {
+                return values.longValue();
+            }
 
-        private final LongValues values;
-
-        private SingletonSortedNumericLongValues(LongValues values) {
-            this.values = values;
-        }
-
-        @Override
-        public boolean advanceExact(int target) throws IOException {
-            return values.advanceExact(target);
-        }
-
-        @Override
-        public long nextValue() throws IOException {
-            return values.longValue();
-        }
-
-        @Override
-        public int docValueCount() {
-            return 1;
-        }
+            @Override
+            public int docValueCount() {
+                return 1;
+            }
+        };
     }
 
     /**
@@ -113,20 +136,7 @@ public abstract class SortedNumericLongValues {
      */
     public static SortedNumericLongValues wrap(SortedNumericDocValues values) {
         NumericDocValues singleton = DocValues.unwrapSingleton(values);
-        if (singleton != null) {
-            return new SingletonSortedNumericLongValues(new LongValues() {
-                @Override
-                public long longValue() throws IOException {
-                    return singleton.longValue();
-                }
-
-                @Override
-                public boolean advanceExact(int doc) throws IOException {
-                    return singleton.advanceExact(doc);
-                }
-            });
-        }
-        return new SortedNumericLongValues() {
+        return new SortedNumericLongValues(singleton != null) {
             @Override
             public boolean advanceExact(int target) throws IOException {
                 return values.advanceExact(target);
@@ -139,8 +149,27 @@ public abstract class SortedNumericLongValues {
 
             @Override
             public int docValueCount() {
-                return values.docValueCount();
+                return singleton != null ? 1 : values.docValueCount();
             }
         };
+    }
+
+    public static abstract class SortedNumericDoubleWrapper extends SortedNumericLongValues {
+        private final SortedNumericDoubleValues doubleValues;
+
+        protected SortedNumericDoubleWrapper(SortedNumericDoubleValues doubleValues) {
+            super(doubleValues.isSingleton());
+            this.doubleValues = doubleValues;
+        }
+
+        @Override
+        public boolean advanceExact(int target) throws IOException {
+            return doubleValues.advanceExact(target);
+        }
+
+        @Override
+        public int docValueCount() {
+            return doubleValues.docValueCount();
+        }
     }
 }

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapper.java
@@ -546,6 +546,7 @@ public class AggregateMetricDoubleFieldMapper extends FieldMapper {
             final Metric metric;
 
             private AggregateMetricValues(SortedNumericDocValues values, Metric metric) {
+                super(DocValues.unwrapSingleton(values) != null);
                 this.values = values;
                 this.metric = metric;
             }

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongLeafFieldData.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongLeafFieldData.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.unsignedlong;
 
-import org.apache.lucene.search.DoubleValues;
-import org.apache.lucene.search.LongValues;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
@@ -41,38 +39,12 @@ public class UnsignedLongLeafFieldData implements LeafNumericFieldData {
     @Override
     public SortedNumericDoubleValues getDoubleValues() {
         final SortedNumericLongValues values = signedLongFD.getLongValues();
-        final LongValues singleValues = SortedNumericLongValues.unwrapSingleton(values);
-        if (singleValues != null) {
-            return FieldData.singleton(new DoubleValues() {
-                @Override
-                public boolean advanceExact(int doc) throws IOException {
-                    return singleValues.advanceExact(doc);
-                }
-
-                @Override
-                public double doubleValue() throws IOException {
-                    return convertUnsignedLongToDouble(singleValues.longValue());
-                }
-            });
-        } else {
-            return new SortedNumericDoubleValues() {
-
-                @Override
-                public boolean advanceExact(int target) throws IOException {
-                    return values.advanceExact(target);
-                }
-
-                @Override
-                public double nextValue() throws IOException {
-                    return convertUnsignedLongToDouble(values.nextValue());
-                }
-
-                @Override
-                public int docValueCount() {
-                    return values.docValueCount();
-                }
-            };
-        }
+        return new SortedNumericDoubleValues.SortedNumericLongWrapper(values) {
+            @Override
+            public double nextValue() throws IOException {
+                return convertUnsignedLongToDouble(values.nextValue());
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
Both `SortedNumericDoubleValues` and `SortedNumericLongValues` have a singleton subclass that wraps around `DoubleValues` and `LongValues` respectively.

Whenever we extend `SortedNumericDoubleValues` or `SortedNumericLongValues` either to cast them either to convert them to other types, we need to identify if they are singletons or not and then provide subclasses for both the `SortedNumeric[Double|Long]Values` and its respective singleton. 

In this PoC we explore the idea, to remove the subclass and track if the doc values are a singleton or not via a flag. Similarly, we lazily create `DoubleValues` and `LongValues` when needed instead passing them in the constructor.

We believe this reduces boiler plate code without hurting performance. 

This improvement was inspired while working in https://github.com/elastic/elasticsearch/pull/149164