### PR TITLE
Skip ReindexRelocationWithSecurityIT on Windows

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -527,9 +527,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {csv-spec:fuse.fuseWithRowRRFAndMultiValueGroupColumn}
   issue: https://github.com/elastic/elasticsearch/issues/149046
-- class: org.elasticsearch.xpack.security.ReindexRelocationWithSecurityIT
-  method: testReindexRelocatesWhenCoordinatorShutsDown
-  issue: https://github.com/elastic/elasticsearch/issues/149055
 - class: org.elasticsearch.xpack.stateless.StatelessCommitServiceIT
   method: testRetainCommitForReadersAfterShardMovedAway
   issue: https://github.com/elastic/elasticsearch/issues/149083

--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexRelocationWithSecurityIT.java
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/ReindexRelocationWithSecurityIT.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.security;
 
 import org.apache.http.HttpHost;
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
@@ -25,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
@@ -103,6 +106,10 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
             "reindex resilience endpoints must be available",
             clusterHasCapability("GET", "/_reindex/{task_id}", List.of(), List.of("reindex_management_api")).orElse(false)
         );
+        // The test cluster framework's Process.destroy() maps to TerminateProcess on Windows, which kills the JVM without running
+        // shutdown hooks. As a result ShutdownPrepareService.prepareForShutdown() never fires, the reindex-stop hook never marks the
+        // task for relocation, and the assertions below cannot be satisfied.
+        assumeFalse("graceful JVM shutdown is not deliverable on Windows by the test cluster framework", Constants.WINDOWS);
 
         final int numDocs = 30;
         createSourceIndexAndPopulate(numDocs);
@@ -244,6 +251,10 @@ public class ReindexRelocationWithSecurityIT extends ESRestTestCase {
             Request list = new Request("GET", "/_reindex");
             Response response = dataClient.performRequest(list);
             ObjectPath body = ObjectPath.createFromResponse(response);
+            // Surface fan-out failures up front so that an unexpectedly empty `reindex` array points at the real cause (e.g. the
+            // coordinator going unreachable mid-list) rather than a bare hasSize(1) mismatch.
+            assertThat(body.<List<?>>evaluate("node_failures"), anyOf(nullValue(), empty()));
+            assertThat(body.<List<?>>evaluate("task_failures"), anyOf(nullValue(), empty()));
             assertThat(body.<List<?>>evaluate("reindex"), hasSize(1));
             assertThat(body.evaluate("reindex.0.id"), equalTo(taskId));
         }


### PR DESCRIPTION
## What

- Skip `ReindexRelocationWithSecurityIT.testReindexRelocatesWhenCoordinatorShutsDown` on Windows via `assumeFalse(Constants.WINDOWS)`.
- Unmute the test in `muted-tests.yml`.
- nice-to-have: In `assertListViaSurvivingNode`, also assert `node_failures` / `task_failures` are empty so a hypothetical future empty `reindex` has more info and points at the real cause instead of a bare Hamcrest failure

## Why

The test exercises the reindex relocation hand-off triggered by graceful coordinator shutdown. That relies on `ShutdownPrepareService.prepareForShutdown()` being invoked from a JVM shutdown hook when the node is asked to stop.

On Windows, the test cluster framework cannot deliver a graceful stop:

- `AbstractLocalClusterFactory.stop(forcibly=false)` calls `ProcessUtils.stopHandle()`, which calls `processHandle.destroy()`.
- On Windows, `Process.destroy()` is implemented as `TerminateProcess`, which kills the JVM immediately and does **not** run shutdown hooks.
- Therefore the reindex-stop hook never fires, nothing logs, the task is never marked for relocation, the coord transport disappears within ~25ms, and the data node's `GET /_reindex` fan-out gets no reindex tasks
- Therefore, all Windows runs of this test fail (22 out of 22)

This is a test-framework limitation, not a product bug. In production, Windows graceful shutdown is delivered via the Windows service stop control (`prunsrv` / `--StopMethod=close`) or the console `CTRL_CLOSE_EVENT` handler — both of which actually run the shutdown hooks. The integration test framework just can't invoke either of those on a child JVM.

## Why a Windows skip is acceptable

- The behavior under test is OS-agnostic reindex relocation + RBAC plumbing; nothing in the test exercises Windows-specific code paths.
- UNIX coverage of this exact test (security plus relocation) is unchanged.
- The underlying relocation flow is also covered without security on all OSes by `ReindexRelocationOnShutdownIT`, which uses `internalCluster()` to invoke `prepareForShutdown()` directly and so does not depend on OS process semantics.
- There is some precedent: the entire `elasticsearch.stateless` Gradle convention skips all stateless integration tests on Windows for the same root cause (`build-tools-internal/src/main/groovy/elasticsearch.stateless.gradle`), including `SigtermShutdownIT` which exercises the same JVM-shutdown-hook chain.

Assisted with Cursor

Closes #149055