### PR TITLE
Fix flaky CCS IT on Windows connect errors

### DIFF
--- a/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
+++ b/qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 
@@ -359,21 +360,21 @@ public class CrossClusterSearchUnavailableClusterIT extends ESRestTestCase {
                 ResponseException.class,
                 () -> client().performRequest(new Request("POST", "/index,remote1:index/_search"))
             );
-            assertThat(exception.getMessage(), containsString("connect_exception"));
+            assertThat(exception.getMessage(), anyOf(containsString("connect_exception"), containsString("connect_timeout")));
         }
         {
             ResponseException exception = expectThrows(
                 ResponseException.class,
                 () -> client().performRequest(new Request("POST", "/remote1:index/_search"))
             );
-            assertThat(exception.getMessage(), containsString("connect_exception"));
+            assertThat(exception.getMessage(), anyOf(containsString("connect_exception"), containsString("connect_timeout")));
         }
         {
             ResponseException exception = expectThrows(
                 ResponseException.class,
                 () -> client().performRequest(new Request("POST", "/remote1:index/_search?scroll=1m"))
             );
-            assertThat(exception.getMessage(), containsString("connect_exception"));
+            assertThat(exception.getMessage(), anyOf(containsString("connect_exception"), containsString("connect_timeout")));
         }
     }
 


### PR DESCRIPTION
On Windows, after MockTransportService.close(), the OS can hold the socket in TIME_WAIT/CLOSE_WAIT longer than on Linux/Mac. This causes the subsequent connection attempt to time out rather than be immediately refused, so TcpTransport emits "connect_timeout[...]" instead of "connect_exception". The assertSearchConnectFailure() assertions checked only for the latter, causing intermittent failures on the Windows CI platform.

Broaden the assertions to accept either string.

Closes #149115