### PR TITLE
Avoid more `assertBusy()` on shard allocations

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -2204,6 +2204,13 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     /**
+     * Blocks until {@code vacatingNode} holds no shards of {@code index} (the node has been vacated for that index).
+     */
+    public void awaitNodeVacated(String index, String vacatingNode) {
+        awaitNodesInclude(index, nodes -> nodes.contains(vacatingNode) == false);
+    }
+
+    /**
      * Performs cluster bootstrap when node with index {@link #bootstrapMasterNodeIndex} is started
      * with the names of all existing and new master-eligible nodes.
      * Indexing starts from 0.

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessHollowIndexShardsIT.java
@@ -571,7 +571,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
 
         String indexNodeB = startIndexNode(indexNodeSettings);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         ensureGreen(indexName);
         final var indexNodeBCacheService = getCacheService(
             BlobStoreCacheDirectory.unwrapDirectory(findIndexShard(indexName).store().directory())
@@ -1013,7 +1013,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
                     Settings.builder().put("index.routing.allocation.exclude._name", clusterInfo.indexNodeB),
                     clusterInfo.indexName
                 );
-                assertBusy(() -> assertThat(internalCluster().nodesInclude(clusterInfo.indexName), not(hasItem(clusterInfo.indexNodeB))));
+                internalCluster().awaitNodeVacated(clusterInfo.indexName, clusterInfo.indexNodeB);
                 ensureGreen(clusterInfo.indexName);
 
                 for (int i = 0; i < clusterInfo.numberOfShards; i++) {
@@ -1274,7 +1274,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         final var hollowThread = new Thread(() -> {
             try {
                 updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-                assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+                internalCluster().awaitNodeVacated(indexName, indexNodeA);
                 ensureGreen(indexName);
             } catch (Exception e) {
                 throw new AssertionError(e);
@@ -1425,7 +1425,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
 
         logger.info("--> relocating {} hollowable shards from {} to {}", numberOfShards, indexNodeA, indexNodeB);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         ensureGreen(indexName);
         logger.info("--> relocated");
 
@@ -1486,7 +1486,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
 
         logger.info("--> relocating {} shards from {} to {}", numberOfShards, indexNodeA, indexNodeB);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         ensureGreen(indexName);
         logger.info("--> relocated");
 
@@ -1514,7 +1514,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         // Try to relocate back hollow shards now initialized with `HollowIndexEngine`
         logger.info("--> relocating {} shards from {} to {}", numberOfShards, indexNodeB, indexNodeA);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeB), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeB))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeB);
         ensureGreen(indexName);
         logger.info("--> relocated");
 
@@ -1605,7 +1605,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         logger.info("--> let relocation complete");
         setNodeRepositoryStrategy(indexNodeA, StatelessMockRepositoryStrategy.DEFAULT);
 
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         ensureGreen(indexName);
         logger.info("--> relocated");
 
@@ -2100,7 +2100,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
 
         logger.info("--> relocating {} hollowable shards from {} to {}", numberOfShards, indexNodeA, indexNodeB);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         ensureGreen(indexName);
         logger.info("--> relocated");
 
@@ -2258,7 +2258,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         // Hollow shards by relocating them
         logger.info("--> relocating {} hollowable shards from {} to {}", numberOfShards, indexNodeA, indexNodeB);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         ensureGreen(indexName);
         logger.info("--> relocated");
         var hollowShardsServiceB = internalCluster().getInstance(HollowShardsService.class, indexNodeB);
@@ -2336,7 +2336,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
 
         logger.debug("--> relocating hollowable shard from {} to {}", indexNodeA, indexNodeB);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         ensureGreen(indexName);
         logger.debug("--> relocated");
 
@@ -2389,7 +2389,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         String indexNodeB = startIndexNode(nodeSettings);
         var commitServiceB = internalCluster().getInstance(StatelessCommitService.class, indexNodeB);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         ensureGreen(indexName);
 
         var hollowShardsServiceB = internalCluster().getInstance(HollowShardsService.class, indexNodeB);
@@ -2626,7 +2626,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         ensureStableCluster(4);
         assertNodeDoesNotReceiveAction.accept(indexingNodeB);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexingNodeA), backingIndex);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(backingIndex), not(hasItem(indexingNodeA))));
+        internalCluster().awaitNodeVacated(backingIndex, indexingNodeA);
         ensureGreen(backingIndex);
 
         // Ensure the shard was hollowed
@@ -3282,7 +3282,7 @@ public class StatelessHollowIndexShardsIT extends AbstractStatelessPluginIntegTe
         }
         logger.info("--> relocating {} hollowable shards from {} to {}", numOfShards, indexNodeA, indexNodeB);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         ensureGreen(indexName);
         logger.info("--> relocated");
         var hollowShardsServiceB = internalCluster().getInstance(HollowShardsService.class, indexNodeB);

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessSearchIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/StatelessSearchIT.java
@@ -119,7 +119,6 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.NONE;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.WAIT_UNTIL;
 import static org.elasticsearch.blobcache.CachePopulationSource.BlobStore;
 import static org.elasticsearch.blobcache.CachePopulationSource.Peer;
-import static org.elasticsearch.index.engine.LiveVersionMapTestUtils.get;
 import static org.elasticsearch.index.engine.LiveVersionMapTestUtils.isUnsafe;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
@@ -137,7 +136,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -1681,12 +1679,12 @@ public class StatelessSearchIT extends AbstractStatelessPluginIntegTestCase {
                         Settings.builder().put(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name", searchNodeOne),
                         indexName
                     );
-                    assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(searchNodeOne))));
+                    internalCluster().awaitNodeVacated(indexName, searchNodeOne);
                     updateIndexSettings(
                         Settings.builder().put(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name", searchNodeTwo),
                         indexName
                     );
-                    assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(searchNodeTwo))));
+                    internalCluster().awaitNodeVacated(indexName, searchNodeTwo);
                 }
                 handler.messageReceived(request, channel, task);
             });
@@ -1897,7 +1895,7 @@ public class StatelessSearchIT extends AbstractStatelessPluginIntegTestCase {
             {
                 logger.info("--> moving shards in index [{}] away from node [{}]", indexName, searchNodeA);
                 updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", searchNodeA), indexName);
-                assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(searchNodeA))));
+                internalCluster().awaitNodeVacated(indexName, searchNodeA);
                 logger.info("--> shards in index [{}] have been moved off of node [{}]", indexName, searchNodeA);
             }
             assertBusy(() -> assertThat(searchNodeAClosedShardService.getPrimaryTermAndGenerations(shardId).size(), equalTo(1)));

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SearchShardCacheWarmingIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SearchShardCacheWarmingIT.java
@@ -39,15 +39,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.elasticsearch.test.ESIntegTestCase.assertBusy;
-import static org.elasticsearch.test.ESTestCase.assertTrue;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
 
 /**
  * Search-only shard recovery with a 4kb shared-cache region so the compound commit spans many regions. Concurrent searches run while
@@ -149,10 +145,10 @@ public class SearchShardCacheWarmingIT extends AbstractStatelessPluginIntegTestC
             indexName
         );
 
-        assertBusy(() -> {
-            assertThat(internalCluster().nodesInclude(indexName), not(hasItem(nodes.searchNodeA)));
-            assertThat(internalCluster().nodesInclude(indexName), hasItem(nodes.searchNodeB));
-        });
+        internalCluster().awaitNodesInclude(
+            indexName,
+            includedNodes -> includedNodes.contains(nodes.searchNodeA) == false && includedNodes.contains(nodes.searchNodeB)
+        );
 
         ensureGreen(indexName);
 
@@ -194,7 +190,7 @@ public class SearchShardCacheWarmingIT extends AbstractStatelessPluginIntegTestC
             indexName
         );
 
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), hasItem(nodes.searchNodeB)));
+        internalCluster().awaitNodesInclude(indexName, includedNodes -> includedNodes.contains(nodes.searchNodeB));
 
         ensureGreen(indexName);
 

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceIT.java
@@ -126,8 +126,6 @@ import static org.elasticsearch.xpack.stateless.recovery.TransportStatelessPrima
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -611,7 +609,7 @@ public class SharedBlobCacheWarmingServiceIT extends AbstractStatelessPluginInte
 
         // Trigger recovery to hollow the shard.
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         ensureGreen(indexName);
 
         // Check that the shard is hollow

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessFileDeletionIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/StatelessFileDeletionIT.java
@@ -144,7 +144,6 @@ import static org.elasticsearch.xpack.stateless.recovery.TransportStatelessPrima
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -1064,7 +1063,7 @@ public class StatelessFileDeletionIT extends AbstractStatelessPluginIntegTestCas
         if (excludeOrStop) {
             updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", nodeToExclude), indexName);
             if (randomBoolean()) {
-                assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(nodeToExclude))));
+                internalCluster().awaitNodeVacated(indexName, nodeToExclude);
             }
         } else {
             internalCluster().stopNode(nodeToExclude);
@@ -1090,7 +1089,7 @@ public class StatelessFileDeletionIT extends AbstractStatelessPluginIntegTestCas
 
         logger.info("--> excluding {}", indexNodeA);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
 
         logger.info("--> deleting index");
         assertAcked(indicesAdmin().delete(new DeleteIndexRequest(indexName)).actionGet());

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommitsIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/commits/VirtualBatchedCompoundCommitsIT.java
@@ -116,11 +116,9 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 
 public class VirtualBatchedCompoundCommitsIT extends AbstractStatelessPluginIntegTestCase {
 
@@ -469,7 +467,7 @@ public class VirtualBatchedCompoundCommitsIT extends AbstractStatelessPluginInte
             threads[i].start();
         }
 
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         for (Thread thread : threads) {
             thread.join();
         }
@@ -580,7 +578,7 @@ public class VirtualBatchedCompoundCommitsIT extends AbstractStatelessPluginInte
                 .currentNodeId()
                 .equals(getNodeId(indexNodeB))
         );
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         logger.info("relocated primary");
 
         CountDownLatch indexNotFoundOnIndexNodeA = new CountDownLatch(1);
@@ -1017,7 +1015,7 @@ public class VirtualBatchedCompoundCommitsIT extends AbstractStatelessPluginInte
                     .currentNodeId()
                     .equals(indexNodeBNodeId)
             );
-            assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+            internalCluster().awaitNodeVacated(indexName, indexNodeA);
             logger.info("--> relocated primary");
             final var indexNodeATransportService = MockTransportService.getInstance(indexNodeA);
             indexNodeATransportService.addRequestHandlingBehavior(
@@ -1092,7 +1090,7 @@ public class VirtualBatchedCompoundCommitsIT extends AbstractStatelessPluginInte
 
         // Relocate the search shard
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", searchNodeA), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(searchNodeA))));
+        internalCluster().awaitNodeVacated(indexName, searchNodeA);
         logger.info("--> relocated search shard");
 
         getVBCCChunkBlocked.countDown();

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/IndexingShardRecoveryIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/IndexingShardRecoveryIT.java
@@ -369,7 +369,7 @@ public class IndexingShardRecoveryIT extends AbstractStatelessPluginIntegTestCas
 
             var excludedNode = indexNode;
             updateIndexSettings(Settings.builder().put(INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getKey() + "_name", excludedNode), indexName);
-            assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(excludedNode))));
+            internalCluster().awaitNodeVacated(indexName, excludedNode);
             assertNodeHasNoCurrentRecoveries(newIndexNode);
             internalCluster().stopNode(excludedNode);
             indexNode = newIndexNode;

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/IndexingShardRelocationAvoidListIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/IndexingShardRelocationAvoidListIT.java
@@ -238,7 +238,7 @@ public class IndexingShardRelocationAvoidListIT extends AbstractStatelessPluginI
         // Trigger relocation
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
         ensureGreen(indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
         // Assert we passed all the uploaded blobs during relocation since we blocked their deletion on source.
         assertThat(passedBlobFiles, equalTo(uploadedFiles));
 
@@ -354,7 +354,7 @@ public class IndexingShardRelocationAvoidListIT extends AbstractStatelessPluginI
         // Trigger relocation
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNodeA), indexName);
         ensureGreen(indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNodeA))));
+        internalCluster().awaitNodeVacated(indexName, indexNodeA);
 
         // Extra activity to trigger deletions on target node after relocation.
         indexDocs(indexName, 10);

--- a/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/IndexingShardRelocationIT.java
+++ b/x-pack/plugin/stateless/src/internalClusterTest/java/org/elasticsearch/xpack/stateless/recovery/IndexingShardRelocationIT.java
@@ -121,7 +121,6 @@ import static org.elasticsearch.xpack.stateless.recovery.TransportStatelessPrima
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -219,7 +218,7 @@ public class IndexingShardRelocationIT extends AbstractStatelessPluginIntegTestC
                 try {
                     logger.info("--> excluding [{}]", nodeToRemove);
                     updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", nodeToRemove), indexName);
-                    assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(nodeToRemove))));
+                    internalCluster().awaitNodeVacated(indexName, nodeToRemove);
                 } finally {
                     running.set(false);
                     for (Thread thread : threads) {
@@ -1198,7 +1197,7 @@ public class IndexingShardRelocationIT extends AbstractStatelessPluginIntegTestC
         ensureStableCluster(3);
 
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", indexNode), indexName);
-        assertBusy(() -> assertThat(internalCluster().nodesInclude(indexName), not(hasItem(indexNode))));
+        internalCluster().awaitNodeVacated(indexName, indexNode);
         ensureGreen(indexName);
 
         var cacheService = internalCluster().getInstance(StatelessPlugin.SharedBlobCacheServiceSupplier.class, indexNode2).get();


### PR DESCRIPTION
Relates #149156