### PR TITLE
[ESQL] REPLACE fast-path review fixes

### DIFF
--- a/docs/changelog/149167.yaml
+++ b/docs/changelog/149167.yaml
@@ -1,0 +1,5 @@
+area: ES|QL
+issues: []
+pr: 149167
+summary: REPLACE fast-path review fixes
+type: enhancement

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Replace.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Replace.java
@@ -227,10 +227,11 @@ public class Replace extends EsqlScalarFunction {
             return NO_LITERAL_PREFIX;
         }
 
-        // Top-level alternation invalidates anchoring: `^a|b` is `(^a)|(b)`, so an input starting with `b`
-        // would still match. Java regex hex / unicode / control / octal escapes always produce literal
-        // characters (they cannot encode a meta `|`), so a simple literal-`|` scan outside `\Q...\E` is enough.
-        if (containsTopLevelAlternation(regex, i)) {
+        // Any alternation invalidates anchoring: `^a|b` is `(^a)|(b)`, so an input starting with `b` would
+        // still match — and even `^foo(a|b)` is rejected by this coarse check, see below. Java regex hex /
+        // unicode / control / octal escapes always produce literal characters (they cannot encode a meta
+        // `|`), so a simple literal-`|` scan outside `\Q...\E` is enough.
+        if (containsUnquotedAlternation(regex, i)) {
             return NO_LITERAL_PREFIX;
         }
 
@@ -347,14 +348,15 @@ public class Replace extends EsqlScalarFunction {
 
     /**
      * Returns {@code true} if a literal {@code |} appears outside a {@code \Q...\E} block in the pattern
-     * starting at {@code from}. This is a deliberately coarse check: any {@code |} (including those nested
-     * in a group) disqualifies the pattern, which keeps the analysis simple at the cost of giving up on
-     * patterns like {@code ^a(b|c)} where a prefix could still be extracted.
+     * starting at {@code from}. Despite the term "alternation" usually referring to a top-level construct,
+     * this check is deliberately coarse: any {@code |} (including those nested in a group) disqualifies
+     * the pattern. It keeps the analysis simple at the cost of giving up on patterns like {@code ^a(b|c)}
+     * where a prefix could still be extracted.
      * <p>
      * Hex / unicode / control / octal escapes in Java regex always produce a literal character (never an
-     * unescaped meta), so they cannot smuggle in a hidden top-level alternation.
+     * unescaped meta), so they cannot smuggle in a hidden alternation.
      */
-    private static boolean containsTopLevelAlternation(String regex, int from) {
+    private static boolean containsUnquotedAlternation(String regex, int from) {
         int n = regex.length();
         for (int i = from; i < n; i++) {
             char c = regex.charAt(i);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceConstantOrdinalEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceConstantOrdinalEvaluator.java
@@ -171,7 +171,11 @@ final class ReplaceConstantOrdinalEvaluator implements ExpressionEvaluator {
 
     @Override
     public long baseRamBytesUsed() {
-        return BASE_RAM_BYTES_USED + str.baseRamBytesUsed();
+        // Track the constant byte arrays we hold; the regex Pattern itself is not accounted (matching the
+        // convention of the generated ReplaceConstantEvaluator, which also doesn't include the Pattern).
+        return BASE_RAM_BYTES_USED + str.baseRamBytesUsed() + RamUsageEstimator.sizeOf(literalPrefix) + RamUsageEstimator.sizeOf(
+            newStr.bytes
+        );
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceStaticTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceStaticTests.java
@@ -103,6 +103,14 @@ public class ReplaceStaticTests extends ESTestCase {
         assertPrefix("\\Aabc", "abc");
     }
 
+    public void testLiteralPrefixInputAnchorEquivalentToCaret() {
+        // \A is the start-of-input anchor and must behave identically to ^ for all of our walker logic,
+        // including the quantifier handling that drops the preceding literal on `?` / `*` and keeps it on `+`.
+        assertPrefix("\\Ahttps?://", "http");
+        assertPrefix("\\Afoob+", "foob");
+        assertPrefix("\\Afoob{0,3}", "foo");
+    }
+
     public void testLiteralPrefixOptionalChar() {
         // `s?` makes the preceding `s` optional, so the prefix is only `http`.
         assertPrefix("^https?://", "http");


### PR DESCRIPTION
## Summary

Three small follow-ups to #149033 addressing post-merge review feedback:

- Rename the helper that scans for unescaped alternation. Despite the name `containsTopLevelAlternation`, it bails on any `|` outside `\Q...\E` (including nested-in-group cases). Renaming to `containsUnquotedAlternation` matches the actual semantics.
- Track the constant `literalPrefix` byte array and the folded `newStr` `BytesRef` in `baseRamBytesUsed`. The values are typically small, but they were the only constants the evaluator held without any RAM accounting.
- Add a regression test that asserts the `\A` anchor produces the same prefix extraction as `^` across the three quantifier shapes (`?`, `+`, `{0,3}`).

Three other points from the review were considered and intentionally not adopted: a defensive try/finally around the `OrdinalBytesRefBlock` constructor (the constructor cannot throw and the rest of the codebase doesn't guard it), reusing a single `Matcher` via `reset()` (right idea, wrong layer — should be a cross-function optimization, not a per-function backdoor), and widening the type check from `KEYWORD` to any string type (string literals in ESQL parse as `KEYWORD`, and the same gate on the outer `regex` check would have to widen too).

## Test plan

- All `org.elasticsearch.xpack.esql.expression.function.scalar.string.Replace*` tests pass.
- `:x-pack:plugin:esql:precommit` passes.

Developed with AI-assisted tooling