### PR TITLE
[8.19] [9.3] Fix ArrayIndexOutOfBoundsException in centroid grouping evaluateFinal (#148815) (#149162)

### DIFF
--- a/docs/changelog/148815.yaml
+++ b/docs/changelog/148815.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+  - 141318
+pr: 148815
+summary: Fix ArrayIndexOutOfBoundsException in centroid grouping evaluateFinal
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidPointAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/spatial/CentroidPointAggregator.java
@@ -138,7 +138,7 @@ abstract class CentroidPointAggregator {
         try (BytesRefBlock.Builder builder = driverContext.blockFactory().newBytesRefBlockBuilder(selected.getPositionCount())) {
             for (int i = 0; i < selected.getPositionCount(); i++) {
                 int si = selected.getInt(i);
-                if (state.hasValue(si) && si < state.xValues.size()) {
+                if (si < state.xValues.size() && state.hasValue(si)) {
                     BytesRef result = state.encodeCentroidResult(si);
                     builder.appendBytesRef(result);
                 } else {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/spatial/CentroidGroupingAggregatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/spatial/CentroidGroupingAggregatorTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.spatial;
+
+import org.elasticsearch.compute.aggregation.GroupingAggregatorEvaluationContext;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.test.ComputeTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Reproduces <a href="https://github.com/elastic/elasticsearch/issues/141318">issue #141318</a>:
+ * {@code evaluateFinal} throws {@link ArrayIndexOutOfBoundsException} when the {@code selected}
+ * vector contains a group id that exceeds the state's allocated capacity. The fix reorders the
+ * condition so the bounds check runs before {@code hasValue()}.
+ */
+public class CentroidGroupingAggregatorTests extends ComputeTestCase {
+
+    public void testPointCentroidEvaluateFinalWithOutOfBoundsSelectedGroup() {
+        var blockFactory = blockFactory();
+        var driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+        try (
+            var state = CentroidPointAggregator.initGrouping(blockFactory.bigArrays());
+            IntVector selected = blockFactory.newIntArrayVector(new int[] { 0, 1 }, 2);
+        ) {
+            var evaluationContext = new GroupingAggregatorEvaluationContext(driverContext);
+            CentroidPointAggregator.combineIntermediate(state, 0, 10.0, 0.0, 20.0, 0.0, 1L);
+            try (Block result = CentroidPointAggregator.evaluateFinal(state, selected, evaluationContext)) {
+                assertThat(result.getPositionCount(), equalTo(2));
+                assertThat("in-bounds group should have a centroid result", BlockUtils.toJavaObject(result, 0), notNullValue());
+                assertThat(
+                    "out-of-bounds group should produce null, not ArrayIndexOutOfBoundsException",
+                    BlockUtils.toJavaObject(result, 1),
+                    nullValue()
+                );
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/spatial/CentroidGroupingAggregatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/spatial/CentroidGroupingAggregatorTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.aggregation.spatial;
 
-import org.elasticsearch.compute.aggregation.GroupingAggregatorEvaluationContext;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.IntVector;
@@ -28,14 +27,13 @@ public class CentroidGroupingAggregatorTests extends ComputeTestCase {
 
     public void testPointCentroidEvaluateFinalWithOutOfBoundsSelectedGroup() {
         var blockFactory = blockFactory();
-        var driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory, null);
+        var driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory);
         try (
             var state = CentroidPointAggregator.initGrouping(blockFactory.bigArrays());
             IntVector selected = blockFactory.newIntArrayVector(new int[] { 0, 1 }, 2);
         ) {
-            var evaluationContext = new GroupingAggregatorEvaluationContext(driverContext);
             CentroidPointAggregator.combineIntermediate(state, 0, 10.0, 0.0, 20.0, 0.0, 1L);
-            try (Block result = CentroidPointAggregator.evaluateFinal(state, selected, evaluationContext)) {
+            try (Block result = CentroidPointAggregator.evaluateFinal(state, selected, driverContext)) {
                 assertThat(result.getPositionCount(), equalTo(2));
                 assertThat("in-bounds group should have a centroid result", BlockUtils.toJavaObject(result, 0), notNullValue());
                 assertThat(


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [9.3] Fix ArrayIndexOutOfBoundsException in centroid grouping evaluateFinal (#148815) (#149162)